### PR TITLE
Change container node pool defaults

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -32,8 +32,8 @@ func schemaLoggingVariant() *schema.Schema {
 	return &schema.Schema{
 		Type: schema.TypeString,
 		Optional: true,
+		Computed: true,
 		Description: `Type of logging agent that is used as the default value for node pools in the cluster. Valid values include DEFAULT and MAX_THROUGHPUT.`,
-		Default: "DEFAULT",
 		ValidateFunc: validation.StringInSlice([]string{"DEFAULT", "MAX_THROUGHPUT"}, false),
 	}
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
@@ -293,15 +293,15 @@ var schemaNodePool = map[string]*schema.Schema{
 				"auto_repair": {
 					Type:        schema.TypeBool,
 					Optional:    true,
-					Default:     false,
-					Description: `Whether the nodes will be automatically repaired.`,
+					Default:     true,
+					Description: `Whether the nodes will be automatically repaired. Enabled by default.`,
 				},
 
 				"auto_upgrade": {
 					Type:        schema.TypeBool,
 					Optional:    true,
-					Default:     false,
-					Description: `Whether the nodes will be automatically upgraded.`,
+					Default:     true,
+					Description: `Whether the nodes will be automatically upgraded. Enabled by default.`,
 				},
 			},
 		},

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -2614,10 +2614,7 @@ resource "google_container_node_pool" "with_kubelet_config" {
       "https://www.googleapis.com/auth/logging.write",
       "https://www.googleapis.com/auth/monitoring",
     ]
-  }
-  management {
-    auto_repair  = false
-    auto_upgrade = false
+    logging_variant = "DEFAULT"
   }
 }
 `, cluster, np, policy, quota, period, podPidsLimit)

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -2615,6 +2615,10 @@ resource "google_container_node_pool" "with_kubelet_config" {
       "https://www.googleapis.com/auth/monitoring",
     ]
   }
+  management {
+    auto_repair  = false
+    auto_upgrade = false
+  }
 }
 `, cluster, np, policy, quota, period, podPidsLimit)
 }

--- a/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
@@ -201,9 +201,9 @@ cluster.
 
 <a name="nested_management"></a>The `management` block supports:
 
-* `auto_repair` - (Optional) Whether the nodes will be automatically repaired.
+* `auto_repair` - (Optional) Whether the nodes will be automatically repaired. Enabled by default.
 
-* `auto_upgrade` - (Optional) Whether the nodes will be automatically upgraded.
+* `auto_upgrade` - (Optional) Whether the nodes will be automatically upgraded. Enabled by default.
 
 <a name="nested_network_config"></a>The `network_config` block supports:
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fixes https://github.com/hashicorp/terraform-provider-google/issues/6236

fixes https://github.com/hashicorp/terraform-provider-google/issues/13706

both auto repair and auto upgrade default to true according to these docs and verified in testing
https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-repair
https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-upgrades

upgrade guide: https://github.com/GoogleCloudPlatform/magic-modules/pull/8969

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
container: removed default for `logging_variant` in `google_container_node_pool`
```

```release-note:breaking-change
container: changed `management.auto_repair` and `management.auto_upgrade` defaults to true in `google_container_node_pool`
```