### PR TITLE
upgrade guide - container cluster removals

### DIFF
--- a/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
@@ -277,6 +277,17 @@ These two unsupported fields were introduced incorrectly. They are now removed.
 
 This unsupported field was introduced incorrectly. It is now removed.
 
+## Resource: `google_container_cluster`
+
+### `enable_binary_authorization` is now removed
+
+`enable_binary_authorization` has been removed in favor of `binary_authorization.enabled`.
+
+### Default value of `network_policy.provider` is now removed
+
+Previously `network_policy.provider` defaulted to "PROVIDER_UNSPECIFIED". It no longer
+as a default value.
+
 ## Resource: `google_dataplex_datascan`
 
 ### `dataQualityResult` and `dataProfileResult` output fields are now removed 

--- a/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
@@ -286,7 +286,7 @@ This unsupported field was introduced incorrectly. It is now removed.
 ### Default value of `network_policy.provider` is now removed
 
 Previously `network_policy.provider` defaulted to "PROVIDER_UNSPECIFIED". It no longer
-as a default value.
+has a default value.
 
 ## Resource: `google_dataplex_datascan`
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

upgrade guides for:
https://github.com/GoogleCloudPlatform/magic-modules/pull/8784
https://github.com/GoogleCloudPlatform/magic-modules/pull/8965

`enable_binary_authorization` is already deprecated.

```release-note:none

```
