### PR TITLE
Replace InstanceInfo call with Instances call for regional reliability

### DIFF
--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
@@ -258,13 +258,9 @@ func resourceBigtableInstanceRead(d *schema.ResourceData, meta interface{}) erro
 
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutRead))
 	defer cancel()
-	instance, err := c.InstanceInfo(ctxWithTimeout, instanceName)
-	if err != nil {
-		if tpgresource.IsNotFoundGrpcError(err) {
-			log.Printf("[WARN] Removing %s because it's gone", instanceName)
-			d.SetId("")
-			return nil
-		}
+	instancesResponse, err := c.Instances(ctxWithTimeout)
+	instance, stop, err := getInstanceFromResponse(instancesResponse, instanceName, err, d)
+	if stop {
 		return err
 	}
 
@@ -272,7 +268,7 @@ func resourceBigtableInstanceRead(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error setting project: %s", err)
 	}
 
-	clusters, err := c.Clusters(ctxWithTimeout, instance.Name)
+	clusters, err := c.Clusters(ctxWithTimeout, instanceName)
 	if err != nil {
 		partiallyUnavailableErr, ok := err.(bigtable.ErrPartiallyUnavailable)
 
@@ -428,6 +424,42 @@ func flattenBigtableCluster(c *bigtable.ClusterInfo) map[string]interface{} {
 		autoscaling_config[0]["storage_target"] = c.AutoscalingConfig.StorageUtilizationPerNode
 	}
 	return cluster
+}
+
+func getInstanceFromResponse(instances []*bigtable.InstanceInfo, instanceName string, err error, d *schema.ResourceData) (*bigtable.InstanceInfo, bool, error) {
+	// Fail on any error other than ParrtiallyUnavailable.
+	isPartiallyUnavailableError := false
+	if err != nil {
+		_, isPartiallyUnavailableError = err.(bigtable.ErrPartiallyUnavailable)
+
+		if !isPartiallyUnavailableError {
+			return nil, true, fmt.Errorf("Error retrieving instance. %s", err)
+		}
+	}
+
+	// Get instance from response.
+	var instanceInfo *bigtable.InstanceInfo
+	for _, instance := range instances {
+		if instance.Name == instanceName {
+			instanceInfo = instance
+		}
+	}
+
+	// If instance found, it either wasn't affected by the outage, or there is no outage.
+	if instanceInfo != nil {
+		return instanceInfo, false, nil
+	}
+
+	// If instance wasn't found and error is PartiallyUnavailable,
+	// continue to clusters call that will reveal overlap between instance regions and unavailable regions.
+	if isPartiallyUnavailableError {
+		return nil, false, nil
+	}
+
+	// If instance wasn't found and error is not PartiallyUnavailable, instance doesn't exist.
+	log.Printf("[WARN] Removing %s because it's gone", instanceName)
+	d.SetId("")
+	return nil, true, nil
 }
 
 func getUnavailableClusterZones(clusters []interface{}, unavailableZones []string) []string {

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
@@ -281,6 +281,13 @@ func resourceBigtableInstanceRead(d *schema.ResourceData, meta interface{}) erro
 		if len(unavailableClusterZones) > 0 {
 			return fmt.Errorf("Error retrieving instance clusters. The following zones are unavailable: %s", strings.Join(unavailableClusterZones, ", "))
 		}
+		// If there is no overlap, and we still couldn't find the instance, it doesn't exist.
+		if instance == nil {
+			log.Printf("[WARN] Removing %s because it's gone", instanceName)
+			d.SetId("")
+			return nil
+		}
+
 	}
 
 	clustersNewState := []map[string]interface{}{}

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_internal_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_internal_test.go
@@ -116,7 +116,7 @@ func TestGetInstanceFromResponse(t *testing.T) {
 		}
 		if (gotErr != nil && tc.wantError == "") ||
 			(gotErr == nil && tc.wantError != "") ||
-			(gotErr != nil && strings.Contains(gotErr.Error(), tc.wantError)) {
+			(gotErr != nil && !strings.Contains(gotErr.Error(), tc.wantError)) {
 			t.Errorf("bad error: %s, got %q, want %q", tn, gotErr, tc.wantError)
 		}
 		if (gotInstance == nil && tc.wantInstanceName != "") ||

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_internal_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_internal_test.go
@@ -103,9 +103,9 @@ func TestGetInstanceFromResponse(t *testing.T) {
 			wantId:           originalId,
 		}}
 	for tn, tc := range cases {
-		instanceResponse = []*bigtable.InstanceInfo{}
+		instancesResponse := []*bigtable.InstanceInfo{}
 		for _, existingInstance := range tc.instanceNames {
-			instanceResponse = append(instanceResponse, &bigtable.InstanceInfo{Name: existingInstance})
+			instancesResponse = append(instancesResponse, &bigtable.InstanceInfo{Name: existingInstance})
 		}
 		d := &schema.ResourceData{}
 		d.SetId(originalId)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigtable: improved regional reliability when instance overlaps a downed region in the resource `google_bigtable_instance`
```

Fixes https://github.com/hashicorp/terraform-provider-google/issues/14565