### PR TITLE
Add support for certificate map datasource

### DIFF
--- a/mmv1/third_party/terraform/provider/provider.go.erb
+++ b/mmv1/third_party/terraform/provider/provider.go.erb
@@ -213,6 +213,7 @@ func DatasourceMapWithErrors() (map[string]*schema.Resource, error) {
 		"google_beyondcorp_app_gateway":                    beyondcorp.DataSourceGoogleBeyondcorpAppGateway(),
 		"google_billing_account":                           billing.DataSourceGoogleBillingAccount(),
 		"google_bigquery_default_service_account":          bigquery.DataSourceGoogleBigqueryDefaultServiceAccount(),
+		"google_certificate_manager_certificate_map":       certificatemanager.DataSourceGoogleCertificateManagerCertificateMap(),
 		"google_cloudbuild_trigger":                        cloudbuild.DataSourceGoogleCloudBuildTrigger(),
 		"google_cloudfunctions_function":                   cloudfunctions.DataSourceGoogleCloudFunctionsFunction(),
 		"google_cloudfunctions2_function":                  cloudfunctions2.DataSourceGoogleCloudFunctions2Function(),

--- a/mmv1/third_party/terraform/services/certificatemanager/data_source_google_certificate_manager_certificate_map.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/data_source_google_certificate_manager_certificate_map.go
@@ -1,0 +1,43 @@
+package certificatemanager
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceGoogleCertificateManagerCertificateMap() *schema.Resource {
+
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceCertificateManagerCertificateMap().Schema)
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "name")
+
+	return &schema.Resource{
+		Read:   dataSourceGoogleCertificateManagerCertificateMapRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceGoogleCertificateManagerCertificateMapRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+
+	name := d.Get("name").(string)
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	id := fmt.Sprintf("projects/%s/locations/global/certificateMaps/%s", project, name)
+	d.SetId(id)
+	err = resourceCertificateManagerCertificateMapRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
+}

--- a/mmv1/third_party/terraform/services/certificatemanager/data_source_google_certificate_manager_certificate_map.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/data_source_google_certificate_manager_certificate_map.go
@@ -12,6 +12,7 @@ func DataSourceGoogleCertificateManagerCertificateMap() *schema.Resource {
 
 	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceCertificateManagerCertificateMap().Schema)
 	tpgresource.AddRequiredFieldsToSchema(dsSchema, "name")
+	tpgresource.AddOptionalFieldsToSchema(dsSchema, "project")
 
 	return &schema.Resource{
 		Read:   dataSourceGoogleCertificateManagerCertificateMapRead,

--- a/mmv1/third_party/terraform/services/certificatemanager/data_source_google_certificate_manager_certificate_map_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/data_source_google_certificate_manager_certificate_map_test.go
@@ -1,0 +1,109 @@
+package certificatemanager_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccDataSourceGoogleCertificateManagerCertificateMap_basic(t *testing.T) {
+	t.Parallel()
+
+	project := envvar.GetTestProjectFromEnv()
+
+	description := "My acceptance data source test certificate map"
+	name := fmt.Sprintf("tf-test-certificate-map-%d", acctest.RandInt(t))
+	id := fmt.Sprintf("projects/%s/locations/global/certificateMaps/%s", project, name)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleCertificateManagerCertificateMap_basic(name, description),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_certificate_manager_certificate_map.cert_map_data", "id", id),
+					resource.TestCheckResourceAttr("data.google_certificate_manager_certificate_map.cert_map_data", "description", description),
+					resource.TestCheckResourceAttr("data.google_certificate_manager_certificate_map.cert_map_data", "name", name),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleCertificateManagerCertificateMap_basic(certificateMapName, certificateMapDescription string) string {
+	return fmt.Sprintf(`
+resource "google_certificate_manager_certificate_map" "cert_map" {
+	name        = "%s"
+	description = "%s"
+	labels      = {
+		"terraform" : true,
+		"acc-test"  : true,
+	}
+}
+data "google_certificate_manager_certificate_map" "cert_map_data" {
+	name = google_certificate_manager_certificate_map.cert_map.name
+}
+`, certificateMapName, certificateMapDescription)
+}
+
+func TestAccDataSourceGoogleCertificateManagerCertificateMap_certificateMapEntryUsingMapDatasource(t *testing.T) {
+	t.Parallel()
+
+	project := envvar.GetTestProjectFromEnv()
+
+	certName := fmt.Sprintf("tf-test-certificate-%d", acctest.RandInt(t))
+	mapEntryName := fmt.Sprintf("tf-test-certificate-map-entry-%d", acctest.RandInt(t))
+	mapName := fmt.Sprintf("tf-test-certificate-map-%d", acctest.RandInt(t))
+	id := fmt.Sprintf("projects/%s/locations/global/certificateMaps/%s", project, mapName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleCertificateManagerCertificateMap_certificateMapEntryUsingMapDatasource(mapName, mapEntryName, certName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_certificate_manager_certificate_map.cert_map_data", "id", id),
+					resource.TestCheckResourceAttr("data.google_certificate_manager_certificate_map.cert_map_data", "name", mapName),
+					resource.TestCheckResourceAttr("google_certificate_manager_certificate_map_entry.cert_map_entry", "map", mapName), // check that the certificate map entry is referencing the data source
+
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleCertificateManagerCertificateMap_certificateMapEntryUsingMapDatasource(certificateMapName, certificateMapEntryName, certificateName string) string {
+	return fmt.Sprintf(`
+resource "google_certificate_manager_certificate_map" "cert_map" {
+	name        = "%s"
+	description = "certificate map example created for testing data sources in TF"
+	labels      = {
+		"terraform" : true,
+		"acc-test"  : true,
+	}
+}
+data "google_certificate_manager_certificate_map" "cert_map_data" {
+	name = google_certificate_manager_certificate_map.cert_map.name
+}
+resource "google_certificate_manager_certificate" "certificate" {
+	name        = "%s"
+	description = "Global cert"
+	self_managed {
+	  pem_certificate = file("test-fixtures/cert.pem")
+	  pem_private_key = file("test-fixtures/private-key.pem")
+	}
+}
+resource "google_certificate_manager_certificate_map_entry" "cert_map_entry" {
+	name        = "%s"
+	description = "certificate map entry that reference a data source of certificate map and a self managed certificate"
+	map = data.google_certificate_manager_certificate_map.cert_map_data.name
+	certificates = [google_certificate_manager_certificate.certificate.id]
+	matcher = "PRIMARY"
+}
+`, certificateMapName, certificateName, certificateMapEntryName)
+}

--- a/mmv1/third_party/terraform/website/docs/d/certificate_manager_certificate_map.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/certificate_manager_certificate_map.html.markdown
@@ -1,0 +1,30 @@
+---
+subcategory: "Certificate manager"
+description: |-
+  Contains the data that describes a Certificate Map
+---
+# google_certificate_manager_certificate_map
+
+Get info about a Google Certificate Manager Certificate Map resource.
+
+## Example Usage
+
+```tf
+data "google_certificate_manager_certificate_map" "default" {
+ name = "cert-map"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the certificate map.
+
+- - -
+* `project` - (Optional) The ID of the project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+## Attributes Reference
+
+See [google_certificate_manager_certificate_map](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/certificate_manager_certificate_map) resource for details of the available attributes.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
- Added a new datasource for CertificateManagerCertificateMap based on the existing terraform resource  following the [documentation](https://googlecloudplatform.github.io/magic-modules/develop/add-handwritten-datasource/)
- Added two tests for the datasource. 
- Added datasource documentation.

The rest of CertificateManager resources will be added later in a subsequent PR.
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
google_certificate_manager_certificate_map
```