### PR TITLE
Add billing account to SQL PSC tests

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -790,6 +790,7 @@ func TestAccSqlDatabaseInstance_withPSCEnabled_withoutAllowedConsumerProjects(t 
 	instanceName := "tf-test-" + acctest.RandString(t, 10)
 	projectId := "psctestproject" + acctest.RandString(t, 10)
 	orgId := envvar.GetTestOrgFromEnv(t)
+	billingAccount := envvar.GetTestBillingAccountFromEnv(t)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -797,7 +798,7 @@ func TestAccSqlDatabaseInstance_withPSCEnabled_withoutAllowedConsumerProjects(t 
 		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSqlDatabaseInstance_withPSCEnabled_withoutAllowedConsumerProjects(instanceName, projectId, orgId),
+				Config: testAccSqlDatabaseInstance_withPSCEnabled_withoutAllowedConsumerProjects(instanceName, projectId, orgId, billingAccount),
 				Check:  resource.ComposeTestCheckFunc(verifyPscOperation("google_sql_database_instance.instance", true, true, nil)),
 			},
 			{
@@ -817,6 +818,7 @@ func TestAccSqlDatabaseInstance_withPSCEnabled_withEmptyAllowedConsumerProjects(
 	instanceName := "tf-test-" + acctest.RandString(t, 10)
 	projectId := "psctestproject" + acctest.RandString(t, 10)
 	orgId := envvar.GetTestOrgFromEnv(t)
+	billingAccount := envvar.GetTestBillingAccountFromEnv(t)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -824,7 +826,7 @@ func TestAccSqlDatabaseInstance_withPSCEnabled_withEmptyAllowedConsumerProjects(
 		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSqlDatabaseInstance_withPSCEnabled_withEmptyAllowedConsumerProjects(instanceName, projectId, orgId),
+				Config: testAccSqlDatabaseInstance_withPSCEnabled_withEmptyAllowedConsumerProjects(instanceName, projectId, orgId, billingAccount),
 				Check:  resource.ComposeTestCheckFunc(verifyPscOperation("google_sql_database_instance.instance", true, true, []string{})),
 			},
 			{
@@ -844,6 +846,7 @@ func TestAccSqlDatabaseInstance_withPSCEnabled_withAllowedConsumerProjects(t *te
 	instanceName := "tf-test-" + acctest.RandString(t, 10)
 	projectId := "psctestproject" + acctest.RandString(t, 10)
 	orgId := envvar.GetTestOrgFromEnv(t)
+	billingAccount := envvar.GetTestBillingAccountFromEnv(t)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -851,7 +854,7 @@ func TestAccSqlDatabaseInstance_withPSCEnabled_withAllowedConsumerProjects(t *te
 		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSqlDatabaseInstance_withPSCEnabled_withAllowedConsumerProjects(instanceName, projectId, orgId),
+				Config: testAccSqlDatabaseInstance_withPSCEnabled_withAllowedConsumerProjects(instanceName, projectId, orgId, billingAccount),
 				Check:  resource.ComposeTestCheckFunc(verifyPscOperation("google_sql_database_instance.instance", true, true, []string{envvar.GetTestProjectFromEnv()})),
 			},
 			{
@@ -871,6 +874,7 @@ func TestAccSqlDatabaseInstance_withPSCEnabled_thenAddAllowedConsumerProjects_th
 	instanceName := "tf-test-" + acctest.RandString(t, 10)
 	projectId := "psctestproject" + acctest.RandString(t, 10)
 	orgId := envvar.GetTestOrgFromEnv(t)
+	billingAccount := envvar.GetTestBillingAccountFromEnv(t)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -878,7 +882,7 @@ func TestAccSqlDatabaseInstance_withPSCEnabled_thenAddAllowedConsumerProjects_th
 		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSqlDatabaseInstance_withPSCEnabled_withoutAllowedConsumerProjects(instanceName, projectId, orgId),
+				Config: testAccSqlDatabaseInstance_withPSCEnabled_withoutAllowedConsumerProjects(instanceName, projectId, orgId, billingAccount),
 				Check:  resource.ComposeTestCheckFunc(verifyPscOperation("google_sql_database_instance.instance", true, true, nil)),
 			},
 			{
@@ -889,7 +893,7 @@ func TestAccSqlDatabaseInstance_withPSCEnabled_thenAddAllowedConsumerProjects_th
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccSqlDatabaseInstance_withPSCEnabled_withAllowedConsumerProjects(instanceName, projectId, orgId),
+				Config: testAccSqlDatabaseInstance_withPSCEnabled_withAllowedConsumerProjects(instanceName, projectId, orgId, billingAccount),
 				Check:  resource.ComposeTestCheckFunc(verifyPscOperation("google_sql_database_instance.instance", true, true, []string{envvar.GetTestProjectFromEnv()})),
 			},
 			{
@@ -900,7 +904,7 @@ func TestAccSqlDatabaseInstance_withPSCEnabled_thenAddAllowedConsumerProjects_th
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccSqlDatabaseInstance_withPSCEnabled_withoutAllowedConsumerProjects(instanceName, projectId, orgId),
+				Config: testAccSqlDatabaseInstance_withPSCEnabled_withoutAllowedConsumerProjects(instanceName, projectId, orgId, billingAccount),
 				Check:  resource.ComposeTestCheckFunc(verifyPscOperation("google_sql_database_instance.instance", true, true, []string{})),
 			},
 			{
@@ -920,6 +924,7 @@ func TestAccSqlDatabaseInstance_basicInstance_thenPSCEnabled(t *testing.T) {
 	instanceName := "tf-test-" + acctest.RandString(t, 10)
 	projectId := "psctestproject" + acctest.RandString(t, 10)
 	orgId := envvar.GetTestOrgFromEnv(t)
+	billingAccount := envvar.GetTestBillingAccountFromEnv(t)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -927,7 +932,7 @@ func TestAccSqlDatabaseInstance_basicInstance_thenPSCEnabled(t *testing.T) {
 		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSqlDatabaseInstance_basicInstanceForPsc(instanceName, projectId, orgId),
+				Config: testAccSqlDatabaseInstance_basicInstanceForPsc(instanceName, projectId, orgId, billingAccount),
 			},
 			{
 				ResourceName:            "google_sql_database_instance.instance",
@@ -937,7 +942,7 @@ func TestAccSqlDatabaseInstance_basicInstance_thenPSCEnabled(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config:      testAccSqlDatabaseInstance_withPSCEnabled_withoutAllowedConsumerProjects(instanceName, projectId, orgId),
+				Config:      testAccSqlDatabaseInstance_withPSCEnabled_withoutAllowedConsumerProjects(instanceName, projectId, orgId, billingAccount),
 				ExpectError: regexp.MustCompile("PSC connectivity can not be enabled"),
 			},
 		},
@@ -950,6 +955,7 @@ func TestAccSqlDatabaseInstance_withPSCEnabled_withIpV4Enabled(t *testing.T) {
 	instanceName := "tf-test-" + acctest.RandString(t, 10)
 	projectId := "psctestproject" + acctest.RandString(t, 10)
 	orgId := envvar.GetTestOrgFromEnv(t)
+	billingAccount := envvar.GetTestBillingAccountFromEnv(t)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -957,7 +963,7 @@ func TestAccSqlDatabaseInstance_withPSCEnabled_withIpV4Enabled(t *testing.T) {
 		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccSqlDatabaseInstance_withPSCEnabled_withIpV4Enable(instanceName, projectId, orgId),
+				Config:      testAccSqlDatabaseInstance_withPSCEnabled_withIpV4Enable(instanceName, projectId, orgId, billingAccount),
 				ExpectError: regexp.MustCompile("PSC connectivity cannot be enabled together with public IP"),
 			},
 		},
@@ -2572,12 +2578,13 @@ resource "google_sql_database_instance" "instance-failover" {
 `, instanceName, failoverName)
 }
 
-func testAccSqlDatabaseInstance_basicInstanceForPsc(instanceName string, projectId string, orgId string) string {
+func testAccSqlDatabaseInstance_basicInstanceForPsc(instanceName string, projectId string, orgId string, billingAccount string) string {
 	return fmt.Sprintf(`
 resource "google_project" "testproject" {
   name                = "%s"
   project_id          = "%s"
   org_id              = "%s"
+  billing_account     = "%s"
 }
 
 resource "google_sql_database_instance" "instance" {
@@ -2595,15 +2602,16 @@ resource "google_sql_database_instance" "instance" {
 	availability_type = "REGIONAL"
   }
 }
-`, projectId, projectId, orgId, instanceName)
+`, projectId, projectId, orgId, billingAccount, instanceName)
 }
 
-func testAccSqlDatabaseInstance_withPSCEnabled_withIpV4Enable(instanceName string, projectId string, orgId string) string {
+func testAccSqlDatabaseInstance_withPSCEnabled_withIpV4Enable(instanceName string, projectId string, orgId string, billingAccount string) string {
 	return fmt.Sprintf(`
 resource "google_project" "testproject" {
   name                = "%s"
   project_id          = "%s"
   org_id              = "%s"
+  billing_account     = "%s"
 }
 
 resource "google_sql_database_instance" "instance" {
@@ -2627,15 +2635,16 @@ resource "google_sql_database_instance" "instance" {
 	availability_type = "REGIONAL"
   }
 }
-`, projectId, projectId, orgId, instanceName)
+`, projectId, projectId, orgId, billingAccount, instanceName)
 }
 
-func testAccSqlDatabaseInstance_withPSCEnabled_withoutAllowedConsumerProjects(instanceName string, projectId string, orgId string) string {
+func testAccSqlDatabaseInstance_withPSCEnabled_withoutAllowedConsumerProjects(instanceName string, projectId string, orgId string, billingAccount string) string {
 	return fmt.Sprintf(`
 resource "google_project" "testproject" {
   name                = "%s"
   project_id          = "%s"
   org_id              = "%s"
+  billing_account     = "%s"
 }
 
 resource "google_sql_database_instance" "instance" {
@@ -2659,15 +2668,16 @@ resource "google_sql_database_instance" "instance" {
 	availability_type = "REGIONAL"
   }
 }
-`, projectId, projectId, orgId, instanceName)
+`, projectId, projectId, orgId, billingAccount, instanceName)
 }
 
-func testAccSqlDatabaseInstance_withPSCEnabled_withEmptyAllowedConsumerProjects(instanceName string, projectId string, orgId string) string {
+func testAccSqlDatabaseInstance_withPSCEnabled_withEmptyAllowedConsumerProjects(instanceName string, projectId string, orgId string, billingAccount string) string {
 	return fmt.Sprintf(`
 resource "google_project" "testproject" {
   name                = "%s"
   project_id          = "%s"
   org_id              = "%s"
+  billing_account     = "%s"
 }
 
 resource "google_sql_database_instance" "instance" {
@@ -2692,16 +2702,18 @@ resource "google_sql_database_instance" "instance" {
 	availability_type = "REGIONAL"
   }
 }
-`, projectId, projectId, orgId, instanceName)
+`, projectId, projectId, orgId, billingAccount, instanceName)
 }
 
-func testAccSqlDatabaseInstance_withPSCEnabled_withAllowedConsumerProjects(instanceName string, projectId string, orgId string) string {
+func testAccSqlDatabaseInstance_withPSCEnabled_withAllowedConsumerProjects(instanceName string, projectId string, orgId string, billingAccount string) string {
 	return fmt.Sprintf(`
 resource "google_project" "testproject" {
   name                = "%s"
   project_id          = "%s"
   org_id              = "%s"
+  billing_account     = "%s"
 }
+
 resource "google_sql_database_instance" "instance" {
   project             = google_project.testproject.project_id
   name                = "%s"
@@ -2724,7 +2736,7 @@ resource "google_sql_database_instance" "instance" {
 	availability_type = "REGIONAL"
   }
 }
-`, projectId, projectId, orgId, instanceName, projectId)
+`, projectId, projectId, orgId, billingAccount, instanceName, projectId)
 }
 
 func verifyPscOperation(resourceName string, isPscConfigExpected bool, expectedPscEnabled bool, expectedAllowedConsumerProjects []string) func(*terraform.State) error {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

They didn't fail in VCR in https://github.com/GoogleCloudPlatform/magic-modules/pull/8580 for some reason, but now seem to require billing on the project intermittently:

```
Error: Error, failed to create instance tf-test-3awzyi4t0n: googleapi: Error 403: The billing account is not in good standing; therefore no new instance can be created., invalidBillingAccountState
```

Filed https://github.com/hashicorp/terraform-provider-google/issues/15864 to track potentially consolidating- this is pretty granular testing for tests that cost a project quota apiece.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
