### PR TITLE
Add accelerators to workstation update masks

### DIFF
--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -198,6 +198,8 @@ properties:
       - 'host.gceInstance.shieldedInstanceConfig.enableVtpm'
       - 'host.gceInstance.shieldedInstanceConfig.enableIntegrityMonitoring'
       - 'host.gceInstance.confidentialInstanceConfig.enableConfidentialCompute'
+      - 'host.gceInstance.accelerators.count'
+      - 'host.gceInstance.accelerators.type'
     properties:
       - !ruby/object:Api::Type::NestedObject
         name: 'gceInstance'

--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -198,8 +198,7 @@ properties:
       - 'host.gceInstance.shieldedInstanceConfig.enableVtpm'
       - 'host.gceInstance.shieldedInstanceConfig.enableIntegrityMonitoring'
       - 'host.gceInstance.confidentialInstanceConfig.enableConfidentialCompute'
-      - 'host.gceInstance.accelerators.count'
-      - 'host.gceInstance.accelerators.type'
+      - 'host.gceInstance.accelerators'
     properties:
       - !ruby/object:Api::Type::NestedObject
         name: 'gceInstance'


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This was missed in #8490, and so in-place updates to accelerators are silently dropped.

Verified the issue by updating my workstation config with accelerators but the actual config did not change. On inspecting the debug logs, I noticed the update mask was wrong in the original PATCH REST request (but the request data was correct). Near the end of the log, the following warning message was present.

```
2023-09-16T04:38:23.768Z [WARN]  Provider "provider[\"registry.terraform.io/hashicorp/google-beta\"]" produced an unexpected new value for google_workstations_workstation_config.sidb, but we are tolerating it because it is using the legacy plugin SDK.
    The following problems may be the cause of any confusing errors from downstream operations:
      - .etag: was cty.StringVal("...."), but now cty.StringVal("...")
      - .host[0].gce_instance[0].accelerators: block count changed from 1 to 0
```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
workstations: fixed in-place updates of `host.gceInstance.accelerators` in `workstation_config`
```
