### PR TITLE
fix(container_node_pool): panic interface conversion on `linux_node_config.sysctls`

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -1008,6 +1008,9 @@ func expandLinuxNodeConfig(v interface{}) *container.LinuxNodeConfig {
 	if len(ls) == 0 {
 		return nil
 	}
+	if ls[0] == nil {
+		return &container.LinuxNodeConfig{}
+	}
 	cfg := ls[0].(map[string]interface{})
 	sysCfgRaw, ok := cfg["sysctls"]
 	if !ok {

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -465,8 +465,17 @@ func TestAccContainerNodePool_withLinuxNodeConfig(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
+			// Create a node pool with empty `linux_node_config.sysctls`.
 			{
-				Config: testAccContainerNodePool_withLinuxNodeConfig(cluster, np, 10000, 12800, "1000 20000 100000", 1),
+				Config: testAccContainerNodePool_withLinuxNodeConfig(cluster, np, ""),
+			},
+			{
+				ResourceName:      "google_container_node_pool.with_linux_node_config",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccContainerNodePool_withLinuxNodeConfig(cluster, np, "1000 20000 100000"),
 			},
 			{
 				ResourceName:      "google_container_node_pool.with_linux_node_config",
@@ -475,7 +484,7 @@ func TestAccContainerNodePool_withLinuxNodeConfig(t *testing.T) {
 			},
 			// Perform an update.
 			{
-				Config: testAccContainerNodePool_withLinuxNodeConfig(cluster, np, 10000, 12800, "1000 20000 200000", 1),
+				Config: testAccContainerNodePool_withLinuxNodeConfig(cluster, np, "1000 20000 200000"),
 			},
 			{
 				ResourceName:      "google_container_node_pool.with_linux_node_config",
@@ -2619,7 +2628,30 @@ resource "google_container_node_pool" "with_kubelet_config" {
 `, cluster, np, policy, quota, period, podPidsLimit)
 }
 
-func testAccContainerNodePool_withLinuxNodeConfig(cluster, np string, maxBacklog, soMaxConn int, tcpMem string, twReuse int) string {
+func testAccContainerNodePool_withLinuxNodeConfig(cluster, np string, tcpMem string) string {
+	linuxNodeConfig := `
+    linux_node_config {
+      sysctls = {}
+    }
+`
+	if len(tcpMem) != 0 {
+		linuxNodeConfig = fmt.Sprintf(`
+    linux_node_config {
+      sysctls = {
+        "net.core.netdev_max_backlog" = "10000"
+        "net.core.rmem_max"           = 10000
+        "net.core.wmem_default"       = 10000
+        "net.core.wmem_max"           = 20000
+        "net.core.optmem_max"         = 10000
+        "net.core.somaxconn"          = 12800
+        "net.ipv4.tcp_rmem"           = "%s"
+        "net.ipv4.tcp_wmem"           = "%s"
+        "net.ipv4.tcp_tw_reuse"       = 1
+      }
+    }
+`, tcpMem, tcpMem)
+	}
+
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
   location = "us-central1-a"
@@ -2639,28 +2671,15 @@ resource "google_container_node_pool" "with_linux_node_config" {
   initial_node_count = 1
   node_config {
     image_type = "COS_CONTAINERD"
-    linux_node_config {
-      sysctls = {
-        "net.core.netdev_max_backlog" = "%d"
-        "net.core.rmem_max"           = 10000
-        "net.core.wmem_default"       = 10000
-        "net.core.wmem_max"           = 20000
-        "net.core.optmem_max"         = 10000
-        "net.core.somaxconn"          = %d
-        "net.ipv4.tcp_rmem"           = "%s"
-        "net.ipv4.tcp_wmem"           = "%s"
-        "net.ipv4.tcp_tw_reuse"       = %d
-      }
-    }
+    %s
     oauth_scopes = [
       "https://www.googleapis.com/auth/logging.write",
       "https://www.googleapis.com/auth/monitoring",
     ]
   }
 }
-`, cluster, np, maxBacklog, soMaxConn, tcpMem, tcpMem, twReuse)
+`, cluster, np, linuxNodeConfig)
 }
-
 
 func testAccContainerNodePool_withNetworkConfig(cluster, np, network string) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/15847

* Add type assertion to extract empty values from `linux_node_config.sysctls` field
* Clean up existing test case to only pass single `sysctls` parameter to be changed
* Add test case to create a nodepool with empty `linux_node_config.sysctls`

Without the fix, the test case to create a nodepool with empty `linux_node_config.sysctls` will fail.

```console
❯ make testacc TEST=./google/services/container TESTARGS='-run=TestAccContainerNodePool_withLinuxNodeConfig'
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/container -v -run=TestAccContainerNodePool_withLinuxNodeConfig -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccContainerNodePool_withLinuxNodeConfig
=== PAUSE TestAccContainerNodePool_withLinuxNodeConfig
=== CONT  TestAccContainerNodePool_withLinuxNodeConfig
panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 1276 [running]:
github.com/hashicorp/terraform-provider-google/google/services/container.expandLinuxNodeConfig(...)
	/Users/tsubasanagasawa/go/src/github.com/hashicorp/terraform-provider-google/google/services/container/node_config.go:927
github.com/hashicorp/terraform-provider-google/google/services/container.expandNodeConfig({0x1071ec840?, 0x14001a923d8?})
	/Users/tsubasanagasawa/go/src/github.com/hashicorp/terraform-provider-google/google/services/container/node_config.go:849 +0x1808
github.com/hashicorp/terraform-provider-google/google/services/container.expandNodePool(0x1079eb778?, {0x0, 0x0})
	/Users/tsubasanagasawa/go/src/github.com/hashicorp/terraform-provider-google/google/services/container/resource_container_node_pool.go:867 +0x2f8
github.com/hashicorp/terraform-provider-google/google/services/container.resourceContainerNodePoolCreate(0x140029c3380, {0x107989740?, 0x14000f32400?})
	/Users/tsubasanagasawa/go/src/github.com/hashicorp/terraform-provider-google/google/services/container/resource_container_node_pool.go:477 +0x120
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0x1079e2678?, {0x1079e2678?, 0x1400140e630?}, 0xd?, {0x107989740?, 0x14000f32400?})
	/Users/tsubasanagasawa/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.24.0/helper/schema/resource.go:695 +0x134
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0x140007ad500, {0x1079e2678, 0x1400140e630}, 0x140019cbc70, 0x140029c3200, {0x107989740, 0x14000f32400})
	/Users/tsubasanagasawa/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.24.0/helper/schema/resource.go:837 +0x888
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0x14000eab110, {0x1079e2678?, 0x1400140e570?}, 0x140024650e0)
	/Users/tsubasanagasawa/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.24.0/helper/schema/grpc_provider.go:1021 +0xb78
github.com/hashicorp/terraform-plugin-mux/tf5muxserver.muxServer.ApplyResourceChange({0x140010720c0, 0x14001072120, {0x1400230eee0, 0x2, 0x2}, {0x0, 0x0, 0x0}, {0x0, 0x0, ...}, ...}, ...)
	/Users/tsubasanagasawa/go/pkg/mod/github.com/hashicorp/terraform-plugin-mux@v0.8.0/tf5muxserver/mux_server_ApplyResourceChange.go:27 +0xdc
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0x140024483c0, {0x1079e2678?, 0x140013d1d40?}, 0x1400196c770)
	/Users/tsubasanagasawa/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.14.3/tfprotov5/tf5server/server.go:818 +0x3bc
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0x107904520?, 0x140024483c0}, {0x1079e2678, 0x140013d1d40}, 0x1400196c700, 0x0)
	/Users/tsubasanagasawa/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.14.3/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:385 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0x14000c22000, {0x1079eb898, 0x140027c7380}, 0x140019bdb00, 0x14001b552c0, 0x108f5a8e0, 0x0)
	/Users/tsubasanagasawa/go/pkg/mod/google.golang.org/grpc@v1.57.0/server.go:1360 +0xcb4
google.golang.org/grpc.(*Server).handleStream(0x14000c22000, {0x1079eb898, 0x140027c7380}, 0x140019bdb00, 0x0)
	/Users/tsubasanagasawa/go/pkg/mod/google.golang.org/grpc@v1.57.0/server.go:1737 +0x82c
google.golang.org/grpc.(*Server).serveStreams.func1.1()
	/Users/tsubasanagasawa/go/pkg/mod/google.golang.org/grpc@v1.57.0/server.go:982 +0x84
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/Users/tsubasanagasawa/go/pkg/mod/google.golang.org/grpc@v1.57.0/server.go:980 +0x16c
FAIL	github.com/hashicorp/terraform-provider-google/google/services/container	331.318s
FAIL
```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: fixed an issue in `google_container_node_pool` where empty `linux_node_config.sysctls` would crash the provider
```
