### PR TITLE
updated to ONLY_SCALE_OUT

### DIFF
--- a/mmv1/products/compute/Autoscaler.yaml
+++ b/mmv1/products/compute/Autoscaler.yaml
@@ -159,7 +159,7 @@ properties:
           Defines operating mode for this policy.
         values:
           - :OFF
-          - :ONLY_UP
+          - :ONLY_SCALE_OUT
           - :ON
       - !ruby/object:Api::Type::NestedObject
         name: 'scaleDownControl'

--- a/mmv1/products/compute/Autoscaler.yaml
+++ b/mmv1/products/compute/Autoscaler.yaml
@@ -152,15 +152,11 @@ properties:
           instance may take to initialize. To do this, create an instance
           and time the startup process.
         default_value: 60
-      - !ruby/object:Api::Type::Enum
+      - !ruby/object:Api::Type::String
         name: 'mode'
-        default_value: :ON
+        default_value: 'ON'
         description: |
           Defines operating mode for this policy.
-        values:
-          - :OFF
-          - :ONLY_SCALE_OUT
-          - :ON
       - !ruby/object:Api::Type::NestedObject
         name: 'scaleDownControl'
         min_version: beta

--- a/mmv1/products/compute/RegionAutoscaler.yaml
+++ b/mmv1/products/compute/RegionAutoscaler.yaml
@@ -139,7 +139,7 @@ properties:
           Defines operating mode for this policy.
         values:
           - :OFF
-          - :ONLY_UP
+          - :ONLY_SCALE_OUT
           - :ON
       - !ruby/object:Api::Type::NestedObject
         name: 'scaleDownControl'

--- a/mmv1/products/compute/RegionAutoscaler.yaml
+++ b/mmv1/products/compute/RegionAutoscaler.yaml
@@ -132,15 +132,11 @@ properties:
           instance may take to initialize. To do this, create an instance
           and time the startup process.
         default_value: 60
-      - !ruby/object:Api::Type::Enum
+      - !ruby/object:Api::Type::String
         name: 'mode'
-        default_value: :ON
+        default_value: 'ON'
         description: |
           Defines operating mode for this policy.
-        values:
-          - :OFF
-          - :ONLY_SCALE_OUT
-          - :ON
       - !ruby/object:Api::Type::NestedObject
         name: 'scaleDownControl'
         min_version: beta


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/15879

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: updated the accepted `autoscaling_policy.mode` from `ONLY_UP` to `ONLY_SCALE_OUT` on `google_compute_autoscaler` 

```
