### PR TITLE
Added internalIpv6Prefix attribute on Subnetwork resource

### DIFF
--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -371,6 +371,11 @@ properties:
     description: |
       The range of internal IPv6 addresses that are owned by this subnetwork.
   - !ruby/object:Api::Type::String
+    name: 'internalIpv6Prefix'
+    output: true
+    description: |
+      The internal IPv6 address range that is assigned to this subnetwork.
+  - !ruby/object:Api::Type::String
     name: 'externalIpv6Prefix'
     output: true
     description: |

--- a/mmv1/third_party/terraform/services/compute/resource_compute_subnetwork_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_subnetwork_test.go.erb
@@ -369,6 +369,29 @@ func TestAccComputeSubnetwork_ipv6(t *testing.T) {
 	})
 }
 
+func TestAccComputeSubnetwork_internal_ipv6(t *testing.T) {
+	t.Parallel()
+
+	cnName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	subnetworkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeSubnetworkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSubnetwork_internal_ipv6(cnName, subnetworkName),
+			},
+			{
+				ResourceName:      "google_compute_subnetwork.subnetwork",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckComputeSubnetworkExists(t *testing.T, n string, subnetwork *compute.Subnetwork) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -797,6 +820,25 @@ resource "google_compute_subnetwork" "subnetwork" {
   network          = google_compute_network.custom-test.self_link
   stack_type       = "IPV4_IPV6"
   ipv6_access_type = "EXTERNAL"
+}
+`, cnName, subnetworkName)
+}
+
+func testAccComputeSubnetwork_internal_ipv6(cnName, subnetworkName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "custom-test" {
+  name                     = "%s"
+  auto_create_subnetworks  = false
+  enable_ula_internal_ipv6 = true
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  name             = "%s"
+  ip_cidr_range    = "10.0.0.0/16"
+  region           = "us-central1"
+  network          = google_compute_network.custom-test.self_link
+  stack_type       = "IPV4_IPV6"
+  ipv6_access_type = "INTERNAL"
 }
 `, cnName, subnetworkName)
 }


### PR DESCRIPTION
As per the PR title this PR adds new internalIpv6Prefix attribute available on the Subnetwork resource as per official documentation available at the following [link](https://cloud.google.com/compute/docs/reference/rest/v1/subnetworks).

This is the new PR to substitute the original #8370 since replacing the unused value is a breaking change. 

If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added output field `internal_ipv6_prefix` to `google_compute_subnetwork` resource
```