### PR TITLE
allow multi-setting for classifications and excludes

### DIFF
--- a/mmv1/products/osconfig/PatchDeployment.yaml
+++ b/mmv1/products/osconfig/PatchDeployment.yaml
@@ -396,9 +396,11 @@ properties:
         properties:
           - !ruby/object:Api::Type::Array
             name: 'classifications'
-            exactly_one_of:
+            at_least_one_of:
               - patch_config.0.windows_update.0.classifications
               - patch_config.0.windows_update.0.excludes
+              - patch_config.0.windows_update.0.exclusive_patches
+            conflicts:
               - patch_config.0.windows_update.0.exclusive_patches
             description: |
               Only apply updates of these windows update classifications. If empty, all updates are applied.
@@ -417,19 +419,24 @@ properties:
                 - :UPDATE
           - !ruby/object:Api::Type::Array
             name: 'excludes'
-            exactly_one_of:
+            at_least_one_of:
               - patch_config.0.windows_update.0.classifications
               - patch_config.0.windows_update.0.excludes
+              - patch_config.0.windows_update.0.exclusive_patches
+            conflicts:
               - patch_config.0.windows_update.0.exclusive_patches
             description: |
               List of KBs to exclude from update.
             item_type: Api::Type::String
           - !ruby/object:Api::Type::Array
             name: 'exclusivePatches'
-            exactly_one_of:
+            at_least_one_of:
               - patch_config.0.windows_update.0.classifications
               - patch_config.0.windows_update.0.excludes
               - patch_config.0.windows_update.0.exclusive_patches
+            conflicts:
+              - patch_config.0.windows_update.0.classifications
+              - patch_config.0.windows_update.0.excludes
             description: |
               An exclusive list of kbs to be updated. These are the only patches that will be updated.
               This field must not be used with other patch configurations.

--- a/mmv1/templates/terraform/examples/os_config_patch_deployment_full.tf.erb
+++ b/mmv1/templates/terraform/examples/os_config_patch_deployment_full.tf.erb
@@ -16,7 +16,7 @@ resource "google_os_config_patch_deployment" "<%= ctx[:primary_resource_id] %>" 
 
   patch_config {
     mig_instances_allowed = true
-    
+
     reboot_config = "ALWAYS"
 
     apt {
@@ -40,6 +40,7 @@ resource "google_os_config_patch_deployment" "<%= ctx[:primary_resource_id] %>" 
 
     windows_update {
       classifications = ["CRITICAL", "SECURITY", "UPDATE"]
+      excludes = ["5012170"]
     }
 
     pre_step {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/13158

If this PR is for Terraform, I acknowledge that I have:
* [x] run make lint on both ga and beta providers
* [x] run make test on both ga and beta providers
* [x] run testacc for osconfig service on both ga and beta providers 
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
osconfig: fixed no more than one setting is allowed under `patch_config.windows_update` on `google_os_config_patch_deployment`
```
