### PR TITLE
fix issue #14893: add the customWriterIdentity parameter to logging_s…

### DIFF
--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
@@ -66,7 +66,7 @@ func resourceLoggingProjectSinkCreate(d *schema.ResourceData, meta interface{}) 
 
 	customWriterIdentity := d.Get("custom_writer_identity").(string)
 
-	client := config.NewLoggingClient(userAgent).Projects.Sinks.Create(id.parent(), sink)
+	projectSinkCreateRequest := config.NewLoggingClient(userAgent).Projects.Sinks.Create(id.parent(), sink)
 
 	if customWriterIdentity != "" {
 		client = client.UniqueWriterIdentity(uniqueWriterIdentity).CustomWriterIdentity(customWriterIdentity)

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
@@ -63,18 +63,17 @@ func resourceLoggingProjectSinkCreate(d *schema.ResourceData, meta interface{}) 
 
 	id, sink := expandResourceLoggingSink(d, "projects", project)
 	uniqueWriterIdentity := d.Get("unique_writer_identity").(bool)
-
 	customWriterIdentity := d.Get("custom_writer_identity").(string)
 
 	projectSinkCreateRequest := config.NewLoggingClient(userAgent).Projects.Sinks.Create(id.parent(), sink)
 
 	if customWriterIdentity != "" {
-		client = client.UniqueWriterIdentity(uniqueWriterIdentity).CustomWriterIdentity(customWriterIdentity)
+		projectSinkCreateRequest = projectSinkCreateRequest.UniqueWriterIdentity(uniqueWriterIdentity).CustomWriterIdentity(customWriterIdentity)
 	} else {
-		client = client.UniqueWriterIdentity(uniqueWriterIdentity)
+		projectSinkCreateRequest = projectSinkCreateRequest.UniqueWriterIdentity(uniqueWriterIdentity)
 	}
 
-	_, err = client.Do()
+	_, err = projectSinkCreateRequest.Do()
 
 	if err != nil {
 		return err

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
@@ -42,10 +42,9 @@ func ResourceLoggingProjectSink() *schema.Resource {
 		Description: `Whether or not to create a unique identity associated with this sink. If false (the legacy behavior), then the writer_identity used is serviceAccount:cloud-logs@system.gserviceaccount.com. If true, then a unique service account is created and used for this sink. If you wish to publish logs across projects, you must set unique_writer_identity to true.`,
 	}
 	schm.Schema["custom_writer_identity"] = &schema.Schema{
-		Type:		schema.TypeString,
-		Optional: 	true,
+		Type:        schema.TypeString,
+		Optional:    true,
 		Description: `A service account provided by the caller that will be used to write the log entries. The format must be serviceAccount:some@email. This field can only be specified if you are routing logs to a destination outside this sink's project. If not specified, a Logging service account will automatically be generated.`,
-		
 	}
 	return schm
 }
@@ -67,12 +66,16 @@ func resourceLoggingProjectSinkCreate(d *schema.ResourceData, meta interface{}) 
 
 	customWriterIdentity := d.Get("custom_writer_identity").(string)
 
-	if (customWriterIdentity != ""){
-		_, err = config.NewLoggingClient(userAgent).Projects.Sinks.Create(id.parent(), sink).UniqueWriterIdentity(uniqueWriterIdentity).CustomWriterIdentity(customWriterIdentity).Do()
+	client := config.NewLoggingClient(userAgent).Projects.Sinks.Create(id.parent(), sink)
+
+	if customWriterIdentity != "" {
+		client = client.UniqueWriterIdentity(uniqueWriterIdentity).CustomWriterIdentity(customWriterIdentity)
 	} else {
-		_, err = config.NewLoggingClient(userAgent).Projects.Sinks.Create(id.parent(), sink).UniqueWriterIdentity(uniqueWriterIdentity).Do()
+		client = client.UniqueWriterIdentity(uniqueWriterIdentity)
 	}
-	
+
+	_, err = client.Do()
+
 	if err != nil {
 		return err
 	}
@@ -152,15 +155,14 @@ func resourceLoggingProjectSinkUpdate(d *schema.ResourceData, meta interface{}) 
 
 	customWriterIdentity := d.Get("custom_writer_identity").(string)
 
-	if (customWriterIdentity != ""){
+	if customWriterIdentity != "" {
 		_, err = config.NewLoggingClient(userAgent).Projects.Sinks.Patch(d.Id(), sink).
-		UpdateMask(updateMask).UniqueWriterIdentity(uniqueWriterIdentity).CustomWriterIdentity(customWriterIdentity).Do()
+			UpdateMask(updateMask).UniqueWriterIdentity(uniqueWriterIdentity).CustomWriterIdentity(customWriterIdentity).Do()
 	} else {
 		_, err = config.NewLoggingClient(userAgent).Projects.Sinks.Patch(d.Id(), sink).
-		UpdateMask(updateMask).UniqueWriterIdentity(uniqueWriterIdentity).Do()
+			UpdateMask(updateMask).UniqueWriterIdentity(uniqueWriterIdentity).Do()
 	}
 
-	
 	if err != nil {
 		return err
 	}

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
@@ -150,8 +150,17 @@ func resourceLoggingProjectSinkUpdate(d *schema.ResourceData, meta interface{}) 
 	sink, updateMask := expandResourceLoggingSinkForUpdate(d)
 	uniqueWriterIdentity := d.Get("unique_writer_identity").(bool)
 
-	_, err = config.NewLoggingClient(userAgent).Projects.Sinks.Patch(d.Id(), sink).
+	customWriterIdentity := d.Get("custom_writer_identity").(string)
+
+	if (customWriterIdentity != ""){
+		_, err = config.NewLoggingClient(userAgent).Projects.Sinks.Patch(d.Id(), sink).
+		UpdateMask(updateMask).UniqueWriterIdentity(uniqueWriterIdentity).CustomWriterIdentity(customWriterIdentity).Do()
+	} else {
+		_, err = config.NewLoggingClient(userAgent).Projects.Sinks.Patch(d.Id(), sink).
 		UpdateMask(updateMask).UniqueWriterIdentity(uniqueWriterIdentity).Do()
+	}
+
+	
 	if err != nil {
 		return err
 	}

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
@@ -67,7 +67,7 @@ func resourceLoggingProjectSinkCreate(d *schema.ResourceData, meta interface{}) 
 
 	projectSinkCreateRequest := config.NewLoggingClient(userAgent).Projects.Sinks.Create(id.parent(), sink)
 
-	// if custom-sa is specified, use it to write log and it reqiures uniqueWriterIdentity to be set as well
+	// if custom-sa is specified, use it to write log and it requires uniqueWriterIdentity to be set as well
 	// otherwise set the uniqueWriter identity
 	if customWriterIdentity != "" {
 		projectSinkCreateRequest = projectSinkCreateRequest.UniqueWriterIdentity(uniqueWriterIdentity).CustomWriterIdentity(customWriterIdentity)

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
@@ -148,6 +148,12 @@ func TestAccLoggingProjectSink_updatePreservesCustomWriter(t *testing.T) {
 	sinkName := "tf-test-sink-" + acctest.RandString(t, 10)
 	account := "tf-test-sink-sa" + acctest.RandString(t, 10)
 	accountUpdated := "tf-test-sink-sa" + acctest.RandString(t, 10)
+	testProject :=  envvar.GetTestProjectFromEnv()
+
+	// custom_writer_identity is write-only, and writer_dietity is an output only field
+	// verify that the value of writer_identity matches the expected custom_writer_identity.
+	expectedWriterIdentity := fmt.Sprintf("serviceAccount:%s@%s.iam.gserviceaccount.com", account, testProject)
+	expectedUpdatedWriterIdentity := fmt.Sprintf("serviceAccount:%s@%s.iam.gserviceaccount.com", accountUpdated, testProject)
 
 	org := envvar.GetTestOrgFromEnv(t)
 	billingId := envvar.GetTestBillingAccountFromEnv(t)
@@ -160,6 +166,9 @@ func TestAccLoggingProjectSink_updatePreservesCustomWriter(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLoggingProjectSink_customWriter(org, billingId, project, sinkName, account),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_logging_project_sink.custom_writer", "custom_writer_identity", expectedWriterIdentity),
+				),
 			},
 			{
 				ResourceName:      "google_logging_project_sink.custom_writer",
@@ -170,6 +179,9 @@ func TestAccLoggingProjectSink_updatePreservesCustomWriter(t *testing.T) {
 			},
 			{
 				Config: testAccLoggingProjectSink_customWriterUpdated(org, billingId, project, sinkName, accountUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_logging_project_sink.custom_writer", "custom_writer_identity", expectedUpdatedWriterIdentity),
+				),
 			},
 			{
 				ResourceName:            "google_logging_project_sink.custom_writer",

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
@@ -167,7 +167,7 @@ func TestAccLoggingProjectSink_updatePreservesCustomWriter(t *testing.T) {
 			{
 				Config: testAccLoggingProjectSink_customWriter(org, billingId, project, sinkName, account),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("google_logging_project_sink.custom_writer", "custom_writer_identity", expectedWriterIdentity),
+					resource.TestCheckResourceAttr("google_logging_project_sink.custom_writer", "writer_identity", expectedWriterIdentity),
 				),
 			},
 			{

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
@@ -147,6 +147,7 @@ func TestAccLoggingProjectSink_updatePreservesCustomWriter(t *testing.T) {
 
 	sinkName := "tf-test-sink-" + acctest.RandString(t, 10)
 	account := "tf-test-sink-sa" + acctest.RandString(t, 10)
+	accountUpdated := "tf-test-sink-sa" + acctest.RandString(t, 10)
 
 	org := envvar.GetTestOrgFromEnv(t)
 	billingId := envvar.GetTestBillingAccountFromEnv(t)
@@ -168,7 +169,7 @@ func TestAccLoggingProjectSink_updatePreservesCustomWriter(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"custom_writer_identity"},
 			},
 			{
-				Config: testAccLoggingProjectSink_customWriterUpdated(org, billingId, project, sinkName, account),
+				Config: testAccLoggingProjectSink_customWriterUpdated(org, billingId, project, sinkName, accountUpdated),
 			},
 			{
 				ResourceName:            "google_logging_project_sink.custom_writer",
@@ -521,15 +522,15 @@ resource "google_logging_project_bucket_config" "destination-bucket" {
   bucket_id = "shared-bucket"
 }
 
-resource "google_service_account" "test-account1" {
+resource "google_service_account" "test-account2" {
   account_id   = "%s"
-  display_name = "Log Sink Custom WriterIdentity Testing Account"
+  display_name = "Updated Log Sink Custom WriterIdentity Testing Account"
 }
 
 resource "google_project_iam_member" "custom-sa-logbucket-binding" {
   project = google_project.destination-project.project_id
   role   = "roles/logging.bucketWriter"
-  member = "serviceAccount:${google_service_account.test-account1.email}"
+  member = "serviceAccount:${google_service_account.test-account2.email}"
 }
 
 data "google_project" "testing_project" {
@@ -541,7 +542,7 @@ locals {
 }
 
 resource "google_service_account_iam_member" "loggingsa-customsa-binding" {
-  service_account_id = google_service_account.test-account1.name
+  service_account_id = google_service_account.test-account2.name
   role   = "roles/iam.serviceAccountTokenCreator"
   member = "serviceAccount:service-${local.project_number}@gcp-sa-logging.iam.gserviceaccount.com"
 }
@@ -552,7 +553,7 @@ resource "google_logging_project_sink" "custom_writer" {
   filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=WARNING"
 
   unique_writer_identity = true
-  custom_writer_identity = "serviceAccount:${google_service_account.test-account1.email}"
+  custom_writer_identity = "serviceAccount:${google_service_account.test-account2.email}"
 
   depends_on = [google_logging_project_bucket_config.destination-bucket]
 }

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
@@ -154,7 +154,6 @@ func TestAccLoggingProjectSink_updatePreservesCustomWriter(t *testing.T) {
 	billingId := envvar.GetTestBillingAccountFromEnv(t)
 	project := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
 
-
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
@@ -168,15 +167,15 @@ func TestAccLoggingProjectSink_updatePreservesCustomWriter(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				// Logging sink create API doesn't return this field in response
-				ImportStateVerifyIgnore: []string{"custom_writer_identity"}, 
+				ImportStateVerifyIgnore: []string{"custom_writer_identity"},
 			},
 			{
 				Config: testAccLoggingProjectSink_customWriterUpdated(org, billingId, project, sinkName, account),
 			},
 			{
-				ResourceName:      "google_logging_project_sink.custom_writer",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_logging_project_sink.custom_writer",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"custom_writer_identity"},
 			},
 		},

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
@@ -148,7 +148,7 @@ func TestAccLoggingProjectSink_updatePreservesCustomWriter(t *testing.T) {
 	sinkName := "tf-test-sink-" + acctest.RandString(t, 10)
 	account := "tf-test-sink-sa" + acctest.RandString(t, 10)
 	accountUpdated := "tf-test-sink-sa" + acctest.RandString(t, 10)
-	testProject :=  envvar.GetTestProjectFromEnv()
+	testProject := envvar.GetTestProjectFromEnv()
 
 	// custom_writer_identity is write-only, and writer_dietity is an output only field
 	// verify that the value of writer_identity matches the expected custom_writer_identity.

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
-/*
 func TestAccLoggingProjectSink_basic(t *testing.T) {
 	t.Parallel()
 
@@ -142,7 +141,6 @@ func TestAccLoggingProjectSink_updatePreservesUniqueWriter(t *testing.T) {
 		},
 	})
 }
-*/
 
 func TestAccLoggingProjectSink_updatePreservesCustomWriter(t *testing.T) {
 	t.Parallel()
@@ -455,19 +453,18 @@ resource "google_storage_bucket" "gcs-bucket" {
 
 func testAccLoggingProjectSink_customWriter(org, billingId, project, name, serviceAccount string) string {
 	return fmt.Sprintf(`
-
 resource "google_project" "destination-project" {
-	project_id      = "%s"
-	name            = "%s"
-	org_id          = "%s"
-	billing_account = "%s"
+  project_id      = "%s"
+  name            = "%s"
+  org_id          = "%s"
+  billing_account = "%s"
 }	
 
 resource "google_logging_project_bucket_config" "destination-bucket" {
-    project    = google_project.destination-project.project_id
-    location  = "us-central1"
-    retention_days = 30
-    bucket_id = "shared-bucket"
+  project    = google_project.destination-project.project_id
+  location  = "us-central1"
+  retention_days = 30
+  bucket_id = "shared-bucket"
 }
 
 resource "google_service_account" "test-account1" {
@@ -482,17 +479,17 @@ resource "google_project_iam_member" "custom-sa-logbucket-binding" {
 }
 
 data "google_project" "testing_project" {
-	project_id = "%s"
+  project_id = "%s"
 }
 
 locals {
-	project_number = data.google_project.testing_project.number
+  project_number = data.google_project.testing_project.number
 }
 
 resource "google_service_account_iam_member" "loggingsa-customsa-binding" {
-	service_account_id = google_service_account.test-account1.name
-	role   = "roles/iam.serviceAccountTokenCreator"
-	member = "serviceAccount:service-${local.project_number}@gcp-sa-logging.iam.gserviceaccount.com"
+  service_account_id = google_service_account.test-account1.name
+  role   = "roles/iam.serviceAccountTokenCreator"
+  member = "serviceAccount:service-${local.project_number}@gcp-sa-logging.iam.gserviceaccount.com"
 }
 
 resource "google_logging_project_sink" "custom_writer" {
@@ -510,55 +507,55 @@ resource "google_logging_project_sink" "custom_writer" {
 
 func testAccLoggingProjectSink_customWriterUpdated(org, billingId, project, name, serviceAccount string) string {
 	return fmt.Sprintf(`
-	resource "google_project" "destination-project" {
-		project_id      = "%s"
-		name            = "%s"
-		org_id          = "%s"
-		billing_account = "%s"
-	}	
-	
-	resource "google_logging_project_bucket_config" "destination-bucket" {
-		project    = google_project.destination-project.project_id
-		location  = "us-central1"
-		retention_days = 30
-		bucket_id = "shared-bucket"
-	}
-	
-	resource "google_service_account" "test-account1" {
-	  account_id   = "%s"
-	  display_name = "Log Sink Custom WriterIdentity Testing Account"
-	}
-	
-	resource "google_project_iam_member" "custom-sa-logbucket-binding" {
-	  project = google_project.destination-project.project_id
-	  role   = "roles/logging.bucketWriter"
-	  member = "serviceAccount:${google_service_account.test-account1.email}"
-	}
-	
-	data "google_project" "testing_project" {
-		project_id = "%s"
-	}
-	
-	locals {
-		project_number = data.google_project.testing_project.number
-	}
-	
-	resource "google_service_account_iam_member" "loggingsa-customsa-binding" {
-		service_account_id = google_service_account.test-account1.name
-		role   = "roles/iam.serviceAccountTokenCreator"
-		member = "serviceAccount:service-${local.project_number}@gcp-sa-logging.iam.gserviceaccount.com"
-	}
-	
-	resource "google_logging_project_sink" "custom_writer" {
-	  	name        = "%s"
-	  	destination = "logging.googleapis.com/projects/${google_project.destination-project.project_id}/locations/us-central1/buckets/shared-bucket"
-		filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=WARNING"
-	  
-		unique_writer_identity = true
-  		custom_writer_identity = "serviceAccount:${google_service_account.test-account1.email}"
+resource "google_project" "destination-project" {
+  project_id      = "%s"
+  name            = "%s"
+  org_id          = "%s"
+  billing_account = "%s"
+}	
 
-  		depends_on = [google_logging_project_bucket_config.destination-bucket]
-	  }
+resource "google_logging_project_bucket_config" "destination-bucket" {
+  project    = google_project.destination-project.project_id
+  location  = "us-central1"
+  retention_days = 30
+  bucket_id = "shared-bucket"
+}
+
+resource "google_service_account" "test-account1" {
+  account_id   = "%s"
+  display_name = "Log Sink Custom WriterIdentity Testing Account"
+}
+
+resource "google_project_iam_member" "custom-sa-logbucket-binding" {
+  project = google_project.destination-project.project_id
+  role   = "roles/logging.bucketWriter"
+  member = "serviceAccount:${google_service_account.test-account1.email}"
+}
+
+data "google_project" "testing_project" {
+  project_id = "%s"
+}
+
+locals {
+  project_number = data.google_project.testing_project.number
+}
+
+resource "google_service_account_iam_member" "loggingsa-customsa-binding" {
+  service_account_id = google_service_account.test-account1.name
+  role   = "roles/iam.serviceAccountTokenCreator"
+  member = "serviceAccount:service-${local.project_number}@gcp-sa-logging.iam.gserviceaccount.com"
+}
+
+resource "google_logging_project_sink" "custom_writer" {
+  name        = "%s"
+  destination = "logging.googleapis.com/projects/${google_project.destination-project.project_id}/locations/us-central1/buckets/shared-bucket"
+  filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=WARNING"
+
+  unique_writer_identity = true
+  custom_writer_identity = "serviceAccount:${google_service_account.test-account1.email}"
+
+  depends_on = [google_logging_project_bucket_config.destination-bucket]
+}
 `, project, project, org, billingId, serviceAccount, envvar.GetTestProjectFromEnv(), name, envvar.GetTestProjectFromEnv())
 }
 

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
@@ -180,7 +180,7 @@ func TestAccLoggingProjectSink_updatePreservesCustomWriter(t *testing.T) {
 			{
 				Config: testAccLoggingProjectSink_customWriterUpdated(org, billingId, project, sinkName, accountUpdated),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("google_logging_project_sink.custom_writer", "custom_writer_identity", expectedUpdatedWriterIdentity),
+					resource.TestCheckResourceAttr("google_logging_project_sink.custom_writer", "writer_identity", expectedUpdatedWriterIdentity),
 				),
 			},
 			{

--- a/mmv1/third_party/terraform/services/logging/resource_logging_sink.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_sink.go
@@ -112,7 +112,7 @@ func expandResourceLoggingSink(d *schema.ResourceData, resourceType, resourceId 
 		Filter:          d.Get("filter").(string),
 		Description:     d.Get("description").(string),
 		Disabled:        d.Get("disabled").(bool),
-		WriterIdentity:	 d.Get("writer_identity").(string),
+		WriterIdentity:  d.Get("writer_identity").(string),
 		Exclusions:      expandLoggingSinkExclusions(d.Get("exclusions")),
 		BigqueryOptions: expandLoggingSinkBigqueryOptions(d.Get("bigquery_options")),
 	}

--- a/mmv1/third_party/terraform/services/logging/resource_logging_sink.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_sink.go
@@ -112,6 +112,7 @@ func expandResourceLoggingSink(d *schema.ResourceData, resourceType, resourceId 
 		Filter:          d.Get("filter").(string),
 		Description:     d.Get("description").(string),
 		Disabled:        d.Get("disabled").(bool),
+		WriterIdentity:	 d.Get("writer_identity").(string),
 		Exclusions:      expandLoggingSinkExclusions(d.Get("exclusions")),
 		BigqueryOptions: expandLoggingSinkBigqueryOptions(d.Get("bigquery_options")),
 	}

--- a/mmv1/third_party/terraform/services/logging/resource_logging_sink.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_sink.go
@@ -112,7 +112,6 @@ func expandResourceLoggingSink(d *schema.ResourceData, resourceType, resourceId 
 		Filter:          d.Get("filter").(string),
 		Description:     d.Get("description").(string),
 		Disabled:        d.Get("disabled").(bool),
-		WriterIdentity:  d.Get("writer_identity").(string),
 		Exclusions:      expandLoggingSinkExclusions(d.Get("exclusions")),
 		BigqueryOptions: expandLoggingSinkBigqueryOptions(d.Get("bigquery_options")),
 	}

--- a/mmv1/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
@@ -194,7 +194,7 @@ The following arguments are supported:
     `bigquery_options`, you must set `unique_writer_identity` to true.
 
 * `custom_writer_identity` - (Optional) A user managed service account that will be used to write
-    the log entries. The format must be serviceAccount:some@email. This field can only be specified if you are
+    the log entries. The format must be `serviceAccount:some@email`. This field can only be specified if you are
     routing logs to a destination outside this sink's project. If not specified, a Logging service account 
     will automatically be generated. You must set `unique_writer_identity` to true to use this feature.
 

--- a/mmv1/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
@@ -196,7 +196,7 @@ The following arguments are supported:
 * `custom_writer_identity` - (Optional) A user managed service account that will be used to write
     the log entries. The format must be `serviceAccount:some@email`. This field can only be specified if you are
     routing logs to a destination outside this sink's project. If not specified, a Logging service account 
-    will automatically be generated. You must set `unique_writer_identity` to true to use this feature.
+    will automatically be generated.
 
 * `bigquery_options` - (Optional) Options that affect sinks exporting data to BigQuery. Structure [documented below](#nested_bigquery_options).
 

--- a/mmv1/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
@@ -89,6 +89,47 @@ resource "google_project_iam_binding" "gcs-bucket-writer" {
 }
 ```
 
+The following example creates a sink that are configured with user-managed service accounts, by specifying
+the `custom_writer_identity` field.
+
+Note that you can only create a sink that uses a user-managed service account when the sink destination
+is a log bucket.
+
+```hcl
+resource "google_service_account" "custom-sa" {
+  project      = "other-project-id"
+  account_id   = "gce-log-bucket-sink"
+  display_name = "gce-log-bucket-sink"
+}
+
+# Create a sink that uses user-managed service account
+resource "google_logging_project_sink" "my-sink" {
+  name = "other-project-log-bucket-sink"
+
+  # Can export to log bucket in another project
+  destination = "logging.googleapis.com/projects/other-project-id/locations/global/buckets/gce-logs"
+
+  # Log all WARN or higher severity messages relating to instances
+  filter = "resource.type = gce_instance AND severity >= WARNING"
+
+  # unique_writer_identity has to be true in order to use user-managed service account
+  unique_writer_identity = true
+  
+  # Use a user-managed service account
+  custom_writer_identity = google_service_account.custom-sa.email
+}
+
+# grant writer access to the user-managed service account
+resource "google_project_iam_member" "custom-sa-logbucket-binding" {
+  project = "destination-project-id"
+  role   = "roles/logging.bucketWriter"
+  member = "serviceAccount:${google_service_account.custom-sa.email}"
+}
+```
+
+The above example will create a log sink that route logs to destination GCP project using
+an user-managed service account. 
+
 The following example uses `exclusions` to filter logs that will not be exported. In this example logs are exported to a [log bucket](https://cloud.google.com/logging/docs/buckets) and there are 2 exclusions configured
 
 ```hcl
@@ -146,6 +187,11 @@ The following arguments are supported:
     (the default), then the `writer_identity` used is `serviceAccount:cloud-logs@system.gserviceaccount.com`. If `true`,
     then a unique service account is created and used for this sink. If you wish to publish logs across projects or utilize
     `bigquery_options`, you must set `unique_writer_identity` to true.
+
+* `custom_writer_identity` - (Optional) A user managed service account that will be used to write
+    the log entries. The format must be serviceAccount:some@email. This field can only be specified if you are
+    routing logs to a destination outside this sink's project. If not specified, a Logging service account 
+    will automatically be generated. You must set `unique_writer_identity` to true to use this feature.
 
 * `bigquery_options` - (Optional) Options that affect sinks exporting data to BigQuery. Structure [documented below](#nested_bigquery_options).
 

--- a/mmv1/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
@@ -18,7 +18,7 @@ Manages a project-level logging sink. For more information see:
 
 ~> **Note** You must [enable the Cloud Resource Manager API](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com)
 
-## Example Usage
+## Example Usage - Basic Sink
 
 ```hcl
 resource "google_logging_project_sink" "my-sink" {
@@ -34,6 +34,8 @@ resource "google_logging_project_sink" "my-sink" {
   unique_writer_identity = true
 }
 ```
+
+## Example Usage - Cloud Storage Bucket Destination
 
 A more complete example follows: this creates a compute instance, as well as a log sink that logs all activity to a
 cloud storage bucket. Because we are using `unique_writer_identity`, we must grant it access to the bucket.
@@ -89,6 +91,8 @@ resource "google_project_iam_binding" "gcs-bucket-writer" {
 }
 ```
 
+## Example Usage - User-managed Service Account 
+
 The following example creates a sink that are configured with user-managed service accounts, by specifying
 the `custom_writer_identity` field.
 
@@ -112,7 +116,6 @@ resource "google_logging_project_sink" "my-sink" {
   # Log all WARN or higher severity messages relating to instances
   filter = "resource.type = gce_instance AND severity >= WARNING"
 
-  # unique_writer_identity has to be true in order to use user-managed service account
   unique_writer_identity = true
   
   # Use a user-managed service account
@@ -129,6 +132,8 @@ resource "google_project_iam_member" "custom-sa-logbucket-binding" {
 
 The above example will create a log sink that route logs to destination GCP project using
 an user-managed service account. 
+
+## Example Usage - Sink Exclusions
 
 The following example uses `exclusions` to filter logs that will not be exported. In this example logs are exported to a [log bucket](https://cloud.google.com/logging/docs/buckets) and there are 2 exclusions configured
 


### PR DESCRIPTION
…ink resources

Fixes https://github.com/hashicorp/terraform-provider-google/issues/14893

add the customWriterIdentity parameter to logging_sink.
This PR only fixes the project logsink.



<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
logging: added `custom_writer_identity` field to `google_logging_project_sink`
```
