### PR TITLE
Unignore empty values location logic 5.0.0

### DIFF
--- a/mmv1/third_party/terraform/fwresource/framework_location.go
+++ b/mmv1/third_party/terraform/fwresource/framework_location.go
@@ -31,23 +31,23 @@ type LocationDescription struct {
 
 func (ld *LocationDescription) GetLocation() (types.String, error) {
 	// Location from resource config
-	if !ld.ResourceLocation.IsNull() && !ld.ResourceLocation.IsUnknown() && !ld.ResourceLocation.Equal(types.StringValue("")) {
+	if !ld.ResourceLocation.IsNull() && !ld.ResourceLocation.IsUnknown() {
 		return ld.ResourceLocation, nil
 	}
 
 	// Location from region in resource config
-	if !ld.ResourceRegion.IsNull() && !ld.ResourceRegion.IsUnknown() && !ld.ResourceRegion.Equal(types.StringValue("")) {
+	if !ld.ResourceRegion.IsNull() && !ld.ResourceRegion.IsUnknown() {
 		return ld.ResourceRegion, nil
 	}
 
 	// Location from zone in resource config
-	if !ld.ResourceZone.IsNull() && !ld.ResourceZone.IsUnknown() && !ld.ResourceZone.Equal(types.StringValue("")) {
+	if !ld.ResourceZone.IsNull() && !ld.ResourceZone.IsUnknown() {
 		location := tpgresource.GetResourceNameFromSelfLink(ld.ResourceZone.ValueString()) // Zone could be a self link
 		return types.StringValue(location), nil
 	}
 
 	// Location from zone in provider config
-	if !ld.ProviderZone.IsNull() && !ld.ProviderZone.IsUnknown() && !ld.ProviderZone.Equal(types.StringValue("")) {
+	if !ld.ProviderZone.IsNull() && !ld.ProviderZone.IsUnknown() {
 		return ld.ProviderZone, nil
 	}
 
@@ -65,21 +65,21 @@ func (ld *LocationDescription) GetRegion() (types.String, error) {
 	// For all checks in this function body
 
 	// Region from resource config
-	if !ld.ResourceRegion.IsNull() && !ld.ResourceRegion.IsUnknown() && !ld.ResourceRegion.Equal(types.StringValue("")) {
+	if !ld.ResourceRegion.IsNull() && !ld.ResourceRegion.IsUnknown() {
 		region := tpgresource.GetResourceNameFromSelfLink(ld.ResourceRegion.ValueString()) // Region could be a self link
 		return types.StringValue(region), nil
 	}
 	// Region from zone in resource config
-	if !ld.ResourceZone.IsNull() && !ld.ResourceZone.IsUnknown() && !ld.ResourceZone.Equal(types.StringValue("")) {
+	if !ld.ResourceZone.IsNull() && !ld.ResourceZone.IsUnknown() {
 		region := tpgresource.GetRegionFromZone(ld.ResourceZone.ValueString())
 		return types.StringValue(region), nil
 	}
 	// Region from provider config
-	if !ld.ProviderRegion.IsNull() && !ld.ProviderRegion.IsUnknown() && !ld.ProviderRegion.Equal(types.StringValue("")) {
+	if !ld.ProviderRegion.IsNull() && !ld.ProviderRegion.IsUnknown() {
 		return ld.ProviderRegion, nil
 	}
 	// Region from zone in provider config
-	if !ld.ProviderZone.IsNull() && !ld.ProviderZone.IsUnknown() && !ld.ProviderZone.Equal(types.StringValue("")) {
+	if !ld.ProviderZone.IsNull() && !ld.ProviderZone.IsUnknown() {
 		region := tpgresource.GetRegionFromZone(ld.ProviderZone.ValueString())
 		return types.StringValue(region), nil
 	}
@@ -97,12 +97,12 @@ func (ld *LocationDescription) GetZone() (types.String, error) {
 	// TODO(SarahFrench): Make empty strings not ignored, see https://github.com/hashicorp/terraform-provider-google/issues/14447
 	// For all checks in this function body
 
-	if !ld.ResourceZone.IsNull() && !ld.ResourceZone.IsUnknown() && !ld.ResourceZone.Equal(types.StringValue("")) {
+	if !ld.ResourceZone.IsNull() && !ld.ResourceZone.IsUnknown() {
 		// Zone could be a self link
 		zone := tpgresource.GetResourceNameFromSelfLink(ld.ResourceZone.ValueString())
 		return types.StringValue(zone), nil
 	}
-	if !ld.ProviderZone.IsNull() && !ld.ProviderZone.IsUnknown() && !ld.ProviderZone.Equal(types.StringValue("")) {
+	if !ld.ProviderZone.IsNull() && !ld.ProviderZone.IsUnknown() {
 		return ld.ProviderZone, nil
 	}
 

--- a/mmv1/third_party/terraform/fwresource/framework_location_test.go
+++ b/mmv1/third_party/terraform/fwresource/framework_location_test.go
@@ -40,12 +40,19 @@ func TestLocationDescription_GetZone(t *testing.T) {
 			ExpectedZone: types.StringValue("provider-zone-a"),
 		},
 		// Handling of empty strings
-		"returns the value of the zone field in provider config when zone is set to an empty string in resource config": {
+		"returns an empty string when zone is set to empty string in a resource config, instead of falling back to other values": {
 			ld: LocationDescription{
 				ResourceZone: types.StringValue(""),
 				ProviderZone: types.StringValue("provider-zone-a"),
 			},
-			ExpectedZone: types.StringValue("provider-zone-a"),
+			ExpectedZone: types.StringValue(""),
+		},
+		"returns an empty string if zone set as empty strings in both resource and provider configs": {
+			ld: LocationDescription{
+				ResourceZone: types.StringValue(""),
+				ProviderZone: types.StringValue(""),
+			},
+			ExpectedZone: types.StringValue(""),
 		},
 		// Error states
 		"returns an error when a zone value can't be found": {
@@ -55,14 +62,7 @@ func TestLocationDescription_GetZone(t *testing.T) {
 			},
 			ExpectedError: true,
 		},
-		"returns an error if zone is set as an empty string in both resource and provider configs": {
-			ld: LocationDescription{
-				ResourceZone: types.StringValue(""),
-				ProviderZone: types.StringValue(""),
-			},
-			ExpectedError: true,
-		},
-		"returns an error that mention non-standard schema field names when a zone value can't be found": {
+		"returns an error that mentions non-standard schema field names when a zone value can't be found": {
 			ld: LocationDescription{
 				ZoneSchemaField: types.StringValue("foobar"),
 			},
@@ -146,34 +146,28 @@ func TestLocationDescription_GetRegion(t *testing.T) {
 			ExpectedRegion: types.StringValue("provider-zone"), // is truncated
 		},
 		// Handling of empty strings
-		"returns a region derived from the zone field in resource config when region is set as an empty string": {
+		"returns an empty string when region is set to empty string in a resource config, instead of falling back to other values": {
 			ld: LocationDescription{
 				ResourceRegion: types.StringValue(""),
-				ResourceZone:   types.StringValue("provider-zone-a"),
-			},
-			ExpectedRegion: types.StringValue("provider-zone"), // is truncated
-		},
-		"returns the value of the region field in provider config when region/zone set as an empty string in resource config": {
-			ld: LocationDescription{
-				ResourceRegion: types.StringValue(""),
-				ResourceZone:   types.StringValue(""),
+				ResourceZone:   types.StringValue("resource-zone-a"),
 				ProviderRegion: types.StringValue("provider-region"),
+				ProviderZone:   types.StringValue("provider-zone-a"),
 			},
-			ExpectedRegion: types.StringValue("provider-region"),
+			ExpectedRegion: types.StringValue(""),
 		},
-		// Error states
-		"returns an error when region/zone values can't be found (location is ignored)": {
-			ld: LocationDescription{
-				ResourceLocation: types.StringValue("resource-location"),
-			},
-			ExpectedError: true,
-		},
-		"returns an error if region and zone set as empty strings in both resource and provider configs": {
+		"returns an empty string if region and zone set as empty strings in both resource and provider configs": {
 			ld: LocationDescription{
 				ResourceRegion: types.StringValue(""),
 				ResourceZone:   types.StringValue(""),
 				ProviderRegion: types.StringValue(""),
 				ProviderZone:   types.StringValue(""),
+			},
+			ExpectedRegion: types.StringValue(""),
+		},
+		// Error states
+		"returns an error when region/zone values can't be found (location is ignored)": {
+			ld: LocationDescription{
+				ResourceLocation: types.StringValue("resource-location"),
 			},
 			ExpectedError: true,
 		},
@@ -273,29 +267,22 @@ func TestLocationDescription_GetLocation(t *testing.T) {
 			ExpectedLocation: types.StringValue("https://www.googleapis.com/compute/v1/projects/my-project/zones/provider-zone-a"),
 		},
 		// Handling of empty strings
-		"returns the region value set in the resource config when location is an empty string": {
+		"returns an empty string when location is set to empty string in a resource config, instead of falling back to other values": {
 			ld: LocationDescription{
 				ResourceLocation: types.StringValue(""),
 				ResourceRegion:   types.StringValue("resource-region"),
 			},
-			ExpectedLocation: types.StringValue("resource-region"),
+			ExpectedLocation: types.StringValue(""),
 		},
-		"returns the zone value set in the resource config when both location or region are empty strings": {
-			ld: LocationDescription{
-				ResourceLocation: types.StringValue(""),
-				ResourceRegion:   types.StringValue(""),
-				ResourceZone:     types.StringValue("resource-zone-a"),
-			},
-			ExpectedLocation: types.StringValue("resource-zone-a"),
-		},
-		"returns the zone value from the provider config when all of location/region/zone are set as empty strings in the resource config": {
+		"returns an empty string if location/region/zone set as empty strings in both resource and provider configs": {
 			ld: LocationDescription{
 				ResourceLocation: types.StringValue(""),
 				ResourceRegion:   types.StringValue(""),
 				ResourceZone:     types.StringValue(""),
-				ProviderZone:     types.StringValue("provider-zone-a"),
+				ProviderRegion:   types.StringValue(""),
+				ProviderZone:     types.StringValue(""),
 			},
-			ExpectedLocation: types.StringValue("provider-zone-a"),
+			ExpectedLocation: types.StringValue(""),
 		},
 		// Error states
 		"does not use the region value set in the provider config": {
@@ -305,16 +292,6 @@ func TestLocationDescription_GetLocation(t *testing.T) {
 			ExpectedError: true,
 		},
 		"returns an error when none of location/region/zone are set on the resource, and neither region or zone is set on the provider": {
-			ExpectedError: true,
-		},
-		"returns an error if location/region/zone are set as empty strings in both resource and provider configs": {
-			ld: LocationDescription{
-				ResourceLocation: types.StringValue(""),
-				ResourceRegion:   types.StringValue(""),
-				ResourceZone:     types.StringValue(""),
-				ProviderRegion:   types.StringValue(""),
-				ProviderZone:     types.StringValue(""),
-			},
 			ExpectedError: true,
 		},
 		"returns an error that mention non-standard schema field names when location value can't be found": {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

I've made this PR with the intention of closing it, as I realised that this work cannot be completed until later in the plugin-framework migration project.

---

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
provider: empty strings provided as `location`/`region`/`zone` arguments to resources will not be ignored in favor of alternative values set on the provider
```
