### PR TITLE
add day_offset field to google_os_config_patch_deployment.recurring_s…

### DIFF
--- a/mmv1/products/osconfig/PatchDeployment.yaml
+++ b/mmv1/products/osconfig/PatchDeployment.yaml
@@ -860,6 +860,12 @@ properties:
                   - :FRIDAY
                   - :SATURDAY
                   - :SUNDAY
+              - !ruby/object:Api::Type::Integer
+                name: 'dayOffset'
+                description: |
+                  Represents the number of days before or after the given week day of month that the patch deployment is scheduled for.
+                validation: !ruby/object:Provider::Terraform::Validation
+                  function: 'validation.IntBetween(-30,30)'
           - !ruby/object:Api::Type::Integer
             name: 'monthDay'
             exactly_one_of:

--- a/mmv1/templates/terraform/examples/os_config_patch_deployment_full.tf.erb
+++ b/mmv1/templates/terraform/examples/os_config_patch_deployment_full.tf.erb
@@ -94,6 +94,7 @@ resource "google_os_config_patch_deployment" "<%= ctx[:primary_resource_id] %>" 
       week_day_of_month {
         week_ordinal = -1
         day_of_week  = "TUESDAY"
+        day_offset   = 3
       }
     }
   }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/15770

Add day_offset field to google_os_config_patch_deployment.recurring_schedule.monthly.week_day_of_month.

See [API Reference](https://cloud.google.com/compute/docs/osconfig/rest/v1/projects.patchDeployments#WeekDayOfMonth) to learn more about day_offset field.

If this PR is for Terraform, I acknowledge that I have:

* [x] run make lint on both ga and beta providers
* [x] run make test on both ga and beta providers
* [x] run testacc for osconfig service on both ga and beta providers

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
osconfig: added `week_day_of_month.day_offset` field to the `google_os_config_patch_deployment` resource
```
