### PR TITLE
Skip duplication validation for empty cluster IDs

### DIFF
--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
@@ -543,6 +543,10 @@ func resourceBigtableInstanceUniqueClusterID(_ context.Context, diff *schema.Res
 	for i := 0; i < newCount.(int); i++ {
 		_, newId := diff.GetChange(fmt.Sprintf("cluster.%d.cluster_id", i))
 		clusterID := newId.(string)
+		// In case clusterID is empty, it is probably computed and this validation will be wrong.
+		if clusterID == "" {
+			continue
+		}
 		if clusters[clusterID] {
 			return fmt.Errorf("duplicated cluster_id: %q", clusterID)
 		}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigtable: fixed a bug where dynamically created clusters would incorrectly run into duplication error in `google_bigtable_instance`
```

Fixes https://github.com/hashicorp/terraform-provider-google/issues/15771