### PR TITLE
Remove wait in Pub/Sub Schema tests

### DIFF
--- a/mmv1/third_party/terraform/services/pubsub/resource_pubsub_schema_test.go
+++ b/mmv1/third_party/terraform/services/pubsub/resource_pubsub_schema_test.go
@@ -48,17 +48,6 @@ func testAccPubsubSchema_basic(schema string) string {
 		type = "PROTOCOL_BUFFER"
 		definition = "syntax = \"proto3\";\nmessage Results {\nstring message_request = 1;\nstring message_response = 2;\n}"
 	}
-
-	# Need to introduce delay for updates in order for tests to complete
-	# successfully due to caching effects.
-	resource "time_sleep" "wait_121_seconds" {
-		create_duration = "121s"
-		lifecycle {
-			replace_triggered_by = [
-				google_pubsub_schema.foo
-			]
-		}
-	}
 `, schema)
 }
 
@@ -68,17 +57,6 @@ func testAccPubsubSchema_updated(schema string) string {
 		name = "%s"
 		type = "PROTOCOL_BUFFER"
 		definition = "syntax = \"proto3\";\nmessage Results {\nstring message_request = 1;\nstring message_response = 2;\nstring timestamp_request = 3;\n}"
-	}
-
-	# Need to introduce delay for updates in order for tests to complete
-	# successfully due to caching effects.
-	resource "time_sleep" "wait_121_seconds" {
-		create_duration = "121s"
-		lifecycle {
-			replace_triggered_by = [
-				google_pubsub_schema.foo
-			]
-		}
 	}
 `, schema)
 }


### PR DESCRIPTION
Remove wait in Pub/Sub Schema tests as server-side changes have been made so that this is not necessary. Fixes https://github.com/hashicorp/terraform-provider-google/issues/14855.

```release-note:none

```
