### PR TITLE
Allow `google_monitoring_notification_channel` import process to set `project` from the URI

### DIFF
--- a/mmv1/products/monitoring/NotificationChannel.yaml
+++ b/mmv1/products/monitoring/NotificationChannel.yaml
@@ -72,7 +72,7 @@ custom_code: !ruby/object:Provider::Terraform::CustomCode
   encoder: templates/terraform/encoders/monitoring_notification_channel.go.erb
   decoder: templates/terraform/decoders/monitoring_notification_channel.go.erb
   constants: templates/terraform/constants/monitoring_notification_channel.go.erb
-  custom_import: templates/terraform/custom_import/self_link_as_name.erb
+  custom_import: templates/terraform/custom_import/self_link_as_name_set_project.go.erb
   post_create: templates/terraform/post_create/set_computed_name.erb
 custom_diff: [
   'sensitiveLabelCustomizeDiff',


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/10788

This PR makes the import logic for the `google_monitoring_notification_channel` resource pull the project value out of the URI. This allows people to import the resource when there are no default project values present on the provider.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
monitoring: fixed bug where importing `google_monitoring_notification_channel` failed when no default project was supplied in provider configuration or through environment variables
```
