### PR TITLE
Avoid recreate instance when cluster not ready

### DIFF
--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
@@ -64,9 +64,8 @@ func ResourceBigtableInstance() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"state": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: `Please don't tell anyone how I live`,
+							Type:     schema.TypeString,
+							Computed: true,
 						},
 						"cluster_id": {
 							Type:        schema.TypeString,

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
@@ -655,7 +655,7 @@ func resourceBigtableInstanceClusterReorderTypeList(_ context.Context, diff *sch
 
 		currentState, _ := diff.GetChange(fmt.Sprintf("cluster.%d.state", i))
 		oST, nST := diff.GetChange(fmt.Sprintf("cluster.%d.storage_type", i))
-		if oST != nST && currentState != "CREATING" {
+		if oST != nST && currentState.(string) != "CREATING" {
 			err := diff.ForceNew(fmt.Sprintf("cluster.%d.storage_type", i))
 			if err != nil {
 				return fmt.Errorf("Error setting cluster diff: %s", err)

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
@@ -63,6 +63,11 @@ func ResourceBigtableInstance() *schema.Resource {
 				Description: `A block of cluster configuration options. This can be specified at least once.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"state": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Please don't tell anyone how I live`,
+						},
 						"cluster_id": {
 							Type:        schema.TypeString,
 							Required:    true,
@@ -589,7 +594,9 @@ func resourceBigtableInstanceClusterReorderTypeList(_ context.Context, diff *sch
 	for i := 0; i < newCount.(int); i++ {
 		_, newId := diff.GetChange(fmt.Sprintf("cluster.%d.cluster_id", i))
 		_, c := diff.GetChange(fmt.Sprintf("cluster.%d", i))
-		clusters[newId.(string)] = c
+		typedCluster, _ := c.(map[string]interface{})
+		typedCluster["state"] = "READY"
+		clusters[newId.(string)] = typedCluster
 	}
 
 	// create a list of clusters using the old order when possible to minimise

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
@@ -418,6 +418,7 @@ func flattenBigtableCluster(c *bigtable.ClusterInfo) map[string]interface{} {
 		"cluster_id":   c.Name,
 		"storage_type": storageType,
 		"kms_key_name": c.KMSKeyName,
+		"state":        c.State,
 	}
 	if c.AutoscalingConfig != nil {
 		cluster["autoscaling_config"] = make([]map[string]interface{}, 1)
@@ -652,8 +653,9 @@ func resourceBigtableInstanceClusterReorderTypeList(_ context.Context, diff *sch
 			}
 		}
 
+		currentState, _ := diff.GetChange(fmt.Sprintf("cluster.%d.state", i))
 		oST, nST := diff.GetChange(fmt.Sprintf("cluster.%d.storage_type", i))
-		if oST != nST {
+		if oST != nST && currentState != "CREATING" {
 			err := diff.ForceNew(fmt.Sprintf("cluster.%d.storage_type", i))
 			if err != nil {
 				return fmt.Errorf("Error setting cluster diff: %s", err)

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_internal_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_internal_test.go
@@ -202,7 +202,7 @@ func TestUnitBigtable_resourceBigtableInstanceClusterReorderTypeListFunc_error(t
 			"cluster.#": 0,
 		},
 	}
-	if _, err := resourceBigtableInstanceClusterReorderTypeListFunc(d); err == nil {
+	if err := resourceBigtableInstanceClusterReorderTypeListFunc(d, nil); err == nil {
 		t.Errorf("expected error, got success")
 	}
 }
@@ -347,7 +347,11 @@ func TestUnitBigtable_resourceBigtableInstanceClusterReorderTypeListFunc(t *test
 				Before: tc.before,
 				After:  tc.after,
 			}
-			clusters, err := resourceBigtableInstanceClusterReorderTypeListFunc(d)
+			var clusters []interface{}
+			err := resourceBigtableInstanceClusterReorderTypeListFunc(d, func(gotClusters []interface{}) error {
+				clusters = gotClusters
+				return nil
+			})
 			if err != nil {
 				t.Fatalf("bad: %s, error: %v", tn, err)
 			}

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_internal_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_internal_test.go
@@ -8,6 +8,7 @@ import (
 
 	"cloud.google.com/go/bigtable"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 )
 
 func TestUnitBigtable_getUnavailableClusterZones(t *testing.T) {
@@ -192,5 +193,175 @@ func TestUnitBigtable_flattenBigtableCluster(t *testing.T) {
 		if got := flattenBigtableCluster(tc.clusterInfo); !reflect.DeepEqual(got, tc.want) {
 			t.Errorf("bad: %s, got %q, want %q", tn, got, tc.want)
 		}
+	}
+}
+
+func TestUnitBigtable_resourceBigtableInstanceClusterReorderTypeListFunc_error(t *testing.T) {
+	d := &tpgresource.ResourceDiffMock{
+		After: map[string]interface{}{
+			"cluster.#": 0,
+		},
+	}
+	if _, err := resourceBigtableInstanceClusterReorderTypeListFunc(d); err == nil {
+		t.Errorf("expected error, got success")
+	}
+}
+
+func TestUnitBigtable_resourceBigtableInstanceClusterReorderTypeListFunc(t *testing.T) {
+	cases := map[string]struct {
+		before           map[string]interface{}
+		after            map[string]interface{}
+		wantClusterOrder []string
+		wantForceNew     bool
+	}{
+		"create": {
+			before: map[string]interface{}{
+				"cluster.#":            1,
+				"cluster.0.cluster_id": "some-id-a",
+			},
+			after: map[string]interface{}{
+				"name":                 "some-name",
+				"cluster.#":            1,
+				"cluster.0.cluster_id": "some-id-a",
+				"cluster.0": map[string]interface{}{
+					"cluster_id": "some-id-a",
+				},
+			},
+			wantClusterOrder: []string{},
+			wantForceNew:     false,
+		},
+		"no force new change": {
+			before: map[string]interface{}{
+				"name":                 "some-name",
+				"cluster.#":            4,
+				"cluster.0.cluster_id": "some-id-a",
+				"cluster.1.cluster_id": "some-id-b",
+				"cluster.2.cluster_id": "some-id-c",
+				"cluster.3.cluster_id": "some-id-e",
+			},
+			after: map[string]interface{}{
+				"name":                 "some-name",
+				"cluster.#":            3,
+				"cluster.0.cluster_id": "some-id-c",
+				"cluster.1.cluster_id": "some-id-a",
+				"cluster.2.cluster_id": "some-id-d",
+				"cluster.0": map[string]interface{}{
+					"cluster_id": "some-id-c",
+				},
+				"cluster.1": map[string]interface{}{
+					"cluster_id": "some-id-a",
+				},
+				"cluster.2": map[string]interface{}{
+					"cluster_id": "some-id-d",
+				},
+			},
+			wantClusterOrder: []string{"some-id-a", "some-id-d", "some-id-c"},
+			wantForceNew:     false,
+		},
+		"force new - zone change": {
+			before: map[string]interface{}{
+				"name":                 "some-name",
+				"cluster.#":            1,
+				"cluster.0.cluster_id": "some-id-a",
+				"cluster.0.zone":       "zone-a",
+			},
+			after: map[string]interface{}{
+				"name":                 "some-name",
+				"cluster.#":            1,
+				"cluster.0.cluster_id": "some-id-a",
+				"cluster.0.zone":       "zone-b",
+				"cluster.0": map[string]interface{}{
+					"cluster_id": "some-id-a",
+					"zone":       "zone-b",
+				},
+			},
+			wantClusterOrder: []string{"some-id-a"},
+			wantForceNew:     true,
+		},
+		"force new - kms_key_name change": {
+			before: map[string]interface{}{
+				"name":                   "some-name",
+				"cluster.#":              1,
+				"cluster.0.cluster_id":   "some-id-a",
+				"cluster.0.kms_key_name": "key-a",
+			},
+			after: map[string]interface{}{
+				"name":                   "some-name",
+				"cluster.#":              1,
+				"cluster.0.cluster_id":   "some-id-a",
+				"cluster.0.kms_key_name": "key-b",
+				"cluster.0": map[string]interface{}{
+					"cluster_id":   "some-id-a",
+					"kms_key_name": "key-b",
+				},
+			},
+			wantClusterOrder: []string{"some-id-a"},
+			wantForceNew:     true,
+		},
+		"force new - storage_type change": {
+			before: map[string]interface{}{
+				"name":                   "some-name",
+				"cluster.#":              1,
+				"cluster.0.cluster_id":   "some-id-a",
+				"cluster.0.storage_type": "HDD",
+				"cluster.0.state":        "READY",
+			},
+			after: map[string]interface{}{
+				"name":                   "some-name",
+				"cluster.#":              1,
+				"cluster.0.cluster_id":   "some-id-a",
+				"cluster.0.storage_type": "SSD",
+				"cluster.0": map[string]interface{}{
+					"cluster_id":   "some-id-a",
+					"storage_type": "SSD",
+				},
+			},
+			wantClusterOrder: []string{"some-id-a"},
+			wantForceNew:     true,
+		},
+		"skip force new - storage_type change for CREATING cluster": {
+			before: map[string]interface{}{
+				"name":                   "some-name",
+				"cluster.#":              1,
+				"cluster.0.cluster_id":   "some-id-a",
+				"cluster.0.storage_type": "SSD",
+				"cluster.0.state":        "CREATING",
+			},
+			after: map[string]interface{}{
+				"name":                   "some-name",
+				"cluster.#":              1,
+				"cluster.0.cluster_id":   "some-id-a",
+				"cluster.0.storage_type": "HDD",
+				"cluster.0": map[string]interface{}{
+					"cluster_id":   "some-id-a",
+					"storage_type": "HDD",
+				},
+			},
+			wantClusterOrder: []string{"some-id-a"},
+			wantForceNew:     false,
+		},
+	}
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			d := &tpgresource.ResourceDiffMock{
+				Before: tc.before,
+				After:  tc.after,
+			}
+			clusters, err := resourceBigtableInstanceClusterReorderTypeListFunc(d)
+			if err != nil {
+				t.Fatalf("bad: %s, error: %v", tn, err)
+			}
+			if d.IsForceNew != tc.wantForceNew {
+				t.Errorf("bad: %s, got %v, want %v", tn, d.IsForceNew, tc.wantForceNew)
+			}
+			gotClusterOrder := []string{}
+			for _, cluster := range clusters {
+				clusterResource := cluster.(map[string]interface{})
+				gotClusterOrder = append(gotClusterOrder, clusterResource["cluster_id"].(string))
+			}
+			if !reflect.DeepEqual(gotClusterOrder, tc.wantClusterOrder) {
+				t.Errorf("bad: %s, got %q, want %q", tn, gotClusterOrder, tc.wantClusterOrder)
+			}
+		})
 	}
 }

--- a/mmv1/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
@@ -142,7 +142,7 @@ If no value is set, Cloud Bigtable automatically allocates nodes based on your d
 In addition to the arguments listed above, the following computed attributes are exported:
 
 * `id` - an identifier for the resource with format `projects/{{project}}/instances/{{name}}`
-* `state` - describes the current state of the cluster.
+* `cluster.0.state` - describes the current state of the cluster.
 
 ## Timeouts
 

--- a/mmv1/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
@@ -142,6 +142,7 @@ If no value is set, Cloud Bigtable automatically allocates nodes based on your d
 In addition to the arguments listed above, the following computed attributes are exported:
 
 * `id` - an identifier for the resource with format `projects/{{project}}/instances/{{name}}`
+* `state` - describes the current state of the cluster.
 
 ## Timeouts
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigtable: avoided re-creation of instance when cluster is still updating and storage type changed
```

```release-note:enhancement
bigtable: added `state` output attribute to `google_bigtable_instance` clusters
```
