### PR TITLE
Add a note to prefer compute_region_instance_template.

### DIFF
--- a/mmv1/third_party/terraform/website/docs/d/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance_template.html.markdown
@@ -6,6 +6,8 @@ description: |-
 
 # google\_compute\_instance\_template
 
+-> **Note**: Global instance templates can be used in any region. To lower the impact of outages outside your region and gain data residency within your region, use [google_compute_region_instance_template](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_instance_template).
+
 Get information about a VM instance template resource within GCE. For more information see
 [the official documentation](https://cloud.google.com/compute/docs/instance-templates)
 and

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -6,6 +6,8 @@ description: |-
 
 # google\_compute\_instance\_template
 
+-> **Note**: Global instance templates can be used in any region. To lower the impact of outages outside your region and gain data residency within your region, use [google_compute_region_instance_template](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_instance_template).
+
 Manages a VM instance template resource within GCE. For more information see
 [the official documentation](https://cloud.google.com/compute/docs/instance-templates)
 and


### PR DESCRIPTION
Adds a note to `compute_instance_template` highlighting the new `compute_region_instance_template` resource.

Not sure how to test the changes locally -- please let me know if that's required.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
