### PR TITLE
Add support for replica zones, service account scopes, and auditd logging in workstations configs

### DIFF
--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -183,6 +183,19 @@ properties:
     description: |
       How long to wait before automatically stopping a workstation after it was started. A value of 0 indicates that workstations using this configuration should never time out from running duration. Must be greater than 0 and less than 24 hours if `encryption_key` is set. Defaults to 12 hours.
       A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.5s".
+  - !ruby/object:Api::Type::Array
+    name: 'replicaZones'
+    item_type: Api::Type::String
+    immutable: true
+    description: |
+      Specifies the zones used to replicate the VM and disk resources within the region. If set, exactly two zones within the workstation cluster's region must be specified—for example, `['us-central1-a', 'us-central1-f']`.
+      If this field is empty, two default zones within the region are used. Immutable after the workstation configuration is created.
+    default_from_api: true
+  - !ruby/object:Api::Type::Boolean
+    name: 'enableAuditAgent'
+    description: |
+      Whether to enable Linux `auditd` logging on the workstation. When enabled, a service account must also be specified that has `logging.buckets.write` permission on the project. Operating system audit logging is distinct from Cloud Audit Logs.
+    ignore_read: true
   - !ruby/object:Api::Type::NestedObject
     name: 'host'
     description: |
@@ -192,6 +205,7 @@ properties:
       - 'host.gceInstance.machineType'
       - 'host.gceInstance.poolSize'
       - 'host.gceInstance.tags'
+      - 'host.gceInstance.serviceAccountScopes'
       - 'host.gceInstance.disablePublicIpAddresses'
       - 'host.gceInstance.enableNestedVirtualization'
       - 'host.gceInstance.shieldedInstanceConfig.enableSecureBoot'
@@ -215,6 +229,12 @@ properties:
             immutable: true
             description: |-
               Email address of the service account that will be used on VM instances used to support this config. This service account must have permission to pull the specified container image. If not set, VMs will run without a service account, in which case the image must be publicly accessible.
+            default_from_api: true
+          - !ruby/object:Api::Type::Array
+            name: 'serviceAccountScopes'
+            item_type: Api::Type::String
+            description: |-
+              Scopes to grant to the service_account. Various scopes are automatically added based on feature usage. When specified, users of workstations under this configuration must have `iam.serviceAccounts.actAs` on the service account.
             default_from_api: true
           - !ruby/object:Api::Type::Integer
             name: 'poolSize'

--- a/mmv1/templates/terraform/examples/workstation_config_service_account.tf.erb
+++ b/mmv1/templates/terraform/examples/workstation_config_service_account.tf.erb
@@ -28,22 +28,28 @@ resource "google_workstations_workstation_cluster" "<%= ctx[:primary_resource_id
   }
 }
 
+resource "google_service_account" "default" {
+  provider = google-beta
+
+  account_id   = "<%= ctx[:vars]['account_id'] %>"
+  display_name = "Service Account"
+}
+
 resource "google_workstations_workstation_config" "<%= ctx[:primary_resource_id] %>" {
   provider               = google-beta
   workstation_config_id  = "<%= ctx[:vars]['workstation_config_name'] %>"
   workstation_cluster_id = google_workstations_workstation_cluster.<%= ctx[:primary_resource_id] %>.workstation_cluster_id
   location   		         = "us-central1"
 
-  idle_timeout = "600s"
-  running_timeout = "21600s"
-
-  replica_zones = ["us-central1-a", "us-central1-b"]
+  enable_audit_agent = true
 
   host {
     gce_instance {
       machine_type                = "e2-standard-4"
       boot_disk_size_gb           = 35
       disable_public_ip_addresses = true
+      service_account             = google_service_account.default.email
+      service_account_scopes      = ["https://www.googleapis.com/auth/cloud-platform"]
     }
   }
 }

--- a/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
+++ b/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
@@ -223,6 +223,81 @@ resource "google_workstations_workstation_config" "default" {
 `, context)
 }
 
+
+func TestAccWorkstationsWorkstationConfig_serviceAccount(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckWorkstationsWorkstationConfigDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkstationsWorkstationConfig_serviceAccount(context),
+			},
+			{
+				ResourceName:            "google_workstations_workstation_cluster.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag"},
+			},
+		},
+	})
+}
+
+func testAccWorkstationsWorkstationConfig_serviceAccount(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+  resource "google_compute_network" "default" {
+    provider                = google-beta
+    name                    = "tf-test-workstation-cluster%{random_suffix}"
+    auto_create_subnetworks = false
+  }
+  
+  resource "google_compute_subnetwork" "default" {
+    provider      = google-beta
+    name          = "tf-test-workstation-cluster%{random_suffix}"
+    ip_cidr_range = "10.0.0.0/24"
+    region        = "us-central1"
+    network       = google_compute_network.default.name
+  }
+  
+  resource "google_workstations_workstation_cluster" "default" {
+    provider                   = google-beta
+    workstation_cluster_id     = "tf-test-workstation-cluster%{random_suffix}"
+    network                    = google_compute_network.default.id
+    subnetwork                 = google_compute_subnetwork.default.id
+    location                   = "us-central1"
+  }
+  
+  resource "google_service_account" "default" {
+    provider = google-beta
+  
+    account_id   = "tf-test-my-account%{random_suffix}"
+    display_name = "Service Account"
+  }
+  
+  resource "google_workstations_workstation_config" "default" {
+    provider               = google-beta
+    workstation_config_id  = "tf-test-workstation-config%{random_suffix}"
+    workstation_cluster_id = google_workstations_workstation_cluster.default.workstation_cluster_id
+    location               = "us-central1"
+
+    enable_audit_agent     = true
+  
+    host {
+      gce_instance {  
+        service_account             = google_service_account.default.email
+        service_account_scopes      = ["https://www.googleapis.com/auth/cloud-platform"]
+      }
+    }
+  }
+`, context)
+}
+
 func TestAccWorkstationsWorkstationConfig_update(t *testing.T) {
 	t.Parallel()
 
@@ -387,6 +462,13 @@ resource "google_workstations_workstation_cluster" "default" {
   location                   = "us-central1"
 }
 
+resource "google_service_account" "default" {
+  provider = google-beta
+
+  account_id   = "tf-test-my-account%{random_suffix}"
+  display_name = "Service Account"
+}
+
 resource "google_workstations_workstation_config" "default" {
   provider               = google-beta
   workstation_config_id  = "tf-test-workstation-config%{random_suffix}"
@@ -399,6 +481,7 @@ resource "google_workstations_workstation_config" "default" {
       boot_disk_size_gb           = 35
       pool_size                   = 0
 
+      service_account             = google_service_account.default.email
       disable_public_ip_addresses = false
 
       shielded_instance_config {


### PR DESCRIPTION
fixes: b/274485263, b/296077546, b/286299420

This change updates  `google_workstations_workstation_config`  with three fields that are supported by the cloud workstations api.

-   `enableAuditAgent`  can now be specified to enable auditd logging
-   `replicaZones`  can now be set on create
-   `host.gceInstance.serviceAccountScopes`  can now be specified

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [make test and make lint](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.


**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
workstations: added `replica_zones`, `service_account_scopes`, and `enable_audit_agent` to `google_workstations_workstation_config` (beta)
```
