### PR TITLE
SecretManager Secret: Prevent recreation for "automatic" to "auto"

### DIFF
--- a/mmv1/products/secretmanager/Secret.yaml
+++ b/mmv1/products/secretmanager/Secret.yaml
@@ -49,6 +49,8 @@ examples:
 import_format: ['projects/{{project}}/secrets/{{secret_id}}']
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   pre_update: templates/terraform/pre_update/secret_manager_secret.go.erb
+  constants:  templates/terraform/constants/secret_manager_secret.go
+custom_diff: ['secretManagerSecretAutoCustomizeDiff']
 parameters:
   - !ruby/object:Api::Type::String
     name: secretId
@@ -125,7 +127,8 @@ properties:
     properties:
       - !ruby/object:Api::Type::Boolean
         name: automatic
-        immutable: true
+        # Immutability is handled by the custom diff function until "automatic" is removed
+        # immutable: true
         exactly_one_of:
           - replication.0.automatic
           - replication.0.user_managed
@@ -137,7 +140,8 @@ properties:
       - !ruby/object:Api::Type::NestedObject
         name: auto
         api_name: automatic
-        immutable: true
+        # Immutability is handled by the custom diff function until "automatic" is removed
+        # immutable: true
         exactly_one_of:
           - replication.0.automatic
           - replication.0.user_managed

--- a/mmv1/products/secretmanager/Secret.yaml
+++ b/mmv1/products/secretmanager/Secret.yaml
@@ -49,7 +49,7 @@ examples:
 import_format: ['projects/{{project}}/secrets/{{secret_id}}']
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   pre_update: templates/terraform/pre_update/secret_manager_secret.go.erb
-  constants:  templates/terraform/constants/secret_manager_secret.go
+  constants: templates/terraform/constants/secret_manager_secret.go
 custom_diff: ['secretManagerSecretAutoCustomizeDiff']
 parameters:
   - !ruby/object:Api::Type::String

--- a/mmv1/templates/terraform/constants/secret_manager_secret.go
+++ b/mmv1/templates/terraform/constants/secret_manager_secret.go
@@ -1,0 +1,25 @@
+// Prevent ForceNew when upgrading replication.automatic -> replication.auto
+func secretManagerSecretAutoCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+	oAutomatic, nAutomatic := diff.GetChange("replication.0.automatic")
+	_, nAuto := diff.GetChange("replication.0.auto")
+	autoLen := len(nAuto.([]interface{}))
+
+	// Do not ForceNew if we are removing "automatic" while adding "auto"
+	if oAutomatic == true && nAutomatic == false && autoLen > 0 {
+		return nil
+	}
+
+	if diff.HasChange("replication.0.automatic") {
+		if err := diff.ForceNew("replication.0.automatic"); err != nil {
+			return err
+		}
+	}
+
+	if diff.HasChange("replication.0.auto") {
+		if err := diff.ForceNew("replication.0.auto"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
fixes https://github.com/hashicorp/terraform-provider-google/issues/15885

Creates a custom diff that prevents immutability when following upgrade guide steps for `replication.auto`
Things to note:

- Does not prevent the reverse: removing "auto" and adding "automatic"
- Updating to an empty `auto {}` still calls the API with a trivial PATCH request.

Tested manually with local provider.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
secretmanager: fixed an issue in `google_secretmanager_secret` where replacing `replication.automatic` with `replication.auto` would destroy and recreate the resource
```
