### PR TITLE
Update Instance.yaml to remove LOOKER_MODELER edition

### DIFF
--- a/mmv1/products/looker/Instance.yaml
+++ b/mmv1/products/looker/Instance.yaml
@@ -344,14 +344,12 @@ properties:
       - LOOKER_CORE_STANDARD_ANNUAL: subscription standard instance
       - LOOKER_CORE_ENTERPRISE_ANNUAL: subscription enterprise instance
       - LOOKER_CORE_EMBED_ANNUAL: subscription embed instance
-      - LOOKER_MODELER: standalone modeling service
     values:
       - :LOOKER_CORE_TRIAL
       - :LOOKER_CORE_STANDARD
       - :LOOKER_CORE_STANDARD_ANNUAL
       - :LOOKER_CORE_ENTERPRISE_ANNUAL
       - :LOOKER_CORE_EMBED_ANNUAL
-      - :LOOKER_MODELER
     default_value: :LOOKER_CORE_TRIAL
     immutable: true
   - !ruby/object:Api::Type::Boolean


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fixes https://github.com/hashicorp/terraform-provider-google/issues/15923

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
looker: removed `LOOKER_MODELER` as a possible value in `google_looker_instance. platform_edition`
```
