### PR TITLE
Comment out PF provider config test that's affected by ADCs in our CI

### DIFF
--- a/mmv1/third_party/terraform/fwtransport/framework_config_test.go.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config_test.go.erb
@@ -335,61 +335,63 @@ func TestFrameworkProvider_LoadAndValidateFramework_credentials(t *testing.T) {
 	}
 }
 
-func TestFrameworkProvider_LoadAndValidateFramework_credentials_unknown(t *testing.T) {
-	// This test case is kept separate from other credentials tests, as it requires comparing
-	// error messages returned by two different error states:
-	// - When credentials = Null
-	// - When credentials = Unknown
+// NOTE: these tests can't run in Cloud Build due to ADC locating credentials despite `GOOGLE_APPLICATION_CREDENTIALS` being unset
+// See https://cloud.google.com/docs/authentication/application-default-credentials#search_order
+// Also, when running these tests locally you need to run `gcloud auth application-default revoke` to ensure your machine isn't supplying ADCs
+// func TestFrameworkProvider_LoadAndValidateFramework_credentials_unknown(t *testing.T) {
+// 	// This test case is kept separate from other credentials tests, as it requires comparing
+// 	// error messages returned by two different error states:
+// 	// - When credentials = Null
+// 	// - When credentials = Unknown
 
-	t.Run("the same error is returned whether credentials is set as a null or unknown value (and access_token isn't set)", func(t *testing.T) {
+// 	t.Run("the same error is returned whether credentials is set as a null or unknown value (and access_token isn't set)", func(t *testing.T) {
+// 		// Arrange
+// 		acctest.UnsetTestProviderConfigEnvs(t)
 
-		// Arrange
-		acctest.UnsetTestProviderConfigEnvs(t)
+// 		ctx := context.Background()
+// 		tfVersion := "foobar"
+// 		providerversion := "999"
 
-		ctx := context.Background()
-		tfVersion := "foobar"
-		providerversion := "999"
+// 		impersonateServiceAccountDelegates, _ := types.ListValue(types.StringType, []attr.Value{}) // empty list
 
-		impersonateServiceAccountDelegates, _ := types.ListValue(types.StringType, []attr.Value{}) // empty list
+// 		// Null data and error collection
+// 		diagsNull := diag.Diagnostics{}
+// 		dataNull := fwmodels.ProviderModel{
+// 			Credentials: types.StringNull(),
+// 		}
+// 		dataNull.ImpersonateServiceAccountDelegates = impersonateServiceAccountDelegates
 
-		// Null data and error collection
-		diagsNull := diag.Diagnostics{}
-		dataNull := fwmodels.ProviderModel{
-			Credentials: types.StringNull(),
-		}
-		dataNull.ImpersonateServiceAccountDelegates = impersonateServiceAccountDelegates
+// 		// Unknown data and error collection
+// 		diagsUnknown := diag.Diagnostics{}
+// 		dataUnknown := fwmodels.ProviderModel{
+// 			Credentials: types.StringUnknown(),
+// 		}
+// 		dataUnknown.ImpersonateServiceAccountDelegates = impersonateServiceAccountDelegates
 
-		// Unknown data and error collection
-		diagsUnknown := diag.Diagnostics{}
-		dataUnknown := fwmodels.ProviderModel{
-			Credentials: types.StringUnknown(),
-		}
-		dataUnknown.ImpersonateServiceAccountDelegates = impersonateServiceAccountDelegates
+// 		pNull := fwtransport.FrameworkProviderConfig{}
+// 		pUnknown := fwtransport.FrameworkProviderConfig{}
 
-		pNull := fwtransport.FrameworkProviderConfig{}
-		pUnknown := fwtransport.FrameworkProviderConfig{}
+// 		// Act
+// 		pNull.LoadAndValidateFramework(ctx, &dataNull, tfVersion, &diagsNull, providerversion)
+// 		pUnknown.LoadAndValidateFramework(ctx, &dataUnknown, tfVersion, &diagsUnknown, providerversion)
 
-		// Act
-		pNull.LoadAndValidateFramework(ctx, &dataNull, tfVersion, &diagsNull, providerversion)
-		pUnknown.LoadAndValidateFramework(ctx, &dataUnknown, tfVersion, &diagsUnknown, providerversion)
+// 		// Assert
+// 		if !diagsNull.HasError() {
+// 			t.Fatalf("expect errors when credentials is null, but [%d] errors occurred", diagsNull.ErrorsCount())
+// 		}
+// 		if !diagsUnknown.HasError() {
+// 			t.Fatalf("expect errors when credentials is unknown, but [%d] errors occurred", diagsUnknown.ErrorsCount())
+// 		}
 
-		// Assert
-		if !diagsNull.HasError() {
-			t.Fatalf("expect errors when credentials is null, but [%d] errors occurred", diagsNull.ErrorsCount())
-		}
-		if !diagsUnknown.HasError() {
-			t.Fatalf("expect errors when credentials is unknown, but [%d] errors occurred", diagsUnknown.ErrorsCount())
-		}
-
-		errNull := diagsNull.Errors()
-		errUnknown := diagsUnknown.Errors()
-		for i := 0; i < len(errNull); i++ {
-			if errNull[i] != errUnknown[i] {
-				t.Fatalf("expect errors to be the same for null and unknown credentials values, instead got \nnull=`%s` \nunknown=%s", errNull[i], errUnknown[i])
-			}
-		}
-	})
-}
+// 		errNull := diagsNull.Errors()
+// 		errUnknown := diagsUnknown.Errors()
+// 		for i := 0; i < len(errNull); i++ {
+// 			if errNull[i] != errUnknown[i] {
+// 				t.Fatalf("expect errors to be the same for null and unknown credentials values, instead got \nnull=`%s` \nunknown=%s", errNull[i], errUnknown[i])
+// 			}
+// 		}
+// 	})
+// }
 
 func TestFrameworkProvider_LoadAndValidateFramework_billingProject(t *testing.T) {
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The test passes but relies on an environment without ADCs, and it's not possible to remove ADCs in the CI

This issue was not picked up by checks on the PR introducing the test: https://github.com/GoogleCloudPlatform/magic-modules/pull/8943

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
