### PR TITLE
improve autoscaling_policy support in google_compute_node_group

### DIFF
--- a/mmv1/products/compute/NodeGroup.yaml
+++ b/mmv1/products/compute/NodeGroup.yaml
@@ -16,10 +16,11 @@ name: 'NodeGroup'
 kind: 'compute#NodeGroup'
 base_url: projects/{{project}}/zones/{{zone}}/nodeGroups
 create_url: projects/{{project}}/zones/{{zone}}/nodeGroups?initialNodeCount=PRE_CREATE_REPLACE_ME
+update_verb: :PATCH
+update_mask: true
 has_self_link: true
 description: |
   Represents a NodeGroup resource to manage a group of sole-tenant nodes.
-immutable: true
 references: !ruby/object:Api::Resource::ReferenceLinks
   guides:
     'Sole-Tenant Nodes': 'https://cloud.google.com/compute/docs/nodes/'
@@ -43,12 +44,6 @@ async: !ruby/object:Api::OpAsync
   error: !ruby/object:Api::OpAsync::Error
     path: 'error/errors'
     message: 'message'
-docs: !ruby/object:Provider::Terraform::Docs
-  warning: |
-    Due to limitations of the API, Terraform cannot update the
-    number of nodes in a node group and changes to node group size either
-    through Terraform config or through external changes will cause
-    Terraform to delete and recreate the node group.
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'node_group_basic'
@@ -112,21 +107,13 @@ properties:
   - !ruby/object:Api::Type::Integer
     name: 'size'
     description: |
-      The total number of nodes in the node group. One of `initial_size` or `size` must be specified.
-    immutable: true
-    send_empty_value: true
-    default_from_api: true
-    exactly_one_of:
-      - size
-      - initial_size
+      The total number of nodes in the node group.
+    output: true
   - !ruby/object:Api::Type::Integer
     name: 'initialSize'
     description: |
-      The initial number of nodes in the node group. One of `initial_size` or `size` must be specified.
+      The initial number of nodes in the node group. One of `initial_size` or `autoscaling_policy` must be configured on resource creation.
     url_param_only: true
-    exactly_one_of:
-      - size
-      - initial_size
   - !ruby/object:Api::Type::String
     name: 'maintenancePolicy'
     description: |
@@ -147,6 +134,8 @@ properties:
     description: |
       If you use sole-tenant nodes for your workloads, you can use the node
       group autoscaler to automatically manage the sizes of your node groups.
+
+      One of `initial_size` or `autoscaling_policy` must be configured on resource creation.
     default_from_api: true
     properties:
       - !ruby/object:Api::Type::Enum

--- a/mmv1/templates/terraform/examples/node_group_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/node_group_basic.tf.erb
@@ -9,6 +9,6 @@ resource "google_compute_node_group" "<%= ctx[:primary_resource_id] %>" {
   zone        = "us-central1-f"
   description = "example google_compute_node_group for Terraform Google Provider"
 
-  size          = 1
+  initial_size          = 1
   node_template = google_compute_node_template.soletenant-tmpl.id
 }

--- a/mmv1/templates/terraform/examples/node_group_share_settings.tf.erb
+++ b/mmv1/templates/terraform/examples/node_group_share_settings.tf.erb
@@ -15,7 +15,7 @@ resource "google_compute_node_group" "<%= ctx[:primary_resource_id] %>" {
   zone        = "us-central1-f"
   description = "example google_compute_node_group for Terraform Google Provider"
 
-  size          = 1
+  initial_size          = 1
   node_template = google_compute_node_template.soletenant-tmpl.id
 
   share_settings {

--- a/mmv1/templates/terraform/pre_create/compute_node_group_url_replace.go.erb
+++ b/mmv1/templates/terraform/pre_create/compute_node_group_url_replace.go.erb
@@ -1,8 +1,12 @@
 var sizeParam string
-if v, ok := d.GetOkExists("size"); ok {
+if v, ok := d.GetOkExists("initial_size"); ok {
 	sizeParam = fmt.Sprintf("%v", v)
-} else if v, ok := d.GetOkExists("initial_size"); ok {
-	sizeParam = fmt.Sprintf("%v", v)
+}else{
+	if _, ok := d.GetOkExists("autoscaling_policy"); ok{
+		sizeParam = fmt.Sprintf("%v", d.Get("autoscaling_policy.min_nodes"))
+	}else{
+		return errors.New("An initial_size or autoscaling_policy must be configured on node group creation.")
+	}
 }
 
 url = regexp.MustCompile("PRE_CREATE_REPLACE_ME").ReplaceAllLiteralString(url, sizeParam)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -5996,7 +5996,7 @@ resource "google_compute_node_group" "nodes" {
   name = "%s"
   zone = "us-central1-a"
 
-  size          = 1
+  initial_size          = 1
   node_template = google_compute_node_template.nodetmpl.self_link
 }
 `, instance, nodeTemplate, nodeGroup)
@@ -6065,7 +6065,7 @@ resource "google_compute_node_group" "nodes" {
   name = "%s"
   zone = "us-central1-a"
 
-  size          = 1
+  initial_size          = 1
   node_template = google_compute_node_template.nodetmpl.self_link
 }
 `, instance, nodeTemplate, nodeGroup)
@@ -6134,7 +6134,7 @@ resource "google_compute_node_group" "nodes" {
   name = "%s"
   zone = "us-central1-a"
 
-  size          = 1
+  initial_size          = 1
   node_template = google_compute_node_template.nodetmpl.self_link
 }
 `, instance, nodeTemplate, nodeGroup)
@@ -6197,7 +6197,7 @@ resource "google_compute_node_group" "nodes" {
   name = "%s"
   zone = "us-central1-a"
 
-  size          = 1
+  initial_size          = 1
   node_template = google_compute_node_template.nodetmpl.self_link
 }
 `, instance, nodeTemplate, nodeGroup)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_node_group_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_node_group_test.go.erb
@@ -61,20 +61,18 @@ func TestAccComputeNodeGroup_fail(t *testing.T) {
 	groupName := fmt.Sprintf("group--%d", acctest.RandInt(t))
 	tmplPrefix := fmt.Sprintf("tmpl--%d", acctest.RandInt(t))
 
-	var timeCreated time.Time
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeNodeGroupDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeNodeGroup_fail(groupName, tmplPrefix, "tmpl1"),
+				Config:      testAccComputeNodeGroup_fail(groupName, tmplPrefix, "tmpl1"),
 				ExpectError: regexp.MustCompile("An initial_size or autoscaling_policy must be configured on node group creation."),
 			},
 		},
 	})
 }
-
 
 func testAccCheckComputeNodeGroupCreationTimeBefore(prevTimeCreated *time.Time) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -167,7 +165,7 @@ resource "google_compute_node_group" "nodes" {
 `, tmplPrefix, tmplPrefix, groupName, tmplToUse)
 }
 
-func testAccComputeNodeGroup_update(groupName, tmplPrefix, tmplToUse string) string {
+func testAccComputeNodeGroup_fail(groupName, tmplPrefix, tmplToUse string) string {
 	return fmt.Sprintf(`
 resource "google_compute_node_template" "tmpl1" {
   name      = "%s-first"
@@ -183,5 +181,5 @@ resource "google_compute_node_group" "nodes" {
   node_template = google_compute_node_template.%s.self_link
 }
 
-`, tmplPrefix, tmplPrefix, groupName, tmplToUse)
+`, tmplPrefix, groupName, tmplToUse)
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_node_group_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_node_group_test.go.erb
@@ -8,12 +8,14 @@ import (
 	"strings"
 	"time"
 
+	"regexp"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 )
 
-func TestAccComputeNodeGroup_updateNodeTemplate(t *testing.T) {
+func TestAccComputeNodeGroup_update(t *testing.T) {
 	t.Parallel()
 
 	groupName := fmt.Sprintf("group--%d", acctest.RandInt(t))
@@ -26,30 +28,53 @@ func TestAccComputeNodeGroup_updateNodeTemplate(t *testing.T) {
 		CheckDestroy:             testAccCheckComputeNodeGroupDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeNodeGroup_updateNodeTemplate(groupName, tmplPrefix, "tmpl1"),
+				Config: testAccComputeNodeGroup_update(groupName, tmplPrefix, "tmpl1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeNodeGroupCreationTimeBefore(&timeCreated),
 				),
 			},
 			{
-				ResourceName:      "google_compute_node_group.nodes",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_node_group.nodes",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"initial_size"},
 			},
 			{
-				Config: testAccComputeNodeGroup_updateNodeTemplate(groupName, tmplPrefix, "tmpl2"),
+				Config: testAccComputeNodeGroup_update2(groupName, tmplPrefix, "tmpl2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeNodeGroupCreationTimeBefore(&timeCreated),
 				),
 			},
 			{
-				ResourceName:      "google_compute_node_group.nodes",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_node_group.nodes",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"initial_size"},
 			},
 		},
 	})
 }
+
+func TestAccComputeNodeGroup_fail(t *testing.T) {
+	t.Parallel()
+
+	groupName := fmt.Sprintf("group--%d", acctest.RandInt(t))
+	tmplPrefix := fmt.Sprintf("tmpl--%d", acctest.RandInt(t))
+
+	var timeCreated time.Time
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeNodeGroupDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeNodeGroup_fail(groupName, tmplPrefix, "tmpl1"),
+				ExpectError: regexp.MustCompile("An initial_size or autoscaling_policy must be configured on node group creation."),
+			},
+		},
+	})
+}
+
 
 func testAccCheckComputeNodeGroupCreationTimeBefore(prevTimeCreated *time.Time) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -86,7 +111,7 @@ func testAccCheckComputeNodeGroupCreationTimeBefore(prevTimeCreated *time.Time) 
 	}
 }
 
-func testAccComputeNodeGroup_updateNodeTemplate(groupName, tmplPrefix, tmplToUse string) string {
+func testAccComputeNodeGroup_update(groupName, tmplPrefix, tmplToUse string) string {
 	return fmt.Sprintf(`
 resource "google_compute_node_template" "tmpl1" {
   name      = "%s-first"
@@ -105,8 +130,58 @@ resource "google_compute_node_group" "nodes" {
   zone        = "us-central1-a"
   description = "example google_compute_node_group for Terraform Google Provider"
 
-  size          = 0
+  initial_size = 1
   node_template = google_compute_node_template.%s.self_link
 }
+
+`, tmplPrefix, tmplPrefix, groupName, tmplToUse)
+}
+
+func testAccComputeNodeGroup_update2(groupName, tmplPrefix, tmplToUse string) string {
+	return fmt.Sprintf(`
+resource "google_compute_node_template" "tmpl1" {
+  name      = "%s-first"
+  region    = "us-central1"
+  node_type = "n1-node-96-624"
+}
+
+resource "google_compute_node_template" "tmpl2" {
+  name      = "%s-second"
+  region    = "us-central1"
+  node_type = "n1-node-96-624"
+}
+
+resource "google_compute_node_group" "nodes" {
+  name        = "%s"
+  zone        = "us-central1-a"
+  description = "example google_compute_node_group for Terraform Google Provider"
+
+  autoscaling_policy {
+    mode      = "ONLY_SCALE_OUT"
+    min_nodes = 1
+    max_nodes = 10
+  }
+  node_template = google_compute_node_template.%s.self_link
+}
+
+`, tmplPrefix, tmplPrefix, groupName, tmplToUse)
+}
+
+func testAccComputeNodeGroup_update(groupName, tmplPrefix, tmplToUse string) string {
+	return fmt.Sprintf(`
+resource "google_compute_node_template" "tmpl1" {
+  name      = "%s-first"
+  region    = "us-central1"
+  node_type = "n1-node-96-624"
+}
+
+resource "google_compute_node_group" "nodes" {
+  name        = "%s"
+  zone        = "us-central1-a"
+  description = "example google_compute_node_group for Terraform Google Provider"
+
+  node_template = google_compute_node_template.%s.self_link
+}
+
 `, tmplPrefix, tmplPrefix, groupName, tmplToUse)
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -7963,7 +7963,7 @@ resource "google_compute_node_group" "group" {
   zone        = "us-central1-f"
   description = "example google_compute_node_group for Terraform Google Provider"
 
-  size          = 1
+  initial_size	= 1
   node_template = google_compute_node_template.soletenant-tmpl.id
 }
 

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -3246,7 +3246,7 @@ resource "google_compute_node_template" "soletenant-tmpl" {
 resource "google_compute_node_group" "nodes" {
   name        = "tf-test-soletenant-group"
   zone        = "us-central1-a"
-  size          = 1
+  initial_size	= 1
   node_template = google_compute_node_template.soletenant-tmpl.id
 }
 

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
@@ -1397,7 +1397,7 @@ resource "google_compute_node_group" "nodes" {
   name = "test-nodegroup-%s"
   zone = "us-central1-f"
 
-  size          = 3
+  initial_size	= 3
   node_template = google_compute_node_template.nodetmpl.self_link
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/13928

* `node_group` is now mutable
* Size is now an output only field
* `inital_size` or `autoscaling_policy` must be configured on resource creation

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
compute: `size` in `google_compute_node_group` is now an output only field. 
```
```release-note:enhancement
compute: `google_compute_node_group` made mutable
```
```release-note:note
compute: `google_compute_node_group` made to require one of `initial_size` or `autoscaling_policy` fields configured upon resource creation
```
