### PR TITLE
Add support for remote OS repositories to Artifact Registry

### DIFF
--- a/mmv1/products/artifactregistry/Repository.yaml
+++ b/mmv1/products/artifactregistry/Repository.yaml
@@ -83,6 +83,18 @@ examples:
       repository_id: 'my-repository'
       description: 'example remote docker repository'
   - !ruby/object:Provider::Terraform::Examples
+    name: 'artifact_registry_repository_remote_apt'
+    primary_resource_id: 'my-repo'
+    vars:
+      repository_id: 'debian-buster'
+      description: 'example remote apt repository'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'artifact_registry_repository_remote_yum'
+    primary_resource_id: 'my-repo'
+    vars:
+      repository_id: 'centos-8'
+      description: 'example remote yum repository'
+  - !ruby/object:Provider::Terraform::Examples
     name: 'artifact_registry_repository_cleanup'
     min_version: beta
     primary_resource_id: 'my-repo'
@@ -329,12 +341,48 @@ properties:
           The description of the remote source.
         immutable: true
       - !ruby/object:Api::Type::NestedObject
-        name: 'dockerRepository'
+        name: 'aptRepository'
         exactly_one_of:
+          - remoteRepositoryConfig.0.apt_repository
           - remoteRepositoryConfig.0.docker_repository
           - remoteRepositoryConfig.0.maven_repository
           - remoteRepositoryConfig.0.npm_repository
           - remoteRepositoryConfig.0.python_repository
+          - remoteRepositoryConfig.0.yum_repository
+        description: |-
+          Specific settings for an Apt remote repository.
+        immutable: true
+        properties:
+          - !ruby/object:Api::Type::NestedObject
+            name: 'publicRepository'
+            description: |-
+              One of the publicly available Apt repositories supported by Artifact Registry.
+            immutable: true
+            properties:
+              - !ruby/object:Api::Type::Enum
+                name: 'repositoryBase'
+                required: true
+                description: |-
+                  A common public repository base for Apt, e.g. `"debian/dists/buster"`
+                immutable: true
+                values:
+                  - :DEBIAN
+                  - :UBUNTU
+              - !ruby/object:Api::Type::String
+                name: 'repositoryPath'
+                required: true
+                description: |-
+                  Specific repository from the base.
+                immutable: true
+      - !ruby/object:Api::Type::NestedObject
+        name: 'dockerRepository'
+        exactly_one_of:
+          - remoteRepositoryConfig.0.apt_repository
+          - remoteRepositoryConfig.0.docker_repository
+          - remoteRepositoryConfig.0.maven_repository
+          - remoteRepositoryConfig.0.npm_repository
+          - remoteRepositoryConfig.0.python_repository
+          - remoteRepositoryConfig.0.yum_repository
         description: |-
           Specific settings for a Docker remote repository.
         immutable: true
@@ -352,10 +400,12 @@ properties:
       - !ruby/object:Api::Type::NestedObject
         name: 'mavenRepository'
         exactly_one_of:
+          - remoteRepositoryConfig.0.apt_repository
           - remoteRepositoryConfig.0.docker_repository
           - remoteRepositoryConfig.0.maven_repository
           - remoteRepositoryConfig.0.npm_repository
           - remoteRepositoryConfig.0.python_repository
+          - remoteRepositoryConfig.0.yum_repository
         description: |-
           Specific settings for a Maven remote repository.
         immutable: true
@@ -373,10 +423,12 @@ properties:
       - !ruby/object:Api::Type::NestedObject
         name: 'npmRepository'
         exactly_one_of:
+          - remoteRepositoryConfig.0.apt_repository
           - remoteRepositoryConfig.0.docker_repository
           - remoteRepositoryConfig.0.maven_repository
           - remoteRepositoryConfig.0.npm_repository
           - remoteRepositoryConfig.0.python_repository
+          - remoteRepositoryConfig.0.yum_repository
         description: |-
           Specific settings for an Npm remote repository.
         immutable: true
@@ -394,10 +446,12 @@ properties:
       - !ruby/object:Api::Type::NestedObject
         name: 'pythonRepository'
         exactly_one_of:
+          - remoteRepositoryConfig.0.apt_repository
           - remoteRepositoryConfig.0.docker_repository
           - remoteRepositoryConfig.0.maven_repository
           - remoteRepositoryConfig.0.npm_repository
           - remoteRepositoryConfig.0.python_repository
+          - remoteRepositoryConfig.0.yum_repository
         description: |-
           Specific settings for a Python remote repository.
         immutable: true
@@ -412,6 +466,45 @@ properties:
             values:
               - :PYPI
             default_value: :PYPI
+      - !ruby/object:Api::Type::NestedObject
+        name: 'yumRepository'
+        exactly_one_of:
+          - remoteRepositoryConfig.0.apt_repository
+          - remoteRepositoryConfig.0.docker_repository
+          - remoteRepositoryConfig.0.maven_repository
+          - remoteRepositoryConfig.0.npm_repository
+          - remoteRepositoryConfig.0.python_repository
+          - remoteRepositoryConfig.0.yum_repository
+        description: |-
+          Specific settings for an Yum remote repository.
+        immutable: true
+        properties:
+          - !ruby/object:Api::Type::NestedObject
+            name: 'publicRepository'
+            description: |-
+              One of the publicly available Yum repositories supported by Artifact Registry.
+            immutable: true
+            properties:
+              - !ruby/object:Api::Type::Enum
+                name: 'repositoryBase'
+                required: true
+                description: |-
+                  A common public repository base for Yum.
+                immutable: true
+                values:
+                  - :CENTOS
+                  - :CENTOS_DEBUG
+                  - :CENTOS_VAULT
+                  - :CENTOS_STREAM
+                  - :ROCKY
+                  - :EPEL
+              - !ruby/object:Api::Type::String
+                name: 'repositoryPath'
+                required: true
+                description: |-
+                  Specific repository from the base, e.g. `"8-stream/BaseOs/x86_64/os"`
+                immutable: true
+
   - !ruby/object:Api::Type::Boolean
     name: 'cleanupPolicyDryRun'
     min_version: beta

--- a/mmv1/templates/terraform/examples/artifact_registry_repository_remote_apt.tf.erb
+++ b/mmv1/templates/terraform/examples/artifact_registry_repository_remote_apt.tf.erb
@@ -1,0 +1,16 @@
+resource "google_artifact_registry_repository" "<%= ctx[:primary_resource_id] %>" {
+  location      = "us-central1"
+  repository_id = "<%= ctx[:vars]['repository_id'] %>"
+  description   = "<%= ctx[:vars]['description'] %>"
+  format        = "APT"
+  mode          = "REMOTE_REPOSITORY"
+  remote_repository_config {
+    description = "Debian buster remote repository"
+    apt_repository {
+      public_repository {
+        repository_base = "DEBIAN"
+        repository_path = "debian/dists/buster"
+      }
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/artifact_registry_repository_remote_yum.tf.erb
+++ b/mmv1/templates/terraform/examples/artifact_registry_repository_remote_yum.tf.erb
@@ -1,0 +1,16 @@
+resource "google_artifact_registry_repository" "<%= ctx[:primary_resource_id] %>" {
+  location      = "us-central1"
+  repository_id = "<%= ctx[:vars]['repository_id'] %>"
+  description   = "<%= ctx[:vars]['description'] %>"
+  format        = "YUM"
+  mode          = "REMOTE_REPOSITORY"
+  remote_repository_config {
+    description = "Centos 8 remote repository"
+    yum_repository {
+      public_repository {
+        repository_base = "CENTOS"
+        repository_path = "8-stream/BaseOs/x86_64/os"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds support for remote APT and YUM repositories to Artifact Registry.

Fixes hashicorp/terraform-provider-google#15703

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
artifactregistry: added support for remote APT and YUM repositories to `google_artifact_registry_repository` 
```
