### PR TITLE
Upgrade guide: Add guidance for removing empty strings from `provider` blocks

### DIFF
--- a/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
@@ -118,6 +118,21 @@ The new annotations model is similar to the new labels model and will be applied
 
 There are now two annotation-related fields with the new model, the `annotations` and the output-only `effective_annotations` fields.
 
+### Updates to how empty strings are handled in the `provider` block
+
+In 5.0.0+ any empty strings set in the `provider` block will be used and not ignored. Previously any empty strings used as arguments in the `provider` block were ignored and did not contribute to configuration of the provider. 
+
+Users should remove empty string arguments to avoid errors during plan/apply stages.
+
+```diff
+provider "google" {
+-  credentials = ""
+  project = "my-project"
+  region = "us-central1"
+-  zone = ""
+}
+```
+
 ### Changes to how default `location`, `region` and `zone` values are obtained for resources
 
 Currently, when configuring resources that require a `location`, `region` or `zone` field you have the choice of specifying it in the resource block or allowing default values to be used. Default [region](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#region) or [zone](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#zone) values can be configured in the provider block or by providing values through environment variables.

--- a/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
@@ -124,12 +124,12 @@ In 5.0.0+ any empty strings set in the `provider` block will be used and not ign
 
 Users should remove empty string arguments to avoid errors during plan/apply stages.
 
-```diff
+```tf
 provider "google" {
--  credentials = ""
+  credentials = "" # this line should be removed
   project = "my-project"
   region = "us-central1"
--  zone = ""
+  zone = "" # this line should be removed
 }
 ```
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This guide accompanies https://github.com/GoogleCloudPlatform/magic-modules/pull/9014

I put this new section below the section on default labels, as both involve users editing the `provider` block.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
