### PR TITLE
Add validation to provider fields in both SDK and PF implementations of provider schema

### DIFF
--- a/mmv1/third_party/terraform/fwprovider/framework_provider.go.erb
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider.go.erb
@@ -71,6 +71,7 @@ func (p *FrameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
                         path.MatchRoot("access_token"),
                     }...),
                     CredentialsValidator(),
+                    NonEmptyStringValidator(),
                 },
             },
             "access_token": schema.StringAttribute{
@@ -79,10 +80,14 @@ func (p *FrameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
                     stringvalidator.ConflictsWith(path.Expressions{
                         path.MatchRoot("credentials"),
                     }...),
+                    NonEmptyStringValidator(),
                 },
             },
             "impersonate_service_account": schema.StringAttribute{
                 Optional: true,
+                Validators: []validator.String{
+                    NonEmptyStringValidator(),
+                },
             },
             "impersonate_service_account_delegates": schema.ListAttribute{
                 Optional:    true,
@@ -90,15 +95,27 @@ func (p *FrameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
             },
             "project": schema.StringAttribute{
                 Optional: true,
+                Validators: []validator.String{
+                    NonEmptyStringValidator(),
+                },
             },
             "billing_project": schema.StringAttribute{
                 Optional: true,
+                Validators: []validator.String{
+                    NonEmptyStringValidator(),
+                },
             },
             "region": schema.StringAttribute{
                 Optional: true,
+                Validators: []validator.String{
+                    NonEmptyStringValidator(),
+                },
             },
             "zone": schema.StringAttribute{
                 Optional: true,
+                Validators: []validator.String{
+                    NonEmptyStringValidator(),
+                },
             },
             "scopes": schema.ListAttribute{
                 Optional:    true,

--- a/mmv1/third_party/terraform/fwprovider/framework_validators.go
+++ b/mmv1/third_party/terraform/fwprovider/framework_validators.go
@@ -84,3 +84,34 @@ func (v nonnegativedurationValidator) ValidateString(ctx context.Context, reques
 func NonNegativeDurationValidator() validator.String {
 	return nonnegativedurationValidator{}
 }
+
+// Non Empty String Validator
+type nonEmptyStringValidator struct {
+}
+
+// Description describes the validation in plain text formatting.
+func (v nonEmptyStringValidator) Description(_ context.Context) string {
+	return "value expected to be a string that isn't an empty string"
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (v nonEmptyStringValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// ValidateString performs the validation.
+func (v nonEmptyStringValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := request.ConfigValue.ValueString()
+
+	if value == "" {
+		response.Diagnostics.AddError("please provide a value that isn't an empty string to this field", fmt.Sprintf("%s was set to `%s`", request.Path, value))
+	}
+}
+
+func NonEmptyStringValidator() validator.String {
+	return nonEmptyStringValidator{}
+}

--- a/mmv1/third_party/terraform/fwprovider/framework_validators.go
+++ b/mmv1/third_party/terraform/fwprovider/framework_validators.go
@@ -108,7 +108,7 @@ func (v nonEmptyStringValidator) ValidateString(ctx context.Context, request val
 	value := request.ConfigValue.ValueString()
 
 	if value == "" {
-		response.Diagnostics.AddError("please provide a value that isn't an empty string to this field", fmt.Sprintf("%s was set to `%s`", request.Path, value))
+		response.Diagnostics.AddError("expected a non-empty string", fmt.Sprintf("%s was set to `%s`", request.Path, value))
 	}
 }
 

--- a/mmv1/third_party/terraform/provider/provider.go.erb
+++ b/mmv1/third_party/terraform/provider/provider.go.erb
@@ -58,21 +58,23 @@ func Provider() *schema.Provider {
 	provider := &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"credentials": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ValidateFunc: ValidateCredentials,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ValidateFunc:  ValidateCredentials,
 				ConflictsWith: []string{"access_token"},
 			},
 
 			"access_token": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ValidateFunc:  ValidateEmptyStrings,
 				ConflictsWith: []string{"credentials"},
 			},
 
 			"impersonate_service_account": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: ValidateEmptyStrings,
 			},
 
 			"impersonate_service_account_delegates": {
@@ -82,23 +84,27 @@ func Provider() *schema.Provider {
 			},
 
 			"project": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: ValidateEmptyStrings,
 			},
 
 			"billing_project": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: ValidateEmptyStrings,
 			},
 
 			"region": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: ValidateEmptyStrings,
 			},
 
 			"zone": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: ValidateEmptyStrings,
 			},
 
 			"scopes": {

--- a/mmv1/third_party/terraform/provider/provider.go.erb
+++ b/mmv1/third_party/terraform/provider/provider.go.erb
@@ -39,8 +39,6 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/tpgiamresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	"github.com/hashicorp/terraform-provider-google/google/verify"
-
-	googleoauth "golang.org/x/oauth2/google"
 )
 
 // Provider returns a *schema.Provider.
@@ -769,25 +767,6 @@ func ProviderConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 	}
 
 	return transport_tpg.ProviderDCLConfigure(d, &config), nil
-}
-
-func ValidateCredentials(v interface{}, k string) (warnings []string, errors []error) {
-	if v == nil || v.(string) == "" {
-		return
-	}
-	// NOTE: Above we have to allow empty string as valid because we don't know if it's a zero value or not
-
-	creds := v.(string)
-	// if this is a path and we can stat it, assume it's ok
-	if _, err := os.Stat(creds); err == nil {
-		return
-	}
-	if _, err := googleoauth.CredentialsFromJSON(context.Background(), []byte(creds)); err != nil {
-		errors = append(errors,
-			fmt.Errorf("JSON credentials are not valid: %s", err))
-	}
-
-	return
 }
 
 func mergeResourceMaps(ms ...map[string]*schema.Resource) (map[string]*schema.Resource, error) {

--- a/mmv1/third_party/terraform/provider/provider_internal_test.go
+++ b/mmv1/third_party/terraform/provider/provider_internal_test.go
@@ -42,10 +42,17 @@ func TestProvider_ValidateCredentials(t *testing.T) {
 				return string(contents)
 			},
 		},
+		"configuring credentials as an empty string is not valid": {
+			ConfigValue: func(t *testing.T) interface{} {
+				return ""
+			},
+			ExpectedErrors: []error{
+				errors.New("please provide a value that isn't an empty string to this field"),
+			},
+		},
 		"leaving credentials unconfigured is valid": {
 			ValueNotProvided: true,
 		},
-		// configuring credentials as an empty string is handled by another validator
 	}
 
 	for tn, tc := range cases {

--- a/mmv1/third_party/terraform/provider/provider_internal_test.go
+++ b/mmv1/third_party/terraform/provider/provider_internal_test.go
@@ -47,7 +47,7 @@ func TestProvider_ValidateCredentials(t *testing.T) {
 				return ""
 			},
 			ExpectedErrors: []error{
-				errors.New("please provide a value that isn't an empty string to this field"),
+				errors.New("expected a non-empty string"),
 			},
 		},
 		"leaving credentials unconfigured is valid": {
@@ -101,7 +101,7 @@ func TestProvider_ValidateEmptyStrings(t *testing.T) {
 		"empty strings are not valid": {
 			ConfigValue: "",
 			ExpectedErrors: []error{
-				errors.New("please provide a value that isn't an empty string to this field"),
+				errors.New("expected a non-empty string"),
 			},
 		},
 	}

--- a/mmv1/third_party/terraform/provider/provider_internal_test.go
+++ b/mmv1/third_party/terraform/provider/provider_internal_test.go
@@ -70,15 +70,15 @@ func TestProvider_ValidateCredentials(t *testing.T) {
 
 			// Assert
 			if len(ws) != len(tc.ExpectedWarnings) {
-				t.Errorf("Expected %d warnings, got %d: %v", len(tc.ExpectedWarnings), len(ws), ws)
+				t.Fatalf("Expected %d warnings, got %d: %v", len(tc.ExpectedWarnings), len(ws), ws)
 			}
 			if len(es) != len(tc.ExpectedErrors) {
-				t.Errorf("Expected %d errors, got %d: %v", len(tc.ExpectedErrors), len(es), es)
+				t.Fatalf("Expected %d errors, got %d: %v", len(tc.ExpectedErrors), len(es), es)
 			}
 
-			if len(tc.ExpectedErrors) > 0 {
+			if len(tc.ExpectedErrors) > 0 && len(es) > 0 {
 				if es[0].Error() != tc.ExpectedErrors[0].Error() {
-					t.Errorf("Expected first error to be \"%s\", got \"%s\"", tc.ExpectedErrors[0], es[0])
+					t.Fatalf("Expected first error to be \"%s\", got \"%s\"", tc.ExpectedErrors[0], es[0])
 				}
 			}
 		})
@@ -120,15 +120,15 @@ func TestProvider_ValidateEmptyStrings(t *testing.T) {
 
 			// Assert
 			if len(ws) != len(tc.ExpectedWarnings) {
-				t.Errorf("Expected %d warnings, got %d: %v", len(tc.ExpectedWarnings), len(ws), ws)
+				t.Fatalf("Expected %d warnings, got %d: %v", len(tc.ExpectedWarnings), len(ws), ws)
 			}
 			if len(es) != len(tc.ExpectedErrors) {
-				t.Errorf("Expected %d errors, got %d: %v", len(tc.ExpectedErrors), len(es), es)
+				t.Fatalf("Expected %d errors, got %d: %v", len(tc.ExpectedErrors), len(es), es)
 			}
 
 			if len(tc.ExpectedErrors) > 0 && len(es) > 0 {
 				if es[0].Error() != tc.ExpectedErrors[0].Error() {
-					t.Errorf("Expected first error to be \"%s\", got \"%s\"", tc.ExpectedErrors[0], es[0])
+					t.Fatalf("Expected first error to be \"%s\", got \"%s\"", tc.ExpectedErrors[0], es[0])
 				}
 			}
 		})

--- a/mmv1/third_party/terraform/provider/provider_internal_test.go
+++ b/mmv1/third_party/terraform/provider/provider_internal_test.go
@@ -42,16 +42,10 @@ func TestProvider_ValidateCredentials(t *testing.T) {
 				return string(contents)
 			},
 		},
-		// There's a risk of changing the validator to saying "" is invalid, as it may mean that
-		// everyone not using the credentials field would get validation errors.
-		"configuring credentials as an empty string is not identified as invalid by the function, as it can't distinguish from zero values ": {
-			ConfigValue: func(t *testing.T) interface{} {
-				return ""
-			},
-		},
 		"leaving credentials unconfigured is valid": {
 			ValueNotProvided: true,
 		},
+		// configuring credentials as an empty string is handled by another validator
 	}
 
 	for tn, tc := range cases {

--- a/mmv1/third_party/terraform/provider/provider_test.go.erb
+++ b/mmv1/third_party/terraform/provider/provider_test.go.erb
@@ -315,7 +315,7 @@ func TestAccProviderEmptyStrings(t *testing.T) {
 				Config:             testAccProvider_checkPlanTimeErrors(`credentials = ""`, acctest.RandString(t, 10)),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
-				ExpectError:        regexp.MustCompile(`unexpected end of JSON input`),
+				ExpectError:        regexp.MustCompile(`please provide a value that isn't an empty string to this field`),
 			},
 			// access_token as an empty string causes a validation error
 			{

--- a/mmv1/third_party/terraform/provider/provider_test.go.erb
+++ b/mmv1/third_party/terraform/provider/provider_test.go.erb
@@ -294,6 +294,75 @@ func TestAccProviderCredentialsUnknownValue(t *testing.T) {
 	})
 }
 
+func TestAccProviderEmptyStrings(t *testing.T) {
+	t.Parallel()
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		// No TestDestroy since that's not really the point of this test
+		Steps: []resource.TestStep{
+			// When no values are set in the provider block there are no errors
+			// This test case is a control to show validation doesn't accidentally flag unset fields
+			// The "" argument is a lack of key = value being passed into the provider block
+			{
+				Config:             testAccProvider_checkPlanTimeErrors("", acctest.RandString(t, 10)),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			// credentials as an empty string causes a validation error
+			{
+				Config:             testAccProvider_checkPlanTimeErrors(`credentials = ""`, acctest.RandString(t, 10)),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+				ExpectError:        regexp.MustCompile(`unexpected end of JSON input`),
+			},
+			// access_token as an empty string causes a validation error
+			{
+				Config:             testAccProvider_checkPlanTimeErrors(`access_token = ""`, acctest.RandString(t, 10)),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+				ExpectError:        regexp.MustCompile(`please provide a value that isn't an empty string to this field`),
+			},
+			// impersonate_service_account as an empty string causes a validation error
+			{
+				Config:             testAccProvider_checkPlanTimeErrors(`impersonate_service_account = ""`, acctest.RandString(t, 10)),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+				ExpectError:        regexp.MustCompile(`please provide a value that isn't an empty string to this field`),
+			},
+			// project as an empty string causes a validation error
+			{
+				Config:             testAccProvider_checkPlanTimeErrors(`project = ""`, acctest.RandString(t, 10)),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+				ExpectError:        regexp.MustCompile(`please provide a value that isn't an empty string to this field`),
+			},
+			// billing_project as an empty string causes a validation error
+			{
+				Config:             testAccProvider_checkPlanTimeErrors(`billing_project = ""`, acctest.RandString(t, 10)),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+				ExpectError:        regexp.MustCompile(`please provide a value that isn't an empty string to this field`),
+			},
+			// region as an empty string causes a validation error
+			{
+				Config:             testAccProvider_checkPlanTimeErrors(`region = ""`, acctest.RandString(t, 10)),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+				ExpectError:        regexp.MustCompile(`please provide a value that isn't an empty string to this field`),
+			},
+			// zone as an empty string causes a validation error
+			{
+				Config:             testAccProvider_checkPlanTimeErrors(`zone = ""`, acctest.RandString(t, 10)),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+				ExpectError:        regexp.MustCompile(`please provide a value that isn't an empty string to this field`),
+			},
+		},
+	})
+}
+
 func testAccProviderBasePath_setBasePath(endpoint, name string) string {
 	return fmt.Sprintf(`
 provider "google" {
@@ -540,4 +609,17 @@ resource "google_firebase_project" "this" {
     google_project_service.activate-firebase
   ]
 }`, credentials, pid, pid, pid, org, billing)
+}
+
+func testAccProvider_checkPlanTimeErrors(providerArgument, randString string) string {
+	return fmt.Sprintf(`
+provider "google" {
+	%s
+}
+
+# A random resource so that the test can generate a plan (can't check validation errors when plan is empty)
+resource "google_pubsub_topic" "example" {
+  name = "tf-test-planned-resource-%s"
+}
+`, providerArgument, randString)
 }

--- a/mmv1/third_party/terraform/provider/provider_test.go.erb
+++ b/mmv1/third_party/terraform/provider/provider_test.go.erb
@@ -315,49 +315,49 @@ func TestAccProviderEmptyStrings(t *testing.T) {
 				Config:             testAccProvider_checkPlanTimeErrors(`credentials = ""`, acctest.RandString(t, 10)),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
-				ExpectError:        regexp.MustCompile(`please provide a value that isn't an empty string to this field`),
+				ExpectError:        regexp.MustCompile(`expected a non-empty string`),
 			},
 			// access_token as an empty string causes a validation error
 			{
 				Config:             testAccProvider_checkPlanTimeErrors(`access_token = ""`, acctest.RandString(t, 10)),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
-				ExpectError:        regexp.MustCompile(`please provide a value that isn't an empty string to this field`),
+				ExpectError:        regexp.MustCompile(`expected a non-empty string`),
 			},
 			// impersonate_service_account as an empty string causes a validation error
 			{
 				Config:             testAccProvider_checkPlanTimeErrors(`impersonate_service_account = ""`, acctest.RandString(t, 10)),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
-				ExpectError:        regexp.MustCompile(`please provide a value that isn't an empty string to this field`),
+				ExpectError:        regexp.MustCompile(`expected a non-empty string`),
 			},
 			// project as an empty string causes a validation error
 			{
 				Config:             testAccProvider_checkPlanTimeErrors(`project = ""`, acctest.RandString(t, 10)),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
-				ExpectError:        regexp.MustCompile(`please provide a value that isn't an empty string to this field`),
+				ExpectError:        regexp.MustCompile(`expected a non-empty string`),
 			},
 			// billing_project as an empty string causes a validation error
 			{
 				Config:             testAccProvider_checkPlanTimeErrors(`billing_project = ""`, acctest.RandString(t, 10)),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
-				ExpectError:        regexp.MustCompile(`please provide a value that isn't an empty string to this field`),
+				ExpectError:        regexp.MustCompile(`expected a non-empty string`),
 			},
 			// region as an empty string causes a validation error
 			{
 				Config:             testAccProvider_checkPlanTimeErrors(`region = ""`, acctest.RandString(t, 10)),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
-				ExpectError:        regexp.MustCompile(`please provide a value that isn't an empty string to this field`),
+				ExpectError:        regexp.MustCompile(`expected a non-empty string`),
 			},
 			// zone as an empty string causes a validation error
 			{
 				Config:             testAccProvider_checkPlanTimeErrors(`zone = ""`, acctest.RandString(t, 10)),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
-				ExpectError:        regexp.MustCompile(`please provide a value that isn't an empty string to this field`),
+				ExpectError:        regexp.MustCompile(`expected a non-empty string`),
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/provider/provider_validators.go.erb
+++ b/mmv1/third_party/terraform/provider/provider_validators.go.erb
@@ -10,10 +10,18 @@ import (
 )
 
 func ValidateCredentials(v interface{}, k string) (warnings []string, errors []error) {
-	if v == nil || v.(string) == "" {
+	if v == nil {
 		return
 	}
 	creds := v.(string)
+
+	// reject empty strings
+	if v.(string) == "" {
+		errors = append(errors,
+			fmt.Errorf("please provide a value that isn't an empty string to this field"))
+		return
+	}
+
 	// if this is a path and we can stat it, assume it's ok
 	if _, err := os.Stat(creds); err == nil {
 		return

--- a/mmv1/third_party/terraform/provider/provider_validators.go.erb
+++ b/mmv1/third_party/terraform/provider/provider_validators.go.erb
@@ -18,7 +18,7 @@ func ValidateCredentials(v interface{}, k string) (warnings []string, errors []e
 	// reject empty strings
 	if v.(string) == "" {
 		errors = append(errors,
-			fmt.Errorf("please provide a value that isn't an empty string to this field"))
+			fmt.Errorf("expected a non-empty string"))
 		return
 	}
 
@@ -41,7 +41,7 @@ func ValidateEmptyStrings(v interface{}, k string) (warnings []string, errors []
 
 	if v.(string) == "" {
 		errors = append(errors,
-			fmt.Errorf("please provide a value that isn't an empty string to this field"))
+			fmt.Errorf("expected a non-empty string"))
 	}
 
 	return

--- a/mmv1/third_party/terraform/provider/provider_validators.go.erb
+++ b/mmv1/third_party/terraform/provider/provider_validators.go.erb
@@ -1,0 +1,40 @@
+<% autogen_exception -%>
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	googleoauth "golang.org/x/oauth2/google"
+)
+
+func ValidateCredentials(v interface{}, k string) (warnings []string, errors []error) {
+	if v == nil || v.(string) == "" {
+		return
+	}
+	creds := v.(string)
+	// if this is a path and we can stat it, assume it's ok
+	if _, err := os.Stat(creds); err == nil {
+		return
+	}
+	if _, err := googleoauth.CredentialsFromJSON(context.Background(), []byte(creds)); err != nil {
+		errors = append(errors,
+			fmt.Errorf("JSON credentials are not valid: %s", err))
+	}
+
+	return
+}
+
+func ValidateEmptyStrings(v interface{}, k string) (warnings []string, errors []error) {
+	if v == nil {
+		return
+	}
+
+	if v.(string) == "" {
+		errors = append(errors,
+			fmt.Errorf("please provide a value that isn't an empty string to this field"))
+	}
+
+	return
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
## Description

Closes https://github.com/hashicorp/terraform-provider-google/issues/14447

This PR adds explicit validation feedback to users, to accompany the changes in https://github.com/GoogleCloudPlatform/magic-modules/pull/9014

The PR above means that `""` values will be processed by all the usual provider configuration logic but the error messages returned to users may be confusing and result in GitHub issues being opened. By adding explicit validation users will be able to identify and address the problems themselves.

I've chosen to add empty string validation to the more popular fields and avoiding things like `request_reason` because I don't know if there's a valid use case for setting that value to an empty string or not?

## Testing

I've added:

- [unit tests](https://github.com/GoogleCloudPlatform/magic-modules/pull/9050/commits/419ae4cd72d4ed6b49cc39219cb628d8e21e4c9f) for the new empty string validators
- [acceptance tests](https://github.com/GoogleCloudPlatform/magic-modules/pull/9050/commits/d6b3efd0dad8f16bf614a8cfe3e0b17b3da065db) showing the validators are present in the provider config and throw errors in appropriate scenarios

Here's a screenshot from a manual test. **NOTE**: there are always 2 errors, as both the SDK and PF validators are rejecting the bad input

<img width="623" alt="Screenshot 2023-09-22 at 18 46 31" src="https://github.com/GoogleCloudPlatform/magic-modules/assets/15078782/63df1f9b-56e9-4d07-bde3-bcbaf943c018">

## Misc details

Previously I thought that provider-level validation protecting against empty strings was a problem due to the SDK being weird/making it easy to footgun when handling zero values. After some manual tests I found this wasn't the case, so added anti-empty string validation to the SDK and PF versions of the provider config code.

**NOTE**: If validation exists on one version of the provider config but not the other then there's a fundamental error in the provider, as provider schemas must match when muxed together.

----

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
provider: added provider-level validation so these fields are not set as empty strings in a user's config: `credentials`, `access_token`, `impersonate_service_account`, `project`, `billing_project`, `region`, `zone`
```
