### PR TITLE
Fix: `external_data_configuration.connection_id` Diff Suppression

### DIFF
--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
@@ -192,10 +192,8 @@ func bigQueryTableConnectionIdSuppress(name, old, new string, _ *schema.Resource
 	re := regexp.MustCompile("projects/(.+)/(?:locations|regions)/(.+)/connections/(.+)")
 	if matches := re.FindStringSubmatch(new); matches != nil {
 		// The Location or Region may be returned in Upper or Lower Case.
-		normalizedIdWithUpperCaseLocation := matches[1] + "." + strings.ToUpper(matches[2]) + "." + matches[3]
 		normalizedIdWithLowerCaseLocation := matches[1] + "." + strings.ToLower(matches[2]) + "." + matches[3]
-
-		return (old == normalizedIdWithUpperCaseLocation) || (old == normalizedIdWithLowerCaseLocation)
+		return old == normalizedIdWithLowerCaseLocation
 	}
 	return false
 }

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
@@ -191,7 +191,11 @@ func bigQueryTableConnectionIdSuppress(name, old, new string, _ *schema.Resource
 
 	re := regexp.MustCompile("projects/(.+)/(?:locations|regions)/(.+)/connections/(.+)")
 	if matches := re.FindStringSubmatch(new); matches != nil {
-		return old == matches[1]+"."+matches[2]+"."+matches[3]
+		// The Location or Region may be returned in Upper or Lower Case.
+		normalizedIdWithUpperCaseLocation := matches[1] + "." + strings.ToUpper(matches[2]) + "." + matches[3]
+		normalizedIdWithLowerCaseLocation := matches[1] + "." + strings.ToLower(matches[2]) + "." + matches[3]
+
+		return (old == normalizedIdWithUpperCaseLocation) || (old == normalizedIdWithLowerCaseLocation)
 	}
 	return false
 }

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
@@ -189,12 +189,21 @@ func bigQueryTableConnectionIdSuppress(name, old, new string, _ *schema.Resource
 		return false
 	}
 
-	re := regexp.MustCompile("projects/(.+)/(?:locations|regions)/(.+)/connections/(.+)")
-	if matches := re.FindStringSubmatch(new); matches != nil {
-		// The Location or Region may be returned in Upper or Lower Case.
-		normalizedIdWithLowerCaseLocation := matches[1] + "." + strings.ToLower(matches[2]) + "." + matches[3]
-		return old == normalizedIdWithLowerCaseLocation
+	// Old is in the dot format, and new is in the slash format.
+	// They represent the same connection if the project, locaition, and IDs are
+	// the same.
+	// Location should use a case-insenstive comparison.
+	dotRe := regexp.MustCompile(`(.+)\.(.+)\.(.+)`)
+	slashRe := regexp.MustCompile("projects/(.+)/(?:locations|regions)/(.+)/connections/(.+)")
+	dotMatches := dotRe.FindStringSubmatch(old)
+	slashMatches := slashRe.FindStringSubmatch(new)
+	if dotMatches != nil && slashMatches != nil {
+		sameProject := dotMatches[1] == slashMatches[1]
+		sameLocation := strings.EqualFold(dotMatches[2], slashMatches[2])
+		sameId := dotMatches[3] == slashMatches[3]
+		return sameProject && sameLocation && sameId
 	}
+
 	return false
 }
 

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
@@ -762,6 +762,7 @@ func TestAccBigQueryExternalDataTable_connectionIdDiff_UseNameReference(t *testi
 	connectionID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
 
 	// Feature Under Test.
+	location := "US"
 	connection_id_reference := "google_bigquery_connection.test.name"
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -770,7 +771,7 @@ func TestAccBigQueryExternalDataTable_connectionIdDiff_UseNameReference(t *testi
 		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigQueryTableExternalDataConfigurationConnectionID(connectionID, datasetID, tableID, bucketName, objectName, connection_id_reference),
+				Config: testAccBigQueryTableExternalDataConfigurationConnectionID(location, connectionID, datasetID, tableID, bucketName, objectName, connection_id_reference),
 			},
 		},
 	})
@@ -786,6 +787,7 @@ func TestAccBigQueryExternalDataTable_connectionIdDiff_UseIdReference(t *testing
 	connectionID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
 
 	// Feature Under Test.
+	location := "US"
 	connection_id_reference := "google_bigquery_connection.test.id"
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -794,7 +796,82 @@ func TestAccBigQueryExternalDataTable_connectionIdDiff_UseIdReference(t *testing
 		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigQueryTableExternalDataConfigurationConnectionID(connectionID, datasetID, tableID, bucketName, objectName, connection_id_reference),
+				Config: testAccBigQueryTableExternalDataConfigurationConnectionID(location, connectionID, datasetID, tableID, bucketName, objectName, connection_id_reference),
+			},
+		},
+	})
+}
+
+func TestAccBigQueryExternalDataTable_connectionIdDiff_UseIdReference_UsCentral1LowerCase(t *testing.T) {
+	t.Parallel()
+	// Setup
+	bucketName := acctest.TestBucketName(t)
+	objectName := fmt.Sprintf("tf_test_%s.csv", acctest.RandString(t, 10))
+	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	tableID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	connectionID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+
+	// Feature Under Test.
+	location := "us-central1"
+	connection_id_reference := "google_bigquery_connection.test.id"
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryTableExternalDataConfigurationConnectionID(location, connectionID, datasetID, tableID, bucketName, objectName, connection_id_reference),
+			},
+		},
+	})
+}
+
+func TestAccBigQueryExternalDataTable_connectionIdDiff_UseIdReference_UsEast1(t *testing.T) {
+	t.Parallel()
+	// Setup
+	bucketName := acctest.TestBucketName(t)
+	objectName := fmt.Sprintf("tf_test_%s.csv", acctest.RandString(t, 10))
+	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	tableID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	connectionID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+
+	// Feature Under Test.
+	location := "US-EAST1"
+	connection_id_reference := "google_bigquery_connection.test.id"
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryTableExternalDataConfigurationConnectionID(location, connectionID, datasetID, tableID, bucketName, objectName, connection_id_reference),
+			},
+		},
+	})
+}
+
+func TestAccBigQueryExternalDataTable_connectionIdDiff_UseIdReference_EuropeWest8(t *testing.T) {
+	t.Parallel()
+	// Setup
+	bucketName := acctest.TestBucketName(t)
+	objectName := fmt.Sprintf("tf_test_%s.csv", acctest.RandString(t, 10))
+	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	tableID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	connectionID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+
+	// Feature Under Test.
+	location := "EUROPE-WEST8"
+	connection_id_reference := "google_bigquery_connection.test.id"
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryTableExternalDataConfigurationConnectionID(location, connectionID, datasetID, tableID, bucketName, objectName, connection_id_reference),
 			},
 		},
 	})
@@ -2427,11 +2504,11 @@ resource "google_bigquery_table" "test" {
 `, datasetID, bucketName, manifestName, parquetFileName, tableID)
 }
 
-func testAccBigQueryTableExternalDataConfigurationConnectionID(connectionID, datasetID, tableID, bucketName, objectName, connectionIdReference string) string {
+func testAccBigQueryTableExternalDataConfigurationConnectionID(location, connectionID, datasetID, tableID, bucketName, objectName, connectionIdReference string) string {
 	return fmt.Sprintf(`
 resource "google_bigquery_connection" "test" {
    connection_id = "%s"
-   location = "US"
+   location = "%s"
    cloud_resource {}
 }
 
@@ -2445,11 +2522,12 @@ resource "google_project_iam_member" "test" {
 
 resource "google_bigquery_dataset" "test" {
   dataset_id = "%s"
+  location = "%s"
 }
 
 resource "google_storage_bucket" "test" {
   name          = "%s"
-  location      = "US"
+  location      = "%s"
   force_destroy = true
 }
 
@@ -2477,7 +2555,7 @@ resource "google_bigquery_table" "test" {
     ]
   }
 }
-`, connectionID, datasetID, bucketName, objectName, tableID, connectionIdReference)
+`, connectionID, location, datasetID, location, bucketName, location, objectName, tableID, connectionIdReference)
 }
 
 func testAccBigQueryTableFromGCSObjectTable(connectionID, datasetID, tableID, bucketName, objectName, maxStaleness string) string {


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/12386

Mentioned in; https://github.com/hashicorp/terraform-provider-google/issues/12465

# Changes
+ Add: Test Coverage for `name` and `id` references in External Data Configuration
+ Fix: case sensitivity in location for connection id. In the slash and dot forms of connection id the region has different case. Change the comparison to be case insensittive

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigquery: fix diff suppression in `external_data_configuration.connection_id`
```
