### PR TITLE
fix downstream-builder for concurrent builds in feature branches

### DIFF
--- a/.ci/scripts/bash-plus/downstream-waiter/wait_for_commit.sh
+++ b/.ci/scripts/bash-plus/downstream-waiter/wait_for_commit.sh
@@ -26,7 +26,7 @@ fi
 while true; do
     if [ "$BASE_BRANCH" != "main" ]; then
         SYNC_HEAD="$(git rev-parse --short origin/$SYNC_BRANCH)"
-        BASE_PARENT="$(git rev-parse --short origin/$BASE_BRANCH~)"
+        BASE_PARENT="$(git rev-parse --short $SHA~)"
         if [ "$SYNC_HEAD" == "$BASE_PARENT" ]; then
             break;
         fi

--- a/.ci/scripts/bash-plus/downstream-waiter/wait_for_commit.sh
+++ b/.ci/scripts/bash-plus/downstream-waiter/wait_for_commit.sh
@@ -29,6 +29,10 @@ while true; do
         BASE_PARENT="$(git rev-parse --short $SHA~)"
         if [ "$SYNC_HEAD" == "$BASE_PARENT" ]; then
             break;
+        else
+            echo "sync branch is at: $SYNC_HEAD"
+            echo "current commit is $SHA"
+            git fetch origin $SYNC_BRANCH
         fi
     else 
         commits="$(git log --pretty=%H origin/$SYNC_BRANCH..origin/$BASE_BRANCH | tail -n 1)"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
