### PR TITLE
Remove upgrade guide entry for google_identity_platform_project_default_config

### DIFF
--- a/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
@@ -660,12 +660,6 @@ resource "google_secret_manager_secret" "my-secret" {
 }
 ```
 
-## Resource: `google_identity_platform_project_default_config`
-
-### `google_identity_platform_project_default_config` has been removed from the provider
-
-Use the `google_identity_platform_config` resource instead. It contains a more comprehensive list of fields, and was created before `google_identity_platform_project_default_config` was added.
-
 ## Resource: `google_compute_service_attachment`
 
 ### `reconcile_connections` now defaults from API


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

It was decided to not remove the resource, and give users more time to switch over. Removing the upgrade guide entry.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
