### PR TITLE
5.0.0 - remove computed keys from JSON in monitoring dashboard

### DIFF
--- a/mmv1/third_party/terraform/services/monitoring/resource_monitoring_dashboard.go
+++ b/mmv1/third_party/terraform/services/monitoring/resource_monitoring_dashboard.go
@@ -14,24 +14,45 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-func monitoringDashboardDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	computedFields := []string{"etag", "name"}
+// This recursive function takes an old map and a new map and is intended to remove the computed keys
+// from the old json string (stored in state) so that it doesn't show a diff if it's not defined in the
+// new map's json string (defined in config)
+func removeComputedKeys(old map[string]interface{}, new map[string]interface{}) map[string]interface{} {
+	for k, v := range old {
+		if _, ok := old[k]; ok && new[k] == nil {
+			delete(old, k)
+			continue
+		}
 
+		if reflect.ValueOf(v).Kind() == reflect.Map {
+			old[k] = removeComputedKeys(v.(map[string]interface{}), new[k].(map[string]interface{}))
+			continue
+		}
+
+		if reflect.ValueOf(v).Kind() == reflect.Slice {
+			for i, j := range v.([]interface{}) {
+				if reflect.ValueOf(j).Kind() == reflect.Map {
+					old[k].([]interface{})[i] = removeComputedKeys(j.(map[string]interface{}), new[k].([]interface{})[i].(map[string]interface{}))
+				}
+			}
+			continue
+		}
+	}
+
+	return old
+}
+
+func monitoringDashboardDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	oldMap, err := structure.ExpandJsonFromString(old)
 	if err != nil {
 		return false
 	}
-
 	newMap, err := structure.ExpandJsonFromString(new)
 	if err != nil {
 		return false
 	}
 
-	for _, f := range computedFields {
-		delete(oldMap, f)
-		delete(newMap, f)
-	}
-
+	oldMap = removeComputedKeys(oldMap, newMap)
 	return reflect.DeepEqual(oldMap, newMap)
 }
 

--- a/mmv1/third_party/terraform/services/monitoring/resource_monitoring_dashboard_test.go
+++ b/mmv1/third_party/terraform/services/monitoring/resource_monitoring_dashboard_test.go
@@ -83,8 +83,6 @@ func TestAccMonitoringDashboard_rowLayout(t *testing.T) {
 }
 
 func TestAccMonitoringDashboard_update(t *testing.T) {
-	// TODO: Fix requires a breaking change https://github.com/hashicorp/terraform-provider-google/issues/9976
-	t.Skip()
 	t.Parallel()
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/website/docs/r/monitoring_dashboard.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/monitoring_dashboard.html.markdown
@@ -114,6 +114,12 @@ The following arguments are supported:
   The JSON representation of a dashboard, following the format at https://cloud.google.com/monitoring/api/ref_v3/rest/v1/projects.dashboards.
   The representation of an existing dashboard can be found by using the [API Explorer](https://cloud.google.com/monitoring/api/ref_v3/rest/v1/projects.dashboards/get)
 
+  ~> **Warning:** Because this is represented as a JSON string, Terraform doesn't have underlying information to know
+    which fields in the string have defaults. To prevent permanent diffs from default values, Terraform will attempt to
+    suppress diffs where the value is returned in the JSON string but doesn't exist in the configuration. Consequently,
+    legitmate remove-only diffs will also be suppressed. For Terraform to detect the diff, key removals must also be
+    accompanied by a non-removal change (trivial or not).
+
 - - -
 
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
rebasing https://github.com/GoogleCloudPlatform/magic-modules/pull/5595
fixes https://github.com/hashicorp/terraform-provider-google/issues/7242
upgrade guide: https://github.com/GoogleCloudPlatform/magic-modules/pull/8970

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
monitoring: fixed perma-diffs in `google_monitoring_dashboard.dashboard_json` by suppressing values returned by the API that are not in configuration
```
