### PR TITLE
fix(vertexai): make contents_delta_uri a required field in `google_vertex_ai_index`

### DIFF
--- a/mmv1/products/vertexai/Index.yaml
+++ b/mmv1/products/vertexai/Index.yaml
@@ -100,6 +100,7 @@ properties:
     properties:
       - !ruby/object:Api::Type::String
         name: 'contentsDeltaUri'
+        required: true
         description: |-
           Allows inserting, updating  or deleting the contents of the Matching Engine Index.
           The string must be a valid Cloud Storage directory path. If this


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/15962
Part of https://github.com/hashicorp/terraform-provider-google/issues/12818

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

Add `required: true` to `contens_delta_url` to be able to avoid the following error at terraform apply:

```
Error: Error creating Index: googleapi: Error 400: contentsDeltaUri is required but missing from Index metadata.
```

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
vertexai: made `contents_delta_uri` a required field in `google_vertex_ai_index` as omitting it would result in an error
```
