### PR TITLE
make vpc-native clusters the default (for new clusters)

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -781,10 +781,9 @@ func ResourceContainerCluster() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ForceNew:      true,
-				Deprecated:    "Deprecated in favor of ip_allocation_policy.cluster_ipv4_cidr_block",
 				ValidateFunc:  verify.OrEmpty(verify.ValidateRFC1918Network(8, 32)),
 				ConflictsWith: []string{"ip_allocation_policy"},
-				Description:   `The IP address range of the Kubernetes pods in this cluster in CIDR notation (e.g. 10.96.0.0/14). Leave blank to have one automatically chosen or specify a /14 block in 10.0.0.0/8. This field will only work for routes-based clusters, where ip_allocation_policy is not defined. Deprecated in favor of ip_allocation_policy.cluster_ipv4_cidr_block`,
+				Description:   `The IP address range of the Kubernetes pods in this cluster in CIDR notation (e.g. 10.96.0.0/14). Leave blank to have one automatically chosen or specify a /14 block in 10.0.0.0/8. This field will only work for routes-based clusters, where ip_allocation_policy is not defined.`,
 			},
 
 			"description": {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -196,6 +196,7 @@ func ResourceContainerCluster() *schema.Resource {
 			containerClusterNetworkPolicyEmptyCustomizeDiff,
 			containerClusterSurgeSettingsCustomizeDiff,
 			containerClusterEnableK8sBetaApisCustomizeDiff,
+			containerClusterNetworkingModeCustomizeDiff,
 		),
 
 		Timeouts: &schema.ResourceTimeout{
@@ -4313,10 +4314,7 @@ func expandIPAllocationPolicy(configured interface{}, networkingMode string, aut
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
 		if networkingMode == "VPC_NATIVE" {
-			if autopilot {
-				return nil, nil
-			}
-			return nil, fmt.Errorf("`ip_allocation_policy` block is required for VPC_NATIVE clusters.")
+			return nil, nil
 		}
 		return &container.IPAllocationPolicy{
 			UseIpAliases:    false,
@@ -6164,6 +6162,21 @@ func containerClusterAutopilotCustomizeDiff(_ context.Context, d *schema.Resourc
 		if err := d.SetNew("networking_mode", "VPC_NATIVE"); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// Default to VPC_NATIVE mode during initial creation
+func containerClusterNetworkingModeCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	// skip if not during initial creation
+	o, _ := d.GetChange("name")
+	if o != "" {
+		return nil
+	}
+
+	err := d.SetNew("networking_mode", "VPC_NATIVE")
+	if err != nil {
+		return fmt.Errorf("Error setting networking mode diff: %s", err)
 	}
 	return nil
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -196,7 +196,6 @@ func ResourceContainerCluster() *schema.Resource {
 			containerClusterNetworkPolicyEmptyCustomizeDiff,
 			containerClusterSurgeSettingsCustomizeDiff,
 			containerClusterEnableK8sBetaApisCustomizeDiff,
-			containerClusterNetworkingModeCustomizeDiff,
 		),
 
 		Timeouts: &schema.ResourceTimeout{
@@ -782,9 +781,10 @@ func ResourceContainerCluster() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ForceNew:      true,
+				Deprecated:    "Deprecated in favor of ip_allocation_policy.cluster_ipv4_cidr_block",
 				ValidateFunc:  verify.OrEmpty(verify.ValidateRFC1918Network(8, 32)),
 				ConflictsWith: []string{"ip_allocation_policy"},
-				Description:   `The IP address range of the Kubernetes pods in this cluster in CIDR notation (e.g. 10.96.0.0/14). Leave blank to have one automatically chosen or specify a /14 block in 10.0.0.0/8. This field will only work for routes-based clusters, where ip_allocation_policy is not defined.`,
+				Description:   `The IP address range of the Kubernetes pods in this cluster in CIDR notation (e.g. 10.96.0.0/14). Leave blank to have one automatically chosen or specify a /14 block in 10.0.0.0/8. This field will only work for routes-based clusters, where ip_allocation_policy is not defined. Deprecated in favor of ip_allocation_policy.cluster_ipv4_cidr_block`,
 			},
 
 			"description": {
@@ -1597,13 +1597,14 @@ func ResourceContainerCluster() *schema.Resource {
 				},
 			},
 
+			// Defaults to "VPC_NATIVE" during create only
 			"networking_mode": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice([]string{"VPC_NATIVE", "ROUTES"}, false),
-				Description:  `Determines whether alias IPs or routes will be used for pod IPs in the cluster.`,
+				Description:  `Determines whether alias IPs or routes will be used for pod IPs in the cluster. Defaults to VPC_NATIVE for new clusters.`,
 			},
 
 			"remove_default_node_pool": {
@@ -2121,6 +2122,21 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	clusterName := d.Get("name").(string)
+
+	// Default to VPC_NATIVE mode during initial creation
+	// This solution (a conditional default) should not be considered to set a precedent on its own.
+	// If you're considering a similar approach on a different resource, strongly weigh making the field required.
+	// GKE tends to require exceptional handling in general- and this default was a breaking change in their API
+	// that was compounded on by numerous product developments afterwards. We have not seen a similar case
+	// since, after several years.
+	networkingMode := d.Get("networking_mode").(string)
+	clusterIpv4Cidr := d.Get("cluster_ipv4_cidr").(string)
+	if networkingMode == "" && clusterIpv4Cidr == "" {
+		err := d.Set("networking_mode", "VPC_NATIVE")
+		if err != nil {
+			return fmt.Errorf("Error setting networking mode during creation: %s", err)
+		}
+	}
 
 	ipAllocationBlock, err := expandIPAllocationPolicy(d.Get("ip_allocation_policy"), d.Get("networking_mode").(string), d.Get("enable_autopilot").(bool))
 	if err != nil {
@@ -6162,21 +6178,6 @@ func containerClusterAutopilotCustomizeDiff(_ context.Context, d *schema.Resourc
 		if err := d.SetNew("networking_mode", "VPC_NATIVE"); err != nil {
 			return err
 		}
-	}
-	return nil
-}
-
-// Default to VPC_NATIVE mode during initial creation
-func containerClusterNetworkingModeCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
-	// skip if not during initial creation
-	o, _ := d.GetChange("name")
-	if o != "" {
-		return nil
-	}
-
-	err := d.SetNew("networking_mode", "VPC_NATIVE")
-	if err != nil {
-		return fmt.Errorf("Error setting networking mode diff: %s", err)
 	}
 	return nil
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -4313,7 +4313,7 @@ resource "google_container_cluster" "secondary" {
 	name               = "%s"
 	location           = "us-central1-a"
 	initial_node_count = 1
-	cluster_ipv4_cidr  = 10.96.0.0/14
+	cluster_ipv4_cidr  = "10.96.0.0/14"
 	deletion_protection = false
   }
 `, firstName, secondName)

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -27,6 +27,7 @@ func TestAccContainerCluster_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("google_container_cluster.primary", "services_ipv4_cidr"),
 					resource.TestCheckResourceAttrSet("google_container_cluster.primary", "self_link"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "networking_mode", "VPC_NATIVE"),
 				),
 			},
 			{

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -57,17 +57,27 @@ func TestAccContainerCluster_basic(t *testing.T) {
 func TestAccContainerCluster_networkingModeRoutes(t *testing.T) {
 	t.Parallel()
 
-	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	firstClusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	secondClusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_networkingModeRoutes(clusterName),
+				Config: testAccContainerCluster_networkingModeRoutes(firstClusterName, secondClusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "networking_mode", "ROUTES"),
+					resource.TestCheckResourceAttr("google_container_cluster.secondary", "networking_mode", "ROUTES"),				),
 			},
 			{
 				ResourceName:	     "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				ResourceName:	     "google_container_cluster.secondary",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
@@ -2713,6 +2723,9 @@ func TestAccContainerCluster_withAutopilot(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccContainerCluster_withAutopilot(pid, containerNetName, clusterName, "us-central1", true, false, ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.with_autopilot", "networking_mode", "VPC_NATIVE"),
+				),
 			},
 			{
 				ResourceName:            "google_container_cluster.with_autopilot",
@@ -4286,7 +4299,7 @@ resource "google_container_cluster" "primary" {
 `, name)
 }
 
-func testAccContainerCluster_networkingModeRoutes(name string) string {
+func testAccContainerCluster_networkingModeRoutes(firstName, secondName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
   name               = "%s"
@@ -4295,7 +4308,15 @@ resource "google_container_cluster" "primary" {
   networking_mode    = "ROUTES"
   deletion_protection = false
 }
-`, name)
+
+resource "google_container_cluster" "secondary" {
+	name               = "%s"
+	location           = "us-central1-a"
+	initial_node_count = 1
+	cluster_ipv4_cidr  = 10.96.0.0/14
+	deletion_protection = false
+  }
+`, firstName, secondName)
 }
 
 func testAccContainerCluster_misc(name string) string {

--- a/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
@@ -381,6 +381,34 @@ Terraform from destroying or recreating the cluster.
 **`deletion_protection` does NOT prevent deletion outside of Terraform.**
 To destroy a `google_container_cluster`, this field must be explicitly set to `false`.
 
+### `networking_mode` defaults to `VPC_NATIVE` for newly created clusters
+
+New clusters will default to `VPC_NATIVE` which enables [IP aliasing](https://cloud.google.com/kubernetes-engine/docs/how-to/ip-aliases). Previously, `google_container_cluster` would default to using routes as
+the networking mode unless `ip_allocation_policy` policy was set. Now, `networking_mode` will
+default to `VPC_NATIVE` and `ip_allocation_policy` will be set by the server if unset in
+configuration. Existing clusters should not be affected.
+
+#### New Minimal Config for VPC-native cluster
+
+```hcl
+resource "google_container_cluster" "primary" {
+  name               = "my_cluster"
+  location           = "us-central1-a"
+  initial_node_count = 1
+}
+```
+
+#### New Minimal Config for Routes-based cluster
+
+```hcl
+resource "google_container_cluster" "primary" {
+  name               = "my_cluster"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  networking_mode    = "ROUTES"
+}
+```
+
 ### `enable_binary_authorization` is now removed
 
 `enable_binary_authorization` has been removed in favor of `binary_authorization.enabled`.

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -133,11 +133,10 @@ the cluster. Unless this field is set to false in Terraform state, a
 `false`. This field should only be enabled for Autopilot clusters (`enable_autopilot`
 set to `true`).
 
-* `cluster_ipv4_cidr` - (Optional, DEPRECATED) The IP address range of the Kubernetes pods
+* `cluster_ipv4_cidr` - (Optional) The IP address range of the Kubernetes pods
 in this cluster in CIDR notation (e.g. `10.96.0.0/14`). Leave blank to have one
 automatically chosen or specify a `/14` block in `10.0.0.0/8`. This field will
 default a new cluster to routes-based, where `ip_allocation_policy` is not defined.
-Deprecated in favor of `ip_allocation_policy.cluster_ipv4_cidr_block`. 
 
 * `cluster_autoscaling` - (Optional)
 Per-cluster configuration of Node Auto-Provisioning with Cluster Autoscaler to
@@ -196,12 +195,10 @@ set this to a value of at least `1`, alongside setting
 
 * `ip_allocation_policy` - (Optional) Configuration of cluster IP allocation for
 VPC-native clusters. If this block is unset during creation, it will be set by the GKE backend. 
-Adding this block enables [IP aliasing](https://cloud.google.com/kubernetes-engine/docs/how-to/ip-aliases),
-making the cluster VPC-native instead of routes-based (unless `"networking_mode` is set to `ROUTES`). Structure is [documented
-below](#nested_ip_allocation_policy).
+Structure is [documented below](#nested_ip_allocation_policy).
 
 * `networking_mode` - (Optional) Determines whether alias IPs or routes will be used for pod IPs in the cluster.
-Options are `VPC_NATIVE` or `ROUTES`. Newly created clusters will default to `VPC_NATIVE`.
+Options are `VPC_NATIVE` or `ROUTES`. `VPC_NATIVE` enables [IP aliasing](https://cloud.google.com/kubernetes-engine/docs/how-to/ip-aliases). Newly created clusters will default to `VPC_NATIVE`.
 
 * `logging_config` - (Optional) Logging configuration for the cluster.
     Structure is [documented below](#nested_logging_config).

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -194,13 +194,14 @@ set this to a value of at least `1`, alongside setting
 `remove_default_node_pool` to `true`.
 
 * `ip_allocation_policy` - (Optional) Configuration of cluster IP allocation for
-VPC-native clusters. Adding this block enables [IP aliasing](https://cloud.google.com/kubernetes-engine/docs/how-to/ip-aliases),
-making the cluster VPC-native instead of routes-based. Structure is [documented
+VPC-native clusters. If this block is unset during creation, it will be set by the GKE backend. 
+Adding this block enables [IP aliasing](https://cloud.google.com/kubernetes-engine/docs/how-to/ip-aliases),
+making the cluster VPC-native instead of routes-based (unless `"networking_mode` is set to `ROUTES`). Structure is [documented
 below](#nested_ip_allocation_policy).
 
 * `networking_mode` - (Optional) Determines whether alias IPs or routes will be used for pod IPs in the cluster.
-Options are `VPC_NATIVE` or `ROUTES`. `VPC_NATIVE` enables [IP aliasing](https://cloud.google.com/kubernetes-engine/docs/how-to/ip-aliases),
-and requires the `ip_allocation_policy` block to be defined. By default, when this field is unspecified and no `ip_allocation_policy` blocks are set, GKE will create a `ROUTES`-based cluster.
+Options are `VPC_NATIVE` or `ROUTES`. `VPC_NATIVE` enables [IP aliasing](https://cloud.google.com/kubernetes-engine/docs/how-to/ip-aliases).
+Newly created clusters will default to `VPC_NATIVE`.
 
 * `logging_config` - (Optional) Logging configuration for the cluster.
     Structure is [documented below](#nested_logging_config).

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -133,10 +133,11 @@ the cluster. Unless this field is set to false in Terraform state, a
 `false`. This field should only be enabled for Autopilot clusters (`enable_autopilot`
 set to `true`).
 
-* `cluster_ipv4_cidr` - (Optional) The IP address range of the Kubernetes pods
+* `cluster_ipv4_cidr` - (Optional, DEPRECATED) The IP address range of the Kubernetes pods
 in this cluster in CIDR notation (e.g. `10.96.0.0/14`). Leave blank to have one
 automatically chosen or specify a `/14` block in `10.0.0.0/8`. This field will
-only work for routes-based clusters, where `ip_allocation_policy` is not defined.
+default a new cluster to routes-based, where `ip_allocation_policy` is not defined.
+Deprecated in favor of `ip_allocation_policy.cluster_ipv4_cidr_block`. 
 
 * `cluster_autoscaling` - (Optional)
 Per-cluster configuration of Node Auto-Provisioning with Cluster Autoscaler to
@@ -200,8 +201,7 @@ making the cluster VPC-native instead of routes-based (unless `"networking_mode`
 below](#nested_ip_allocation_policy).
 
 * `networking_mode` - (Optional) Determines whether alias IPs or routes will be used for pod IPs in the cluster.
-Options are `VPC_NATIVE` or `ROUTES`. `VPC_NATIVE` enables [IP aliasing](https://cloud.google.com/kubernetes-engine/docs/how-to/ip-aliases).
-Newly created clusters will default to `VPC_NATIVE`.
+Options are `VPC_NATIVE` or `ROUTES`. Newly created clusters will default to `VPC_NATIVE`.
 
 * `logging_config` - (Optional) Logging configuration for the cluster.
     Structure is [documented below](#nested_logging_config).


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fixes https://github.com/hashicorp/terraform-provider-google/issues/5842

makes `networking_mode` default to `VPC_NATIVE` only during creation

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
container: newly created `google_container_cluster` resources now default to VPC-native instead of routes-based.
```