### PR TITLE
Adds device name parameter to scratch disk

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
@@ -822,6 +822,12 @@ be from 0 to 999,999,999 inclusive.`,
 				Description: `The scratch disks attached to the instance.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"device_name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: `Name with which the attached disk is accessible under /dev/disk/by-id/`,
+						},
 						"interface": {
 							Type:         schema.TypeString,
 							Required:     true,
@@ -2789,6 +2795,7 @@ func expandScratchDisks(d *schema.ResourceData, config *transport_tpg.Config, pr
 		scratchDisks = append(scratchDisks, &compute.AttachedDisk{
 			AutoDelete: true,
 			Type:       "SCRATCH",
+			DeviceName: d.Get(fmt.Sprintf("scratch_disk.%d.device_name", i)).(string),
 			Interface:  d.Get(fmt.Sprintf("scratch_disk.%d.interface", i)).(string),
 			DiskSizeGb: int64(d.Get(fmt.Sprintf("scratch_disk.%d.size", i)).(int)),
 			InitializeParams: &compute.AttachedDiskInitializeParams{
@@ -2802,6 +2809,7 @@ func expandScratchDisks(d *schema.ResourceData, config *transport_tpg.Config, pr
 
 func flattenScratchDisk(disk *compute.AttachedDisk) map[string]interface{} {
 	result := map[string]interface{}{
+		"device_name": disk.DeviceName,
 		"interface": disk.Interface,
 		"size": disk.DiskSizeGb,
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_test.go.erb
@@ -244,8 +244,10 @@ func TestAccComputeInstanceFromTemplate_overrideScratchDisk(t *testing.T) {
 					testAccCheckComputeInstanceExists(t, resourceName, &instance),
 
 					// Check that fields were set based on the template
-					resource.TestCheckResourceAttr(resourceName, "scratch_disk.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scratch_disk.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "scratch_disk.0.interface", "NVME"),
+          resource.TestCheckResourceAttr(resourceName, "scratch_disk.1.interface", "NVME"),
+          resource.TestCheckResourceAttr(resourceName, "scratch_disk.1.device_name", "override-local-ssd"),
 				),
 			},
 		},
@@ -395,6 +397,14 @@ resource "google_compute_instance_template" "foobar" {
   }
 
   disk {
+    device_name  = "test-local-ssd"
+    disk_type    = "local-ssd"
+    type         = "SCRATCH"
+    interface    = "NVME"
+    disk_size_gb = 375
+  }
+
+  disk {
     source_image = data.google_compute_image.my_image.self_link
     auto_delete  = true
     disk_size_gb = 100
@@ -462,6 +472,14 @@ resource "google_compute_instance_template" "foobar" {
   }
 
   disk {
+    disk_type    = "local-ssd"
+    type         = "SCRATCH"
+    interface    = "NVME"
+    disk_size_gb = 375
+  }
+
+  disk {
+    device_name  = "test-local-ssd"
     disk_type    = "local-ssd"
     type         = "SCRATCH"
     interface    = "NVME"
@@ -540,6 +558,14 @@ resource "google_compute_instance_template" "foobar" {
   }
 
   disk {
+    disk_type    = "local-ssd"
+    type         = "SCRATCH"
+    interface    = "NVME"
+    disk_size_gb = 375
+  }
+
+  disk {
+    device_name  = "test-local-ssd"
     disk_type    = "local-ssd"
     type         = "SCRATCH"
     interface    = "NVME"
@@ -640,6 +666,14 @@ resource "google_compute_region_instance_template" "foobar" {
     disk_size_gb = 375
   }
 
+  disk {
+    device_name  = "test-local-ssd"
+    disk_type    = "local-ssd"
+    type         = "SCRATCH"
+    interface    = "NVME"
+    disk_size_gb = 375
+  }
+
   network_interface {
     network = "default"
   }
@@ -701,6 +735,14 @@ resource "google_compute_instance_template" "foobar" {
   }
 
   disk {
+    disk_type    = "local-ssd"
+    type         = "SCRATCH"
+    interface    = "NVME"
+    disk_size_gb = 375
+  }
+
+  disk {
+    device_name  = "test-local-ssd"
     disk_type    = "local-ssd"
     type         = "SCRATCH"
     interface    = "NVME"
@@ -922,6 +964,16 @@ resource "google_compute_instance_template" "template" {
     boot         = false
   }
 
+  disk {
+    device_name  = "test-local-ssd"
+    type         = "SCRATCH"
+    disk_type    = "local-ssd"
+    disk_size_gb = 375
+    interface    = "SCSI"
+    auto_delete  = true
+    boot         = false
+  }
+
   network_interface {
     network = "default"
   }
@@ -936,6 +988,11 @@ resource "google_compute_instance_from_template" "inst" {
   // Overrides
   scratch_disk {
     interface = "NVME"
+  }
+
+  scratch_disk {
+    device_name = "override-local-ssd"
+    interface   = "NVME"
   }
 }
 `, templateDisk, overrideDisk, template, instance)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.erb
@@ -2120,7 +2120,7 @@ data "google_compute_image" "my_image" {
 }
 resource "google_compute_instance_template" "foobar" {
   name           = "tf-test-instance-template-%s"
-  machine_type   = "e2-medium"
+  machine_type   = "n1-standard-1"   // can't be e2 because of local-ssd
   can_ip_forward = false
   disk {
     source_image = data.google_compute_image.my_image.name
@@ -2129,6 +2129,13 @@ resource "google_compute_instance_template" "foobar" {
   }
   disk {
     auto_delete  = true
+    disk_size_gb = 375
+    type         = "SCRATCH"
+    disk_type    = "local-ssd"
+  }
+  disk {
+    auto_delete  = true
+	device_name  = "test-local-ssd"
     disk_size_gb = 375
     type         = "SCRATCH"
     disk_type    = "local-ssd"

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -838,7 +838,22 @@ func TestAccComputeInstance_with375GbScratchDisk(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
 						t, "google_compute_instance.foobar", &instance),
-					testAccCheckComputeInstanceScratchDisk(&instance, []string{"NVME", "SCSI"}),
+					testAccCheckComputeInstanceScratchDisk(&instance, []map[string]string{
+						map[string]string{
+							"interface": "NVME",
+						},
+						map[string]string{
+							"interface": "SCSI",
+						},
+						map[string]string{
+							"interface": "NVME",
+							"deviceName": "nvme-local-ssd",
+						},
+						map[string]string{
+							"interface": "SCSI",
+							"deviceName": "scsi-local-ssd",
+						},
+					}),
 				),
 			},
 			computeInstanceImportStep("us-central1-a", instanceName, []string{}),
@@ -865,7 +880,26 @@ func TestAccComputeInstance_with18TbScratchDisk(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
 						t, "google_compute_instance.foobar", &instance),
-					testAccCheckComputeInstanceScratchDisk(&instance, []string{"NVME", "NVME", "NVME", "NVME", "NVME", "NVME"}),
+					testAccCheckComputeInstanceScratchDisk(&instance, []map[string]string{
+						map[string]string{
+							"interface": "NVME",
+						},
+						map[string]string{
+							"interface": "NVME",
+						},
+						map[string]string{
+							"interface": "NVME",
+						},
+						map[string]string{
+							"interface": "NVME",
+						},
+						map[string]string{
+							"interface": "NVME",
+						},
+						map[string]string{
+							"interface": "NVME",
+						},
+					}),
 				),
 			},
 			computeInstanceImportStep("us-central1-a", instanceName, []string{}),
@@ -3310,7 +3344,7 @@ func testAccCheckComputeInstanceBootDiskType(t *testing.T, instanceName string, 
 	}
 }
 
-func testAccCheckComputeInstanceScratchDisk(instance *compute.Instance, interfaces []string) resource.TestCheckFunc {
+func testAccCheckComputeInstanceScratchDisk(instance *compute.Instance, interfaces []map[string]string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if instance.Disks == nil {
 			return fmt.Errorf("no disks")
@@ -3322,10 +3356,17 @@ func testAccCheckComputeInstanceScratchDisk(instance *compute.Instance, interfac
 				if i >= len(interfaces) {
 					return fmt.Errorf("Expected %d scratch disks, found more", len(interfaces))
 				}
-				if disk.Interface != interfaces[i] {
+				if disk.Interface != interfaces[i]["interface"] {
 					return fmt.Errorf("Mismatched interface on scratch disk #%d, expected: %q, found: %q",
 						i, interfaces[i], disk.Interface)
 				}
+				if deviceName, ok := interfaces[i]["deviceName"]; ok {
+					if disk.DeviceName != deviceName {
+						return fmt.Errorf("Mismatched device name on scratch disk #%d, expected: %q, found: %q",
+						i, deviceName, disk.DeviceName)
+					}
+				}
+				
 				i++
 			}
 		}
@@ -5273,6 +5314,16 @@ resource "google_compute_instance" "foobar" {
 
   scratch_disk {
     interface = "SCSI"
+  }
+
+  scratch_disk {
+    interface   = "NVME"
+	device_name = "nvme-local-ssd"
+  }
+
+  scratch_disk {
+    interface   = "SCSI"
+	device_name = "scsi-local-ssd"
   }
 
   network_interface {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

- Adds a `device_name` parameter to the `scratch_disk` block of the resource `google_compute_instance`
- Fixes https://github.com/hashicorp/terraform-provider-google/issues/15942

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `device_name` field to `scratch_disk` block of `google_compute_instance` resource
```
