### PR TITLE
Improve documentation for Pub/Sub Schema updates

### DIFF
--- a/mmv1/products/pubsub/Schema.yaml
+++ b/mmv1/products/pubsub/Schema.yaml
@@ -70,4 +70,8 @@ properties:
     description: |
       The definition of the schema.
       This should contain a string representing the full definition of the schema
-      that is a valid schema definition of the type specified in type.
+      that is a valid schema definition of the type specified in type. Changes
+      to the definition commit new [schema revisions](https://cloud.google.com/pubsub/docs/commit-schema-revision).
+      A schema can only have up to 20 revisions, so updates that fail with an
+      error indicating that the limit has been reached require manually
+      [deleting old revisions](https://cloud.google.com/pubsub/docs/delete-schema-revision).

--- a/mmv1/third_party/terraform/services/pubsub/resource_pubsub_schema_test.go
+++ b/mmv1/third_party/terraform/services/pubsub/resource_pubsub_schema_test.go
@@ -48,17 +48,6 @@ func testAccPubsubSchema_basic(schema string) string {
 		type = "PROTOCOL_BUFFER"
 		definition = "syntax = \"proto3\";\nmessage Results {\nstring message_request = 1;\nstring message_response = 2;\n}"
 	}
-
-	# Need to introduce delay for updates in order for tests to complete
-	# successfully due to caching effects.
-	resource "time_sleep" "wait_121_seconds" {
-		create_duration = "121s"
-		lifecycle {
-			replace_triggered_by = [
-				google_pubsub_schema.foo
-			]
-		}
-	}
 `, schema)
 }
 
@@ -68,17 +57,6 @@ func testAccPubsubSchema_updated(schema string) string {
 		name = "%s"
 		type = "PROTOCOL_BUFFER"
 		definition = "syntax = \"proto3\";\nmessage Results {\nstring message_request = 1;\nstring message_response = 2;\nstring timestamp_request = 3;\n}"
-	}
-
-	# Need to introduce delay for updates in order for tests to complete
-	# successfully due to caching effects.
-	resource "time_sleep" "wait_121_seconds" {
-		create_duration = "121s"
-		lifecycle {
-			replace_triggered_by = [
-				google_pubsub_schema.foo
-			]
-		}
 	}
 `, schema)
 }


### PR DESCRIPTION
Add documentation indicating that revisions may need to be manually deleted. Fixes hashicorp/terraform-provider-google#15228.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
