### PR TITLE
Fixing advanced_options_config.user_ip_request_headers is set to null when empty list is passed

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.erb
@@ -739,7 +739,9 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 		Fingerprint: d.Get("fingerprint").(string),
 	}
 
+	<% unless version == 'ga' -%>
 	updateMask := []string{}
+	<% end -%>
 
 	if d.HasChange("type") {
 		securityPolicy.Type = d.Get("type").(string)
@@ -754,7 +756,6 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 	if d.HasChange("advanced_options_config") {
 		securityPolicy.AdvancedOptionsConfig = expandSecurityPolicyAdvancedOptionsConfig(d.Get("advanced_options_config").([]interface{}))
 		securityPolicy.ForceSendFields = append(securityPolicy.ForceSendFields, "AdvancedOptionsConfig", "advancedOptionsConfig.jsonParsing", "advancedOptionsConfig.jsonCustomConfig", "advancedOptionsConfig.logLevel")
-		
 		<% unless version == 'ga' -%>
 		securityPolicy.ForceSendFields = append(securityPolicy.ForceSendFields, "advanceOptionConfig.userIpRequestHeaders")
 		if len(securityPolicy.AdvancedOptionsConfig.UserIpRequestHeaders) == 0 {
@@ -780,7 +781,11 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 	if len(securityPolicy.ForceSendFields) > 0 {
 		client := config.NewComputeClient(userAgent)
 
+		<% if version == 'ga' -%>
+		op, err := client.SecurityPolicies.Patch(project, sp, securityPolicy).Do()
+		<% elsif version == 'beta' -%>
 		op, err := client.SecurityPolicies.Patch(project, sp, securityPolicy).UpdateMask(strings.Join(updateMask, ",")).Do()
+		<% end -%>
 
 		if err != nil {
 			return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.erb
@@ -739,6 +739,8 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 		Fingerprint: d.Get("fingerprint").(string),
 	}
 
+	updateMask := []string{}
+
 	if d.HasChange("type") {
 		securityPolicy.Type = d.Get("type").(string)
 		securityPolicy.ForceSendFields = append(securityPolicy.ForceSendFields, "Type")
@@ -752,6 +754,14 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 	if d.HasChange("advanced_options_config") {
 		securityPolicy.AdvancedOptionsConfig = expandSecurityPolicyAdvancedOptionsConfig(d.Get("advanced_options_config").([]interface{}))
 		securityPolicy.ForceSendFields = append(securityPolicy.ForceSendFields, "AdvancedOptionsConfig", "advancedOptionsConfig.jsonParsing", "advancedOptionsConfig.jsonCustomConfig", "advancedOptionsConfig.logLevel")
+		
+		<% unless version == 'ga' -%>
+		securityPolicy.ForceSendFields = append(securityPolicy.ForceSendFields, "advanceOptionConfig.userIpRequestHeaders")
+		if len(securityPolicy.AdvancedOptionsConfig.UserIpRequestHeaders) == 0 {
+			// to clean this list we must send the updateMask of this field on the request.
+			updateMask = append(updateMask, "advanced_options_config.user_ip_request_headers")
+		}
+		<% end -%>
 	}
 
 	if d.HasChange("adaptive_protection_config") {
@@ -770,7 +780,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 	if len(securityPolicy.ForceSendFields) > 0 {
 		client := config.NewComputeClient(userAgent)
 
-		op, err := client.SecurityPolicies.Patch(project, sp, securityPolicy).Do()
+		op, err := client.SecurityPolicies.Patch(project, sp, securityPolicy).UpdateMask(strings.Join(updateMask, ",")).Do()
 
 		if err != nil {
 			return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
@@ -1129,9 +1129,9 @@ resource "google_compute_security_policy" "policy" {
       ]
     }
     log_level    = "VERBOSE"
-	user_ip_request_headers = [
-	  "x-custom-ip",
-	]
+    user_ip_request_headers = [
+      "x-custom-ip",
+    ]
   }
 }
 `, spName)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
@@ -198,6 +198,15 @@ func TestAccComputeSecurityPolicy_withAdvancedOptionsConfig(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			// change all AdvancedOptionConfig values.
+			{
+				Config: testAccComputeSecurityPolicy_withAdvancedOptionsConfig_update2(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			<% end -%>
 			{
 				Config: testAccComputeSecurityPolicy_basic(spName),
@@ -1122,6 +1131,28 @@ resource "google_compute_security_policy" "policy" {
     log_level    = "VERBOSE"
 	user_ip_request_headers = [
 	  "x-custom-ip",
+	]
+  }
+}
+`, spName)
+}
+
+func testAccComputeSecurityPolicy_withAdvancedOptionsConfig_update2(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+  name        = "%s"
+  description = "updated description changing all advancedOptionsConfig values"
+
+  advanced_options_config {
+    json_parsing = "DISABLED"
+    json_custom_config {
+      content_types = [
+        "application/json",
+        "application/vnd.hyper+json"
+      ]
+    }
+    log_level    = "NORMAL"
+	user_ip_request_headers = [
 	]
   }
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
@@ -1152,8 +1152,8 @@ resource "google_compute_security_policy" "policy" {
       ]
     }
     log_level    = "NORMAL"
-	user_ip_request_headers = [
-	]
+    user_ip_request_headers = [
+    ]
   }
 }
 `, spName)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/15646

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
securitypolicy: fixed a bug where setting `advanced_options_config.user_ip_request_headers` field with empty value was not cleaning the list (beta)
```