### PR TITLE
Add sms_region_config block to identity platform.

### DIFF
--- a/mmv1/products/identityplatform/Config.yaml
+++ b/mmv1/products/identityplatform/Config.yaml
@@ -230,8 +230,9 @@ properties:
     properties:
       - !ruby/object:Api::Type::NestedObject
         name: 'allowByDefault'
-        conflicts:
-          - smsRegionConfig.allowlistOnly
+        exactly_one_of:
+          - sms_region_config.0.allow_by_default
+          - sms_region_config.0.allowlist_only
         description: |
           A policy of allowing SMS to every region by default and adding disallowed regions to a disallow list.
         properties:
@@ -242,8 +243,9 @@ properties:
             item_type: Api::Type::String
       - !ruby/object:Api::Type::NestedObject
         name: 'allowlistOnly'
-        conflicts:
-          - smsRegionConfig.allowByDefault
+        exactly_one_of:
+          - sms_region_config.0.allow_by_default
+          - sms_region_config.0.allowlist_only
         description: |
           A policy of only allowing regions by explicitly adding them to an allowlist.
         properties:

--- a/mmv1/products/identityplatform/Config.yaml
+++ b/mmv1/products/identityplatform/Config.yaml
@@ -223,3 +223,32 @@ properties:
       List of domains authorized for OAuth redirects.
     item_type: Api::Type::String
     default_from_api: true
+  - !ruby/object:Api::Type::NestedObject
+    name: 'smsRegionConfig'
+    description: |
+      Configures the regions where users are allowed to send verification SMS for the project or tenant. This is based on the calling code of the destination phone number.
+    properties:
+      - !ruby/object:Api::Type::NestedObject
+        name: 'allowByDefault'
+        conflicts:
+          - smsRegionConfig.allowlistOnly
+        description: |
+          A policy of allowing SMS to every region by default and adding disallowed regions to a disallow list.
+        properties:
+          - !ruby/object:Api::Type::Array
+            name: disallowedRegions
+            description: |
+              Two letter unicode region codes to disallow as defined by https://cldr.unicode.org/ The full list of these region codes is here: https://github.com/unicode-cldr/cldr-localenames-full/blob/master/main/en/territories.json
+            item_type: Api::Type::String
+      - !ruby/object:Api::Type::NestedObject
+        name: 'allowlistOnly'
+        conflicts:
+          - smsRegionConfig.allowByDefault
+        description: |
+          A policy of only allowing regions by explicitly adding them to an allowlist.
+        properties:
+          - !ruby/object:Api::Type::Array
+            name: allowedRegions
+            description: |
+              Two letter unicode region codes to allow as defined by https://cldr.unicode.org/ The full list of these region codes is here: https://github.com/unicode-cldr/cldr-localenames-full/blob/master/main/en/territories.json
+            item_type: Api::Type::String

--- a/mmv1/templates/terraform/examples/identity_platform_config_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/identity_platform_config_basic.tf.erb
@@ -33,6 +33,14 @@ resource "google_identity_platform_config" "default" {
         }
     }
   }
+  sms_region_config {
+    allowlist_only {
+      allowed_regions = [
+        "US",
+        "CA",
+      ]
+    }
+  }
   blocking_functions {
     triggers {
       event_type = "beforeSignIn"

--- a/mmv1/third_party/terraform/services/identityplatform/resource_identity_platform_config_test.go
+++ b/mmv1/third_party/terraform/services/identityplatform/resource_identity_platform_config_test.go
@@ -85,6 +85,7 @@ resource "google_identity_platform_config" "basic" {
   sms_region_config {
     allow_by_default {
       disallowed_regions = [
+        "CA",
         "US",
       ]
     }
@@ -132,7 +133,8 @@ resource "google_identity_platform_config" "basic" {
   sms_region_config {
     allowlist_only {
       allowed_regions = [
-        "US",
+        "AU",
+        "NZ",
       ]
     }
   }

--- a/mmv1/third_party/terraform/services/identityplatform/resource_identity_platform_config_test.go
+++ b/mmv1/third_party/terraform/services/identityplatform/resource_identity_platform_config_test.go
@@ -82,6 +82,13 @@ resource "google_identity_platform_config" "basic" {
         }
     }
   }
+  sms_region_config {
+    allow_by_default {
+      disallowed_regions = [
+        "US",
+      ]
+    }
+  }
 }
 `, context)
 }
@@ -120,6 +127,13 @@ resource "google_identity_platform_config" "basic" {
         test_phone_numbers = {
 	    "+17651212343" = "111111"
         }
+    }
+  }
+  sms_region_config {
+    allowlist_only {
+      allowed_regions = [
+        "US",
+      ]
     }
   }
 }


### PR DESCRIPTION
Permits configuring the allow/denylist for SMS regions.

Addresses a portion of https://github.com/hashicorp/terraform-provider-google/issues/14194

```release-note:enhancement
identityplatform: added `sms_region_config` to the resource `google_identity_platform_config`
```
