### PR TITLE
add PREMIUM for Global external IP addresses

### DIFF
--- a/mmv1/products/compute/GlobalAddress.yaml
+++ b/mmv1/products/compute/GlobalAddress.yaml
@@ -58,6 +58,7 @@ examples:
       network_name: 'my-network-name'
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   post_create: templates/terraform/post_create/labels.erb
+  pre_create: templates/terraform/pre_create/compute_global_address.go.erb
 properties:
   - !ruby/object:Api::Type::String
     name: 'address'

--- a/mmv1/templates/terraform/pre_create/compute_global_address.go.erb
+++ b/mmv1/templates/terraform/pre_create/compute_global_address.go.erb
@@ -1,2 +1,5 @@
 // Note: Global external IP addresses and internal IP addresses are always Premium Tier.
-obj["networkTier"] = "PREMIUM"
+// An address with type INTERNAL cannot have a network tier
+if addressTypeProp != "INTERNAL" {
+    obj["networkTier"] = "PREMIUM"
+}

--- a/mmv1/templates/terraform/pre_create/compute_global_address.go.erb
+++ b/mmv1/templates/terraform/pre_create/compute_global_address.go.erb
@@ -1,0 +1,2 @@
+// Note: Global external IP addresses and internal IP addresses are always Premium Tier.
+obj["networkTier"] = "PREMIUM"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/15982

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed `google_compute_global_address` can't be created when default_network_tier set to STANDARD
```
