### PR TITLE
DNS: always set rrdatas and routing_policy when reading record_set

### DIFF
--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
@@ -425,15 +425,11 @@ func resourceDnsRecordSetRead(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("ttl", rrset.Ttl); err != nil {
 		return fmt.Errorf("Error setting ttl: %s", err)
 	}
-	if len(rrset.Rrdatas) > 0 {
-		if err := d.Set("rrdatas", rrset.Rrdatas); err != nil {
-			return fmt.Errorf("Error setting rrdatas: %s", err)
-		}
+	if err := d.Set("rrdatas", rrset.Rrdatas); err != nil {
+		return fmt.Errorf("Error setting rrdatas: %s", err)
 	}
-	if rrset.RoutingPolicy != nil {
-		if err := d.Set("routing_policy", flattenDnsRecordSetRoutingPolicy(rrset.RoutingPolicy)); err != nil {
-			return fmt.Errorf("Error setting routing_policy: %s", err)
-		}
+	if err := d.Set("routing_policy", flattenDnsRecordSetRoutingPolicy(rrset.RoutingPolicy)); err != nil {
+		return fmt.Errorf("Error setting routing_policy: %s", err)
 	}
 	if err := d.Set("project", project); err != nil {
 		return fmt.Errorf("Error setting project: %s", err)

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.erb
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.erb
@@ -344,6 +344,15 @@ func TestAccDNSRecordSet_changeRouting(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+            {
+				Config: testAccDnsRecordSet_basic(zoneName, "127.0.0.10", 300),
+			},
+			{
+				ResourceName:      "google_dns_record_set.foobar",
+				ImportStateId:     fmt.Sprintf("%s/%s/test-record.%s.hashicorptest.com./A", envvar.GetTestProjectFromEnv(), zoneName, zoneName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.erb
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.erb
@@ -380,6 +380,181 @@ func TestAccDNSRecordSet_interpolated(t *testing.T) {
 	})
 }
 
+func TestAccDNSRecordSet_readOutOfBandRoutingPolicyChange(t *testing.T) {
+	t.Parallel()
+
+	zoneName := fmt.Sprintf("dnszone-test-%s", acctest.RandString(t, 10))
+	rrsetName := fmt.Sprintf("test-record.%s.hashicorptest.com.", zoneName)
+	ttl := 300
+	rrdata := []string{"127.0.0.1", "127.0.0.10"}
+	routingPolicy := &dns.RRSetRoutingPolicy{
+		Wrr: &dns.RRSetRoutingPolicyWrrPolicy{
+			Items: []*dns.RRSetRoutingPolicyWrrPolicyWrrPolicyItem{
+				{
+					Weight:  0,
+					Rrdatas: []string{"1.2.3.4", "4.3.2.1"},
+				},
+				{
+					Weight:  0,
+					Rrdatas: []string{"2.3.4.5", "5.4.3.2"},
+				},
+			},
+		},
+	}
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDnsRecordSetDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDnsRecordSet_basic(zoneName, "127.0.0.10", 300),
+			},
+			{
+				ResourceName:      "google_dns_record_set.foobar",
+				ImportStateId:     fmt.Sprintf("%s/%s/test-record.%s.hashicorptest.com./A", envvar.GetTestProjectFromEnv(), zoneName, zoneName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				PreConfig: testAccCheckDnsRecordSetSetRoutingPolicyOutOfBand(t, zoneName, rrsetName, ttl, rrdata, routingPolicy),
+				Config:    testAccDnsRecordSet_basic(zoneName, "127.0.0.10", 300),
+			},
+			{
+				ResourceName:      "google_dns_record_set.foobar",
+				ImportStateId:     fmt.Sprintf("%s/%s/test-record.%s.hashicorptest.com./A", envvar.GetTestProjectFromEnv(), zoneName, zoneName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccDNSRecordSet_readOutOfBandRrDataChange(t *testing.T) {
+	t.Parallel()
+
+	zoneName := fmt.Sprintf("dnszone-test-%s", acctest.RandString(t, 10))
+	rrsetName := fmt.Sprintf("test-record.%s.hashicorptest.com.", zoneName)
+	ttl := 300
+	rrdata := []string{"127.0.0.1", "127.0.0.10"}
+	routingPolicy := &dns.RRSetRoutingPolicy{
+		Wrr: &dns.RRSetRoutingPolicyWrrPolicy{
+			Items: []*dns.RRSetRoutingPolicyWrrPolicyWrrPolicyItem{
+				{
+					Weight:  0,
+					Rrdatas: []string{"1.2.3.4", "4.3.2.1"},
+				},
+				{
+					Weight:  0,
+					Rrdatas: []string{"2.3.4.5", "5.4.3.2"},
+				},
+			},
+		},
+	}
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDnsRecordSetDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDnsRecordSet_routingPolicy(zoneName, 300),
+			},
+			{
+				ResourceName:      "google_dns_record_set.foobar",
+				ImportStateId:     fmt.Sprintf("%s/%s/test-record.%s.hashicorptest.com./A", envvar.GetTestProjectFromEnv(), zoneName, zoneName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				PreConfig: testAccCheckDnsRecordSetSetRrdataOutOfBand(t, zoneName, rrsetName, ttl, rrdata, routingPolicy),
+				Config:    testAccDnsRecordSet_routingPolicy(zoneName, 300),
+			},
+			{
+				ResourceName:      "google_dns_record_set.foobar",
+				ImportStateId:     fmt.Sprintf("%s/%s/test-record.%s.hashicorptest.com./A", envvar.GetTestProjectFromEnv(), zoneName, zoneName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckDnsRecordSetSetRoutingPolicyOutOfBand(t *testing.T, zoneName, rrsetName string, ttl int, rrdata []string, routingPolicy *dns.RRSetRoutingPolicy) func() {
+	return func() {
+		config := acctest.GoogleProviderConfig(t)
+		service := config.NewDnsClient(config.UserAgent).Changes
+		chg := &dns.Change{
+			Deletions: []*dns.ResourceRecordSet{
+				{
+					Name:    rrsetName,
+					Type:    "A",
+					Ttl:     int64(ttl),
+					Rrdatas: rrdata,
+				},
+			},
+			Additions: []*dns.ResourceRecordSet{
+				{
+					Name:          rrsetName,
+					Type:          "A",
+					Ttl:           int64(ttl),
+					RoutingPolicy: routingPolicy,
+				},
+			},
+		}
+		chg, err := service.Create(config.Project, zoneName, chg).Do()
+		if err != nil {
+			t.Errorf("Error while changing rrset %s/%s/%s out of band: %s", config.Project, zoneName, rrsetName, err)
+			return
+		}
+		w := &tpgdns.DnsChangeWaiter{
+			Service:     config.NewDnsClient(config.UserAgent),
+			Change:      chg,
+			Project:     config.Project,
+			ManagedZone: zoneName,
+		}
+		if _, err = w.Conf().WaitForState(); err != nil {
+			t.Errorf("Error waiting for out of band Google DNS change: %s", err)
+		}
+	}
+}
+
+func testAccCheckDnsRecordSetSetRrdataOutOfBand(t *testing.T, zoneName, rrsetName string, ttl int, rrdata []string, routingPolicy *dns.RRSetRoutingPolicy) func() {
+	return func() {
+		config := acctest.GoogleProviderConfig(t)
+		service := config.NewDnsClient(config.UserAgent).Changes
+		chg := &dns.Change{
+			Deletions: []*dns.ResourceRecordSet{
+				{
+					Name:          rrsetName,
+					Type:          "A",
+					Ttl:           int64(ttl),
+					RoutingPolicy: routingPolicy,
+				},
+			},
+			Additions: []*dns.ResourceRecordSet{
+				{
+					Name:    rrsetName,
+					Type:    "A",
+					Ttl:     int64(ttl),
+					Rrdatas: rrdata,
+				},
+			},
+		}
+		chg, err := service.Create(config.Project, zoneName, chg).Do()
+		if err != nil {
+			t.Errorf("Error while changing rrset %s/%s/%s out of band: %s", config.Project, zoneName, rrsetName, err)
+			return
+		}
+		w := &tpgdns.DnsChangeWaiter{
+			Service:     config.NewDnsClient(config.UserAgent),
+			Change:      chg,
+			Project:     config.Project,
+			ManagedZone: zoneName,
+		}
+		if _, err = w.Conf().WaitForState(); err != nil {
+			t.Errorf("Error waiting for out of band Google DNS change: %s", err)
+		}
+	}
+}
 
 func testAccCheckDnsRecordSetDestroyProducer(t *testing.T) func(s *terraform.State) error {
 

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.erb
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.erb
@@ -15,6 +15,7 @@ import (
 	tpgdns "github.com/hashicorp/terraform-provider-google/google/services/dns"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+    "google.golang.org/api/dns/v1"
 )
 
 func TestIpv6AddressDiffSuppress(t *testing.T) {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Motivating bug: b/301469376

Currently on read, we only update `rrdatas` or `routing_policy` if there is a non-nil value to be read from the API response - if `rrdatas` or `routing_policy` is nil, we don't do anything. This is a problem specifically when out-of-band changes are made, since either field could be set to nil and we would never update the state to match (e.g. if `rrdatas` is switched to `routing_policy` outside of Terraform, we would not update `rrdatas` to nil within the Terraform state).

Setting `rrdatas` and `routing_policy` unconditionally on read (with `flatten` when appropriate) should resolve this.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

```release-note:bug
dns: fixed record set configuration parsing in `google_dns_record_set`
```
