### PR TITLE
Add info about plannable import to handwritten documentation (non-IAM resources), Part 2

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1332,12 +1332,27 @@ This resource provides the following
 GKE clusters can be imported using the `project` , `location`, and `name`. If the project is omitted, the default
 provider value will be used. Examples:
 
+* `projects/{{project_id}}/locations/{{location}}/clusters/{{cluster_id}}`
+* `{{project_id}}/{{location}}/{{cluster_id}}`
+* `{{location}}/{{cluster_id}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import GKE clusters using one of the formats above. For example:
+
+```tf
+import {
+  id = "projects/{{project_id}}/locations/{{location}}/clusters/{{cluster_id}}"
+  to = google_container_cluster.default
+}
 ```
-$ terraform import google_container_cluster.mycluster projects/my-gcp-project/locations/us-east1-a/clusters/my-cluster
 
-$ terraform import google_container_cluster.mycluster my-gcp-project/us-east1-a/my-cluster
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), GKE clusters can be imported using one of the formats above. For example:
 
-$ terraform import google_container_cluster.mycluster us-east1-a/my-cluster
+```
+$ terraform import google_container_cluster.default projects/{{project_id}}/locations/{{location}}/clusters/{{cluster_id}}
+
+$ terraform import google_container_cluster.default {{project_id}}/{{location}}/{{cluster_id}}
+
+$ terraform import google_container_cluster.default {{location}}/{{cluster_id}}
 ```
 
 ~> **Note:** This resource has several fields that control Terraform-specific behavior and aren't present in the API. If they are set in config and you import a cluster, Terraform may need to perform an update immediately after import. Most of these updates should be no-ops but some may modify your cluster if the imported state differs.

--- a/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
@@ -300,8 +300,22 @@ In addition to the arguments listed above, the following computed attributes are
 Node pools can be imported using the `project`, `location`, `cluster` and `name`. If
 the project is omitted, the project value in the provider configuration will be used. Examples:
 
-```
-$ terraform import google_container_node_pool.mainpool my-gcp-project/us-east1-a/my-cluster/main-pool
+* `{{project_id}}/{{location}}/{{cluster_id}}/{{pool_id}}`
+* `{{location}}/{{cluster_id}}/{{pool_id}}`
 
-$ terraform import google_container_node_pool.mainpool us-east1/my-cluster/main-pool
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import node pools using one of the formats above. For example:
+
+```tf
+import {
+  id = "{{project_id}}/{{location}}/{{cluster_id}}/{{pool_id}}"
+  to = google_container_node_pool.default
+}
+```
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), node pools can be imported using one of the formats above. For example:
+
+```
+$ terraform import google_container_node_pool.default {{project_id}}/{{location}}/{{cluster_id}}/{{pool_id}}
+
+$ terraform import google_container_node_pool.default {{location}}/{{cluster_id}}/{{pool_id}}
 ```

--- a/mmv1/third_party/terraform/website/docs/r/dataflow_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataflow_job.html.markdown
@@ -130,6 +130,19 @@ The following arguments are supported:
 
 Dataflow jobs can be imported using the job `id` e.g.
 
+* `{{id}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import dataflow jobs using one of the formats above. For example:
+
+```tf
+import {
+  id = "{{id}}"
+  to = google_dataflow_job.default
+}
 ```
-$ terraform import google_dataflow_job.example 2022-07-31_06_25_42-11926927532632678660
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), dataflow jobs can be imported using one of the formats above. For example:
+
+```
+$ terraform import google_dataflow_job.default {{id}}
 ```

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_workflow_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_workflow_template.html.markdown
@@ -962,6 +962,21 @@ This resource provides the following
 
 WorkflowTemplate can be imported using any of these accepted formats:
 
+* `projects/{{project}}/locations/{{location}}/workflowTemplates/{{name}}`
+* `{{project}}/{{location}}/{{name}}`
+* `{{location}}/{{name}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import WorkflowTemplate using one of the formats above. For example:
+
+```tf
+import {
+  id = "projects/{{project}}/locations/{{location}}/workflowTemplates/{{name}}"
+  to = google_dataproc_workflow_template.default
+}
+```
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), WorkflowTemplate can be imported using one of the formats above. For example:
+
 ```
 $ terraform import google_dataproc_workflow_template.default projects/{{project}}/locations/{{location}}/workflowTemplates/{{name}}
 $ terraform import google_dataproc_workflow_template.default {{project}}/{{location}}/{{name}}

--- a/mmv1/third_party/terraform/website/docs/r/dialogflow_cx_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dialogflow_cx_environment.html.markdown
@@ -118,6 +118,20 @@ This resource provides the following
 
 Environment can be imported using any of these accepted formats:
 
+* `{{parent}}/environments/{{name}}`
+* `{{parent}}/{{name}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Environment using one of the formats above. For example:
+
+```tf
+import {
+  id = "{{parent}}/environments/{{name}}"
+  to = google_dialogflow_cx_environment.default
+}
+```
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), Environment can be imported using one of the formats above. For example:
+
 ```
 $ terraform import google_dialogflow_cx_environment.default {{parent}}/environments/{{name}}
 $ terraform import google_dialogflow_cx_environment.default {{parent}}/{{name}}

--- a/mmv1/third_party/terraform/website/docs/r/dialogflow_cx_version.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dialogflow_cx_version.html.markdown
@@ -126,8 +126,21 @@ This resource provides the following
 
 ## Import
 
-
 Version can be imported using any of these accepted formats:
+
+* `{{parent}}/versions/{{name}}`
+* `{{parent}}/{{name}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Version using one of the formats above. For example:
+
+```tf
+import {
+  id = "{{parent}}/versions/{{name}}"
+  to = google_dialogflow_cx_version.default
+}
+```
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), Version can be imported using one of the formats above. For example:
 
 ```
 $ terraform import google_dialogflow_cx_version.default {{parent}}/versions/{{name}}

--- a/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
@@ -341,10 +341,25 @@ The following arguments are supported:
 
 DNS record sets can be imported using either of these accepted formats:
 
+* `projects/{{project}}/managedZones/{{zone}}/rrsets/{{name}}/{{type}}`
+* `{{project}}/{{zone}}/{{name}}/{{type}}`
+* `{{zone}}/{{name}}/{{type}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import DNS record sets using one of the formats above. For example:
+
+```tf
+import {
+  id = "projects/{{project}}/managedZones/{{zone}}/rrsets/{{name}}/{{type}}"
+  to = google_dns_record_set.default
+}
 ```
-$ terraform import google_dns_record_set.frontend projects/{{project}}/managedZones/{{zone}}/rrsets/{{name}}/{{type}}
-$ terraform import google_dns_record_set.frontend {{project}}/{{zone}}/{{name}}/{{type}}
-$ terraform import google_dns_record_set.frontend {{zone}}/{{name}}/{{type}}
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), DNS record sets can be imported using one of the formats above. For example:
+
+```
+$ terraform import google_dns_record_set.default projects/{{project}}/managedZones/{{zone}}/rrsets/{{name}}/{{type}}
+$ terraform import google_dns_record_set.default {{project}}/{{zone}}/{{name}}/{{type}}
+$ terraform import google_dns_record_set.default {{zone}}/{{name}}/{{type}}
 ```
 
 Note: The record name must include the trailing dot at the end.

--- a/mmv1/third_party/terraform/website/docs/r/gke_hub_feature_membership.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/gke_hub_feature_membership.html.markdown
@@ -365,6 +365,21 @@ This resource provides the following
 
 FeatureMembership can be imported using any of these accepted formats:
 
+* `projects/{{project}}/locations/{{location}}/features/{{feature}}/membershipId/{{membership}}`
+* `{{project}}/{{location}}/{{feature}}/{{membership}}`
+* `{{location}}/{{feature}}/{{membership}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import FeatureMembership using one of the formats above. For example:
+
+```tf
+import {
+  id = "projects/{{project}}/locations/{{location}}/features/{{feature}}/membershipId/{{membership}}"
+  to = google_gke_hub_feature_membership.default
+}
+```
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), FeatureMembership can be imported using one of the formats above. For example:
+
 ```
 $ terraform import google_gke_hub_feature_membership.default projects/{{project}}/locations/{{location}}/features/{{feature}}/membershipId/{{membership}}
 $ terraform import google_gke_hub_feature_membership.default {{project}}/{{location}}/{{feature}}/{{membership}}

--- a/mmv1/third_party/terraform/website/docs/r/google_billing_subaccount.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_billing_subaccount.html.markdown
@@ -42,6 +42,19 @@ The following additional attributes are exported:
 
 Billing Subaccounts can be imported using any of these accepted formats:
 
+* `billingAccounts/{billing_account_id}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Billing Subaccounts using one of the formats above. For example:
+
+```tf
+import {
+  id = "billingAccounts/{billing_account_id}"
+  to = google_billing_subaccount.default
+}
+```
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), Billing Subaccounts can be imported using one of the formats above. For example:
+
 ```
 $ terraform import google_billing_subaccount.default billingAccounts/{billing_account_id}
 ```

--- a/mmv1/third_party/terraform/website/docs/r/google_folder.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_folder.html.markdown
@@ -60,8 +60,21 @@ exported:
 
 Folders can be imported using the folder's id, e.g.
 
+* `folders/{{folder_id}}`
+* `{{folder_id}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Folders using one of the formats above. For example:
+
+```tf
+import {
+  id = "folders/{{folder_id}}"
+  to = google_folder.default
+}
 ```
-# Both syntaxes are valid
-$ terraform import google_folder.department1 1234567
-$ terraform import google_folder.department1 folders/1234567
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), Folders can be imported using one of the formats above. For example:
+
+```
+$ terraform import google_folder.default {{folder_id}}
+$ terraform import google_folder.default folders/{{folder_id}}
 ```

--- a/mmv1/third_party/terraform/website/docs/r/google_folder_organization_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_folder_organization_policy.html.markdown
@@ -138,7 +138,21 @@ exported:
 
 Folder organization policies can be imported using any of the follow formats:
 
+* `folders/{{folder_id}}/constraints/serviceuser.services`
+* `{{folder_id}}/serviceuser.services`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import folder organization policies using one of the formats above. For example:
+
+```tf
+import {
+  id = "folders/{{folder_id}}/constraints/serviceuser.services"
+  to = google_folder_organization_policy.default
+}
 ```
-$ terraform import google_folder_organization_policy.policy folders/folder-1234/constraints/serviceuser.services
-$ terraform import google_folder_organization_policy.policy folder-1234/serviceuser.services
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), folder organization policies can be imported using one of the formats above. For example:
+
+```
+* `$ terraform import google_folder_organization_policy.default folders/* ``{{folder_id}}/constraints/serviceuser.services`
+* `* `$ terraform import google_folder_organization_policy.default {{folder_id}}/``serviceuser.services
 ```

--- a/mmv1/third_party/terraform/website/docs/r/google_organization_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_organization_policy.html.markdown
@@ -137,8 +137,21 @@ exported:
 
 Organization Policies can be imported using the `org_id` and the `constraint`, e.g.
 
+* `{{org_id}}/constraints/{{constraint}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Organization Policies using one of the formats above. For example:
+
+```tf
+import {
+  id = "{{org_id}}/constraints/{{constraint}}"
+  to = google_organization_policy.default
+}
 ```
-$ terraform import google_organization_policy.services_policy 123456789/constraints/serviceuser.services
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), Organization Policies can be imported using one of the formats above. For example:
+
+```
+$ terraform import google_organization_policy.default {{org_id}}/constraints/{{constraint}}
 ```
 
 It is all right if the constraint contains a slash, as in the example above.

--- a/mmv1/third_party/terraform/website/docs/r/google_project.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project.html.markdown
@@ -112,6 +112,19 @@ This resource provides the following
 
 Projects can be imported using the `project_id`, e.g.
 
+* `{{project_id}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Projects using one of the formats above. For example:
+
+```tf
+import {
+  id = "{{project_id}}"
+  to = google_project.default
+}
 ```
-$ terraform import google_project.my_project your-project-id
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), Projects can be imported using one of the formats above. For example:
+
+```
+$ terraform import google_project.default {{project_id}}
 ```

--- a/mmv1/third_party/terraform/website/docs/r/google_project_iam_custom_role.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project_iam_custom_role.html.markdown
@@ -63,8 +63,22 @@ exported:
 
 ## Import
 
-
 Custom Roles can be imported using any of these accepted formats:
+
+* `projects/{{project}}/roles/{{role_id}}`
+* `{{project}}/{{role_id}}`
+* `{{role_id}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Custom Roles using one of the formats above. For example:
+
+```tf
+import {
+  id = "projects/{{project}}/roles/{{role_id}}"
+  to = google_project_iam_custom_role.default
+}
+```
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), Custom Roles can be imported using one of the formats above. For example:
 
 ```
 $ terraform import google_project_iam_custom_role.default projects/{{project}}/roles/{{role_id}}

--- a/mmv1/third_party/terraform/website/docs/r/google_project_organization_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project_organization_policy.html.markdown
@@ -137,8 +137,23 @@ exported:
 
 Project organization policies can be imported using any of the follow formats:
 
+* `projects/{{project_id}}:constraints/{{constraint}}`
+* `{{project_id}}:constraints/{{constraint}}`
+* `{{project_id}}:{{constraint}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import project organization policies using one of the formats above. For example:
+
+```tf
+import {
+  id = "projects/{{project_id}}:constraints/{{constraint}}"
+  to = google_project_organization_policy.default
+}
 ```
-$ terraform import google_project_organization_policy.policy projects/test-project:constraints/serviceuser.services
-$ terraform import google_project_organization_policy.policy test-project:constraints/serviceuser.services
-$ terraform import google_project_organization_policy.policy test-project:serviceuser.services
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), project organization policies can be imported using one of the formats above. For example:
+
+```
+$ terraform import google_project_organization_policy.default projects/{{project_id}}:constraints/{{constraint}}
+$ terraform import google_project_organization_policy.default {{project_id}}:constraints/{{constraint}}
+$ terraform import google_project_organization_policy.default {{project_id}}:{{constraint}}
 ```

--- a/mmv1/third_party/terraform/website/docs/r/google_project_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project_service.html.markdown
@@ -76,8 +76,21 @@ This resource provides the following
 
 Project services can be imported using the `project_id` and `service`, e.g.
 
+* `{{project_id}}/{{service}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import project services using one of the formats above. For example:
+
+```tf
+import {
+  id = "{{project_id}}/{{service}}"
+  to = google_project_service.default
+}
 ```
-$ terraform import google_project_service.my_project your-project-id/iam.googleapis.com
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), project services can be imported using one of the formats above. For example:
+
+```
+$ terraform import google_project_service.default {{project_id}}/{{service}}
 ```
 
 Note that unlike other resources that fail if they already exist,

--- a/mmv1/third_party/terraform/website/docs/r/google_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_service_account.html.markdown
@@ -79,6 +79,19 @@ This resource provides the following
 
 Service accounts can be imported using their URI, e.g.
 
+* `projects/{{project_id}}/serviceAccounts/{{email}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import NAME_HERE using one of the formats above. For example:
+
+```tf
+import {
+  id = "projects/{{project_id}}/serviceAccounts/{{email}}"
+  to = google_service_account.default
+}
 ```
-$ terraform import google_service_account.my_sa projects/my-project/serviceAccounts/my-sa@my-project.iam.gserviceaccount.com
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), NAME_HERE can be imported using one of the formats above. For example:
+
+```
+$ terraform import google_service_account.default projects/{{project_id}}/serviceAccounts/{{email}}
 ```

--- a/mmv1/third_party/terraform/website/docs/r/google_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_service_account.html.markdown
@@ -81,7 +81,7 @@ Service accounts can be imported using their URI, e.g.
 
 * `projects/{{project_id}}/serviceAccounts/{{email}}`
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import NAME_HERE using one of the formats above. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import service accounts using one of the formats above. For example:
 
 ```tf
 import {
@@ -90,7 +90,7 @@ import {
 }
 ```
 
-When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), NAME_HERE can be imported using one of the formats above. For example:
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), service accounts can be imported using one of the formats above. For example:
 
 ```
 $ terraform import google_service_account.default projects/{{project_id}}/serviceAccounts/{{email}}

--- a/mmv1/third_party/terraform/website/docs/r/google_service_networking_peered_dns_domain.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_service_networking_peered_dns_domain.html.markdown
@@ -56,18 +56,30 @@ This resource provides the following
 
 ## Import
 
-Project peered DNS domains can be imported using the `service`, `project`, `network` and `name`, e.g.
-
-```
-$ terraform import google_service_networking_peered_dns_domain.my_domain services/{service}/projects/{project}/global/networks/{network}/peeredDnsDomains/{name}
-```
-
-Where:
+Project peered DNS domains can be imported using the `service`, `project`, `network` and `name`, where:
 
 - `service` is the service connection, defaults to `servicenetworking.googleapis.com`.
 - `project` is the producer project name.
 - `network` is the consumer network name.
 - `name` is the name of your peered DNS domain.
+
+* `services/{service}/projects/{project}/global/networks/{network}/peeredDnsDomains/{name}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import project peered DNS domains using one of the formats above. For example:
+
+```tf
+import {
+  id = "services/{service}/projects/{project}/global/networks/{network}/peeredDnsDomains/{name}"
+  to = google_service_networking_peered_dns_domain.default
+}
+```
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), project peered DNS domains can be imported using one of the formats above. For example:
+
+```
+$ terraform import google_service_networking_peered_dns_domain.default services/{service}/projects/{project}/global/networks/{network}/peeredDnsDomains/{name}
+```
+
 
 ## User Project Overrides
 

--- a/mmv1/third_party/terraform/website/docs/r/google_tags_location_tag_binding.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_tags_location_tag_binding.html.markdown
@@ -117,6 +117,19 @@ This resource provides the following
 
 TagBinding can be imported using any of these accepted formats:
 
+* `{{location}}/{{name}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import TagBinding using one of the formats above. For example:
+
+```tf
+import {
+  id = "{{location}}/{{name}}"
+  to = google_tags_location_tag_binding.default
+}
+```
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), TagBinding can be imported using one of the formats above. For example:
+
 ```
 $ terraform import google_tags_location_tag_binding.default {{location}}/{{name}}
 ```

--- a/mmv1/third_party/terraform/website/docs/r/logging_billing_account_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_billing_account_bucket_config.html.markdown
@@ -56,6 +56,19 @@ exported:
 
 This resource can be imported using the following format:
 
+* `billingAccounts/{{billingAccount}}/locations/{{location}}/buckets/{{bucket_id}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import this resource using one of the formats above. For example:
+
+```tf
+import {
+  id = "billingAccounts/{{billingAccount}}/locations/{{location}}/buckets/{{bucket_id}}"
+  to = google_logging_billing_account_bucket_config.default
+}
+```
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), this resource can be imported using one of the formats above. For example:
+
 ```
 $ terraform import google_logging_billing_account_bucket_config.default billingAccounts/{{billingAccount}}/locations/{{location}}/buckets/{{bucket_id}}
 ```

--- a/mmv1/third_party/terraform/website/docs/r/logging_billing_account_exclusion.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_billing_account_exclusion.html.markdown
@@ -55,6 +55,19 @@ In addition to the arguments listed above, the following computed attributes are
 
 Billing account logging exclusions can be imported using their URI, e.g.
 
+* `billingAccounts/{{billing_account}}/exclusions/{{name}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import billing account logging exclusions using one of the formats above. For example:
+
+```tf
+import {
+  id = "billingAccounts/{{billing_account}}/exclusions/{{name}}"
+  to = google_logging_billing_account_exclusion.default
+}
 ```
-$ terraform import google_logging_billing_account_exclusion.my_exclusion billingAccounts/my-billing_account/exclusions/my-exclusion
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), billing account logging exclusions can be imported using one of the formats above. For example:
+
+```
+$ terraform import google_logging_billing_account_exclusion.default billingAccounts/{{billing_account}}/exclusions/{{name}}
 ```

--- a/mmv1/third_party/terraform/website/docs/r/logging_billing_account_sink.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_billing_account_sink.html.markdown
@@ -101,6 +101,19 @@ exported:
 
 Billing account logging sinks can be imported using this format:
 
+* `billingAccounts/{{billing_account_id}}/sinks/{{sink_id}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import billing account logging sinks using one of the formats above. For example:
+
+```tf
+import {
+  id = "billingAccounts/{{billing_account_id}}/sinks/{{sink_id}}"
+  to = google_logging_billing_account_sink.default
+}
 ```
-$ terraform import google_logging_billing_account_sink.my_sink billingAccounts/{{billing_account_id}}/sinks/{{sink_id}}
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), billing account logging sinks can be imported using one of the formats above. For example:
+
+```
+$ terraform import google_logging_billing_account_sink.default billingAccounts/{{billing_account_id}}/sinks/{{sink_id}}
 ```

--- a/mmv1/third_party/terraform/website/docs/r/logging_folder_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_folder_bucket_config.html.markdown
@@ -57,6 +57,19 @@ exported:
 
 This resource can be imported using the following format:
 
+* `folders/{{folder}}/locations/{{location}}/buckets/{{bucket_id}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import this resource using one of the formats above. For example:
+
+```tf
+import {
+  id = "folders/{{folder}}/locations/{{location}}/buckets/{{bucket_id}}"
+  to = google_logging_folder_bucket_config.default
+}
+```
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), this resource can be imported using one of the formats above. For example:
+
 ```
 $ terraform import google_logging_folder_bucket_config.default folders/{{folder}}/locations/{{location}}/buckets/{{bucket_id}}
 ```

--- a/mmv1/third_party/terraform/website/docs/r/logging_folder_exclusion.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_folder_exclusion.html.markdown
@@ -61,6 +61,19 @@ In addition to the arguments listed above, the following computed attributes are
 
 Folder-level logging exclusions can be imported using their URI, e.g.
 
+* `folders/{{folder}}/exclusions/{{name}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import folder-level logging exclusions using one of the formats above. For example:
+
+```tf
+import {
+  id = "folders/{{folder}}/exclusions/{{name}}"
+  to = google_logging_folder_exclusion.default
+}
 ```
-$ terraform import google_logging_folder_exclusion.my_exclusion folders/my-folder/exclusions/my-exclusion
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), folder-level logging exclusions can be imported using one of the formats above. For example:
+
+```
+$ terraform import google_logging_folder_exclusion.default folders/{{folder}}/exclusions/{{name}}
 ```

--- a/mmv1/third_party/terraform/website/docs/r/logging_folder_sink.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_folder_sink.html.markdown
@@ -110,6 +110,19 @@ exported:
 
 Folder-level logging sinks can be imported using this format:
 
+* `folders/{{folder_id}}/sinks/{{name}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import folder-level logging sinks using one of the formats above. For example:
+
+```tf
+import {
+  id = "folders/{{folder_id}}/sinks/{{name}}"
+  to = google_logging_folder_sink.default
+}
 ```
-$ terraform import google_logging_folder_sink.my_sink folders/{{folder_id}}/sinks/{{name}}
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), folder-level logging sinks can be imported using one of the formats above. For example:
+
+```
+$ terraform import google_logging_folder_sink.default folders/{{folder_id}}/sinks/{{name}}
 ```

--- a/mmv1/third_party/terraform/website/docs/r/logging_organization_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_organization_bucket_config.html.markdown
@@ -54,8 +54,20 @@ exported:
 
 ## Import
 
-
 This resource can be imported using the following format:
+
+* `organizations/{{organization}}/locations/{{location}}/buckets/{{bucket_id}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import this resource using one of the formats above. For example:
+
+```tf
+import {
+  id = "organizations/{{organization}}/locations/{{location}}/buckets/{{bucket_id}}"
+  to = google_logging_organization_bucket_config.default
+}
+```
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), this resource can be imported using one of the formats above. For example:
 
 ```
 $ terraform import google_logging_organization_bucket_config.default organizations/{{organization}}/locations/{{location}}/buckets/{{bucket_id}}

--- a/mmv1/third_party/terraform/website/docs/r/logging_organization_exclusion.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_organization_exclusion.html.markdown
@@ -55,6 +55,19 @@ In addition to the arguments listed above, the following computed attributes are
 
 Organization-level logging exclusions can be imported using their URI, e.g.
 
+* `organizations/{{organization}}/exclusions/{{name}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import organization-level logging exclusions using one of the formats above. For example:
+
+```tf
+import {
+  id = "organizations/{{organization}}/exclusions/{{name}}"
+  to = google_logging_organization_exclusion.default
+}
 ```
-$ terraform import google_logging_organization_exclusion.my_exclusion organizations/{{organization}}/exclusions/{{name}}
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), organization-level logging exclusions can be imported using one of the formats above. For example:
+
+```
+$ terraform import google_logging_organization_exclusion.default organizations/{{organization}}/exclusions/{{name}}
 ```

--- a/mmv1/third_party/terraform/website/docs/r/logging_organization_sink.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_organization_sink.html.markdown
@@ -100,6 +100,19 @@ exported:
 
 Organization-level logging sinks can be imported using this format:
 
+* `organizations/{{organization_id}}/sinks/{{sink_id}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import organization-level logging sinks using one of the formats above. For example:
+
+```tf
+import {
+  id = "organizations/{{organization_id}}/sinks/{{sink_id}}"
+  to = google_logging_organization_sink.default
+}
 ```
-$ terraform import google_logging_organization_sink.my_sink organizations/{{organization_id}}/sinks/{{sink_id}}
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), organization-level logging sinks can be imported using one of the formats above. For example:
+
+```
+$ terraform import google_logging_organization_sink.default organizations/{{organization_id}}/sinks/{{sink_id}}
 ```

--- a/mmv1/third_party/terraform/website/docs/r/logging_project_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_project_bucket_config.html.markdown
@@ -151,6 +151,19 @@ exported:
 
 This resource can be imported using the following format:
 
+* `projects/{{project}}/locations/{{location}}/buckets/{{bucket_id}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import this resource using one of the formats above. For example:
+
+```tf
+import {
+  id = "projects/{{project}}/locations/{{location}}/buckets/{{bucket_id}}"
+  to = google_logging_project_bucket_config.default
+}
+```
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), this resource can be imported using one of the formats above. For example:
+
 ```
 $ terraform import google_logging_project_bucket_config.default projects/{{project}}/locations/{{location}}/buckets/{{bucket_id}}
 ```

--- a/mmv1/third_party/terraform/website/docs/r/logging_project_exclusion.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_project_exclusion.html.markdown
@@ -55,6 +55,19 @@ In addition to the arguments listed above, the following computed attributes are
 
 Project-level logging exclusions can be imported using their URI, e.g.
 
+* `projects/{{project_id}}/exclusions/{{name}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import project-level logging exclusions using one of the formats above. For example:
+
+```tf
+import {
+  id = "projects/{{project_id}}/exclusions/{{name}}"
+  to = google_logging_project_exclusion.default
+}
 ```
-$ terraform import google_logging_project_exclusion.my_exclusion projects/my-project/exclusions/my-exclusion
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), project-level logging exclusions can be imported using one of the formats above. For example:
+
+```
+$ terraform import google_logging_project_exclusion.default projects/{{project_id}}/exclusions/{{name}}
 ```

--- a/mmv1/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
@@ -180,6 +180,19 @@ exported:
 
 Project-level logging sinks can be imported using their URI, e.g.
 
+* `projects/{{project_id}}/sinks/{{name}}`
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import project-level logging sinks using one of the formats above. For example:
+
+```tf
+import {
+  id = "projects/{{project_id}}/sinks/{{name}}"
+  to = google_logging_project_sink.default
+}
 ```
-$ terraform import google_logging_project_sink.my_sink projects/my-project/sinks/my-sink
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), project-level logging sinks can be imported using one of the formats above. For example:
+
+```
+$ terraform import google_logging_project_sink.default projects/{{project_id}}/sinks/{{name}}
 ```


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR makes changes to the Import sections of resource docs.

The text changes were originally discussed in this PR: https://github.com/GoogleCloudPlatform/magic-modules/pull/9017

---

To be merged at the same time as:
- https://github.com/GoogleCloudPlatform/magic-modules/pull/9017
- https://github.com/GoogleCloudPlatform/magic-modules/pull/9086
- https://github.com/GoogleCloudPlatform/magic-modules/pull/9101
- https://github.com/GoogleCloudPlatform/magic-modules/pull/9136

---

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
