### PR TITLE
Subnet allowSubnetCidrRoutesOverlap

### DIFF
--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -408,4 +408,3 @@ properties:
       existing resources are dropped and prevented from leaving the VPC.
       Setting this field to true will allow these packets to match dynamic routes injected
       via BGP even if their destinations match existing subnet ranges.
-

--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -116,6 +116,13 @@ examples:
     vars:
       subnetwork_name: 'subnet-purpose-test-subnetwork'
       network_name: 'subnet-purpose-test-network'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'subnetwork_cidr_overlap'
+    min_version: beta
+    primary_resource_id: 'subnetwork-cidr-overlap'
+    vars:
+      subnetwork_name: 'subnet-cidr-overlap'
+      network_name: 'net-cidr-overlap'
 properties:
   - !ruby/object:Api::Type::Time
     name: 'creationTimestamp'
@@ -388,3 +395,13 @@ properties:
     output: true
     description: |
       The range of external IPv6 addresses that are owned by this subnetwork.
+  - !ruby/object:Api::Type::Boolean
+    name: 'allowSubnetCidrRoutesOverlap'
+    default_from_api: true
+    min_version: beta
+    description: |
+      Typically packets destined to IPs within the subnetwork range that do not match
+      existing resources are dropped and prevented from leaving the VPC.
+      Setting this field to true will allow these packets to match dynamic routes injected
+      via BGP even if their destinations match existing subnet ranges.
+

--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -398,6 +398,10 @@ properties:
   - !ruby/object:Api::Type::Boolean
     name: 'allowSubnetCidrRoutesOverlap'
     default_from_api: true
+    update_verb: :PATCH
+    update_url: projects/{{project}}/regions/{{region}}/subnetworks/{{name}}
+    fingerprint_name: 'fingerprint'
+    update_id: 'allowSubnetCidrRoutesOverlap'
     min_version: beta
     description: |
       Typically packets destined to IPs within the subnetwork range that do not match

--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -401,7 +401,7 @@ properties:
     update_verb: :PATCH
     update_url: projects/{{project}}/regions/{{region}}/subnetworks/{{name}}
     fingerprint_name: 'fingerprint'
-    update_id: 'allowSubnetCidrRoutesOverlap'
+    send_empty_value: true
     min_version: beta
     description: |
       Typically packets destined to IPs within the subnetwork range that do not match

--- a/mmv1/templates/terraform/examples/subnetwork_cidr_overlap.tf.erb
+++ b/mmv1/templates/terraform/examples/subnetwork_cidr_overlap.tf.erb
@@ -1,0 +1,16 @@
+resource "google_compute_subnetwork" "subnetwork-cidr-overlap" {
+  provider = google-beta
+
+  name                             = "<%= ctx[:vars]['subnetwork_name'] %>"
+  region                           = "us-west2"
+  ip_cidr_range                    = "192.168.1.0/24"
+  allow_subnet_cidr_routes_overlap = true
+  network                          = google_compute_network.net-cidr-overlap.id
+}
+
+resource "google_compute_network" "net-cidr-overlap" {
+  provider                = google-beta
+
+  name                    = "<%= ctx[:vars]['network_name'] %>"
+  auto_create_subnetworks = false
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `allow_subnet_cidr_routes_overlap` field to `google_compute_subnetwork` resource
```
