### PR TITLE
Add index_configs field to log bucket configuration

### DIFF
--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config.go
@@ -11,8 +11,6 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
-var indexTypes = []string{"INDEX_TYPE_UNSPECIFIED", "INDEX_TYPE_STRING", "INDEX_TYPE_INTEGER"}
-
 var loggingBucketConfigSchema = map[string]*schema.Schema{
 	"name": {
 		Type:        schema.TypeString,
@@ -99,7 +97,7 @@ See [Enabling CMEK for Logging Buckets](https://cloud.google.com/logging/docs/ro
 			Schema: map[string]*schema.Schema{
 				"field_path": &schema.Schema{
 					Type:        schema.TypeString,
-					Required: true,
+					Required:    true,
 					Description: `The LogEntry field path to index.`,
 				},
 				"type": &schema.Schema{
@@ -108,13 +106,6 @@ See [Enabling CMEK for Logging Buckets](https://cloud.google.com/logging/docs/ro
 					Description: `The type of data in this index
 Note that some paths are automatically indexed, and other paths are not eligible for indexing. See [indexing documentation]( https://cloud.google.com/logging/docs/view/advanced-queries#indexed-fields) for details.
 For example: jsonPayload.request.status`,
-				},
-				"create_time": &schema.Schema{
-					Type:     schema.TypeString,
-					Computed: true,
-					Description: `The timestamp when the index was last modified..
-This is used to return the timestamp, and will be ignored if supplied during update.
-A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".`,
 				},
 			},
 		},
@@ -370,7 +361,7 @@ func resourceLoggingBucketConfigUpdate(d *schema.ResourceData, meta interface{})
 	if d.HasChange("index_configs") {
 		updateMask = append(updateMask, "indexConfigs")
 	}
-	
+
 	url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
 	if err != nil {
 		return err
@@ -463,19 +454,10 @@ func expandIndexConfigs(originalIndexConfigs []interface{}) ([]map[string]interf
 	transformedIndexConfigs := make([]map[string]interface{}, 0, len(originalIndexConfigs))
 	for _, entry := range originalIndexConfigs {
 		original := entry.(map[string]interface{})
-		var validIndexType = false
-		for _, indexType := range indexTypes {
-			if indexType == fmt.Sprintf("%v", original["type"]) {
-				validIndexType = true
-			}
-		}
-		if !validIndexType {
-			return nil, fmt.Errorf("Invalid index type, should be one of %s", indexTypes)
-		}
 
 		transformed := map[string]interface{}{
-			"fieldPath":  original["field_path"],
-			"type":       original["type"],
+			"fieldPath": original["field_path"],
+			"type":      original["type"],
 		}
 		transformedIndexConfigs = append(transformedIndexConfigs, transformed)
 	}

--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config.go
@@ -314,7 +314,7 @@ func resourceLoggingBucketConfigRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error setting cmek_settings: %s", err)
 	}
 
-	if err := d.Set("index_configs", flattenIndexConfigs(indexConfigs.([]interface{}))); err != nil {
+	if err := d.Set("index_configs", flattenIndexConfigs(res["indexConfigs"].([]interface{}))); err != nil {
 		return fmt.Errorf("Error setting index_configs: %s", err)
 	}
 

--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config.go
@@ -88,19 +88,19 @@ See [Enabling CMEK for Logging Buckets](https://cloud.google.com/logging/docs/ro
 			},
 		},
 	},
-	"index_configs": &schema.Schema{
+	"index_configs": {
 		Type:        schema.TypeSet,
 		MaxItems:    20,
 		Optional:    true,
 		Description: `A list of indexed fields and related configuration data.`,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"field_path": &schema.Schema{
+				"field_path": {
 					Type:        schema.TypeString,
 					Required:    true,
 					Description: `The LogEntry field path to index.`,
 				},
-				"type": &schema.Schema{
+				"type": {
 					Type:     schema.TypeString,
 					Required: true,
 					Description: `The type of data in this index
@@ -314,11 +314,8 @@ func resourceLoggingBucketConfigRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error setting cmek_settings: %s", err)
 	}
 
-	indexConfigs, ok := res["indexConfigs"]
-	if ok {
-		if err := d.Set("index_configs", flattenIndexConfigs(indexConfigs.([]interface{}))); err != nil {
-			return fmt.Errorf("Error setting index_configs: %s", err)
-		}
+	if err := d.Set("index_configs", flattenIndexConfigs(indexConfigs.([]interface{}))); err != nil {
+		return fmt.Errorf("Error setting index_configs: %s", err)
 	}
 
 	return nil

--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config.go
@@ -469,9 +469,8 @@ func flattenIndexConfigs(indexConfigs []interface{}) []map[string]interface{} {
 	for _, entry := range indexConfigs {
 		indexConfig := entry.(map[string]interface{})
 		data := map[string]interface{}{
-			"field_path":  indexConfig["fieldPath"],
-			"type":        indexConfig["type"],
-			"create_time": indexConfig["createTime"],
+			"field_path": indexConfig["fieldPath"],
+			"type":       indexConfig["type"],
 		}
 		flattenedIndexConfigs = append(flattenedIndexConfigs, data)
 	}

--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
@@ -523,3 +523,69 @@ func getLoggingBucketConfigs(context map[string]interface{}) map[string]string {
 	}
 
 }
+
+func TestAccLoggingBucketConfigProject_indexConfigs(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project_name":    "tf-test-" + acctest.RandString(t, 10),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
+		"bucket_id":       "tf-test-bucket-" + acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingBucketConfigProject_indexConfigs(context, "INDEX_TYPE_STRING", "INDEX_TYPE_STRING"),
+			},
+			{
+				ResourceName:            "google_logging_project_bucket_config.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"project"},
+			},
+			{
+				Config: testAccLoggingBucketConfigProject_indexConfigs(context, "INDEX_TYPE_STRING", "INDEX_TYPE_INTEGER"),
+			},
+			{
+				ResourceName:            "google_logging_project_bucket_config.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"project"},
+			},
+		},
+	})
+}
+
+func testAccLoggingBucketConfigProject_indexConfigs(context map[string]interface{}, urlIndexType, statusIndexType string) string {
+	return fmt.Sprintf(acctest.Nprintf(`
+
+resource "google_project" "default" {
+	project_id      = "%{project_name}"
+	name            = "%{project_name}"
+	org_id          = "%{org_id}"
+	billing_account = "%{billing_account}"
+}
+
+resource "google_logging_project_bucket_config" "basic" {
+	project        	= google_project.default.name
+	location       	= "us-east1"
+	retention_days 	= 30
+	description    	= "retention test 30 days"
+	bucket_id      	= "%{bucket_id}"
+
+	index_configs {
+		field_path 	= "jsonPayload.request.url"
+		type		= "%s"
+	}
+
+	index_configs {
+		field_path 	= "jsonPayload.response.status"
+		type		= "%s"
+	}
+}
+`, context), urlIndexType, statusIndexType)
+}

--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
@@ -546,7 +546,7 @@ func TestAccLoggingBucketConfigOrganization_indexConfigs(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"organization"},
 			},
 			{
-				Config: testAccLoggingBucketConfigOrganization_indexConfigs(context, "INDEX_TYPE_STRING", "INDEX_TYPE_STRING"),
+				Config: testAccLoggingBucketConfigOrganization_indexConfigs(context, "INDEX_TYPE_STRING", "INDEX_TYPE_INTEGER"),
 			},
 			{
 				ResourceName:            "google_logging_organization_bucket_config.basic",
@@ -571,7 +571,7 @@ resource "google_logging_organization_bucket_config" "basic" {
 	description = "retention test 30 days"
 	bucket_id = "_Default"
 
-    index_configs {
+	index_configs {
 		field_path 	= "jsonPayload.request.url"
 		type		= "%s"
 	}

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_bucket_config.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_bucket_config.go
@@ -214,11 +214,7 @@ func resourceLoggingProjectBucketConfigCreate(d *schema.ResourceData, meta inter
 	obj["retentionDays"] = d.Get("retention_days")
 	obj["analyticsEnabled"] = d.Get("enable_analytics")
 	obj["cmekSettings"] = expandCmekSettings(d.Get("cmek_settings"))
-	expandedIndexConfigs, err := expandIndexConfigs(d.Get("index_configs").(*schema.Set).List())
-	obj["indexConfigs"] = expandedIndexConfigs
-	if err != nil {
-		return err
-	}
+	obj["indexConfigs"] = expandIndexConfigs(d.Get("index_configs"))
 
 	url, err := tpgresource.ReplaceVars(d, config, "{{LoggingBasePath}}projects/{{project}}/locations/{{location}}/buckets?bucketId={{bucket_id}}")
 	if err != nil {
@@ -309,7 +305,7 @@ func resourceLoggingProjectBucketConfigRead(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("Error setting cmek_settings: %s", err)
 	}
 
-	if err := d.Set("index_configs", flattenIndexConfigs(res["indexConfigs"].([]interface{}))); err != nil {
+	if err := d.Set("index_configs", flattenIndexConfigs(res["indexConfigs"])); err != nil {
 		return fmt.Errorf("Error setting index_configs: %s", err)
 	}
 
@@ -356,12 +352,7 @@ func resourceLoggingProjectBucketConfigUpdate(d *schema.ResourceData, meta inter
 	obj["retentionDays"] = d.Get("retention_days")
 	obj["description"] = d.Get("description")
 	obj["cmekSettings"] = expandCmekSettings(d.Get("cmek_settings"))
-
-	expandedIndexConfigs, err := expandIndexConfigs(d.Get("index_configs").(*schema.Set).List())
-	obj["indexConfigs"] = expandedIndexConfigs
-	if err != nil {
-		return err
-	}
+	obj["indexConfigs"] = expandIndexConfigs(d.Get("index_configs"))
 
 	updateMask := []string{}
 	if d.HasChange("retention_days") {

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_bucket_config.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_bucket_config.go
@@ -309,7 +309,7 @@ func resourceLoggingProjectBucketConfigRead(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("Error setting cmek_settings: %s", err)
 	}
 
-	if err := d.Set("index_configs", flattenIndexConfigs(indexConfigs.([]interface{}))); err != nil {
+	if err := d.Set("index_configs", flattenIndexConfigs(res["indexConfigs"].([]interface{}))); err != nil {
 		return fmt.Errorf("Error setting index_configs: %s", err)
 	}
 

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_bucket_config.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_bucket_config.go
@@ -106,31 +106,24 @@ See [Enabling CMEK for Logging Buckets](https://cloud.google.com/logging/docs/ro
 			},
 		},
 	},
-	"index_configs": &schema.Schema{
+	"index_configs": {
 		Type:        schema.TypeSet,
 		MaxItems:    20,
 		Optional:    true,
 		Description: `A list of indexed fields and related configuration data.`,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"field_path": &schema.Schema{
+				"field_path": {
 					Type:        schema.TypeString,
-					Required: true,
+					Required:    true,
 					Description: `The LogEntry field path to index.`,
 				},
-				"type": &schema.Schema{
+				"type": {
 					Type:     schema.TypeString,
 					Required: true,
 					Description: `The type of data in this index
 Note that some paths are automatically indexed, and other paths are not eligible for indexing. See [indexing documentation]( https://cloud.google.com/logging/docs/view/advanced-queries#indexed-fields) for details.
 For example: jsonPayload.request.status`,
-				},
-				"create_time": &schema.Schema{
-					Type:     schema.TypeString,
-					Computed: true,
-					Description: `The timestamp when the index was last modified..
-This is used to return the timestamp, and will be ignored if supplied during update.
-A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".`,
 				},
 			},
 		},
@@ -316,11 +309,8 @@ func resourceLoggingProjectBucketConfigRead(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("Error setting cmek_settings: %s", err)
 	}
 
-	indexConfigs, ok := res["indexConfigs"]
-	if ok {
-		if err := d.Set("index_configs", flattenIndexConfigs(indexConfigs.([]interface{}))); err != nil {
-			return fmt.Errorf("Error setting index_configs: %s", err)
-		}
+	if err := d.Set("index_configs", flattenIndexConfigs(indexConfigs.([]interface{}))); err != nil {
+		return fmt.Errorf("Error setting index_configs: %s", err)
 	}
 
 	return nil

--- a/mmv1/third_party/terraform/website/docs/r/logging_billing_account_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_billing_account_bucket_config.html.markdown
@@ -16,14 +16,30 @@ Manages a billing account level logging bucket config. For more information see
 
 ```hcl
 data "google_billing_account" "default" {
-	billing_account = "00AA00-000AAA-00AA0A"
+  billing_account = "00AA00-000AAA-00AA0A"
 }
 
 resource "google_logging_billing_account_bucket_config" "basic" {
-	billing_account    = data.google_billing_account.default.billing_account
-	location  = "global"
-	retention_days = 30
-	bucket_id = "_Default"
+  billing_account = data.google_billing_account.default.billing_account
+  location        = "global"
+  retention_days  = 30
+  bucket_id       = "_Default"
+}
+```
+
+Create logging bucket with index configs
+
+```hcl
+resource "google_logging_billing_account_bucket_config" "example-billing-account-bucket-index-configs" {
+  folder          = data.google_billing_account.default.billing_account
+  location        = "global"
+  retention_days  = 30
+  bucket_id       = "_Default"
+	
+  index_configs   = {
+    file_path   = "jsonPayload.request.status"
+    type        = "INDEX_TYPE_STRING"
+  }
 }
 ```
 
@@ -40,6 +56,15 @@ The following arguments are supported:
 * `description` - (Optional) Describes this bucket.
 
 * `retention_days` - (Optional) Logs will be retained by default for this amount of time, after which they will automatically be deleted. The minimum retention period is 1 day. If this value is set to zero at bucket creation time, the default time of 30 days will be used. Bucket retention can not be increased on buckets outside of projects.
+
+* `index_configs` - (Optional) A list of indexed fields and related configuration data. Structure is [documented below](#nested_index_configs).
+
+<a name="nested_index_configs"></a>The `index_configs` block supports:
+
+* `field_path` - The LogEntry field path to index.
+  Note that some paths are automatically indexed, and other paths are not eligible for indexing. See [indexing documentation]( https://cloud.google.com/logging/docs/view/advanced-queries#indexed-fields) for details.
+
+* `type` - The type of data in this index. Allowed types include `INDEX_TYPE_UNSPECIFIED`, `INDEX_TYPE_STRING` and `INDEX_TYPE_INTEGER`.
 
 ## Attributes Reference
 

--- a/mmv1/third_party/terraform/website/docs/r/logging_folder_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_folder_bucket_config.html.markdown
@@ -16,15 +16,15 @@ Manages a folder-level logging bucket config. For more information see
 
 ```hcl
 resource "google_folder" "default" {
-	display_name = "some-folder-name"
-	parent       = "organizations/123456789"
+  display_name = "some-folder-name"
+  parent       = "organizations/123456789"
 }
 
 resource "google_logging_folder_bucket_config" "basic" {
-	folder    = google_folder.default.name
-	location  = "global"
-	retention_days = 30
-	bucket_id = "_Default"
+  folder         = google_folder.default.name
+  location       = "global"
+  retention_days = 30
+  bucket_id      = "_Default"
 }
 ```
 
@@ -32,15 +32,15 @@ Create logging bucket with index configs
 
 ```hcl
 resource "google_logging_folder_bucket_config" "example-folder-bucket-index-configs" {
-	folder          = google_folder.default.name
-	location        = "global"
-	retention_days  = 30
-	bucket_id       = "_Default"
+  folder          = google_folder.default.name
+  location        = "global"
+  retention_days  = 30
+  bucket_id       = "_Default"
 	
-	index_configs   = {
-      file_path   = "jsonPayload.request.status"
-      type        = "INDEX_TYPE_STRING"
-    }
+  index_configs   = {
+    file_path   = "jsonPayload.request.status"
+    type        = "INDEX_TYPE_STRING"
+  }
 }
 ```
 
@@ -65,11 +65,7 @@ The following arguments are supported:
 * `field_path` - The LogEntry field path to index.
   Note that some paths are automatically indexed, and other paths are not eligible for indexing. See [indexing documentation]( https://cloud.google.com/logging/docs/view/advanced-queries#indexed-fields) for details.
 
-* `type` - The type of data in this index.
-
-* `create_time` - The timestamp when the index was last modified.
-  This is used to return the timestamp, and will be ignored if supplied during update.
-  A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+* `type` - The type of data in this index. Allowed types include `INDEX_TYPE_UNSPECIFIED`, `INDEX_TYPE_STRING` and `INDEX_TYPE_INTEGER`.
 
 ## Attributes Reference
 

--- a/mmv1/third_party/terraform/website/docs/r/logging_folder_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_folder_bucket_config.html.markdown
@@ -28,6 +28,22 @@ resource "google_logging_folder_bucket_config" "basic" {
 }
 ```
 
+Create logging bucket with index configs
+
+```hcl
+resource "google_logging_folder_bucket_config" "example-folder-bucket-index-configs" {
+	folder          = google_folder.default.name
+	location        = "global"
+	retention_days  = 30
+	bucket_id       = "_Default"
+	
+	index_configs   = {
+      file_path   = "jsonPayload.request.status"
+      type        = "INDEX_TYPE_STRING"
+    }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -41,6 +57,19 @@ The following arguments are supported:
 * `description` - (Optional) Describes this bucket.
 
 * `retention_days` - (Optional) Logs will be retained by default for this amount of time, after which they will automatically be deleted. The minimum retention period is 1 day. If this value is set to zero at bucket creation time, the default time of 30 days will be used. Bucket retention can not be increased on buckets outside of projects.
+
+* `index_configs` - (Optional) A list of indexed fields and related configuration data. Structure is [documented below](#nested_index_configs).
+
+<a name="nested_index_configs"></a>The `index_configs` block supports:
+
+* `field_path` - The LogEntry field path to index.
+  Note that some paths are automatically indexed, and other paths are not eligible for indexing. See [indexing documentation]( https://cloud.google.com/logging/docs/view/advanced-queries#indexed-fields) for details.
+
+* `type` - The type of data in this index.
+
+* `create_time` - The timestamp when the index was last modified.
+  This is used to return the timestamp, and will be ignored if supplied during update.
+  A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
 
 ## Attributes Reference
 

--- a/mmv1/third_party/terraform/website/docs/r/logging_folder_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_folder_bucket_config.html.markdown
@@ -25,18 +25,7 @@ resource "google_logging_folder_bucket_config" "basic" {
   location       = "global"
   retention_days = 30
   bucket_id      = "_Default"
-}
-```
-
-Create logging bucket with index configs
-
-```hcl
-resource "google_logging_folder_bucket_config" "example-folder-bucket-index-configs" {
-  folder          = google_folder.default.name
-  location        = "global"
-  retention_days  = 30
-  bucket_id       = "_Default"
-	
+  
   index_configs   = {
     file_path   = "jsonPayload.request.status"
     type        = "INDEX_TYPE_STRING"

--- a/mmv1/third_party/terraform/website/docs/r/logging_organization_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_organization_bucket_config.html.markdown
@@ -20,25 +20,14 @@ data "google_organization" "default" {
 }
 
 resource "google_logging_organization_bucket_config" "basic" {
-	organization    = data.google_organization.default.organization
-	location  = "global"
-	retention_days = 30
-	bucket_id = "_Default"
-}
-```
-
-Create logging bucket with index configs
-
-```hcl
-resource "google_logging_organization_bucket_config" "example-organisation-bucket-index-configs" {
-  organization    = data.google_organization.default.organization
-  location        = "global"
-  retention_days  = 30
-  bucket_id       = "_Default"
-
-  index_configs   = {
-    file_path   = "jsonPayload.request.status"
-    type        = "INDEX_TYPE_STRING"
+  organization   = data.google_organization.default.organization
+  location       = "global"
+  retention_days = 30
+  bucket_id      = "_Default"
+  
+  index_configs  = {
+    file_path = "jsonPayload.request.status"
+    type      = "INDEX_TYPE_STRING"
   }
 }
 ```

--- a/mmv1/third_party/terraform/website/docs/r/logging_organization_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_organization_bucket_config.html.markdown
@@ -27,6 +27,22 @@ resource "google_logging_organization_bucket_config" "basic" {
 }
 ```
 
+Create logging bucket with index configs
+
+```hcl
+resource "google_logging_organization_bucket_config" "example-organisation-bucket-index-configs" {
+	organization    = data.google_organization.default.organization
+	location        = "global"
+	retention_days  = 30
+	bucket_id       = "_Default"
+
+    index_configs   = {
+      file_path   = "jsonPayload.request.status"
+      type        = "INDEX_TYPE_STRING"
+    }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -40,6 +56,19 @@ The following arguments are supported:
 * `description` - (Optional) Describes this bucket.
 
 * `retention_days` - (Optional) Logs will be retained by default for this amount of time, after which they will automatically be deleted. The minimum retention period is 1 day. If this value is set to zero at bucket creation time, the default time of 30 days will be used. Bucket retention can not be increased on buckets outside of projects.
+
+* `index_configs` - (Optional) A list of indexed fields and related configuration data. Structure is [documented below](#nested_index_configs).
+
+<a name="nested_index_configs"></a>The `index_configs` block supports:
+
+* `field_path` - The LogEntry field path to index.
+  Note that some paths are automatically indexed, and other paths are not eligible for indexing. See [indexing documentation]( https://cloud.google.com/logging/docs/view/advanced-queries#indexed-fields) for details.
+
+* `type` - The type of data in this index.
+
+* `create_time` - The timestamp when the index was last modified.
+  This is used to return the timestamp, and will be ignored if supplied during update.
+  A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
 
 ## Attributes Reference
 

--- a/mmv1/third_party/terraform/website/docs/r/logging_organization_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_organization_bucket_config.html.markdown
@@ -31,15 +31,15 @@ Create logging bucket with index configs
 
 ```hcl
 resource "google_logging_organization_bucket_config" "example-organisation-bucket-index-configs" {
-	organization    = data.google_organization.default.organization
-	location        = "global"
-	retention_days  = 30
-	bucket_id       = "_Default"
+  organization    = data.google_organization.default.organization
+  location        = "global"
+  retention_days  = 30
+  bucket_id       = "_Default"
 
-    index_configs   = {
-      file_path   = "jsonPayload.request.status"
-      type        = "INDEX_TYPE_STRING"
-    }
+  index_configs   = {
+    file_path   = "jsonPayload.request.status"
+    type        = "INDEX_TYPE_STRING"
+  }
 }
 ```
 
@@ -64,11 +64,7 @@ The following arguments are supported:
 * `field_path` - The LogEntry field path to index.
   Note that some paths are automatically indexed, and other paths are not eligible for indexing. See [indexing documentation]( https://cloud.google.com/logging/docs/view/advanced-queries#indexed-fields) for details.
 
-* `type` - The type of data in this index.
-
-* `create_time` - The timestamp when the index was last modified.
-  This is used to return the timestamp, and will be ignored if supplied during update.
-  A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+* `type` - The type of data in this index. Allowed types include `INDEX_TYPE_UNSPECIFIED`, `INDEX_TYPE_STRING` and `INDEX_TYPE_INTEGER`.
 
 ## Attributes Reference
 

--- a/mmv1/third_party/terraform/website/docs/r/logging_project_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_project_bucket_config.html.markdown
@@ -97,15 +97,15 @@ Create logging bucket with index configs
 
 ```hcl
 resource "google_logging_project_bucket_config" "example-project-bucket-index-configs" {
-	project          = "project_id"
-	location         = "global"
-	retention_days   = 30
-	bucket_id        = "custom-bucket"
+  project          = "project_id"
+  location         = "global"
+  retention_days   = 30
+  bucket_id        = "custom-bucket"
 
-    index_configs   = {
-      file_path   = "jsonPayload.request.status"
-      type        = "INDEX_TYPE_STRING"
-    }
+  index_configs   = {
+    file_path   = "jsonPayload.request.status"
+    type        = "INDEX_TYPE_STRING"
+  }
 }
 ```
 
@@ -158,11 +158,7 @@ See [Enabling CMEK for Logging Buckets](https://cloud.google.com/logging/docs/ro
 * `field_path` - The LogEntry field path to index.
 Note that some paths are automatically indexed, and other paths are not eligible for indexing. See [indexing documentation]( https://cloud.google.com/logging/docs/view/advanced-queries#indexed-fields) for details.
 
-* `type` - The type of data in this index.
-
-* `create_time` - The timestamp when the index was last modified.
-This is used to return the timestamp, and will be ignored if supplied during update.
-A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+* `type` - The type of data in this index. Allowed types include `INDEX_TYPE_UNSPECIFIED`, `INDEX_TYPE_STRING` and `INDEX_TYPE_INTEGER`.
 
 ## Attributes Reference
 

--- a/mmv1/third_party/terraform/website/docs/r/logging_project_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_project_bucket_config.html.markdown
@@ -93,6 +93,22 @@ resource "google_logging_project_bucket_config" "example-project-bucket-cmek-set
 }
 ```
 
+Create logging bucket with index configs
+
+```hcl
+resource "google_logging_project_bucket_config" "example-project-bucket-index-configs" {
+	project          = "project_id"
+	location         = "global"
+	retention_days   = 30
+	bucket_id        = "custom-bucket"
+
+    index_configs   = {
+      file_path   = "jsonPayload.request.status"
+      type        = "INDEX_TYPE_STRING"
+    }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -113,6 +129,7 @@ The following arguments are supported:
 
 * `cmek_settings` - (Optional) The CMEK settings of the log bucket. If present, new log entries written to this log bucket are encrypted using the CMEK key provided in this configuration. If a log bucket has CMEK settings, the CMEK settings cannot be disabled later by updating the log bucket. Changing the KMS key is allowed. Structure is [documented below](#nested_cmek_settings).
 
+* `index_configs` - (Optional) A list of indexed fields and related configuration data. Structure is [documented below](#nested_index_configs).
 
 <a name="nested_cmek_settings"></a>The `cmek_settings` block supports:
 
@@ -135,6 +152,17 @@ This is a read-only field used to convey the specific configured CryptoKeyVersio
 * `service_account_id` - The service account associated with a project for which CMEK will apply.
 Before enabling CMEK for a logging bucket, you must first assign the cloudkms.cryptoKeyEncrypterDecrypter role to the service account associated with the project for which CMEK will apply. Use [v2.getCmekSettings](https://cloud.google.com/logging/docs/reference/v2/rest/v2/TopLevel/getCmekSettings#google.logging.v2.ConfigServiceV2.GetCmekSettings) to obtain the service account ID.
 See [Enabling CMEK for Logging Buckets](https://cloud.google.com/logging/docs/routing/managed-encryption-storage) for more information.
+
+<a name="nested_index_configs"></a>The `index_configs` block supports:
+
+* `field_path` - The LogEntry field path to index.
+Note that some paths are automatically indexed, and other paths are not eligible for indexing. See [indexing documentation]( https://cloud.google.com/logging/docs/view/advanced-queries#indexed-fields) for details.
+
+* `type` - The type of data in this index.
+
+* `create_time` - The timestamp when the index was last modified.
+This is used to return the timestamp, and will be ignored if supplied during update.
+A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
 
 ## Attributes Reference
 


### PR DESCRIPTION
Ability to manage log bucket index configurations by adding `index_configs` field to logging_bucket_config resources.

Addresses feature request raised in [hashicorp/terraform-provider-google#13287](https://github.com/hashicorp/terraform-provider-google/issues/13287)

```release-note:enhancement
logging: added `index_configs` field to `logging_bucket_config` resource
```

```release-note:enhancement
logging: added `index_configs` field to `logging_project_bucket_config` resource
```
