### PR TITLE
docs(alloydb): use network_config instead of deprecated network in examples

### DIFF
--- a/mmv1/templates/terraform/examples/alloydb_backup_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/alloydb_backup_basic.tf.erb
@@ -9,7 +9,9 @@ resource "google_alloydb_backup" "<%= ctx[:primary_resource_id] %>" {
 resource "google_alloydb_cluster" "<%= ctx[:primary_resource_id] %>" {
   cluster_id = "<%= ctx[:vars]['alloydb_cluster_name'] %>"
   location   = "us-central1"
-  network    = google_compute_network.default.id
+  network_config {
+    network = google_compute_network.default.id
+  }
 }
 
 resource "google_alloydb_instance" "<%= ctx[:primary_resource_id] %>" {

--- a/mmv1/templates/terraform/examples/alloydb_backup_full.tf.erb
+++ b/mmv1/templates/terraform/examples/alloydb_backup_full.tf.erb
@@ -14,7 +14,9 @@ resource "google_alloydb_backup" "<%= ctx[:primary_resource_id] %>" {
 resource "google_alloydb_cluster" "<%= ctx[:primary_resource_id] %>" {
   cluster_id = "<%= ctx[:vars]['alloydb_cluster_name'] %>"
   location   = "us-central1"
-  network    = google_compute_network.default.id
+  network_config {
+    network = google_compute_network.default.id
+  }
 }
 
 resource "google_alloydb_instance" "<%= ctx[:primary_resource_id] %>" {

--- a/mmv1/templates/terraform/examples/alloydb_cluster_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/alloydb_cluster_basic.tf.erb
@@ -1,7 +1,9 @@
 resource "google_alloydb_cluster" "<%= ctx[:primary_resource_id] %>" {
   cluster_id = "<%= ctx[:vars]['alloydb_cluster_name'] %>"
   location   = "us-central1"
-  network    = google_compute_network.default.id
+  network_config {
+    network = google_compute_network.default.id
+  }
 }
 
 data "google_project" "project" {}

--- a/mmv1/templates/terraform/examples/alloydb_cluster_full.tf.erb
+++ b/mmv1/templates/terraform/examples/alloydb_cluster_full.tf.erb
@@ -1,7 +1,9 @@
 resource "google_alloydb_cluster" "<%= ctx[:primary_resource_id] %>" {
-  cluster_id   = "<%= ctx[:vars]['alloydb_cluster_name'] %>"
-  location     = "us-central1"
-  network      = google_compute_network.default.id
+  cluster_id = "<%= ctx[:vars]['alloydb_cluster_name'] %>"
+  location   = "us-central1"
+  network_config {
+    network = google_compute_network.default.id
+  }
   database_version = "POSTGRES_15"
 
   initial_user {

--- a/mmv1/templates/terraform/examples/alloydb_cluster_restore.tf.erb
+++ b/mmv1/templates/terraform/examples/alloydb_cluster_restore.tf.erb
@@ -31,7 +31,9 @@ resource "google_alloydb_backup" "<%= ctx[:primary_resource_id] %>" {
 resource "google_alloydb_cluster" "restored_from_backup" {
   cluster_id            = "<%= ctx[:vars]['alloydb_backup_restored_cluster_name'] %>"
   location              = "us-central1"
-  network               = data.google_compute_network.default.id
+  network_config {
+    network = data.google_compute_network.default.id
+  }
   restore_backup_source {
     backup_name = google_alloydb_backup.<%= ctx[:primary_resource_id] %>.name
   }

--- a/mmv1/templates/terraform/examples/alloydb_instance_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/alloydb_instance_basic.tf.erb
@@ -13,7 +13,9 @@ resource "google_alloydb_instance" "<%= ctx[:primary_resource_id] %>" {
 resource "google_alloydb_cluster" "<%= ctx[:primary_resource_id] %>" {
   cluster_id = "<%= ctx[:vars]['alloydb_cluster_name'] %>"
   location   = "us-central1"
-  network    = google_compute_network.default.id
+  network_config {
+    network = google_compute_network.default.id
+  }
 
   initial_user {
     password = "<%= ctx[:vars]['alloydb_cluster_name'] %>"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The `network` field in `google_alloydb_cluster` resource has been deprecated by https://github.com/GoogleCloudPlatform/magic-modules/pull/8963, but examples in the documentation have not been updated accordingly. This PR makes changes to use `network_config` in the examples.

Part of https://github.com/hashicorp/terraform-provider-google/issues/16119

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
