### PR TITLE
revert downstream waiter change in main

### DIFF
--- a/.ci/scripts/bash-plus/downstream-waiter/wait_for_commit.sh
+++ b/.ci/scripts/bash-plus/downstream-waiter/wait_for_commit.sh
@@ -24,14 +24,25 @@ if git merge-base --is-ancestor $SHA origin/$SYNC_BRANCH; then
 fi
 
 while true; do
-    SYNC_HEAD="$(git rev-parse --short origin/$SYNC_BRANCH)"
-    BASE_PARENT="$(git rev-parse --short origin/$BASE_BRANCH~)"
-    if [ "$SYNC_HEAD" == "$BASE_PARENT" ]; then
-        break;
-    else
-        echo "sync branch at: $SYNC_HEAD"
-        echo "base branch at: $BASE_BRANCH"
-        git fetch origin $SYNC_BRANCH
+    if [ "$BASE_BRANCH" != "main" ]; then
+        SYNC_HEAD="$(git rev-parse --short origin/$SYNC_BRANCH)"
+        BASE_PARENT="$(git rev-parse --short $SHA~)"
+        if [ "$SYNC_HEAD" == "$BASE_PARENT" ]; then
+            break;
+        else
+            echo "sync branch is at: $SYNC_HEAD"
+            echo "current commit is $SHA"
+            git fetch origin $SYNC_BRANCH
+        fi
+    else 
+        commits="$(git log --pretty=%H origin/$SYNC_BRANCH..origin/$BASE_BRANCH | tail -n 1)"
+        if [ "$commits" == "$SHA" ]; then
+            break
+        else
+            echo "git log says waiting on: $commits"
+            echo "command says waiting on $SHA"
+            git fetch origin $SYNC_BRANCH
+        fi
     fi
     sleep 5
 done


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This is to revert the change in https://github.com/GoogleCloudPlatform/magic-modules/pull/9095 and add potential fix (https://github.com/GoogleCloudPlatform/magic-modules/pull/9056) for handling concurrent builds in feature branches. Even if the fix failed, it should not affect the main branch

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
