### PR TITLE
Run Nightly Tests against `main` every night of week, no longer test release branch

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/generated/project.erb
+++ b/mmv1/third_party/terraform/.teamcity/components/generated/project.erb
@@ -114,15 +114,4 @@ class NightlyTriggerConfiguration(environment: String, branchRef: String, nightl
     var daysOfWeek = daysOfWeek
     var daysOfMonth = daysOfMonth
 
-    init {
-        // If the environment parameter is set to the value of MAJOR_RELEASE_TESTING, 
-        // change the days of week to the day for v5.0.0 feature branch testing
-        if (environment == MAJOR_RELEASE_TESTING) {
-<% if version == 'ga' -%>
-            this.daysOfWeek = "5" // Thursday for GA, TeamCity numbers days Sun=1...Sat=7
-<% elsif version == 'beta' -%>
-            this.daysOfWeek = "6" // Friday for Beta, TeamCity numbers days Sun=1...Sat=7
-<% end -%>
-        }
-    }
 }

--- a/mmv1/third_party/terraform/.teamcity/components/generated/settings.erb
+++ b/mmv1/third_party/terraform/.teamcity/components/generated/settings.erb
@@ -16,11 +16,7 @@ var defaultParallelism = 6
 var defaultTerraformCoreVersion = "1.2.5"
 
 // This represents a cron view of days of the week
-<% if version == 'ga' -%>
-const val defaultDaysOfWeek = "1-4,6-7" // All nights except Thursday (5) for GA; feature branch testing happens on Thursdays and TeamCity numbers days Sun=1...Sat=7
-<% elsif version == 'beta' -%>
-const val defaultDaysOfWeek = "1-5,7" // All nights except Friday (6) for Beta; feature branch testing happens on Fridays and TeamCity numbers days Sun=1...Sat=7
-<% end -%>
+const val defaultDaysOfWeek = "*"
 
 // Cron value for any day of month
 const val defaultDaysOfMonth = "*"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR makes the cron triggers in TeamCity schedule builds every night of the week with no variation based on GA/Beta or `main`/`FEATURE-BRANCH-major-release-5.0.0`.

When this PR is merged I'll disconnect the old 5.0.0 test projects and remove their CRON triggers manually


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
