### PR TITLE
Add support for enable_confidential_storage flag

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -682,12 +682,14 @@ func schemaNodeConfig() *schema.Schema {
 						},
 					},
 				},
+				<% unless version == 'ga' -%>
 				"enable_confidential_storage": {
 						Type:     schema.TypeBool,
 						Optional: true,
 						ForceNew: true,
 						Description: `If enabled boot disks are configured with confidential mode.`,
 				},
+				<% end -%>
 			},
 		},
 	}

--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -682,6 +682,12 @@ func schemaNodeConfig() *schema.Schema {
 						},
 					},
 				},
+				"enable_confidential_storage": {
+						Type:     schema.TypeBool,
+						Optional: true,
+						ForceNew: true,
+						Description: `If enabled boot disks are configured with confidential mode.`,
+				},
 			},
 		},
 	}
@@ -968,6 +974,12 @@ func expandNodeConfig(v interface{}) *container.NodeConfig {
 		nc.SoleTenantConfig = expandSoleTenantConfig(v)
 	}
 
+	<% unless version == 'ga' -%>
+	if v,ok := nodeConfig["enable_confidential_storage"]; ok {
+		nc.EnableConfidentialStorage = v.(bool)
+	}
+	<% end -%>
+	
 	<% unless version == "ga" -%>
 	if v, ok := nodeConfig["host_maintenance_policy"]; ok {
 		nc.HostMaintenancePolicy = expandHostMaintenancePolicy(v)
@@ -1206,6 +1218,9 @@ func flattenNodeConfig(c *container.NodeConfig, v interface{}) []map[string]inte
 		"advanced_machine_features": flattenAdvancedMachineFeaturesConfig(c.AdvancedMachineFeatures),
 		"sole_tenant_config":        flattenSoleTenantConfig(c.SoleTenantConfig),
 		"fast_socket":               flattenFastSocket(c.FastSocket),
+	<% unless version == 'ga' -%>		
+		"enable_confidential_storage": c.EnableConfidentialStorage,
+	<% end -%>
 	})
 
 	if len(c.OauthScopes) > 0 {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -8643,7 +8643,7 @@ func TestAccContainerCluster_withConfidentialBootDisk(t *testing.T) {
 				ResourceName:            "google_container_cluster.with_confidential_boot_disk",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"min_master_version"},
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
 	})
@@ -8696,7 +8696,7 @@ func TestAccContainerCluster_withConfidentialBootDiskNodeConfig(t *testing.T) {
 				ResourceName:            "google_container_cluster.with_confidential_boot_disk_node_config",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"min_master_version"},
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
 	})
@@ -8743,7 +8743,7 @@ func TestAccContainerCluster_withoutConfidentialBootDisk(t *testing.T) {
 				ResourceName:            "google_container_cluster.without_confidential_boot_disk",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"min_master_version"},
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -8625,6 +8625,7 @@ func TestAccContainerCluster_withConfidentialBootDisk(t *testing.T) {
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	npName := fmt.Sprintf("tf-test-node-pool-%s", acctest.RandString(t, 10))
 	kms := acctest.BootstrapKMSKeyInLocation(t, "us-central1")
 
 	if acctest.BootstrapPSARole(t, "service-", "compute-system", "roles/cloudkms.cryptoKeyEncrypterDecrypter") {
@@ -8637,7 +8638,7 @@ func TestAccContainerCluster_withConfidentialBootDisk(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withConfidentialBootDisk(clusterName, kms.CryptoKey.Name),
+				Config: testAccContainerCluster_withConfidentialBootDisk(clusterName, npName, kms.CryptoKey.Name),
 			},
 			{
 				ResourceName:            "google_container_cluster.with_confidential_boot_disk",
@@ -8649,7 +8650,7 @@ func TestAccContainerCluster_withConfidentialBootDisk(t *testing.T) {
 	})
 }
 
-func testAccContainerCluster_withConfidentialBootDisk(clusterName, kmsKeyName string) string {
+func testAccContainerCluster_withConfidentialBootDisk(clusterName, npName, kmsKeyName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_confidential_boot_disk" {
   name               = "%s"
@@ -8658,7 +8659,9 @@ resource "google_container_cluster" "with_confidential_boot_disk" {
     channel = "RAPID"
   }
   node_pool {
-  node_config {
+	name = "%s"
+	initial_node_count = 1
+	node_config {
     oauth_scopes = [
       "https://www.googleapis.com/auth/cloud-platform",
     ]
@@ -8671,7 +8674,7 @@ resource "google_container_cluster" "with_confidential_boot_disk" {
 }
  deletion_protection = false
 }
-`, clusterName, kmsKeyName)
+`, clusterName, npName, kmsKeyName)
 }
 
 func TestAccContainerCluster_withConfidentialBootDiskNodeConfig(t *testing.T) {
@@ -8730,6 +8733,7 @@ func TestAccContainerCluster_withoutConfidentialBootDisk(t *testing.T) {
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	npName := fmt.Sprintf("tf-test-cluster-nodepool-%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
@@ -8737,7 +8741,7 @@ func TestAccContainerCluster_withoutConfidentialBootDisk(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withoutConfidentialBootDisk(clusterName),
+				Config: testAccContainerCluster_withoutConfidentialBootDisk(clusterName, npName),
 			},
 			{
 				ResourceName:            "google_container_cluster.without_confidential_boot_disk",
@@ -8748,7 +8752,7 @@ func TestAccContainerCluster_withoutConfidentialBootDisk(t *testing.T) {
 		},
 	})
 }
-func testAccContainerCluster_withoutConfidentialBootDisk(clusterName string) string {
+func testAccContainerCluster_withoutConfidentialBootDisk(clusterName string, npName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "without_confidential_boot_disk" {
   name               = "%s"
@@ -8757,7 +8761,9 @@ resource "google_container_cluster" "without_confidential_boot_disk" {
     channel = "RAPID"
   }
   node_pool {
-  node_config {
+	name = "%s"
+	initial_node_count = 1
+	node_config {
     oauth_scopes = [
       "https://www.googleapis.com/auth/cloud-platform",
     ]
@@ -8769,6 +8775,6 @@ resource "google_container_cluster" "without_confidential_boot_disk" {
 }
  deletion_protection = false
 }
-`, clusterName)
+`, clusterName, npName)
 }
 <% end -%>

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -8653,23 +8653,23 @@ func TestAccContainerCluster_withConfidentialBootDisk(t *testing.T) {
 func testAccContainerCluster_withConfidentialBootDisk(clusterName, npName, kmsKeyName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_confidential_boot_disk" {
-  name               = "%s"
-  location           = "us-central1-a"
-  release_channel {
-    channel = "RAPID"
-  }
-  node_pool {
-	name = "%s"
-	initial_node_count = 1
-	node_config {
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/cloud-platform",
-    ]
-	image_type = "COS_CONTAINERD"
-	boot_disk_kms_key = "%s"
-	machine_type = "n2-standard-2"
-	enable_confidential_storage = true
-	disk_type = "hyperdisk-balanced"
+ name               = "%s"
+ location           = "us-central1-a"
+ release_channel {
+ channel = "RAPID"
+}
+ node_pool {
+  name = "%s"
+  initial_node_count = 1
+  node_config {
+  oauth_scopes = [
+    "https://www.googleapis.com/auth/cloud-platform",
+   ]
+  image_type = "COS_CONTAINERD"
+  boot_disk_kms_key = "%s"
+  machine_type = "n2-standard-2"
+  enable_confidential_storage = true
+  disk_type = "hyperdisk-balanced"
   }
 }
  deletion_protection = false
@@ -8708,23 +8708,23 @@ func TestAccContainerCluster_withConfidentialBootDiskNodeConfig(t *testing.T) {
 func testAccContainerCluster_withConfidentialBootDiskNodeConfig(clusterName, kmsKeyName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_confidential_boot_disk_node_config" {
-  name               = "%s"
-  location           = "us-central1-a"
-  initial_node_count = 1
-  release_channel {
-    channel = "RAPID"
+ name               = "%s"
+ location           = "us-central1-a"
+ initial_node_count = 1
+ release_channel {
+   channel = "RAPID"
   }
-  node_config {
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/cloud-platform",
-    ]
-	image_type = "COS_CONTAINERD"
-	boot_disk_kms_key = "%s"
-	machine_type = "n2-standard-2"
-	enable_confidential_storage = true
-	disk_type = "hyperdisk-balanced"
-  }
-  deletion_protection = false
+ node_config {
+  oauth_scopes = [
+    "https://www.googleapis.com/auth/cloud-platform",
+  ]
+ image_type = "COS_CONTAINERD"
+ boot_disk_kms_key = "%s"
+ machine_type = "n2-standard-2"
+ enable_confidential_storage = true
+ disk_type = "hyperdisk-balanced"
+ }
+deletion_protection = false
 }
 `, clusterName, kmsKeyName)
 }
@@ -8755,22 +8755,22 @@ func TestAccContainerCluster_withoutConfidentialBootDisk(t *testing.T) {
 func testAccContainerCluster_withoutConfidentialBootDisk(clusterName string, npName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "without_confidential_boot_disk" {
-  name               = "%s"
-  location           = "us-central1-a"
-  release_channel {
-    channel = "RAPID"
+ name               = "%s"
+ location           = "us-central1-a"
+ release_channel {
+   channel = "RAPID"
   }
-  node_pool {
-	name = "%s"
-	initial_node_count = 1
-	node_config {
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/cloud-platform",
-    ]
-	image_type = "COS_CONTAINERD"
-    machine_type = "n2-standard-2"
-    enable_confidential_storage = false
-	disk_type = "pd-balanced"
+ node_pool {
+  name = "%s"
+  initial_node_count = 1
+  node_config {
+  oauth_scopes = [
+   "https://www.googleapis.com/auth/cloud-platform",
+  ]
+  image_type = "COS_CONTAINERD"
+  machine_type = "n2-standard-2"
+  enable_confidential_storage = false
+  disk_type = "pd-balanced"
   }
 }
  deletion_protection = false

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -8619,3 +8619,153 @@ func testAccContainerCluster_additional_pod_ranges_config(name string, nameCount
 	}
 	`, name, name, name, aprc)
 }
+
+<% unless version == 'ga' -%>
+func TestAccContainerCluster_withConfidentialBootDisk(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	kms := acctest.BootstrapKMSKeyInLocation(t, "us-central1")
+
+	if acctest.BootstrapPSARole(t, "service-", "compute-system", "roles/cloudkms.cryptoKeyEncrypterDecrypter") {
+		t.Fatal("Stopping the test because a role was added to the policy.")
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withConfidentialBootDisk(clusterName, kms.CryptoKey.Name),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_confidential_boot_disk",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version"},
+			},
+		},
+	})
+}
+
+func testAccContainerCluster_withConfidentialBootDisk(clusterName, kmsKeyName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_confidential_boot_disk" {
+  name               = "%s"
+  location           = "us-central1-a"
+  release_channel {
+    channel = "RAPID"
+  }
+  node_pool {
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+    ]
+	image_type = "COS_CONTAINERD"
+	boot_disk_kms_key = "%s"
+	machine_type = "n2-standard-2"
+	enable_confidential_storage = true
+	disk_type = "hyperdisk-balanced"
+  }
+}
+}
+`, clusterName, kmsKeyName)
+}
+
+func TestAccContainerCluster_withConfidentialBootDiskNodeConfig(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	kms := acctest.BootstrapKMSKeyInLocation(t, "us-central1")
+
+	if acctest.BootstrapPSARole(t, "service-", "compute-system", "roles/cloudkms.cryptoKeyEncrypterDecrypter") {
+		t.Fatal("Stopping the test because a role was added to the policy.")
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withConfidentialBootDiskNodeConfig(clusterName, kms.CryptoKey.Name),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_confidential_boot_disk_node_config",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version"},
+			},
+		},
+	})
+}
+
+func testAccContainerCluster_withConfidentialBootDiskNodeConfig(clusterName, kmsKeyName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_confidential_boot_disk_node_config" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  release_channel {
+    channel = "RAPID"
+  }
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+    ]
+	image_type = "COS_CONTAINERD"
+	boot_disk_kms_key = "%s"
+	machine_type = "n2-standard-2"
+	enable_confidential_storage = true
+	disk_type = "hyperdisk-balanced"
+  }
+}
+`, clusterName, kmsKeyName)
+}
+
+func TestAccContainerCluster_withoutConfidentialBootDisk(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withoutConfidentialBootDisk(clusterName),
+			},
+			{
+				ResourceName:            "google_container_cluster.without_confidential_boot_disk",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version"},
+			},
+		},
+	})
+}
+func testAccContainerCluster_withoutConfidentialBootDisk(clusterName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "without_confidential_boot_disk" {
+  name               = "%s"
+  location           = "us-central1-a"
+  release_channel {
+    channel = "RAPID"
+  }
+  node_pool {
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+    ]
+	image_type = "COS_CONTAINERD"
+    machine_type = "n2-standard-2"
+    enable_confidential_storage = false
+	disk_type = "hyperdisk-balanced"
+  }
+}
+}
+`, clusterName)
+}
+<% end -%>

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -8669,6 +8669,7 @@ resource "google_container_cluster" "with_confidential_boot_disk" {
 	disk_type = "hyperdisk-balanced"
   }
 }
+ deletion_protection = false
 }
 `, clusterName, kmsKeyName)
 }
@@ -8720,6 +8721,7 @@ resource "google_container_cluster" "with_confidential_boot_disk_node_config" {
 	enable_confidential_storage = true
 	disk_type = "hyperdisk-balanced"
   }
+  deletion_protection = false
 }
 `, clusterName, kmsKeyName)
 }
@@ -8762,9 +8764,10 @@ resource "google_container_cluster" "without_confidential_boot_disk" {
 	image_type = "COS_CONTAINERD"
     machine_type = "n2-standard-2"
     enable_confidential_storage = false
-	disk_type = "hyperdisk-balanced"
+	disk_type = "pd-balanced"
   }
 }
+ deletion_protection = false
 }
 `, clusterName)
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -3682,28 +3682,28 @@ data "google_container_engine_versions" "central1a" {
 }
 
 resource "google_container_cluster" "cluster" {
-  name               = "%s"
-  location           = "us-central1-a"
-  initial_node_count = 1
-  min_master_version = data.google_container_engine_versions.central1a.latest_master_version
-  deletion_protection = false
+ name               = "%s"
+ location           = "us-central1-a"
+ initial_node_count = 1
+ min_master_version = data.google_container_engine_versions.central1a.latest_master_version
+ deletion_protection = false
 }
 
 resource "google_container_node_pool" "with_confidential_boot_disk" {
-  name               = "%s"
-  location           = "us-central1-a"
-  cluster            = google_container_cluster.cluster.name
+ name               = "%s"
+ location           = "us-central1-a"
+ cluster            = google_container_cluster.cluster.name
   
-  node_config {
-    image_type = "COS_CONTAINERD"
-    boot_disk_kms_key = "%s"
-    oauth_scopes = [
+node_config {
+ image_type = "COS_CONTAINERD"
+ boot_disk_kms_key = "%s"
+ oauth_scopes = [
       "https://www.googleapis.com/auth/logging.write",
       "https://www.googleapis.com/auth/monitoring",
     ]
-	enable_confidential_storage = true
-	machine_type = "n2-standard-2"
-  	disk_type = "hyperdisk-balanced"
+ enable_confidential_storage = true
+ machine_type = "n2-standard-2"
+ disk_type = "hyperdisk-balanced"
   }
 }
 `, cluster, np, kmsKeyName)
@@ -3739,27 +3739,27 @@ data "google_container_engine_versions" "central1a" {
 }
 
 resource "google_container_cluster" "cluster" {
-  name               = "%s"
-  location           = "us-central1-a"
-  initial_node_count = 1
-  min_master_version = data.google_container_engine_versions.central1a.latest_master_version
-  deletion_protection = false
+ name               = "%s"
+ location           = "us-central1-a"
+ initial_node_count = 1
+ min_master_version = data.google_container_engine_versions.central1a.latest_master_version
+ deletion_protection = false
 }
 
 resource "google_container_node_pool" "without_confidential_boot_disk" {
-  name               = "%s"
-  location           = "us-central1-a"
-  cluster            = google_container_cluster.cluster.name
+ name               = "%s"
+ location           = "us-central1-a"
+ cluster            = google_container_cluster.cluster.name
   
-  node_config {
-    image_type = "COS_CONTAINERD"
-    oauth_scopes = [
+ node_config {
+  image_type = "COS_CONTAINERD"
+  oauth_scopes = [
       "https://www.googleapis.com/auth/logging.write",
       "https://www.googleapis.com/auth/monitoring",
     ]
-	enable_confidential_storage = false
-	machine_type = "n2-standard-2"
-  	disk_type = "pd-balanced"
+  enable_confidential_storage = false
+  machine_type = "n2-standard-2"
+  disk_type = "pd-balanced"
   }
 }
 `, cluster, np)

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -3644,3 +3644,194 @@ resource "google_container_node_pool" "np" {
 `, cluster, np)
 }
 <% end -%>
+
+<% unless version == 'ga' -%>
+
+func TestAccContainerNodePool_withConfidentialBootDisk(t *testing.T) {
+	// Uses generated time-based rotation time
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+
+	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	np := fmt.Sprintf("tf-test-np-%s", acctest.RandString(t, 10))
+	kms := acctest.BootstrapKMSKeyInLocation(t, "us-central1")
+
+	if acctest.BootstrapPSARole(t, "service-", "compute-system", "roles/cloudkms.cryptoKeyEncrypterDecrypter") {
+		t.Fatal("Stopping the test because a role was added to the policy.")
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePool_withConfidentialBootDisk(cluster, np, kms.CryptoKey.Name),
+			},
+			{
+				ResourceName:      "google_container_node_pool.with_confidential_boot_disk",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccContainerNodePool_withConfidentialBootDisk(cluster, np string, kmsKeyName string) string {
+	return fmt.Sprintf(`
+data "google_container_engine_versions" "central1a" {
+  location = "us-central1-a"
+}
+
+resource "google_container_cluster" "cluster" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  min_master_version = data.google_container_engine_versions.central1a.latest_master_version
+}
+
+resource "google_container_node_pool" "with_confidential_boot_disk" {
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  
+  node_pool {
+  node_config {
+    image_type = "COS_CONTAINERD"
+    boot_disk_kms_key = "%s"
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+	enable_confidential_storage = true
+	machine_type = "n2-standard-2"
+  	disk_type = "hyperdisk-balanced"
+  }
+}
+}
+`, cluster, np, kmsKeyName)
+}
+
+func TestAccContainerNodePool_withoutConfidentialBootDisk(t *testing.T) {
+	// Uses generated time-based rotation time
+	acctest.SkipIfVcr(t)
+	t.Parallel()	
+
+	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	np := fmt.Sprintf("tf-test-np-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePool_withoutConfidentialBootDisk(cluster, np),
+			},
+			{
+				ResourceName:      "google_container_node_pool.without_confidential_boot_disk",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccContainerNodePool_withoutConfidentialBootDisk(cluster, np string) string {
+	return fmt.Sprintf(`
+data "google_container_engine_versions" "central1a" {
+  location = "us-central1-a"
+}
+
+resource "google_container_cluster" "cluster" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  min_master_version = data.google_container_engine_versions.central1a.latest_master_version
+}
+
+resource "google_container_node_pool" "without_confidential_boot_disk" {
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  
+node_pool{
+  node_config {
+    image_type = "COS_CONTAINERD"
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+	enable_confidential_storage = false
+	machine_type = "n2-standard-2"
+  	disk_type = "hyperdisk-balanced"
+  }
+}
+}
+`, cluster, np)
+}
+
+func TestAccContainerNodePool_withConfidentialBootDiskNodeConfig(t *testing.T) {
+	// Uses generated time-based rotation time
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+
+	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	np := fmt.Sprintf("tf-test-np-%s", acctest.RandString(t, 10))
+	kms := acctest.BootstrapKMSKeyInLocation(t, "us-central1")
+
+	if acctest.BootstrapPSARole(t, "service-", "compute-system", "roles/cloudkms.cryptoKeyEncrypterDecrypter") {
+		t.Fatal("Stopping the test because a role was added to the policy.")
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePool_withConfidentialBootDiskNodeConfig(cluster, np, kms.CryptoKey.Name),
+			},
+			{
+				ResourceName:      "google_container_node_pool.with_confidential_boot_disk_node_config",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccContainerNodePool_withConfidentialBootDiskNodeConfig(cluster, np string, kmsKeyName string) string {
+	return fmt.Sprintf(`
+data "google_container_engine_versions" "central1a" {
+  location = "us-central1-a"
+}
+
+resource "google_container_cluster" "cluster" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  min_master_version = data.google_container_engine_versions.central1a.latest_master_version
+}
+
+resource "google_container_node_pool" "with_confidential_boot_disk_node_config" {
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  initial_node_count = 1
+  
+  node_config {
+    image_type = "COS_CONTAINERD"
+    boot_disk_kms_key = "%s"
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+	enable_confidential_storage = true
+	machine_type = "n2-standard-2"
+  	disk_type = "hyperdisk-balanced"
+  }
+}
+`, cluster, np, kmsKeyName)
+}
+<% end -%>

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -3648,8 +3648,6 @@ resource "google_container_node_pool" "np" {
 <% unless version == 'ga' -%>
 
 func TestAccContainerNodePool_withConfidentialBootDisk(t *testing.T) {
-	// Uses generated time-based rotation time
-	acctest.SkipIfVcr(t)
 	t.Parallel()
 
 	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
@@ -3695,7 +3693,6 @@ resource "google_container_node_pool" "with_confidential_boot_disk" {
   location           = "us-central1-a"
   cluster            = google_container_cluster.cluster.name
   
-  node_pool {
   node_config {
     image_type = "COS_CONTAINERD"
     boot_disk_kms_key = "%s"
@@ -3708,13 +3705,10 @@ resource "google_container_node_pool" "with_confidential_boot_disk" {
   	disk_type = "hyperdisk-balanced"
   }
 }
-}
 `, cluster, np, kmsKeyName)
 }
 
 func TestAccContainerNodePool_withoutConfidentialBootDisk(t *testing.T) {
-	// Uses generated time-based rotation time
-	acctest.SkipIfVcr(t)
 	t.Parallel()	
 
 	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
@@ -3755,7 +3749,6 @@ resource "google_container_node_pool" "without_confidential_boot_disk" {
   location           = "us-central1-a"
   cluster            = google_container_cluster.cluster.name
   
-node_pool{
   node_config {
     image_type = "COS_CONTAINERD"
     oauth_scopes = [
@@ -3767,71 +3760,6 @@ node_pool{
   	disk_type = "hyperdisk-balanced"
   }
 }
-}
 `, cluster, np)
-}
-
-func TestAccContainerNodePool_withConfidentialBootDiskNodeConfig(t *testing.T) {
-	// Uses generated time-based rotation time
-	acctest.SkipIfVcr(t)
-	t.Parallel()
-
-	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
-	np := fmt.Sprintf("tf-test-np-%s", acctest.RandString(t, 10))
-	kms := acctest.BootstrapKMSKeyInLocation(t, "us-central1")
-
-	if acctest.BootstrapPSARole(t, "service-", "compute-system", "roles/cloudkms.cryptoKeyEncrypterDecrypter") {
-		t.Fatal("Stopping the test because a role was added to the policy.")
-	}
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccContainerNodePool_withConfidentialBootDiskNodeConfig(cluster, np, kms.CryptoKey.Name),
-			},
-			{
-				ResourceName:      "google_container_node_pool.with_confidential_boot_disk_node_config",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func testAccContainerNodePool_withConfidentialBootDiskNodeConfig(cluster, np string, kmsKeyName string) string {
-	return fmt.Sprintf(`
-data "google_container_engine_versions" "central1a" {
-  location = "us-central1-a"
-}
-
-resource "google_container_cluster" "cluster" {
-  name               = "%s"
-  location           = "us-central1-a"
-  initial_node_count = 1
-  min_master_version = data.google_container_engine_versions.central1a.latest_master_version
-}
-
-resource "google_container_node_pool" "with_confidential_boot_disk_node_config" {
-  name               = "%s"
-  location           = "us-central1-a"
-  cluster            = google_container_cluster.cluster.name
-  initial_node_count = 1
-  
-  node_config {
-    image_type = "COS_CONTAINERD"
-    boot_disk_kms_key = "%s"
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring",
-    ]
-	enable_confidential_storage = true
-	machine_type = "n2-standard-2"
-  	disk_type = "hyperdisk-balanced"
-  }
-}
-`, cluster, np, kmsKeyName)
 }
 <% end -%>

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -3686,6 +3686,7 @@ resource "google_container_cluster" "cluster" {
   location           = "us-central1-a"
   initial_node_count = 1
   min_master_version = data.google_container_engine_versions.central1a.latest_master_version
+  deletion_protection = false
 }
 
 resource "google_container_node_pool" "with_confidential_boot_disk" {
@@ -3742,6 +3743,7 @@ resource "google_container_cluster" "cluster" {
   location           = "us-central1-a"
   initial_node_count = 1
   min_master_version = data.google_container_engine_versions.central1a.latest_master_version
+  deletion_protection = false
 }
 
 resource "google_container_node_pool" "without_confidential_boot_disk" {
@@ -3757,7 +3759,7 @@ resource "google_container_node_pool" "without_confidential_boot_disk" {
     ]
 	enable_confidential_storage = false
 	machine_type = "n2-standard-2"
-  	disk_type = "hyperdisk-balanced"
+  	disk_type = "pd-balanced"
   }
 }
 `, cluster, np)

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -778,14 +778,14 @@ The `master_authorized_networks_config.cidr_blocks` block supports:
 
 <a name="nested_node_config"></a>The `node_config` block supports:
 
-* `enable_confidential_storage` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
-Enabling Confidential Storage will create boot disk with confidential mode. It is disabled by default, to enable it set `enable_confidential_storage=true` in  `node_config` in resource `google_container_cluster` or in `google_container_node_pool`.
-
 * `disk_size_gb` - (Optional) Size of the disk attached to each node, specified
     in GB. The smallest allowed disk size is 10GB. Defaults to 100GB.
 
 * `disk_type` - (Optional) Type of the disk attached to each node
     (e.g. 'pd-standard', 'pd-balanced' or 'pd-ssd'). If unspecified, the default disk type is 'pd-standard'
+
+* `enable_confidential_storage` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+Enabling Confidential Storage will create boot disk with confidential mode. It is disabled by default.
 
 * `ephemeral_storage_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Parameters for the ephemeral storage filesystem. If unspecified, ephemeral storage is backed by the boot disk. Structure is [documented below](#nested_ephemeral_storage_config).
 

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -378,16 +378,6 @@ subnetwork in which the cluster's instances are launched.
 * `security_posture_config` - (Optional)
 Enable/Disable Security Posture API features for the cluster. Structure is [documented below](#nested_security_posture_config).
 
-* `enable_confidential_storage` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
-Enabling Confidential Storage will create boot disk with confidential mode. It is disabled by default, to enable it set `enable_confidential_storage=true` in resource `google_container_node_pool`.
-```
-node_pool{
-  node_config{
-    enable_confidential_storage = true
-  }
-}
-```
-
 <a name="nested_default_snat_status"></a>The `default_snat_status` block supports
 
 *  `disabled` - (Required) Whether the cluster disables default in-node sNAT rules. In-node sNAT rules will be disabled when defaultSnatStatus is disabled.When disabled is set to false, default IP masquerade rules will be applied to the nodes to prevent sNAT on cluster internal traffic
@@ -787,6 +777,9 @@ The `master_authorized_networks_config.cidr_blocks` block supports:
 * `enabled` - (Required) Whether network policy is enabled on the cluster.
 
 <a name="nested_node_config"></a>The `node_config` block supports:
+
+* `enable_confidential_storage` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+Enabling Confidential Storage will create boot disk with confidential mode. It is disabled by default, to enable it set `enable_confidential_storage=true` in  `node_config` in resource `google_container_cluster` or in `google_container_node_pool`.
 
 * `disk_size_gb` - (Optional) Size of the disk attached to each node, specified
     in GB. The smallest allowed disk size is 10GB. Defaults to 100GB.

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -378,6 +378,16 @@ subnetwork in which the cluster's instances are launched.
 * `security_posture_config` - (Optional)
 Enable/Disable Security Posture API features for the cluster. Structure is [documented below](#nested_security_posture_config).
 
+* `enable_confidential_storage` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+Enabling Confidential Storage will create boot disk with confidential mode. It is disabled by default, to enable it set `enable_confidential_storage=true` in resource `google_container_node_pool`.
+```
+node_pool{
+  node_config{
+    enable_confidential_storage = true
+  }
+}
+```
+
 <a name="nested_default_snat_status"></a>The `default_snat_status` block supports
 
 *  `disabled` - (Required) Whether the cluster disables default in-node sNAT rules. In-node sNAT rules will be disabled when defaultSnatStatus is disabled.When disabled is set to false, default IP masquerade rules will be applied to the nodes to prevent sNAT on cluster internal traffic


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds support for new parameter "enable_confidential_storage" while creating cluster and node-pool. This flag does not support update operations.


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added `enable_confidential_storage` to `node_config` in `google_container_cluster` and `google_container_node_pool` (beta)
```
