### PR TITLE
adding validation while setting empty active ranges in cloud_nat

### DIFF
--- a/mmv1/products/compute/RouterNat.yaml
+++ b/mmv1/products/compute/RouterNat.yaml
@@ -105,6 +105,8 @@ examples:
       spoke_name: 'my-spoke'
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   constants: 'templates/terraform/constants/router_nat.go.erb'
+  pre_create: 'templates/terraform/constants/router_nat_validate_action_active_range.go.erb'
+  pre_update: 'templates/terraform/constants/router_nat_validate_action_active_range.go.erb'
 custom_diff: [
   'resourceComputeRouterNatDrainNatIpsCustomDiff',
 ]

--- a/mmv1/templates/terraform/constants/router_nat_validate_action_active_range.go.erb
+++ b/mmv1/templates/terraform/constants/router_nat_validate_action_active_range.go.erb
@@ -1,0 +1,29 @@
+<% unless version == 'ga' -%>
+// validates if the field action.source_nat_active_ranges is filled when the type is PRIVATE.
+natType := d.Get("type").(string)
+if natType == "PRIVATE" {
+	rules := d.Get("rules").(*schema.Set)
+	for _, rule := range rules.List() {
+		objRule := rule.(map[string]interface{})
+		actions := objRule["action"].([]interface{})
+
+		containAction := len(actions) != 0 && actions[0] != nil
+		containActiveRange := true
+
+		if containAction {
+			action := actions[0].(map[string]interface{})
+			sourceNatActiveRanges := action["source_nat_active_ranges"]
+			if sourceNatActiveRanges != nil {
+				sourceNatActiveRangesSet := sourceNatActiveRanges.(*schema.Set)
+				if len(sourceNatActiveRangesSet.List()) == 0 {
+					containActiveRange = false
+				}
+			}
+		}
+
+		if !containAction || !containActiveRange {
+			return fmt.Errorf("The rule for PRIVATE nat type must contain an action with source_nat_active_ranges set")
+		}
+	}
+}
+<% end -%>

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_nat_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_nat_test.go.erb
@@ -533,6 +533,86 @@ func TestAccComputeRouterNat_withPrivateNatAndRules(t *testing.T) {
 		},
 	})
 }
+
+func TestAccComputeRouterNat_withPrivateNatAndEmptyAction(t *testing.T) {
+	t.Parallel()
+
+	testId := acctest.RandString(t, 10)
+	routerName := fmt.Sprintf("tf-test-router-private-nat-%s", testId)
+	hubName := fmt.Sprintf("%s-hub", routerName)
+	pEnv := envvar.GetTestProjectFromEnv()
+	ruleDescription := acctest.RandString(t, 10)
+	match := fmt.Sprintf("nexthop.hub == '//networkconnectivity.googleapis.com/projects/%s/locations/global/hubs/%s'", pEnv, hubName)
+	activeRangesNetworkOne := "google_compute_subnetwork.subnet1.self_link"
+	drainRangesEmpty := ""
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRouterNatDestroyProducer(t),
+		Steps: []resource.TestStep{
+			// (ERROR): Creation with empty action should fail
+			{
+				Config:      testAccComputeRouterNatRulesBasic_privateNatWithRuleAndEmptyAction(routerName, hubName, 100, ruleDescription, match),
+				ExpectError: regexp.MustCompile("The rule for PRIVATE nat type must contain an action with source_nat_active_ranges set"),
+			},
+			// Create NAT with action and active ranges set
+			{
+				Config: testAccComputeRouterNatRulesBasic_privateNatWithRuleAndActiveDrainRange(routerName, hubName, 100, ruleDescription, match, activeRangesNetworkOne, drainRangesEmpty),
+			},
+			{
+				ResourceName:      "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// (ERROR) - Updating the rule by removing the action should fail
+			{
+				Config:      testAccComputeRouterNatRulesBasic_privateNatWithRuleAndEmptyAction(routerName, hubName, 100, ruleDescription, match),
+				ExpectError: regexp.MustCompile("The rule for PRIVATE nat type must contain an action with source_nat_active_ranges set"),
+			},
+		},
+	})
+}
+
+func TestAccComputeRouterNat_withPrivateNatAndEmptyActionActiveRanges(t *testing.T) {
+	t.Parallel()
+
+	testId := acctest.RandString(t, 10)
+	routerName := fmt.Sprintf("tf-test-router-private-nat-%s", testId)
+	hubName := fmt.Sprintf("%s-hub", routerName)
+	pEnv := envvar.GetTestProjectFromEnv()
+	ruleDescription := acctest.RandString(t, 10)
+	match := fmt.Sprintf("nexthop.hub == '//networkconnectivity.googleapis.com/projects/%s/locations/global/hubs/%s'", pEnv, hubName)
+	activeRangesNetworkOne := "google_compute_subnetwork.subnet1.self_link"
+	drainRangesEmpty := ""
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRouterNatDestroyProducer(t),
+		Steps: []resource.TestStep{
+			// (ERROR): Creation with empty action active ranges should fail
+			{
+				Config:      testAccComputeRouterNatRulesBasic_privateNatWithRuleAndEmptyActionActiveRanges(routerName, hubName, 100, ruleDescription, match),
+				ExpectError: regexp.MustCompile("The rule for PRIVATE nat type must contain an action with source_nat_active_ranges set"),
+			},
+			// Create NAT with action and active ranges set
+			{
+				Config: testAccComputeRouterNatRulesBasic_privateNatWithRuleAndActiveDrainRange(routerName, hubName, 100, ruleDescription, match, activeRangesNetworkOne, drainRangesEmpty),
+			},
+			{
+				ResourceName:      "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// (ERROR) - Updating the rule by erasing the action active ranges should fail
+			{
+				Config:      testAccComputeRouterNatRulesBasic_privateNatWithRuleAndEmptyActionActiveRanges(routerName, hubName, 100, ruleDescription, match),
+				ExpectError: regexp.MustCompile("The rule for PRIVATE nat type must contain an action with source_nat_active_ranges set"),
+			},
+		},
+	})
+}
 <% end -%>
 
 func testAccCheckComputeRouterNatDestroyProducer(t *testing.T) func(s *terraform.State) error {
@@ -1653,6 +1733,64 @@ resource "google_compute_router_nat" "foobar" {
   }
 }
 `, testAccComputeRouterNatBaseResourcesWithPrivateNatSubnetworks(routerName, hubName), routerName, ruleNumber, ruleDescription, match, activeRanges, drainRanges)
+}
+
+func testAccComputeRouterNatRulesBasic_privateNatWithRuleAndEmptyAction(routerName, hubName string, ruleNumber int, ruleDescription, match string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "google_compute_router_nat" "foobar" {
+  name                                = "%s"
+  router                              = google_compute_router.foobar.name
+  region                              = google_compute_router.foobar.region
+  source_subnetwork_ip_ranges_to_nat  = "LIST_OF_SUBNETWORKS"
+  type                                = "PRIVATE" 
+  enable_dynamic_port_allocation      = false
+  enable_endpoint_independent_mapping = false
+  min_ports_per_vm = 32
+  subnetwork {
+    name                    = google_compute_subnetwork.subnet1.id
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+
+  rules {
+    rule_number = %d
+    description = "%s"
+    match       = "%s"
+    # action is missing
+  }
+}
+`, testAccComputeRouterNatBaseResourcesWithPrivateNatSubnetworks(routerName, hubName), routerName, ruleNumber, ruleDescription, match)
+}
+
+func testAccComputeRouterNatRulesBasic_privateNatWithRuleAndEmptyActionActiveRanges(routerName, hubName string, ruleNumber int, ruleDescription, match string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "google_compute_router_nat" "foobar" {
+  name                                = "%s"
+  router                              = google_compute_router.foobar.name
+  region                              = google_compute_router.foobar.region
+  source_subnetwork_ip_ranges_to_nat  = "LIST_OF_SUBNETWORKS"
+  type                                = "PRIVATE" 
+  enable_dynamic_port_allocation      = false
+  enable_endpoint_independent_mapping = false
+  min_ports_per_vm = 32
+  subnetwork {
+    name                    = google_compute_subnetwork.subnet1.id
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+
+  rules {
+    rule_number = %d
+    description = "%s"
+    match       = "%s"
+    action {
+      source_nat_active_ranges = []
+    }
+  }
+}
+`, testAccComputeRouterNatBaseResourcesWithPrivateNatSubnetworks(routerName, hubName), routerName, ruleNumber, ruleDescription, match)
 }
 
 <% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/16040

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added validation while setting empty rule.action.source_nat_active_ranges to `google_compute_router_nat` resource (beta)
```
