### PR TITLE
CI - fix tests run for no provider changes

### DIFF
--- a/.ci/scripts/go-plus/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/scripts/go-plus/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -22,9 +22,12 @@ pushd $local_path
 
 # Only skip tests if we can tell for sure that no go files were changed
 echo "Checking for modified go files"
+# Fetch the latest commit in the old branch, associating them locally
+# This will let us compare the old and new branch by name on the next line
 git fetch origin $old_branch:$old_branch --depth 1
 # get the names of changed files and look for go files
 # (ignoring "no matches found" errors from grep)
+# If there was no code generated, this will always return nothing (because there's no diff)
 gofiles=$(git diff $new_branch $old_branch --name-only | { grep -e "\.go$" -e "go.mod$" -e "go.sum$" || test $? = 1; })
 if [[ -z $gofiles ]]; then
   echo "Skipping tests: No go files changed"

--- a/.ci/scripts/go-plus/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/scripts/go-plus/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -327,5 +327,3 @@ fi
 set -e
 
 update_status ${test_state}
-
-# No provider change but still trigger tests due to a bug in CI

--- a/.ci/scripts/go-plus/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/scripts/go-plus/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -325,3 +325,5 @@ fi
 set -e
 
 update_status ${test_state}
+
+# No provider change but still trigger tests due to a bug in CI

--- a/.ci/scripts/go-plus/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/scripts/go-plus/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -13,6 +13,7 @@ gh_repo=terraform-provider-google-beta
 NEWLINE=$'\n'
 
 new_branch="auto-pr-$pr_number"
+old_branch="auto-pr-$pr_number-old"
 git_remote=https://github.com/$github_username/$gh_repo
 local_path=$GOPATH/src/github.com/hashicorp/$gh_repo
 mkdir -p "$(dirname $local_path)"
@@ -21,9 +22,10 @@ pushd $local_path
 
 # Only skip tests if we can tell for sure that no go files were changed
 echo "Checking for modified go files"
+git fetch origin $old_branch:$old_branch --depth 1
 # get the names of changed files and look for go files
 # (ignoring "no matches found" errors from grep)
-gofiles=$(git diff --name-only HEAD~1 | { grep -e "\.go$" -e "go.mod$" -e "go.sum$" || test $? = 1; })
+gofiles=$(git diff $new_branch $old_branch --name-only | { grep -e "\.go$" -e "go.mod$" -e "go.sum$" || test $? = 1; })
 if [[ -z $gofiles ]]; then
   echo "Skipping tests: No go files changed"
   exit 0

--- a/mmv1/templates/terraform/examples/cloudrunv2_job_directvpc.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_job_directvpc.tf.erb
@@ -11,7 +11,7 @@ resource "google_cloud_run_v2_job" "<%= ctx[:primary_resource_id] %>" {
         network_interfaces {
           network = "default"
           subnetwork = "default"
-          tags = ["tag1", "tag2", "tag3", "tag4"]
+          tags = ["tag1", "tag2", "tag3"]
         }
         egress = "ALL_TRAFFIC"
       }

--- a/mmv1/templates/terraform/examples/cloudrunv2_job_directvpc.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_job_directvpc.tf.erb
@@ -11,7 +11,7 @@ resource "google_cloud_run_v2_job" "<%= ctx[:primary_resource_id] %>" {
         network_interfaces {
           network = "default"
           subnetwork = "default"
-          tags = ["tag1", "tag2", "tag3"]
+          tags = ["tag1", "tag2", "tag3", "tag4"]
         }
         egress = "ALL_TRAFFIC"
       }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

We determine if presubmit tests (including VCR, tpg/tpgb and tgc unit tests) are needed by checking if there's go files changes in the generated providers (magician) for the PR. We detect the changes by comparing the most recent change in `auto-pr-<pr_number>` branch in magician. In most of the cases, this reflects the correct changes, since we generates a new commit in the branch ([example](https://github.com/modular-magician/terraform-provider-google/tree/auto-pr-8900)). However, if the PR does not generate any provider changes, the two most recent commits in the `auto-pr-<pr_number>` branch are the commits from the main branch ([example](https://github.com/modular-magician/terraform-provider-google/commits/auto-pr-9095)). Therefore, we often run into the scenarios that the PR generates no provider change but the tests are still triggered.

Instead of comparing the latest two commits in `auto-pr-<pr_number>`, we need to compare the head of `auto-pr-<pr_number>` and `auto-pr-<pr_number>-old` (the generated providers of the base of the PR). This is also how we show the diffs in the diff report.

This PR only changes the logic in VCR, as it's the most time consuming step in our PR checks. We can also implement this in other test triggers.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
