### PR TITLE
Update GCE VM Instance example

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -15,13 +15,13 @@ and
 
 ```hcl
 resource "google_service_account" "default" {
-  account_id   = "service_account_id"
-  display_name = "Service Account"
+  account_id   = "my-custom-sa"
+  display_name = "Custom SA for VM Instance"
 }
 
 resource "google_compute_instance" "default" {
-  name         = "test"
-  machine_type = "e2-medium"
+  name         = "my-instance"
+  machine_type = "n2-standard-2"
   zone         = "us-central1-a"
 
   tags = ["foo", "bar"]
@@ -37,7 +37,7 @@ resource "google_compute_instance" "default" {
 
   // Local SSD disk
   scratch_disk {
-    interface = "SCSI"
+    interface = "NVME"
   }
 
   network_interface {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This was changed in https://github.com/GoogleCloudPlatform/magic-modules/pull/4113, but e2 vm instances can't use local ssds! This has been broken for years 🤯 

`service_account_id` was also not a valid value, but changing the machine type broke it first. Added some slightly better prefilled values, although there are still numerous foobars kicking around.

As funny as updating a broken config with another broken config would be, works on my machine (tm):

```
Plan: 2 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

google_service_account.default: Creating...
google_service_account.default: Creation complete after 2s [id=projects/graphite-test-rileykarson/serviceAccounts/my-custom-sa@graphite-test-rileykarson.iam.gserviceaccount.com]
google_compute_instance.default: Creating...
google_compute_instance.default: Still creating... [10s elapsed]
google_compute_instance.default: Creation complete after 13s [id=projects/graphite-test-rileykarson/zones/us-central1-a/instances/my-instance]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
