### PR TITLE
Make `tpuv2` tests and code (Beta) not be created in the GA provider

### DIFF
--- a/mmv1/third_party/terraform/services/tpuv2/data_source_tpu_v2_accelerator_types.go.erb
+++ b/mmv1/third_party/terraform/services/tpuv2/data_source_tpu_v2_accelerator_types.go.erb
@@ -1,5 +1,7 @@
+<% autogen_exception -%>
 package tpuv2
 
+<% unless version == 'ga' -%>
 import (
 	"fmt"
 	"log"
@@ -91,3 +93,4 @@ func flattenTpuV2AcceleratorTypes(resp map[string]interface{}) []interface{} {
 	}
 	return types
 }
+<% end -%>

--- a/mmv1/third_party/terraform/services/tpuv2/data_source_tpu_v2_accelerator_types_test.go.erb
+++ b/mmv1/third_party/terraform/services/tpuv2/data_source_tpu_v2_accelerator_types_test.go.erb
@@ -66,6 +66,8 @@ func testAccCheckTpuV2AcceleratorTypes(n string) resource.TestCheckFunc {
 }
 
 const testAccTpuV2AcceleratorTypesConfig = `
-data "google_tpu_v2_accelerator_types" "available" {}
+data "google_tpu_v2_accelerator_types" "available" {
+	provider = google-beta
+}
 `
 <% end -%>

--- a/mmv1/third_party/terraform/services/tpuv2/data_source_tpu_v2_accelerator_types_test.go.erb
+++ b/mmv1/third_party/terraform/services/tpuv2/data_source_tpu_v2_accelerator_types_test.go.erb
@@ -1,5 +1,7 @@
+<% autogen_exception -%>
 package tpuv2_test
 
+<% unless version == 'ga' -%>
 import (
 	"errors"
 	"fmt"
@@ -11,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 )
 
-func TestAccTpuV2RuntimeVersions_basic(t *testing.T) {
+func TestAccTpuV2AcceleratorTypes_basic(t *testing.T) {
 	t.Parallel()
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -19,50 +21,51 @@ func TestAccTpuV2RuntimeVersions_basic(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTpuV2RuntimeVersionsConfig,
+				Config: testAccTpuV2AcceleratorTypesConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTpuV2RuntimeVersions("data.google_tpu_v2_runtime_versions.available"),
+					testAccCheckTpuV2AcceleratorTypes("data.google_tpu_v2_accelerator_types.available"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckTpuV2RuntimeVersions(n string) resource.TestCheckFunc {
+func testAccCheckTpuV2AcceleratorTypes(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("can't find TPU v2 runtime versions data source: %s", n)
+			return fmt.Errorf("can't find TPU v2 accelerator types data source: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
 			return errors.New("data source id not set")
 		}
 
-		count, ok := rs.Primary.Attributes["versions.#"]
+		count, ok := rs.Primary.Attributes["types.#"]
 		if !ok {
-			return errors.New("can't find 'versions' attribute")
+			return errors.New("can't find 'types' attribute")
 		}
 
 		cnt, err := strconv.Atoi(count)
 		if err != nil {
-			return errors.New("failed to read number of versions")
+			return errors.New("failed to read number of types")
 		}
 		if cnt < 2 {
-			return fmt.Errorf("expected at least 2 versions, received %d, this is most likely a bug", cnt)
+			return fmt.Errorf("expected at least 2 types, received %d, this is most likely a bug", cnt)
 		}
 
 		for i := 0; i < cnt; i++ {
-			idx := fmt.Sprintf("versions.%d", i)
+			idx := fmt.Sprintf("types.%d", i)
 			_, ok := rs.Primary.Attributes[idx]
 			if !ok {
-				return fmt.Errorf("expected %q, version not found", idx)
+				return fmt.Errorf("expected %q, type not found", idx)
 			}
 		}
 		return nil
 	}
 }
 
-const testAccTpuV2RuntimeVersionsConfig = `
-data "google_tpu_v2_runtime_versions" "available" {}
+const testAccTpuV2AcceleratorTypesConfig = `
+data "google_tpu_v2_accelerator_types" "available" {}
 `
+<% end -%>

--- a/mmv1/third_party/terraform/services/tpuv2/data_source_tpu_v2_accelerator_types_test.go.erb
+++ b/mmv1/third_party/terraform/services/tpuv2/data_source_tpu_v2_accelerator_types_test.go.erb
@@ -18,7 +18,7 @@ func TestAccTpuV2AcceleratorTypes_basic(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTpuV2AcceleratorTypesConfig,

--- a/mmv1/third_party/terraform/services/tpuv2/data_source_tpu_v2_runtime_versions.go.erb
+++ b/mmv1/third_party/terraform/services/tpuv2/data_source_tpu_v2_runtime_versions.go.erb
@@ -1,5 +1,7 @@
+<% autogen_exception -%>
 package tpuv2
 
+<% unless version == 'ga' -%>
 import (
 	"fmt"
 	"log"
@@ -91,3 +93,4 @@ func flattenTpuV2RuntimeVersions(resp map[string]interface{}) []interface{} {
 	}
 	return versions
 }
+<% end -%>

--- a/mmv1/third_party/terraform/services/tpuv2/data_source_tpu_v2_runtime_versions_test.go.erb
+++ b/mmv1/third_party/terraform/services/tpuv2/data_source_tpu_v2_runtime_versions_test.go.erb
@@ -1,5 +1,7 @@
+<% autogen_exception -%>
 package tpuv2_test
 
+<% unless version == 'ga' -%>
 import (
 	"errors"
 	"fmt"
@@ -11,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 )
 
-func TestAccTpuV2AcceleratorTypes_basic(t *testing.T) {
+func TestAccTpuV2RuntimeVersions_basic(t *testing.T) {
 	t.Parallel()
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -19,50 +21,51 @@ func TestAccTpuV2AcceleratorTypes_basic(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTpuV2AcceleratorTypesConfig,
+				Config: testAccTpuV2RuntimeVersionsConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckTpuV2AcceleratorTypes("data.google_tpu_v2_accelerator_types.available"),
+					testAccCheckTpuV2RuntimeVersions("data.google_tpu_v2_runtime_versions.available"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckTpuV2AcceleratorTypes(n string) resource.TestCheckFunc {
+func testAccCheckTpuV2RuntimeVersions(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("can't find TPU v2 accelerator types data source: %s", n)
+			return fmt.Errorf("can't find TPU v2 runtime versions data source: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
 			return errors.New("data source id not set")
 		}
 
-		count, ok := rs.Primary.Attributes["types.#"]
+		count, ok := rs.Primary.Attributes["versions.#"]
 		if !ok {
-			return errors.New("can't find 'types' attribute")
+			return errors.New("can't find 'versions' attribute")
 		}
 
 		cnt, err := strconv.Atoi(count)
 		if err != nil {
-			return errors.New("failed to read number of types")
+			return errors.New("failed to read number of versions")
 		}
 		if cnt < 2 {
-			return fmt.Errorf("expected at least 2 types, received %d, this is most likely a bug", cnt)
+			return fmt.Errorf("expected at least 2 versions, received %d, this is most likely a bug", cnt)
 		}
 
 		for i := 0; i < cnt; i++ {
-			idx := fmt.Sprintf("types.%d", i)
+			idx := fmt.Sprintf("versions.%d", i)
 			_, ok := rs.Primary.Attributes[idx]
 			if !ok {
-				return fmt.Errorf("expected %q, type not found", idx)
+				return fmt.Errorf("expected %q, version not found", idx)
 			}
 		}
 		return nil
 	}
 }
 
-const testAccTpuV2AcceleratorTypesConfig = `
-data "google_tpu_v2_accelerator_types" "available" {}
+const testAccTpuV2RuntimeVersionsConfig = `
+data "google_tpu_v2_runtime_versions" "available" {}
 `
+<% end -%>

--- a/mmv1/third_party/terraform/services/tpuv2/data_source_tpu_v2_runtime_versions_test.go.erb
+++ b/mmv1/third_party/terraform/services/tpuv2/data_source_tpu_v2_runtime_versions_test.go.erb
@@ -66,6 +66,8 @@ func testAccCheckTpuV2RuntimeVersions(n string) resource.TestCheckFunc {
 }
 
 const testAccTpuV2RuntimeVersionsConfig = `
-data "google_tpu_v2_runtime_versions" "available" {}
+data "google_tpu_v2_runtime_versions" "available" {
+	provider = google-beta
+}
 `
 <% end -%>

--- a/mmv1/third_party/terraform/services/tpuv2/data_source_tpu_v2_runtime_versions_test.go.erb
+++ b/mmv1/third_party/terraform/services/tpuv2/data_source_tpu_v2_runtime_versions_test.go.erb
@@ -18,7 +18,7 @@ func TestAccTpuV2RuntimeVersions_basic(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTpuV2RuntimeVersionsConfig,


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Closes https://github.com/hashicorp/terraform-provider-google/issues/16038

TPUv2 data sources were [added to the Beta provider](https://github.com/GoogleCloudPlatform/magic-modules/pull/8899), but the files for the data sources and tests are present in the GA provider. This means acceptance tests that are meant for the Beta provider are being run during the GA provider nightly tests, for a data source that doesn't exist in GA.

This PR makes the files .erb templated files and makes them be empty when the GA provider is generated. Also, the tests are updated to explicitly use `provider = google-beta`


---

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
