### PR TITLE
Make Notebook Instance acceptance test ignore `update_time` after import

### DIFF
--- a/mmv1/third_party/terraform/services/notebooks/resource_notebooks_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/notebooks/resource_notebooks_instance_test.go.erb
@@ -47,7 +47,7 @@ func TestAccNotebooksInstance_update(t *testing.T) {
 				ResourceName:            "google_notebooks_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"vm_image", "metadata"},
+				ImportStateVerifyIgnore: []string{"vm_image", "metadata", "update_time"},
 			},
 			{
 				Config: testAccNotebooksInstance_update(context, true),
@@ -56,7 +56,7 @@ func TestAccNotebooksInstance_update(t *testing.T) {
 				ResourceName:            "google_notebooks_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"vm_image", "metadata", "labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"vm_image", "metadata", "labels", "terraform_labels", "update_time"},
 			},
 			{
 				Config: testAccNotebooksInstance_update(context, false),
@@ -65,7 +65,7 @@ func TestAccNotebooksInstance_update(t *testing.T) {
 				ResourceName:            "google_notebooks_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"vm_image", "metadata", "labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"vm_image", "metadata", "labels", "terraform_labels", "update_time"},
 			},
 		},
 	})


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Partially addresses https://github.com/hashicorp/terraform-provider-google/issues/16058

Ignore update time when verifying import of Notebook Instances during acceptance tests

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
