### PR TITLE
Adding support for privateServiceConnectConnectivity to Postgresql DBMS Connection Profiles

### DIFF
--- a/mmv1/products/databasemigrationservice/connectionprofile.yaml
+++ b/mmv1/products/databasemigrationservice/connectionprofile.yaml
@@ -336,8 +336,30 @@ properties:
           Output only. If the source is a Cloud SQL database, this field indicates the network architecture it's associated with.
         values:
           - :NETWORK_ARCHITECTURE_OLD_CSQL_PRODUCER
-          - :NETWORK_ARCHITECTURE_NEW_CSQL_PRODUCER -
-            !ruby/object:Api::Type::NestedObject
+          - :NETWORK_ARCHITECTURE_NEW_CSQL_PRODUCER
+      - !ruby/object:Api::Type::NestedObject
+        name: 'staticIpConnectivity'
+        allow_empty_object: true
+        ignore_read: true
+        description: |
+          This type has no fields.
+
+          The source database will allow incoming connections from the public IP of the destination database, default configuration.
+        properties: []
+        conflicts:
+          - postgresql.0.private_service_connect_connectivity
+      - !ruby/object:Api::Type::NestedObject
+        name: 'privateServiceConnectConnectivity'
+        description: |
+          A service attachment that exposes the database, and has the following format: projects/{project}/regions/{region}/serviceAttachments/{service_attachment_name}
+        conflicts:
+          - postgresql.0.static_ip_connectivity
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'serviceAttachment'
+            required: true
+            description: |
+              URI of the service attachment.
   - !ruby/object:Api::Type::NestedObject
     name: 'cloudsql'
     description: |

--- a/mmv1/templates/terraform/examples/database_migration_service_connection_profile_postgres.tf.erb
+++ b/mmv1/templates/terraform/examples/database_migration_service_connection_profile_postgres.tf.erb
@@ -41,6 +41,7 @@ resource "google_database_migration_service_connection_profile" "<%= ctx[:primar
       ca_certificate = google_sql_ssl_cert.sql_client_cert.server_ca_cert
     }
     cloud_sql_id = "<%= ctx[:vars]["sqldb"] %>"
+    static_ip_connectivity {}
   }
   depends_on = [google_sql_user.sqldb_user]
 }

--- a/mmv1/third_party/terraform/services/databasemigrationservice/resource_database_migration_service_connection_profile_test.go
+++ b/mmv1/third_party/terraform/services/databasemigrationservice/resource_database_migration_service_connection_profile_test.go
@@ -144,3 +144,166 @@ resource "google_database_migration_service_connection_profile" "alloydbprofile"
 }
 `, context)
 }
+
+func TestAccDatabaseMigrationServiceConnectionProfile_Postgres_PSC(t *testing.T) {
+	t.Parallel()
+
+	instanceName := "tf-test-" + acctest.RandString(t, 10)
+	projectId := "psctestproject" + acctest.RandString(t, 10)
+	orgId := envvar.GetTestOrgFromEnv(t)
+	billingAccount := envvar.GetTestBillingAccountFromEnv(t)
+	certName := "sqlcert" + acctest.RandString(t, 10)
+	userName := "username" + acctest.RandString(t, 10)
+	passWord := "password" + acctest.RandString(t, 10)
+	profileName := "dbmsprofile" + acctest.RandString(t, 10)
+	profileDisplay := "profiledisplay" + acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseMigrationServiceConnectionProfile_Postgres_PSC(instanceName, projectId, orgId, billingAccount, certName, userName, passWord, profileName, profileDisplay),
+				Check:  resource.ComposeTestCheckFunc(verifyPscOperation("google_sql_database_instance.instance", true, true, []string{envvar.GetTestProjectFromEnv()})),
+			},
+			{
+				ResourceName:            "google_database_migration_service_connection_profile.dbms_profile",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdPrefix:     fmt.Sprintf("%s/", projectId),
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+func testAccDatabaseMigrationServiceConnectionProfile_Postgres_PSC(instanceName, projectId, orgId, billingAccount, certName, userName, passWord, profileName, profileDisplay string) string {
+	return fmt.Sprintf(`
+resource "google_project" "testproject" {
+  name                = "%s"
+  project_id          = "%s"
+  org_id              = "%s"
+  billing_account     = "%s"
+}
+
+resource "google_sql_database_instance" "postgresqldb" {
+  project             = google_project.testproject.project_id
+  name                = "%s"
+  region              = "us-south1"
+  database_version    = "MYSQL_8_0"
+  deletion_protection = false
+  settings {
+    tier = "db-f1-micro"
+    ip_configuration {
+    psc_config {
+      psc_enabled = true
+      allowed_consumer_projects = ["%s"]
+    }
+    ipv4_enabled = false
+    }
+  backup_configuration {
+    enabled = true
+    binary_log_enabled = true
+  }
+  availability_type = "REGIONAL"
+  }
+}
+
+resource "google_sql_ssl_cert" "sql_client_cert" {
+  common_name = "%s"
+  instance    = google_sql_database_instance.postgresqldb.name
+
+  depends_on = [google_sql_database_instance.postgresqldb]
+}
+
+resource "google_sql_user" "sqldb_user" {
+  name     = "%s"
+  instance = google_sql_database_instance.postgresqldb.name
+  password = "%s"
+
+
+  depends_on = [google_sql_ssl_cert.sql_client_cert]
+}
+
+resource "google_database_migration_service_connection_profile" "dbms_profile" {
+  location = "us-central1"
+  connection_profile_id = "%s"
+  display_name          = "%s"
+  labels = { 
+    foo = "bar" 
+  }
+  postgresql {
+    host = google_sql_database_instance.postgresqldb.ip_address.0.ip_address
+    port = 5432
+  username = "%s"
+  password = "%s"
+    ssl {
+      client_key = google_sql_ssl_cert.sql_client_cert.private_key
+      client_certificate = google_sql_ssl_cert.sql_client_cert.cert
+      ca_certificate = google_sql_ssl_cert.sql_client_cert.server_ca_cert
+    }
+    cloud_sql_id = "%s"
+    private_service_connect_connectivity {
+      service_attachment = google_sql_database_instance.postgresqldb.psc_service_attachment_link
+    }
+  }
+  depends_on = [google_sql_user.sqldb_user]
+
+`, projectId, projectId, orgId, billingAccount, instanceName, projectId, certName, userName, passWord, profileName, profileDisplay, userName, passWord, instanceName)
+}
+
+func testAccSqlDatabaseInstanceDestroyProducer(t *testing.T) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			config := acctest.GoogleProviderConfig(t)
+			if rs.Type != "google_sql_database_instance" {
+				continue
+			}
+
+			_, err := config.NewSqlAdminClient(config.UserAgent).Instances.Get(config.Project,
+				rs.Primary.Attributes["name"]).Do()
+			if err == nil {
+				return fmt.Errorf("Database Instance still exists")
+			}
+		}
+
+		return nil
+	}
+}
+
+func verifyPscOperation(resourceName string, isPscConfigExpected bool, expectedPscEnabled bool, expectedAllowedConsumerProjects []string) func(*terraform.State) error {
+	return func(s *terraform.State) error {
+		resource, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Can't find %s in state", resourceName)
+		}
+
+		resourceAttributes := resource.Primary.Attributes
+		_, ok = resourceAttributes["settings.0.ip_configuration.#"]
+		if !ok {
+			return fmt.Errorf("settings.0.ip_configuration.# block is not present in state for %s", resourceName)
+		}
+
+		if isPscConfigExpected {
+			_, ok := resourceAttributes["settings.0.ip_configuration.0.psc_config.#"]
+			if !ok {
+				return fmt.Errorf("settings.0.ip_configuration.0.psc_config property is not present or set in state of %s", resourceName)
+			}
+
+			pscEnabledStr, ok := resourceAttributes["settings.0.ip_configuration.0.psc_config.0.psc_enabled"]
+			pscEnabled, err := strconv.ParseBool(pscEnabledStr)
+			if err != nil || pscEnabled != expectedPscEnabled {
+				return fmt.Errorf("settings.0.ip_configuration.0.psc_config.0.psc_enabled property value is not set as expected in state of %s, expected %v, actual %v", resourceName, expectedPscEnabled, pscEnabled)
+			}
+
+			allowedConsumerProjectsStr, ok := resourceAttributes["settings.0.ip_configuration.0.psc_config.0.allowed_consumer_projects.#"]
+			allowedConsumerProjects, err := strconv.Atoi(allowedConsumerProjectsStr)
+			if !ok || allowedConsumerProjects != len(expectedAllowedConsumerProjects) {
+				return fmt.Errorf("settings.0.ip_configuration.0.psc_config.0.allowed_consumer_projects property is not present or set as expected in state of %s", resourceName)
+			}
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
moved work from https://github.com/GoogleCloudPlatform/magic-modules/pull/9114

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
databasemigrationservice: added support for `postgresql.private_service_connect_connectivity` to `google_database_migration_service_connection_profile`
```
