### PR TITLE
add upstream reference to downstream commit messages

### DIFF
--- a/.ci/scripts/build-environment/downstream-builder/generate_downstream.sh
+++ b/.ci/scripts/build-environment/downstream-builder/generate_downstream.sh
@@ -1,6 +1,7 @@
 #! /bin/bash
 
 set -e
+NEWLINE=$'\n'
 
 function clone_repo() {
     SCRATCH_OWNER=modular-magician
@@ -96,7 +97,8 @@ elif [ "$COMMAND" == "base" ]; then
     COMMIT_MESSAGE="Old generated code for MM PR $REFERENCE."
 elif [ "$COMMAND" == "downstream" ]; then
     BRANCH=downstream-pr-$REFERENCE
-    COMMIT_MESSAGE="$(git log -1 --pretty=%B "$REFERENCE")"
+    ORIGINAL_MESSAGE="$(git log -1 --pretty=%B "$REFERENCE")"
+    COMMIT_MESSAGE="$ORIGINAL_MESSAGE$NEWLINE[upstream:$REFERENCE]"
 fi
 
 if [ "$REPO" == "terraform" ]; then
@@ -107,7 +109,7 @@ if [ "$REPO" == "terraform" ]; then
 fi
 
 if [ "$REPO" == "terraform-google-conversion" ]; then
-    # Generate tfplan2cai 
+    # Generate tfplan2cai
     pushd $LOCAL_PATH
     # clear out the templates as they are copied during
     # generation from mmv1/third_party/validator/tests/data


### PR DESCRIPTION
Add upstream SHA to downstream commit messages

example log
```git
commit fbd2d0dffcedd025d1fc27866f3259d34c8ddc50
Author: The Magician <magic-modules@google.com>
Author: The Magician <magic-modules@google.com>
Date:   Fri Sep 29 14:06:06 2023 -0400

    Container wording tweaks (#9135)
    [upstream:73bae90bda95900baabef881b87dcabe3092b580] (#6412)
    
    Signed-off-by: Modular Magician <magic-modules@google.com>
```

closes https://github.com/hashicorp/terraform-provider-google/issues/14609
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
