### PR TITLE
Add some reference documentation regarding nested fields

### DIFF
--- a/mmv1/api/type.rb
+++ b/mmv1/api/type.rb
@@ -41,7 +41,8 @@ module Api
       # child, etc.).
       attr_reader :output
 
-      # If set to true value is used only on creation.
+      # If set to true, changes in the field's value require recreating the
+      # resource.
       # For nested fields, this only applies at the current level. This means
       # it should be explicitly added to each field that needs the ForceNew
       # behavior.
@@ -132,8 +133,9 @@ module Api
       # if true, then we get the default value from the Google API if no value
       # is set in the terraform configuration for this field.
       # It translates to setting the field to Computed & Optional in the schema.
-      # For nested fields, this also needs to be set on each ancestor (ie. self,
-      # parent, etc.).
+      # For nested fields, this only applies at the current level. This means
+      # it should be explicitly added to each field that needs the defaulting
+      # behavior.
       attr_reader :default_from_api
 
       # https://github.com/hashicorp/terraform/pull/20837

--- a/mmv1/api/type.rb
+++ b/mmv1/api/type.rb
@@ -36,7 +36,11 @@ module Api
       # a different version.
       attr_reader :removed_message
 
-      attr_reader :output # If set value will not be sent to server on sync
+      # If set value will not be sent to server on sync.
+      # For nested fields, this also needs to be set on each descendant (ie. self,
+      # child, etc.).
+      attr_reader :output
+
       attr_reader :immutable # If set to true value is used only on creation
 
       # url_param_only will not send the field in the resource body and will

--- a/mmv1/api/type.rb
+++ b/mmv1/api/type.rb
@@ -43,6 +43,8 @@ module Api
       # not attempt to read the field from the API response.
       # NOTE - this doesn't work for nested fields
       attr_reader :url_param_only
+
+      # For nested fields, this only applies within the parent.
       attr_reader :required
 
       # [Additional query Parameters to append to GET calls.
@@ -121,6 +123,8 @@ module Api
       # if true, then we get the default value from the Google API if no value
       # is set in the terraform configuration for this field.
       # It translates to setting the field to Computed & Optional in the schema.
+      # For nested fields, this also needs to be set on each ancestor (ie. self,
+      # parent, etc.).
       attr_reader :default_from_api
 
       # https://github.com/hashicorp/terraform/pull/20837

--- a/mmv1/api/type.rb
+++ b/mmv1/api/type.rb
@@ -41,7 +41,11 @@ module Api
       # child, etc.).
       attr_reader :output
 
-      attr_reader :immutable # If set to true value is used only on creation
+      # If set to true value is used only on creation.
+      # For nested fields, this only applies at the current level. This means
+      # it should be explicitly added to each field that needs the ForceNew
+      # behavior.
+      attr_reader :immutable
 
       # url_param_only will not send the field in the resource body and will
       # not attempt to read the field from the API response.
@@ -49,6 +53,7 @@ module Api
       attr_reader :url_param_only
 
       # For nested fields, this only applies within the parent.
+      # For example, an optional parent can contain a required child.
       attr_reader :required
 
       # [Additional query Parameters to append to GET calls.


### PR DESCRIPTION
I've personally had trouble remembering how many of our magic-modules configs work for nested fields, so trying to document them a bit more here (if nothing else so I don't need to hold it in my head).

Changes
* `required` is not global, it is scoped to the parent
* `default_from_api` needs to be set on each ancestor

Open questions I wasn't sure about (but would like to add if someone knows):
* Typically, `required` and `default_from_api` don't make sense on the same field, but I think it is needed in some cases for nested fields?
* I'm still unclear how `output` behaves for nested fields

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
