### PR TITLE
GA compute address labels

### DIFF
--- a/mmv1/products/compute/Address.yaml
+++ b/mmv1/products/compute/Address.yaml
@@ -200,7 +200,6 @@ properties:
       Labels to apply to this address.  A list of key->value pairs.
     update_verb: :POST
     update_url: 'projects/{{project}}/regions/{{region}}/addresses/{{name}}/setLabels'
-    min_version: beta
   - !ruby/object:Api::Type::Fingerprint
     name: 'labelFingerprint'
     description: |

--- a/mmv1/products/compute/Address.yaml
+++ b/mmv1/products/compute/Address.yaml
@@ -207,7 +207,6 @@ properties:
       internally during updates.
     update_url: 'projects/{{project}}/regions/{{region}}/addresses/{{name}}/setLabels'
     update_verb: :POST
-    min_version: beta
   - !ruby/object:Api::Type::ResourceRef
     name: 'network'
     resource: 'Network'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_address_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_address_test.go
@@ -1,5 +1,3 @@
-<% autogen_exception -%>
-
 package compute_test
 
 import (
@@ -59,7 +57,6 @@ func TestAccComputeAddress_internal(t *testing.T) {
 	})
 }
 
-<% unless version == "ga" -%>
 func TestAccComputeAddress_networkTier_withLabels(t *testing.T) {
 	t.Parallel()
 
@@ -113,9 +110,9 @@ func TestAccComputeAddress_networkTier_withLabels(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "google_compute_address.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_address.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			{
@@ -138,26 +135,18 @@ func TestAccComputeAddress_networkTier_withProvider5(t *testing.T) {
 	acctest.SkipIfVcr(t)
 	t.Parallel()
 
-	oldVersion := map[string]resource.ExternalProvider{
-		"google": {
-			VersionConstraint: "4.75.0", // a version that doesn't separate user defined labels and system labels
-			Source:            "registry.terraform.io/hashicorp/google",
-		},
-	}
-
 	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		PreCheck: func() { acctest.AccTestPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccComputeAddress_networkTier(acctest.RandString(t, 10)),
-				ExternalProviders: oldVersion,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckNoResourceAttr("google_compute_address.foobar", "labels.%"),
 					resource.TestCheckNoResourceAttr("google_compute_address.foobar", "effective_labels.%"),
 				),
 			},
 			{
-				Config: testAccComputeAddress_networkTier_withLabels(acctest.RandString(t, 10)),
+				Config:                   testAccComputeAddress_networkTier_withLabels(acctest.RandString(t, 10)),
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_compute_address.foobar", "labels.%", "2"),
@@ -175,7 +164,7 @@ func TestAccComputeAddress_networkTier_withProvider5(t *testing.T) {
 
 func TestAccComputeAddress_withProviderDefaultLabels(t *testing.T) {
 	// The test failed if VCR testing is enabled, because the cached provider config is used.
-	// With the cached provider config, any changes in the provider default labels will not be applied. 
+	// With the cached provider config, any changes in the provider default labels will not be applied.
 	acctest.SkipIfVcr(t)
 	t.Parallel()
 
@@ -200,9 +189,9 @@ func TestAccComputeAddress_withProviderDefaultLabels(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "google_compute_address.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_address.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			{
@@ -245,9 +234,9 @@ func TestAccComputeAddress_withProviderDefaultLabels(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "google_compute_address.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_address.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			{
@@ -267,9 +256,9 @@ func TestAccComputeAddress_withProviderDefaultLabels(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "google_compute_address.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_address.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			{
@@ -377,7 +366,6 @@ resource "google_compute_address" "foobar" {
 }
 `, i)
 }
-<% end -%>
 
 func testAccComputeAddress_internal(i string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/services/compute/resource_compute_address_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_address_test.go
@@ -136,7 +136,8 @@ func TestAccComputeAddress_networkTier_withProvider5(t *testing.T) {
 	t.Parallel()
 
 	acctest.VcrTest(t, resource.TestCase{
-		PreCheck: func() { acctest.AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccComputeAddress_networkTier(acctest.RandString(t, 10)),
@@ -146,8 +147,7 @@ func TestAccComputeAddress_networkTier_withProvider5(t *testing.T) {
 				),
 			},
 			{
-				Config:                   testAccComputeAddress_networkTier_withLabels(acctest.RandString(t, 10)),
-				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+				Config: testAccComputeAddress_networkTier_withLabels(acctest.RandString(t, 10)),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_compute_address.foobar", "labels.%", "2"),
 					resource.TestCheckResourceAttr("google_compute_address.foobar", "labels.env", "foo"),


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fixes https://github.com/hashicorp/terraform-provider-google/issues/16082
alternative: https://github.com/GoogleCloudPlatform/magic-modules/pull/9158

- confirmed `labels` and `labelFingerprint` are in https://cloud.google.com/compute/docs/reference/rest/v1/addresses
- tested all GA Compute Address tests in MM Upstream TC
- tested with the exact example locally this time:

```
provider "google" {
  default_labels = {
    my_global_key  = "one"
    my_default_key = "two"
  }
}

resource "google_compute_address" "my_address" {
  name = "my-address"

  labels = {
    my_key = "three"
    # overrides provider-wide setting
    my_default_key = "four"
  }
}
```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `labels`, `effective_labels`, `terraform_labels`, and `label_fingerprint` to `google_compute_address` (GA)
```
