### PR TITLE
Add `google_cloud_identity_group_lookup` data source

### DIFF
--- a/mmv1/third_party/terraform/provider/provider.go.erb
+++ b/mmv1/third_party/terraform/provider/provider.go.erb
@@ -232,6 +232,7 @@ func DatasourceMapWithErrors() (map[string]*schema.Resource, error) {
 		<% end -%>
 		"google_cloud_identity_groups":                     cloudidentity.DataSourceGoogleCloudIdentityGroups(),
 		"google_cloud_identity_group_memberships":          cloudidentity.DataSourceGoogleCloudIdentityGroupMemberships(),
+		"google_cloud_identity_group_lookup":               cloudidentity.DataSourceGoogleCloudIdentityGroupLookup(),
 		"google_cloud_run_locations":                       cloudrun.DataSourceGoogleCloudRunLocations(),
 		"google_cloud_run_service":                         cloudrun.DataSourceGoogleCloudRunService(),
 		"google_composer_environment":                      composer.DataSourceGoogleComposerEnvironment(),

--- a/mmv1/third_party/terraform/services/cloudidentity/data_source_cloud_identity_group_lookup.go.erb
+++ b/mmv1/third_party/terraform/services/cloudidentity/data_source_cloud_identity_group_lookup.go.erb
@@ -1,0 +1,102 @@
+<% autogen_exception -%>
+package cloudidentity
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func DataSourceGoogleCloudIdentityGroupLookup() *schema.Resource {
+
+	return &schema.Resource{
+		Read: dataSourceGoogleCloudIdentityGroupLookupRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The [resource name](https://cloud.google.com/apis/design/resource_names) of the looked-up Group.`,
+			},
+			"group_key": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Required: true,
+				Description: `The EntityKey of the Group to lookup. A unique identifier for an entity in the Cloud Identity Groups API.
+An entity can represent either a group with an optional namespace or a user without a namespace.
+The combination of id and namespace must be unique; however, the same id can be used with different namespaces.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Required: true,
+							Description: `The ID of the entity. For Google-managed entities, the id should be the email address of an existing group or user.
+For external-identity-mapped entities, the id must be a string conforming to the Identity Source's requirements.
+Must be unique within a namespace.`,
+						},
+						"namespace": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Description: `The namespace in which the entity exists. If not specified, the EntityKey represents a Google-managed entity such as a Google user or a Google Group.
+If specified, the EntityKey represents an external-identity-mapped group. The namespace must correspond to an identity source created in Admin Console and must be in the form of identitysources/{identity_source}.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGoogleCloudIdentityGroupLookupRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	gkId, ok := d.GetOk("group_key.0.id")
+	if !ok {
+		return fmt.Errorf("error getting group key id")
+	}
+	id := gkId.(string)
+
+	groupsLookupCall := config.NewCloudIdentityClient(userAgent).Groups.Lookup().GroupKeyId(id)
+
+	gkNamespace, ok := d.GetOk("group_key.0.namespace")
+	if ok {
+		// If optional namespace argument provided, add as param to API call
+		namespace := gkNamespace.(string)
+		groupsLookupCall = groupsLookupCall.GroupKeyNamespace(namespace)
+	}
+
+	if config.UserProjectOverride {
+		billingProject := ""
+		// err may be nil - project isn't required for this resource
+		if project, err := tpgresource.GetProject(d, config); err == nil {
+			billingProject = project
+		}
+
+		// err == nil indicates that the billing_project value was found
+		if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+			billingProject = bp
+		}
+
+		if billingProject != "" {
+			groupsLookupCall.Header().Set("X-Goog-User-Project", billingProject)
+		}
+	}
+	resp, err := groupsLookupCall.Do()
+	if err != nil {
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("CloudIdentityGroups %q", d.Id()), "Groups")
+	}
+
+	if err := d.Set("name", resp.Name); err != nil {
+		return fmt.Errorf("error setting group lookup name: %s", err)
+	}
+	d.SetId(time.Now().UTC().String())
+	return nil
+}

--- a/mmv1/third_party/terraform/services/cloudidentity/data_source_cloud_identity_group_lookup_test.go
+++ b/mmv1/third_party/terraform/services/cloudidentity/data_source_cloud_identity_group_lookup_test.go
@@ -55,7 +55,7 @@ resource "google_cloud_identity_group" "cloud_identity_group_basic" {
   parent = "customers/%{cust_id}"
 
   group_key {
-  	id = "tf-test-my-identity-group%{random_suffix}@%{org_domain}"
+    id = "tf-test-my-identity-group%{random_suffix}@%{org_domain}"
   }
 
   labels = {
@@ -81,7 +81,7 @@ resource "google_cloud_identity_group" "cloud_identity_group_basic" {
   parent = "customers/%{cust_id}"
 
   group_key {
-  	id = "tf-test-my-identity-group%{random_suffix}@%{org_domain}"
+    id = "tf-test-my-identity-group%{random_suffix}@%{org_domain}"
   }
 
   labels = {
@@ -97,7 +97,7 @@ data "google_cloud_identity_group_lookup" "email" {
 
 data "google_cloud_identity_group_lookup" "additional-groupkey" {
   group_key {
-	# This value is an automatically created 'additionalGroupKeys' value
+    # This value is an automatically created 'additionalGroupKeys' value
     id = "tf-test-my-identity-group%{random_suffix}@%{org_domain}.test-google-a.com"
   }
   depends_on = [

--- a/mmv1/third_party/terraform/services/cloudidentity/data_source_cloud_identity_group_lookup_test.go
+++ b/mmv1/third_party/terraform/services/cloudidentity/data_source_cloud_identity_group_lookup_test.go
@@ -89,12 +89,6 @@ resource "google_cloud_identity_group" "cloud_identity_group_basic" {
   }
 }
 
-data "google_cloud_identity_group_lookup" "email" {
-  group_key {
-    id = google_cloud_identity_group.cloud_identity_group_basic.group_key[0].id
-  }
-}
-
 data "google_cloud_identity_group_lookup" "additional-groupkey" {
   group_key {
     # This value is an automatically created 'additionalGroupKeys' value

--- a/mmv1/third_party/terraform/services/cloudidentity/data_source_cloud_identity_group_lookup_test.go
+++ b/mmv1/third_party/terraform/services/cloudidentity/data_source_cloud_identity_group_lookup_test.go
@@ -37,8 +37,6 @@ func testAccDataSourceCloudIdentityGroupLookup_basicTest(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair("data.google_cloud_identity_group_lookup.additional-groupkey", "name",
 						"google_cloud_identity_group.cloud_identity_group_basic", "name"),
-					resource.TestCheckResourceAttrPair("data.google_cloud_identity_group_lookup.additional-groupkey", "name",
-						"data.google_cloud_identity_group_lookup.email", "name"),
 				),
 			},
 		},

--- a/mmv1/third_party/terraform/services/cloudidentity/data_source_cloud_identity_group_lookup_test.go
+++ b/mmv1/third_party/terraform/services/cloudidentity/data_source_cloud_identity_group_lookup_test.go
@@ -26,6 +26,8 @@ func testAccDataSourceCloudIdentityGroupLookup_basicTest(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("data.google_cloud_identity_group_lookup.lookup",
 						"name", regexp.MustCompile("^groups/.*$")),
+					resource.TestCheckResourceAttrPair("data.google_cloud_identity_group_lookup.lookup", "name",
+						"google_cloud_identity_group.cloud_identity_group_basic", "name"),
 				),
 			},
 		},
@@ -33,14 +35,12 @@ func testAccDataSourceCloudIdentityGroupLookup_basicTest(t *testing.T) {
 }
 
 func testAccCloudIdentityGroupLookupConfig(context map[string]interface{}) string {
+	// reused function below creates a group resource `google_cloud_identity_group.cloud_identity_group_basic`
 	return testAccCloudIdentityGroup_cloudIdentityGroupsBasicExample(context) + acctest.Nprintf(`
 data "google_cloud_identity_group_lookup" "lookup" {
   group_key {
-    id = "tf-test-my-identity-group%{random_suffix}@%{org_domain}"
+    id = google_cloud_identity_group.cloud_identity_group_basic.group_key[0].id
   }
-  depends_on = [
-	google_cloud_identity_group.cloud_identity_group_basic,
-  ]
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/cloudidentity/data_source_cloud_identity_group_lookup_test.go
+++ b/mmv1/third_party/terraform/services/cloudidentity/data_source_cloud_identity_group_lookup_test.go
@@ -38,6 +38,9 @@ data "google_cloud_identity_group_lookup" "lookup" {
   group_key {
     id = "tf-test-my-identity-group%{random_suffix}@%{org_domain}"
   }
+  depends_on = [
+	google_cloud_identity_group.cloud_identity_group_basic,
+  ]
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/cloudidentity/data_source_cloud_identity_group_lookup_test.go
+++ b/mmv1/third_party/terraform/services/cloudidentity/data_source_cloud_identity_group_lookup_test.go
@@ -1,0 +1,43 @@
+package cloudidentity_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func testAccDataSourceCloudIdentityGroupLookup_basicTest(t *testing.T) {
+
+	context := map[string]interface{}{
+		"org_domain":    envvar.GetTestOrgDomainFromEnv(t),
+		"cust_id":       envvar.GetTestCustIdFromEnv(t),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudIdentityGroupLookupConfig(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("data.google_cloud_identity_group_lookup.lookup",
+						"name", regexp.MustCompile("^groups/.*$")),
+				),
+			},
+		},
+	})
+}
+
+func testAccCloudIdentityGroupLookupConfig(context map[string]interface{}) string {
+	return testAccCloudIdentityGroup_cloudIdentityGroupsBasicExample(context) + acctest.Nprintf(`
+data "google_cloud_identity_group_lookup" "lookup" {
+  group_key {
+    id = "tf-test-my-identity-group%{random_suffix}@%{org_domain}"
+  }
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/cloudidentity/data_source_cloud_identity_groups.go.erb
+++ b/mmv1/third_party/terraform/services/cloudidentity/data_source_cloud_identity_groups.go.erb
@@ -4,6 +4,7 @@ package cloudidentity
 import (
 	"fmt"
 	"time"
+
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 

--- a/mmv1/third_party/terraform/services/cloudidentity/resource_cloud_identity_group_membership_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudidentity/resource_cloud_identity_group_membership_test.go.erb
@@ -296,7 +296,7 @@ resource "google_cloud_identity_group" "group" {
   parent = "customers/%{cust_id}"
 
   group_key {
-  	id = "tf-test-my-identity-group%{random_suffix}@%{org_domain}"
+  id = "tf-test-my-identity-group%{random_suffix}@%{org_domain}"
   }
 
   labels = {
@@ -310,7 +310,7 @@ resource "google_cloud_identity_group" "child-group" {
   parent = "customers/%{cust_id}"
 
   group_key {
-  	id = "tf-test-my-identity-group%{random_suffix}-child@%{org_domain}"
+    id = "tf-test-my-identity-group%{random_suffix}-child@%{org_domain}"
   }
 
   labels = {
@@ -326,7 +326,7 @@ resource "google_cloud_identity_group_membership" "cloud_identity_group_membersh
   }
 
   roles {
-  	name = "MEMBER"
+    name = "MEMBER"
   }
 }
 `, context)
@@ -425,7 +425,7 @@ resource "google_cloud_identity_group" "group" {
   parent = "customers/%{cust_id}"
 
   group_key {
-  	id = "tf-test-my-identity-group%{random_suffix}@%{org_domain}"
+    id = "tf-test-my-identity-group%{random_suffix}@%{org_domain}"
   }
 
   labels = {
@@ -439,7 +439,7 @@ resource "google_cloud_identity_group" "child-group" {
   parent = "customers/%{cust_id}"
 
   group_key {
-  	id = "tf-test-my-identity-group%{random_suffix}-child@%{org_domain}"
+    id = "tf-test-my-identity-group%{random_suffix}-child@%{org_domain}"
   }
 
   labels = {
@@ -455,7 +455,7 @@ resource "google_cloud_identity_group_membership" "cloud_identity_group_membersh
   }
 
   roles {
-  	name = "MEMBER"
+    name = "MEMBER"
   }
 }
 `, context)

--- a/mmv1/third_party/terraform/services/cloudidentity/resource_cloud_identity_group_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudidentity/resource_cloud_identity_group_test.go.erb
@@ -125,7 +125,7 @@ resource "google_cloud_identity_group" "cloud_identity_group_basic" {
   parent = "customers/%{cust_id}"
 
   group_key {
-  	id = "tf-test-my-identity-group%{random_suffix}@%{org_domain}"
+    id = "tf-test-my-identity-group%{random_suffix}@%{org_domain}"
   }
 
   labels = {

--- a/mmv1/third_party/terraform/services/cloudidentity/resource_cloud_identity_group_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudidentity/resource_cloud_identity_group_test.go.erb
@@ -34,6 +34,7 @@ func TestAccCloudIdentityGroup(t *testing.T) {
 <% end -%>
 		"data_source_basic":            testAccDataSourceCloudIdentityGroups_basicTest,
 		"data_source_membership_basic": testAccDataSourceCloudIdentityGroupMemberships_basicTest,
+		"data_source_group_lookup":     testAccDataSourceCloudIdentityGroupLookup_basicTest,
 	}
 
 	for name, tc := range testCases {

--- a/mmv1/third_party/terraform/website/docs/d/cloud_identity_group_lookup.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/cloud_identity_group_lookup.html.markdown
@@ -1,0 +1,51 @@
+---
+subcategory: "Cloud Identity"
+description: |-
+  Get list of the Cloud Identity Groups under a customer or namespace.
+---
+
+# google_cloud_identity_group_lookup
+
+Use this data source to look up the resource name of a Cloud Identity Group by its EntityKey, i.e. the group's email.
+
+https://cloud.google.com/identity/docs/concepts/overview#groups
+
+## Example Usage
+
+```tf
+data "google_cloud_identity_group_lookup" "group" {
+  group_key {
+    id = "my-group@example.com"
+  }
+}
+```
+
+## Argument Reference
+
+* `group_key` - (Required) The EntityKey of the Group to lookup. A unique identifier for an entity in the Cloud Identity Groups API.
+An entity can represent either a group with an optional namespace or a user without a namespace.
+The combination of id and namespace must be unique; however, the same id can be used with different namespaces. Structure is [documented below](#nested_group_key).
+
+<a name="nested_group_key"></a>The `group_key` block supports:
+
+* `id` -
+  (Required) The ID of the entity.
+  For Google-managed entities, the id is the email address of an existing group or user.
+  For external-identity-mapped entities, the id is a string conforming
+  to the Identity Source's requirements.
+
+* `namespace` -
+  (Optional) The namespace in which the entity exists.
+  If not populated, the EntityKey represents a Google-managed entity
+  such as a Google user or a Google Group.
+  If populated, the EntityKey represents an external-identity-mapped group.
+  The namespace must correspond to an identity source created in Admin Console
+  and must be in the form of `identitysources/{identity_source_id}`.
+
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following attributes are exported:
+
+* `name` -
+  Resource name of the Group in the format: groups/{group_id}, where `group_id` is the unique ID assigned to the Group.

--- a/mmv1/third_party/terraform/website/docs/d/cloud_identity_group_lookup.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/cloud_identity_group_lookup.html.markdown
@@ -1,12 +1,12 @@
 ---
 subcategory: "Cloud Identity"
 description: |-
-  Get list of the Cloud Identity Groups under a customer or namespace.
+  Look up a Cloud Identity Group using its email and namespace.
 ---
 
 # google_cloud_identity_group_lookup
 
-Use this data source to look up the resource name of a Cloud Identity Group by its EntityKey, i.e. the group's email.
+Use this data source to look up the resource name of a Cloud Identity Group by its [EntityKey](https://cloud.google.com/identity/docs/reference/rest/v1/EntityKey), i.e. the group's email.
 
 https://cloud.google.com/identity/docs/concepts/overview#groups
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Closes https://github.com/hashicorp/terraform-provider-google/issues/15812

This PR adds a data source that makes it easier to find the API-generated name for a Group when you only know the email for a given Group.

I've added:
- [x] Handwritten docs for the new data source
- [x] Acceptance test showing the data source can retrieve the name for a Group using its email
- [x] Acceptance test showing the data source can retrieve the name for a Group using an alias email - there isn't a way to create aliases through the Google provider but I'd added a test that uses a Group alias that's automatically created by the API.


Note: debug logs for the test updated in this PR currently 404, and I've made an issue for that here: https://github.com/hashicorp/terraform-provider-google/issues/16124



----


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
`google_cloud_identity_group_lookup`
```
