### PR TITLE
Update Cloud Run V2 custom audiences schema reference

### DIFF
--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -246,7 +246,7 @@ properties:
         description: |
           If True, indicates to use the default project's binary authorization policy. If False, binary authorization will be disabled.
   - !ruby/object:Api::Type::Array
-    name: 'custom_audiences'
+    name: 'customAudiences'
     min_version: beta
     description: |
       One or more custom audiences that you want this service to support. Specify each custom audience as the full URL in a string. The custom audiences are encoded in the token and used to authenticate requests.

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.erb
@@ -679,7 +679,7 @@ func TestAccCloudRunV2Service_cloudrunv2ServiceCustomAudienceUpdate(t *testing.T
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 		CheckDestroy:             testAccCheckCloudRunV2ServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -707,6 +707,7 @@ func TestAccCloudRunV2Service_cloudrunv2ServiceCustomAudienceUpdate(t *testing.T
 func testAccCloudRunV2Service_cloudRunServiceUpdateWithoutCustomAudience(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_cloud_run_v2_service" "default" {
+  provider     = google-beta
   name         = "%{service_name}"
   location     = "us-central1"
   launch_stage = "BETA"
@@ -726,6 +727,7 @@ resource "google_cloud_run_v2_service" "default" {
 func testAccCloudRunV2Service_cloudRunServiceUpdateWithCustomAudience(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_cloud_run_v2_service" "default" {
+  provider         = google-beta
   name             = "%{service_name}"
   location         = "us-central1"
   launch_stage     = "BETA"

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.erb
@@ -683,22 +683,22 @@ func TestAccCloudRunV2Service_cloudrunv2ServiceCustomAudienceUpdate(t *testing.T
 		CheckDestroy:             testAccCheckCloudRunV2ServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCloudRunV2Service_cloudRunServiceUpdateWithoutCustomAudience(context),
-			},
-			{
-				ResourceName:            "google_cloud_run_v2_service.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"name", "location", "annotations"},
-			},
-			{
 				Config: testAccCloudRunV2Service_cloudRunServiceUpdateWithCustomAudience(context),
 			},
 			{
 				ResourceName:            "google_cloud_run_v2_service.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"name", "location", "annotations"},
+				ImportStateVerifyIgnore: []string{"name", "location", "annotations", "launch_stage"},
+			},
+			{
+				Config: testAccCloudRunV2Service_cloudRunServiceUpdateWithoutCustomAudience(context),
+			},
+			{
+				ResourceName:            "google_cloud_run_v2_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "location", "annotations", "launch_stage"},
 			},
 		},
 	})
@@ -710,7 +710,6 @@ resource "google_cloud_run_v2_service" "default" {
   provider     = google-beta
   name         = "%{service_name}"
   location     = "us-central1"
-  launch_stage = "BETA"
 
   template {
     containers {

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package cloudrunv2_test
 
 import (
@@ -666,3 +667,87 @@ resource "google_cloud_run_v2_service" "default" {
 }
 `, context)
 }
+
+<% unless version == "ga" -%>
+func TestAccCloudRunV2Service_cloudrunv2ServiceCustomAudienceUpdate(t *testing.T) {
+	t.Parallel()
+
+  serviceName := fmt.Sprintf("tf-test-cloudrun-service%s", acctest.RandString(t, 10))
+	context := map[string]interface{}{
+		"service_name": serviceName,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckCloudRunV2ServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudRunV2Service_cloudRunServiceUpdateWithoutCustomAudience(context),
+			},
+			{
+				ResourceName:            "google_cloud_run_v2_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "location", "annotations"},
+			},
+			{
+				Config: testAccCloudRunV2Service_cloudRunServiceUpdateWithCustomAudience(context),
+			},
+			{
+				ResourceName:            "google_cloud_run_v2_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "location", "annotations"},
+			},
+		},
+	})
+}
+
+func testAccCloudRunV2Service_cloudRunServiceUpdateWithoutCustomAudience(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_cloud_run_v2_service" "default" {
+  provider     = google-beta
+  name         = "%{service_name}"
+  location     = "us-central1"
+  launch_stage = "BETA"
+
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+      ports {
+        container_port = 8080
+      }
+      liveness_probe {
+        grpc {}
+      }
+    }
+  }
+}
+`, context)
+}
+
+func testAccCloudRunV2Service_cloudRunServiceUpdateWithCustomAudience(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_cloud_run_v2_service" "default" {
+  provider         = google-beta
+  name             = "%{service_name}"
+  location         = "us-central1"
+  launch_stage     = "BETA"
+  custom_audiences = ["test"]
+
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+      ports {
+        container_port = 8080
+      }
+      liveness_probe {
+        grpc {}
+      }
+    }
+  }
+}
+`, context)
+}
+<% end -%>

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.erb
@@ -707,7 +707,6 @@ func TestAccCloudRunV2Service_cloudrunv2ServiceCustomAudienceUpdate(t *testing.T
 func testAccCloudRunV2Service_cloudRunServiceUpdateWithoutCustomAudience(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_cloud_run_v2_service" "default" {
-  provider     = google-beta
   name         = "%{service_name}"
   location     = "us-central1"
   launch_stage = "BETA"
@@ -718,9 +717,6 @@ resource "google_cloud_run_v2_service" "default" {
       ports {
         container_port = 8080
       }
-      liveness_probe {
-        grpc {}
-      }
     }
   }
 }
@@ -730,7 +726,6 @@ resource "google_cloud_run_v2_service" "default" {
 func testAccCloudRunV2Service_cloudRunServiceUpdateWithCustomAudience(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_cloud_run_v2_service" "default" {
-  provider         = google-beta
   name             = "%{service_name}"
   location         = "us-central1"
   launch_stage     = "BETA"
@@ -741,9 +736,6 @@ resource "google_cloud_run_v2_service" "default" {
       image = "us-docker.pkg.dev/cloudrun/container/hello"
       ports {
         container_port = 8080
-      }
-      liveness_probe {
-        grpc {}
       }
     }
   }

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.erb
@@ -673,9 +673,6 @@ func TestAccCloudRunV2Service_cloudrunv2ServiceCustomAudienceUpdate(t *testing.T
 	t.Parallel()
 
   serviceName := fmt.Sprintf("tf-test-cloudrun-service%s", acctest.RandString(t, 10))
-	context := map[string]interface{}{
-		"service_name": serviceName,
-	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -683,7 +680,16 @@ func TestAccCloudRunV2Service_cloudrunv2ServiceCustomAudienceUpdate(t *testing.T
 		CheckDestroy:             testAccCheckCloudRunV2ServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCloudRunV2Service_cloudRunServiceUpdateWithCustomAudience(context),
+				Config: testAccCloudRunV2Service_cloudRunServiceUpdateWithCustomAudience(serviceName, "test"),
+			},
+			{
+				ResourceName:            "google_cloud_run_v2_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "location", "annotations", "launch_stage"},
+			},
+      {
+				Config: testAccCloudRunV2Service_cloudRunServiceUpdateWithCustomAudience(serviceName, "test_update"),
 			},
 			{
 				ResourceName:            "google_cloud_run_v2_service.default",
@@ -692,7 +698,7 @@ func TestAccCloudRunV2Service_cloudrunv2ServiceCustomAudienceUpdate(t *testing.T
 				ImportStateVerifyIgnore: []string{"name", "location", "annotations", "launch_stage"},
 			},
 			{
-				Config: testAccCloudRunV2Service_cloudRunServiceUpdateWithoutCustomAudience(context),
+				Config: testAccCloudRunV2Service_cloudRunServiceUpdateWithoutCustomAudience(serviceName),
 			},
 			{
 				ResourceName:            "google_cloud_run_v2_service.default",
@@ -704,11 +710,11 @@ func TestAccCloudRunV2Service_cloudrunv2ServiceCustomAudienceUpdate(t *testing.T
 	})
 }
 
-func testAccCloudRunV2Service_cloudRunServiceUpdateWithoutCustomAudience(context map[string]interface{}) string {
-	return acctest.Nprintf(`
+func testAccCloudRunV2Service_cloudRunServiceUpdateWithoutCustomAudience(serviceName string) string {
+	return fmt.Sprintf(`
 resource "google_cloud_run_v2_service" "default" {
   provider     = google-beta
-  name         = "%{service_name}"
+  name         = "%s"
   location     = "us-central1"
 
   template {
@@ -720,17 +726,17 @@ resource "google_cloud_run_v2_service" "default" {
     }
   }
 }
-`, context)
+`, serviceName)
 }
 
-func testAccCloudRunV2Service_cloudRunServiceUpdateWithCustomAudience(context map[string]interface{}) string {
-	return acctest.Nprintf(`
+func testAccCloudRunV2Service_cloudRunServiceUpdateWithCustomAudience(serviceName string, customAudience string) string {
+	return fmt.Sprintf(`
 resource "google_cloud_run_v2_service" "default" {
   provider         = google-beta
-  name             = "%{service_name}"
+  name             = "%s"
   location         = "us-central1"
   launch_stage     = "BETA"
-  custom_audiences = ["test"]
+  custom_audiences = ["%s"]
 
   template {
     containers {
@@ -741,6 +747,6 @@ resource "google_cloud_run_v2_service" "default" {
     }
   }
 }
-`, context)
+`, serviceName, customAudience)
 }
 <% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Custom audience is incorrectly set [here](https://github.com/DanielRieske/magic-modules/blob/0c9bef9f18781b93585fe3edf844f0ccd0641aa2/mmv1/products/cloudrunv2/Service.yaml#L249) which causes a perpetual change for this field.
While it can be created it cannot be read/updated.

This PR also adds update test scenarios to increase the coverage on this field.

Small note for the reviewer that I wasn't able to run the tests locally due to issues with my account.

https://github.com/hashicorp/terraform-provider-google/issues/16117

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
cloudrunv2: fixed bug where `google_cloud_run_v2_service.custom_audiences` could not be set or updated properly
```

Fixes https://github.com/hashicorp/terraform-provider-google/issues/16117
