### PR TITLE
Move Custom Org Policy from beta to GA

### DIFF
--- a/mmv1/products/orgpolicy/CustomConstraint.yaml
+++ b/mmv1/products/orgpolicy/CustomConstraint.yaml
@@ -16,7 +16,6 @@ name: 'CustomConstraint'
 self_link: '{{parent}}/customConstraints/{{name}}'
 base_url: '{{parent}}/customConstraints'
 update_verb: :PATCH
-min_version: beta
 references: !ruby/object:Api::Resource::ReferenceLinks
   guides:
     'Official Documentation': 'https://cloud.google.com/resource-manager/docs/organization-policy/creating-managing-custom-constraints'
@@ -30,13 +29,11 @@ custom_code: !ruby/object:Provider::Terraform::CustomCode
   update_encoder: 'templates/terraform/update_encoder/org_policy_custom_constraint.go.erb'
 examples:
   - !ruby/object:Provider::Terraform::Examples
-    min_version: beta
     name: 'org_policy_custom_constraint_basic'
     primary_resource_id: 'constraint'
     test_env_vars:
       org_id: :ORG_ID
   - !ruby/object:Provider::Terraform::Examples
-    min_version: beta
     name: 'org_policy_custom_constraint_full'
     primary_resource_id: 'constraint'
     test_env_vars:

--- a/mmv1/products/orgpolicy/product.yaml
+++ b/mmv1/products/orgpolicy/product.yaml
@@ -16,6 +16,9 @@ name: OrgPolicy
 display_name: Organization Policy
 versions:
   - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: https://orgpolicy.googleapis.com/v2/
+  - !ruby/object:Api::Product::Version
     name: beta
     base_url: https://orgpolicy.googleapis.com/v2/
 scopes:

--- a/mmv1/templates/terraform/examples/org_policy_custom_constraint_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/org_policy_custom_constraint_basic.tf.erb
@@ -1,5 +1,4 @@
 resource "google_org_policy_custom_constraint" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
 
   name         = "custom.disableGkeAutoUpgrade"
   parent       = "organizations/<%= ctx[:test_env_vars]['org_id'] %>"

--- a/mmv1/templates/terraform/examples/org_policy_custom_constraint_full.tf.erb
+++ b/mmv1/templates/terraform/examples/org_policy_custom_constraint_full.tf.erb
@@ -1,5 +1,4 @@
 resource "google_org_policy_custom_constraint" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
 
   name         = "custom.disableGkeAutoUpgrade"
   parent       = "organizations/<%= ctx[:test_env_vars]['org_id'] %>"
@@ -13,7 +12,6 @@ resource "google_org_policy_custom_constraint" "<%= ctx[:primary_resource_id] %>
 }
 
 resource "google_org_policy_policy" "bool" {
-  provider = google-beta
 
   name   = "organizations/<%= ctx[:test_env_vars]['org_id'] %>/policies/${google_org_policy_custom_constraint.constraint.name}"
   parent = "organizations/<%= ctx[:test_env_vars]['org_id'] %>"

--- a/mmv1/third_party/terraform/fwmodels/provider_model.go.erb
+++ b/mmv1/third_party/terraform/fwmodels/provider_model.go.erb
@@ -54,9 +54,6 @@ type ProviderModel struct {
 	CloudResourceManagerCustomEndpoint types.String `tfsdk:"cloud_resource_manager_custom_endpoint"`
 	EventarcCustomEndpoint             types.String `tfsdk:"eventarc_custom_endpoint"`
 	FirebaserulesCustomEndpoint        types.String `tfsdk:"firebaserules_custom_endpoint"`
-<% if version == "ga" -%>
-	OrgPolicyCustomEndpoint            types.String `tfsdk:"org_policy_custom_endpoint"`
-<% end -%>
 	RecaptchaEnterpriseCustomEndpoint  types.String `tfsdk:"recaptcha_enterprise_custom_endpoint"`
 
 	GkehubFeatureCustomEndpoint        types.String `tfsdk:"gkehub_feature_custom_endpoint"`

--- a/mmv1/third_party/terraform/services/orgpolicy/resource_org_policy_custom_constraint_test.go.erb
+++ b/mmv1/third_party/terraform/services/orgpolicy/resource_org_policy_custom_constraint_test.go.erb
@@ -1,6 +1,5 @@
 <% autogen_exception -%>
 package orgpolicy_test
-<% unless version == 'ga' -%>
 
 import (
 	"testing"
@@ -77,4 +76,3 @@ resource "google_org_policy_custom_constraint" "constraint" {
 `, context)
 }
 
-<% end -%>


### PR DESCRIPTION
This promotes Custom Org Policy functionalities from beta to GA .  https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/org_policy_custom_constraint
Reference bug: b/294278891

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_org_policy_custom_constraint` (GA)
```
