### PR TITLE
Add the SEV_LIVE_MIGRATABLE_V2 tag to the list of guest os features.

### DIFF
--- a/mmv1/products/compute/Image.yaml
+++ b/mmv1/products/compute/Image.yaml
@@ -147,6 +147,7 @@ properties:
             - :SEV_SNP_CAPABLE
             - :SUSPEND_RESUME_COMPATIBLE
             - :TDX_CAPABLE
+            - :SEV_LIVE_MIGRATABLE_V2
   - !ruby/object:Api::Type::NestedObject
     name: 'imageEncryptionKey'
     description: |


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add SEV_LIVE_MIGRATABLE to the list of guestOsFeatures.
This guestOsFeature is already available in gcloud.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: dded SEV_LIVE_MIGRATABLE to guestOsFeatures enum.
```
