### PR TITLE
Add option to recreate PSC FW rule when status changed to closed

### DIFF
--- a/mmv1/products/compute/ForwardingRule.yaml
+++ b/mmv1/products/compute/ForwardingRule.yaml
@@ -216,6 +216,10 @@ examples:
       - "target"
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   post_create: templates/terraform/post_create/labels.erb
+  constants: 'templates/terraform/constants/compute_forwarding_rule.go.erb'
+custom_diff: [
+  'forwardingRuleCustomizeDiff',
+]
 parameters:
   - !ruby/object:Api::Type::ResourceRef
     name: 'region'
@@ -650,3 +654,9 @@ properties:
       - :IPV6
     immutable: true
     default_from_api: true
+virtual_fields:
+  - !ruby/object:Api::Type::Boolean
+    name: recreate_closed_psc
+    description:
+      This is used in PSC consumer ForwardingRule to make terraform recreate the ForwardingRule when the status is closed
+    default_value: false

--- a/mmv1/templates/terraform/constants/compute_forwarding_rule.go.erb
+++ b/mmv1/templates/terraform/constants/compute_forwarding_rule.go.erb
@@ -1,0 +1,16 @@
+func forwardingRuleCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+	log.Println("[DEBUG] [PSC] Reached forwardingRuleCustomizeDiff function")
+
+	// if target is not a string it's not set so no PSC connection
+	if target, ok := diff.Get("target").(string); ok {
+		if strings.Contains(target, "/serviceAttachments/") {
+			recreateClosedPsc, _ := diff.Get("recreate_closed_psc").(bool)
+			if pscConnectionStatus, ok := diff.Get("psc_connection_status").(string); ok && recreateClosedPsc && pscConnectionStatus == "CLOSED" {
+				// https://discuss.hashicorp.com/t/force-new-resource-based-on-api-read-difference/29759/6
+				diff.SetNewComputed("psc_connection_status")
+				diff.ForceNew("psc_connection_status")
+			}
+		}
+	}
+	return nil
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_forwarding_rule_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_forwarding_rule_test.go.erb
@@ -205,6 +205,51 @@ func TestAccComputeForwardingRule_forwardingRuleVpcPscExampleUpdate(t *testing.T
 	})
 }
 
+func TestAccComputeForwardingRule_forwardingRulePscRecreate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeForwardingRuleDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeForwardingRule_forwardingRulePscRecreate(context),
+			},
+			{
+				ResourceName:      "google_compute_forwarding_rule.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"recreate_closed_psc"},
+			},
+			{
+				Config: testAccComputeForwardingRule_forwardingRulePscRecreate(context),
+			},
+			{
+				ResourceName:      "google_compute_forwarding_rule.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ExpectNonEmptyPlan: true,
+        ImportStateVerifyIgnore: []string{"recreate_closed_psc"},
+			},
+			{
+				Config: testAccComputeForwardingRule_forwardingRulePscRecreate(context),
+			},
+			{
+				ResourceName:      "google_compute_forwarding_rule.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ExpectNonEmptyPlan: true,
+        ImportStateVerifyIgnore: []string{"recreate_closed_psc"},
+			},
+		},
+	})
+}
+
 func TestAccComputeForwardingRule_forwardingRuleRegionalSteeringExampleUpdate(t *testing.T) {
 	t.Parallel()
 
@@ -472,7 +517,7 @@ resource "google_compute_firewall" "fw_hc" {
   target_tags = ["allow-health-check"]
 }
 
-# allow communication within the subnet 
+# allow communication within the subnet
 resource "google_compute_firewall" "fw_ilb_to_backends" {
   name          = "tf-test-l4-ilb-fw-allow-ilb-to-backends%{random_suffix}"
   provider      = google-beta
@@ -604,6 +649,107 @@ resource "google_compute_forwarding_rule" "default" {
   ip_address              = google_compute_address.consumer_address.id
   allow_psc_global_access = false
   %{lifecycle_block}
+}
+
+// Consumer service endpoint
+
+resource "google_compute_network" "consumer_net" {
+  name                    = "tf-test-consumer-net%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "consumer_subnet" {
+  name          = "tf-test-consumer-net%{random_suffix}"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.consumer_net.id
+}
+
+resource "google_compute_address" "consumer_address" {
+  name         = "tf-test-website-ip%{random_suffix}-1"
+  region       = "us-central1"
+  subnetwork   = google_compute_subnetwork.consumer_subnet.id
+  address_type = "INTERNAL"
+}
+
+
+// Producer service attachment
+
+resource "google_compute_network" "producer_net" {
+  name                    = "tf-test-producer-net%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "producer_subnet" {
+  name          = "tf-test-producer-net%{random_suffix}"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.producer_net.id
+}
+
+resource "google_compute_subnetwork" "psc_producer_subnet" {
+  name          = "tf-test-producer-psc-net%{random_suffix}"
+  ip_cidr_range = "10.1.0.0/16"
+  region        = "us-central1"
+
+  purpose       = "PRIVATE_SERVICE_CONNECT"
+  network       = google_compute_network.producer_net.id
+}
+
+resource "google_compute_service_attachment" "producer_service_attachment" {
+  name        = "tf-test-producer-service%{random_suffix}"
+  region      = "us-central1"
+  description = "A service attachment configured with Terraform"
+
+  enable_proxy_protocol = true
+  connection_preference = "ACCEPT_AUTOMATIC"
+  nat_subnets           = [google_compute_subnetwork.psc_producer_subnet.name]
+  target_service        = google_compute_forwarding_rule.producer_target_service.id
+}
+
+resource "google_compute_forwarding_rule" "producer_target_service" {
+  name     = "tf-test-producer-forwarding-rule%{random_suffix}"
+  region   = "us-central1"
+
+  load_balancing_scheme = "INTERNAL"
+  backend_service       = google_compute_region_backend_service.producer_service_backend.id
+  all_ports             = true
+  network               = google_compute_network.producer_net.name
+  subnetwork            = google_compute_subnetwork.producer_subnet.name
+}
+
+resource "google_compute_region_backend_service" "producer_service_backend" {
+  name     = "tf-test-producer-service-backend%{random_suffix}"
+  region   = "us-central1"
+
+  health_checks = [google_compute_health_check.producer_service_health_check.id]
+}
+
+resource "google_compute_health_check" "producer_service_health_check" {
+  name     = "tf-test-producer-service-health-check%{random_suffix}"
+
+  check_interval_sec = 1
+  timeout_sec        = 1
+  tcp_health_check {
+    port = "80"
+  }
+}
+`, context)
+}
+
+func testAccComputeForwardingRule_forwardingRulePscRecreate(context map[string]interface{}) string {
+
+	return acctest.Nprintf(`
+// Forwarding rule for VPC private service connect
+resource "google_compute_forwarding_rule" "default" {
+  name                    = "tf-test-psc-endpoint%{random_suffix}"
+  region                  = "us-central1"
+  load_balancing_scheme   = ""
+  target                  = google_compute_service_attachment.producer_service_attachment.id
+  network                 = google_compute_network.consumer_net.name
+  ip_address              = google_compute_address.consumer_address.id
+  allow_psc_global_access = true
+  recreate_closed_psc     = true
 }
 
 // Consumer service endpoint


### PR DESCRIPTION
This PR adds an option to recreate the Forwarding rule for a PSC consumer endpoint if the endpoint changed to closed.
This is an issue mentioned with multiple GCP Customers. e.g. b/238844418 and multiple internal bugs.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: add `recreate_closed_psc` flag to recreate the PSC Consumer forwarding rule if the `psc_connection_status` is closed on `google_compute_forwarding_rule`.
```
