### PR TITLE
Dataform Repository Resource Adding requested fields

### DIFF
--- a/mmv1/products/dataform/Repository.yaml
+++ b/mmv1/products/dataform/Repository.yaml
@@ -69,23 +69,23 @@ properties:
           - gitRemoteSettings.0.sshAuthenticationConfig
         description:
           The name of the Secret Manager secret version to use as an
-          authentication token for Git operations. This secret is for assigning with HTTPS and is different from the secret of SSH one. Must be in the format
+          authentication token for Git operations. This secret is for assigning with HTTPS only(for SSH use `ssh_authentication_config`). Must be in the format
           projects/*/secrets/*/versions/*.
       - !ruby/object:Api::Type::NestedObject
         name: 'sshAuthenticationConfig'
         exactly_one_of:
           - gitRemoteSettings.0.authenticationTokenSecretVersion
           - gitRemoteSettings.0.sshAuthenticationConfig
-        description: Optional. Authentication fields for remote uris using SSH protocol.
+        description: Authentication fields for remote uris using SSH protocol.
         properties:
           - !ruby/object:Api::Type::String
             name: userPrivateKeySecretVersion
             required: true
-            description: Required. The name of the Secret Manager secret version to use as a ssh private key for Git operations. Must be in the format projects/*/secrets/*/versions/*.
+            description: The name of the Secret Manager secret version to use as a ssh private key for Git operations. Must be in the format projects/*/secrets/*/versions/*.
           - !ruby/object:Api::Type::String
             name: hostPublicKey
             required: true
-            description: Required. Content of a public SSH key to verify an identity of a remote Git host.
+            description: Content of a public SSH key to verify an identity of a remote Git host.
       - !ruby/object:Api::Type::String
         name: 'tokenStatus'
         output: true
@@ -93,17 +93,17 @@ properties:
           Indicates the status of the Git access token. https://cloud.google.com/dataform/reference/rest/v1beta1/projects.locations.repositories#TokenStatus
   - !ruby/object:Api::Type::NestedObject
     name: 'workspaceCompilationOverrides'
-    description: Optional. If set, fields of workspaceCompilationOverrides override the default compilation settings that are specified in dataform.json when creating workspace-scoped compilation results.
+    description: If set, fields of workspaceCompilationOverrides override the default compilation settings that are specified in dataform.json when creating workspace-scoped compilation results.
     properties:
       - !ruby/object:Api::Type::String
         name: defaultDatabase
-        description: Optional. The default database (Google Cloud project ID).
+        description: The default database (Google Cloud project ID).
       - !ruby/object:Api::Type::String
         name: 'schemaSuffix'
-        description: Optional. The suffix that should be appended to all schema (BigQuery dataset ID) names.
+        description: The suffix that should be appended to all schema (BigQuery dataset ID) names.
       - !ruby/object:Api::Type::String
         name: 'tablePrefix'
-        description: Optional. The prefix that should be prepended to all table names.
+        description: The prefix that should be prepended to all table names.
   - !ruby/object:Api::Type::String
     name: 'serviceAccount'
-    description: Optional. The service account to run workflow invocations under.
+    description: The service account to run workflow invocations under.

--- a/mmv1/products/dataform/Repository.yaml
+++ b/mmv1/products/dataform/Repository.yaml
@@ -64,11 +64,28 @@ properties:
         description: The Git remote's default branch name.
       - !ruby/object:Api::Type::String
         name: 'authenticationTokenSecretVersion'
-        required: true
+        exactly_one_of:
+          - gitRemoteSettings.0.authenticationTokenSecretVersion
+          - gitRemoteSettings.0.sshAuthenticationConfig
         description:
           The name of the Secret Manager secret version to use as an
-          authentication token for Git operations. Must be in the format
+          authentication token for Git operations. This secret is for assigning with HTTPS and is different from the secret of SSH one. Must be in the format
           projects/*/secrets/*/versions/*.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'sshAuthenticationConfig'
+        exactly_one_of:
+          - gitRemoteSettings.0.authenticationTokenSecretVersion
+          - gitRemoteSettings.0.sshAuthenticationConfig
+        description: Optional. Authentication fields for remote uris using SSH protocol.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: userPrivateKeySecretVersion
+            required: true
+            description: Required. The name of the Secret Manager secret version to use as a ssh private key for Git operations. Must be in the format projects/*/secrets/*/versions/*.
+          - !ruby/object:Api::Type::String
+            name: hostPublicKey
+            required: true
+            description: Required. Content of a public SSH key to verify an identity of a remote Git host.
       - !ruby/object:Api::Type::String
         name: 'tokenStatus'
         output: true
@@ -87,3 +104,6 @@ properties:
       - !ruby/object:Api::Type::String
         name: 'tablePrefix'
         description: Optional. The prefix that should be prepended to all table names.
+  - !ruby/object:Api::Type::String
+    name: 'serviceAccount'
+    description: Optional. The service account to run workflow invocations under.

--- a/mmv1/products/dataform/Repository.yaml
+++ b/mmv1/products/dataform/Repository.yaml
@@ -36,6 +36,14 @@ examples:
       git_repository_name: 'my/repository'
       dataform_repository_name: 'dataform_repository'
       data: secret-data
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'dataform_repository_ssh'
+    primary_resource_id: dataform_respository
+    min_version: beta
+    vars:
+      git_repository_name: 'my/repository'
+      dataform_repository_name: 'dataform_repository'
+      data: secret-data
 parameters:
   - !ruby/object:Api::Type::String
     name: 'region'

--- a/mmv1/templates/terraform/examples/dataform_repository.tf.erb
+++ b/mmv1/templates/terraform/examples/dataform_repository.tf.erb
@@ -19,7 +19,7 @@ resource "google_secret_manager_secret_version" "secret_version" {
   secret_data = "<%= ctx[:vars]['data'] %>"
 }
 
-resource "google_dataform_repository" "<%= ctx[:primary_resource_id] %>" {
+resource "google_dataform_repository" "<%= ctx[:primary_resource_id] %>_git_https_connection" {
   provider = google-beta
   name = "<%= ctx[:vars]['dataform_repository_name'] %>"
 
@@ -34,4 +34,26 @@ resource "google_dataform_repository" "<%= ctx[:primary_resource_id] %>" {
     schema_suffix = "_suffix"
     table_prefix = "prefix_"
   }
+}
+
+resource "google_dataform_repository" "<%= ctx[:primary_resource_id] %>_git_ssh_connection" {
+  provider = google-beta
+  name = "<%= ctx[:vars]['dataform_repository_name'] %>"
+
+  git_remote_settings {
+      url = google_sourcerepo_repository.git_repository.url
+      default_branch = "main"
+      ssh_authentication_config {
+        user_private_key_secret_version = google_secret_manager_secret_version.secret_version.id
+        host_public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSU"
+      }
+  }
+
+  workspace_compilation_overrides {
+    default_database = "database"
+    schema_suffix = "_suffix"
+    table_prefix = "prefix_"
+  }
+
+  service_account = "1234567890-compute@developer.gserviceaccount.com"
 }

--- a/mmv1/templates/terraform/examples/dataform_repository_ssh.tf.erb
+++ b/mmv1/templates/terraform/examples/dataform_repository_ssh.tf.erb
@@ -19,14 +19,17 @@ resource "google_secret_manager_secret_version" "secret_version" {
   secret_data = "<%= ctx[:vars]['data'] %>"
 }
 
-resource "google_dataform_repository" "<%= ctx[:primary_resource_id] %>" {
+resource "google_dataform_repository" "<%= ctx[:primary_resource_id] %>_git_ssh_connection" {
   provider = google-beta
   name = "<%= ctx[:vars]['dataform_repository_name'] %>"
 
   git_remote_settings {
       url = google_sourcerepo_repository.git_repository.url
       default_branch = "main"
-      authentication_token_secret_version = google_secret_manager_secret_version.secret_version.id
+      ssh_authentication_config {
+        user_private_key_secret_version = google_secret_manager_secret_version.secret_version.id
+        host_public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAklOUpkDHrfHY17SbrmTIpNLTGK9Tjom/BWDSU"
+      }
   }
 
   workspace_compilation_overrides {
@@ -34,4 +37,6 @@ resource "google_dataform_repository" "<%= ctx[:primary_resource_id] %>" {
     schema_suffix = "_suffix"
     table_prefix = "prefix_"
   }
+
+  service_account = "1234567890-compute@developer.gserviceaccount.com"
 }

--- a/mmv1/templates/terraform/examples/dataform_repository_ssh.tf.erb
+++ b/mmv1/templates/terraform/examples/dataform_repository_ssh.tf.erb
@@ -19,7 +19,7 @@ resource "google_secret_manager_secret_version" "secret_version" {
   secret_data = "<%= ctx[:vars]['data'] %>"
 }
 
-resource "google_dataform_repository" "<%= ctx[:primary_resource_id] %>_git_ssh_connection" {
+resource "google_dataform_repository" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
   name = "<%= ctx[:vars]['dataform_repository_name'] %>"
 


### PR DESCRIPTION
Dataform Repository Resource Adding Service Account and SshAuthentication fields, this was requested to our team through internal mail chain from a client.

Product Resource API Documentation: https://cloud.google.com/dataform/reference/rest/v1beta1/projects.locations.repositories 

Did Manual Testing and it creates the repository successfully with the added fields.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dataform: added `ssh_authentication_config` and `service_account` to `google_dataform_repository` resource
```
