### PR TITLE
Revert "Enforce mutual exclusivity among view, materialized view, and…

### DIFF
--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
@@ -821,7 +821,6 @@ func ResourceBigQueryTable() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			// Schema: [Optional] Describes the schema of this table.
-			// Schema is mutually exclusive with View and Materialized View.
 			"schema": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -833,10 +832,8 @@ func ResourceBigQueryTable() *schema.Resource {
 				},
 				DiffSuppressFunc: bigQueryTableSchemaDiffSuppress,
 				Description:      `A JSON schema for the table.`,
-				ConflictsWith:    []string{"view", "materialized_view"},
 			},
 			// View: [Optional] If specified, configures this table as a view.
-			// View is mutually exclusive with Schema and Materialized View.
 			"view": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -863,11 +860,9 @@ func ResourceBigQueryTable() *schema.Resource {
 						},
 					},
 				},
-				ConflictsWith: []string{"schema", "materialized_view"},
 			},
 
 			// Materialized View: [Optional] If specified, configures this table as a materialized view.
-			// Materialized View is mutually exclusive with Schema and View.
 			"materialized_view": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -912,7 +907,6 @@ func ResourceBigQueryTable() *schema.Resource {
 						},
 					},
 				},
-				ConflictsWith: []string{"schema", "view"},
 			},
 
 			// TimePartitioning: [Experimental] If specified, configures time-based
@@ -1376,15 +1370,40 @@ func resourceBigQueryTableCreate(d *schema.ResourceData, meta interface{}) error
 
 	datasetID := d.Get("dataset_id").(string)
 
-	log.Printf("[INFO] Creating BigQuery table: %s", table.TableReference.TableId)
+	if table.View != nil && table.Schema != nil {
 
-	res, err := config.NewBigQueryClient(userAgent).Tables.Insert(project, datasetID, table).Do()
-	if err != nil {
-		return err
+		log.Printf("[INFO] Removing schema from table definition because big query does not support setting schema on view creation")
+		schemaBack := table.Schema
+		table.Schema = nil
+
+		log.Printf("[INFO] Creating BigQuery table: %s without schema", table.TableReference.TableId)
+
+		res, err := config.NewBigQueryClient(userAgent).Tables.Insert(project, datasetID, table).Do()
+		if err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] BigQuery table %s has been created", res.Id)
+		d.SetId(fmt.Sprintf("projects/%s/datasets/%s/tables/%s", res.TableReference.ProjectId, res.TableReference.DatasetId, res.TableReference.TableId))
+
+		table.Schema = schemaBack
+		log.Printf("[INFO] Updating BigQuery table: %s with schema", table.TableReference.TableId)
+		if _, err = config.NewBigQueryClient(userAgent).Tables.Update(project, datasetID, res.TableReference.TableId, table).Do(); err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] BigQuery table %s has been update with schema", res.Id)
+	} else {
+		log.Printf("[INFO] Creating BigQuery table: %s", table.TableReference.TableId)
+
+		res, err := config.NewBigQueryClient(userAgent).Tables.Insert(project, datasetID, table).Do()
+		if err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] BigQuery table %s has been created", res.Id)
+		d.SetId(fmt.Sprintf("projects/%s/datasets/%s/tables/%s", res.TableReference.ProjectId, res.TableReference.DatasetId, res.TableReference.TableId))
 	}
-
-	log.Printf("[INFO] BigQuery table %s has been created", res.Id)
-	d.SetId(fmt.Sprintf("projects/%s/datasets/%s/tables/%s", res.TableReference.ProjectId, res.TableReference.DatasetId, res.TableReference.TableId))
 
 	return resourceBigQueryTableRead(d, meta)
 }

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
@@ -454,8 +454,22 @@ func TestAccBigQueryTable_WithViewAndSchema(t *testing.T) {
 		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccBigQueryTableWithViewAndSchema(datasetID, tableID, "table description"),
-				ExpectError: regexp.MustCompile("\"view\": conflicts with schema"),
+				Config: testAccBigQueryTableWithViewAndSchema(datasetID, tableID, "table description1"),
+			},
+			{
+				ResourceName:            "google_bigquery_table.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccBigQueryTableWithViewAndSchema(datasetID, tableID, "table description2"),
+			},
+			{
+				ResourceName:            "google_bigquery_table.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
 	})
@@ -588,51 +602,6 @@ func TestAccBigQueryTable_MaterializedView_NonIncremental_basic(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection"},
-			},
-		},
-	})
-}
-
-func TestAccBigQueryTable_MaterializedView_WithSchema(t *testing.T) {
-	t.Parallel()
-	// Pending VCR support in https://github.com/hashicorp/terraform-provider-google/issues/15427.
-	acctest.SkipIfVcr(t)
-
-	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
-	tableID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
-	materializedViewID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
-	query := fmt.Sprintf("SELECT some_int FROM `%s.%s`", datasetID, tableID)
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccBigQueryTableWithMatViewAndSchema(datasetID, tableID, materializedViewID, query),
-				ExpectError: regexp.MustCompile("\"materialized_view\": conflicts with schema"),
-			},
-		},
-	})
-}
-
-func TestAccBigQueryTable_MaterializedView_WithView(t *testing.T) {
-	t.Parallel()
-	acctest.SkipIfVcr(t)
-
-	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
-	tableID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
-	materializedViewID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
-	query := fmt.Sprintf("SELECT some_int FROM `%s.%s`", datasetID, tableID)
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccBigQueryTableWithMatViewAndView(datasetID, tableID, materializedViewID, query),
-				ExpectError: regexp.MustCompile("\"materialized_view\": conflicts with view"),
 			},
 		},
 	})
@@ -2172,103 +2141,6 @@ resource "google_bigquery_table" "mv_test" {
   ]
 }
 `, datasetID, tableID, mViewID, enable_refresh, refresh_interval, query)
-}
-
-func testAccBigQueryTableWithMatViewAndSchema(datasetID, tableID, mViewID, query string) string {
-	return fmt.Sprintf(`
-resource "google_bigquery_dataset" "test" {
-  dataset_id = "%s"
-}
-
-resource "google_bigquery_table" "test" {
-  deletion_protection = false
-  table_id   = "%s"
-  dataset_id = google_bigquery_dataset.test.dataset_id
-
-  schema     = <<EOH
-[
-  {
-    "name": "some_int",
-    "type": "INTEGER"
-  }
-]
-EOH
-
-}
-
-resource "google_bigquery_table" "mv_test" {
-  deletion_protection = false
-  table_id   = "%s"
-  dataset_id = google_bigquery_dataset.test.dataset_id
-
-  materialized_view {
-    enable_refresh = true
-    refresh_interval_ms = 360000
-    query          = "%s"
-  }
-
-  schema     = <<EOH
-[
-  {
-    "description": "special new description with capital letter Z",
-    "name": "some_int",
-    "type": "INTEGER"
-  }
-]
-EOH
-
-  depends_on = [
-    google_bigquery_table.test,
-  ]
-}
-`, datasetID, tableID, mViewID, query)
-}
-
-func testAccBigQueryTableWithMatViewAndView(datasetID, tableID, mViewID, query string) string {
-	return fmt.Sprintf(`
-resource "google_bigquery_dataset" "test" {
-  dataset_id = "%s"
-}
-
-resource "google_bigquery_table" "test" {
-  deletion_protection = false
-  table_id   = "%s"
-  dataset_id = google_bigquery_dataset.test.dataset_id
-
-  schema     = <<EOH
-[
-  {
-    "name": "some_int",
-    "type": "INTEGER"
-  }
-]
-EOH
-
-}
-
-resource "google_bigquery_table" "mv_test" {
-  deletion_protection = false
-  table_id   = "%s"
-  dataset_id = google_bigquery_dataset.test.dataset_id
-
-  view {
-    query = <<SQL
-select "val1" as col1, "val2" as col2
-SQL
-    use_legacy_sql = false
-  }
-
-  materialized_view {
-    enable_refresh = true
-    refresh_interval_ms = 360000
-    query          = "%s"
-  }
-
-  depends_on = [
-    google_bigquery_table.test,
-  ]
-}
-`, datasetID, tableID, mViewID, query)
 }
 
 func testAccBigQueryTableWithMatViewNonIncremental_basic(datasetID, tableID, mViewID, query, maxStaleness string) string {


### PR DESCRIPTION
… schema in BigQuery table config (#7973)"

This reverts commit 87e4f293f0030189f8ee24f20a20d7fa57eb2cc8.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes [https://github.com/hashicorp/terraform-provider-google/issues/16134](https://www.google.com/url?q=https://github.com/hashicorp/terraform-provider-google/issues/16134&sa=D&source=buganizer&usg=AOvVaw3QM4ah4tSARlTyUNGgKX39).
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigquery: removed mutual exclusivity checks for view, materialized view, and schema for the Table resource.
```
