### PR TITLE
Promoting Cloud Memorystore Redis Cluster service to GA on terraform

### DIFF
--- a/mmv1/products/redis/Cluster.yaml
+++ b/mmv1/products/redis/Cluster.yaml
@@ -51,7 +51,6 @@ parameters:
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: "redis_cluster_ha"
-    min_version: beta
     primary_resource_id: "cluster-ha"
     vars:
       cluster_name: "ha-cluster"

--- a/mmv1/products/redis/Cluster.yaml
+++ b/mmv1/products/redis/Cluster.yaml
@@ -18,12 +18,11 @@ description: |
 references: !ruby/object:Api::Resource::ReferenceLinks
   guides:
     'Official Documentation': 'https://cloud.google.com/memorystore/docs/cluster/'
-  api: 'https://cloud.google.com/memorystore/docs/cluster/reference/rest/v1beta1/projects.locations.clusters'
+  api: 'https://cloud.google.com/memorystore/docs/cluster/reference/rest/v1/projects.locations.clusters'
 timeouts: !ruby/object:Api::Timeouts
   insert_minutes: 60
   update_minutes: 120
   delete_minutes: 30
-min_version: beta
 base_url: 'projects/{{project}}/locations/{{region}}/clusters'
 self_link: 'projects/{{project}}/locations/{{region}}/clusters/{{name}}'
 create_url: 'projects/{{project}}/locations/{{region}}/clusters?clusterId={{name}}'

--- a/mmv1/templates/terraform/examples/redis_cluster_ha.tf.erb
+++ b/mmv1/templates/terraform/examples/redis_cluster_ha.tf.erb
@@ -1,5 +1,4 @@
 resource "google_redis_cluster" "<%= ctx[:primary_resource_id] %>" {
-  provider       = google-beta
   name           = "<%= ctx[:vars]['cluster_name'] %>"
   shard_count    = 3
   psc_configs {
@@ -15,7 +14,6 @@ resource "google_redis_cluster" "<%= ctx[:primary_resource_id] %>" {
 }
 
 resource "google_network_connectivity_service_connection_policy" "default" {
-  provider = google-beta
   name = "<%= ctx[:vars]['policy_name'] %>"
   location = "us-central1"
   service_class = "gcp-memorystore-redis"
@@ -27,7 +25,6 @@ resource "google_network_connectivity_service_connection_policy" "default" {
 }
 
 resource "google_compute_subnetwork" "producer_subnet" {
-  provider      = google-beta
   name          = "<%= ctx[:vars]['subnet_name'] %>"
   ip_cidr_range = "10.0.0.248/29"
   region        = "us-central1"
@@ -35,7 +32,6 @@ resource "google_compute_subnetwork" "producer_subnet" {
 }
 
 resource "google_compute_network" "producer_net" {
-  provider                = google-beta
   name                    = "<%= ctx[:vars]['network_name'] %>"
   auto_create_subnetworks = false
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_redis_cluster` (GA)
```
