### PR TITLE
Update resource_compute_network_endpoint_group to support more values…

### DIFF
--- a/mmv1/products/compute/NetworkEndpointGroup.yaml
+++ b/mmv1/products/compute/NetworkEndpointGroup.yaml
@@ -110,11 +110,15 @@ properties:
       INTERNAL_MANAGED, and INTERNAL_SELF_MANAGED and 2) support the RATE or
       CONNECTION balancing modes.
 
-      Possible values include: GCE_VM_IP, GCE_VM_IP_PORT, and NON_GCP_PRIVATE_IP_PORT.
+      Possible values include: GCE_VM_IP, GCE_VM_IP_PORT, NON_GCP_PRIVATE_IP_PORT, INTERNET_IP_PORT, INTERNET_FQDN_PORT, SERVERLESS, and PRIVATE_SERVICE_CONNECT.
     values:
       - :GCE_VM_IP
       - :GCE_VM_IP_PORT
       - :NON_GCP_PRIVATE_IP_PORT
+      - :INTERNET_IP_PORT
+      - :INTERNET_FQDN_PORT
+      - :SERVERLESS
+      - :PRIVATE_SERVICE_CONNECT
     default_value: :GCE_VM_IP_PORT
   - !ruby/object:Api::Type::Integer
     name: 'size'


### PR DESCRIPTION
… for network_endpoint_type parameter

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

To resolve https://github.com/hashicorp/terraform-provider-google/issues/16138, this PR adds the following possible values, as taken from [Google's documentation](https://cloud.google.com/load-balancing/docs/negs):

* INTERNET_IP_PORT
* INTERNET_FQDN_PORT
* SERVERLESS
* PRIVATE_SERVICE_CONNECT

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `INTERNET_IP_PORT`, `INTERNET_FQDN_PORT`, `SERVERLESS`, and `PRIVATE_SERVICE_CONNECT` as acceptable values for the `network_endpoint_type` field for the `resource_compute_network_endpoint_group` resource
```
