### PR TITLE
Update the field description of certificateManagerCertificates and sslCertificates

### DIFF
--- a/mmv1/products/compute/TargetHttpsProxy.yaml
+++ b/mmv1/products/compute/TargetHttpsProxy.yaml
@@ -129,9 +129,10 @@ properties:
   - !ruby/object:Api::Type::Array
     name: 'certificateManagerCertificates'
     description: |
-      A list of Certificate Manager certificate URLs that are used to authenticate
-      connections between users and the load balancer. At least one resource must be specified.
-      Accepted format is `//certificatemanager.googleapis.com/projects/{project}/locations/{location}/certificates/{resourceName}` or just the self_link projects/{project}/locations/{location}/certificates/{resourceName}
+      URLs to certificate manager certificate resources that are used to authenticate connections between users and the load balancer.
+      Currently, you may specify up to 15 certificates. Certificate manager certificates do not apply when the load balancing scheme is set to INTERNAL_SELF_MANAGED.
+      sslCertificates and certificateManagerCertificates fields can not be defined together.
+      Accepted format is `//certificatemanager.googleapis.com/projects/{project}/locations/{location}/certificates/{resourceName}` or just the self_link `projects/{project}/locations/{location}/certificates/{resourceName}`
     update_verb: :POST
     update_url: 'projects/{{project}}/targetHttpsProxies/{{name}}/setSslCertificates'
     item_type: Api::Type::String
@@ -142,8 +143,9 @@ properties:
   - !ruby/object:Api::Type::Array
     name: 'sslCertificates'
     description: |
-      A list of SslCertificate resource URLs that are used to authenticate
-      connections between users and the load balancer. At least one resource must be specified.
+      URLs to SslCertificate resources that are used to authenticate connections between users and the load balancer.
+      Currently, you may specify up to 15 SSL certificates. sslCertificates do not apply when the load balancing scheme is set to INTERNAL_SELF_MANAGED.
+      sslCertificates and certificateManagerCertificates can not be defined together.
     update_verb: :POST
     update_url: 'projects/{{project}}/targetHttpsProxies/{{name}}/setSslCertificates'
     item_type: !ruby/object:Api::Type::ResourceRef


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
- Updated the description of the fields `certificateManagerCertificates` and `sslCertificates` to match the description existing in API website: https://cloud.google.com/compute/docs/reference/rest/v1/targetHttpsProxies
- Added in the fields description that` certificateManagerCertificates` and `sslCertificates` can not be defined together.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
docs: updated the description of the `ssl_certificates` and `certificate_manager_certificates` fields in `google_compute_target_https_proxy`
```
