### PR TITLE
Fix update bigquery transfer config

### DIFF
--- a/mmv1/products/bigquerydatatransfer/Config.yaml
+++ b/mmv1/products/bigquerydatatransfer/Config.yaml
@@ -15,7 +15,7 @@
 name: 'Config'
 base_url: projects/{{project}}/locations/{{location}}/transferConfigs?serviceAccountName={{service_account_name}}
 self_link: '{{name}}'
-update_url: "{{name}}?serviceAccountName={{service_account_name}}&updateMask=serviceAccountName,displayName,destinationDatasetId,schedule,scheduleOptions,emailPreferences,notificationPubsubTopic,dataRefreshWindowDays,disabled,params"
+update_url: "{{name}}?serviceAccountName={{service_account_name}}"
 update_verb: :PATCH
 description: |
   Represents a data transfer configuration. A transfer configuration
@@ -33,6 +33,7 @@ custom_code: !ruby/object:Provider::Terraform::CustomCode
   encoder: templates/terraform/encoders/bigquery_data_transfer.go.erb
   custom_import: templates/terraform/custom_import/bigquery_data_transfer_self_link_as_name_set_location.go.erb
   post_create: templates/terraform/post_create/set_computed_name.erb
+  pre_update: templates/terraform/pre_update/bigquerydatatransfer_config.erb
 custom_diff: [
   'sensitiveParamCustomizeDiff',
   'paramsCustomizeDiff',

--- a/mmv1/templates/terraform/pre_update/bigquerydatatransfer_config.erb
+++ b/mmv1/templates/terraform/pre_update/bigquerydatatransfer_config.erb
@@ -1,0 +1,54 @@
+<%- # the license inside this block applies to this file
+	# Copyright 2023 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+updateMask := []string{}
+if v, ok := d.GetOk("service_account_name"); ok {
+  if v != nil && d.HasChange("service_account_name") {
+    updateMask = append(updateMask, "serviceAccountName")
+  }
+}
+if d.HasChange("display_name") {
+  updateMask = append(updateMask, "displayName")
+}
+if d.HasChange("destination_dataset_id") {
+  updateMask = append(updateMask, "destinationDatasetId")
+}
+if d.HasChange("schedule") {
+  updateMask = append(updateMask, "schedule")
+}
+if d.HasChange("schedule_options") {
+  updateMask = append(updateMask, "scheduleOptions")
+}
+if d.HasChange("email_preferences") {
+  updateMask = append(updateMask, "emailPreferences")
+}
+if d.HasChange("notification_pubsub_topic") {
+  updateMask = append(updateMask, "notificationPubsubTopic")
+}
+if d.HasChange("data_refresh_window_days") {
+  updateMask = append(updateMask, "dataRefreshWindowDays")
+}
+if d.HasChange("disabled") {
+  updateMask = append(updateMask, "disabled")
+}
+if d.HasChange("params") {
+  updateMask = append(updateMask, "params")
+}
+
+// updateMask is a URL parameter but not present in the schema, so ReplaceVars
+// won't set it
+url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
+if err != nil {
+	return err
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Dynamically add update mask for changed properties instead of having a static list of all updatable properties.

In the case of `service_account_name`, it is only added to the update mask if it was set to a non-null value, as `service_account_name` cannot be removed from a transfer config using the [patch API](https://cloud.google.com/bigquery/docs/reference/datatransfer/rest/v1/projects.locations.transferConfigs/patch).

Fixes https://github.com/hashicorp/terraform-provider-google/issues/16033 and https://github.com/hashicorp/terraform-provider-google/issues/16126

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigquerydatatransfer: fixed an error when updating `google_bigquery_data_transfer_config` related to incorrect update masks
```
