### PR TITLE
Add `additional_group_keys` attribute to `google_cloud_identity_group` resource

### DIFF
--- a/mmv1/products/cloudidentity/Group.yaml
+++ b/mmv1/products/cloudidentity/Group.yaml
@@ -136,6 +136,7 @@ properties:
       properties:
         - !ruby/object:Api::Type::String
           name: 'id'
+          output: true
           description: |
             The ID of the entity.
 
@@ -148,7 +149,7 @@ properties:
             Must be unique within a namespace.
         - !ruby/object:Api::Type::String
           name: 'namespace'
-          immutable: true
+          output: true
           description: |
             The namespace in which the entity exists.
 

--- a/mmv1/products/cloudidentity/Group.yaml
+++ b/mmv1/products/cloudidentity/Group.yaml
@@ -128,6 +128,36 @@ properties:
     description: |
       An extended description to help users determine the purpose of a Group.
       Must not be longer than 4,096 characters.
+  - !ruby/object:Api::Type::Array
+    name: 'additionalGroupKeys'
+    output: true
+    description: 'Additional group keys associated with the Group'
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties:
+        - !ruby/object:Api::Type::String
+          name: 'id'
+          description: |
+            The ID of the entity.
+
+            For Google-managed entities, the id must be the email address of an existing
+            group or user.
+
+            For external-identity-mapped entities, the id must be a string conforming
+            to the Identity Source's requirements.
+
+            Must be unique within a namespace.
+        - !ruby/object:Api::Type::String
+          name: 'namespace'
+          immutable: true
+          description: |
+            The namespace in which the entity exists.
+
+            If not specified, the EntityKey represents a Google-managed entity
+            such as a Google user or a Google Group.
+
+            If specified, the EntityKey represents an external-identity-mapped group.
+            The namespace must correspond to an identity source created in Admin Console
+            and must be in the form of `identitysources/{identity_source_id}`.
   - !ruby/object:Api::Type::String
     name: 'createTime'
     output: true

--- a/mmv1/third_party/terraform/services/cloudidentity/resource_cloud_identity_group_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudidentity/resource_cloud_identity_group_test.go.erb
@@ -105,7 +105,7 @@ func testAccCloudIdentityGroup_cloudIdentityGroupsBasicExampleTest(t *testing.T)
 			{
 				Config: testAccCloudIdentityGroup_cloudIdentityGroupsBasicExample(context),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.google_cloud_identity_groups.groups",
+					resource.TestCheckResourceAttrSet("google_cloud_identity_group.cloud_identity_group_basic",
 						"additional_group_keys.#"),
 				),
 			},

--- a/mmv1/third_party/terraform/services/cloudidentity/resource_cloud_identity_group_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudidentity/resource_cloud_identity_group_test.go.erb
@@ -104,6 +104,10 @@ func testAccCloudIdentityGroup_cloudIdentityGroupsBasicExampleTest(t *testing.T)
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCloudIdentityGroup_cloudIdentityGroupsBasicExample(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.google_cloud_identity_groups.groups",
+						"additional_group_keys.#"),
+				),
 			},
 			{
 				ResourceName:            "google_cloud_identity_group.cloud_identity_group_basic",


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Tangentially related to (https://github.com/hashicorp/terraform-provider-google/issues/15812) - this PR exposes the 'additional group keys' of a group which could be used to find a Group via the Lookup API mentioned there.


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudidentity: Added `additional_group_keys` attribute to `google_cloud_identity_group` resource
```
