### PR TITLE
Update TeamCity config generator tool to only use directories in `google/services/` folder

### DIFF
--- a/tools/teamcity-generator/main.go
+++ b/tools/teamcity-generator/main.go
@@ -88,7 +88,9 @@ func readAllServicePackages(providerDir string) ([]string, error) {
 	var services = make([]string, 0)
 
 	for _, p := range packages {
-		services = append(services, p.Name())
+		if p.IsDir() {
+			services = append(services, p.Name())
+		}
 	}
 	if len(services) == 0 {
 		return nil, fmt.Errorf("found 0 service packages in %s", providerDir)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR is to avoid unexpected additions to services.kt like this:

![Screenshot 2023-10-10 at 21 53 42](https://github.com/GoogleCloudPlatform/magic-modules/assets/15078782/910a2360-24c3-4786-a168-09252e902337)

I couldn't find the `.DS_Store` file that was causing this - seems like it was being created transiently during the generation process? I think this is a problem that would only be an annoyance to developers and wouldn't impact our CI.

The mmv1 version of generating this file only uses directories but I overlooked this in the Go version.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
