### PR TITLE
Added support for in-place update for `ttl` field in `google_secret_manager_secret`

### DIFF
--- a/mmv1/products/secretmanager/Secret.yaml
+++ b/mmv1/products/secretmanager/Secret.yaml
@@ -198,13 +198,14 @@ properties:
     description: |
       Timestamp in UTC when the Secret is scheduled to expire. This is always provided on output, regardless of what was sent on input.
       A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+      Only one of `expire_time` or `ttl` can be provided.
     default_from_api: true
   - !ruby/object:Api::Type::String
     name: ttl
-    immutable: true
     description: |
       The TTL for the Secret.
       A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s".
+      Only one of `ttl` or `expire_time` can be provided.
     ignore_read: true
   - !ruby/object:Api::Type::NestedObject
     name: rotation

--- a/mmv1/templates/terraform/pre_update/secret_manager_secret.go.erb
+++ b/mmv1/templates/terraform/pre_update/secret_manager_secret.go.erb
@@ -23,10 +23,15 @@ if d.HasChange("replication") {
     updateMask = append(updateMask, "replication")
 }
 
+// As the API expects only one of ttl or expireTime
+if d.HasChange("ttl") && !d.HasChange("expire_time") {
+    delete(obj, "expireTime")
+}
+
 // Refreshing updateMask after adding extra schema entries
 url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
 if err != nil {
-	return err
+    return err
 }
 
 log.Printf("[DEBUG] Update URL %q: %v", d.Id(), url)

--- a/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_test.go.erb
+++ b/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_test.go.erb
@@ -327,6 +327,101 @@ func TestAccSecretManagerSecret_rotationPeriodUpdate(t *testing.T) {
 	})
 }
 
+func TestAccSecretManagerSecret_ttlUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerSecretDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretManagerSecret_withoutTtl(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_secret.secret-basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerSecret_basic(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_secret.secret-basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerSecret_ttlUpdate(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_secret.secret-basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerSecret_withoutTtl(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_secret.secret-basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func TestAccSecretManagerSecret_updateBetweenTtlAndExpireTime(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerSecretDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretManagerSecret_basic(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_secret.secret-basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerSecret_expireTime(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_secret.secret-basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerSecret_basic(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_secret.secret-basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
 func testAccSecretManagerSecret_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_secret_manager_secret" "secret-basic" {
@@ -956,6 +1051,81 @@ resource "google_secret_manager_secret" "secret-basic" {
   depends_on = [
     google_pubsub_topic_iam_member.secrets_manager_access,
   ]
+}
+`, context)
+}
+
+func testAccSecretManagerSecret_withoutTtl(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_secret" "secret-basic" {
+  secret_id = "tf-test-secret-%{random_suffix}"
+
+  labels = {
+    label = "my-label"
+  }
+
+  replication {
+    user_managed {
+      replicas {
+        location = "us-central1"
+      }
+      replicas {
+        location = "us-east1"
+      }
+    }
+  }
+}
+`, context)
+}
+
+func testAccSecretManagerSecret_ttlUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_secret" "secret-basic" {
+  secret_id = "tf-test-secret-%{random_suffix}"
+
+  labels = {
+    label = "my-label"
+  }
+
+  replication {
+    user_managed {
+      replicas {
+        location = "us-central1"
+      }
+      replicas {
+        location = "us-east1"
+      }
+    }
+  }
+
+  ttl = "7200s"
+
+}
+`, context)
+}
+
+func testAccSecretManagerSecret_expireTime(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_secret" "secret-basic" {
+  secret_id = "tf-test-secret-%{random_suffix}"
+
+  labels = {
+    label = "my-label"
+  }
+
+  replication {
+    user_managed {
+      replicas {
+        location = "us-central1"
+      }
+      replicas {
+        location = "us-east1"
+      }
+    }
+  }
+
+  expire_time = "2122-09-26T10:55:55.163240682Z"
+
 }
 `, context)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Added support for the in-place update for the `ttl` field in the `google_secret_manager_secret` resource.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
secretmanager: `ttl` field made mutable in `google_secret_manager_secret`
```