### PR TITLE
Remove IP validation for host of on-premise instance

### DIFF
--- a/mmv1/products/sql/SourceRepresentationInstance.yaml
+++ b/mmv1/products/sql/SourceRepresentationInstance.yaml
@@ -80,8 +80,6 @@ properties:
         description: |
           The externally accessible IPv4 address for the source database server.
         required: true
-        validation: !ruby/object:Provider::Terraform::Validation
-          function: 'verify.ValidateIpAddress'
       - !ruby/object:Api::Type::Integer
         name: 'port'
         default_value: 3306


### PR DESCRIPTION
In admin API, we don't have validation for host of on-premise instances. Host can take the value of IP address or DNS address. As of now it is validating that host contain the IP address in terraform, in order to be consistent with admin API and accept DNS address as well, removing the validation function for host.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```
fix host validation to support IP address and DNS address in host
```
