### PR TITLE
update documentation for google_logging_project_sink

### DIFF
--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
@@ -39,7 +39,7 @@ func ResourceLoggingProjectSink() *schema.Resource {
 		Type:        schema.TypeBool,
 		Optional:    true,
 		Default:     true,
-		Description: `Whether or not to create a unique identity associated with this sink. If false (the legacy behavior), then the writer_identity used is serviceAccount:cloud-logs@system.gserviceaccount.com. If true, then a unique service account is created and used for this sink. If you wish to publish logs across projects, you must set unique_writer_identity to true.`,
+		Description: `Whether or not to create a unique identity associated with this sink. If false (the legacy behavior), then the writer_identity used is serviceAccount:cloud-logs@system.gserviceaccount.com. If true (defaults), then a unique service account is created and used for this sink. If you wish to publish logs across projects, you must set unique_writer_identity to true.`,
 	}
 	return schm
 }

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
@@ -39,7 +39,7 @@ func ResourceLoggingProjectSink() *schema.Resource {
 		Type:        schema.TypeBool,
 		Optional:    true,
 		Default:     true,
-		Description: `Whether or not to create a unique identity associated with this sink. If false (the legacy behavior), then the writer_identity used is serviceAccount:cloud-logs@system.gserviceaccount.com. If true (defaults), then a unique service account is created and used for this sink. If you wish to publish logs across projects, you must set unique_writer_identity to true.`,
+		Description: `Whether or not to create a unique identity associated with this sink. If false (the legacy behavior), then the writer_identity used is serviceAccount:cloud-logs@system.gserviceaccount.com. If true (default), then a unique service account is created and used for this sink. If you wish to publish logs across projects, you must set unique_writer_identity to true.`,
 	}
 	return schm
 }

--- a/mmv1/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
@@ -142,8 +142,7 @@ The following arguments are supported:
 * `project` - (Optional) The ID of the project to create the sink in. If omitted, the project associated with the provider is
     used.
 
-* `unique_writer_identity` - (Optional) Whether or not to create a unique identity associated with this sink. If `false`
-    (the default), then the `writer_identity` used is `serviceAccount:cloud-logs@system.gserviceaccount.com`. If `true`,
+* `unique_writer_identity` - (Optional) Whether or not to create a unique identity associated with this sink. If `false`, then the `writer_identity` used is `serviceAccount:cloud-logs@system.gserviceaccount.com`. If `true` (the default),
     then a unique service account is created and used for this sink. If you wish to publish logs across projects or utilize
     `bigquery_options`, you must set `unique_writer_identity` to true.
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Updated documentation, as default behavior of `unique_writer_identity` has changed for v5.x
see https://github.com/hashicorp/terraform-provider-google/blob/main/website/docs/guides/version_5_upgrade.html.markdown#resource-google_logging_project_sink

```release-note:note
google_logging_project_sink: updated documentation for unique_writer_identity
```
