### PR TITLE
Adding google_compute_networks data source

### DIFF
--- a/mmv1/third_party/terraform/provider/provider.go.erb
+++ b/mmv1/third_party/terraform/provider/provider.go.erb
@@ -255,6 +255,7 @@ func DatasourceMapWithErrors() (map[string]*schema.Resource, error) {
 		"google_compute_instance_template":                 compute.DataSourceGoogleComputeInstanceTemplate(),
 		"google_compute_lb_ip_ranges":                      compute.DataSourceGoogleComputeLbIpRanges(),
 		"google_compute_network":                           compute.DataSourceGoogleComputeNetwork(),
+		"google_compute_networks":                          compute.DataSourceGoogleComputeNetworks(),
 		"google_compute_network_endpoint_group":            compute.DataSourceGoogleComputeNetworkEndpointGroup(),
 		"google_compute_network_peering":                   compute.DataSourceComputeNetworkPeering(),
 		"google_compute_node_types":                        compute.DataSourceGoogleComputeNodeTypes(),

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_networks.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_networks.go
@@ -1,0 +1,74 @@
+package compute
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceGoogleComputeNetworks() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGoogleComputeNetworksRead,
+
+		Schema: map[string]*schema.Schema{
+
+			"self_link": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"networks": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceGoogleComputeNetworksRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	networkList, err := config.NewComputeClient(userAgent).Networks.List(project).Do()
+	if err != nil {
+		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Network Not Found : %s", project))
+	}
+
+	var networks = make([]string, len(networkList.Items))
+
+	for i := 0; i < len(networkList.Items); i++ {
+		fmt.Println(networkList.Items[i])
+		networks[i] = networkList.Items[i].Name
+	}
+
+	if err := d.Set("networks", networks); err != nil {
+		return fmt.Errorf("Error setting the network names: %s", err)
+	}
+
+	if err := d.Set("project", project); err != nil {
+		return fmt.Errorf("Error setting the network names: %s", err)
+	}
+
+	if err := d.Set("self_link", networkList.SelfLink); err != nil {
+		return fmt.Errorf("Error setting self_link: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("projects/%s/global/networks/", project))
+	return nil
+}

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_networks.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_networks.go
@@ -53,7 +53,6 @@ func dataSourceGoogleComputeNetworksRead(d *schema.ResourceData, meta interface{
 	var networks = make([]string, len(networkList.Items))
 
 	for i := 0; i < len(networkList.Items); i++ {
-		fmt.Println(networkList.Items[i])
 		networks[i] = networkList.Items[i].Name
 	}
 
@@ -69,6 +68,6 @@ func dataSourceGoogleComputeNetworksRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error setting self_link: %s", err)
 	}
 
-	d.SetId(fmt.Sprintf("projects/%s/global/networks/", project))
+	d.SetId(fmt.Sprintf("projects/%s/global/networks", project))
 	return nil
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_networks_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_networks_test.go
@@ -1,0 +1,79 @@
+package compute_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccDataSourceGoogleNetworks(t *testing.T) {
+	t.Parallel()
+
+	networkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleNetworksConfig(networkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceGoogleNetworksCheck("data.google_compute_networks.my_networks", "google_compute_network.foobar"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleNetworksCheck(data_source_name string, resource_name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		ds, ok := s.RootModule().Resources[data_source_name]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", data_source_name)
+		}
+
+		rs, ok := s.RootModule().Resources[resource_name]
+		if !ok {
+			return fmt.Errorf("can't find %s in state", resource_name)
+		}
+
+		ds_attr := ds.Primary.Attributes
+		rs_attr := rs.Primary.Attributes
+
+		containsNetwork := false
+
+		for _, itm := range ds_attr {
+			if string(itm) == rs_attr["name"] {
+				containsNetwork = true
+				break
+			}
+		}
+
+		if !containsNetwork {
+			return fmt.Errorf(
+				"Was expecting %s in %v",
+				rs_attr["name"],
+				ds_attr["networks"],
+			)
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourceGoogleNetworksConfig(name string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  name        = "%s"
+  description = "my-description"
+}
+
+data "google_compute_networks" "my_networks" {
+	depends_on = [
+		google_compute_network.foobar
+	]
+}
+`, name)
+}

--- a/mmv1/third_party/terraform/website/docs/d/compute_networks.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_networks.html.markdown
@@ -20,15 +20,13 @@ data "google_compute_networks" "my-networks" {
 
 The following arguments are supported:
 
-* `project` - (Required) The name of the project.
+* `project` - (Optional) The name of the project.
 
 ## Attributes Reference
 
 In addition to the arguments listed above, the following attributes are exported:
 
-* `id` - an identifier for the resource with format projects/{{project}}/global/networks/
-
-* `description` - Description of this network.
+* `id` - an identifier for the resource with format projects/{{project}}/global/networks
 
 * `networks` - The list of networks in the specified project.
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_networks.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_networks.html.markdown
@@ -1,0 +1,37 @@
+---
+subcategory: "Compute Engine"
+description: |-
+  List networks in a Google Cloud project.
+---
+
+# google\_compute\_networks
+
+List all networks in a specified Google Cloud project.
+
+## Example Usage
+
+```tf
+data "google_compute_networks" "my-networks" {
+  project = "my-cloud-project"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project` - (Required) The name of the project.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following attributes are exported:
+
+* `id` - an identifier for the resource with format projects/{{project}}/global/networks/
+
+* `description` - Description of this network.
+
+* `networks` - The list of networks in the specified project.
+
+* `project` - The project name being queried.
+
+* `self_link` - The URI of the resource.


### PR DESCRIPTION
Adding a new data source google_compute_networks that will allow for listing networks in a given Google Cloud Project. This PR is for hashicorp/terraform-provider-google#16130


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
`google_compute_networks`
```
