### PR TITLE
TeamCity: Update build step so tests only run if there are tests to run

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
+++ b/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
@@ -117,14 +117,30 @@ fun BuildSteps.RunAcceptanceTests() {
     } else {
         step(ScriptBuildStep {
             name = "Compile Test Binary"
-            scriptContent = "go test -c -o test-binary"
             workingDir = "%PACKAGE_PATH%"
+            scriptContent = "go test -c -o test-binary"
         })
 
         step(ScriptBuildStep {
             name = "Run via jen20/teamcity-go-test"
-            scriptContent = "./test-binary -test.list=\"%TEST_PREFIX%\" | teamcity-go-test -test ./test-binary -parallelism \"%PARALLELISM%\" -timeout \"%TIMEOUT%h\""
             workingDir = "%PACKAGE_PATH%"
+            scriptContent = """
+                #!/bin/bash
+                if ! test -f "./test-binary"; then
+                  echo "Skipping test execution; file ./test-binary does not exist."
+                  exit 0
+                fi
+                
+                export TEST_COUNT=${'$'}(./test-binary -test.list=%TEST_PREFIX% | wc -l)
+                echo "Found ${'$'}{TEST_COUNT} tests that match the given test prefix %TEST_PREFIX%"
+                if test ${'$'}TEST_COUNT -le "0"; then
+                  echo "Skipping test execution; no tests to run"
+                  exit 0
+                fi
+                
+                echo "Starting tests"  
+                ./test-binary -test.list="%TEST_PREFIX%" | teamcity-go-test -test ./test-binary -parallelism "%PARALLELISM%" -timeout "%TIMEOUT%h"
+            """.trimIndent()
         })
     }
 }

--- a/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
+++ b/mmv1/third_party/terraform/.teamcity/components/generated/build_components.erb
@@ -118,7 +118,17 @@ fun BuildSteps.RunAcceptanceTests() {
         step(ScriptBuildStep {
             name = "Compile Test Binary"
             workingDir = "%PACKAGE_PATH%"
-            scriptContent = "go test -c -o test-binary"
+            scriptContent = """
+                #!/bin/bash
+                export TEST_FILE_COUNT=$(ls ./*_test.go | wc -l)
+                if test ${'$'}TEST_FILE_COUNT -gt "0"; then
+                    echo "Compiling test binary"
+                    go test -c -o test-binary
+                else
+                    echo "Skipping compilation of test binary; no Go test files found"
+                fi
+            """.trimIndent()
+
         })
 
         step(ScriptBuildStep {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR addresses this issue:

![Screenshot 2023-10-11 at 21 38 58](https://github.com/GoogleCloudPlatform/magic-modules/assets/15078782/d523a77a-eccc-48c5-8cc5-97ed0769db91)

This error is raised when there are no tests to run - either due to no test binary or a test prefix that filters out all tests and leaves none to be run.

Here is a build affected by this : [API GATEWAY FAILING BUILD](https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_Google_NightlyTests_GOOGLE_PACKAGE_APIGATEWAY/40306?buildTab=log&logView=flowAware)

Here is a build that shows the effects of the change in this PR: [API GATEWAY BUILD USING THIS PRS CHANGES](https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_Google_SarahManualTestingProject_GOOGLE_PACKAGE_APIGATEWAY/40903?expandBuildDeploymentsSection=false&hideTestsFromDependencies=false&hideProblemsFromDependencies=false) 

![Screenshot 2023-10-11 at 21 41 34](https://github.com/GoogleCloudPlatform/magic-modules/assets/15078782/36b1ad3e-bc18-4eaa-baf9-13c139f6339a)



Also, this PR fixes https://github.com/hashicorp/terraform-provider-google/issues/16226

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
