### PR TITLE
cleanup(tgc): update all tf file to use google-beta

### DIFF
--- a/mmv1/third_party/tgc/tests/data-ignored/example_compute_security_policy.tf
+++ b/mmv1/third_party/tgc/tests/data-ignored/example_compute_security_policy.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data-ignored/example_redis_instance.tf
+++ b/mmv1/third_party/tgc/tests/data-ignored/example_redis_instance.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/bucket.tf
+++ b/mmv1/third_party/tgc/tests/data/bucket.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/disk.tf
+++ b/mmv1/third_party/tgc/tests/data/disk.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_access_context_manager_access_policy.tf
+++ b/mmv1/third_party/tgc/tests/data/example_access_context_manager_access_policy.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_access_context_manager_service_perimeter.tf
+++ b/mmv1/third_party/tgc/tests/data/example_access_context_manager_service_perimeter.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_bigquery_dataset.tf
+++ b/mmv1/third_party/tgc/tests/data/example_bigquery_dataset.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_bigquery_dataset_iam_binding.tf
+++ b/mmv1/third_party/tgc/tests/data/example_bigquery_dataset_iam_binding.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }
@@ -36,7 +36,7 @@ resource "google_bigquery_dataset" "example_dataset" {
   labels = {
     env = "dev"
   }
-  
+
 }
 
 resource "google_bigquery_dataset_iam_binding" "dataset" {

--- a/mmv1/third_party/tgc/tests/data/example_bigquery_dataset_iam_member.tf
+++ b/mmv1/third_party/tgc/tests/data/example_bigquery_dataset_iam_member.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }
@@ -36,14 +36,14 @@ resource "google_bigquery_dataset" "example_dataset" {
   labels = {
     env = "dev"
   }
-  
+
 }
 
 resource "google_bigquery_dataset_iam_member" "dataset" {
   dataset_id = google_bigquery_dataset.example_dataset.dataset_id
   role       = "roles/bigquery.dataEditor"
   member     = "allAuthenticatedUsers"
-    
+
 }
 
 

--- a/mmv1/third_party/tgc/tests/data/example_bigquery_dataset_iam_policy.tf
+++ b/mmv1/third_party/tgc/tests/data/example_bigquery_dataset_iam_policy.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }
@@ -36,7 +36,7 @@ resource "google_bigquery_dataset" "example-dataset" {
   labels = {
     env = "dev"
   }
-  
+
 }
 
 resource "google_bigquery_dataset_iam_policy" "dataset" {

--- a/mmv1/third_party/tgc/tests/data/example_bigquery_dataset_iam_policy_empty_policy_data.tf
+++ b/mmv1/third_party/tgc/tests/data/example_bigquery_dataset_iam_policy_empty_policy_data.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_bigquery_table.tf
+++ b/mmv1/third_party/tgc/tests/data/example_bigquery_table.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_bigtable_instance.tf
+++ b/mmv1/third_party/tgc/tests/data/example_bigtable_instance.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_cloud_run_mapping.tf
+++ b/mmv1/third_party/tgc/tests/data/example_cloud_run_mapping.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_cloud_run_service.tf
+++ b/mmv1/third_party/tgc/tests/data/example_cloud_run_service.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_cloud_run_service_iam_binding.tf
+++ b/mmv1/third_party/tgc/tests/data/example_cloud_run_service_iam_binding.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_cloud_run_service_iam_member.tf
+++ b/mmv1/third_party/tgc/tests/data/example_cloud_run_service_iam_member.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_cloud_run_service_iam_policy.tf
+++ b/mmv1/third_party/tgc/tests/data/example_cloud_run_service_iam_policy.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_compute_address.tf
+++ b/mmv1/third_party/tgc/tests/data/example_compute_address.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_compute_disk.tf
+++ b/mmv1/third_party/tgc/tests/data/example_compute_disk.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_compute_disk_empty_image.tf
+++ b/mmv1/third_party/tgc/tests/data/example_compute_disk_empty_image.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_compute_firewall.tf
+++ b/mmv1/third_party/tgc/tests/data/example_compute_firewall.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_compute_forwarding_rule.tf
+++ b/mmv1/third_party/tgc/tests/data/example_compute_forwarding_rule.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }
@@ -28,7 +28,7 @@ provider "google" {
 }
 
 resource "google_compute_forwarding_rule" "default" {
-  
+
   name                  = "test-forwarding-rule"
   load_balancing_scheme = "INTERNAL_MANAGED"
   ip_protocol           = "TCP"

--- a/mmv1/third_party/tgc/tests/data/example_compute_global_address.tf
+++ b/mmv1/third_party/tgc/tests/data/example_compute_global_address.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_compute_global_forwarding_rule.tf
+++ b/mmv1/third_party/tgc/tests/data/example_compute_global_forwarding_rule.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_compute_instance.tf
+++ b/mmv1/third_party/tgc/tests/data/example_compute_instance.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_compute_instance_iam_binding.tf
+++ b/mmv1/third_party/tgc/tests/data/example_compute_instance_iam_binding.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_compute_instance_iam_member.tf
+++ b/mmv1/third_party/tgc/tests/data/example_compute_instance_iam_member.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_compute_instance_iam_policy.tf
+++ b/mmv1/third_party/tgc/tests/data/example_compute_instance_iam_policy.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_compute_network.tf
+++ b/mmv1/third_party/tgc/tests/data/example_compute_network.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_compute_snapshot.tf
+++ b/mmv1/third_party/tgc/tests/data/example_compute_snapshot.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_compute_ssl_policy.tf
+++ b/mmv1/third_party/tgc/tests/data/example_compute_ssl_policy.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_compute_subnetwork.tf
+++ b/mmv1/third_party/tgc/tests/data/example_compute_subnetwork.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_compute_target_https_proxy.tf
+++ b/mmv1/third_party/tgc/tests/data/example_compute_target_https_proxy.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_compute_target_ssl_proxy.tf
+++ b/mmv1/third_party/tgc/tests/data/example_compute_target_ssl_proxy.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_container_cluster.tf
+++ b/mmv1/third_party/tgc/tests/data/example_container_cluster.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_dns_managed_zone.tf
+++ b/mmv1/third_party/tgc/tests/data/example_dns_managed_zone.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }
@@ -30,7 +30,7 @@ provider "google" {
 resource "google_dns_managed_zone" "zone1" {
   name        = "publiczone"
   dns_name    = "publiczone.gsecurity.net."
-  
+
   force_destroy = true
   visibility = "public"
 

--- a/mmv1/third_party/tgc/tests/data/example_dns_policy.tf
+++ b/mmv1/third_party/tgc/tests/data/example_dns_policy.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_filestore_instance.tf
+++ b/mmv1/third_party/tgc/tests/data/example_filestore_instance.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_folder_iam_member.tf
+++ b/mmv1/third_party/tgc/tests/data/example_folder_iam_member.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_folder_iam_member_empty_folder.tf
+++ b/mmv1/third_party/tgc/tests/data/example_folder_iam_member_empty_folder.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_folder_organization_policy.tf
+++ b/mmv1/third_party/tgc/tests/data/example_folder_organization_policy.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_google_cloudfunctions_function.tf
+++ b/mmv1/third_party/tgc/tests/data/example_google_cloudfunctions_function.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_google_sql_database.tf
+++ b/mmv1/third_party/tgc/tests/data/example_google_sql_database.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_kms_crypto_key.tf
+++ b/mmv1/third_party/tgc/tests/data/example_kms_crypto_key.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_kms_crypto_key_iam_binding.tf
+++ b/mmv1/third_party/tgc/tests/data/example_kms_crypto_key_iam_binding.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_kms_crypto_key_iam_member.tf
+++ b/mmv1/third_party/tgc/tests/data/example_kms_crypto_key_iam_member.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_kms_crypto_key_iam_policy.tf
+++ b/mmv1/third_party/tgc/tests/data/example_kms_crypto_key_iam_policy.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_kms_key_ring.tf
+++ b/mmv1/third_party/tgc/tests/data/example_kms_key_ring.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_kms_key_ring_iam_binding.tf
+++ b/mmv1/third_party/tgc/tests/data/example_kms_key_ring_iam_binding.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_kms_key_ring_iam_member.tf
+++ b/mmv1/third_party/tgc/tests/data/example_kms_key_ring_iam_member.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_kms_key_ring_iam_policy.tf
+++ b/mmv1/third_party/tgc/tests/data/example_kms_key_ring_iam_policy.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_logging_metric.tf
+++ b/mmv1/third_party/tgc/tests/data/example_logging_metric.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_org_policy_policy.tf
+++ b/mmv1/third_party/tgc/tests/data/example_org_policy_policy.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }
@@ -41,8 +41,8 @@ resource "google_org_policy_policy" "project_policy" {
         location    = "sample-location.log"
         title       = "sample-condition"
       }
-      
-    
+
+
       values {
         allowed_values = ["projects/allowed-project1", "projects/allowed-project2"]
         denied_values  = ["projects/denied-project"]

--- a/mmv1/third_party/tgc/tests/data/example_organization_iam_binding.tf
+++ b/mmv1/third_party/tgc/tests/data/example_organization_iam_binding.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_organization_iam_member.tf
+++ b/mmv1/third_party/tgc/tests/data/example_organization_iam_member.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_organization_iam_policy.tf
+++ b/mmv1/third_party/tgc/tests/data/example_organization_iam_policy.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_organization_policy.tf
+++ b/mmv1/third_party/tgc/tests/data/example_organization_policy.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_project_create.tf
+++ b/mmv1/third_party/tgc/tests/data/example_project_create.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_project_create_empty_project_id.tf
+++ b/mmv1/third_party/tgc/tests/data/example_project_create_empty_project_id.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_project_iam.tf
+++ b/mmv1/third_party/tgc/tests/data/example_project_iam.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_project_iam_binding.tf
+++ b/mmv1/third_party/tgc/tests/data/example_project_iam_binding.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_project_iam_member.tf
+++ b/mmv1/third_party/tgc/tests/data/example_project_iam_member.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_project_iam_member_empty_project.tf
+++ b/mmv1/third_party/tgc/tests/data/example_project_iam_member_empty_project.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_project_iam_policy.tf
+++ b/mmv1/third_party/tgc/tests/data/example_project_iam_policy.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_project_in_folder.tf
+++ b/mmv1/third_party/tgc/tests/data/example_project_in_folder.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_project_in_org.tf
+++ b/mmv1/third_party/tgc/tests/data/example_project_in_org.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_project_organization_policy.tf
+++ b/mmv1/third_party/tgc/tests/data/example_project_organization_policy.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_project_service.tf
+++ b/mmv1/third_party/tgc/tests/data/example_project_service.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_project_update.tf
+++ b/mmv1/third_party/tgc/tests/data/example_project_update.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_pubsub_lite_reservation.tf
+++ b/mmv1/third_party/tgc/tests/data/example_pubsub_lite_reservation.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_pubsub_lite_subscription.tf
+++ b/mmv1/third_party/tgc/tests/data/example_pubsub_lite_subscription.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_pubsub_lite_topic.tf
+++ b/mmv1/third_party/tgc/tests/data/example_pubsub_lite_topic.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_pubsub_schema.tf
+++ b/mmv1/third_party/tgc/tests/data/example_pubsub_schema.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_pubsub_subscription.tf
+++ b/mmv1/third_party/tgc/tests/data/example_pubsub_subscription.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_pubsub_subscription_iam_binding.tf
+++ b/mmv1/third_party/tgc/tests/data/example_pubsub_subscription_iam_binding.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_pubsub_subscription_iam_member.tf
+++ b/mmv1/third_party/tgc/tests/data/example_pubsub_subscription_iam_member.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_pubsub_subscription_iam_policy.tf
+++ b/mmv1/third_party/tgc/tests/data/example_pubsub_subscription_iam_policy.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_pubsub_topic.tf
+++ b/mmv1/third_party/tgc/tests/data/example_pubsub_topic.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_service_account.tf
+++ b/mmv1/third_party/tgc/tests/data/example_service_account.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_service_account_update.tf
+++ b/mmv1/third_party/tgc/tests/data/example_service_account_update.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_spanner_database.tf
+++ b/mmv1/third_party/tgc/tests/data/example_spanner_database.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_spanner_database_iam_binding.tf
+++ b/mmv1/third_party/tgc/tests/data/example_spanner_database_iam_binding.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_spanner_database_iam_member.tf
+++ b/mmv1/third_party/tgc/tests/data/example_spanner_database_iam_member.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_spanner_database_iam_policy.tf
+++ b/mmv1/third_party/tgc/tests/data/example_spanner_database_iam_policy.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_spanner_instance_iam_binding.tf
+++ b/mmv1/third_party/tgc/tests/data/example_spanner_instance_iam_binding.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_spanner_instance_iam_member.tf
+++ b/mmv1/third_party/tgc/tests/data/example_spanner_instance_iam_member.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_spanner_instance_iam_policy.tf
+++ b/mmv1/third_party/tgc/tests/data/example_spanner_instance_iam_policy.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_sql_database_instance.tf
+++ b/mmv1/third_party/tgc/tests/data/example_sql_database_instance.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_storage_bucket.tf
+++ b/mmv1/third_party/tgc/tests/data/example_storage_bucket.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_storage_bucket_iam_binding.tf
+++ b/mmv1/third_party/tgc/tests/data/example_storage_bucket_iam_binding.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_storage_bucket_iam_member.tf
+++ b/mmv1/third_party/tgc/tests/data/example_storage_bucket_iam_member.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_storage_bucket_iam_member_random_suffix.tf
+++ b/mmv1/third_party/tgc/tests/data/example_storage_bucket_iam_member_random_suffix.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_storage_bucket_iam_policy.tf
+++ b/mmv1/third_party/tgc/tests/data/example_storage_bucket_iam_policy.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_vpc_access_connector.tf
+++ b/mmv1/third_party/tgc/tests/data/example_vpc_access_connector.tf
@@ -16,7 +16,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/firewall.tf
+++ b/mmv1/third_party/tgc/tests/data/firewall.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/full_compute_firewall.tf
+++ b/mmv1/third_party/tgc/tests/data/full_compute_firewall.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/full_compute_instance.tf
+++ b/mmv1/third_party/tgc/tests/data/full_compute_instance.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/full_container_cluster.tf
+++ b/mmv1/third_party/tgc/tests/data/full_container_cluster.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/full_container_node_pool.tf
+++ b/mmv1/third_party/tgc/tests/data/full_container_node_pool.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/full_spanner_instance.tf
+++ b/mmv1/third_party/tgc/tests/data/full_spanner_instance.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/full_sql_database_instance.tf
+++ b/mmv1/third_party/tgc/tests/data/full_sql_database_instance.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/full_storage_bucket.tf
+++ b/mmv1/third_party/tgc/tests/data/full_storage_bucket.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/instance.tf
+++ b/mmv1/third_party/tgc/tests/data/instance.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }

--- a/mmv1/third_party/tgc/tests/data/sql.tf
+++ b/mmv1/third_party/tgc/tests/data/sql.tf
@@ -17,7 +17,7 @@
 terraform {
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source = "hashicorp/google-beta"
       version = "~> {{.Provider.version}}"
     }
   }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
For tf dev override, if removing "direct {}" in the config, then tpg has to use the beta version. 

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
