### PR TITLE
Setting ForceNew to false in the taint block of the GKE nodepool node_config resource

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -413,26 +413,22 @@ func schemaNodeConfig() *schema.Schema {
 				"taint": {
 					Type:        schema.TypeList,
 					Optional:    true,
-					ForceNew:    false,
 					Description: `List of Kubernetes taints to be applied to each node.`,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							"key": {
 								Type:     schema.TypeString,
 								Required: true,
-								ForceNew: false,
 								Description: `Key for taint.`,
 							},
 							"value": {
 								Type:     schema.TypeString,
 								Required: true,
-								ForceNew: false,
 								Description: `Value for taint.`,
 							},
 							"effect": {
 								Type:         schema.TypeString,
 								Required:     true,
-								ForceNew: 	  false,
 								ValidateFunc: validation.StringInSlice([]string{"NO_SCHEDULE", "PREFER_NO_SCHEDULE", "NO_EXECUTE"}, false),
 								Description: `Effect for taint.`,
 							},

--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -413,7 +413,7 @@ func schemaNodeConfig() *schema.Schema {
 				"taint": {
 					Type:        schema.TypeList,
 					Optional:    true,
-					ForceNew:    true,
+					ForceNew:    false,
 					Description: `List of Kubernetes taints to be applied to each node.`,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{

--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -420,19 +420,19 @@ func schemaNodeConfig() *schema.Schema {
 							"key": {
 								Type:     schema.TypeString,
 								Required: true,
-								ForceNew: true,
+								ForceNew: false,
 								Description: `Key for taint.`,
 							},
 							"value": {
 								Type:     schema.TypeString,
 								Required: true,
-								ForceNew: true,
+								ForceNew: false,
 								Description: `Value for taint.`,
 							},
 							"effect": {
 								Type:         schema.TypeString,
 								Required:     true,
-								ForceNew:     true,
+								ForceNew: 	  false,
 								ValidateFunc: validation.StringInSlice([]string{"NO_SCHEDULE", "PREFER_NO_SCHEDULE", "NO_EXECUTE"}, false),
 								Description: `Effect for taint.`,
 							},

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
@@ -1389,18 +1389,32 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 			}
 		}
 
-		if d.HasChange(prefix + "nodeconfig.0.taints") {
+		if d.HasChange(prefix + "node_config.0.taint") {
 			req := &container.UpdateNodePoolRequest{
 				Name: name,
 			}
-			if v, ok := d.GetOk(prefix + "node_config.0.taints"); ok {
+			if v, ok := d.GetOk(prefix + "node_config.0.taint"); ok {
 				taintsList := v.([]interface{})
-				taints := []string{}
+				taints := make([]*container.NodeTaint, 0, len(taintsList))
 				for _, v := range taintsList {
 					if v != nil {
-						taints = append(taints, v.(string))
+						data := v.(map[string]interface{})
+						taint := &container.NodeTaint{
+							Key:    data["key"].(string),
+							Value:  data["value"].(string),
+							Effect: data["effect"].(string),
+						}
+						taints = append(taints, taint)
 					}
 				}
+				ntaints := &container.NodeTaints{
+					Taints: taints,
+				}
+				req.Taints = ntaints
+			}
+
+			if req.Taints == nil {
+				taints := make([]*container.NodeTaint, 0, 0)
 				ntaints := &container.NodeTaints{
 					Taints: taints,
 				}
@@ -1421,7 +1435,7 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 				return ContainerOperationWait(config, op,
 					nodePoolInfo.project,
 					nodePoolInfo.location,
-					"updating GKE node pool", userAgent,
+					"updating GKE node pool taints", userAgent,
 					timeout)
 			}
 

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
@@ -1389,6 +1389,48 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 			}
 		}
 
+		if d.HasChange(prefix + "nodeconfig.0.taints") {
+			req := &container.UpdateNodePoolRequest{
+				Name: name,
+			}
+			if v, ok := d.GetOk(prefix + "node_config.0.taints"); ok {
+				taintsList := v.([]interface{})
+				taints := []string{}
+				for _, v := range taintsList {
+					if v != nil {
+						taints = append(taints, v.(string))
+					}
+				}
+				ntaints := &container.NodeTaints{
+					Taints: taints,
+				}
+				req.Taints = ntaints
+			}
+
+			updateF := func() error {
+				clusterNodePoolsUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.NodePools.Update(nodePoolInfo.fullyQualifiedName(name), req)
+				if config.UserProjectOverride {
+					clusterNodePoolsUpdateCall.Header().Add("X-Goog-User-Project", nodePoolInfo.project)
+				}
+				op, err := clusterNodePoolsUpdateCall.Do()
+				if err != nil {
+					return err
+				}
+
+				// Wait until it's updated
+				return ContainerOperationWait(config, op,
+					nodePoolInfo.project,
+					nodePoolInfo.location,
+					"updating GKE node pool", userAgent,
+					timeout)
+			}
+
+			if err := retryWhileIncompatibleOperation(timeout, npLockKey, updateF); err != nil {
+					return err
+			}
+			log.Printf("[INFO] Updated taints for Node Pool %s", d.Id())
+		}
+
 		if d.HasChange(prefix + "node_config.0.tags") {
 			req := &container.UpdateNodePoolRequest{
 				Name: name,

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -255,7 +255,7 @@ func TestAccContainerNodePool_withTaintsUpdate(t *testing.T) {
 				Config: testAccContainerNodePool_withTaintsUpdate(cluster, nodePool),
 			},
 			resource.TestStep{
-				ResourceName:      "google_container_node_pool.np_with_node_config",
+				ResourceName:      "google_container_node_pool.np",
 				ImportState:       true,
 				ImportStateVerify: true,
 				// autoscaling.# = 0 is equivalent to no autoscaling at all,
@@ -2409,6 +2409,40 @@ resource "google_container_node_pool" "np_with_node_config" {
   }
 }
 `, cluster, nodePool)
+}
+
+func testAccContainerNodePool_withTaintsUpdate(cluster, np string) string {
+	return fmt.Sprintf(`
+provider "google" {
+  alias                 = "user-project-override"
+  user_project_override = true
+}
+resource "google_container_cluster" "cluster" {
+  provider           = google.user-project-override
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 3
+  deletion_protection = false
+}
+
+resource "google_container_node_pool" "np" {
+  provider           = google.user-project-override
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  initial_node_count = 2
+
+  node_config {
+	taint {
+      key    = "taint_key"
+      value  = "taint_value"
+      effect = "PREFER_NO_SCHEDULE"
+    }
+  }
+
+
+}
+`, cluster, np)
 }
 
 func testAccContainerNodePool_withReservationAffinity(cluster, np string) string {

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -260,7 +260,7 @@ func TestAccContainerNodePool_withTaintsUpdate(t *testing.T) {
 				ImportStateVerify: true,
 				// autoscaling.# = 0 is equivalent to no autoscaling at all,
 				// but will still cause an import diff
-				ImportStateVerifyIgnore: []string{"autoscaling.#"},
+				ImportStateVerifyIgnore: []string{"autoscaling.#", "node_config.0.taint"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -232,6 +232,40 @@ func TestAccContainerNodePool_withNodeConfig(t *testing.T) {
 	})
 }
 
+func TestAccContainerNodePool_withTaintsUpdate(t *testing.T) {
+	t.Parallel()
+
+	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	nodePool := fmt.Sprintf("tf-test-nodepool-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccContainerNodePool_basic(cluster, nodePool),
+			},
+			resource.TestStep{
+				ResourceName:      "google_container_node_pool.np",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			resource.TestStep{
+				Config: testAccContainerNodePool_withTaintsUpdate(cluster, nodePool),
+			},
+			resource.TestStep{
+				ResourceName:      "google_container_node_pool.np_with_node_config",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// autoscaling.# = 0 is equivalent to no autoscaling at all,
+				// but will still cause an import diff
+				ImportStateVerifyIgnore: []string{"autoscaling.#"},
+			},
+		},
+	})
+}
+
 func TestAccContainerNodePool_withReservationAffinity(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The context for this, even if I didn't find that API doc, is that gcloud and the Console UI do not require the node_pool recreation.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement 
container: added update support for `google_container_node_pool.node_config.taint` 
```
