### PR TITLE
Skip failing AlloyDB test in VCR

### DIFF
--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_secondary_cluster_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_secondary_cluster_test.go
@@ -173,6 +173,9 @@ resource "google_service_networking_connection" "vpc_connection" {
 func TestAccAlloydbCluster_secondaryClusterDefinedSecondaryConfigButMissingClusterTypeSecondary(t *testing.T) {
 	t.Parallel()
 
+	// Unskip in https://github.com/hashicorp/terraform-provider-google/issues/16231
+	acctest.SkipIfVcr(t)
+
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
 	}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Scott updated most recordings, but TestAccAlloydbCluster_secondaryClusterDefinedSecondaryConfigButMissingClusterTypeSecondary one is stubborn. Skip it for now.

https://github.com/hashicorp/terraform-provider-google/issues/16231 to unskip

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
