### PR TITLE
Adding in support for confidential_compute on boot disk

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
@@ -244,7 +244,7 @@ func ResourceComputeInstance() *schema.Resource {
 										ForceNew:     true,
 										Description:  `A map of resource manager tags. Resource manager tag keys and values have the same definition as resource manager tags. Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456. The field is ignored (both PUT & PATCH) when empty.`,
 									},
-									<% unless version == 'ga' -%>
+<% unless version == 'ga' -%>
 									"enable_confidential_compute": {
 										Type:             schema.TypeBool,
 										Optional:         true,
@@ -252,7 +252,7 @@ func ResourceComputeInstance() *schema.Resource {
 										ForceNew:         true,
 										Description:      `A flag to enble confidential compute mode on boot disk`,
 									},
-									<% end -%>
+<% end -%>
 								},
 							},
 						},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
@@ -46,6 +46,9 @@ var (
 		"boot_disk.0.initialize_params.0.image",
 		"boot_disk.0.initialize_params.0.labels",
 		"boot_disk.0.initialize_params.0.resource_manager_tags",
+<% unless version == 'ga' -%>
+		"boot_disk.0.initialize_params.0.enable_confidential_compute",
+<% end -%>
 	}
 
 	schedulingKeys = []string{
@@ -241,6 +244,15 @@ func ResourceComputeInstance() *schema.Resource {
 										ForceNew:     true,
 										Description:  `A map of resource manager tags. Resource manager tag keys and values have the same definition as resource manager tags. Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456. The field is ignored (both PUT & PATCH) when empty.`,
 									},
+									<% unless version == 'ga' -%>
+									"enable_confidential_compute": {
+										Type:             schema.TypeBool,
+										Optional:         true,
+										AtLeastOneOf: initializeParamsKeys,
+										ForceNew:         true,
+										Description:      `A flag to enble confidential compute mode on boot disk`,
+									},
+									<% end -%>
 								},
 							},
 						},
@@ -2729,6 +2741,12 @@ func expandBootDisk(d *schema.ResourceData, config *transport_tpg.Config, projec
 			disk.InitializeParams.DiskSizeGb = int64(v.(int))
 		}
 
+		<% unless version == 'ga' -%>
+		if v, ok := d.GetOk("boot_disk.0.initialize_params.0.enable_confidential_compute"); ok {
+			disk.InitializeParams.EnableConfidentialCompute = v.(bool)
+		}
+		<% end -%>
+
 		if v, ok := d.GetOk("boot_disk.0.initialize_params.0.type"); ok {
 			diskTypeName := v.(string)
 			diskType, err := readDiskType(config, d, diskTypeName)
@@ -2794,6 +2812,9 @@ func flattenBootDisk(d *schema.ResourceData, disk *compute.AttachedDisk, config 
 			"size":   diskDetails.SizeGb,
 			"labels": diskDetails.Labels,
 			"resource_manager_tags": d.Get("boot_disk.0.initialize_params.0.resource_manager_tags"),
+<% unless version == 'ga' -%>
+			"enable_confidential_compute": diskDetails.EnableConfidentialCompute,
+<% end -%>
 		}}
 	}
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -1786,22 +1786,23 @@ func TestAccComputeInstanceConfidentialInstanceConfigMain(t *testing.T) {
 }
 
 <% unless version = 'ga' -%>
-func TestAccComputeInstanceConfidentialHyperDiskBootDisk(t *testing.T) {
+func TestAccComputeInstance_confidentialHyperDiskBootDisk(t *testing.T) {
 	t.Parallel()
 
 	context_1 := map[string]interface{}{
-		"name":        fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
-		"confidential_compute": true,
-		"kms_key" : acctest.BootstrapKMSKey(t)
+		"instance_name":         fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"confidential_compute":  true,
+		"kms_key" :              acctest.BootstrapKMSKey(t)
+		"zone":                  "us-central1-a"
 	}
 
 	context_2 := map[string]interface{}{
-		"name":        context_1["random_suffix"],
+		"instance_name":        context_1["instance_name"],
 		"confidential_compute": false,
-		"kms_key" : acctest.BootstrapKMSKey(t)
+		"kms_key" :             context_1["kms_key"],
+		"zone":                 context_1["zone]
 	}
 
-	var instance compute.Instance
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -1810,15 +1811,12 @@ func TestAccComputeInstanceConfidentialHyperDiskBootDisk(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccComputeInstanceConfidentialHyperDiskBootDisk(context_1),
-				Check: resource.ComposeTestCheckFunc(testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance)
-				),
 			},
+			computeInstanceImportStep(context_1["zone"], context_1["instance_name"], []string{"allow_stopping_for_update"}),
 			{
 				Config: testAccComputeInstanceConfidentialHyperDiskBootDisk(context_2),
-				Check: resource.ComposeTestCheckFunc(testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
-				),
 			},
-
+			computeInstanceImportStep(context_2["zone"], context_2["instance_name"], []string{"allow_stopping_for_update"}),
 		},
 	})
 }
@@ -6894,14 +6892,14 @@ func testAccComputeInstanceConfidentialHyperDiskBootDisk(context map[string]inte
 	return acctest.Nprintf(`
 }
 data "google_compute_image" "my_image" {
-  family    = "ubuntu-2004-lts"
+  family    = "ubuntu-2204-lts"
   project   = "ubuntu-os-cloud"
 }
 
 resource "google_compute_instance" "foobar" {
   name         = "%{name}"
   machine_type = "n2-standard-2"
-  zone         = "us-central1-a"
+  zone         = "%{zone}"
 
   boot_disk {
 
@@ -6911,17 +6909,12 @@ resource "google_compute_instance" "foobar" {
       type  = "hyperdisk-balanced"
     }
 
-    kms_key_self_link = %{kms_key}
+    kms_key_self_link = "%{kms_key}"
   }
 
   network_interface {
     network = "default"
   }
-
-  scheduling {
-	  on_host_maintenance = "TERMINATE"
-  }
-
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -1785,6 +1785,45 @@ func TestAccComputeInstanceConfidentialInstanceConfigMain(t *testing.T) {
 	})
 }
 
+<% unless version = 'ga' -%>
+func TestAccComputeInstanceConfidentialHyperDiskBootDisk(t *testing.T) {
+	t.Parallel()
+
+	context_1 := map[string]interface{}{
+		"name":        fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"confidential_compute": true,
+		"kms_key" : acctest.BootstrapKMSKey(t)
+	}
+
+	context_2 := map[string]interface{}{
+		"name":        context_1["random_suffix"],
+		"confidential_compute": false,
+		"kms_key" : acctest.BootstrapKMSKey(t)
+	}
+
+	var instance compute.Instance
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceConfidentialHyperDiskBootDisk(context_1),
+				Check: resource.ComposeTestCheckFunc(testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance)
+				),
+			},
+			{
+				Config: testAccComputeInstanceConfidentialHyperDiskBootDisk(context_2),
+				Check: resource.ComposeTestCheckFunc(testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+				),
+			},
+
+		},
+	})
+}
+<% end -%>
+
 func TestAccComputeInstance_enableDisplay(t *testing.T) {
 	t.Parallel()
 
@@ -6849,6 +6888,44 @@ resource "google_compute_instance" "foobar" {
 }
 `, instance, enableConfidentialCompute)
 }
+
+<% unless version = 'ga' -%>
+func testAccComputeInstanceConfidentialHyperDiskBootDisk(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+}
+data "google_compute_image" "my_image" {
+  family    = "ubuntu-2004-lts"
+  project   = "ubuntu-os-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%{name}"
+  machine_type = "n2-standard-2"
+  zone         = "us-central1-a"
+
+  boot_disk {
+
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+      enable_confidential_compute = %{confidential_compute}
+      type  = "hyperdisk-balanced"
+    }
+
+    kms_key_self_link = %{kms_key}
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+	  on_host_maintenance = "TERMINATE"
+  }
+
+}
+`, context)
+}
+<% end -%>
 
 func testAccComputeInstance_enableDisplay(instance string) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adding in Support for enable_confidential_compute on boot_disk within initialize_params for google_compute_instance resource for beta only

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**


```release-note:enhancement
compute: added `enable_confidential_compute` field under `boot_disk.0.initialize_params` in `google_compute_instance`
```
