### PR TITLE
ForceNew on labels field when the dataflow job has type JOB_TYPE_BATCH

### DIFF
--- a/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job.go.erb
+++ b/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job.go.erb
@@ -789,7 +789,7 @@ func resourceDataflowFlexJobTypeCustomizeDiff(_ context.Context, d *schema.Resou
 				continue
 			}
 
-			if field != "labels" && field != "terraform_labels" && d.HasChange(field) {
+			if field != "terraform_labels" && d.HasChange(field) {
 				if err := d.ForceNew(field); err != nil {
 					return err
 				}

--- a/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job.go.erb
+++ b/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job.go.erb
@@ -540,66 +540,67 @@ func resourceDataflowFlexTemplateJobUpdate(d *schema.ResourceData, meta interfac
 		return nil
 	}
 
-	config := meta.(*transport_tpg.Config)
-	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
-	if err != nil {
-		return err
+	if jobHasUpdate(d, ResourceDataflowFlexTemplateJob().Schema) {
+		config := meta.(*transport_tpg.Config)
+		userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+		if err != nil {
+			return err
+		}
+
+		project, err := tpgresource.GetProject(d, config)
+		if err != nil {
+			return err
+		}
+
+		region, err := tpgresource.GetRegion(d, config)
+		if err != nil {
+			return err
+		}
+
+		tnamemapping := tpgresource.ExpandStringMap(d, "transform_name_mapping")
+
+		env, updatedParameters, err := resourceDataflowFlexJobSetupEnv(d, config)
+		if err != nil {
+			return err
+		}
+
+		// wait until current job is running or terminated
+		err = waitForDataflowJobState(d, config, d.Id(), userAgent, d.Timeout(schema.TimeoutUpdate), "JOB_STATE_RUNNING")
+		if err != nil {
+			return fmt.Errorf("Error waiting for job with job ID %q to be running: %s", d.Id(), err)
+		}
+
+		request := dataflow.LaunchFlexTemplateRequest{
+			LaunchParameter: &dataflow.LaunchFlexTemplateParameter{
+
+				ContainerSpecGcsPath:  d.Get("container_spec_gcs_path").(string),
+				JobName:               d.Get("name").(string),
+				Parameters:            updatedParameters,
+				TransformNameMappings: tnamemapping,
+				Environment:           &env,
+				Update:                true,
+			},
+		}
+
+		response, err := config.NewDataflowClient(userAgent).Projects.Locations.FlexTemplates.Launch(project, region, &request).Do()
+		if err != nil {
+			return err
+		}
+
+		// don't set id until new job is successfully running
+		job := response.Job
+		err = waitForDataflowJobState(d, config, job.Id, userAgent, d.Timeout(schema.TimeoutUpdate), "JOB_STATE_RUNNING")
+		if err != nil {
+			// the default behavior is to overwrite the resource's state with the state of the "new" job, even though we are returning an error here. this call to Partial prevents this behavior
+			d.Partial(true)
+			return fmt.Errorf("Error waiting for Job with job ID %q to be updated: %s", job.Id, err)
+		}
+
+		d.SetId(job.Id)
+		if err := d.Set("job_id", job.Id); err != nil {
+			return fmt.Errorf("Error setting job_id: %s", err)
+		}
 	}
-
-	project, err := tpgresource.GetProject(d, config)
-	if err != nil {
-		return err
-	}
-
-	region, err := tpgresource.GetRegion(d, config)
-	if err != nil {
-		return err
-	}
-
-	tnamemapping := tpgresource.ExpandStringMap(d, "transform_name_mapping")
-
-	env, updatedParameters, err := resourceDataflowFlexJobSetupEnv(d, config)
-	if err != nil {
-		return err
-	}
-
-	// wait until current job is running or terminated
-	err = waitForDataflowJobState(d, config, d.Id(), userAgent, d.Timeout(schema.TimeoutUpdate), "JOB_STATE_RUNNING")
-	if err != nil {
-		return fmt.Errorf("Error waiting for job with job ID %q to be running: %s", d.Id(), err)
-	}
-
-	request := dataflow.LaunchFlexTemplateRequest{
-		LaunchParameter: &dataflow.LaunchFlexTemplateParameter{
-
-			ContainerSpecGcsPath:  d.Get("container_spec_gcs_path").(string),
-			JobName:               d.Get("name").(string),
-			Parameters:            updatedParameters,
-			TransformNameMappings: tnamemapping,
-			Environment:           &env,
-			Update:                true,
-		},
-	}
-
-	response, err := config.NewDataflowClient(userAgent).Projects.Locations.FlexTemplates.Launch(project, region, &request).Do()
-	if err != nil {
-		return err
-	}
-
-	// don't set id until new job is successfully running
-	job := response.Job
-	err = waitForDataflowJobState(d, config, job.Id, userAgent, d.Timeout(schema.TimeoutUpdate), "JOB_STATE_RUNNING")
-	if err != nil {
-		// the default behavior is to overwrite the resource's state with the state of the "new" job, even though we are returning an error here. this call to Partial prevents this behavior
-		d.Partial(true)
-		return fmt.Errorf("Error waiting for Job with job ID %q to be updated: %s", job.Id, err)
-	}
-
-	d.SetId(job.Id)
-	if err := d.Set("job_id", job.Id); err != nil {
-		return fmt.Errorf("Error setting job_id: %s", err)
-	}
-
 	return resourceDataflowFlexTemplateJobRead(d, meta)
 }
 

--- a/mmv1/third_party/terraform/services/dataflow/resource_dataflow_job.go.erb
+++ b/mmv1/third_party/terraform/services/dataflow/resource_dataflow_job.go.erb
@@ -415,57 +415,58 @@ func resourceDataflowJobUpdateByReplacement(d *schema.ResourceData, meta interfa
 		return nil
 	}
 
-	config := meta.(*transport_tpg.Config)
-	userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
-	if err != nil {
-		return err
+	if jobHasUpdate(d, ResourceDataflowJob().Schema) {
+		config := meta.(*transport_tpg.Config)
+		userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
+		if err != nil {
+			return err
+		}
+
+		project, err := tpgresource.GetProject(d, config)
+		if err != nil {
+			return err
+		}
+
+		region, err := tpgresource.GetRegion(d, config)
+		if err != nil {
+			return err
+		}
+
+		params := tpgresource.ExpandStringMap(d, "parameters")
+		tnamemapping := tpgresource.ExpandStringMap(d, "transform_name_mapping")
+
+		env, err := resourceDataflowJobSetupEnv(d, config)
+		if err != nil {
+			return err
+		}
+
+		request := dataflow.LaunchTemplateParameters{
+			JobName:              d.Get("name").(string),
+			Parameters:           params,
+			TransformNameMapping: tnamemapping,
+			Environment:          &env,
+			Update:               true,
+		}
+
+		var response *dataflow.LaunchTemplateResponse
+		err = transport_tpg.Retry(transport_tpg.RetryOptions{
+			RetryFunc: func() (updateErr error) {
+				response, updateErr = resourceDataflowJobLaunchTemplate(config, project, region, userAgent, d.Get("template_gcs_path").(string), &request)
+				return updateErr
+			},
+			Timeout: time.Minute*time.Duration(5),
+			ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{transport_tpg.IsDataflowJobUpdateRetryableError},
+		})
+		if err != nil {
+			return err
+		}
+
+		if err := waitForDataflowJobToBeUpdated(d, config, response.Job.Id, userAgent, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return fmt.Errorf("Error updating job with job ID %q: %v", d.Id(), err)
+		}
+
+		d.SetId(response.Job.Id)
 	}
-
-	project, err := tpgresource.GetProject(d, config)
-	if err != nil {
-		return err
-	}
-
-	region, err := tpgresource.GetRegion(d, config)
-	if err != nil {
-		return err
-	}
-
-	params := tpgresource.ExpandStringMap(d, "parameters")
-	tnamemapping := tpgresource.ExpandStringMap(d, "transform_name_mapping")
-
-	env, err := resourceDataflowJobSetupEnv(d, config)
-	if err != nil {
-		return err
-	}
-
-	request := dataflow.LaunchTemplateParameters{
-		JobName:              d.Get("name").(string),
-		Parameters:           params,
-		TransformNameMapping: tnamemapping,
-		Environment:          &env,
-		Update:               true,
-	}
-
-	var response *dataflow.LaunchTemplateResponse
-	err = transport_tpg.Retry(transport_tpg.RetryOptions{
-		RetryFunc: func() (updateErr error) {
-			response, updateErr = resourceDataflowJobLaunchTemplate(config, project, region, userAgent, d.Get("template_gcs_path").(string), &request)
-			return updateErr
-		},
-		Timeout: time.Minute*time.Duration(5),
-		ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{transport_tpg.IsDataflowJobUpdateRetryableError},
-	})
-	if err != nil {
-		return err
-	}
-
-	if err := waitForDataflowJobToBeUpdated(d, config, response.Job.Id, userAgent, d.Timeout(schema.TimeoutUpdate)); err != nil {
-		return fmt.Errorf("Error updating job with job ID %q: %v", d.Id(), err)
-	}
-
-	d.SetId(response.Job.Id)
-
 	return resourceDataflowJobRead(d, meta)
 }
 
@@ -648,7 +649,7 @@ func resourceDataflowJobIsVirtualUpdate(d *schema.ResourceData, resourceSchema m
 				continue
 			}
 
-			if field != "labels" && field != "terraform_labels" && d.HasChange(field) {
+			if d.HasChange(field) {
 				return false
 			}
 		}
@@ -657,6 +658,25 @@ func resourceDataflowJobIsVirtualUpdate(d *schema.ResourceData, resourceSchema m
 	}
 
 	return false
+}
+
+// If only fields on_delete, terraform_labels are changing, no update request is needed
+func jobHasUpdate(d *schema.ResourceData, resourceSchema map[string]*schema.Schema) bool {
+	if d.HasChange("on_delete") || d.HasChange("labels") || d.HasChange("terraform_labels") {
+		for field := range resourceSchema {
+			if field == "on_delete" || field == "labels" || field == "terraform_labels" {
+				continue
+			}
+
+			if d.HasChange(field) {
+				return true
+			}
+		}
+		// on_delete, or terraform_labels are changing, but nothing else
+		return false
+	}
+
+	return true
 }
 
 func waitForDataflowJobToBeUpdated(d *schema.ResourceData, config *transport_tpg.Config, replacementJobID, userAgent string, timeout time.Duration) error {

--- a/mmv1/third_party/terraform/services/dataflow/resource_dataflow_job.go.erb
+++ b/mmv1/third_party/terraform/services/dataflow/resource_dataflow_job.go.erb
@@ -262,7 +262,7 @@ func resourceDataflowJobTypeCustomizeDiff(_ context.Context, d *schema.ResourceD
 				continue
 			}
 
-			if field != "labels" && field != "terraform_labels" && d.HasChange(field) {
+			if field != "terraform_labels" && d.HasChange(field) {
 				if err := d.ForceNew(field); err != nil {
 					return err
 				}

--- a/mmv1/third_party/terraform/services/dataflow/resource_dataflow_job_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataflow/resource_dataflow_job_test.go.erb
@@ -243,12 +243,12 @@ func TestAccDataflowJob_withLabels(t *testing.T) {
 			{
 				Config: testAccDataflowJob_labels(bucket, job, key, value),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataflowJobExists(t, "google_dataflow_job.with_labels"),
-					testAccDataflowJobHasLabels(t, "google_dataflow_job.with_labels", key),
+					testAccDataflowJobExists(t, "google_dataflow_job.big_data"),
+					testAccDataflowJobHasLabels(t, "google_dataflow_job.big_data", key),
 				),
 			},
 			{
-				ResourceName:            "google_dataflow_job.with_labels",
+				ResourceName:            "google_dataflow_job.big_data",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "state", "labels", "terraform_labels"},
@@ -276,20 +276,20 @@ func TestAccDataflowJob_withProviderDefaultLabels(t *testing.T) {
 			{
 				Config: testAccDataflowJob_withProviderDefaultLabels(bucket, job),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "labels.%", "2"),
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "labels.env", "foo"),
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "labels.default_expiration_ms", "3600000"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "labels.%", "2"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "labels.env", "foo"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "labels.default_expiration_ms", "3600000"),
 
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "terraform_labels.%", "3"),
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "terraform_labels.default_key1", "default_value1"),
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "terraform_labels.env", "foo"),
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "terraform_labels.default_expiration_ms", "3600000"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.%", "3"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.default_key1", "default_value1"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.env", "foo"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.default_expiration_ms", "3600000"),
 
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "effective_labels.%", "6"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.%", "6"),
 				),
 			},
 			{
-				ResourceName:      "google_dataflow_job.with_labels",
+				ResourceName:      "google_dataflow_job.big_data",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "state", "labels", "terraform_labels"},
@@ -297,21 +297,21 @@ func TestAccDataflowJob_withProviderDefaultLabels(t *testing.T) {
 			{
 				Config: testAccDataflowJob_resourceLabelsOverridesProviderDefaultLabels(bucket, job),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "labels.%", "3"),
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "labels.env", "foo"),
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "labels.default_expiration_ms", "3600000"),
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "labels.default_key1", "value1"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "labels.%", "3"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "labels.env", "foo"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "labels.default_expiration_ms", "3600000"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "labels.default_key1", "value1"),
 
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "terraform_labels.%", "3"),
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "terraform_labels.default_key1", "value1"),
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "terraform_labels.env", "foo"),
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "terraform_labels.default_expiration_ms", "3600000"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.%", "3"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.default_key1", "value1"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.env", "foo"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.default_expiration_ms", "3600000"),
 
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "effective_labels.%", "6"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.%", "6"),
 				),
 			},
 			{
-				ResourceName:      "google_dataflow_job.with_labels",
+				ResourceName:      "google_dataflow_job.big_data",
 				ImportState:       true,
 				ImportStateVerify: true,
 				// The labels field in the state is decided by the configuration.
@@ -321,20 +321,20 @@ func TestAccDataflowJob_withProviderDefaultLabels(t *testing.T) {
 			{
 				Config: testAccDataflowJob_moveResourceLabelToProviderDefaultLabels(bucket, job),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "labels.%", "2"),
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "labels.default_expiration_ms", "3600000"),
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "labels.default_key1", "value1"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "labels.%", "2"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "labels.default_expiration_ms", "3600000"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "labels.default_key1", "value1"),
 
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "terraform_labels.%", "3"),
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "terraform_labels.default_key1", "value1"),
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "terraform_labels.env", "foo"),
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "terraform_labels.default_expiration_ms", "3600000"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.%", "3"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.default_key1", "value1"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.env", "foo"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.default_expiration_ms", "3600000"),
 
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "effective_labels.%", "6"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.%", "6"),
 				),
 			},
 			{
-				ResourceName:      "google_dataflow_job.with_labels",
+				ResourceName:      "google_dataflow_job.big_data",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "state", "labels", "terraform_labels"},
@@ -342,21 +342,21 @@ func TestAccDataflowJob_withProviderDefaultLabels(t *testing.T) {
 			{
 				Config: testAccDataflowJob_resourceLabelsOverridesProviderDefaultLabels(bucket, job),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "labels.%", "3"),
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "labels.env", "foo"),
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "labels.default_expiration_ms", "3600000"),
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "labels.default_key1", "value1"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "labels.%", "3"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "labels.env", "foo"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "labels.default_expiration_ms", "3600000"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "labels.default_key1", "value1"),
 
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "terraform_labels.%", "3"),
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "terraform_labels.default_key1", "value1"),
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "terraform_labels.env", "foo"),
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "terraform_labels.default_expiration_ms", "3600000"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.%", "3"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.default_key1", "value1"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.env", "foo"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.default_expiration_ms", "3600000"),
 
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "effective_labels.%", "6"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.%", "6"),
 				),
 			},
 			{
-				ResourceName:      "google_dataflow_job.with_labels",
+				ResourceName:      "google_dataflow_job.big_data",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "state", "labels", "terraform_labels"},
@@ -364,14 +364,15 @@ func TestAccDataflowJob_withProviderDefaultLabels(t *testing.T) {
 			{
 				Config: testAccDataflowJob_zone(bucket, job, zone),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckNoResourceAttr("google_dataflow_job.with_labels", "labels.%"),
-					resource.TestCheckResourceAttr("google_dataflow_job.with_labels", "effective_labels.%", "3"),
+					resource.TestCheckNoResourceAttr("google_dataflow_job.big_data", "labels.%"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.%", "3"),
 				),
 			},
 			{
-				ResourceName:      "google_dataflow_job.with_labels",
+				ResourceName:      "google_dataflow_job.big_data",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "zone", "state"},
 			},
 		},
 	})
@@ -1076,7 +1077,7 @@ resource "google_storage_bucket" "temp" {
   force_destroy = true
 }
 
-resource "google_dataflow_job" "with_labels" {
+resource "google_dataflow_job" "big_data" {
   name = "%s"
 
   labels = {
@@ -1108,7 +1109,7 @@ resource "google_storage_bucket" "temp" {
   force_destroy = true
 }
 
-resource "google_dataflow_job" "with_labels" {
+resource "google_dataflow_job" "big_data" {
   name = "%s"
 
   labels = {
@@ -1141,7 +1142,7 @@ resource "google_storage_bucket" "temp" {
   force_destroy = true
 }
 
-resource "google_dataflow_job" "with_labels" {
+resource "google_dataflow_job" "big_data" {
   name = "%s"
 
   labels = {
@@ -1176,7 +1177,7 @@ resource "google_storage_bucket" "temp" {
   force_destroy = true
 }
 
-resource "google_dataflow_job" "with_labels" {
+resource "google_dataflow_job" "big_data" {
   name = "%s"
 
   labels = {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
fixes https://github.com/hashicorp/terraform-provider-google/issues/16159

Added `ForceNew` to `labels` field when the dataflow job has type JOB_TYPE_BATCH to match other resources, so `effective_labels` and `labels` fields both have `ForceNew`

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
dataflow: fixed the bug that the resource update returns error if `labels` field has changes for batch `google_dataflow_job`
```
```release-note:bug
dataflow: fixed the bug that the resource update returns error if `labels` field has changes for batch `google_dataflow_flex_template_job`
```