### PR TITLE
Add how to manually trigger build-downstreams job

### DIFF
--- a/.ci/README.md
+++ b/.ci/README.md
@@ -92,7 +92,7 @@ Pausing the pipeline is done in the cloud console, by setting the downstream-bui
 ### Downstream build job is not triggered by commits.
 This is rare but we've seen this happened before. In this case, we need to manually trigger a Cloud Build job by running 
 ```
-gcloud builds triggers run build-downstreams --sha=<COMMIT_SHA> --project=graphite-docker-images --substitutions=BRANCH_NAME=<BASE_BRANCH_NAME>
+gcloud builds triggers run build-downstreams --project=graphite-docker-images --substitutions=BRANCH_NAME=<BASE_BRANCH_NAME> --sha=<COMMIT_SHA>
 ```
 You'll need to substitute `<COMMIT_SHA>` with the commit sha that you'd like to trigger the build against and `<BASE_BRANCH_NAME>=` with base branch that this commit is pushed into, likely `main` but could be feature branches in some cases.
 

--- a/.ci/README.md
+++ b/.ci/README.md
@@ -82,19 +82,19 @@ done
 
 In the event of a failure, this will stop running.  If it succeeds, update the sync tag with `git push origin HEAD:tpg-sync`.
 
+### Downstream build job is not triggered by commits.
+This is rare but we've seen this happened before. In this case, we need to manually trigger a Cloud Build job by running 
+```
+gcloud builds triggers run build-downstreams --project=graphite-docker-images --substitutions=BRANCH_NAME=<BASE_BRANCH_NAME> --sha=<COMMIT_SHA>
+```
+You'll need to substitute `<COMMIT_SHA>` with the commit sha that you'd like to trigger the build against and `<BASE_BRANCH_NAME>` with base branch that this commit is pushed into, likely `main` but could be feature branches in some cases.
+
 ## Deploying the pipeline
 The code on the PR's branch is used to plan actions - no merge is performed.
 If you are making changes to the workflows, your changes will not trigger a workflow run, because of the risk of an untrusted contributor introducing malicious code in this way.  You will need to test locally by using the [cloud build local builder](https://cloud.google.com/cloud-build/docs/build-debug-locally).
 If you are making changes to the containers, your changes will not apply until they are merged in and built - this can take up to 15 minutes.  If you need to make a breaking change, you will need to pause the pipeline while the build happens.  If you are making changes to both the containers and the workflows and those changes need to be coordinated, you will need to pause the build while the containers build and enforce every open PR be rebased on top of our PR.  It is probably better to build in backwards-compatibility into your containers.  We recommend a 14 day window - 14 days after your change goes in, you can remove the backwards-compatibility.
 
 Pausing the pipeline is done in the cloud console, by setting the downstream-builder trigger to disabled.  You can find that trigger [here](https://console.cloud.google.com/cloud-build/triggers/edit/f80a7496-b2f4-4980-a706-c5425a52045b?project=graphite-docker-images)
-
-### Downstream build job is not triggered by commits.
-This is rare but we've seen this happened before. In this case, we need to manually trigger a Cloud Build job by running 
-```
-gcloud builds triggers run build-downstreams --project=graphite-docker-images --substitutions=BRANCH_NAME=<BASE_BRANCH_NAME> --sha=<COMMIT_SHA>
-```
-You'll need to substitute `<COMMIT_SHA>` with the commit sha that you'd like to trigger the build against and `<BASE_BRANCH_NAME>=` with base branch that this commit is pushed into, likely `main` but could be feature branches in some cases.
 
 ## Dependency change handbook:
 If someone (often a bot) creates a PR which updates Gemfile or Gemfile.lock, they will not be able to generate diffs.  This is because bundler doesn't allow you to run a binary unless your installed gems exactly match the Gemfile.lock, and since we have to run generation before and after the change, there is no possible container that will satisfy all requirements.

--- a/.ci/README.md
+++ b/.ci/README.md
@@ -92,7 +92,7 @@ Pausing the pipeline is done in the cloud console, by setting the downstream-bui
 ### Downstream build job is not triggered by commits.
 This is rare but we've seen this happened before. In this case, we need to manually trigger a Cloud Build job by running 
 ```
-gcloud builds triggers run build-downstreams --sha=<COMMIT_SHA> --substitutions=BRANCH_NAME=<BASE_BRANCH_NAME>
+gcloud builds triggers run build-downstreams --sha=<COMMIT_SHA> --project=graphite-docker-images --substitutions=BRANCH_NAME=<BASE_BRANCH_NAME>
 ```
 You'll need to substitute `<COMMIT_SHA>` with the commit sha that you'd like to trigger the build against and `<BASE_BRANCH_NAME>=` with base branch that this commit is pushed into, likely `main` but could be feature branches in some cases.
 

--- a/.ci/README.md
+++ b/.ci/README.md
@@ -89,6 +89,12 @@ If you are making changes to the containers, your changes will not apply until t
 
 Pausing the pipeline is done in the cloud console, by setting the downstream-builder trigger to disabled.  You can find that trigger [here](https://console.cloud.google.com/cloud-build/triggers/edit/f80a7496-b2f4-4980-a706-c5425a52045b?project=graphite-docker-images)
 
+### Downstream build job is not triggered by commits.
+This is rare but we've seen this happened before. In this case, we need to manually trigger a Cloud Build job by running 
+```
+gcloud builds triggers run build-downstreams --sha=<COMMIT_SHA> --substitutions=BRANCH_NAME=<BASE_BRANCH_NAME>
+```
+You'll need to substitute `<COMMIT_SHA>` with the commit sha that you'd like to trigger the build against and `<BASE_BRANCH_NAME>=` with base branch that this commit is pushed into, likely `main` but could be feature branches in some cases.
 
 ## Dependency change handbook:
 If someone (often a bot) creates a PR which updates Gemfile or Gemfile.lock, they will not be able to generate diffs.  This is because bundler doesn't allow you to run a binary unless your installed gems exactly match the Gemfile.lock, and since we have to run generation before and after the change, there is no possible container that will satisfy all requirements.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
