### PR TITLE
Skip alloydb vcr tests failling due to tennent project issues

### DIFF
--- a/mmv1/products/alloydb/Backup.yaml
+++ b/mmv1/products/alloydb/Backup.yaml
@@ -56,6 +56,8 @@ examples:
     ignore_read_extra:
       - 'reconciling'
       - 'update_time'
+    # https://github.com/hashicorp/terraform-provider-google/issues/16231
+    skip_vcr: true
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   encoder: templates/terraform/encoders/alloydb_backup.erb
 parameters:

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_secondary_cluster_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_secondary_cluster_test.go
@@ -11,7 +11,8 @@ import (
 // The cluster creation should succeed with minimal number of arguments
 func TestAccAlloydbCluster_secondaryClusterMandatoryFields(t *testing.T) {
 	t.Parallel()
-
+	// https://github.com/hashicorp/terraform-provider-google/issues/16231
+	acctest.SkipIfVcr(t)
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
 	}
@@ -491,7 +492,7 @@ resource "google_alloydb_cluster" "secondary" {
   secondary_config {
     primary_cluster_name = google_alloydb_cluster.primary.name
   }
-  
+
   automated_backup_policy {
     location      = "us-central1"
     backup_window = "1800s"


### PR DESCRIPTION
skipping more tennent project issues for alloydb

related to 
https://github.com/hashicorp/terraform-provider-google/issues/16231


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
