### PR TITLE
Fixed diff processor logic around functions in the Elem schema

### DIFF
--- a/tools/diff-processor/diff/diff.go
+++ b/tools/diff-processor/diff/diff.go
@@ -3,10 +3,10 @@ package diff
 import (
 	"reflect"
 
-	"golang.org/x/exp/maps"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"golang.org/x/exp/maps"
 )
 
 // SchemaDiff is a nested map with field names as keys and Field objects
@@ -16,7 +16,7 @@ type SchemaDiff map[string]ResourceDiff
 
 type ResourceDiff struct {
 	ResourceConfig ResourceConfigDiff
-	Fields map[string]FieldDiff
+	Fields         map[string]FieldDiff
 }
 
 type ResourceConfigDiff struct {

--- a/tools/diff-processor/diff/diff.go
+++ b/tools/diff-processor/diff/diff.go
@@ -171,17 +171,24 @@ func fieldChanged(oldField, newField *schema.Schema) bool {
 	}
 
 	// Check if Elem changed (unless old and new both represent nested fields)
-	if (oldField.Elem == nil || newField.Elem == nil) && !(oldField.Elem == nil && newField.Elem == nil) {
+	if (oldField.Elem == nil && newField.Elem != nil) || (oldField.Elem != nil && newField.Elem == nil) {
 		return true
 	}
-	_, oldHasChildren := oldField.Elem.(*schema.Resource)
-	_, newHasChildren := newField.Elem.(*schema.Resource)
-	if !oldHasChildren && !newHasChildren {
-		if !reflect.DeepEqual(oldField.Elem, newField.Elem) {
+	if oldField.Elem != nil && newField.Elem != nil {
+		// At this point new/old Elems are either schema.Schema or schema.Resource.
+		// If both are schema.Resource we don't need to do anything. Diffs on subfields
+		// are handled separately.
+		_, oldIsResource := oldField.Elem.(*schema.Resource)
+		_, newIsResource := newField.Elem.(*schema.Resource)
+
+		if (oldIsResource && !newIsResource) || (!oldIsResource && newIsResource) {
 			return true
 		}
-	} else if (oldHasChildren || newHasChildren) && !(oldHasChildren && newHasChildren) {
-		return true
+		if !oldIsResource && !newIsResource {
+			if fieldChanged(oldField.Elem.(*schema.Schema), newField.Elem.(*schema.Schema)) {
+				return true
+			}
+		}
 	}
 
 	// Check if any Schema struct fields that are functions have changed

--- a/tools/diff-processor/diff/diff_test.go
+++ b/tools/diff-processor/diff/diff_test.go
@@ -1,7 +1,6 @@
 package diff
 
 import (
-	"fmt"
 	"testing"
 
 	newProvider "google/provider/new/google/provider"
@@ -11,8 +10,8 @@ import (
 	oldProvider "google/provider/old/google/provider"
 	oldVerify "google/provider/old/google/verify"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -573,6 +572,49 @@ func TestFieldChanged(t *testing.T) {
 			},
 			expectChanged: false,
 		},
+		"Elem DiffSuppressFunc added": {
+			oldField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			newField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					DiffSuppressFunc: oldTpgresource.CaseDiffSuppress,
+				},
+			},
+			expectChanged: true,
+		},
+		"Elem DiffSuppressFunc removed": {
+			oldField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					DiffSuppressFunc: newTpgresource.CaseDiffSuppress,
+				},
+			},
+			newField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			expectChanged: true,
+		},
+		"Elem DiffSuppressFunc remains set": {
+			oldField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					DiffSuppressFunc: newTpgresource.CaseDiffSuppress,
+				},
+			},
+			newField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					DiffSuppressFunc: oldTpgresource.CaseDiffSuppress,
+				},
+			},
+			expectChanged: false,
+		},
 
 		"DefaultFunc added": {
 			oldField: &schema.Schema{},
@@ -594,6 +636,49 @@ func TestFieldChanged(t *testing.T) {
 			},
 			newField: &schema.Schema{
 				DefaultFunc: testDefaultFunc2,
+			},
+			expectChanged: false,
+		},
+		"Elem DefaultFunc added": {
+			oldField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			newField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type:        schema.TypeString,
+					DefaultFunc: testDefaultFunc2,
+				},
+			},
+			expectChanged: true,
+		},
+		"Elem DefaultFunc removed": {
+			oldField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type:        schema.TypeString,
+					DefaultFunc: testDefaultFunc1,
+				},
+			},
+			newField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			expectChanged: true,
+		},
+		"Elem DefaultFunc remains set": {
+			oldField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type:        schema.TypeString,
+					DefaultFunc: testDefaultFunc1,
+				},
+			},
+			newField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type:        schema.TypeString,
+					DefaultFunc: testDefaultFunc2,
+				},
 			},
 			expectChanged: false,
 		},
@@ -621,6 +706,49 @@ func TestFieldChanged(t *testing.T) {
 			},
 			expectChanged: false,
 		},
+		"Elem StateFunc added": {
+			oldField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			newField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type:      schema.TypeString,
+					StateFunc: testStateFunc2,
+				},
+			},
+			expectChanged: true,
+		},
+		"Elem StateFunc removed": {
+			oldField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type:      schema.TypeString,
+					StateFunc: testStateFunc1,
+				},
+			},
+			newField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			expectChanged: true,
+		},
+		"Elem StateFunc remains set": {
+			oldField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type:      schema.TypeString,
+					StateFunc: testStateFunc1,
+				},
+			},
+			newField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type:      schema.TypeString,
+					StateFunc: testStateFunc2,
+				},
+			},
+			expectChanged: false,
+		},
 
 		"Set added": {
 			oldField: &schema.Schema{},
@@ -642,6 +770,49 @@ func TestFieldChanged(t *testing.T) {
 			},
 			newField: &schema.Schema{
 				Set: newTpgresource.SelfLinkRelativePathHash,
+			},
+			expectChanged: false,
+		},
+		"Elem Set added": {
+			oldField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			newField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					Set:  newTpgresource.SelfLinkRelativePathHash,
+				},
+			},
+			expectChanged: true,
+		},
+		"Elem Set removed": {
+			oldField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					Set:  oldTpgresource.SelfLinkRelativePathHash,
+				},
+			},
+			newField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			expectChanged: true,
+		},
+		"Elem Set remains set": {
+			oldField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					Set:  oldTpgresource.SelfLinkRelativePathHash,
+				},
+			},
+			newField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					Set:  newTpgresource.SelfLinkRelativePathHash,
+				},
 			},
 			expectChanged: false,
 		},
@@ -669,6 +840,49 @@ func TestFieldChanged(t *testing.T) {
 			},
 			expectChanged: false,
 		},
+		"Elem ValidateFunc added": {
+			oldField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			newField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: newVerify.ValidateBase64String,
+				},
+			},
+			expectChanged: true,
+		},
+		"Elem ValidateFunc removed": {
+			oldField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: oldVerify.ValidateBase64String,
+				},
+			},
+			newField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			expectChanged: true,
+		},
+		"Elem ValidateFunc remains set": {
+			oldField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: oldVerify.ValidateBase64String,
+				},
+			},
+			newField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: newVerify.ValidateBase64String,
+				},
+			},
+			expectChanged: false,
+		},
 
 		"ValidateDiagFunc added": {
 			oldField: &schema.Schema{},
@@ -693,6 +907,49 @@ func TestFieldChanged(t *testing.T) {
 			},
 			expectChanged: false,
 		},
+		"Elem ValidateDiagFunc added": {
+			oldField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			newField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: testValidateDiagFunc2,
+				},
+			},
+			expectChanged: true,
+		},
+		"Elem ValidateDiagFunc removed": {
+			oldField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: testValidateDiagFunc1,
+				},
+			},
+			newField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			expectChanged: true,
+		},
+		"Elem ValidateDiagFunc remains set": {
+			oldField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: testValidateDiagFunc1,
+				},
+			},
+			newField: &schema.Schema{
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: testValidateDiagFunc2,
+				},
+			},
+			expectChanged: false,
+		},
 	}
 
 	for tn, tc := range cases {
@@ -700,31 +957,35 @@ func TestFieldChanged(t *testing.T) {
 		t.Run(tn, func(t *testing.T) {
 			t.Parallel()
 			changed := fieldChanged(tc.oldField, tc.newField)
-			assert.Equal(
-				t,
-				tc.expectChanged,
-				changed,
-				fmt.Sprintf(
-					"want %t; got %t.\nOld field: %s\nNew field: %s\n",
-					tc.expectChanged,
-					changed,
-					spew.Sdump(tc.oldField),
-					spew.Sdump(tc.newField),
-				),
-			)
+			if changed != tc.expectChanged {
+				if diff := cmp.Diff(tc.oldField, tc.newField); diff != "" {
+					t.Errorf("want %t; got %t.\nField diff (-old, +new):\n%s",
+						tc.expectChanged,
+						changed,
+						diff,
+					)
+				} else {
+					t.Errorf("want %t; got %t. No field diff.\nOld field: %s\nNew field: %s\n",
+						tc.expectChanged,
+						changed,
+						spew.Sdump(tc.oldField),
+						spew.Sdump(tc.newField),
+					)
+				}
+			}
 		})
 	}
 }
 
 func TestComputeSchemaDiff(t *testing.T) {
 	cases := map[string]struct {
-		oldResourceMap   map[string]*schema.Resource
-		newResourceMap   map[string]*schema.Resource
+		oldResourceMap     map[string]*schema.Resource
+		newResourceMap     map[string]*schema.Resource
 		expectedSchemaDiff SchemaDiff
 	}{
 		"empty-maps": {
-			oldResourceMap:   map[string]*schema.Resource{},
-			newResourceMap:   map[string]*schema.Resource{},
+			oldResourceMap:     map[string]*schema.Resource{},
+			newResourceMap:     map[string]*schema.Resource{},
 			expectedSchemaDiff: SchemaDiff{},
 		},
 		"empty-resources": {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Elem schemas can include functions (ValidateFunc, DiffSuppressFunc, etc), which the current diff logic (reflect.DeepEqual) always detects as changed if set. The new logic matches our general handling of funcs as only changed if added or removed.

Note that the test failure commit has a lot of output from TestNewProviderOldProviderChanges (which passes) - jump to the bottom of the output to see the failures from `TestFieldChanged/Elem*`

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
