### PR TITLE
Made output for TestNewProviderOldProviderChanges easier to read

### DIFF
--- a/tools/diff-processor/diff/diff_test.go
+++ b/tools/diff-processor/diff/diff_test.go
@@ -22,7 +22,35 @@ import (
 func TestNewProviderOldProviderChanges(t *testing.T) {
 	changes := ComputeSchemaDiff(oldProvider.ResourceMap(), newProvider.ResourceMap())
 
-	t.Logf("Changes between old and new providers: %s", spew.Sdump(changes))
+	for resource, resourceDiff := range changes {
+		if resourceDiff.ResourceConfig.Old == nil {
+			t.Logf("%s is added", resource)
+			continue
+		}
+		if resourceDiff.ResourceConfig.New == nil {
+			t.Logf("%s is removed", resource)
+			continue
+		}
+		t.Logf("%s is modified", resource)
+		if diff := cmp.Diff(resourceDiff.ResourceConfig.Old, resourceDiff.ResourceConfig.New); diff != "" {
+			t.Logf("%s config changes (-old, +new):\n%s", resource, diff)
+		}
+		for field, fieldDiff := range resourceDiff.Fields {
+			if fieldDiff.Old == nil {
+				t.Logf("%s.%s is added", resource, field)
+				continue
+			}
+			if fieldDiff.New == nil {
+				t.Logf("%s.%s is removed", resource, field)
+				continue
+			}
+			t.Logf("%s.%s is modified", resource, field)
+			if diff := cmp.Diff(fieldDiff.Old, fieldDiff.New); diff != "" {
+				t.Logf("%s.%s changes (-old, +new):\n%s", resource, field, diff)
+			}
+		}
+
+	}
 }
 
 func TestFlattenSchema(t *testing.T) {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Compare diff processor unit test output to https://github.com/GoogleCloudPlatform/magic-modules/actions/runs/6511193001/job/17686407729.

Note that the diffs on this PR are spurious & are addressed in https://github.com/GoogleCloudPlatform/magic-modules/pull/9260

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
