### PR TITLE
Fix vmwareengine tests

### DIFF
--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go.erb
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go.erb
@@ -11,24 +11,24 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 func TestAccVmwareenginePrivateCloud_vmwareEnginePrivateCloudUpdate(t *testing.T) {
+	acctest.SkipIfVcr(t)
 	t.Parallel()
+
 	context := map[string]interface{}{
-		"region":        "southamerica-west1", // using region with low node utilization.
-		"random_suffix": 	acctest.RandString(t, 10),
-		"organization":    envvar.GetTestOrgFromEnv(t),
-		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
+		"region":          "southamerica-east1",
+		"random_suffix":   acctest.RandString(t, 10),
 	}
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 		CheckDestroy:             testAccCheckVmwareenginePrivateCloudDestroyProducer(t),
-    ExternalProviders: map[string]resource.ExternalProvider {
+		ExternalProviders: map[string]resource.ExternalProvider {
 			"time":   {},
 		},
 		Steps: []resource.TestStep{
@@ -69,17 +69,16 @@ func testPrivateCloudUpdateConfig(context map[string]interface{}, description st
 
 	return acctest.Nprintf(`
 resource "google_vmwareengine_network" "default-nw" {
-   provider      	   = google-beta
-   project           = google_project_service.acceptance.project
-   name              = "%{region}-default"
-   location          = "%{region}"
-   type              = "LEGACY"
+  provider          = google-beta
+  name              = "%{region}-default"
+  location          = "%{region}"
+  type              = "LEGACY"
+  description       = "PC network description."
 }
 
 resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
   location = "%{region}-a"
   name = "tf-test-sample-pc%{random_suffix}"
-  project = google_project_service.acceptance.project
   provider = google-beta
   description = "%{description}"
   network_config {
@@ -94,30 +93,6 @@ resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
       custom_core_count = 32
     }
   }
-}
-
-# there can be only 1 Legacy network per region for a given project, so creating new project to isolate tests.
-resource "google_project" "acceptance" {
-  name            = "tf-test-%{random_suffix}"
-  provider        = google-beta
-  project_id      = "tf-test-%{random_suffix}"
-  org_id          = "%{organization}"
-  billing_account = "%{billing_account}"
-}
-
-resource "google_project_service" "acceptance" {
-  project  = google_project.acceptance.project_id
-  provider = google-beta
-  service  = "vmwareengine.googleapis.com"
-
-  # Needed for CI tests for permissions to propagate, should not be needed for actual usage
-  depends_on = [time_sleep.wait_60_seconds]
-}
-
-resource "time_sleep" "wait_60_seconds" {
-  depends_on = [google_project.acceptance]
-
-  create_duration = "60s"
 }
 `, context)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fixes https://github.com/hashicorp/terraform-provider-google/issues/16059

`TestAccVmwareenginePrivateCloud_vmwareEnginePrivateCloudUpdate` is flaky.

Skip this test `TestAccVmwareenginePrivateCloud_vmwareEnginePrivateCloudUpdate` in vcr as it takes about 5 hours to finish and causes pre-submit timeouts.

Test  `TestAccVmwareenginePrivateCloud_vmwareEnginePrivateCloudUpdate`  passed https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_GoogleBeta_MmUpstreamTesting_GOOGLEBETA_PACKAGE_VMWAREENGINE/43360?buildTab=tests&expandedTest=build%3A%28id%3A43360%29%2Cid%3A2000000002


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
