### PR TITLE
fix beta only flag in compute instance tests

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -1792,7 +1792,7 @@ func TestAccComputeInstance_confidentialHyperDiskBootDisk(t *testing.T) {
 	context_1 := map[string]interface{}{
 		"instance_name":         fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
 		"confidential_compute":  true,
-		"kms_key" :              acctest.BootstrapKMSKey(t)
+		"kms_key" :              acctest.BootstrapKMSKey(t),
 		"zone":                  "us-central1-a"
 	}
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -1785,7 +1785,7 @@ func TestAccComputeInstanceConfidentialInstanceConfigMain(t *testing.T) {
 	})
 }
 
-<% unless version = 'ga' -%>
+<% unless version == 'ga' -%>
 func TestAccComputeInstance_confidentialHyperDiskBootDisk(t *testing.T) {
 	t.Parallel()
 
@@ -6887,7 +6887,7 @@ resource "google_compute_instance" "foobar" {
 `, instance, enableConfidentialCompute)
 }
 
-<% unless version = 'ga' -%>
+<% unless version == 'ga' -%>
 func testAccComputeInstanceConfidentialHyperDiskBootDisk(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -1793,14 +1793,14 @@ func TestAccComputeInstance_confidentialHyperDiskBootDisk(t *testing.T) {
 		"instance_name":         fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
 		"confidential_compute":  true,
 		"kms_key" :              acctest.BootstrapKMSKey(t),
-		"zone":                  "us-central1-a"
+		"zone":                  "us-central1-a",
 	}
 
 	context_2 := map[string]interface{}{
 		"instance_name":        context_1["instance_name"],
 		"confidential_compute": false,
 		"kms_key" :             context_1["kms_key"],
-		"zone":                 context_1["zone]
+		"zone":                 context_1["zone"],
 	}
 
 
@@ -1812,11 +1812,11 @@ func TestAccComputeInstance_confidentialHyperDiskBootDisk(t *testing.T) {
 			{
 				Config: testAccComputeInstanceConfidentialHyperDiskBootDisk(context_1),
 			},
-			computeInstanceImportStep(context_1["zone"], context_1["instance_name"], []string{"allow_stopping_for_update"}),
+			computeInstanceImportStep(context_1["zone"].(string), context_1["instance_name"].(string), []string{"allow_stopping_for_update"}),
 			{
 				Config: testAccComputeInstanceConfidentialHyperDiskBootDisk(context_2),
 			},
-			computeInstanceImportStep(context_2["zone"], context_2["instance_name"], []string{"allow_stopping_for_update"}),
+			computeInstanceImportStep(context_2["zone"].(string), context_2["instance_name"].(string), []string{"allow_stopping_for_update"}),
 		},
 	})
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixed the issue introduced in https://github.com/GoogleCloudPlatform/magic-modules/pull/9250. This should bring back 1500+ lines in beta provider

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
