### PR TITLE
Adding support for Autoclass 2.1

### DIFF
--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
@@ -284,6 +284,12 @@ func ResourceStorageBucket() *schema.Resource {
 							Required:    true,
 							Description: `While set to true, autoclass automatically transitions objects in your bucket to appropriate storage classes based on each object's access pattern.`,
 						},
+						"terminal_storage_class": {
+								Type:        schema.TypeString,
+								Optional:    true,
+								Computed:    true,
+								Description: `The storage class that objects in the bucket eventually transition to if they are not read for a certain length of time. Supported values include: NEARLINE, ARCHIVE.`,
+						},
 					},
 				},
 				Description: `The bucket's autoclass configuration.`,
@@ -1142,6 +1148,9 @@ func expandBucketAutoclass(configured interface{}) *storage.BucketAutoclass {
 	bucketAutoclass := &storage.BucketAutoclass{}
 
 	bucketAutoclass.Enabled = autoclass["enabled"].(bool)
+	if autoclass["terminal_storage_class"] != "" {
+		bucketAutoclass.TerminalStorageClass = autoclass["terminal_storage_class"].(string)
+	}
 	bucketAutoclass.ForceSendFields = append(bucketAutoclass.ForceSendFields, "Enabled")
 
 	return bucketAutoclass
@@ -1169,7 +1178,8 @@ func flattenBucketAutoclass(bucketAutoclass *storage.BucketAutoclass) []map[stri
 	}
 
 	autoclass := map[string]interface{}{
-		"enabled": bucketAutoclass.Enabled,
+		"enabled":                bucketAutoclass.Enabled,
+		"terminal_storage_class": bucketAutoclass.TerminalStorageClass,
 	}
 	autoclassList = append(autoclassList, autoclass)
 	return autoclassList

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
@@ -1710,9 +1710,9 @@ resource "google_storage_bucket" "bucket" {
   }
   lifecycle_rule {
     action {
-	  type = "Delete"
-	}
-	condition {
+      type = "Delete"
+    }
+    condition {
       matches_suffix = ["test"]
       age            = 2
     }

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
@@ -84,8 +84,16 @@ func TestAccStorageBucket_basicWithAutoclass(t *testing.T) {
 					testAccCheckStorageBucketExists(
 						t, "google_storage_bucket.bucket", bucketName, &updated),
 					testAccCheckStorageBucketWasUpdated(&updated, &bucket),
-					testAccCheckAutoclassTerminalStorageClass("ARCHIVE", &updated),
 				),
+			},
+			{
+				ResourceName:            "google_storage_bucket.bucket",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+			{
+				Config: testAccStorageBucket_basicWithAutoclass(bucketName, false),
 			},
 			{
 				ResourceName:            "google_storage_bucket.bucket",
@@ -1244,16 +1252,6 @@ func testAccCheckStorageBucketMissing(t *testing.T, bucketName string) resource.
 		}
 
 		return err
-	}
-}
-
-func testAccCheckAutoclassTerminalStorageClass(expected string, b *storage.Bucket) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		actual := b.Autoclass.TerminalStorageClass
-		if expected != actual {
-			return fmt.Errorf("expected Autoclass Terminal Storage Class %s, instead got %s", expected, actual)
-		}
-		return nil
 	}
 }
 

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
@@ -1708,8 +1708,11 @@ resource "google_storage_bucket" "bucket" {
       age            = 2
     }
   }
-  lifecycle_rule {testAccStorageBucket_lifecycleRulesMultiple_update
-    condition {
+  lifecycle_rule {
+    action {
+	  type = "Delete"
+	}
+	condition {
       matches_suffix = ["test"]
       age            = 2
     }

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
@@ -56,6 +56,8 @@ func TestAccStorageBucket_basic(t *testing.T) {
 func TestAccStorageBucket_basicWithAutoclass(t *testing.T) {
 	t.Parallel()
 
+	var bucket storage.Bucket
+	var updated storage.Bucket
 	bucketName := acctest.TestBucketName(t)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -66,8 +68,8 @@ func TestAccStorageBucket_basicWithAutoclass(t *testing.T) {
 			{
 				Config: testAccStorageBucket_basicWithAutoclass(bucketName, true),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"google_storage_bucket.bucket", "force_destroy", "false"),
+					testAccCheckStorageBucketExists(
+						t, "google_storage_bucket.bucket", bucketName, &bucket),
 				),
 			},
 			{
@@ -76,12 +78,13 @@ func TestAccStorageBucket_basicWithAutoclass(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
-			// Autoclass is ForceNew, so this destroys & recreates, but does test the explicitly disabled config
 			{
-				Config: testAccStorageBucket_basicWithAutoclass(bucketName, false),
+				Config: testAccStorageBucket_basicWithAutoclass_update(bucketName, true),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"google_storage_bucket.bucket", "force_destroy", "false"),
+					testAccCheckStorageBucketExists(
+						t, "google_storage_bucket.bucket", bucketName, &updated),
+					testAccCheckStorageBucketWasUpdated(&updated, &bucket),
+					testAccCheckAutoclassTerminalStorageClass("ARCHIVE", &updated),
 				),
 			},
 			{
@@ -1244,6 +1247,16 @@ func testAccCheckStorageBucketMissing(t *testing.T, bucketName string) resource.
 	}
 }
 
+func testAccCheckAutoclassTerminalStorageClass(expected string, b *storage.Bucket) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		actual := b.Autoclass.TerminalStorageClass
+		if expected != actual {
+			return fmt.Errorf("expected Autoclass Terminal Storage Class %s, instead got %s", expected, actual)
+		}
+		return nil
+	}
+}
+
 func testAccCheckStorageBucketLifecycleConditionState(expected *bool, b *storage.Bucket) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		actual := b.Lifecycle.Rule[0].Condition.IsLive
@@ -1296,9 +1309,24 @@ func testAccStorageBucket_basicWithAutoclass(bucketName string, autoclass bool) 
 resource "google_storage_bucket" "bucket" {
   name     = "%s"
   location = "US"
+  force_destroy = true
   autoclass  {
     enabled  = %t
   }
+}
+`, bucketName, autoclass)
+}
+
+func testAccStorageBucket_basicWithAutoclass_update(bucketName string, autoclass bool) string {
+	return fmt.Sprintf(`
+resource "google_storage_bucket" "bucket" {
+	name     = "%s"
+	location = "US"
+	force_destroy = true
+	autoclass  {
+		enabled  = %t
+		terminal_storage_class = "ARCHIVE"
+	}
 }
 `, bucketName, autoclass)
 }
@@ -1680,10 +1708,7 @@ resource "google_storage_bucket" "bucket" {
       age            = 2
     }
   }
-  lifecycle_rule {
-    action {
-      type = "Delete"
-    }
+  lifecycle_rule {testAccStorageBucket_lifecycleRulesMultiple_update
     condition {
       matches_suffix = ["test"]
       age            = 2

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -168,6 +168,8 @@ The following arguments are supported:
 
 * `enabled` - (Required) While set to `true`, autoclass automatically transitions objects in your bucket to appropriate storage classes based on each object's access pattern.
 
+* `terminal_storage_class` - (Optional) The storage class that objects in the bucket eventually transition to if they are not read for a certain length of time. Supported values include: `NEARLINE`, `ARCHIVE`.
+
 <a name="nested_versioning"></a>The `versioning` block supports:
 
 * `enabled` - (Required) While set to `true`, versioning is fully enabled for this bucket.


### PR DESCRIPTION
Adds the `terminal_storage_class` field to autoclass configurations for `google_storage_bucket`.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
storage: added `terminal_storage_class` to the `autoclass` field in `google_storage_bucket` resource
```
