### PR TITLE
Add internal ipv6 prefix into compute network and subnetwork data source reference attribute

### DIFF
--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_network.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_network.go
@@ -28,6 +28,11 @@ func DataSourceGoogleComputeNetwork() *schema.Resource {
 				Computed: true,
 			},
 
+			"internal_ipv6_range": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"self_link": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -68,6 +73,9 @@ func dataSourceGoogleComputeNetworkRead(d *schema.ResourceData, meta interface{}
 	}
 	if err := d.Set("gateway_ipv4", network.GatewayIPv4); err != nil {
 		return fmt.Errorf("Error setting gateway_ipv4: %s", err)
+	}
+	if err := d.Set("internal_ipv6_range", network.InternalIpv6Range); err != nil {
+		return fmt.Errorf("Error setting internal_ipv6_range: %s", err)
 	}
 	if err := d.Set("self_link", network.SelfLink); err != nil {
 		return fmt.Errorf("Error setting self_link: %s", err)

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_network_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_network_test.go
@@ -46,6 +46,7 @@ func testAccDataSourceGoogleNetworkCheck(data_source_name string, resource_name 
 			"id",
 			"name",
 			"description",
+			"internal_ipv6_range",
 		}
 
 		for _, attr_to_check := range network_attrs_to_test {
@@ -72,6 +73,8 @@ func testAccDataSourceGoogleNetworkConfig(name string) string {
 resource "google_compute_network" "foobar" {
   name        = "%s"
   description = "my-description"
+  enable_ula_internal_ipv6 = true
+  auto_create_subnetworks = false
 }
 
 data "google_compute_network" "my_network" {

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_network_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_network_test.go
@@ -71,10 +71,10 @@ func testAccDataSourceGoogleNetworkCheck(data_source_name string, resource_name 
 func testAccDataSourceGoogleNetworkConfig(name string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
-  name        = "%s"
-  description = "my-description"
+  name                     = "%s"
+  description              = "my-description"
   enable_ula_internal_ipv6 = true
-  auto_create_subnetworks = false
+  auto_create_subnetworks  = false
 }
 
 data "google_compute_network" "my_network" {

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_subnetwork.go.erb
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_subnetwork.go.erb
@@ -36,6 +36,10 @@ func DataSourceGoogleComputeSubnetwork() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"internal_ipv6_prefix": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"private_ip_google_access": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -99,6 +103,9 @@ func dataSourceGoogleComputeSubnetworkRead(d *schema.ResourceData, meta interfac
 
 	if err := d.Set("ip_cidr_range", subnetwork.IpCidrRange); err != nil {
 		return fmt.Errorf("Error setting ip_cidr_range: %s", err)
+	}
+	if err := d.Set("internal_ipv6_prefix", subnetwork.InternalIpv6Prefix); err != nil {
+		return fmt.Errorf("Error setting internal_ipv6_prefix: %s", err)
 	}
 	if err := d.Set("private_ip_google_access", subnetwork.PrivateIpGoogleAccess); err != nil {
 		return fmt.Errorf("Error setting private_ip_google_access: %s", err)

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_subnetwork_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_subnetwork_test.go
@@ -90,8 +90,8 @@ resource "google_compute_subnetwork" "foobar" {
   description              = "my-description"
   ip_cidr_range            = "10.0.0.0/24"
   network                  = google_compute_network.foobar.self_link
-  stack_type			   = "IPV4_IPV6"
-  ipv6_access_type		   = "INTERNAL"
+  stack_type               = "IPV4_IPV6"
+  ipv6_access_type         = "INTERNAL"
   private_ip_google_access = true
   secondary_ip_range {
     range_name    = "tf-test-secondary-range"

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_subnetwork_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_subnetwork_test.go
@@ -49,6 +49,7 @@ func testAccDataSourceGoogleSubnetworkCheck(data_source_name string, resource_na
 			"description",
 			"ip_cidr_range",
 			"private_ip_google_access",
+			"internal_ipv6_prefix",
 			"secondary_ip_range",
 		}
 
@@ -80,6 +81,8 @@ func testAccDataSourceGoogleSubnetwork(networkName, subnetName string) string {
 resource "google_compute_network" "foobar" {
   name        = "%s"
   description = "my-description"
+  enable_ula_internal_ipv6 = true
+  auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "foobar" {
@@ -87,6 +90,8 @@ resource "google_compute_subnetwork" "foobar" {
   description              = "my-description"
   ip_cidr_range            = "10.0.0.0/24"
   network                  = google_compute_network.foobar.self_link
+  stack_type			   = "IPV4_IPV6"
+  ipv6_access_type		   = "INTERNAL"
   private_ip_google_access = true
   secondary_ip_range {
     range_name    = "tf-test-secondary-range"

--- a/mmv1/third_party/terraform/website/docs/d/compute_network.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_network.html.markdown
@@ -37,7 +37,9 @@ In addition to the arguments listed above, the following attributes are exported
 * `description` - Description of this network.
 
 * `gateway_ipv4` - The IP address of the gateway.
+
 * `internal_ipv6_range` - The ula internal ipv6 range assigned to this network.
+
 * `subnetworks_self_links` - the list of subnetworks which belong to the network
 
 * `self_link` - The URI of the resource.

--- a/mmv1/third_party/terraform/website/docs/d/compute_network.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_network.html.markdown
@@ -37,7 +37,7 @@ In addition to the arguments listed above, the following attributes are exported
 * `description` - Description of this network.
 
 * `gateway_ipv4` - The IP address of the gateway.
-
+* `internal_ipv6_range` - The ula internal ipv6 range assigned to this network.
 * `subnetworks_self_links` - the list of subnetworks which belong to the network
 
 * `self_link` - The URI of the resource.

--- a/mmv1/third_party/terraform/website/docs/d/compute_subnetwork.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_subnetwork.html.markdown
@@ -45,6 +45,8 @@ In addition to the arguments listed above, the following attributes are exported
 * `ip_cidr_range` - The IP address range that machines in this
     network are assigned to, represented as a CIDR block.
 
+* `internal_ipv6_prefix` - The internal IPv6 address range that is assigned to this subnetwork.
+
 * `gateway_address` - The IP address of the gateway.
 
 * `private_ip_google_access` - Whether the VMs in this subnet


### PR DESCRIPTION
… datasource

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This PR is to make `data_source_google_compute_network` and `data_source_google_compute_subnetwork` include `internal_ipv6_range` and `_internal_ipv6_prefix` into their attribute reference respectively when they have dual stack support enabled upon creation. 
Added field names are based on REST API reference and compute client protobuf:
- https://cloud.google.com/compute/docs/reference/rest/v1/networks
- https://cloud.google.com/compute/docs/reference/rest/v1/subnetworks
- https://pkg.go.dev/google.golang.org/api/compute/v1#Network
- https://pkg.go.dev/google.golang.org/api/compute/v1#Subnetwork
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `internal_ipv6_range` to `data.google_compute_network` data source and `internal_ipv6_prefix` field to `data.google_compute_subnetwork` data source
```
