### PR TITLE
Revert "Adding in support for confidential_compute on boot disk (#9250)"

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
@@ -46,9 +46,6 @@ var (
 		"boot_disk.0.initialize_params.0.image",
 		"boot_disk.0.initialize_params.0.labels",
 		"boot_disk.0.initialize_params.0.resource_manager_tags",
-<% unless version == 'ga' -%>
-		"boot_disk.0.initialize_params.0.enable_confidential_compute",
-<% end -%>
 	}
 
 	schedulingKeys = []string{
@@ -244,15 +241,6 @@ func ResourceComputeInstance() *schema.Resource {
 										ForceNew:     true,
 										Description:  `A map of resource manager tags. Resource manager tag keys and values have the same definition as resource manager tags. Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456. The field is ignored (both PUT & PATCH) when empty.`,
 									},
-<% unless version == 'ga' -%>
-									"enable_confidential_compute": {
-										Type:             schema.TypeBool,
-										Optional:         true,
-										AtLeastOneOf: initializeParamsKeys,
-										ForceNew:         true,
-										Description:      `A flag to enble confidential compute mode on boot disk`,
-									},
-<% end -%>
 								},
 							},
 						},
@@ -2741,12 +2729,6 @@ func expandBootDisk(d *schema.ResourceData, config *transport_tpg.Config, projec
 			disk.InitializeParams.DiskSizeGb = int64(v.(int))
 		}
 
-		<% unless version == 'ga' -%>
-		if v, ok := d.GetOk("boot_disk.0.initialize_params.0.enable_confidential_compute"); ok {
-			disk.InitializeParams.EnableConfidentialCompute = v.(bool)
-		}
-		<% end -%>
-
 		if v, ok := d.GetOk("boot_disk.0.initialize_params.0.type"); ok {
 			diskTypeName := v.(string)
 			diskType, err := readDiskType(config, d, diskTypeName)
@@ -2812,9 +2794,6 @@ func flattenBootDisk(d *schema.ResourceData, disk *compute.AttachedDisk, config 
 			"size":   diskDetails.SizeGb,
 			"labels": diskDetails.Labels,
 			"resource_manager_tags": d.Get("boot_disk.0.initialize_params.0.resource_manager_tags"),
-<% unless version == 'ga' -%>
-			"enable_confidential_compute": diskDetails.EnableConfidentialCompute,
-<% end -%>
 		}}
 	}
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -1785,43 +1785,6 @@ func TestAccComputeInstanceConfidentialInstanceConfigMain(t *testing.T) {
 	})
 }
 
-<% unless version = 'ga' -%>
-func TestAccComputeInstance_confidentialHyperDiskBootDisk(t *testing.T) {
-	t.Parallel()
-
-	context_1 := map[string]interface{}{
-		"instance_name":         fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
-		"confidential_compute":  true,
-		"kms_key" :              acctest.BootstrapKMSKey(t)
-		"zone":                  "us-central1-a"
-	}
-
-	context_2 := map[string]interface{}{
-		"instance_name":        context_1["instance_name"],
-		"confidential_compute": false,
-		"kms_key" :             context_1["kms_key"],
-		"zone":                 context_1["zone]
-	}
-
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccComputeInstanceConfidentialHyperDiskBootDisk(context_1),
-			},
-			computeInstanceImportStep(context_1["zone"], context_1["instance_name"], []string{"allow_stopping_for_update"}),
-			{
-				Config: testAccComputeInstanceConfidentialHyperDiskBootDisk(context_2),
-			},
-			computeInstanceImportStep(context_2["zone"], context_2["instance_name"], []string{"allow_stopping_for_update"}),
-		},
-	})
-}
-<% end -%>
-
 func TestAccComputeInstance_enableDisplay(t *testing.T) {
 	t.Parallel()
 
@@ -6886,39 +6849,6 @@ resource "google_compute_instance" "foobar" {
 }
 `, instance, enableConfidentialCompute)
 }
-
-<% unless version = 'ga' -%>
-func testAccComputeInstanceConfidentialHyperDiskBootDisk(context map[string]interface{}) string {
-	return acctest.Nprintf(`
-}
-data "google_compute_image" "my_image" {
-  family    = "ubuntu-2204-lts"
-  project   = "ubuntu-os-cloud"
-}
-
-resource "google_compute_instance" "foobar" {
-  name         = "%{name}"
-  machine_type = "n2-standard-2"
-  zone         = "%{zone}"
-
-  boot_disk {
-
-    initialize_params {
-      image = data.google_compute_image.my_image.self_link
-      enable_confidential_compute = %{confidential_compute}
-      type  = "hyperdisk-balanced"
-    }
-
-    kms_key_self_link = "%{kms_key}"
-  }
-
-  network_interface {
-    network = "default"
-  }
-}
-`, context)
-}
-<% end -%>
 
 func testAccComputeInstance_enableDisplay(instance string) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
This reverts commit 5cedf2c8cd099d31d01de1b4783089f0974db6a2.

https://github.com/GoogleCloudPlatform/magic-modules/pull/9270 revealed that the test was not passing- that had been disguised because the beta code wasn't getting generated correctly.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

FYI @NA2047 

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
