### PR TITLE
feat: add credentials_secret field in azure blob storage block for google storage transfer job resource

### DIFF
--- a/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go
+++ b/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go
@@ -50,6 +50,10 @@ var (
 		"transfer_spec.0.aws_s3_data_source.0.aws_access_key",
 		"transfer_spec.0.aws_s3_data_source.0.role_arn",
 	}
+	azureOptionCredentials = []string{
+		"transfer_spec.0.azure_blob_storage_data_source.0.azure_credentials",
+		"transfer_spec.0.azure_blob_storage_data_source.0.credentials_secret",
+	}
 )
 
 func ResourceStorageTransferJob() *schema.Resource {
@@ -559,9 +563,10 @@ func azureBlobStorageDataSchema() *schema.Resource {
 				Description: `Root path to transfer objects. Must be an empty string or full path name that ends with a '/'. This field is treated as an object prefix. As such, it should generally not begin with a '/'.`,
 			},
 			"azure_credentials": {
-				Type:     schema.TypeList,
-				Required: true,
-				MaxItems: 1,
+				Type:         schema.TypeList,
+				Optional:     true,
+				MaxItems:     1,
+				ExactlyOneOf: azureOptionCredentials,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"sas_token": {
@@ -573,6 +578,12 @@ func azureBlobStorageDataSchema() *schema.Resource {
 					},
 				},
 				Description: ` Credentials used to authenticate API requests to Azure.`,
+			},
+			"credentials_secret": {
+				Optional:     true,
+				Type:         schema.TypeString,
+				Description:  `Optional. The Resource name of a secret in Secret Manager.`,
+				ExactlyOneOf: azureOptionCredentials,
 			},
 		},
 	}
@@ -1099,6 +1110,9 @@ func expandAzureCredentials(azureCredentials []interface{}) *storagetransfer.Azu
 }
 
 func flattenAzureCredentials(d *schema.ResourceData) []map[string]interface{} {
+	if d.Get("transfer_spec.0.azure_blob_storage_data_source.0.azure_credentials.0.sas_token") == "" {
+		return []map[string]interface{}{}
+	}
 	data := map[string]interface{}{
 		"sas_token": d.Get("transfer_spec.0.azure_blob_storage_data_source.0.azure_credentials.0.sas_token"),
 	}
@@ -1114,19 +1128,21 @@ func expandAzureBlobStorageData(azureBlobStorageDatas []interface{}) *storagetra
 	azureBlobStorageData := azureBlobStorageDatas[0].(map[string]interface{})
 
 	return &storagetransfer.AzureBlobStorageData{
-		Container:        azureBlobStorageData["container"].(string),
-		Path:             azureBlobStorageData["path"].(string),
-		StorageAccount:   azureBlobStorageData["storage_account"].(string),
-		AzureCredentials: expandAzureCredentials(azureBlobStorageData["azure_credentials"].([]interface{})),
+		Container:         azureBlobStorageData["container"].(string),
+		Path:              azureBlobStorageData["path"].(string),
+		StorageAccount:    azureBlobStorageData["storage_account"].(string),
+		AzureCredentials:  expandAzureCredentials(azureBlobStorageData["azure_credentials"].([]interface{})),
+		CredentialsSecret: azureBlobStorageData["credentials_secret"].(string),
 	}
 }
 
 func flattenAzureBlobStorageData(azureBlobStorageData *storagetransfer.AzureBlobStorageData, d *schema.ResourceData) []map[string]interface{} {
 	data := map[string]interface{}{
-		"container":         azureBlobStorageData.Container,
-		"path":              azureBlobStorageData.Path,
-		"storage_account":   azureBlobStorageData.StorageAccount,
-		"azure_credentials": flattenAzureCredentials(d),
+		"container":          azureBlobStorageData.Container,
+		"path":               azureBlobStorageData.Path,
+		"storage_account":    azureBlobStorageData.StorageAccount,
+		"azure_credentials":  flattenAzureCredentials(d),
+		"credentials_secret": azureBlobStorageData.CredentialsSecret,
 	}
 
 	return []map[string]interface{}{data}

--- a/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go.erb
+++ b/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package storagetransfer
 
 import (
@@ -50,10 +51,12 @@ var (
 		"transfer_spec.0.aws_s3_data_source.0.aws_access_key",
 		"transfer_spec.0.aws_s3_data_source.0.role_arn",
 	}
+	<% unless version == 'ga' -%>
 	azureOptionCredentials = []string{
 		"transfer_spec.0.azure_blob_storage_data_source.0.azure_credentials",
 		"transfer_spec.0.azure_blob_storage_data_source.0.credentials_secret",
 	}
+	<% end -%>
 )
 
 func ResourceStorageTransferJob() *schema.Resource {
@@ -564,9 +567,13 @@ func azureBlobStorageDataSchema() *schema.Resource {
 			},
 			"azure_credentials": {
 				Type:         schema.TypeList,
+				<% unless version == 'ga' -%>
 				Optional:     true,
-				MaxItems:     1,
 				ExactlyOneOf: azureOptionCredentials,
+				<% else -%>
+				Required:     true,
+				<% end -%>
+				MaxItems:     1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"sas_token": {
@@ -579,12 +586,14 @@ func azureBlobStorageDataSchema() *schema.Resource {
 				},
 				Description: ` Credentials used to authenticate API requests to Azure.`,
 			},
+			<% unless version == 'ga' -%>
 			"credentials_secret": {
 				Optional:     true,
 				Type:         schema.TypeString,
-				Description:  `Optional. The Resource name of a secret in Secret Manager.`,
+				Description:  `The Resource name of a secret in Secret Manager containing SAS Credentials in JSON form. Service Agent must have permissions to access secret. If credentials_secret is specified, do not specify azure_credentials.`,
 				ExactlyOneOf: azureOptionCredentials,
 			},
+			<% end -%>
 		},
 	}
 }
@@ -1110,9 +1119,11 @@ func expandAzureCredentials(azureCredentials []interface{}) *storagetransfer.Azu
 }
 
 func flattenAzureCredentials(d *schema.ResourceData) []map[string]interface{} {
+	<% unless version == 'ga' -%>
 	if d.Get("transfer_spec.0.azure_blob_storage_data_source.0.azure_credentials.0.sas_token") == "" {
 		return []map[string]interface{}{}
 	}
+	<% end -%>
 	data := map[string]interface{}{
 		"sas_token": d.Get("transfer_spec.0.azure_blob_storage_data_source.0.azure_credentials.0.sas_token"),
 	}
@@ -1132,7 +1143,9 @@ func expandAzureBlobStorageData(azureBlobStorageDatas []interface{}) *storagetra
 		Path:              azureBlobStorageData["path"].(string),
 		StorageAccount:    azureBlobStorageData["storage_account"].(string),
 		AzureCredentials:  expandAzureCredentials(azureBlobStorageData["azure_credentials"].([]interface{})),
+		<% unless version == 'ga' -%>
 		CredentialsSecret: azureBlobStorageData["credentials_secret"].(string),
+		<% end -%>
 	}
 }
 
@@ -1142,7 +1155,9 @@ func flattenAzureBlobStorageData(azureBlobStorageData *storagetransfer.AzureBlob
 		"path":               azureBlobStorageData.Path,
 		"storage_account":    azureBlobStorageData.StorageAccount,
 		"azure_credentials":  flattenAzureCredentials(d),
+		<% unless version == 'ga' -%>
 		"credentials_secret": azureBlobStorageData.CredentialsSecret,
+		<% end -%>
 	}
 
 	return []map[string]interface{}{data}

--- a/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
@@ -247,7 +247,9 @@ The `aws_access_key` block supports:
 
 * `path` - (Required) Root path to transfer objects. Must be an empty string or full path name that ends with a '/'. This field is treated as an object prefix. As such, it should generally not begin with a '/'.
 
-* `azure_credentials` - (Required) Credentials used to authenticate API requests to Azure block.
+* `credentials_secret` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Full Resource name of a secret in Secret Manager containing [SAS Credentials in JSON form](https://cloud.google.com/storage-transfer/docs/reference/rest/v1/TransferSpec#azureblobstoragedata:~:text=begin%20with%20a%20%27/%27.-,credentialsSecret,-string). Service Agent for Storage Transfer must have permissions to access secret. If credentials_secret is specified, do not specify azure_credentials.`,
+
+* `azure_credentials` - (Required in GA, Optional in [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Credentials used to authenticate API requests to Azure block.
 
 The `azure_credentials` block supports:
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Modifies the handwritten config for `google_storage_transfer_job` resource to add the `credentials_secret` field in the `azure_blob_storage_data_source` block.

Note the `credentials_secret` field is in preview, so the change will only be present in the beta provider

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/16263

Note to reviewer: There are no existing tests which cover the fields in the`transfer_spec.azure_blob_storage_data_source` block. Please advise on how to proceed! 

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
storagetransferservice: added field `transfer_spec.azure_blob_storage_data_source.credentials_secret` to `google_storage_transfer_job` (beta)
```
