### PR TITLE
Remove iam member resource from project service identity test

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/resource_project_service_identity_test.go.erb
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_project_service_identity_test.go.erb
@@ -3,6 +3,8 @@ package resourcemanager_test
 
 <% unless version == 'ga' -%>
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 
@@ -19,6 +21,13 @@ func TestAccProjectServiceIdentity_basic(t *testing.T) {
 			{
 				Config: testGoogleProjectServiceIdentity_basic(),
 				Check: resource.ComposeTestCheckFunc(
+					// Email field for healthcare service account should be non-empty and contain at least an "@".
+					resource.TestCheckResourceAttrWith("google_project_service_identity.hc_sa", "email", func(value string) error {
+						if strings.Contains(value, "@") {
+							return nil
+						}
+						return fmt.Errorf("hc_sa service identity email value was %s, expected a valid email", value)
+					}),
 					// Email field for logging service identity will be empty for as long as
 					// `gcloud beta services identity create --service=logging.googleapis.com` doesn't return an email address
 					resource.TestCheckNoResourceAttr("google_project_service_identity.log_sa", "email"),
@@ -36,12 +45,6 @@ data "google_project" "project" {}
 resource "google_project_service_identity" "hc_sa" {
   project = data.google_project.project.project_id
   service = "healthcare.googleapis.com"
-}
-
-resource "google_project_iam_member" "hc_sa_bq_jobuser" {
-  project = data.google_project.project.project_id
-  role    = "roles/bigquery.jobUser"
-  member  = "serviceAccount:${google_project_service_identity.hc_sa.email}"
 }
 
 # Service which does NOT have email returned from service identity API


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Contributes to https://github.com/hashicorp/terraform-provider-google/issues/14394

This test has an iam member resource, which means that when it completes it will remove permissions from a project service account needed by another test.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
resolving test conflict, no user impact
```
