### PR TITLE
Add data boost and parallelism input options to google_bigquery_connection

### DIFF
--- a/mmv1/products/bigqueryconnection/Connection.yaml
+++ b/mmv1/products/bigqueryconnection/Connection.yaml
@@ -313,15 +313,15 @@ properties:
           the Cloud Spanner instance configuration. `useParallelism` and `useDataBoost` must be set
           when setting max parallelism.
         required_with:
-          - useDataBoost
-          - useParallelism
+          - cloudSpanner.0.useDataBoost
+          - cloudSpanner.0.useParallelism
       - !ruby/object:Api::Type::Boolean
         name: 'useDataBoost'
         description:
           If set, the request will be executed via Spanner independent compute resources.
           `use_parallelism` must be set when using data boost.
         required_with:
-          - useParallelism
+          - cloudSpanner.0.useParallelism
       - !ruby/object:Api::Type::String
         name: 'databaseRole'
         description:

--- a/mmv1/products/bigqueryconnection/Connection.yaml
+++ b/mmv1/products/bigqueryconnection/Connection.yaml
@@ -111,7 +111,7 @@ examples:
     vars:
       connection_id: 'my-connection'
       database: 'projects/project/instances/instance/databases/database'
-      databse_role: 'database_role'
+      database_role: 'database_role'
   - !ruby/object:Provider::Terraform::Examples
     name: 'bigquery_connection_cloudspanner_databoost'
     pull_external: true

--- a/mmv1/products/bigqueryconnection/Connection.yaml
+++ b/mmv1/products/bigqueryconnection/Connection.yaml
@@ -111,10 +111,10 @@ examples:
     vars:
       connection_id: 'my-connection'
       database: 'projects/project/instances/instance/databases/database'
+      databse_role: 'database_role'
   - !ruby/object:Provider::Terraform::Examples
-    name: 'bigquery_connection_cloudspanner_analytics'
+    name: 'bigquery_connection_cloudspanner_databoost'
     pull_external: true
-    skip_docs: true
     primary_resource_id: 'connection'
     vars:
       connection_id: 'my-connection'
@@ -299,18 +299,48 @@ properties:
       - !ruby/object:Api::Type::String
         name: 'database'
         description:
-          Cloud Spanner database in the form `project/instance/database'
+          Cloud Spanner database in the form `project/instance/database'.
         required: true
       - !ruby/object:Api::Type::Boolean
         name: 'useParallelism'
         description:
-          If parallelism should be used when reading from Cloud Spanner
+          If parallelism should be used when reading from Cloud Spanner.
+      - !ruby/object:Api::Type::Integer
+        name: 'maxParallelism'
+        description:
+          Allows setting max parallelism per query when executing on Spanner independent compute
+          resources. If unspecified, default values of parallelism are chosen that are dependent on
+          the Cloud Spanner instance configuration. `useParallelism` and `useDataBoost` must be set
+          when setting max parallelism.
+        required_with:
+          - useDataBoost
+          - useParallelism
+      - !ruby/object:Api::Type::Boolean
+        name: 'useDataBoost'
+        description:
+          If set, the request will be executed via Spanner independent compute resources.
+          `use_parallelism` must be set when using data boost.
+        required_with:
+          - useParallelism
+      - !ruby/object:Api::Type::String
+        name: 'databaseRole'
+        description:
+          Cloud Spanner database role for fine-grained access control. The Cloud Spanner admin
+          should have provisioned the database role with appropriate permissions, such as `SELECT`
+          and `INSERT`. Other users should only use roles provided by their Cloud Spanner admins.
+          The database role name must start with a letter, and can only contain letters, numbers,
+          and underscores. For more details, see https://cloud.google.com/spanner/docs/fgac-about.
+        validation: !ruby/object:Provider::Terraform::Validation
+          regex: '^[a-zA-Z][a-zA-Z0-9_]*$'
       - !ruby/object:Api::Type::Boolean
         name: 'useServerlessAnalytics'
         description:
           If the serverless analytics service should be used to read data from
-          Cloud Spanner. useParallelism must be set when using serverless
-          analytics
+          Cloud Spanner. `useParallelism` must be set when using serverless
+          analytics.
+        deprecation_message: >-
+          `useServerlessAnalytics` is deprecated and will be removed in a future major release. Use
+          `useDataBoost` instead.
   - !ruby/object:Api::Type::NestedObject
     name: cloudResource
     description:

--- a/mmv1/templates/terraform/examples/bigquery_connection_cloudspanner.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_connection_cloudspanner.tf.erb
@@ -5,5 +5,6 @@ resource "google_bigquery_connection" "<%= ctx[:primary_resource_id] %>" {
    description   = "a riveting description"
    cloud_spanner { 
       database = "<%= ctx[:vars]['database'] %>"
+      database_role = "<%= ctx[:vars]['database_role'] %>"
    }
 }

--- a/mmv1/templates/terraform/examples/bigquery_connection_cloudspanner_databoost.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_connection_cloudspanner_databoost.tf.erb
@@ -4,8 +4,9 @@ resource "google_bigquery_connection" "<%= ctx[:primary_resource_id] %>" {
    friendly_name = "👋"
    description   = "a riveting description"
    cloud_spanner { 
-      database                 = "<%= ctx[:vars]['database'] %>"
-      use_serverless_analytics = true
-      use_parallelism          = true
+      database        = "<%= ctx[:vars]['database'] %>"
+      use_parallelism = true
+      use_data_boost  = true
+      max_parallelism = 100
    }
 }

--- a/mmv1/third_party/terraform/services/bigqueryconnection/resource_bigquery_connection_test.go
+++ b/mmv1/third_party/terraform/services/bigqueryconnection/resource_bigquery_connection_test.go
@@ -282,3 +282,56 @@ resource "google_bigquery_connection" "connection" {
 }
 `, context)
 }
+
+func TestAccBigqueryConnectionConnection_bigqueryConnectionCloudSpannerServerlessAnalyticsToDataBoostUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckBigqueryConnectionConnectionDestroyProducer(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigqueryConnectionConnection_bigqueryConnectionCloudSpannerServerlessAnalytics(context),
+			},
+			{
+				ResourceName:            "google_bigquery_connection.connection",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location"},
+			},
+			{
+				Config: testAccBigqueryConnectionConnection_bigqueryConnectionCloudSpannerDataBoostWithParallelismUpdate(context),
+			},
+			{
+				ResourceName:            "google_bigquery_connection.connection",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location"},
+			},
+		},
+	})
+}
+
+func testAccBigqueryConnectionConnection_bigqueryConnectionCloudSpannerServerlessAnalytics(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_bigquery_connection" "connection" {
+  connection_id = "tf-test-my-connection%{random_suffix}"
+    location      = "US"
+    friendly_name = "👋"
+    description   = "a riveting description"
+    cloud_spanner { 
+      database                 = "projects/project/instances/instance/databases/database"
+      use_parallelism          = true
+      use_serverless_analytics = true
+    }
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/bigqueryconnection/resource_bigquery_connection_test.go
+++ b/mmv1/third_party/terraform/services/bigqueryconnection/resource_bigquery_connection_test.go
@@ -181,15 +181,15 @@ func TestAccBigqueryConnectionConnection_bigqueryConnectionAwsUpdate(t *testing.
 func testAccBigqueryConnectionConnection_bigqueryConnectionAws(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_bigquery_connection" "connection" {
-   connection_id = "tf-test-my-connection%{random_suffix}"
-   location      = "aws-us-east-1"
-   friendly_name = "👋"
-   description   = "a riveting description"
-   aws {
+  connection_id = "tf-test-my-connection%{random_suffix}"
+  location      = "aws-us-east-1"
+  friendly_name = "👋"
+  description   = "a riveting description"
+  aws {
       access_role {
-         iam_role_id =  "arn:aws:iam::999999999999:role/omnirole%{random_suffix}"
+        iam_role_id =  "arn:aws:iam::999999999999:role/omnirole%{random_suffix}"
       }
-   }
+  }
 }
 `, context)
 }
@@ -197,15 +197,88 @@ resource "google_bigquery_connection" "connection" {
 func testAccBigqueryConnectionConnection_bigqueryConnectionAwsUpdate(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_bigquery_connection" "connection" {
-   connection_id = "tf-test-my-connection%{random_suffix}"
-   location      = "aws-us-east-1"
-   friendly_name = "👋"
-   description   = "a riveting description"
-   aws {
+  connection_id = "tf-test-my-connection%{random_suffix}"
+  location      = "aws-us-east-1"
+  friendly_name = "👋"
+  description   = "a riveting description"
+  aws {
       access_role {
-         iam_role_id =  "arn:aws:iam::999999999999:role/omnirole%{random_suffix}update"
+        iam_role_id =  "arn:aws:iam::999999999999:role/omnirole%{random_suffix}update"
       }
-   }
+  }
+}
+`, context)
+}
+
+func TestAccBigqueryConnectionConnection_bigqueryConnectionCloudSpannerDataBoostWithParallelism(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckBigqueryConnectionConnectionDestroyProducer(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigqueryConnectionConnection_bigqueryConnectionCloudSpannerDataBoostWithParallelism(context),
+			},
+			{
+				ResourceName:            "google_bigquery_connection.connection",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location"},
+			},
+			{
+				Config: testAccBigqueryConnectionConnection_bigqueryConnectionCloudSpannerDataBoostWithParallelismUpdate(context),
+			},
+			{
+				ResourceName:            "google_bigquery_connection.connection",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location"},
+			},
+		},
+	})
+}
+
+func testAccBigqueryConnectionConnection_bigqueryConnectionCloudSpannerDataBoostWithParallelism(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_bigquery_connection" "connection" {
+  connection_id = "tf-test-my-connection%{random_suffix}"
+    location      = "US"
+    friendly_name = "👋"
+    description   = "a riveting description"
+    cloud_spanner { 
+      database        = "projects/project/instances/instance/databases/database"
+      use_parallelism = true
+      use_data_boost  = true
+      max_parallelism = 10
+      database_role   = "database_role"
+    }
+}
+`, context)
+}
+
+func testAccBigqueryConnectionConnection_bigqueryConnectionCloudSpannerDataBoostWithParallelismUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_bigquery_connection" "connection" {
+  connection_id = "tf-test-my-connection%{random_suffix}"
+    location      = "US"
+    friendly_name = "👋"
+    description   = "a riveting description"
+    cloud_spanner { 
+      database        = "projects/project/instances/instance/databases/databaseUpdate"
+      use_parallelism = true
+      use_data_boost  = true
+      max_parallelism = 20
+      database_role   = "database_role_update"
+    }
 }
 `, context)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/15650.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigquery: added data boost and parallelism input options to `google_bigquery_connection`
```
