### PR TITLE
Handle bigquery_reservation_capacity_commitment creation when capacity_commitment_id is unspecified

### DIFF
--- a/mmv1/products/bigqueryreservation/CapacityCommitment.yaml
+++ b/mmv1/products/bigqueryreservation/CapacityCommitment.yaml
@@ -27,7 +27,10 @@ references: !ruby/object:Api::Resource::ReferenceLinks
     'Introduction to Reservations': 'https://cloud.google.com/bigquery/docs/reservations-intro'
   api: 'https://cloud.google.com/bigquery/docs/reference/reservations/rest/v1/projects.locations.capacityCommitments'
 id_format: '{{name}}'
-import_format: ['{{name}}']
+import_format:
+  [
+    'projects/{{project}}/locations/{{location}}/capacityCommitments/{{capacity_commitment_id}}',
+  ]
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   constants: templates/terraform/constants/bigquery_reservation_capacity_commitment.go.erb
 examples:

--- a/mmv1/products/bigqueryreservation/CapacityCommitment.yaml
+++ b/mmv1/products/bigqueryreservation/CapacityCommitment.yaml
@@ -33,6 +33,7 @@ import_format:
   ]
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   constants: templates/terraform/constants/bigquery_reservation_capacity_commitment.go.erb
+  custom_import: templates/terraform/custom_import/bigquery_reservation_capacity_commitment_set_id.go.erb
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'bigquery_reservation_capacity_commitment_basic'

--- a/mmv1/products/bigqueryreservation/CapacityCommitment.yaml
+++ b/mmv1/products/bigqueryreservation/CapacityCommitment.yaml
@@ -15,7 +15,7 @@
 name: 'CapacityCommitment'
 base_url: projects/{{project}}/locations/{{location}}/capacityCommitments
 create_url: projects/{{project}}/locations/{{location}}/capacityCommitments?capacityCommitmentId={{capacity_commitment_id}}
-self_link: 'projects/{{project}}/locations/{{location}}/capacityCommitments/{{capacity_commitment_id}}'
+self_link: '{{name}}'
 update_verb: :PATCH
 update_mask: true
 description: |
@@ -26,16 +26,18 @@ references: !ruby/object:Api::Resource::ReferenceLinks
   guides:
     'Introduction to Reservations': 'https://cloud.google.com/bigquery/docs/reservations-intro'
   api: 'https://cloud.google.com/bigquery/docs/reference/reservations/rest/v1/projects.locations.capacityCommitments'
-id_format: 'projects/{{project}}/locations/{{location}}/capacityCommitments/{{capacity_commitment_id}}'
-import_format:
-  [
-    'projects/{{project}}/locations/{{location}}/capacityCommitments/{{capacity_commitment_id}}',
-  ]
+id_format: '{{name}}'
+import_format: ['{{name}}']
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   constants: templates/terraform/constants/bigquery_reservation_capacity_commitment.go.erb
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'bigquery_reservation_capacity_commitment_basic'
+    pull_external: true
+    skip_docs: true
+    primary_resource_id: 'commitment'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'bigquery_reservation_capacity_commitment_no_id'
     pull_external: true
     skip_docs: true
     primary_resource_id: 'commitment'
@@ -102,7 +104,7 @@ properties:
   - !ruby/object:Api::Type::String
     name: 'renewalPlan'
     description: |
-      The plan this capacity commitment is converted to after commitmentEndTime passes. Once the plan is changed, committed period is extended according to commitment plan. Only applicable some commitment plans.
+      The plan this capacity commitment is converted to after commitmentEndTime passes. Once the plan is changed, committed period is extended according to commitment plan. Only applicable for some commitment plans.
   - !ruby/object:Api::Type::String
     name: 'edition'
     immutable: true

--- a/mmv1/templates/terraform/custom_import/bigquery_reservation_capacity_commitment_set_id.go.erb
+++ b/mmv1/templates/terraform/custom_import/bigquery_reservation_capacity_commitment_set_id.go.erb
@@ -1,0 +1,22 @@
+config := meta.(*transport_tpg.Config)
+if err := tpgresource.ParseImportId([]string{
+  "^projects/(?P<project>[^/]+)/locations/(?P<location>[^/]+)/capacityCommitments/(?P<capacity_commitment_id>[^/]+)$",
+  "^(?P<project>[^/]+)/(?P<location>[^/]+)/(?P<capacity_commitment_id>[^/]+)$",
+  "^(?P<location>[^/]+)/(?P<capacity_commitment_id>[^/]+)$",
+}, d, config); err != nil {
+  return nil, err
+}
+
+// Set name based on the components
+if err := d.Set("name", "projects/{{project}}/locations/{{location}}/capacityCommitments/{{capacity_commitment_id}}"); err != nil {
+  return nil, fmt.Errorf("Error setting name: %s", err)
+}
+
+// Replace import id for the resource id
+id, err := tpgresource.ReplaceVars(d, config, d.Get("name").(string))
+if err != nil {
+  return nil, fmt.Errorf("Error constructing id: %s", err)
+}
+d.SetId(id)
+
+return []*schema.ResourceData{d}, nil

--- a/mmv1/templates/terraform/examples/bigquery_reservation_capacity_commitment_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_reservation_capacity_commitment_basic.tf.erb
@@ -1,15 +1,15 @@
 resource "google_bigquery_capacity_commitment" "<%= ctx[:primary_resource_id] %>" {
-	capacity_commitment_id = "capacity-tf-test%{random_suffix}"
+  capacity_commitment_id = "capacity-tf-test%{random_suffix}"
 
-	location   = "us-west2"
-	slot_count = 100
-	plan       = "FLEX_FLAT_RATE"
-	edition    = "ENTERPRISE"
+  location   = "us-west2"
+  slot_count = 100
+  plan       = "FLEX_FLAT_RATE"
+  edition    = "ENTERPRISE"
 }
 
 resource "time_sleep" "wait_61_seconds" {
 	depends_on = [google_bigquery_capacity_commitment.<%= ctx[:primary_resource_id] %>]
-    
+
 	# Only needed for CI tests to be able to tear down the commitment once it's expired
-    create_duration = "61s"
+  create_duration = "61s"
 }

--- a/mmv1/templates/terraform/examples/bigquery_reservation_capacity_commitment_no_id.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_reservation_capacity_commitment_no_id.tf.erb
@@ -9,5 +9,5 @@ resource "time_sleep" "wait_61_seconds" {
   depends_on = [google_bigquery_capacity_commitment.<%= ctx[:primary_resource_id] %>]
 
   # Only needed for CI tests to be able to tear down the commitment once it's expired
-    create_duration = "61s"
+  create_duration = "61s"
 }

--- a/mmv1/templates/terraform/examples/bigquery_reservation_capacity_commitment_no_id.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_reservation_capacity_commitment_no_id.tf.erb
@@ -1,13 +1,13 @@
 resource "google_bigquery_capacity_commitment" "<%= ctx[:primary_resource_id] %>" {
-	location   = "us-west2"
-	slot_count = 100
-	plan       = "FLEX_FLAT_RATE"
-	edition    = "ENTERPRISE"
+  location   = "us-west2"
+  slot_count = 100
+  plan       = "FLEX_FLAT_RATE"
+  edition    = "ENTERPRISE"
 }
 
 resource "time_sleep" "wait_61_seconds" {
-	depends_on = [google_bigquery_capacity_commitment.<%= ctx[:primary_resource_id] %>]
-    
-	# Only needed for CI tests to be able to tear down the commitment once it's expired
+  depends_on = [google_bigquery_capacity_commitment.<%= ctx[:primary_resource_id] %>]
+
+  # Only needed for CI tests to be able to tear down the commitment once it's expired
     create_duration = "61s"
 }

--- a/mmv1/templates/terraform/examples/bigquery_reservation_capacity_commitment_no_id.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_reservation_capacity_commitment_no_id.tf.erb
@@ -1,0 +1,13 @@
+resource "google_bigquery_capacity_commitment" "<%= ctx[:primary_resource_id] %>" {
+	location   = "us-west2"
+	slot_count = 100
+	plan       = "FLEX_FLAT_RATE"
+	edition    = "ENTERPRISE"
+}
+
+resource "time_sleep" "wait_61_seconds" {
+	depends_on = [google_bigquery_capacity_commitment.<%= ctx[:primary_resource_id] %>]
+    
+	# Only needed for CI tests to be able to tear down the commitment once it's expired
+    create_duration = "61s"
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/16204.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigqueryreservation: fixed bug of incorrect resource recreation when `capacity_commitment_id` is unspecified in resource `bigquery_reservation_capacity_commitment`
```
