### PR TITLE
Update links for RELEASE_NOTES_GUIDE

### DIFF
--- a/tools/go-changelog/cmd/changelog-pr-body-check/main.go
+++ b/tools/go-changelog/cmd/changelog-pr-body-check/main.go
@@ -63,7 +63,7 @@ func main() {
 		case changelog.EntryErrorNotFound:
 			body := "Oops! It looks like no changelog entry is attached to" +
 				" this PR. Please include a release note block" +
-				" in the PR body, as described in https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md:" +
+				" in the PR body, as described in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/:" +
 				"\n\n~~~\n```release-note:TYPE\nRelease note" +
 				"\n```\n~~~"
 			log.Fatal(body)
@@ -82,7 +82,7 @@ func main() {
 			for _, t := range unknownTypes {
 				body += "\n* " + t
 			}
-			body += "\n\nPlease only use the types listed in https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md."
+			body += "\n\nPlease only use the types listed in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/."
 			log.Fatal(body)
 		}
 	}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The link that appeared when I made the correction to https://github.com/GoogleCloudPlatform/magic-modules/pull/9288 seemed to be a mistake, so I fixed it.

- https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md was a dead link when the branch name was changed from master to main. It is still there.
- https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md was scheduled to be removed, so I fixed link to https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement

```
