### PR TITLE
Copy magician dependencies to the container image

### DIFF
--- a/.ci/containers/go-plus/Dockerfile
+++ b/.ci/containers/go-plus/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app1/magic-modules-main/.ci/magician
 # Build the binary (we won't use it in the final image, but it's cached)
 RUN go build -o /dev/null .
 
-# Stage 2: Creating the final imag
+# Stage 2: Creating the final image
 FROM golang:1.19-bullseye
 SHELL ["/bin/bash", "-c"]
 ENV GOCACHE=/go/cache

--- a/.ci/containers/go-plus/Dockerfile
+++ b/.ci/containers/go-plus/Dockerfile
@@ -1,5 +1,18 @@
-from golang:1.19-bullseye as resource
+# Stage 1: Download go module cache for builds
+FROM golang:1.19-bullseye AS builder
+
+WORKDIR /app1
+ADD "https://raw.githubusercontent.com/GoogleCloudPlatform/magic-modules/main/.ci/magician/go.mod" go.mod
+ADD "https://raw.githubusercontent.com/GoogleCloudPlatform/magic-modules/main/.ci/magician/go.sum" go.sum
+RUN go mod download
+
+# Stage 2: Creating the final imag
+FROM golang:1.19-bullseye
 SHELL ["/bin/bash", "-c"]
+
+# Copy Go dependencies from builder
+COPY --from=builder /go/pkg/mod /go/pkg/mod
+
 # Set up Github SSH cloning.
 RUN ssh-keyscan github.com >> /known_hosts
 RUN echo "UserKnownHostsFile /known_hosts" >> /etc/ssh/ssh_config

--- a/.ci/containers/go-plus/Dockerfile
+++ b/.ci/containers/go-plus/Dockerfile
@@ -1,17 +1,24 @@
 # Stage 1: Download go module cache for builds
 FROM golang:1.19-bullseye AS builder
+ENV GOCACHE=/go/cache
 
+RUN apt-get update && apt-get install -y unzip
 WORKDIR /app1
-ADD "https://raw.githubusercontent.com/GoogleCloudPlatform/magic-modules/main/.ci/magician/go.mod" go.mod
-ADD "https://raw.githubusercontent.com/GoogleCloudPlatform/magic-modules/main/.ci/magician/go.sum" go.sum
-RUN go mod download
+# Add the source code and build
+ADD "https://github.com/GoogleCloudPlatform/magic-modules/archive/refs/heads/main.zip" source.zip
+RUN unzip source.zip && rm source.zip
+WORKDIR /app1/magic-modules-main/.ci/magician
+# Build the binary (we won't use it in the final image, but it's cached)
+RUN go build -o /dev/null .
 
 # Stage 2: Creating the final imag
 FROM golang:1.19-bullseye
 SHELL ["/bin/bash", "-c"]
+ENV GOCACHE=/go/cache
 
-# Copy Go dependencies from builder
+# Copy Go dependencies and Go build cache
 COPY --from=builder /go/pkg/mod /go/pkg/mod
+COPY --from=builder /go/cache /go/cache
 
 # Set up Github SSH cloning.
 RUN ssh-keyscan github.com >> /known_hosts

--- a/.ci/scripts/go-plus/magician/exec.sh
+++ b/.ci/scripts/go-plus/magician/exec.sh
@@ -1,20 +1,28 @@
 #!/bin/bash
 
-# Check if there's at least one argument
-if [ "$#" -eq 0 ]; then
-    echo "No arguments provided"
-    exit 1
-fi
-
 # Get the directory of the current script
 DIR="$(dirname $(realpath $0))"
 
-# Construct the path to the Go program
-GO_PROGRAM="$DIR/../../../magician/"
+# Construct the path to the Go program directory and binary
+GO_PROGRAM_DIR="$DIR/../../../magician/"
+GO_BINARY="$GO_PROGRAM_DIR/magician_binary"
 
-pushd $GO_PROGRAM
+pushd $GO_PROGRAM_DIR
 
 set -x
-# Pass all arguments to the child command
-go run . "$@"
+# Check if the binary exists
+if [ ! -f "$GO_BINARY" ]; then
+    # If it doesn't exist, compile the binary
+    echo "Building the magician binary at $GO_BINARY"
+    go build -o "$GO_BINARY"
+fi
+
+# If there are no arguments only compile the binary
+if [ "$#" -eq 0 ]; then
+    echo "No arguments provided"
+    exit 0
+fi
+
+# Run the binary and pass all arguments
+$GO_BINARY "$@"
 set +x


### PR DESCRIPTION
I've made serval improvements to the magician build. 

1. only build binary once
2. copy cache and go pkg data for magician build to the container image.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
