### PR TITLE
Add admin_groups field to the containerattached  resource.

### DIFF
--- a/mmv1/products/containerattached/Cluster.yaml
+++ b/mmv1/products/containerattached/Cluster.yaml
@@ -296,6 +296,16 @@ properties:
           For more info on RBAC, see
           https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles
         item_type: Api::Type::String
+      - !ruby/object:Api::Type::Array
+        name: adminGroups
+        description: |
+          Groups that can perform operations as a cluster admin. A managed
+          ClusterRoleBinding will be created to grant the `cluster-admin` ClusterRole
+          to the groups. Up to ten admin groups can be provided.
+
+          For more info on RBAC, see
+          https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles
+        item_type: Api::Type::String
   - !ruby/object:Api::Type::NestedObject
     name: monitoringConfig
     description: |

--- a/mmv1/templates/terraform/custom_expand/containerattached_cluster_authorization_user.go.erb
+++ b/mmv1/templates/terraform/custom_expand/containerattached_cluster_authorization_user.go.erb
@@ -17,11 +17,19 @@ type attachedClusterUser struct {
     Username string     `json:"username"`
 }
 
+type attachedClusterGroup struct {
+		Group string				`json:"group"`
+}
+
 // The custom expander transforms input into something like this:
 // authorization {
 //    admin_users [
 //      { username = "user1" },
 //      { username = "user2" }
+//    ]
+//    admin_groups [
+//      { group = "group1" },
+//      { group = "group2" },
 //    ]
 // }
 // The custom flattener transforms input back into something like this:
@@ -30,19 +38,30 @@ type attachedClusterUser struct {
 //      "user1",
 //      "user2"
 //    ]
+//    admin_groups = [
+//      "group1",
+//      "group2"
+//    ],
 // }
 func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
-  	l := v.([]interface{})
+  l := v.([]interface{})
 	if len(l) == 0 || l[0] == nil {
 		return nil, nil
 	}
-  	raw := l[0]
+	raw := l[0]
 	orig := raw.(map[string]interface{})["admin_users"].([]interface{})
 	transformed := make(map[string][]interface{})
 	transformed["admin_users"] = make([]interface{}, len(orig))
 	for i, u := range orig {
 		if u != nil {
 			transformed["admin_users"][i] = attachedClusterUser{ Username: u.(string) }
+		}
+	}
+	orig = raw.(map[string]interface{})["admin_groups"].([]interface{})
+	transformed["admin_groups"] = make([]interface{}, len(orig))
+	for i, u := range orig {
+		if u != nil {
+			transformed["admin_groups"][i] = attachedClusterGroup{ Group: u.(string) }
 		}
 	}
 	return transformed, nil

--- a/mmv1/templates/terraform/custom_expand/containerattached_cluster_authorization_user.go.erb
+++ b/mmv1/templates/terraform/custom_expand/containerattached_cluster_authorization_user.go.erb
@@ -44,7 +44,7 @@ type attachedClusterGroup struct {
 //    ],
 // }
 func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
-  l := v.([]interface{})
+	l := v.([]interface{})
 	if len(l) == 0 || l[0] == nil {
 		return nil, nil
 	}

--- a/mmv1/templates/terraform/custom_flatten/containerattached_cluster_authorization_user.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/containerattached_cluster_authorization_user.go.erb
@@ -19,6 +19,10 @@
 //      { username = "user1" },
 //      { username = "user2" }
 //    ]
+//    admin_groups [
+//      { group = "group1" },
+//      { group = "group2" },
+//    ]
 // }
 // The custom flattener transforms input back into something like this:
 // authorization {
@@ -26,6 +30,10 @@
 //      "user1",
 //      "user2"
 //    ]
+//    admin_groups = [
+//      "group1",
+//      "group2"
+//    ],
 // }
 func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
     if v == nil {
@@ -38,6 +46,13 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d 
 	for i, u := range orig {
 		if u != nil {
 			transformed["admin_users"][i] = u.(map[string]interface{})["username"].(string)
+		}
+	}
+	orig = v.(map[string]interface{})["adminGroups"].([]interface{})
+	transformed["admin_groups"] = make([]string, len(orig))
+	for i, u := range orig {
+		if u != nil {
+			transformed["admin_groups"][i] = u.(map[string]interface{})["group"].(string)
 		}
 	}
 

--- a/mmv1/templates/terraform/examples/container_attached_cluster_full.tf.erb
+++ b/mmv1/templates/terraform/examples/container_attached_cluster_full.tf.erb
@@ -17,6 +17,7 @@ resource "google_container_attached_cluster" "primary" {
   }
   authorization {
     admin_users = [ "user1@example.com", "user2@example.com"]
+    admin_groups = [ "group1@example.com", "group2@example.com"]
   }
   oidc_config {
       issuer_url = "https://oidc.issuer.url"

--- a/mmv1/templates/terraform/pre_update/containerattached_update.go.erb
+++ b/mmv1/templates/terraform/pre_update/containerattached_update.go.erb
@@ -1,7 +1,10 @@
 // The generated code sets the wrong masks for the following fields.
 newUpdateMask := []string{}
-if d.HasChange("authorization") {
+if d.HasChange("authorization.0.admin_users") {
     newUpdateMask = append(newUpdateMask, "authorization.admin_users")
+}
+if d.HasChange("authorization.0.admin_groups") {
+    newUpdateMask = append(newUpdateMask, "authorization.admin_groups")
 }
 if d.HasChange("logging_config") {
     newUpdateMask = append(newUpdateMask, "logging_config.component_config.enable_components")

--- a/mmv1/third_party/terraform/services/containerattached/resource_container_attached_cluster_update_test.go
+++ b/mmv1/third_party/terraform/services/containerattached/resource_container_attached_cluster_update_test.go
@@ -71,6 +71,7 @@ resource "google_container_attached_cluster" "primary" {
   }
   authorization {
     admin_users = [ "user1@example.com", "user2@example.com"]
+    admin_groups = [ "group1@example.com", "group2@example.com"]
   }
   oidc_config {
       issuer_url = "https://oidc.issuer.url"
@@ -119,6 +120,7 @@ resource "google_container_attached_cluster" "primary" {
   }
   authorization {
     admin_users = [ "user2@example.com", "user3@example.com"]
+    admin_groups = [ "group3@example.com"]
   }
   oidc_config {
       issuer_url = "https://oidc.issuer.url"
@@ -165,6 +167,7 @@ resource "google_container_attached_cluster" "primary" {
   }
   authorization {
     admin_users = [ "user2@example.com", "user3@example.com"]
+    admin_groups = [ "group3@example.com"]
   }
   oidc_config {
       issuer_url = "https://oidc.issuer.url"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add `admin_groups` field to the `containerattached`  resource.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
containerattached: added `admin_groups` field to `google_container_attached_cluster` resource
```
