### PR TITLE
Set labels and annotations fields in cloudrunv2 data sources

### DIFF
--- a/mmv1/third_party/terraform/services/cloudrunv2/data_source_google_cloud_run_v2_job.go
+++ b/mmv1/third_party/terraform/services/cloudrunv2/data_source_google_cloud_run_v2_job.go
@@ -37,6 +37,14 @@ func dataSourceGoogleCloudRunV2JobRead(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
+	if err := tpgresource.SetDataSourceLabels(d); err != nil {
+		return err
+	}
+
+	if err := tpgresource.SetDataSourceAnnotations(d); err != nil {
+		return err
+	}
+
 	if d.Id() == "" {
 		return fmt.Errorf("%s not found", id)
 	}

--- a/mmv1/third_party/terraform/services/cloudrunv2/data_source_google_cloud_run_v2_job_test.go
+++ b/mmv1/third_party/terraform/services/cloudrunv2/data_source_google_cloud_run_v2_job_test.go
@@ -48,6 +48,14 @@ resource "google_cloud_run_v2_job" "hello" {
     }
   }
 
+  labels = {
+    "key" = "value"
+  }
+
+  annotations = {
+    "key" = "value"
+  }
+
   lifecycle {
     ignore_changes = [
       launch_stage,

--- a/mmv1/third_party/terraform/services/cloudrunv2/data_source_google_cloud_run_v2_service.go
+++ b/mmv1/third_party/terraform/services/cloudrunv2/data_source_google_cloud_run_v2_service.go
@@ -37,6 +37,14 @@ func dataSourceGoogleCloudRunV2ServiceRead(d *schema.ResourceData, meta interfac
 		return err
 	}
 
+	if err := tpgresource.SetDataSourceLabels(d); err != nil {
+		return err
+	}
+
+	if err := tpgresource.SetDataSourceAnnotations(d); err != nil {
+		return err
+	}
+
 	if d.Id() == "" {
 		return fmt.Errorf("%s not found", id)
 	}

--- a/mmv1/third_party/terraform/services/cloudrunv2/data_source_google_cloud_run_v2_service_test.go
+++ b/mmv1/third_party/terraform/services/cloudrunv2/data_source_google_cloud_run_v2_service_test.go
@@ -46,6 +46,14 @@ resource "google_cloud_run_v2_service" "hello" {
       image = "us-docker.pkg.dev/cloudrun/container/hello"
     }
   }
+
+  labels = {
+    "key" = "value"
+  }
+
+  annotations = {
+    "key" = "value"
+  }
 }
 
 data "google_cloud_run_v2_service" "hello" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
cloudrunv2: set fields `labels` and `terraform_labels` having all of labels present on the resource in GCP in data source `google_cloud_run_v2_service`
```

```release-note:bug
cloudrunv2: set field `annotations` having all of annotations present on the resource in GCP in data source `google_cloud_run_v2_service`
```

```release-note:bug
cloudrunv2: set fields `labels` and `terraform_labels` having all of labels present on the resource in GCP in data source `google_cloud_run_v2_job`
```

```release-note:bug
cloudrunv2: set field `annotations` having all of annotations present on the resource in GCP in data source `google_cloud_run_v2_job`
```
