### PR TITLE
Use a GPU with higher quota in nodepool accelerator tests

### DIFF
--- a/mmv1/templates/terraform/examples/workstation_config_accelerators.tf.erb
+++ b/mmv1/templates/terraform/examples/workstation_config_accelerators.tf.erb
@@ -40,7 +40,7 @@ resource "google_workstations_workstation_config" "<%= ctx[:primary_resource_id]
       boot_disk_size_gb           = 35
       disable_public_ip_addresses = true
       accelerators {
-        type  = "nvidia-tesla-p100"
+        type  = "nvidia-tesla-t4"
         count = "1"
       }
     }

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -1593,7 +1593,7 @@ resource "google_container_node_pool" "np" {
     machine_type = "n1-standard-8"
     image_type = "COS_CONTAINERD"
     guest_accelerator {
-      type  = "nvidia-tesla-p100"
+      type  = "nvidia-tesla-t4"
       count = 1
       }
     gvnic {
@@ -3173,7 +3173,7 @@ resource "google_container_node_pool" "np" {
   node_config {
     guest_accelerator {
       count = 1
-      type  = "nvidia-tesla-p100"
+      type  = "nvidia-tesla-t4"
     }
 	machine_type = "n1-highmem-4"
   }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
fixes https://github.com/hashicorp/terraform-provider-google/issues/16165

limited `nvidia-tesla-p100` GPUs to just `TestAccContainerNodePool_EmptyGuestAccelerator` configs

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
