### PR TITLE
bootstrap network for dataproc tests

### DIFF
--- a/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
+++ b/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
@@ -1040,6 +1040,74 @@ func BootstrapNetworkAttachment(t *testing.T, networkAttachmentName string, subn
 	return networkAttachment.Name
 }
 
+const SharedTestFirewallPrefix = "tf-bootstrap-firewall-"
+
+func BootstrapFirewallForDataprocSharedNetwork(t *testing.T, firewallName string, networkName string) {
+	project := envvar.GetTestProjectFromEnv()
+	firewallName = SharedTestFirewallPrefix + firewallName
+
+	config := BootstrapConfig(t)
+	if config == nil {
+		return
+	}
+
+	log.Printf("[DEBUG] Getting Firewall %q for Network %q", firewallName, networkName)
+	_, err := config.NewComputeClient(config.UserAgent).Firewalls.Get(project, firewallName).Do()
+	if err != nil && transport_tpg.IsGoogleApiErrorWithCode(err, 404) {
+		log.Printf("[DEBUG] firewallName %q not found, bootstrapping", firewallName)
+		url := fmt.Sprintf("%sprojects/%s/global/firewalls", config.ComputeBasePath, project)
+
+		networkId := fmt.Sprintf("projects/%s/global/networks/%s", project, networkName)
+		allowObj := []interface{}{
+			map[string]interface{}{
+				"IPProtocol": "icmp",
+			},
+			map[string]interface{}{
+				"IPProtocol": "tcp",
+				"ports":      []string{"0-65535"},
+			},
+			map[string]interface{}{
+				"IPProtocol": "udp",
+				"ports":      []string{"0-65535"},
+			},
+		}
+
+		firewallObj := map[string]interface{}{
+			"name":    firewallName,
+			"network": networkId,
+			"allowed": allowObj,
+		}
+
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: config.UserAgent,
+			Body:      firewallObj,
+			Timeout:   4 * time.Minute,
+		})
+		if err != nil {
+			t.Fatalf("Error bootstrapping Firewall %q for Network %q: %s", firewallName, networkName, err)
+		}
+
+		log.Printf("[DEBUG] Waiting for Firewall creation to finish")
+		err = tpgcompute.ComputeOperationWaitTime(config, res, project, "Error bootstrapping Firewall", config.UserAgent, 4*time.Minute)
+		if err != nil {
+			t.Fatalf("Error bootstrapping Firewall %q: %s", firewallName, err)
+		}
+	}
+
+	firewall, err := config.NewComputeClient(config.UserAgent).Firewalls.Get(project, firewallName).Do()
+	if err != nil {
+		t.Errorf("Error getting Firewall %q: %s", firewallName, err)
+	}
+	if firewall == nil {
+		t.Fatalf("Error getting Firewall %q: is nil", firewallName)
+	}
+	return
+}
+
 func SetupProjectsAndGetAccessToken(org, billing, pid, service string, config *transport_tpg.Config) (string, error) {
 	// Create project-1 and project-2
 	rmService := config.NewResourceManagerClient(config.UserAgent)

--- a/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
+++ b/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
@@ -1040,6 +1040,11 @@ func BootstrapNetworkAttachment(t *testing.T, networkAttachmentName string, subn
 	return networkAttachment.Name
 }
 
+// The default network within GCP already comes pre configured with
+// certain firewall rules open to allow internal communication. As we
+// are boostrapping a network for dataproc tests, we need to additionally
+// open up similar rules to allow the nodes to talk to each other
+// internally as part of their configuration or this will just hang.
 const SharedTestFirewallPrefix = "tf-bootstrap-firewall-"
 
 func BootstrapFirewallForDataprocSharedNetwork(t *testing.T, firewallName string, networkName string) {

--- a/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
+++ b/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
@@ -1047,13 +1047,13 @@ func BootstrapNetworkAttachment(t *testing.T, networkAttachmentName string, subn
 // internally as part of their configuration or this will just hang.
 const SharedTestFirewallPrefix = "tf-bootstrap-firewall-"
 
-func BootstrapFirewallForDataprocSharedNetwork(t *testing.T, firewallName string, networkName string) {
+func BootstrapFirewallForDataprocSharedNetwork(t *testing.T, firewallName string, networkName string) string {
 	project := envvar.GetTestProjectFromEnv()
 	firewallName = SharedTestFirewallPrefix + firewallName
 
 	config := BootstrapConfig(t)
 	if config == nil {
-		return
+		return ""
 	}
 
 	log.Printf("[DEBUG] Getting Firewall %q for Network %q", firewallName, networkName)
@@ -1110,7 +1110,7 @@ func BootstrapFirewallForDataprocSharedNetwork(t *testing.T, firewallName string
 	if firewall == nil {
 		t.Fatalf("Error getting Firewall %q: is nil", firewallName)
 	}
-	return
+	return firewall.Name
 }
 
 func SetupProjectsAndGetAccessToken(org, billing, pid, service string, config *transport_tpg.Config) (string, error) {

--- a/mmv1/third_party/terraform/services/dataproc/iam_dataproc_cluster_test.go
+++ b/mmv1/third_party/terraform/services/dataproc/iam_dataproc_cluster_test.go
@@ -230,9 +230,7 @@ resource "google_dataproc_cluster" "cluster" {
     gce_cluster_config {
       subnetwork = "%s"
     }
-  }
-
-  cluster_config {
+      
     # Keep the costs down with smallest config we can get away with
     software_config {
       override_properties = {

--- a/mmv1/third_party/terraform/services/dataproc/iam_dataproc_cluster_test.go
+++ b/mmv1/third_party/terraform/services/dataproc/iam_dataproc_cluster_test.go
@@ -16,6 +16,10 @@ func TestAccDataprocClusterIamBinding(t *testing.T) {
 	account := "tf-dataproc-iam-" + acctest.RandString(t, 10)
 	role := "roles/editor"
 
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	importId := fmt.Sprintf("projects/%s/regions/%s/clusters/%s %s",
 		envvar.GetTestProjectFromEnv(), "us-central1", cluster, role)
 
@@ -25,7 +29,7 @@ func TestAccDataprocClusterIamBinding(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Test IAM Binding creation
-				Config: testAccDataprocClusterIamBinding_basic(cluster, account, role),
+				Config: testAccDataprocClusterIamBinding_basic(cluster, subnetworkName, account, role),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"google_dataproc_cluster_iam_binding.binding", "role", role),
@@ -39,7 +43,7 @@ func TestAccDataprocClusterIamBinding(t *testing.T) {
 			},
 			{
 				// Test IAM Binding update
-				Config: testAccDataprocClusterIamBinding_update(cluster, account, role),
+				Config: testAccDataprocClusterIamBinding_update(cluster, subnetworkName, account, role),
 			},
 			{
 				ResourceName:      "google_dataproc_cluster_iam_binding.binding",
@@ -58,6 +62,10 @@ func TestAccDataprocClusterIamMember(t *testing.T) {
 	account := "tf-dataproc-iam-" + acctest.RandString(t, 10)
 	role := "roles/editor"
 
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	importId := fmt.Sprintf("projects/%s/regions/%s/clusters/%s %s serviceAccount:%s",
 		envvar.GetTestProjectFromEnv(),
 		"us-central1",
@@ -71,7 +79,7 @@ func TestAccDataprocClusterIamMember(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Test IAM Binding creation
-				Config: testAccDataprocClusterIamMember(cluster, account, role),
+				Config: testAccDataprocClusterIamMember(cluster, subnetworkName, account, role),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"google_dataproc_cluster_iam_member.member", "role", role),
@@ -96,6 +104,10 @@ func TestAccDataprocClusterIamPolicy(t *testing.T) {
 	account := "tf-dataproc-iam-" + acctest.RandString(t, 10)
 	role := "roles/editor"
 
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	importId := fmt.Sprintf("projects/%s/regions/%s/clusters/%s",
 		envvar.GetTestProjectFromEnv(), "us-central1", cluster)
 
@@ -105,7 +117,7 @@ func TestAccDataprocClusterIamPolicy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Test IAM Binding creation
-				Config: testAccDataprocClusterIamPolicy(cluster, account, role),
+				Config: testAccDataprocClusterIamPolicy(cluster, subnetworkName, account, role),
 				Check:  resource.TestCheckResourceAttrSet("data.google_dataproc_cluster_iam_policy.policy", "policy_data"),
 			},
 			{
@@ -118,7 +130,7 @@ func TestAccDataprocClusterIamPolicy(t *testing.T) {
 	})
 }
 
-func testAccDataprocClusterIamBinding_basic(cluster, account, role string) string {
+func testAccDataprocClusterIamBinding_basic(cluster, subnetworkName, account, role string) string {
 	return fmt.Sprintf(testDataprocIamSingleNodeCluster+`
 resource "google_service_account" "test-account1" {
   account_id   = "%s-1"
@@ -138,10 +150,10 @@ resource "google_dataproc_cluster_iam_binding" "binding" {
     "serviceAccount:${google_service_account.test-account1.email}",
   ]
 }
-`, cluster, account, account, role)
+`, cluster, subnetworkName, account, account, role)
 }
 
-func testAccDataprocClusterIamBinding_update(cluster, account, role string) string {
+func testAccDataprocClusterIamBinding_update(cluster, subnetworkName, account, role string) string {
 	return fmt.Sprintf(testDataprocIamSingleNodeCluster+`
 resource "google_service_account" "test-account1" {
   account_id   = "%s-1"
@@ -162,10 +174,10 @@ resource "google_dataproc_cluster_iam_binding" "binding" {
     "serviceAccount:${google_service_account.test-account2.email}",
   ]
 }
-`, cluster, account, account, role)
+`, cluster, subnetworkName, account, account, role)
 }
 
-func testAccDataprocClusterIamMember(cluster, account, role string) string {
+func testAccDataprocClusterIamMember(cluster, subnetworkName, account, role string) string {
 	return fmt.Sprintf(testDataprocIamSingleNodeCluster+`
 resource "google_service_account" "test-account" {
   account_id   = "%s"
@@ -177,10 +189,10 @@ resource "google_dataproc_cluster_iam_member" "member" {
   role    = "%s"
   member  = "serviceAccount:${google_service_account.test-account.email}"
 }
-`, cluster, account, role)
+`, cluster, subnetworkName, account, role)
 }
 
-func testAccDataprocClusterIamPolicy(cluster, account, role string) string {
+func testAccDataprocClusterIamPolicy(cluster, subnetworkName, account, role string) string {
 	return fmt.Sprintf(testDataprocIamSingleNodeCluster+`
 resource "google_service_account" "test-account" {
   account_id   = "%s"
@@ -205,7 +217,7 @@ data "google_dataproc_cluster_iam_policy" "policy" {
   region      = "us-central1"
 }
 
-`, cluster, account, role)
+`, cluster, subnetworkName, account, role)
 }
 
 // Smallest cluster possible for testing
@@ -213,6 +225,12 @@ var testDataprocIamSingleNodeCluster = `
 resource "google_dataproc_cluster" "cluster" {
   name   = "%s"
   region = "us-central1"
+
+  cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+  }
 
   cluster_config {
     # Keep the costs down with smallest config we can get away with

--- a/mmv1/third_party/terraform/services/dataproc/iam_dataproc_job_test.go
+++ b/mmv1/third_party/terraform/services/dataproc/iam_dataproc_job_test.go
@@ -17,6 +17,10 @@ func TestAccDataprocJobIamBinding(t *testing.T) {
 	account := "tf-dataproc-iam-" + acctest.RandString(t, 10)
 	role := "roles/editor"
 
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	importId := fmt.Sprintf("projects/%s/regions/%s/jobs/%s %s",
 		envvar.GetTestProjectFromEnv(), "us-central1", job, role)
 
@@ -26,7 +30,7 @@ func TestAccDataprocJobIamBinding(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Test IAM Binding creation
-				Config: testAccDataprocJobIamBinding_basic(cluster, job, account, role),
+				Config: testAccDataprocJobIamBinding_basic(cluster, subnetworkName, job, account, role),
 			},
 			{
 				ResourceName:      "google_dataproc_job_iam_binding.binding",
@@ -36,7 +40,7 @@ func TestAccDataprocJobIamBinding(t *testing.T) {
 			},
 			{
 				// Test IAM Binding update
-				Config: testAccDataprocJobIamBinding_update(cluster, job, account, role),
+				Config: testAccDataprocJobIamBinding_update(cluster, subnetworkName, job, account, role),
 			},
 			{
 				ResourceName:      "google_dataproc_job_iam_binding.binding",
@@ -56,6 +60,10 @@ func TestAccDataprocJobIamMember(t *testing.T) {
 	account := "tf-dataproc-iam-" + acctest.RandString(t, 10)
 	role := "roles/editor"
 
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	importId := fmt.Sprintf("projects/%s/regions/%s/jobs/%s %s serviceAccount:%s",
 		envvar.GetTestProjectFromEnv(),
 		"us-central1",
@@ -69,7 +77,7 @@ func TestAccDataprocJobIamMember(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Test IAM Binding creation
-				Config: testAccDataprocJobIamMember(cluster, job, account, role),
+				Config: testAccDataprocJobIamMember(cluster, subnetworkName, job, account, role),
 			},
 			{
 				ResourceName:      "google_dataproc_job_iam_member.member",
@@ -89,6 +97,10 @@ func TestAccDataprocJobIamPolicy(t *testing.T) {
 	account := "tf-dataproc-iam-" + acctest.RandString(t, 10)
 	role := "roles/editor"
 
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	importId := fmt.Sprintf("projects/%s/regions/%s/jobs/%s",
 		envvar.GetTestProjectFromEnv(), "us-central1", job)
 
@@ -98,7 +110,7 @@ func TestAccDataprocJobIamPolicy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Test IAM Binding creation
-				Config: testAccDataprocJobIamPolicy(cluster, job, account, role),
+				Config: testAccDataprocJobIamPolicy(cluster, subnetworkName, job, account, role),
 				Check:  resource.TestCheckResourceAttrSet("data.google_dataproc_job_iam_policy.policy", "policy_data"),
 			},
 			{
@@ -139,7 +151,7 @@ resource "google_dataproc_job" "pyspark" {
 }
 `
 
-func testAccDataprocJobIamBinding_basic(cluster, job, account, role string) string {
+func testAccDataprocJobIamBinding_basic(cluster, subnetworkName, job, account, role string) string {
 	return fmt.Sprintf(testDataprocIamJobConfig+`
 resource "google_service_account" "test-account1" {
   account_id   = "%s-1"
@@ -159,10 +171,10 @@ resource "google_dataproc_job_iam_binding" "binding" {
     "serviceAccount:${google_service_account.test-account1.email}",
   ]
 }
-`, cluster, job, account, account, role)
+`, cluster, subnetworkName, job, account, account, role)
 }
 
-func testAccDataprocJobIamBinding_update(cluster, job, account, role string) string {
+func testAccDataprocJobIamBinding_update(cluster, subnetworkName, job, account, role string) string {
 	return fmt.Sprintf(testDataprocIamJobConfig+`
 resource "google_service_account" "test-account1" {
   account_id   = "%s-1"
@@ -183,10 +195,10 @@ resource "google_dataproc_job_iam_binding" "binding" {
     "serviceAccount:${google_service_account.test-account2.email}",
   ]
 }
-`, cluster, job, account, account, role)
+`, cluster, subnetworkName, job, account, account, role)
 }
 
-func testAccDataprocJobIamMember(cluster, job, account, role string) string {
+func testAccDataprocJobIamMember(cluster, subnetworkName, job, account, role string) string {
 	return fmt.Sprintf(testDataprocIamJobConfig+`
 resource "google_service_account" "test-account" {
   account_id   = "%s"
@@ -198,10 +210,10 @@ resource "google_dataproc_job_iam_member" "member" {
   role   = "%s"
   member = "serviceAccount:${google_service_account.test-account.email}"
 }
-`, cluster, job, account, role)
+`, cluster, subnetworkName, job, account, role)
 }
 
-func testAccDataprocJobIamPolicy(cluster, job, account, role string) string {
+func testAccDataprocJobIamPolicy(cluster, subnetworkName, job, account, role string) string {
 	return fmt.Sprintf(testDataprocIamJobConfig+`
 resource "google_service_account" "test-account" {
   account_id   = "%s"
@@ -226,5 +238,5 @@ data "google_dataproc_job_iam_policy" "policy" {
   region      = "us-central1"
 }
 
-`, cluster, job, account, role)
+`, cluster, subnetworkName, job, account, role)
 }

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
@@ -61,16 +61,13 @@ func TestAccDataprocCluster_basic(t *testing.T) {
 
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
-	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
-	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_basic(rnd, subnetworkName),
+				Config: testAccDataprocCluster_basic(rnd),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.basic", &cluster),
 
@@ -116,6 +113,9 @@ func TestAccDataprocVirtualCluster_basic(t *testing.T) {
 	rnd := acctest.RandString(t, 10)
 	pid := envvar.GetTestProjectFromEnv()
 	version := "3.1-dataproc-7"
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -123,7 +123,7 @@ func TestAccDataprocVirtualCluster_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocVirtualCluster_basic(pid, rnd),
+				Config: testAccDataprocVirtualCluster_basic(pid, rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.virtual_cluster", &cluster),
 
@@ -156,6 +156,9 @@ func TestAccDataprocCluster_withAccelerators(t *testing.T) {
 	project := envvar.GetTestProjectFromEnv()
 	acceleratorType := "nvidia-tesla-k80"
 	zone := "us-central1-c"
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -163,7 +166,7 @@ func TestAccDataprocCluster_withAccelerators(t *testing.T) {
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withAccelerators(rnd, acceleratorType, zone),
+				Config: testAccDataprocCluster_withAccelerators(rnd, acceleratorType, zone, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.accelerated_cluster", &cluster),
 					testAccCheckDataprocClusterAccelerator(&cluster, project, 1, 1),
@@ -241,13 +244,17 @@ func TestAccDataprocCluster_withMetadataAndTags(t *testing.T) {
 
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withMetadataAndTags(rnd),
+				Config: testAccDataprocCluster_withMetadataAndTags(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.basic", &cluster),
 
@@ -265,13 +272,17 @@ func TestAccDataprocCluster_withMinNumInstances(t *testing.T) {
 
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withMinNumInstances(rnd),
+				Config: testAccDataprocCluster_withMinNumInstances(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_min_num_instances", &cluster),
 
@@ -287,13 +298,17 @@ func TestAccDataprocCluster_withReservationAffinity(t *testing.T) {
 
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withReservationAffinity(rnd),
+				Config: testAccDataprocCluster_withReservationAffinity(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.basic", &cluster),
 
@@ -311,13 +326,17 @@ func TestAccDataprocCluster_withDataprocMetricConfig(t *testing.T) {
 
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withDataprocMetricConfig(rnd),
+				Config: testAccDataprocCluster_withDataprocMetricConfig(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.basic", &cluster),
 
@@ -336,13 +355,17 @@ func TestAccDataprocCluster_withNodeGroupAffinity(t *testing.T) {
 
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withNodeGroupAffinity(rnd),
+				Config: testAccDataprocCluster_withNodeGroupAffinity(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.basic", &cluster),
 
@@ -357,6 +380,10 @@ func TestAccDataprocCluster_singleNodeCluster(t *testing.T) {
 	t.Parallel()
 
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	var cluster dataproc.Cluster
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -364,7 +391,7 @@ func TestAccDataprocCluster_singleNodeCluster(t *testing.T) {
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_singleNodeCluster(rnd),
+				Config: testAccDataprocCluster_singleNodeCluster(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.single_node_cluster", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.single_node_cluster", "cluster_config.0.master_config.0.num_instances", "1"),
@@ -383,6 +410,9 @@ func TestAccDataprocCluster_updatable(t *testing.T) {
 	t.Parallel()
 
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	var cluster dataproc.Cluster
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -391,7 +421,7 @@ func TestAccDataprocCluster_updatable(t *testing.T) {
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_updatable(rnd, 2, 1),
+				Config: testAccDataprocCluster_updatable(rnd, subnetworkName, 2, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.updatable", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.master_config.0.num_instances", "1"),
@@ -399,7 +429,7 @@ func TestAccDataprocCluster_updatable(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.preemptible_worker_config.0.num_instances", "1")),
 			},
 			{
-				Config: testAccDataprocCluster_updatable(rnd, 2, 0),
+				Config: testAccDataprocCluster_updatable(rnd, subnetworkName, 2, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.updatable", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.master_config.0.num_instances", "1"),
@@ -407,7 +437,7 @@ func TestAccDataprocCluster_updatable(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.preemptible_worker_config.0.num_instances", "0")),
 			},
 			{
-				Config: testAccDataprocCluster_updatable(rnd, 3, 2),
+				Config: testAccDataprocCluster_updatable(rnd, subnetworkName, 3, 2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.master_config.0.num_instances", "1"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.worker_config.0.num_instances", "3"),
@@ -421,14 +451,18 @@ func TestAccDataprocCluster_nonPreemptibleSecondary(t *testing.T) {
 	t.Parallel()
 
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	var cluster dataproc.Cluster
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_nonPreemptibleSecondary(rnd),
+				Config: testAccDataprocCluster_nonPreemptibleSecondary(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.non_preemptible_secondary", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.non_preemptible_secondary", "cluster_config.0.preemptible_worker_config.0.preemptibility", "NON_PREEMPTIBLE"),
@@ -442,14 +476,18 @@ func TestAccDataprocCluster_spotSecondary(t *testing.T) {
 	t.Parallel()
 
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	var cluster dataproc.Cluster
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_spotSecondary(rnd),
+				Config: testAccDataprocCluster_spotSecondary(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.spot_secondary", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.spot_secondary", "cluster_config.0.preemptible_worker_config.0.preemptibility", "SPOT"),
@@ -466,6 +504,9 @@ func TestAccDataprocCluster_withStagingBucket(t *testing.T) {
 	var cluster dataproc.Cluster
 	clusterName := fmt.Sprintf("tf-test-dproc-%s", rnd)
 	bucketName := fmt.Sprintf("%s-bucket", clusterName)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -473,7 +514,7 @@ func TestAccDataprocCluster_withStagingBucket(t *testing.T) {
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withStagingBucketAndCluster(clusterName, bucketName),
+				Config: testAccDataprocCluster_withStagingBucketAndCluster(clusterName, bucketName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_bucket", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_bucket", "cluster_config.0.staging_bucket", bucketName),
@@ -498,6 +539,9 @@ func TestAccDataprocCluster_withTempBucket(t *testing.T) {
 	var cluster dataproc.Cluster
 	clusterName := fmt.Sprintf("tf-test-dproc-%s", rnd)
 	bucketName := fmt.Sprintf("%s-temp-bucket", clusterName)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -505,7 +549,7 @@ func TestAccDataprocCluster_withTempBucket(t *testing.T) {
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withTempBucketAndCluster(clusterName, bucketName),
+				Config: testAccDataprocCluster_withTempBucketAndCluster(clusterName, bucketName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_bucket", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_bucket", "cluster_config.0.temp_bucket", bucketName)),
@@ -529,13 +573,17 @@ func TestAccDataprocCluster_withInitAction(t *testing.T) {
 	var cluster dataproc.Cluster
 	bucketName := fmt.Sprintf("tf-test-dproc-%s-init-bucket", rnd)
 	objectName := "msg.txt"
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withInitAction(rnd, bucketName, objectName),
+				Config: testAccDataprocCluster_withInitAction(rnd, bucketName, objectName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_init_action", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_init_action", "cluster_config.0.initialization_action.#", "2"),
@@ -552,13 +600,17 @@ func TestAccDataprocCluster_withConfigOverrides(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	var cluster dataproc.Cluster
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withConfigOverrides(rnd),
+				Config: testAccDataprocCluster_withConfigOverrides(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_config_overrides", &cluster),
 					validateDataprocCluster_withConfigOverrides("google_dataproc_cluster.with_config_overrides", &cluster),
@@ -574,6 +626,9 @@ func TestAccDataprocCluster_withServiceAcc(t *testing.T) {
 	sa := "a" + acctest.RandString(t, 10)
 	saEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", sa, envvar.GetTestProjectFromEnv())
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	var cluster dataproc.Cluster
 
@@ -583,7 +638,7 @@ func TestAccDataprocCluster_withServiceAcc(t *testing.T) {
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withServiceAcc(sa, rnd),
+				Config: testAccDataprocCluster_withServiceAcc(sa, rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(
 						t, "google_dataproc_cluster.with_service_account", &cluster),
@@ -605,6 +660,9 @@ func TestAccDataprocCluster_withImageVersion(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	version := "2.0.35-debian10"
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	var cluster dataproc.Cluster
 	acctest.VcrTest(t, resource.TestCase{
@@ -613,7 +671,7 @@ func TestAccDataprocCluster_withImageVersion(t *testing.T) {
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withImageVersion(rnd, version),
+				Config: testAccDataprocCluster_withImageVersion(rnd, version, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_image_version", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_image_version", "cluster_config.0.software_config.0.image_version", version),
@@ -627,14 +685,18 @@ func TestAccDataprocCluster_withOptionalComponents(t *testing.T) {
 	t.Parallel()
 
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	var cluster dataproc.Cluster
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withOptionalComponents(rnd),
+				Config: testAccDataprocCluster_withOptionalComponents(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_opt_components", &cluster),
 					testAccCheckDataprocClusterHasOptionalComponents(&cluster, "ZOOKEEPER", "DOCKER"),
@@ -648,20 +710,24 @@ func TestAccDataprocCluster_withLifecycleConfigIdleDeleteTtl(t *testing.T) {
 	t.Parallel()
 
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	var cluster dataproc.Cluster
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withLifecycleConfigIdleDeleteTtl(rnd, "600s"),
+				Config: testAccDataprocCluster_withLifecycleConfigIdleDeleteTtl(rnd, "600s", subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_lifecycle_config", &cluster),
 				),
 			},
 			{
-				Config: testAccDataprocCluster_withLifecycleConfigIdleDeleteTtl(rnd, "610s"),
+				Config: testAccDataprocCluster_withLifecycleConfigIdleDeleteTtl(rnd, "610s", subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_lifecycle_config", &cluster),
 				),
@@ -678,6 +744,9 @@ func TestAccDataprocCluster_withLifecycleConfigAutoDeletion(t *testing.T) {
 	rnd := acctest.RandString(t, 10)
 	now := time.Now()
 	fmtString := "2006-01-02T15:04:05.072Z"
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	var cluster dataproc.Cluster
 	acctest.VcrTest(t, resource.TestCase{
@@ -686,13 +755,13 @@ func TestAccDataprocCluster_withLifecycleConfigAutoDeletion(t *testing.T) {
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withLifecycleConfigAutoDeletionTime(rnd, now.Add(time.Hour * 10).Format(fmtString)),
+				Config: testAccDataprocCluster_withLifecycleConfigAutoDeletionTime(rnd, now.Add(time.Hour * 10).Format(fmtString), subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_lifecycle_config", &cluster),
 				),
 			},
 			{
-				Config: testAccDataprocCluster_withLifecycleConfigAutoDeletionTime(rnd, now.Add(time.Hour * 20).Format(fmtString)),
+				Config: testAccDataprocCluster_withLifecycleConfigAutoDeletionTime(rnd, now.Add(time.Hour * 20).Format(fmtString), subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_lifecycle_config", &cluster),
 				),
@@ -705,14 +774,18 @@ func TestAccDataprocCluster_withLabels(t *testing.T) {
 	t.Parallel()
 
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	var cluster dataproc.Cluster
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withoutLabels(rnd),
+				Config: testAccDataprocCluster_withoutLabels(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_labels", &cluster),
 
@@ -722,7 +795,7 @@ func TestAccDataprocCluster_withLabels(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDataprocCluster_withLabels(rnd),
+				Config: testAccDataprocCluster_withLabels(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_labels", &cluster),
 
@@ -734,7 +807,7 @@ func TestAccDataprocCluster_withLabels(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDataprocCluster_withLabelsUpdate(rnd),
+				Config: testAccDataprocCluster_withLabelsUpdate(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_labels", &cluster),
 
@@ -744,7 +817,7 @@ func TestAccDataprocCluster_withLabels(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDataprocCluster_withoutLabels(rnd),
+				Config: testAccDataprocCluster_withoutLabels(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_labels", &cluster),
 
@@ -787,13 +860,17 @@ func TestAccDataprocCluster_withEndpointConfig(t *testing.T) {
 
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withEndpointConfig(rnd),
+				Config: testAccDataprocCluster_withEndpointConfig(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_endpoint_config", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_endpoint_config", "cluster_config.0.endpoint_config.0.enable_http_port_access", "true"),
@@ -808,6 +885,9 @@ func TestAccDataprocCluster_KMS(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	kms := acctest.BootstrapKMSKey(t)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	if acctest.BootstrapPSARole(t, "service-", "compute-system", "roles/cloudkms.cryptoKeyEncrypterDecrypter") {
 		t.Fatal("Stopping the test because a role was added to the policy.")
@@ -820,7 +900,7 @@ func TestAccDataprocCluster_KMS(t *testing.T) {
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_KMS(rnd, kms.CryptoKey.Name),
+				Config: testAccDataprocCluster_KMS(rnd, kms.CryptoKey.Name, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.kms", &cluster),
 				),
@@ -834,6 +914,9 @@ func TestAccDataprocCluster_withKerberos(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	kms := acctest.BootstrapKMSKey(t)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	var cluster dataproc.Cluster
 	acctest.VcrTest(t, resource.TestCase{
@@ -842,7 +925,7 @@ func TestAccDataprocCluster_withKerberos(t *testing.T) {
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withKerberos(rnd, kms.CryptoKey.Name),
+				Config: testAccDataprocCluster_withKerberos(rnd, kms.CryptoKey.Name, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.kerb", &cluster),
 				),
@@ -855,6 +938,9 @@ func TestAccDataprocCluster_withAutoscalingPolicy(t *testing.T) {
 	t.Parallel()
 
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	var cluster dataproc.Cluster
 	acctest.VcrTest(t, resource.TestCase{
@@ -863,14 +949,14 @@ func TestAccDataprocCluster_withAutoscalingPolicy(t *testing.T) {
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withAutoscalingPolicy(rnd),
+				Config: testAccDataprocCluster_withAutoscalingPolicy(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.basic", &cluster),
 					testAccCheckDataprocClusterAutoscaling(t, &cluster, true),
 				),
 			},
 			{
-				Config: testAccDataprocCluster_removeAutoscalingPolicy(rnd),
+				Config: testAccDataprocCluster_removeAutoscalingPolicy(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.basic", &cluster),
 					testAccCheckDataprocClusterAutoscaling(t, &cluster, false),
@@ -888,6 +974,9 @@ func TestAccDataprocCluster_withMetastoreConfig(t *testing.T) {
 	updateServiceId := "tf-test-metastore-srv-update-" + acctest.RandString(t, 10)
 	msName_basic := fmt.Sprintf("projects/%s/locations/us-central1/services/%s", pid, basicServiceId)
 	msName_update := fmt.Sprintf("projects/%s/locations/us-central1/services/%s", pid, updateServiceId)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	
 	var cluster dataproc.Cluster
 	clusterName := "tf-test-" + acctest.RandString(t, 10)
@@ -897,7 +986,7 @@ func TestAccDataprocCluster_withMetastoreConfig(t *testing.T) {
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withMetastoreConfig(clusterName, basicServiceId),
+				Config: testAccDataprocCluster_withMetastoreConfig(clusterName, basicServiceId, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_metastore_config", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_metastore_config", "cluster_config.0.metastore_config.0.dataproc_metastore_service",msName_basic),
@@ -905,7 +994,7 @@ func TestAccDataprocCluster_withMetastoreConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDataprocCluster_withMetastoreConfig_update(clusterName, updateServiceId),
+				Config: testAccDataprocCluster_withMetastoreConfig_update(clusterName, updateServiceId, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_metastore_config", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_metastore_config", "cluster_config.0.metastore_config.0.dataproc_metastore_service", msName_update),
@@ -1165,22 +1254,17 @@ resource "google_dataproc_cluster" "basic" {
 `, rnd)
 }
 
-func testAccDataprocCluster_basic(rnd, subnetworkName string) string {
+func testAccDataprocCluster_basic(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "basic" {
   name   = "tf-test-dproc-%s"
   region = "us-central1"
-  cluster_config {
-    gce_cluster_config {
-      subnetwork = "%s"
-    }
-  }
 }
-`, rnd, subnetworkName)
+`, rnd)
 }
 
 <% if version == "ga" -%>
-func testAccDataprocVirtualCluster_basic(projectID string, rnd string) string {
+func testAccDataprocVirtualCluster_basic(projectID, rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 data "google_project" "project" {
   project_id = "%s"
@@ -1189,6 +1273,11 @@ data "google_project" "project" {
 resource "google_container_cluster" "primary" {
   name     = "tf-test-gke-%s"
   location = "us-central1-a"
+  cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+  }
 
   initial_node_count = 1
 
@@ -1237,7 +1326,7 @@ resource "google_dataproc_cluster" "virtual_cluster" {
 	  }
 	}
   }
-`, projectID, rnd, projectID, rnd, rnd, rnd, rnd, rnd, rnd)
+`, projectID, rnd, subnetworkName, projectID, rnd, rnd, rnd, rnd, rnd, rnd)
 }
 <% end -%>
 
@@ -1254,7 +1343,7 @@ func testAccCheckDataprocGkeClusterNodePoolsHaveRoles(cluster *dataproc.Cluster,
 	}
 }
 
-func testAccDataprocCluster_withAccelerators(rnd, acceleratorType, zone string) string {
+func testAccDataprocCluster_withAccelerators(rnd, acceleratorType, zone, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "accelerated_cluster" {
   name   = "tf-test-dproc-%s"
@@ -1262,6 +1351,7 @@ resource "google_dataproc_cluster" "accelerated_cluster" {
 
   cluster_config {
     gce_cluster_config {
+      subnetwork = "%s"
       zone = "%s"
     }
 
@@ -1280,7 +1370,7 @@ resource "google_dataproc_cluster" "accelerated_cluster" {
     }
   }
 }
-`, rnd, zone, acceleratorType, acceleratorType)
+`, rnd, subnetworkName, zone, acceleratorType, acceleratorType)
 }
 
 func testAccDataprocCluster_withInternalIpOnlyTrueAndShieldedConfig(rnd string) string {
@@ -1355,7 +1445,7 @@ resource "google_dataproc_cluster" "basic" {
 `, rnd, rnd, rnd, rnd)
 }
 
-func testAccDataprocCluster_withMetadataAndTags(rnd string) string {
+func testAccDataprocCluster_withMetadataAndTags(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "basic" {
   name   = "tf-test-dproc-%s"
@@ -1363,6 +1453,7 @@ resource "google_dataproc_cluster" "basic" {
 
   cluster_config {
     gce_cluster_config {
+      subnetwork = "%s"
       metadata = {
         foo = "bar"
         baz = "qux"
@@ -1371,16 +1462,19 @@ resource "google_dataproc_cluster" "basic" {
     }
   }
 }
-`, rnd)
+`, rnd, subnetworkName)
 }
 
-func testAccDataprocCluster_withMinNumInstances(rnd string) string {
+func testAccDataprocCluster_withMinNumInstances(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_min_num_instances" {
   name   = "tf-test-dproc-%s"
   region = "us-central1"
  
   cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
     master_config{
       num_instances=1
     }
@@ -1390,10 +1484,10 @@ resource "google_dataproc_cluster" "with_min_num_instances" {
     }
   }
 }
-`, rnd)
+`, rnd, subnetworkName)
 }
 
-func testAccDataprocCluster_withReservationAffinity(rnd string) string {
+func testAccDataprocCluster_withReservationAffinity(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 
 resource "google_compute_reservation" "reservation" {
@@ -1414,7 +1508,6 @@ resource "google_dataproc_cluster" "basic" {
   region = "us-central1"
 
   cluster_config {
-
     master_config {
       machine_type  = "n1-standard-2"
     }
@@ -1424,6 +1517,7 @@ resource "google_dataproc_cluster" "basic" {
     }
 
     gce_cluster_config {
+      subnetwork = "%s"
       zone = "us-central1-f"
       reservation_affinity {
         consume_reservation_type = "SPECIFIC_RESERVATION"
@@ -1433,16 +1527,19 @@ resource "google_dataproc_cluster" "basic" {
     }
   }
 }
-`, rnd, rnd)
+`, rnd, rnd, subnetworkName)
 }
 
-func testAccDataprocCluster_withDataprocMetricConfig(rnd string) string {
+func testAccDataprocCluster_withDataprocMetricConfig(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "basic" {
   name   = "tf-test-dproc-%s"
   region = "us-central1"
 
   cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
     dataproc_metric_config {
       metrics {
         metric_source = "HDFS"
@@ -1456,10 +1553,10 @@ resource "google_dataproc_cluster" "basic" {
     }
   }
 }
-`, rnd)
+`, rnd, subnetworkName)
 }
 
-func testAccDataprocCluster_withNodeGroupAffinity(rnd string) string {
+func testAccDataprocCluster_withNodeGroupAffinity(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 
 resource "google_compute_node_template" "nodetmpl" {
@@ -1489,6 +1586,7 @@ resource "google_dataproc_cluster" "basic" {
 
   cluster_config {
     gce_cluster_config {
+      subnetwork = "%s"
       zone = "us-central1-f"
       node_group_affinity {
         node_group_uri = google_compute_node_group.nodes.name
@@ -1496,16 +1594,20 @@ resource "google_dataproc_cluster" "basic" {
     }
   }
 }
-`, rnd, rnd, rnd)
+`, rnd, rnd, rnd, subnetworkName)
 }
 
-func testAccDataprocCluster_singleNodeCluster(rnd string) string {
+func testAccDataprocCluster_singleNodeCluster(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "single_node_cluster" {
   name   = "tf-test-dproc-%s"
   region = "us-central1"
 
   cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+
     # Keep the costs down with smallest config we can get away with
     software_config {
       override_properties = {
@@ -1514,16 +1616,19 @@ resource "google_dataproc_cluster" "single_node_cluster" {
     }
   }
 }
-`, rnd)
+`, rnd, subnetworkName)
 }
 
-func testAccDataprocCluster_withConfigOverrides(rnd string) string {
+func testAccDataprocCluster_withConfigOverrides(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_config_overrides" {
   name     = "tf-test-dproc-%s"
   region   = "us-central1"
 
   cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
     master_config {
       num_instances = 3
       machine_type  = "n1-standard-2"  // can't be e2 because of min_cpu_platform
@@ -1556,10 +1661,10 @@ resource "google_dataproc_cluster" "with_config_overrides" {
     }
   }
 }
-`, rnd)
+`, rnd, subnetworkName)
 }
 
-func testAccDataprocCluster_withInitAction(rnd, bucket, objName string) string {
+func testAccDataprocCluster_withInitAction(rnd, bucket, objName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "init_bucket" {
   name          = "%s"
@@ -1583,6 +1688,10 @@ resource "google_dataproc_cluster" "with_init_action" {
   region = "us-central1"
 
   cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+
     # Keep the costs down with smallest config we can get away with
     software_config {
       override_properties = {
@@ -1606,10 +1715,10 @@ resource "google_dataproc_cluster" "with_init_action" {
     }
   }
 }
-`, bucket, rnd, objName, objName, rnd)
+`, bucket, rnd, objName, objName, rnd, subnetworkName)
 }
 
-func testAccDataprocCluster_updatable(rnd string, w, p int) string {
+func testAccDataprocCluster_updatable(rnd, subnetworkName string, w, p int) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "updatable" {
   name   = "tf-test-dproc-%s"
@@ -1617,6 +1726,10 @@ resource "google_dataproc_cluster" "updatable" {
   graceful_decommission_timeout = "0.2s"
 
   cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+
     master_config {
       num_instances = "1"
       machine_type  = "e2-medium"
@@ -1641,51 +1754,59 @@ resource "google_dataproc_cluster" "updatable" {
     }
   }
 }
-`, rnd, w, p)
+`, rnd, subnetworkName, w, p)
 }
 
-func testAccDataprocCluster_nonPreemptibleSecondary(rnd string) string {
+func testAccDataprocCluster_nonPreemptibleSecondary(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "non_preemptible_secondary" {
   name   = "tf-test-dproc-%s"
   region = "us-central1"
 
   cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+
     master_config {
-	  num_instances = "1"
-	  machine_type  = "e2-medium"
-	  disk_config {
-		boot_disk_size_gb = 35
-	  }
-	}
+      num_instances = "1"
+      machine_type  = "e2-medium"
+      disk_config {
+        boot_disk_size_gb = 35
+      }
+    }
   
-	worker_config {
-	  num_instances = "2"
-	  machine_type  = "e2-medium"
-	  disk_config {
-		boot_disk_size_gb = 35
-	  }
-	}
+    worker_config {
+      num_instances = "2"
+      machine_type  = "e2-medium"
+      disk_config {
+        boot_disk_size_gb = 35
+      }
+    }
   
-	preemptible_worker_config {
-	  num_instances = "1"
-	  preemptibility = "NON_PREEMPTIBLE"
-	  disk_config {
-		boot_disk_size_gb = 35
-	  }
-	}
+    preemptible_worker_config {
+      num_instances = "1"
+      preemptibility = "NON_PREEMPTIBLE"
+      disk_config {
+        boot_disk_size_gb = 35
+      }
+    }
   }
 }
-	`, rnd)
+	`, rnd, subnetworkName)
 }
 
-func testAccDataprocCluster_spotSecondary(rnd string) string {
+func testAccDataprocCluster_spotSecondary(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "spot_secondary" {
   name   = "tf-test-dproc-%s"
   region = "us-central1"
 
   cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+
     master_config {
       num_instances = "1"
       machine_type  = "e2-medium"
@@ -1711,7 +1832,7 @@ resource "google_dataproc_cluster" "spot_secondary" {
     }
   }
 }
-	`, rnd)
+	`, rnd, subnetworkName)
 }
 
 func testAccDataprocCluster_withStagingBucketOnly(bucketName string) string {
@@ -1734,7 +1855,7 @@ resource "google_storage_bucket" "bucket" {
 `, bucketName)
 }
 
-func testAccDataprocCluster_withStagingBucketAndCluster(clusterName, bucketName string) string {
+func testAccDataprocCluster_withStagingBucketAndCluster(clusterName, bucketName, subnetworkName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -1745,6 +1866,10 @@ resource "google_dataproc_cluster" "with_bucket" {
   cluster_config {
     staging_bucket = google_storage_bucket.bucket.name
 
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+
     # Keep the costs down with smallest config we can get away with
     software_config {
       override_properties = {
@@ -1760,10 +1885,10 @@ resource "google_dataproc_cluster" "with_bucket" {
     }
   }
 }
-`, testAccDataprocCluster_withStagingBucketOnly(bucketName), clusterName)
+`, testAccDataprocCluster_withStagingBucketOnly(bucketName), clusterName, subnetworkName)
 }
 
-func testAccDataprocCluster_withTempBucketAndCluster(clusterName, bucketName string) string {
+func testAccDataprocCluster_withTempBucketAndCluster(clusterName, bucketName, subnetworkName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -1774,6 +1899,10 @@ resource "google_dataproc_cluster" "with_bucket" {
   cluster_config {
     temp_bucket = google_storage_bucket.bucket.name
 
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+
     # Keep the costs down with smallest config we can get away with
     software_config {
       override_properties = {
@@ -1789,120 +1918,155 @@ resource "google_dataproc_cluster" "with_bucket" {
     }
   }
 }
-`, testAccDataprocCluster_withTempBucketOnly(bucketName), clusterName)
+`, testAccDataprocCluster_withTempBucketOnly(bucketName), clusterName, subnetworkName)
 }
 
-func testAccDataprocCluster_withLabels(rnd string) string {
+func testAccDataprocCluster_withLabels(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_labels" {
   name   = "tf-test-dproc-%s"
   region = "us-central1"
+  cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+  }
 
   labels = {
     key1 = "value1"
   }
 }
-`, rnd)
+`, rnd, subnetworkName)
 }
 
-func testAccDataprocCluster_withLabelsUpdate(rnd string) string {
+func testAccDataprocCluster_withLabelsUpdate(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_labels" {
   name   = "tf-test-dproc-%s"
   region = "us-central1"
+  cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+  }
 
   labels = {
     key2 = "value2"
   }
 }
-`, rnd)
+`, rnd, subnetworkName)
 }
 
-func testAccDataprocCluster_withoutLabels(rnd string) string {
+func testAccDataprocCluster_withoutLabels(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_labels" {
   name   = "tf-test-dproc-%s"
   region = "us-central1"
+  cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+  }
 }
-`, rnd)
+`, rnd, subnetworkName)
 }
 
-func testAccDataprocCluster_withEndpointConfig(rnd string) string {
+func testAccDataprocCluster_withEndpointConfig(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_endpoint_config" {
 	name                  = "tf-test-%s"
 	region                = "us-central1"
 
 	cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+
 		endpoint_config {
 			enable_http_port_access = "true"
 		}
 	}
 }
-`, rnd)
+`, rnd, subnetworkName)
 }
 
-func testAccDataprocCluster_withImageVersion(rnd, version string) string {
+func testAccDataprocCluster_withImageVersion(rnd, version, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_image_version" {
   name   = "tf-test-dproc-%s"
   region = "us-central1"
 
   cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+
     software_config {
       image_version = "%s"
     }
   }
 }
-`, rnd, version)
+`, rnd, subnetworkName, version)
 }
 
-func testAccDataprocCluster_withOptionalComponents(rnd string) string {
+func testAccDataprocCluster_withOptionalComponents(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_opt_components" {
   name   = "tf-test-dproc-%s"
   region = "us-central1"
 
   cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+
     software_config {
       optional_components = ["DOCKER", "ZOOKEEPER"]
     }
   }
 }
-`, rnd)
+`, rnd, subnetworkName)
 }
 
-func testAccDataprocCluster_withLifecycleConfigIdleDeleteTtl(rnd, tm string) string {
+func testAccDataprocCluster_withLifecycleConfigIdleDeleteTtl(rnd, tm, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_lifecycle_config" {
   name   = "tf-test-dproc-%s"
   region = "us-central1"
 
   cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+
     lifecycle_config {
       idle_delete_ttl = "%s"
     }
   }
 }
-`, rnd, tm)
+`, rnd, subnetworkName, tm)
 }
 
-func testAccDataprocCluster_withLifecycleConfigAutoDeletionTime(rnd, tm string) string {
+func testAccDataprocCluster_withLifecycleConfigAutoDeletionTime(rnd, tm, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_lifecycle_config" {
  name   = "tf-test-dproc-%s"
  region = "us-central1"
 
  cluster_config {
+  gce_cluster_config {
+      subnetwork = "%s"
+    }
+
    lifecycle_config {
      auto_delete_time = "%s"
    }
  }
 }
-`, rnd, tm)
+`, rnd, subnetworkName, tm)
 }
 
-func testAccDataprocCluster_withServiceAcc(sa string, rnd string) string {
+func testAccDataprocCluster_withServiceAcc(sa, rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 data "google_project" "project" {}
 
@@ -1936,6 +2100,7 @@ resource "google_dataproc_cluster" "with_service_account" {
     }
 
     gce_cluster_config {
+      subnetwork = "%s"
       service_account = google_service_account.service_account.email
       service_account_scopes = [
 		#	User supplied scopes
@@ -1954,7 +2119,7 @@ resource "google_dataproc_cluster" "with_service_account" {
 
   depends_on = [google_project_iam_member.service_account]
 }
-`, sa, rnd)
+`, sa, rnd, subnetworkName)
 }
 
 func testAccDataprocCluster_withNetworkRefs(rnd, netName string) string {
@@ -1998,6 +2163,7 @@ resource "google_dataproc_cluster" "with_net_ref_by_name" {
   depends_on = [google_compute_firewall.dataproc_network_firewall]
 
   cluster_config {
+
     # Keep the costs down with smallest config we can get away with
     software_config {
       override_properties = {
@@ -2024,6 +2190,7 @@ resource "google_dataproc_cluster" "with_net_ref_by_url" {
   depends_on = [google_compute_firewall.dataproc_network_firewall]
 
   cluster_config {
+
     # Keep the costs down with smallest config we can get away with
     software_config {
       override_properties = {
@@ -2046,22 +2213,26 @@ resource "google_dataproc_cluster" "with_net_ref_by_url" {
 `, netName, rnd, rnd, rnd)
 }
 
-func testAccDataprocCluster_KMS(rnd, kmsKey string) string {
+func testAccDataprocCluster_KMS(rnd, kmsKey, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "kms" {
   name   = "tf-test-dproc-%s"
   region = "us-central1"
 
   cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+
     encryption_config {
       kms_key_name = "%s"
     }
   }
 }
-`, rnd, kmsKey)
+`, rnd, subnetworkName, kmsKey)
 }
 
-func testAccDataprocCluster_withKerberos(rnd, kmsKey string) string {
+func testAccDataprocCluster_withKerberos(rnd, kmsKey, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
   name     = "tf-test-dproc-%s"
@@ -2078,6 +2249,10 @@ resource "google_dataproc_cluster" "kerb" {
   region = "us-central1"
 
   cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+
     security_config {
       kerberos_config {
         root_principal_password_uri = google_storage_bucket_object.password.self_link
@@ -2086,16 +2261,20 @@ resource "google_dataproc_cluster" "kerb" {
     }
   }
 }
-`, rnd, rnd, rnd, kmsKey)
+`, rnd, rnd, rnd, subnetworkName, kmsKey)
 }
 
-func testAccDataprocCluster_withAutoscalingPolicy(rnd string) string {
+func testAccDataprocCluster_withAutoscalingPolicy(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "basic" {
   name     = "tf-test-dataproc-policy-%s"
   region   = "us-central1"
 
   cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+
     autoscaling_config {
       policy_uri = google_dataproc_autoscaling_policy.asp.id
     }
@@ -2118,16 +2297,20 @@ resource "google_dataproc_autoscaling_policy" "asp" {
     }
   }
 }
-`, rnd, rnd)
+`, rnd, subnetworkName, rnd)
 }
 
-func testAccDataprocCluster_removeAutoscalingPolicy(rnd string) string {
+func testAccDataprocCluster_removeAutoscalingPolicy(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "basic" {
   name     = "tf-test-dataproc-policy-%s"
   region   = "us-central1"
 
   cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+
     autoscaling_config {
       policy_uri = ""
     }
@@ -2150,16 +2333,20 @@ resource "google_dataproc_autoscaling_policy" "asp" {
     }
   }
 }
-`, rnd, rnd)
+`, rnd, subnetworkName, rnd)
 }
 
-func testAccDataprocCluster_withMetastoreConfig(clusterName, serviceId string) string {
+func testAccDataprocCluster_withMetastoreConfig(clusterName, serviceId, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_metastore_config" {
 	name                  = "%s"
 	region                = "us-central1"
 
 	cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+
 		metastore_config {
 			dataproc_metastore_service = google_dataproc_metastore_service.ms.name
 		}
@@ -2181,16 +2368,20 @@ resource "google_dataproc_metastore_service" "ms" {
 		version = "3.1.2"
 	}
 }
-`, clusterName, serviceId)
+`, clusterName, subnetworkName, serviceId)
 }
 
-func testAccDataprocCluster_withMetastoreConfig_update(clusterName, serviceId string) string {
+func testAccDataprocCluster_withMetastoreConfig_update(clusterName, serviceId, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_metastore_config" {
 	name                  = "%s"
 	region                = "us-central1"
 
 	cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+
 		metastore_config {
 			dataproc_metastore_service = google_dataproc_metastore_service.ms.name
 		}
@@ -2212,5 +2403,5 @@ resource "google_dataproc_metastore_service" "ms" {
 		version = "3.1.2"
 	}
 }
-`, clusterName, serviceId)
+`, clusterName, subnetworkName, serviceId)
 }

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
@@ -410,9 +410,6 @@ func TestAccDataprocCluster_updatable(t *testing.T) {
 	t.Parallel()
 
 	rnd := acctest.RandString(t, 10)
-	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
-	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	var cluster dataproc.Cluster
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -421,7 +418,7 @@ func TestAccDataprocCluster_updatable(t *testing.T) {
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_updatable(rnd, subnetworkName, 2, 1),
+				Config: testAccDataprocCluster_updatable(rnd, 2, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.updatable", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.master_config.0.num_instances", "1"),
@@ -429,7 +426,7 @@ func TestAccDataprocCluster_updatable(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.preemptible_worker_config.0.num_instances", "1")),
 			},
 			{
-				Config: testAccDataprocCluster_updatable(rnd, subnetworkName, 2, 0),
+				Config: testAccDataprocCluster_updatable(rnd, 2, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.updatable", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.master_config.0.num_instances", "1"),
@@ -437,7 +434,7 @@ func TestAccDataprocCluster_updatable(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.preemptible_worker_config.0.num_instances", "0")),
 			},
 			{
-				Config: testAccDataprocCluster_updatable(rnd, subnetworkName, 3, 2),
+				Config: testAccDataprocCluster_updatable(rnd, 3, 2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.master_config.0.num_instances", "1"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.worker_config.0.num_instances", "3"),
@@ -1718,7 +1715,7 @@ resource "google_dataproc_cluster" "with_init_action" {
 `, bucket, rnd, objName, objName, rnd, subnetworkName)
 }
 
-func testAccDataprocCluster_updatable(rnd, subnetworkName string, w, p int) string {
+func testAccDataprocCluster_updatable(rnd string, w, p int) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "updatable" {
   name   = "tf-test-dproc-%s"
@@ -1726,10 +1723,6 @@ resource "google_dataproc_cluster" "updatable" {
   graceful_decommission_timeout = "0.2s"
 
   cluster_config {
-    gce_cluster_config {
-      subnetwork = "%s"
-    }
-
     master_config {
       num_instances = "1"
       machine_type  = "e2-medium"
@@ -1754,7 +1747,7 @@ resource "google_dataproc_cluster" "updatable" {
     }
   }
 }
-`, rnd, subnetworkName, w, p)
+`, rnd, w, p)
 }
 
 func testAccDataprocCluster_nonPreemptibleSecondary(rnd, subnetworkName string) string {

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
@@ -61,13 +61,16 @@ func TestAccDataprocCluster_basic(t *testing.T) {
 
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_basic(rnd),
+				Config: testAccDataprocCluster_basic(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.basic", &cluster),
 
@@ -1162,13 +1165,18 @@ resource "google_dataproc_cluster" "basic" {
 `, rnd)
 }
 
-func testAccDataprocCluster_basic(rnd string) string {
+func testAccDataprocCluster_basic(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "basic" {
   name   = "tf-test-dproc-%s"
   region = "us-central1"
+  cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+  }
 }
-`, rnd)
+`, rnd, subnetworkName)
 }
 
 <% if version == "ga" -%>

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
@@ -2367,8 +2367,14 @@ resource "google_dataproc_metastore_service" "ms" {
 	hive_metastore_config {
 		version = "3.1.2"
 	}
+
+  network_config {
+    consumers {
+      subnetwork = "%s"
+    }
+  }
 }
-`, clusterName, subnetworkName, serviceId)
+`, clusterName, subnetworkName, serviceId, subnetworkName)
 }
 
 func testAccDataprocCluster_withMetastoreConfig_update(clusterName, serviceId, subnetworkName string) string {
@@ -2402,6 +2408,12 @@ resource "google_dataproc_metastore_service" "ms" {
 	hive_metastore_config {
 		version = "3.1.2"
 	}
+
+  network_config {
+    consumers {
+      subnetwork = "%s"
+    }
+  }
 }
-`, clusterName, subnetworkName, serviceId)
+`, clusterName, subnetworkName, serviceId, subnetworkName)
 }

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
@@ -971,9 +971,6 @@ func TestAccDataprocCluster_withMetastoreConfig(t *testing.T) {
 	updateServiceId := "tf-test-metastore-srv-update-" + acctest.RandString(t, 10)
 	msName_basic := fmt.Sprintf("projects/%s/locations/us-central1/services/%s", pid, basicServiceId)
 	msName_update := fmt.Sprintf("projects/%s/locations/us-central1/services/%s", pid, updateServiceId)
-	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
-	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	
 	var cluster dataproc.Cluster
 	clusterName := "tf-test-" + acctest.RandString(t, 10)
@@ -983,7 +980,7 @@ func TestAccDataprocCluster_withMetastoreConfig(t *testing.T) {
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withMetastoreConfig(clusterName, basicServiceId, subnetworkName),
+				Config: testAccDataprocCluster_withMetastoreConfig(clusterName, basicServiceId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_metastore_config", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_metastore_config", "cluster_config.0.metastore_config.0.dataproc_metastore_service",msName_basic),
@@ -991,7 +988,7 @@ func TestAccDataprocCluster_withMetastoreConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDataprocCluster_withMetastoreConfig_update(clusterName, updateServiceId, subnetworkName),
+				Config: testAccDataprocCluster_withMetastoreConfig_update(clusterName, updateServiceId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_metastore_config", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_metastore_config", "cluster_config.0.metastore_config.0.dataproc_metastore_service", msName_update),
@@ -2329,92 +2326,64 @@ resource "google_dataproc_autoscaling_policy" "asp" {
 `, rnd, subnetworkName, rnd)
 }
 
-func testAccDataprocCluster_withMetastoreConfig(clusterName, serviceId, subnetworkName string) string {
+func testAccDataprocCluster_withMetastoreConfig(clusterName, serviceId string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_metastore_config" {
-	name                  = "%s"
-	region                = "us-central1"
+  name                  = "%s"
+  region                = "us-central1"
 
-	cluster_config {
-    gce_cluster_config {
-      subnetwork = "%s"
-    }
-
-		metastore_config {
-			dataproc_metastore_service = google_dataproc_metastore_service.ms.name
-		}
-	}
-}
-
-resource "google_dataproc_metastore_service" "ms" {
-	service_id = "%s"
-	location   = "us-central1"
-	port       = 9080
-	tier       = "DEVELOPER"
-
-	maintenance_window {
-		hour_of_day = 2
-		day_of_week = "SUNDAY"
-	}
-
-	hive_metastore_config {
-		version = "3.1.2"
-	}
-
-  network_config {
-    consumers {
-      subnetwork = data.google_compute_subnetwork.subnet.id
+  cluster_config {
+    metastore_config {
+      dataproc_metastore_service = google_dataproc_metastore_service.ms.name
     }
   }
 }
 
-data "google_compute_subnetwork" "subnet" {
-  name = "%s"
+resource "google_dataproc_metastore_service" "ms" {
+  service_id = "%s"
+  location   = "us-central1"
+  port       = 9080
+  tier       = "DEVELOPER"
+
+  maintenance_window {
+    hour_of_day = 2
+    day_of_week = "SUNDAY"
+  }
+
+  hive_metastore_config {
+    version = "3.1.2"
+  }
 }
-`, clusterName, subnetworkName, serviceId, subnetworkName)
+`, clusterName, serviceId)
 }
 
-func testAccDataprocCluster_withMetastoreConfig_update(clusterName, serviceId, subnetworkName string) string {
+func testAccDataprocCluster_withMetastoreConfig_update(clusterName, serviceId string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_metastore_config" {
-	name                  = "%s"
-	region                = "us-central1"
+  name                  = "%s"
+  region                = "us-central1"
 
-	cluster_config {
-    gce_cluster_config {
-      subnetwork = "%s"
-    }
-
-		metastore_config {
-			dataproc_metastore_service = google_dataproc_metastore_service.ms.name
-		}
-	}
-}
-
-resource "google_dataproc_metastore_service" "ms" {
-	service_id = "%s"
-	location   = "us-central1"
-	port       = 9080
-	tier       = "DEVELOPER"
-
-	maintenance_window {
-		hour_of_day = 2
-		day_of_week = "SUNDAY"
-	}
-
-	hive_metastore_config {
-		version = "3.1.2"
-	}
-
-  network_config {
-    consumers {
-      subnetwork = data.google_compute_subnetwork.subnet.id
+  cluster_config {
+    metastore_config {
+      dataproc_metastore_service = google_dataproc_metastore_service.ms.name
     }
   }
 }
 
-data "google_compute_subnetwork" "subnet" {
-  name = "%s"
+resource "google_dataproc_metastore_service" "ms" {
+  service_id = "%s"
+  location   = "us-central1"
+  port       = 9080
+  tier       = "DEVELOPER"
+
+  maintenance_window {
+    hour_of_day = 2
+    day_of_week = "SUNDAY"
+  }
+
+  hive_metastore_config {
+    version = "3.1.2"
+  }
 }
-`, clusterName, subnetworkName, serviceId, subnetworkName)
+`, clusterName, serviceId)
 }

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
@@ -2370,9 +2370,13 @@ resource "google_dataproc_metastore_service" "ms" {
 
   network_config {
     consumers {
-      subnetwork = "%s"
+      subnetwork = data.google_compute_subnetwork.subnet.id
     }
   }
+}
+
+data "google_compute_subnetwork" "subnet" {
+  name = "%s"
 }
 `, clusterName, subnetworkName, serviceId, subnetworkName)
 }
@@ -2411,9 +2415,13 @@ resource "google_dataproc_metastore_service" "ms" {
 
   network_config {
     consumers {
-      subnetwork = "%s"
+      subnetwork = data.google_compute_subnetwork.subnet.id
     }
   }
+}
+
+data "google_compute_subnetwork" "subnet" {
+  name = "%s"
 }
 `, clusterName, subnetworkName, serviceId, subnetworkName)
 }

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_upgrade_test.go
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_upgrade_test.go
@@ -18,6 +18,10 @@ func TestAccDataprocClusterLabelsMigration_withoutLabels_withoutChanges(t *testi
 
 	rnd := acctest.RandString(t, 10)
 	var cluster dataproc.Cluster
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	oldVersion := map[string]resource.ExternalProvider{
 		"google": {
 			VersionConstraint: "4.65.0", // a version that doesn't separate user defined labels and system labels
@@ -30,11 +34,11 @@ func TestAccDataprocClusterLabelsMigration_withoutLabels_withoutChanges(t *testi
 		CheckDestroy: testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config:            testAccDataprocCluster_withoutLabels(rnd),
+				Config:            testAccDataprocCluster_withoutLabels(rnd, subnetworkName),
 				ExternalProviders: oldVersion,
 			},
 			{
-				Config:                   testAccDataprocCluster_withoutLabels(rnd),
+				Config:                   testAccDataprocCluster_withoutLabels(rnd, subnetworkName),
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_labels", &cluster),
@@ -45,7 +49,7 @@ func TestAccDataprocClusterLabelsMigration_withoutLabels_withoutChanges(t *testi
 				),
 			},
 			{
-				Config:                   testAccDataprocCluster_withLabels(rnd),
+				Config:                   testAccDataprocCluster_withLabels(rnd, subnetworkName),
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_labels", &cluster),
@@ -67,6 +71,10 @@ func TestAccDataprocClusterLabelsMigration_withLabels_withoutChanges(t *testing.
 
 	rnd := acctest.RandString(t, 10)
 	var cluster dataproc.Cluster
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	oldVersion := map[string]resource.ExternalProvider{
 		"google": {
 			VersionConstraint: "4.65.0", // a version that doesn't separate user defined labels and system labels
@@ -79,11 +87,11 @@ func TestAccDataprocClusterLabelsMigration_withLabels_withoutChanges(t *testing.
 		CheckDestroy: testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config:            testAccDataprocCluster_withLabels(rnd),
+				Config:            testAccDataprocCluster_withLabels(rnd, subnetworkName),
 				ExternalProviders: oldVersion,
 			},
 			{
-				Config:                   testAccDataprocCluster_withLabels(rnd),
+				Config:                   testAccDataprocCluster_withLabels(rnd, subnetworkName),
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_labels", &cluster),
@@ -96,7 +104,7 @@ func TestAccDataprocClusterLabelsMigration_withLabels_withoutChanges(t *testing.
 				),
 			},
 			{
-				Config:                   testAccDataprocCluster_withLabelsUpdate(rnd),
+				Config:                   testAccDataprocCluster_withLabelsUpdate(rnd, subnetworkName),
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_labels", &cluster),
@@ -119,6 +127,10 @@ func TestAccDataprocClusterLabelsMigration_withUpdate(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	var cluster dataproc.Cluster
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	oldVersion := map[string]resource.ExternalProvider{
 		"google": {
 			VersionConstraint: "4.65.0", // a version that doesn't separate user defined labels and system labels
@@ -131,11 +143,11 @@ func TestAccDataprocClusterLabelsMigration_withUpdate(t *testing.T) {
 		CheckDestroy: testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config:            testAccDataprocCluster_withoutLabels(rnd),
+				Config:            testAccDataprocCluster_withoutLabels(rnd, subnetworkName),
 				ExternalProviders: oldVersion,
 			},
 			{
-				Config:                   testAccDataprocCluster_withLabels(rnd),
+				Config:                   testAccDataprocCluster_withLabels(rnd, subnetworkName),
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_labels", &cluster),
@@ -148,7 +160,7 @@ func TestAccDataprocClusterLabelsMigration_withUpdate(t *testing.T) {
 				),
 			},
 			{
-				Config:                   testAccDataprocCluster_withoutLabels(rnd),
+				Config:                   testAccDataprocCluster_withoutLabels(rnd, subnetworkName),
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_labels", &cluster),

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job_test.go.erb
@@ -50,20 +50,24 @@ func TestAccDataprocJob_updatable(t *testing.T) {
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
 	jobId := fmt.Sprintf("dproc-update-job-id-%s", rnd)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocJobDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocJob_updatable(rnd, jobId, "false"),
+				Config: testAccDataprocJob_updatable(rnd, subnetworkName, jobId, "false"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocJobExists(t, "google_dataproc_job.updatable", &job),
 					resource.TestCheckResourceAttr("google_dataproc_job.updatable", "force_delete", "false"),
 				),
 			},
 			{
-				Config: testAccDataprocJob_updatable(rnd, jobId, "true"),
+				Config: testAccDataprocJob_updatable(rnd, subnetworkName, jobId, "true"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocJobExists(t, "google_dataproc_job.updatable", &job),
 					resource.TestCheckResourceAttr("google_dataproc_job.updatable", "force_delete", "true"),
@@ -79,13 +83,17 @@ func TestAccDataprocJob_PySpark(t *testing.T) {
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
 	jobId := fmt.Sprintf("dproc-custom-job-id-%s", rnd)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocJobDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocJob_pySpark(rnd),
+				Config: testAccDataprocJob_pySpark(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 
 					testAccCheckDataprocJobExists(t, "google_dataproc_job.pyspark", &job),
@@ -117,13 +125,17 @@ func TestAccDataprocJob_Spark(t *testing.T) {
 
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocJobDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocJob_spark(rnd),
+				Config: testAccDataprocJob_spark(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocJobExists(t, "google_dataproc_job.spark", &job),
 
@@ -149,13 +161,17 @@ func TestAccDataprocJob_Hadoop(t *testing.T) {
 
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocJobDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocJob_hadoop(rnd),
+				Config: testAccDataprocJob_hadoop(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocJobExists(t, "google_dataproc_job.hadoop", &job),
 
@@ -181,13 +197,17 @@ func TestAccDataprocJob_Hive(t *testing.T) {
 
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocJobDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocJob_hive(rnd),
+				Config: testAccDataprocJob_hive(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocJobExists(t, "google_dataproc_job.hive", &job),
 
@@ -213,13 +233,17 @@ func TestAccDataprocJob_Pig(t *testing.T) {
 
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocJobDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocJob_pig(rnd),
+				Config: testAccDataprocJob_pig(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocJobExists(t, "google_dataproc_job.pig", &job),
 
@@ -245,13 +269,17 @@ func TestAccDataprocJob_SparkSql(t *testing.T) {
 
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocJobDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocJob_sparksql(rnd),
+				Config: testAccDataprocJob_sparksql(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocJobExists(t, "google_dataproc_job.sparksql", &job),
 
@@ -277,13 +305,17 @@ func TestAccDataprocJob_Presto(t *testing.T) {
 
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+	
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocJobDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocJob_presto(rnd),
+				Config: testAccDataprocJob_presto(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocJobExists(t, "google_dataproc_job.presto", &job),
 
@@ -637,11 +669,15 @@ resource "google_dataproc_cluster" "basic" {
         boot_disk_size_gb = 35
       }
     }
+
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
   }
 }
 `
 
-func testAccDataprocJob_updatable(rnd, jobId, del string) string {
+func testAccDataprocJob_updatable(rnd, subnetworkName, jobId, del string) string {
 	return fmt.Sprintf(
 		singleNodeClusterConfig+`
 resource "google_dataproc_job" "updatable" {
@@ -659,10 +695,10 @@ resource "google_dataproc_job" "updatable" {
     main_python_file_uri = "gs://dataproc-examples-2f10d78d114f6aaec76462e3c310f31f/src/pyspark/hello-world/hello-world.py"
   }
 }
-`, rnd, jobId, del)
+`, rnd, subnetworkName, jobId, del)
 }
 
-func testAccDataprocJob_pySpark(rnd string) string {
+func testAccDataprocJob_pySpark(rnd, subnetworkName string) string {
 	return fmt.Sprintf(
 		singleNodeClusterConfig+`
 resource "google_dataproc_job" "pyspark" {
@@ -697,10 +733,10 @@ resource "google_dataproc_job" "pyspark" {
     one = "1"
   }
 }
-`, rnd, rnd)
+`, rnd, subnetworkName, rnd)
 }
 
-func testAccDataprocJob_spark(rnd string) string {
+func testAccDataprocJob_spark(rnd, subnetworkName string) string {
 	return fmt.Sprintf(
 		singleNodeClusterConfig+`
 resource "google_dataproc_job" "spark" {
@@ -723,11 +759,11 @@ resource "google_dataproc_job" "spark" {
     }
   }
 }
-`, rnd)
+`, rnd, subnetworkName)
 
 }
 
-func testAccDataprocJob_hadoop(rnd string) string {
+func testAccDataprocJob_hadoop(rnd, subnetworkName string) string {
 	return fmt.Sprintf(
 		singleNodeClusterConfig+`
 resource "google_dataproc_job" "hadoop" {
@@ -746,11 +782,11 @@ resource "google_dataproc_job" "hadoop" {
     ]
   }
 }
-`, rnd, rnd)
+`, rnd, subnetworkName, rnd)
 
 }
 
-func testAccDataprocJob_hive(rnd string) string {
+func testAccDataprocJob_hive(rnd, subnetworkName string) string {
 	return fmt.Sprintf(
 		singleNodeClusterConfig+`
 resource "google_dataproc_job" "hive" {
@@ -768,11 +804,11 @@ resource "google_dataproc_job" "hive" {
     ]
   }
 }
-`, rnd)
+`, rnd, subnetworkName)
 
 }
 
-func testAccDataprocJob_pig(rnd string) string {
+func testAccDataprocJob_pig(rnd, subnetworkName string) string {
 	return fmt.Sprintf(
 		singleNodeClusterConfig+`
 resource "google_dataproc_job" "pig" {
@@ -792,11 +828,11 @@ resource "google_dataproc_job" "pig" {
     ]
   }
 }
-`, rnd)
+`, rnd, subnetworkName)
 
 }
 
-func testAccDataprocJob_sparksql(rnd string) string {
+func testAccDataprocJob_sparksql(rnd, subnetworkName string) string {
 	return fmt.Sprintf(
 		singleNodeClusterConfig+`
 resource "google_dataproc_job" "sparksql" {
@@ -814,11 +850,11 @@ resource "google_dataproc_job" "sparksql" {
     ]
   }
 }
-`, rnd)
+`, rnd, subnetworkName)
 
 }
 
-func testAccDataprocJob_presto(rnd string) string {
+func testAccDataprocJob_presto(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "basic" {
   name   = "dproc-job-test-%s"
@@ -830,7 +866,7 @@ resource "google_dataproc_cluster" "basic" {
       override_properties = {
         "dataproc:dataproc.allow.zero.workers" = "true"
       }
-	  optional_components = ["PRESTO"]
+      optional_components = ["PRESTO"]
     }
 
     master_config {
@@ -839,6 +875,10 @@ resource "google_dataproc_cluster" "basic" {
       disk_config {
         boot_disk_size_gb = 35
       }
+    }
+
+    gce_cluster_config {
+      subnetwork = "%s"
     }
   }
 }
@@ -856,6 +896,6 @@ resource "google_dataproc_job" "presto" {
     ]
   }
 }
-`, rnd)
+`, rnd, subnetworkName)
 
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

part of https://github.com/hashicorp/terraform-provider-google/issues/16313

Bootstrap a specific network used for dataproc tests to avoid using default network and running into error `The resource 'projects/xxxxxxx/regions/us-central1/subnetworks/default' is not ready

Left `TestAccDataprocCluster_basic` unchanged to still use the default network.

Exclude the changes in `TestAccDataprocCluster_withMetastoreConfig` and `TestAccDataprocCluster_updatable` from this PR as I couldn't get the tests pass and I suspected it might be related to some setup in our VCR project. I'll fix them and covert them to use bootstrapped network in a later PR.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
