### PR TITLE
Maintenance interval for sole-tenant node groups.

### DIFF
--- a/mmv1/products/compute/NodeGroup.yaml
+++ b/mmv1/products/compute/NodeGroup.yaml
@@ -52,6 +52,13 @@ examples:
       group_name: 'soletenant-group'
       template_name: 'soletenant-tmpl'
   - !ruby/object:Provider::Terraform::Examples
+    name: 'node_group_maintenance_interval'
+    min_version: beta
+    primary_resource_id: 'nodes'
+    vars:
+      group_name: 'soletenant-group'
+      template_name: 'soletenant-tmpl'
+  - !ruby/object:Provider::Terraform::Examples
     name: 'node_group_autoscaling_policy'
     primary_resource_id: 'nodes'
     vars:
@@ -196,3 +203,14 @@ properties:
               required: true
               description: |
                 The project id/number should be the same as the key of this project config in the project map.
+  - !ruby/object:Api::Type::Enum
+    name: 'maintenanceInterval'
+    min_version: beta
+    description: |
+      Specifies the frequency of planned maintenance events. Set to one of the following:
+        - AS_NEEDED: Hosts are eligible to receive infrastructure and hypervisor updates as they become available.
+        - RECURRENT: Hosts receive planned infrastructure and hypervisor updates on a periodic basis, but not more frequently than every 28 days. This minimizes the number of planned maintenance operations on individual hosts and reduces the frequency of disruptions, both live migrations and terminations, on individual VMs.
+    values:
+      - :AS_NEEDED
+      - :RECURRENT
+    default_from_api: true

--- a/mmv1/templates/terraform/examples/node_group_maintenance_interval.tf.erb
+++ b/mmv1/templates/terraform/examples/node_group_maintenance_interval.tf.erb
@@ -1,0 +1,18 @@
+resource "google_compute_node_template" "soletenant-tmpl" {
+  provider  = google-beta
+  name      = "<%= ctx[:vars]['template_name'] %>"
+  region    = "us-central1"
+  node_type = "c2-node-60-240"
+}
+
+resource "google_compute_node_group" "<%= ctx[:primary_resource_id] %>" {
+  provider    = google-beta
+  name        = "<%= ctx[:vars]['group_name'] %>"
+  zone        = "us-central1-a"
+  description = "example google_compute_node_group for Terraform Google Provider"
+
+  initial_size          = 1
+  node_template = google_compute_node_template.soletenant-tmpl.id
+
+  maintenance_interval  = "RECURRENT"
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `maintenance_interval` field to `google_compute_node_group` resource (beta)
```
Fixes https://github.com/hashicorp/terraform-provider-google/issues/16276.
