### PR TITLE
Add remaining fields to TPU VM resource

### DIFF
--- a/mmv1/products/tpuv2/Vm.yaml
+++ b/mmv1/products/tpuv2/Vm.yaml
@@ -50,14 +50,12 @@ examples:
     primary_resource_id: 'tpu'
     vars:
       vm_name: 'test-tpu'
-    skip_test: true # The test case is covered in the update test
   - !ruby/object:Provider::Terraform::Examples
     name: 'tpu_v2_vm_full'
     min_version: 'beta'
     primary_resource_id: 'tpu'
     vars:
       vm_name: 'test-tpu'
-    skip_test: true # The test case is covered in the update test
 parameters:
   - !ruby/object:Api::Type::String
     name: 'zone'

--- a/mmv1/products/tpuv2/Vm.yaml
+++ b/mmv1/products/tpuv2/Vm.yaml
@@ -43,6 +43,8 @@ async: !ruby/object:Api::OpAsync
   error: !ruby/object:Api::OpAsync::Error
     path: 'error'
     message: 'message'
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  constants: templates/terraform/constants/tpu_vm.go.erb
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'tpu_v2_vm_basic'
@@ -56,6 +58,8 @@ examples:
     primary_resource_id: 'tpu'
     vars:
       vm_name: 'test-tpu'
+      sa_id: 'tpu-sa'
+      disk_name: 'tpu-disk'
 parameters:
   - !ruby/object:Api::Type::String
     name: 'zone'
@@ -88,3 +92,196 @@ properties:
     name: 'description'
     description: |
       Text description of the TPU.
+  - !ruby/object:Api::Type::NestedObject
+    name: 'networkConfig'
+    default_from_api: true
+    immutable: true
+    description: |
+      Network configurations for the TPU node.
+    properties:
+      - !ruby/object:Api::Type::Boolean
+        name: 'enableExternalIps'
+        default_from_api: true
+        immutable: true
+        send_empty_value: true
+        description: |
+          Indicates that external IP addresses would be associated with the TPU workers. If set to
+          false, the specified subnetwork or network should have Private Google Access enabled.
+      - !ruby/object:Api::Type::Boolean
+        name: 'canIpForward'
+        default_from_api: true
+        immutable: true
+        send_empty_value: true
+        description: |
+          Allows the TPU node to send and receive packets with non-matching destination or source
+          IPs. This is required if you plan to use the TPU workers to forward routes.
+  - !ruby/object:Api::Type::NestedObject
+    name: 'serviceAccount'
+    default_from_api: true
+    description: |
+      The Google Cloud Platform Service Account to be used by the TPU node VMs. If None is
+      specified, the default compute service account will be used.
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'email'
+        default_from_api: true
+        immutable: true
+        description: |
+          Email address of the service account. If empty, default Compute service account will be used.
+      - !ruby/object:Api::Type::Array
+        name: 'scope'
+        default_from_api: true
+        immutable: true
+        diff_suppress_func: 'tpuServiceAccountAddedScopesSuppress'
+        description: |
+          The list of scopes to be made available for this service account. If empty, access to all
+          Cloud APIs will be allowed.
+        item_type: Api::Type::String
+  - !ruby/object:Api::Type::NestedObject
+    name: 'schedulingConfig'
+    description: |
+      The scheduling options for this node.
+    immutable: true
+    properties:
+      - !ruby/object:Api::Type::Boolean
+        name: 'preemptible'
+        immutable: true
+        send_empty_value: true
+        description: |
+          Defines whether the node is preemptible.
+      - !ruby/object:Api::Type::Boolean
+        name: 'reserved'
+        immutable: true
+        send_empty_value: true
+        description: |
+          Whether the node is created under a reservation.
+  - !ruby/object:Api::Type::Array
+    name: 'dataDisks'
+    description: |
+      The additional data disks for the Node.
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties:
+        - !ruby/object:Api::Type::String
+          name: 'sourceDisk'
+          required: true
+          description: |
+            Specifies the full path to an existing disk. For example:
+            "projects/my-project/zones/us-central1-c/disks/my-disk".
+        - !ruby/object:Api::Type::Enum
+          name: 'mode'
+          description: |
+            The mode in which to attach this disk. If not specified, the default is READ_WRITE
+            mode. Only applicable to dataDisks.
+          values:
+            - 'READ_WRITE'
+            - 'READ_ONLY'
+  - !ruby/object:Api::Type::NestedObject
+    name: 'shieldedInstanceConfig'
+    description: |
+      Shielded Instance options.
+    immutable: true
+    properties:
+      - !ruby/object:Api::Type::Boolean
+        name: 'enableSecureBoot'
+        immutable: true
+        send_empty_value: true
+        required: true
+        description: |
+          Defines whether the instance has Secure Boot enabled.
+  - !ruby/object:Api::Type::KeyValueLabels
+    name: 'labels'
+    description: Resource labels to represent user-provided metadata.
+  - !ruby/object:Api::Type::KeyValuePairs
+    name: 'metadata'
+    description: Custom metadata to apply to the TPU Node. Can set startup-script and shutdown-script.
+  - !ruby/object:Api::Type::Array
+    name: 'tags'
+    description: |
+      Tags to apply to the TPU Node. Tags are used to identify valid sources or targets for network firewalls.
+    item_type: Api::Type::String
+  - !ruby/object:Api::Type::String
+    name: 'state'
+    output: true
+    description: |
+      The current state for the TPU Node.
+  - !ruby/object:Api::Type::String
+    name: 'health'
+    output: true
+    description: |
+      The health status of the TPU node.
+  - !ruby/object:Api::Type::String
+    name: 'healthDescription'
+    output: true
+    description: |
+      If this field is populated, it contains a description of why the TPU Node is unhealthy.
+  - !ruby/object:Api::Type::String
+    name: 'apiVersion'
+    output: true
+    description: |
+      The API version that created this Node.
+  - !ruby/object:Api::Type::String
+    name: 'queuedResource'
+    output: true
+    description: |
+      The qualified name of the QueuedResource that requested this Node.
+  - !ruby/object:Api::Type::Boolean
+    name: 'multisliceNode'
+    output: true
+    description: |
+      Whether the Node belongs to a Multislice group.
+  - !ruby/object:Api::Type::Array
+    name: 'networkEndpoints'
+    output: true
+    description: |
+      The network endpoints where TPU workers can be accessed and sent work. It is recommended that
+      runtime clients of the node reach out to the 0th entry in this map first.
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties:
+        - !ruby/object:Api::Type::String
+          name: 'ipAddress'
+          output: true
+          description: |
+            The internal IP address of this network endpoint.
+        - !ruby/object:Api::Type::Integer
+          name: 'port'
+          output: true
+          description: |
+            The port of this network endpoint.
+        - !ruby/object:Api::Type::NestedObject
+          name: 'accessConfig'
+          output: true
+          description: |
+            The access config for the TPU worker.
+          properties:
+            - !ruby/object:Api::Type::String
+              name: 'externalIp'
+              output: true
+              description: |
+                An external IP address associated with the TPU worker.
+  - !ruby/object:Api::Type::Array
+    name: 'symptoms'
+    output: true
+    description: |
+      The Symptoms that have occurred to the TPU Node.
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties:
+        - !ruby/object:Api::Type::String
+          name: 'createTime'
+          output: true
+          description: |
+            Timestamp when the Symptom is created.
+        - !ruby/object:Api::Type::String
+          name: 'symptomType'
+          output: true
+          description: |
+            Type of the Symptom.
+        - !ruby/object:Api::Type::String
+          name: 'details'
+          output: true
+          description: |
+            Detailed information of the current Symptom.
+        - !ruby/object:Api::Type::String
+          name: 'workerId'
+          output: true
+          description: |
+            A string used to uniquely distinguish a worker within a TPU node.

--- a/mmv1/products/tpuv2/Vm.yaml
+++ b/mmv1/products/tpuv2/Vm.yaml
@@ -97,6 +97,7 @@ properties:
   - !ruby/object:Api::Type::String
     name: 'cidrBlock'
     default_from_api: true
+    immutable: true
     description: |
       The CIDR block that the TPU node will use when selecting an IP address. This CIDR block must
       be a /29 block; the Compute Engine networks API forbids a smaller block, and using a larger
@@ -113,21 +114,20 @@ properties:
     properties:
       - !ruby/object:Api::Type::String
         name: 'network'
-        immutable: true
         default_from_api: true
+        immutable: true
         description: |
           The name of the network for the TPU node. It must be a preexisting Google Compute Engine
           network. If none is provided, "default" will be used.
       - !ruby/object:Api::Type::String
         name: 'subnetwork'
-        immutable: true
         default_from_api: true
+        immutable: true
         description: |
           The name of the subnetwork for the TPU node. It must be a preexisting Google Compute
           Engine subnetwork. If none is provided, "default" will be used.
       - !ruby/object:Api::Type::Boolean
         name: 'enableExternalIps'
-        default_from_api: true
         immutable: true
         send_empty_value: true
         description: |
@@ -135,7 +135,6 @@ properties:
           false, the specified subnetwork or network should have Private Google Access enabled.
       - !ruby/object:Api::Type::Boolean
         name: 'canIpForward'
-        default_from_api: true
         immutable: true
         send_empty_value: true
         description: |
@@ -144,6 +143,7 @@ properties:
   - !ruby/object:Api::Type::NestedObject
     name: 'serviceAccount'
     default_from_api: true
+    immutable: true
     description: |
       The Google Cloud Platform Service Account to be used by the TPU node VMs. If None is
       specified, the default compute service account will be used.
@@ -165,9 +165,9 @@ properties:
         item_type: Api::Type::String
   - !ruby/object:Api::Type::NestedObject
     name: 'schedulingConfig'
+    immutable: true
     description: |
       The scheduling options for this node.
-    immutable: true
     properties:
       - !ruby/object:Api::Type::Boolean
         name: 'preemptible'
@@ -195,6 +195,7 @@ properties:
             "projects/my-project/zones/us-central1-c/disks/my-disk".
         - !ruby/object:Api::Type::Enum
           name: 'mode'
+          default_value: :READ_WRITE
           description: |
             The mode in which to attach this disk. If not specified, the default is READ_WRITE
             mode. Only applicable to dataDisks.
@@ -203,9 +204,9 @@ properties:
             - 'READ_ONLY'
   - !ruby/object:Api::Type::NestedObject
     name: 'shieldedInstanceConfig'
+    immutable: true
     description: |
       Shielded Instance options.
-    immutable: true
     properties:
       - !ruby/object:Api::Type::Boolean
         name: 'enableSecureBoot'

--- a/mmv1/products/tpuv2/Vm.yaml
+++ b/mmv1/products/tpuv2/Vm.yaml
@@ -58,6 +58,8 @@ examples:
     primary_resource_id: 'tpu'
     vars:
       vm_name: 'test-tpu'
+      network_name: 'tpu-net'
+      subnet_name: 'tpu-subnet'
       sa_id: 'tpu-sa'
       disk_name: 'tpu-disk'
 parameters:
@@ -92,6 +94,16 @@ properties:
     name: 'description'
     description: |
       Text description of the TPU.
+  - !ruby/object:Api::Type::String
+    name: 'cidrBlock'
+    default_from_api: true
+    description: |
+      The CIDR block that the TPU node will use when selecting an IP address. This CIDR block must
+      be a /29 block; the Compute Engine networks API forbids a smaller block, and using a larger
+      block would be wasteful (a node can only consume one IP address). Errors will occur if the
+      CIDR block has already been used for a currently existing TPU node, the CIDR block conflicts
+      with any subnetworks in the user's provided network, or the provided network is peered with
+      another network that is using that CIDR block.
   - !ruby/object:Api::Type::NestedObject
     name: 'networkConfig'
     default_from_api: true
@@ -99,6 +111,20 @@ properties:
     description: |
       Network configurations for the TPU node.
     properties:
+      - !ruby/object:Api::Type::String
+        name: 'network'
+        immutable: true
+        default_from_api: true
+        description: |
+          The name of the network for the TPU node. It must be a preexisting Google Compute Engine
+          network. If none is provided, "default" will be used.
+      - !ruby/object:Api::Type::String
+        name: 'subnetwork'
+        immutable: true
+        default_from_api: true
+        description: |
+          The name of the subnetwork for the TPU node. It must be a preexisting Google Compute
+          Engine subnetwork. If none is provided, "default" will be used.
       - !ruby/object:Api::Type::Boolean
         name: 'enableExternalIps'
         default_from_api: true

--- a/mmv1/products/tpuv2/Vm.yaml
+++ b/mmv1/products/tpuv2/Vm.yaml
@@ -118,14 +118,18 @@ properties:
         immutable: true
         description: |
           The name of the network for the TPU node. It must be a preexisting Google Compute Engine
-          network. If none is provided, "default" will be used.
+          network. If both network and subnetwork are specified, the given subnetwork must belong
+          to the given network. If network is not specified, it will be looked up from the
+          subnetwork if one is provided, or otherwise use "default".
       - !ruby/object:Api::Type::String
         name: 'subnetwork'
         default_from_api: true
         immutable: true
         description: |
           The name of the subnetwork for the TPU node. It must be a preexisting Google Compute
-          Engine subnetwork. If none is provided, "default" will be used.
+          Engine subnetwork. If both network and subnetwork are specified, the given subnetwork
+          must belong to the given network. If subnetwork is not specified, the subnetwork with the
+          same name as the network will be used.
       - !ruby/object:Api::Type::Boolean
         name: 'enableExternalIps'
         immutable: true

--- a/mmv1/templates/terraform/constants/tpu_vm.go.erb
+++ b/mmv1/templates/terraform/constants/tpu_vm.go.erb
@@ -1,0 +1,29 @@
+
+// Suppress unremovable default scope values from GCP.
+func tpuServiceAccountAddedScopesSuppress(k, old, new string, d *schema.ResourceData) bool {
+	if strings.Contains(k, "scope.#") && (new == "0" || new == "") && old != new {
+		return false
+	}
+
+	// Get changes for service_account.xx.scope
+	b := strings.Split(k, ".")
+	o, n := d.GetChange(strings.TrimSuffix(k, "."+b[len(b)-1]))
+	if o == nil || n == nil {
+		return false
+	}
+
+	oList := normalizeScopes(tpgresource.ConvertStringArr(o.([]interface{})))
+	nList := normalizeScopes(tpgresource.ConvertStringArr(n.([]interface{})))
+
+	return reflect.DeepEqual(oList, nList)
+}
+
+func normalizeScopes(scopes []string) []string {
+	var result []string
+	for _, s := range scopes {
+		if s != "https://www.googleapis.com/auth/pubsub" {
+			result = append(result, s)
+		}
+	}
+	return result
+}

--- a/mmv1/templates/terraform/constants/tpu_vm.go.erb
+++ b/mmv1/templates/terraform/constants/tpu_vm.go.erb
@@ -18,6 +18,8 @@ func tpuServiceAccountAddedScopesSuppress(k, old, new string, d *schema.Resource
 	return reflect.DeepEqual(oList, nList)
 }
 
+// Normalize the scopes by filtering out the `https://www.googleapis.com/auth/pubsub` scope during
+// comparison
 func normalizeScopes(scopes []string) []string {
 	var result []string
 	for _, s := range scopes {

--- a/mmv1/templates/terraform/examples/tpu_v2_vm_full.tf.erb
+++ b/mmv1/templates/terraform/examples/tpu_v2_vm_full.tf.erb
@@ -15,4 +15,56 @@ resource "google_tpu_v2_vm" "<%= ctx[:primary_resource_id] %>" {
 
   runtime_version  = "tpu-vm-tf-2.13.0"
   accelerator_type = "v2-8"
+
+  network_config {
+    can_ip_forward      = true
+    enable_external_ips = true
+  }
+  
+  scheduling_config {
+    preemptible = true
+  }
+
+  shielded_instance_config {
+    enable_secure_boot = true
+  }
+
+  service_account {
+    email = google_service_account.sa.email
+    scope = [
+      "https://www.googleapis.com/auth/cloud-platform",
+    ]
+  }
+
+  data_disks {
+    source_disk = google_compute_disk.disk.id
+    mode        = "READ_ONLY"
+  }
+
+  labels = {
+    foo = "bar"
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+
+  tags = ["foo"]
+}
+
+resource "google_service_account" "sa" {
+  provider = google-beta
+
+  account_id   = "<%= ctx[:vars]['sa_id'] %>"
+  display_name = "Test TPU V2 VM"
+}
+
+resource "google_compute_disk" "disk" {
+  provider = google-beta
+
+  name  = "<%= ctx[:vars]['disk_name'] %>"
+  image = "debian-cloud/debian-11"
+  size  = 10
+  type  = "pd-ssd"
+  zone  = "us-central1-c"
 }

--- a/mmv1/templates/terraform/examples/tpu_v2_vm_full.tf.erb
+++ b/mmv1/templates/terraform/examples/tpu_v2_vm_full.tf.erb
@@ -16,9 +16,13 @@ resource "google_tpu_v2_vm" "<%= ctx[:primary_resource_id] %>" {
   runtime_version  = "tpu-vm-tf-2.13.0"
   accelerator_type = "v2-8"
 
+  cidr_block = "10.0.0.0/29"
+
   network_config {
     can_ip_forward      = true
     enable_external_ips = true
+    network             = google_compute_network.network.id
+    subnetwork          = google_compute_subnetwork.subnet.id
   }
   
   scheduling_config {
@@ -50,6 +54,22 @@ resource "google_tpu_v2_vm" "<%= ctx[:primary_resource_id] %>" {
   }
 
   tags = ["foo"]
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  provider = google-beta
+
+  name          = "<%= ctx[:vars]['subnet_name'] %>"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.network.id
+}
+
+resource "google_compute_network" "network" {
+  provider = google-beta
+
+  name                    = "<%= ctx[:vars]['network_name'] %>"
+  auto_create_subnetworks = false
 }
 
 resource "google_service_account" "sa" {

--- a/mmv1/templates/terraform/examples/tpu_v2_vm_full.tf.erb
+++ b/mmv1/templates/terraform/examples/tpu_v2_vm_full.tf.erb
@@ -76,7 +76,7 @@ resource "google_service_account" "sa" {
   provider = google-beta
 
   account_id   = "<%= ctx[:vars]['sa_id'] %>"
-  display_name = "Test TPU V2 VM"
+  display_name = "Test TPU VM"
 }
 
 resource "google_compute_disk" "disk" {

--- a/mmv1/third_party/terraform/services/tpuv2/resource_tpu_v2_vm_test.go.erb
+++ b/mmv1/third_party/terraform/services/tpuv2/resource_tpu_v2_vm_test.go.erb
@@ -121,6 +121,11 @@ resource "google_tpu_v2_vm" "tpu" {
   }
 
   data_disks {
+    source_disk = google_compute_disk.disk.id
+    mode        = "READ_WRITE"
+  }
+
+  data_disks {
     source_disk = google_compute_disk.disk2.id
     mode        = "READ_ONLY"
   }

--- a/mmv1/third_party/terraform/services/tpuv2/resource_tpu_v2_vm_test.go.erb
+++ b/mmv1/third_party/terraform/services/tpuv2/resource_tpu_v2_vm_test.go.erb
@@ -140,6 +140,16 @@ resource "google_tpu_v2_vm" "tpu" {
   }
 }
 
+resource "google_compute_disk" "disk" {
+  provider = google-beta
+
+  name  = "tf-test-tpu-%{random_suffix}"
+  image = "debian-cloud/debian-11"
+  size  = 10
+  type  = "pd-ssd"
+  zone  = "us-central1-c"
+}
+
 resource "google_compute_disk" "disk2" {
   provider = google-beta
 

--- a/mmv1/third_party/terraform/services/tpuv2/resource_tpu_v2_vm_test.go.erb
+++ b/mmv1/third_party/terraform/services/tpuv2/resource_tpu_v2_vm_test.go.erb
@@ -4,6 +4,7 @@ package tpuv2_test
 <% unless version == 'ga' -%>
 import (
 	"testing"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
@@ -13,14 +14,8 @@ import (
 func TestAccTpuV2Vm_update(t *testing.T) {
 	t.Parallel()
 
-        randomSuffix := acctest.RandString(t, 10)
 	context := map[string]interface{}{
-                "random_suffix": randomSuffix,
-                "description": "Old description original context",
-	}
-	updatedContext := map[string]interface{}{
-                "random_suffix": randomSuffix,
-                "description": "New description updated context",
+		"random_suffix": acctest.RandString(t, 10),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -35,16 +30,25 @@ func TestAccTpuV2Vm_update(t *testing.T) {
 				ResourceName:            "google_tpu_v2_vm.tpu",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"zone"},
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels", "zone"},
 			},
 			{
-				Config: testAccTpuV2Vm_update(updatedContext),
+				Config: testAccTpuV2Vm_update(context, true),
 			},
 			{
 				ResourceName:            "google_tpu_v2_vm.tpu",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"zone"},
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels", "zone"},
+			},
+			{
+				Config: testAccTpuV2Vm_update(context, false),
+			},
+			{
+				ResourceName:            "google_tpu_v2_vm.tpu",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels", "zone"},
 			},
 		},
 	})
@@ -52,46 +56,90 @@ func TestAccTpuV2Vm_update(t *testing.T) {
 
 func testAccTpuV2Vm_full(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-data "google_tpu_v2_runtime_versions" "available" {
-  provider = google-beta
-}
-
-data "google_tpu_v2_accelerator_types" "available" {
-  provider = google-beta
-}
-
 resource "google_tpu_v2_vm" "tpu" {
   provider = google-beta
 
-  name = "tf-test-test-tpu%{random_suffix}"
-  zone = "us-central1-c"
-  description = "%{description}"
+  name        = "tf-test-test-tpu-%{random_suffix}"
+  zone        = "us-central1-c"
+  description = "Text description of the TPU."
 
   runtime_version  = "tpu-vm-tf-2.13.0"
   accelerator_type = "v2-8"
+
+  data_disks {
+    source_disk = google_compute_disk.disk.id
+    mode        = "READ_ONLY"
+  }
+
+  labels = {
+    foo = "bar"
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+
+  tags = ["foo"]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_compute_disk" "disk" {
+  provider = google-beta
+
+  name  = "tf-test-tpu-%{random_suffix}"
+  image = "debian-cloud/debian-11"
+  size  = 10
+  type  = "pd-ssd"
+  zone  = "us-central1-c"
 }
 `, context)
 }
 
-func testAccTpuV2Vm_update(context map[string]interface{}) string {
+func testAccTpuV2Vm_update(context map[string]interface{}, preventDestroy bool) string {
+	context["prevent_destroy"] = strconv.FormatBool(preventDestroy)
+
 	return acctest.Nprintf(`
-data "google_tpu_v2_runtime_versions" "available" {
-  provider = google-beta
-}
-
-data "google_tpu_v2_accelerator_types" "available" {
-  provider = google-beta
-}
-
 resource "google_tpu_v2_vm" "tpu" {
   provider = google-beta
 
-  name = "tf-test-test-tpu%{random_suffix}"
-  zone = "us-central1-c"
-  description = "%{description}"
+  name        = "tf-test-test-tpu-%{random_suffix}"
+  zone        = "us-central1-c"
+  description = "Text description of the TPU updated."
 
   runtime_version  = "tpu-vm-tf-2.13.0"
   accelerator_type = "v2-8"
+
+  data_disks {
+    source_disk = google_compute_disk.disk2.id
+    mode        = "READ_ONLY"
+  }
+
+  labels = {
+    baz = "bar"
+  }
+
+  metadata = {
+    baz = "bar"
+  }
+
+  tags = ["baz"]
+
+  lifecycle {
+    prevent_destroy = %{prevent_destroy}
+  }
+}
+
+resource "google_compute_disk" "disk2" {
+  provider = google-beta
+
+  name  = "tf-test-tpu2-%{random_suffix}"
+  image = "debian-cloud/debian-11"
+  size  = 10
+  type  = "pd-ssd"
+  zone  = "us-central1-c"
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/tpuv2/resource_tpu_v2_vm_test.go.erb
+++ b/mmv1/third_party/terraform/services/tpuv2/resource_tpu_v2_vm_test.go.erb
@@ -3,16 +3,11 @@ package tpuv2_test
 
 <% unless version == 'ga' -%>
 import (
-	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
-	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 func TestAccTpuV2Vm_update(t *testing.T) {
@@ -99,44 +94,5 @@ resource "google_tpu_v2_vm" "tpu" {
   accelerator_type = "v2-8"
 }
 `, context)
-}
-
-func testAccCheckTpuV2VmDestroyProducer(t *testing.T) func(s *terraform.State) error {
-	return func(s *terraform.State) error {
-		for name, rs := range s.RootModule().Resources {
-			if rs.Type != "google_tpu_v2_vm" {
-				continue
-			}
-			if strings.HasPrefix(name, "data.") {
-				continue
-			}
-
-			config := acctest.GoogleProviderConfig(t)
-
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{TpuV2BasePath}}projects/{{project}}/locations/{{zone}}/nodes/{{name}}")
-			if err != nil {
-				return err
-			}
-
-			billingProject := ""
-
-			if config.BillingProject != "" {
-				billingProject = config.BillingProject
-			}
-
-			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-				Config:    config,
-				Method:    "GET",
-				Project:   billingProject,
-				RawURL:    url,
-				UserAgent: config.UserAgent,
-			})
-			if err == nil {
-				return fmt.Errorf("TpuV2Vm still exists at %s", url)
-			}
-		}
-
-		return nil
-	}
 }
 <% end -%>

--- a/mmv1/third_party/terraform/services/tpuv2/resource_tpu_v2_vm_test.go.erb
+++ b/mmv1/third_party/terraform/services/tpuv2/resource_tpu_v2_vm_test.go.erb
@@ -66,6 +66,10 @@ resource "google_tpu_v2_vm" "tpu" {
   runtime_version  = "tpu-vm-tf-2.13.0"
   accelerator_type = "v2-8"
 
+  scheduling_config {
+    preemptible = true
+  }
+
   data_disks {
     source_disk = google_compute_disk.disk.id
     mode        = "READ_ONLY"
@@ -111,6 +115,10 @@ resource "google_tpu_v2_vm" "tpu" {
 
   runtime_version  = "tpu-vm-tf-2.13.0"
   accelerator_type = "v2-8"
+
+  scheduling_config {
+    preemptible = true
+  }
 
   data_disks {
     source_disk = google_compute_disk.disk2.id

--- a/mmv1/third_party/terraform/services/tpuv2/resource_tpu_v2_vm_test.go.erb
+++ b/mmv1/third_party/terraform/services/tpuv2/resource_tpu_v2_vm_test.go.erb
@@ -59,7 +59,7 @@ func testAccTpuV2Vm_full(context map[string]interface{}) string {
 resource "google_tpu_v2_vm" "tpu" {
   provider = google-beta
 
-  name        = "tf-test-test-tpu-%{random_suffix}"
+  name        = "tf-test-tpu-%{random_suffix}"
   zone        = "us-central1-c"
   description = "Text description of the TPU."
 
@@ -93,7 +93,7 @@ resource "google_tpu_v2_vm" "tpu" {
 resource "google_compute_disk" "disk" {
   provider = google-beta
 
-  name  = "tf-test-tpu-%{random_suffix}"
+  name  = "tf-test-tpu-disk-%{random_suffix}"
   image = "debian-cloud/debian-11"
   size  = 10
   type  = "pd-ssd"
@@ -109,7 +109,7 @@ func testAccTpuV2Vm_update(context map[string]interface{}, preventDestroy bool) 
 resource "google_tpu_v2_vm" "tpu" {
   provider = google-beta
 
-  name        = "tf-test-test-tpu-%{random_suffix}"
+  name        = "tf-test-tpu-%{random_suffix}"
   zone        = "us-central1-c"
   description = "Text description of the TPU updated."
 
@@ -148,7 +148,7 @@ resource "google_tpu_v2_vm" "tpu" {
 resource "google_compute_disk" "disk" {
   provider = google-beta
 
-  name  = "tf-test-tpu-%{random_suffix}"
+  name  = "tf-test-tpu-disk-%{random_suffix}"
   image = "debian-cloud/debian-11"
   size  = 10
   type  = "pd-ssd"
@@ -158,7 +158,7 @@ resource "google_compute_disk" "disk" {
 resource "google_compute_disk" "disk2" {
   provider = google-beta
 
-  name  = "tf-test-tpu2-%{random_suffix}"
+  name  = "tf-test-tpu-disk2-%{random_suffix}"
   image = "debian-cloud/debian-11"
   size  = 10
   type  = "pd-ssd"


### PR DESCRIPTION
b/292585830

This adds the remaining fields to `google_tpu_v2_vm` that are available from the API.

Notable exceptions (which may end up making it into this PR):
- `accelerator_config`
    - This conflicts with `accelerator_type`, and we'll need to work around the existing default behavior

One other interesting piece is `service_account.scopes`. If the user specifies this field but does not include `https://www.googleapis.com/auth/pubsub`, it will be automatically added by the server, so I've added a diff_suppress to ignore that value.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
tpuv2: added more fields to `google_tpu_v2_vm` resource, including `network_config`, `scheduling_config`, `shielded_instance_config`, `service_account` and `data_disks`
```
