### PR TITLE
Add an IPV6 example-derived test for `google_firestore_instance`

### DIFF
--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -37,6 +37,12 @@ examples:
     vars:
       instance_name: 'test-instance'
   - !ruby/object:Provider::Terraform::Examples
+    name: 'filestore_instance_basic_ipv6'
+    skip_docs: true
+    primary_resource_id: 'instance'
+    vars:
+      instance_name: 'test-instance'
+  - !ruby/object:Provider::Terraform::Examples
     name: 'filestore_instance_full'
     primary_resource_id: 'instance'
     vars:

--- a/mmv1/templates/terraform/examples/filestore_instance_basic_ipv6.tf.erb
+++ b/mmv1/templates/terraform/examples/filestore_instance_basic_ipv6.tf.erb
@@ -1,0 +1,15 @@
+resource "google_filestore_instance" "<%= ctx[:primary_resource_id] %>" {
+  name     = "<%= ctx[:vars]["instance_name"] %>"
+  location = "us-central1-b"
+  tier     = "BASIC_HDD"
+
+  file_shares {
+    capacity_gb = 1024
+    name        = "share1"
+  }
+
+  networks {
+    network = "default"
+    modes   = ["MODE_IPV6"]
+  }
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Relates to https://github.com/hashicorp/terraform-provider-google/issues/16299

This PR adds a new test to the `google_filestore_instance ` resource that shows how a permadiff occurs when setting `modes   = ["MODE_IPV6"]`

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
