### PR TITLE
Remove TestAccContainerCluster_failedCreation

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -5165,34 +5165,6 @@ func TestAccContainerCluster_withEnablePrivateEndpointToggle(t *testing.T) {
 	})
 }
 
-func TestAccContainerCluster_failedCreation(t *testing.T) {
-	// Test that in a scenario where the cluster fails to create, a subsequent apply will delete the resource.
-	// Skip this test for now as we don't have a good way to force cluster creation to fail. https://github.com/hashicorp/terraform-provider-google/issues/13711
-	t.Skip()
-	t.Parallel()
-
-	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
-
-	project := acctest.BootstrapProject(t, "tf-fail-cluster-", envvar.GetTestBillingAccountFromEnv(t), []string{"container.googleapis.com"})
-	acctest.RemoveContainerServiceAgentRoleFromContainerEngineRobot(t, project)
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:  func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccContainerCluster_failedCreation(clusterName, project.ProjectId),
-				ExpectError: regexp.MustCompile("timeout while waiting for state to become 'DONE'"),
-			},
-			{
-				Config:      testAccContainerCluster_failedCreation_update(clusterName, project.ProjectId),
-				ExpectError: regexp.MustCompile("Failed to create cluster"),
-				Check:       testAccCheckContainerClusterDestroyProducer(t),
-			},
-		},
-	})
-}
-
 func testAccContainerCluster_withEnablePrivateEndpoint(clusterName string, flag string) string {
 
 	return fmt.Sprintf(`
@@ -8376,40 +8348,6 @@ resource "google_container_cluster" "with_tpu_config" {
 `, network, cluster)
 }
 <% end -%>
-
-func testAccContainerCluster_failedCreation(cluster, project string) string {
-	return fmt.Sprintf(`
-resource "google_container_cluster" "primary" {
-  name               = "%s"
-  project            = "%s"
-  location           = "us-central1-a"
-  initial_node_count = 1
-
-  workload_identity_config {
-    workload_pool = "%s.svc.id.goog"
-  }
-
-  timeouts {
-    create = "40s"
-  }
-  deletion_protection = false
-}`, cluster, project, project)
-}
-
-func testAccContainerCluster_failedCreation_update(cluster, project string) string {
-	return fmt.Sprintf(`
-resource "google_container_cluster" "primary" {
-  name               = "%s"
-  project            = "%s"
-  location           = "us-central1-a"
-  initial_node_count = 1
-
-  workload_identity_config {
-    workload_pool = "%s.svc.id.goog"
-  }
-  deletion_protection = false
-}`, cluster, project, project)
-}
 
 <% unless version == 'ga' -%>
 func testAccContainerCluster_withProtectConfig(name string) string {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/13711

This is redundant with [TestAccContainerCluster_errorCleanDanglingCluster](https://github.com/GoogleCloudPlatform/magic-modules/blob/ca3785760ee461ebef5ac0eea99c385bdced653a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb#L3509-L3549), but is harder to trigger.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
