### PR TITLE
Link to firestore_database migration instructions

### DIFF
--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -22,7 +22,9 @@ description: |
 
   If you wish to use Firestore with App Engine, use the
   [`google_app_engine_application`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/app_engine_application)
-  resource instead.
+  resource instead. If you were previously using the `google_app_engine_application` resource exclusively for managing a Firestore database
+  and would like to use the `google_firestore_database` resource instead, please follow the instructions
+  [here](https://cloud.google.com/firestore/docs/app-engine-requirement).
 references: !ruby/object:Api::Resource::ReferenceLinks
   guides:
     'Official Documentation': 'https://cloud.google.com/firestore/docs/'


### PR DESCRIPTION
To make it easier to migrate from the `google_app_engine_application` resource to the `google_firestore_database` resource for those who wish to do so, I'm linking to the instructions on the docs.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```