### PR TITLE
fix failing project service disabledependentservices test

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service_test.go
@@ -78,7 +78,7 @@ func TestAccProjectService_disableDependentServices(t *testing.T) {
 	org := envvar.GetTestOrgFromEnv(t)
 	billingId := envvar.GetTestBillingAccountFromEnv(t)
 	pid := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
-	services := []string{"cloudbuild.googleapis.com", "containerregistry.googleapis.com"}
+	services := []string{"bigquerystorage.googleapis.com", "bigquery.googleapis.com"}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
fixes https://github.com/hashicorp/terraform-provider-google/issues/16149

Old scenario assumed cloud build was dependent on container registry -- this appears to no longer be the case. Probably safe to assume bigquerystorage will remain dependent on bigquery for the forseeable future.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
