### PR TITLE
Use functional options in BootstrapSharedTestGlobalAddress

### DIFF
--- a/mmv1/products/looker/Instance.yaml
+++ b/mmv1/products/looker/Instance.yaml
@@ -69,9 +69,9 @@ examples:
       client_id: 'my-client-id'
       client_secret: 'my-client-secret'
     test_vars_overrides:
-      address_name: 'acctest.BootstrapSharedTestGlobalAddress(t, "looker-vpc-network-1", 20)'
+      address_name: 'acctest.BootstrapSharedTestGlobalAddress(t, "looker-vpc-network-1", acctest.AddressWithPrefixLength(20))'
       kms_key_name: 'acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
-      network_name: 'acctest.BootstrapSharedServiceNetworkingConnection(t, "looker-vpc-network-1", 20)'
+      network_name: 'acctest.BootstrapSharedServiceNetworkingConnection(t, "looker-vpc-network-1", acctest.AddressWithPrefixLength(20))'
     skip_docs: true
 parameters:
   - !ruby/object:Api::Type::String

--- a/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
+++ b/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
@@ -361,10 +361,31 @@ func BootstrapSharedTestNetwork(t *testing.T, testId string) string {
 	return network.Name
 }
 
+type AddressSettings struct {
+	PrefixLength int
+}
+
+func AddressWithPrefixLength(prefixLength int) func(*AddressSettings) {
+	return func(settings *AddressSettings) {
+		settings.PrefixLength = prefixLength
+	}
+}
+
+func NewAddressSettings(options ...func(*AddressSettings)) *AddressSettings {
+	settings := &AddressSettings{
+		PrefixLength: 16, // default prefix length
+	}
+
+	for _, o := range options {
+		o(settings)
+	}
+	return settings
+}
+
 const SharedTestGlobalAddressPrefix = "tf-bootstrap-addr-"
 
-// params := [prefixLength] prefixLength should be the first item in params
-func BootstrapSharedTestGlobalAddress(t *testing.T, testId string, params ...interface{}) string {
+// params are the functions to set compute global address
+func BootstrapSharedTestGlobalAddress(t *testing.T, testId string, params ...func(*AddressSettings)) string {
 	project := envvar.GetTestProjectFromEnv()
 	projectNumber := envvar.GetTestProjectNumberFromEnv()
 	addressName := SharedTestGlobalAddressPrefix + testId
@@ -382,16 +403,13 @@ func BootstrapSharedTestGlobalAddress(t *testing.T, testId string, params ...int
 		log.Printf("[DEBUG] Global address %q not found, bootstrapping", addressName)
 		url := fmt.Sprintf("%sprojects/%s/global/addresses", config.ComputeBasePath, project)
 
-		prefixLength := 16
-		if len(params) != 0 {
-			prefixLength = params[0].(int)
-		}
+		settings := NewAddressSettings(params...)
 
 		netObj := map[string]interface{}{
 			"name":          addressName,
 			"address_type":  "INTERNAL",
 			"purpose":       "VPC_PEERING",
-			"prefix_length": prefixLength,
+			"prefix_length": settings.PrefixLength,
 			"network":       networkId,
 		}
 
@@ -430,7 +448,7 @@ func BootstrapSharedTestGlobalAddress(t *testing.T, testId string, params ...int
 // if it hasn't been created in the test project, and a service networking connection
 // if it hasn't been created in the test project.
 //
-// params := [prefixLength] prefixLength should be the first item in params
+// params are the functions to set compute global address
 //
 // BootstrapSharedServiceNetworkingConnection returns a persistent compute network name
 // for a test or set of tests.
@@ -443,7 +461,7 @@ func BootstrapSharedTestGlobalAddress(t *testing.T, testId string, params ...int
 // https://cloud.google.com/vpc/docs/configure-private-services-access#removing-connection
 //
 // testId specifies the test for which a shared network and a gobal address are used/initialized.
-func BootstrapSharedServiceNetworkingConnection(t *testing.T, testId string, params ...interface{}) string {
+func BootstrapSharedServiceNetworkingConnection(t *testing.T, testId string, params ...func(*AddressSettings)) string {
 	parentService := "services/servicenetworking.googleapis.com"
 	projectId := envvar.GetTestProjectFromEnv()
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

To resolve the comment in the previous PR  https://github.com/GoogleCloudPlatform/magic-modules/pull/9295#discussion_r1365920938

`functional options` is a better solution.

https://www.sohamkamani.com/golang/options-pattern/

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
