### PR TITLE
Add google_network_connectivity_policy_based_route resource

### DIFF
--- a/mmv1/products/networkconnectivity/PolicyBasedRoute.yaml
+++ b/mmv1/products/networkconnectivity/PolicyBasedRoute.yaml
@@ -91,7 +91,7 @@ properties:
           Internet protocol versions this policy-based route applies to.
         values:
           - :IPV4
-      - !ruby/object:Api::Type::String # probably could have been an enum, but it's a string in the API
+      - !ruby/object:Api::Type::String  # probably could have been an enum, but it's a string in the API
         name: 'ipProtocol'
         default_value: "ALL"
         description: |
@@ -108,18 +108,18 @@ properties:
           The destination IP range of outgoing packets that this policy-based route applies to. Default is "0.0.0.0/0" if protocol version is IPv4.
   - !ruby/object:Api::Type::Enum
     name: 'nextHopOtherRoutes'
-    exactly_one_of: # next_hop union
-    - next_hop_ilb_ip
-    - next_hop_other_routes
+    exactly_one_of:  # next_hop union
+      - next_hop_ilb_ip
+      - next_hop_other_routes
     description: |
       Other routes that will be referenced to determine the next hop of the packet.
     values:
     - :DEFAULT_ROUTING
   - !ruby/object:Api::Type::String
     name: 'nextHopIlbIp'
-    exactly_one_of: # next_hop union
-    - next_hop_ilb_ip
-    - next_hop_other_routes
+    exactly_one_of:  # next_hop union
+      - next_hop_ilb_ip
+      - next_hop_other_routes
     description: |
       The IP address of a global-access-enabled L4 ILB that is the next hop for matching packets.
   - !ruby/object:Api::Type::Integer
@@ -129,29 +129,29 @@ properties:
       The priority of this policy-based route. Priority is used to break ties in cases where there are more than one matching policy-based routes found. In cases where multiple policy-based routes are matched, the one with the lowest-numbered priority value wins. The default value is 1000. The priority value must be from 1 to 65535, inclusive.
   - !ruby/object:Api::Type::NestedObject
     name: 'virtualMachine'
-    exactly_one_of: # target union
-    - virtual_machine
-    - interconnect_attachment
+    exactly_one_of:  # target union
+      - virtual_machine
+      - interconnect_attachment
     description: |
       VM instances to which this policy-based route applies to.
     properties:
       - !ruby/object:Api::Type::Array
         name: 'tags'
-        required: true # optional in API docs, but that doesn't make sense here
+        required: true  # optional in API docs, but that doesn't make sense here
         description: |
           A list of VM instance tags that this policy-based route applies to. VM instances that have ANY of tags specified here will install this PBR.
         item_type: Api::Type::String
   - !ruby/object:Api::Type::NestedObject
     name: 'interconnectAttachment'
-    exactly_one_of: # target union
-    - virtual_machine
-    - interconnect_attachment
+    exactly_one_of:  # target union
+      - virtual_machine
+      - interconnect_attachment
     description: |
       The interconnect attachments that this policy-based route applies to.
     properties:
       - !ruby/object:Api::Type::String
         name: 'region'
-        required: true # optional in API docs, but that doesn't make sense here
+        required: true  # optional in API docs, but that doesn't make sense here
         description: |
           Cloud region to install this policy-based route on for Interconnect attachments. Use `all` to install it on all Interconnect attachments.
   - !ruby/object:Api::Type::Time
@@ -176,7 +176,7 @@ properties:
        If potential misconfigurations are detected for this route, this field will be populated with warning messages.
     item_type: !ruby/object:Api::Type::NestedObject
       properties:
-        - !ruby/object:Api::Type::String # technically enum, but doesn't matter for output fields
+        - !ruby/object:Api::Type::String  # technically enum, but doesn't matter for output fields
           name: 'code'
           output: true
           description: |

--- a/mmv1/products/networkconnectivity/PolicyBasedRoute.yaml
+++ b/mmv1/products/networkconnectivity/PolicyBasedRoute.yaml
@@ -114,7 +114,7 @@ properties:
     description: |
       Other routes that will be referenced to determine the next hop of the packet.
     values:
-    - :DEFAULT_ROUTING
+      - :DEFAULT_ROUTING
   - !ruby/object:Api::Type::String
     name: 'nextHopIlbIp'
     exactly_one_of:  # next_hop union

--- a/mmv1/products/networkconnectivity/PolicyBasedRoute.yaml
+++ b/mmv1/products/networkconnectivity/PolicyBasedRoute.yaml
@@ -129,8 +129,7 @@ properties:
       The priority of this policy-based route. Priority is used to break ties in cases where there are more than one matching policy-based routes found. In cases where multiple policy-based routes are matched, the one with the lowest-numbered priority value wins. The default value is 1000. The priority value must be from 1 to 65535, inclusive.
   - !ruby/object:Api::Type::NestedObject
     name: 'virtualMachine'
-    exactly_one_of:  # target union
-      - virtual_machine
+    conflicts:  # target union
       - interconnect_attachment
     description: |
       VM instances to which this policy-based route applies to.
@@ -143,9 +142,8 @@ properties:
         item_type: Api::Type::String
   - !ruby/object:Api::Type::NestedObject
     name: 'interconnectAttachment'
-    exactly_one_of:  # target union
+    conflicts:  # target union
       - virtual_machine
-      - interconnect_attachment
     description: |
       The interconnect attachments that this policy-based route applies to.
     properties:

--- a/mmv1/products/networkconnectivity/PolicyBasedRoute.yaml
+++ b/mmv1/products/networkconnectivity/PolicyBasedRoute.yaml
@@ -1,0 +1,194 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'PolicyBasedRoute'
+base_url: 'projects/{{project}}/locations/global/policyBasedRoutes'
+create_url: 'projects/{{project}}/locations/global/policyBasedRoutes?policyBasedRouteId={{name}}'
+self_link: 'projects/{{project}}/locations/global/policyBasedRoutes/{{name}}'
+immutable: true
+description:
+  'Policy-based Routes are more powerful routes that route L4 network traffic based on not just destination IP, but also source IP, protocol and more. A Policy-based Route always take precedence when it conflicts with other types of routes.'
+references: !ruby/object:Api::Resource::ReferenceLinks
+  api: 'https://cloud.google.com/network-connectivity/docs/reference/networkconnectivity/rest/v1/projects.locations.global.policyBasedRoutes'
+  guides:
+    'Use policy-based routes': 'https://cloud.google.com/vpc/docs/use-policy-based-routes#api'
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
+    path: 'name'
+    base_url: '{{op_id}}'
+    wait_ms: 1000
+    timeouts: !ruby/object:Api::Timeouts
+      insert_minutes: 30
+      update_minutes: 30
+      delete_minutes: 30
+  result: !ruby/object:Api::OpAsync::Result
+    path: 'response'
+  status: !ruby/object:Api::OpAsync::Status
+    path: 'done'
+    complete: true
+    allowed:
+      - true
+      - false
+  error: !ruby/object:Api::OpAsync::Error
+    path: 'error'
+    message: 'message'
+autogen_async: true
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'network_connectivity_policy_based_route_basic'
+    primary_resource_id: 'default'
+    vars:
+      pbr_name: 'my-pbr'
+      network_name: 'my-network'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'network_connectivity_policy_based_route_full'
+    primary_resource_id: 'default'
+    vars:
+      pbr_name: 'my-pbr'
+      network_name: 'my-network'
+      ilb_name: 'my-ilb'
+properties:
+  - !ruby/object:Api::Type::String
+    name: 'name'
+    required: true
+    url_param_only: true
+    description: |
+      The name of the policy based route.
+  - !ruby/object:Api::Type::String
+    name: 'description'
+    description: |
+      An optional description of this resource.
+  - !ruby/object:Api::Type::KeyValueLabels
+    name: 'labels'
+    description: |
+      User-defined labels.
+  - !ruby/object:Api::Type::String
+    name: 'network'
+    required: true
+    description: |
+      Fully-qualified URL of the network that this route applies to, for example: projects/my-project/global/networks/my-network.
+  - !ruby/object:Api::Type::NestedObject
+    name: 'filter'
+    required: true
+    description: |
+      The filter to match L4 traffic.
+    properties:
+      - !ruby/object:Api::Type::Enum
+        name: 'protocolVersion'
+        required: true
+        description: |
+          Internet protocol versions this policy-based route applies to.
+        values:
+          - :IPV4
+      - !ruby/object:Api::Type::String # probably could have been an enum, but it's a string in the API
+        name: 'ipProtocol'
+        default_value: "ALL"
+        description: |
+          The IP protocol that this policy-based route applies to. Valid values are 'TCP', 'UDP', and 'ALL'. Default is 'ALL'.
+      - !ruby/object:Api::Type::String
+        name: 'srcRange'
+        default_value: "0.0.0.0/0"
+        description: |
+          The source IP range of outgoing packets that this policy-based route applies to. Default is "0.0.0.0/0" if protocol version is IPv4.
+      - !ruby/object:Api::Type::String
+        name: 'destRange'
+        default_value: "0.0.0.0/0"
+        description: |
+          The destination IP range of outgoing packets that this policy-based route applies to. Default is "0.0.0.0/0" if protocol version is IPv4.
+  - !ruby/object:Api::Type::Enum
+    name: 'nextHopOtherRoutes'
+    exactly_one_of: # next_hop union
+    - next_hop_ilb_ip
+    - next_hop_other_routes
+    description: |
+      Other routes that will be referenced to determine the next hop of the packet.
+    values:
+    - :DEFAULT_ROUTING
+  - !ruby/object:Api::Type::String
+    name: 'nextHopIlbIp'
+    exactly_one_of: # next_hop union
+    - next_hop_ilb_ip
+    - next_hop_other_routes
+    description: |
+      The IP address of a global-access-enabled L4 ILB that is the next hop for matching packets.
+  - !ruby/object:Api::Type::Integer
+    name: 'priority'
+    default_value: 1000
+    description: |
+      The priority of this policy-based route. Priority is used to break ties in cases where there are more than one matching policy-based routes found. In cases where multiple policy-based routes are matched, the one with the lowest-numbered priority value wins. The default value is 1000. The priority value must be from 1 to 65535, inclusive.
+  - !ruby/object:Api::Type::NestedObject
+    name: 'virtualMachine'
+    exactly_one_of: # target union
+    - virtual_machine
+    - interconnect_attachment
+    description: |
+      VM instances to which this policy-based route applies to.
+    properties:
+      - !ruby/object:Api::Type::Array
+        name: 'tags'
+        required: true # optional in API docs, but that doesn't make sense here
+        description: |
+          A list of VM instance tags that this policy-based route applies to. VM instances that have ANY of tags specified here will install this PBR.
+        item_type: Api::Type::String
+  - !ruby/object:Api::Type::NestedObject
+    name: 'interconnectAttachment'
+    exactly_one_of: # target union
+    - virtual_machine
+    - interconnect_attachment
+    description: |
+      The interconnect attachments that this policy-based route applies to.
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'region'
+        required: true # optional in API docs, but that doesn't make sense here
+        description: |
+          Cloud region to install this policy-based route on for Interconnect attachments. Use `all` to install it on all Interconnect attachments.
+  - !ruby/object:Api::Type::Time
+    name: 'createTime'
+    output: true
+    description: |
+      Time when the policy-based route was created.
+  - !ruby/object:Api::Type::Time
+    name: 'updateTime'
+    output: true
+    description: |
+      Time when the policy-based route was created.
+  - !ruby/object:Api::Type::Time
+    name: 'kind'
+    output: true
+    description: |
+      Type of this resource.
+  - !ruby/object:Api::Type::Array
+    name: 'warnings'
+    output: true
+    description: |
+       If potential misconfigurations are detected for this route, this field will be populated with warning messages.
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties:
+        - !ruby/object:Api::Type::String # technically enum, but doesn't matter for output fields
+          name: 'code'
+          output: true
+          description: |
+            A warning code, if applicable.
+        - !ruby/object:Api::Type::KeyValuePairs
+          name: 'data'
+          output: true
+          description: |
+            Metadata about this warning in key: value format. The key should provides more detail on the warning being returned. For example, for warnings where there are no results in a list request for a particular zone, this key might be scope and the key value might be the zone name. Other examples might be a key indicating a deprecated resource and a suggested replacement.
+        - !ruby/object:Api::Type::String
+          name: 'warningMessage'
+          output: true
+          description: |
+            A human-readable description of the warning code.
+# note: the API includes a "selfLink" output field that is not populated

--- a/mmv1/templates/terraform/examples/network_connectivity_policy_based_route_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/network_connectivity_policy_based_route_basic.tf.erb
@@ -1,0 +1,13 @@
+resource "google_network_connectivity_policy_based_route" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['pbr_name'] %>"
+  network = google_compute_network.my_network.id
+  filter {
+    protocol_version = "IPV4"
+  }
+  next_hop_other_routes = "DEFAULT_ROUTING"
+}
+
+resource "google_compute_network" "my_network" {
+  name                    = "<%= ctx[:vars]['network_name'] %>"
+  auto_create_subnetworks = false
+}

--- a/mmv1/templates/terraform/examples/network_connectivity_policy_based_route_full.tf.erb
+++ b/mmv1/templates/terraform/examples/network_connectivity_policy_based_route_full.tf.erb
@@ -1,0 +1,34 @@
+resource "google_network_connectivity_policy_based_route" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['pbr_name'] %>"
+  description = "My routing policy"
+  network = google_compute_network.my_network.id
+  priority = 2302
+
+  filter {
+    protocol_version = "IPV4"
+    ip_protocol = "UDP"
+    src_range = "10.0.0.0/24"
+    dest_range = "0.0.0.0/0"
+  }
+  next_hop_ilb_ip = google_compute_global_address.ilb.address
+
+  virtual_machine {
+    tags = ["restricted"]
+  }
+
+  labels = {
+    env = "default"
+  }
+}
+
+resource "google_compute_network" "my_network" {
+  name                    = "<%= ctx[:vars]['network_name'] %>"
+  auto_create_subnetworks = false
+}
+
+# This example substitutes an arbitrary internal IP for an internal network
+# load balancer for brevity. Consult https://cloud.google.com/load-balancing/docs/internal
+# to set one up.
+resource "google_compute_global_address" "ilb" {
+  name = "<%= ctx[:vars]['ilb_name'] %>"
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/15414, b/249847932

I didn't test the `interconnect_attachment` target, given we don't own an interconnect attachment ourselves to test against.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_network_connectivity_policy_based_route`
```
