### PR TITLE
Fix google_iam_deny_policy tests

### DIFF
--- a/mmv1/templates/terraform/examples/iam_deny_policy_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/iam_deny_policy_basic.tf.erb
@@ -17,7 +17,7 @@ resource "google_iam_deny_policy" "<%= ctx[:primary_resource_id] %>" {
         title = "Some expr"
         expression = "!resource.matchTag('12345678/env', 'test')"
       }
-      denied_permissions = ["cloudresourcemanager.googleapis.com/projects.delete"]
+      denied_permissions = ["cloudresourcemanager.googleapis.com/projects.update"]
     }
   }
   rules {
@@ -28,7 +28,7 @@ resource "google_iam_deny_policy" "<%= ctx[:primary_resource_id] %>" {
         title = "Some expr"
         expression = "!resource.matchTag('12345678/env', 'test')"
       }
-      denied_permissions = ["cloudresourcemanager.googleapis.com/projects.delete"]
+      denied_permissions = ["cloudresourcemanager.googleapis.com/projects.update"]
       exception_principals = ["principal://iam.googleapis.com/projects/-/serviceAccounts/${google_service_account.test-account.email}"]
     }
   }

--- a/mmv1/third_party/terraform/services/iam2/resource_iam_deny_policy_test.go.erb
+++ b/mmv1/third_party/terraform/services/iam2/resource_iam_deny_policy_test.go.erb
@@ -111,7 +111,7 @@ resource "google_iam_deny_policy" "example" {
         title = "Some expr"
         expression = "!resource.matchTag('12345678/env', 'test')"
       }
-      denied_permissions = ["cloudresourcemanager.googleapis.com/projects.delete"]
+      denied_permissions = ["cloudresourcemanager.googleapis.com/projects.update"]
     }
   }
   rules {
@@ -122,7 +122,7 @@ resource "google_iam_deny_policy" "example" {
         title = "Some expr"
         expression = "!resource.matchTag('12345678/env', 'test')"
       }
-      denied_permissions = ["cloudresourcemanager.googleapis.com/projects.delete"]
+      denied_permissions = ["cloudresourcemanager.googleapis.com/projects.update"]
       exception_principals = ["principal://iam.googleapis.com/projects/-/serviceAccounts/${google_service_account.test-account.email}"]
     }
   }
@@ -159,7 +159,7 @@ resource "google_iam_deny_policy" "example" {
         location = "/some/file"
         description = "A denial condition"
       }
-      denied_permissions = ["cloudresourcemanager.googleapis.com/projects.delete"]
+      denied_permissions = ["cloudresourcemanager.googleapis.com/projects.update"]
     }
   }
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
fixes https://github.com/hashicorp/terraform-provider-google/issues/11509

The tests failed and returned the error that the caller doesn't have the permission to delete the created project.


The deny policy created in the tests is to prevent the deletion of projects. After the deny policy is deleted, it takes time to propagate in the system. The delay could cause the failure to delete the project.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
