### PR TITLE
Make issue labeler require exact match

### DIFF
--- a/tools/issue-labeler/labels.go
+++ b/tools/issue-labeler/labels.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	_ "embed"
+
 	"github.com/golang/glog"
 	"gopkg.in/yaml.v2"
 )
@@ -38,8 +39,9 @@ func buildRegexLabels(teamsYaml []byte) ([]regexpLabel, error) {
 
 	for label, data := range enrolledTeams {
 		for _, resource := range data.Resources {
+			exactResource := fmt.Sprintf("^%s$", resource)
 			regexpLabels = append(regexpLabels, regexpLabel{
-				Regexp: regexp.MustCompile(resource),
+				Regexp: regexp.MustCompile(exactResource),
 				Label:  label,
 			})
 		}
@@ -76,8 +78,8 @@ func computeLabels(resources []string, regexpLabels []regexpLabel) []string {
 
 	var labels []string
 
-	for l, _ := range labelSet {
-		labels = append(labels, l)
+	for label := range labelSet {
+		labels = append(labels, label)
 	}
 	sort.Strings(labels)
 

--- a/tools/issue-labeler/labels_test.go
+++ b/tools/issue-labeler/labels_test.go
@@ -72,15 +72,15 @@ service/service2:
   - google_service2_resource2`),
 			expectedRegexpLabels: []regexpLabel{
 				{
-					Regexp: regexp.MustCompile("google_service1_.*"),
+					Regexp: regexp.MustCompile("^google_service1_.*$"),
 					Label:  "service/service1",
 				},
 				{
-					Regexp: regexp.MustCompile("google_service2_resource1"),
+					Regexp: regexp.MustCompile("^google_service2_resource1$"),
 					Label:  "service/service2",
 				},
 				{
-					Regexp: regexp.MustCompile("google_service2_resource2"),
+					Regexp: regexp.MustCompile("^google_service2_resource2$"),
 					Label:  "service/service2",
 				},
 			},
@@ -93,7 +93,7 @@ service/service1:
     - google_service1_resource1`),
 			expectedRegexpLabels: []regexpLabel{
 				{
-					Regexp: regexp.MustCompile("google_service1_resource1"),
+					Regexp: regexp.MustCompile("^google_service1_resource1$"),
 					Label:  "service/service1",
 				},
 			},
@@ -119,20 +119,24 @@ service/service1:
 func TestComputeLabels(t *testing.T) {
 	defaultRegexpLabels := []regexpLabel{
 		{
-			Regexp: regexp.MustCompile("google_service1_.*"),
+			Regexp: regexp.MustCompile("^google_service1_.*$"),
 			Label:  "service/service1",
 		},
 		{
-			Regexp: regexp.MustCompile("google_service2_resource1"),
+			Regexp: regexp.MustCompile("^google_service2_resource1$"),
 			Label:  "service/service2-subteam1",
 		},
 		{
-			Regexp: regexp.MustCompile("google_service2_resource2"),
+			Regexp: regexp.MustCompile("^google_service2_resource2$"),
 			Label:  "service/service2-subteam2",
 		},
 		{
-			Regexp: regexp.MustCompile("google_service1_resource5"),
+			Regexp: regexp.MustCompile("^google_service1_resource5$"),
 			Label:  "service/service1-subteam1",
+		},
+		{
+			Regexp: regexp.MustCompile("^google_resource6$"),
+			Label:  "service/service3",
 		},
 	}
 	cases := map[string]struct {
@@ -159,6 +163,16 @@ func TestComputeLabels(t *testing.T) {
 			resources:      []string{"google_service1_resource1"},
 			regexpLabels:   defaultRegexpLabels,
 			expectedLabels: []string{"service/service1"},
+		},
+		"exact resource match": {
+			resources:      []string{"google_resource6"},
+			regexpLabels:   defaultRegexpLabels,
+			expectedLabels: []string{"service/service3"},
+		},
+		"no partial match allowed": {
+			resources:      []string{"google_resource6_foo"},
+			regexpLabels:   defaultRegexpLabels,
+			expectedLabels: []string{},
 		},
 		"only return first label matching a resource": {
 			resources:      []string{"google_service1_resource5"},


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The issue labeler should only match resources exactly, and exclude partial matches.

See b/304724817#comment6 for additional context.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
