### PR TITLE
firebaserules_release: Document how to create a release for non-default Firestore databases

### DIFF
--- a/tpgtools/overrides/firebaserules/samples/release/firestore_secondary_release.tf.tmpl
+++ b/tpgtools/overrides/firebaserules/samples/release/firestore_secondary_release.tf.tmpl
@@ -26,7 +26,7 @@ resource "google_firebaserules_ruleset" "firestore" {
   source {
     files {
       name    = "firestore.rules"
-      content = "service cloud.firestore {match /databases/{database}/documents { match /{document=**} { allow read, write: if false; } } }""
+      content = "service cloud.firestore {match /databases/{database}/documents { match /{document=**} { allow read, write: if false; } } }"
     }
   }
 

--- a/tpgtools/overrides/firebaserules/samples/release/firestore_secondary_release.tf.tmpl
+++ b/tpgtools/overrides/firebaserules/samples/release/firestore_secondary_release.tf.tmpl
@@ -1,0 +1,36 @@
+resource "google_firebaserules_release" "primary" {
+  provider     = google-beta
+  name         = "cloud.firestore/${google_firestore_database.secondary.name}"
+  ruleset_name = "projects/{{project}}/rulesets/${google_firebaserules_ruleset.firestore.name}"
+  project      = "{{project}}"
+
+  lifecycle {
+    replace_triggered_by = [
+      google_firebaserules_ruleset.firestore
+    ]
+  }
+}
+
+# Provision a non-default Firestore database.
+resource "google_firestore_database" "secondary" {
+  project     = "{{project}}"
+  name        = "{{database}"
+  location_id = "{{region}}"
+  type        = "FIRESTORE_NATIVE"
+}
+
+# Create a ruleset of Firebase Security Rules from a local file.
+resource "google_firebaserules_ruleset" "firestore" {
+  provider = google-beta
+  project  = "{{project}}"
+  source {
+    files {
+      name    = "firestore.rules"
+      content = "service cloud.firestore {match /databases/{database}/documents { match /{document=**} { allow read, write: if false; } } }""
+    }
+  }
+
+  depends_on = [
+    google_firestore_database.secondary
+  ]
+}

--- a/tpgtools/overrides/firebaserules/samples/release/firestore_secondary_release.yaml
+++ b/tpgtools/overrides/firebaserules/samples/release/firestore_secondary_release.yaml
@@ -1,0 +1,26 @@
+# Copyright 2022 Google LLC. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: firestore_secondary_release
+description: Creates a Firebase Rules Release for a non-default Firestore database
+type: release
+versions:
+- beta
+resource: ./firestore_secondary_release.tf.tmpl
+variables:
+- name: project
+  type: project
+- name: region 
+  type: region
+- name: database
+  type: resource_name


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add additional samples to explain how non-default Firestore database can be generated.

Fixes  https://github.com/hashicorp/terraform-provider-google/issues/16324

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:note
firebaserules_release: Added example for a release to a non-default Firestore database.
```
