### PR TITLE
google_firestore_database: Fix deleting (protected) Firestore databases

### DIFF
--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -104,6 +104,8 @@ examples:
     name: 'firestore_database_with_delete_protection'
     primary_resource_id: 'database'
     skip_test: true
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  pre_delete: templates/terraform/pre_delete/firestore_database.go.erb
 properties:
   - !ruby/object:Api::Type::String
     name: name

--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -106,6 +106,19 @@ examples:
     skip_test: true
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   pre_delete: templates/terraform/pre_delete/firestore_database.go.erb
+virtual_fields:
+  - !ruby/object:Api::Type::Enum
+    name: 'deletion_policy'
+    description: |
+      The deletion policy for the database. Setting `ABANDON` allows the resource
+      to be abandoned rather than deleted. Setting `DELETE` will delete the resource
+      on destroy. Default is `ABANDON`. Possible values are:
+        * DELETE
+        * ABANDON
+    values:
+      - :DELETE
+      - :ABANDON
+    default_value: :ABANDON
 properties:
   - !ruby/object:Api::Type::String
     name: name

--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -47,7 +47,6 @@ async: !ruby/object:Api::OpAsync
   error: !ruby/object:Api::OpAsync::Error
     path: 'error'
     message: 'message'
-skip_delete: true
 autogen_async: true
 id_format: 'projects/{{project}}/databases/{{name}}'
 import_format:

--- a/mmv1/templates/terraform/examples/firestore_database_with_delete_protection.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_database_with_delete_protection.tf.erb
@@ -9,5 +9,9 @@ resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
   # Then delete the database resource and apply the changes again.
   delete_protection_state           = "DELETE_PROTECTION_ENABLED"
 
+  # Enables deletion of the database on destory.
+  # By default the database is just abandoned and not deleted on destroy.
+  deletion_policy = "DELETE"
+
   depends_on = [google_project_service.firestore]
 }

--- a/mmv1/templates/terraform/pre_delete/firestore_database.go.erb
+++ b/mmv1/templates/terraform/pre_delete/firestore_database.go.erb
@@ -1,0 +1,20 @@
+<%- # the license inside this block applies to this file
+	# Copyright 2023 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+
+// start of customized code
+if d.Get("delete_protection_state").(string) == "DELETE_PROTECTION_ENABLED" {
+  return fmt.Errorf("Firestore Database %q has delete protection enabled, please disable delete protection first.", d.Id())
+}
+// end of customized code

--- a/mmv1/templates/terraform/pre_delete/firestore_database.go.erb
+++ b/mmv1/templates/terraform/pre_delete/firestore_database.go.erb
@@ -14,7 +14,13 @@
 -%>
 
 // start of customized code
+deletionPolicy := d.Get("deletion_policy");
+
+if deletionPolicy == "ABANDON" {
+	return nil
+}
+
 if d.Get("delete_protection_state").(string) == "DELETE_PROTECTION_ENABLED" {
-  return fmt.Errorf("Firestore Database %q has delete protection enabled, please disable delete protection first.", d.Id())
+	return fmt.Errorf("Firestore Database %q has delete protection enabled, please disable delete protection first.", d.Id())
 }
 // end of customized code

--- a/mmv1/third_party/terraform/services/firestore/resource_firestore_database_update_test.go.erb
+++ b/mmv1/third_party/terraform/services/firestore/resource_firestore_database_update_test.go.erb
@@ -183,6 +183,7 @@ resource "google_firestore_database" "default" {
   type                    = "DATASTORE_MODE"
   location_id             = "nam5"
   delete_protection_state = "%s"
+  deletion_policy         = "DELETE"
 
   project = google_project.default.project_id
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Makes it possible to delete Firestore databases when they are not delete protected.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/16325
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
google_firestore_database: Allowed deletion of non-delete protected databases.
```
