### PR TITLE
Clarify the database resource name in firestore document surface

### DIFF
--- a/mmv1/products/firestore/Document.yaml
+++ b/mmv1/products/firestore/Document.yaml
@@ -36,6 +36,8 @@ docs: !ruby/object:Provider::Terraform::Docs
     `google_app_engine_application` resource with `database_type` set to
     `"CLOUD_FIRESTORE"`. Your Firestore location will be the same as
     the App Engine location specified.
+    Note: The surface does not support configurable database id. Only `(default)`
+    is allowed for the database parameter.
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'firestore_document_basic'


### PR DESCRIPTION
Clarify the database resource name in firestore document surface. 

The issue was spot at https://github.com/hashicorp/terraform-provider-google/issues/15550. Firestore document does not support databaseId in Terraform due to resource header constraint. Add a warning note section to clarify the beahvior.

```release-note:none

```