### PR TITLE
Retry on firestore field create 409 with 'underlying data changed'

### DIFF
--- a/mmv1/products/firestore/Field.yaml
+++ b/mmv1/products/firestore/Field.yaml
@@ -20,6 +20,8 @@ immutable: false
 update_verb: :PATCH
 update_mask: true
 create_verb: :PATCH
+error_retry_predicates:
+  ["transport_tpg.FirestoreField409RetryUnderlyingDataChanged"]
 description: |
   Represents a single field in the database.
   Fields are grouped by their "Collection Group", which represent all collections

--- a/mmv1/third_party/terraform/transport/error_retry_predicates.go
+++ b/mmv1/third_party/terraform/transport/error_retry_predicates.go
@@ -320,6 +320,16 @@ func DatastoreIndex409Contention(err error) (bool, string) {
 	return false, ""
 }
 
+// relevant for firestore in datastore mode
+func FirestoreField409RetryUnderlyingDataChanged(err error) (bool, string) {
+	if gerr, ok := err.(*googleapi.Error); ok {
+		if gerr.Code == 409 && strings.Contains(gerr.Body, "Please retry, underlying data changed") {
+			return true, "underlying data changed - retrying"
+		}
+	}
+	return false, ""
+}
+
 func IapClient409Operation(err error) (bool, string) {
 	if gerr, ok := err.(*googleapi.Error); ok {
 		if gerr.Code == 409 && strings.Contains(strings.ToLower(gerr.Body), "operation was aborted") {

--- a/mmv1/third_party/terraform/transport/error_retry_predicates_test.go
+++ b/mmv1/third_party/terraform/transport/error_retry_predicates_test.go
@@ -170,3 +170,14 @@ func TestIsSwgAutogenRouterRetryableError_notReady(t *testing.T) {
 		t.Errorf("Error not detected as retryable")
 	}
 }
+
+func TestFirestoreField409_retryUnderlyingDataChanged(t *testing.T) {
+	err := googleapi.Error{
+		Code: 409,
+		Body: "Please retry, underlying data changed",
+	}
+	isRetryable, _ := FirestoreField409RetryUnderlyingDataChanged(&err)
+	if !isRetryable {
+		t.Errorf("Error not detected as retryable")
+	}
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/16329

Retry firestore field create operation in case of `409` error with the text `Please retry, underlying data changed`. This happened by creating more than one field, the first fields in the newly created database in datastore mode.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
filestore: retry field creation for error 409 with the text "Please retry, underlying data changed" in `google_firestore_field `
```
