### PR TITLE
Add accelerator_config to google_tpu_v2_vm

### DIFF
--- a/mmv1/products/tpuv2/Vm.yaml
+++ b/mmv1/products/tpuv2/Vm.yaml
@@ -26,6 +26,9 @@ update_url: projects/{{project}}/locations/{{zone}}/nodes/{{name}}
 update_verb: :PATCH
 update_mask: true
 autogen_async: true
+custom_diff: [
+  'acceleratorTypeCustomizeDiff',
+]
 async: !ruby/object:Api::OpAsync
   operation: !ruby/object:Api::OpAsync::Operation
     path: 'name'
@@ -86,10 +89,13 @@ properties:
       Runtime version for the TPU.
   - !ruby/object:Api::Type::String
     name: 'acceleratorType'
+    default_from_api: true
     immutable: true
-    default_value: 'v2-8'
+    conflicts:
+      - accelerator_config
     description: |
-      TPU accelerator type for the TPU. If not specified, this defaults to 'v2-8'.
+      TPU accelerator type for the TPU. `accelerator_type` cannot be used at the same time as
+      `accelerator_config`. If neither is specified, `accelerator_type` defaults to 'v2-8'.
   - !ruby/object:Api::Type::String
     name: 'description'
     description: |
@@ -219,6 +225,32 @@ properties:
         required: true
         description: |
           Defines whether the instance has Secure Boot enabled.
+  - !ruby/object:Api::Type::NestedObject
+    name: 'acceleratorConfig'
+    default_from_api: true
+    immutable: true
+    conflicts:
+      - accelerator_type
+    description: |
+      The AccleratorConfig for the TPU Node. `accelerator_config` cannot be used at the same time
+      as `accelerator_type`. If neither is specified, `accelerator_type` defaults to 'v2-8'.
+    properties:
+      - !ruby/object:Api::Type::Enum
+        name: 'type'
+        immutable: true
+        required: true
+        description: |
+          Type of TPU.
+        values:
+          - 'V2'
+          - 'V3'
+          - 'V4'
+      - !ruby/object:Api::Type::String
+        name: 'topology'
+        immutable: true
+        required: true
+        description: |
+          Topology of TPU in chips.
   - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: Resource labels to represent user-provided metadata.

--- a/mmv1/templates/terraform/constants/tpu_vm.go.erb
+++ b/mmv1/templates/terraform/constants/tpu_vm.go.erb
@@ -29,3 +29,18 @@ func normalizeScopes(scopes []string) []string {
 	}
 	return result
 }
+
+// For backwards compatibility, we need to maintain original behavior where `accelerator_type`
+// defaults "v2-8" when nothing is set. However, if the newly introduced `accelerator_config` field
+// is set, then use that value instead of the `accelerator_type` default.
+func acceleratorTypeCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+	_, isTypeSet := diff.GetOk("accelerator_type")
+	_, isConfigSet := diff.GetOk("accelerator_config")
+	if !isTypeSet && !isConfigSet {
+		if err := diff.SetNew("accelerator_type", "v2-8"); err != nil {
+			return err
+		}
+	}
+
+	return nil	
+}

--- a/mmv1/templates/terraform/examples/tpu_v2_vm_full.tf.erb
+++ b/mmv1/templates/terraform/examples/tpu_v2_vm_full.tf.erb
@@ -14,7 +14,11 @@ resource "google_tpu_v2_vm" "<%= ctx[:primary_resource_id] %>" {
   description = "Text description of the TPU."
 
   runtime_version  = "tpu-vm-tf-2.13.0"
-  accelerator_type = "v2-8"
+
+  accelerator_config {
+    type     = "V2"
+    topology = "2x2"
+  }
 
   cidr_block = "10.0.0.0/29"
 


### PR DESCRIPTION
b/292585830

Follow-up to https://github.com/GoogleCloudPlatform/magic-modules/pull/9308

This adds `accelerator_config`, which is a more flexible alternative to `accelerator_type`. Only one can be specified for creation, but both will be returned by the API.

The notable piece here is that we previously had a client-side default for `accelerator_type`, so adding the `accelerator_config` alternative without introducing a breaking change presented a challenge:
* Since the API does not accept both fields at once, the "v2-8" default needed to be removed, so that `accelerator_config` could be set.
* However, to continue supporting config without either of these fields specified the same way (default to "v2-8"), a customize diff was needed to conditionally populate the `accelerator_type` default.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
tpuv2: added`accelerator_config` field to `google_tpu_v2_vm` resource
```
