### PR TITLE
Custom Frontend Port: Update ports, portRange, and allPorts fields documentation on resources compute_global_forwarding_rule and compute_forwarding_rule

### DIFF
--- a/mmv1/products/compute/ForwardingRule.yaml
+++ b/mmv1/products/compute/ForwardingRule.yaml
@@ -402,56 +402,58 @@ properties:
   - !ruby/object:Api::Type::String
     name: 'portRange'
     description: |
-      This field can only be used:
+      The `ports`, `portRange`, and `allPorts` fields are mutually exclusive.
+      Only packets addressed to ports in the specified range will be forwarded
+      to the backends configured with this forwarding rule.
 
-      * If `IPProtocol` is one of TCP, UDP, or SCTP.
-      * By backend service-based network load balancers, target pool-based
-      network load balancers, internal proxy load balancers, external proxy load
-      balancers, Traffic Director, external protocol forwarding, and Classic VPN.
-      Some products have restrictions on what ports can be used. See
+      The `portRange` field has the following limitations:
+      * It requires that the forwarding rule `IPProtocol` be TCP, UDP, or SCTP,
+      and
+      * It's applicable only to the following products: external passthrough
+      Network Load Balancers, internal and external proxy Network Load
+      Balancers, internal and external Application Load Balancers, external
+      protocol forwarding, and Classic VPN.
+      * Some products have restrictions on what ports can be used. See
       [port specifications](https://cloud.google.com/load-balancing/docs/forwarding-rule-concepts#port_specifications)
       for details.
 
-
-      Only packets addressed to ports in the specified range will be forwarded to
-      the backends configured with this forwarding rule.
-
-      The `ports` and `port_range` fields are mutually exclusive.
-
       For external forwarding rules, two or more forwarding rules cannot use the
-      same `[IPAddress, IPProtocol]` pair, and cannot have
-      overlapping `portRange`s.
+      same `[IPAddress, IPProtocol]` pair, and cannot have overlapping
+      `portRange`s.
 
       For internal forwarding rules within the same VPC network, two or more
-      forwarding rules cannot use the same `[IPAddress, IPProtocol]`
-      pair, and cannot have overlapping `portRange`s.
+      forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
+      cannot have overlapping `portRange`s.
+
+      @pattern: \d+(?:-\d+)?
     diff_suppress_func: 'tpgresource.PortRangeDiffSuppress'
     default_from_api: true
   - !ruby/object:Api::Type::Array
     name: 'ports'
     max_size: 5
     description: |
-      This field can only be used:
+      The `ports`, `portRange`, and `allPorts` fields are mutually exclusive.
+      Only packets addressed to ports in the specified range will be forwarded
+      to the backends configured with this forwarding rule.
 
-      * If `IPProtocol` is one of TCP, UDP, or SCTP.
-      * By internal TCP/UDP load balancers, backend service-based network load
-      balancers, internal protocol forwarding and when protocol is not L3_DEFAULT.
-
-
-      You can specify a list of up to five ports by number, separated by commas.
-      The ports can be contiguous or discontiguous. Only packets addressed to
-      these ports will be forwarded to the backends configured with this
-      forwarding rule.
+      The `ports` field has the following limitations:
+      * It requires that the forwarding rule `IPProtocol` be TCP, UDP, or SCTP,
+      and
+      * It's applicable only to the following products: internal passthrough
+      Network Load Balancers, backend service-based external passthrough Network
+      Load Balancers, and internal protocol forwarding.
+      * You can specify a list of up to five ports by number, separated by
+      commas. The ports can be contiguous or discontiguous.
 
       For external forwarding rules, two or more forwarding rules cannot use the
-      same `[IPAddress, IPProtocol]` pair, and cannot share any values
-      defined in `ports`.
+      same `[IPAddress, IPProtocol]` pair if they share at least one port
+      number.
 
       For internal forwarding rules within the same VPC network, two or more
-      forwarding rules cannot use the same `[IPAddress, IPProtocol]`
-      pair, and cannot share any values defined in `ports`.
+      forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair if
+      they share at least one port number.
 
-      The `ports` and `port_range` fields are mutually exclusive.
+      @pattern: \d+(?:-\d+)?
     is_set: true
     custom_expand: 'templates/terraform/custom_expand/set_to_list.erb'
     item_type: Api::Type::String
@@ -523,21 +525,21 @@ properties:
   - !ruby/object:Api::Type::Boolean
     name: 'allPorts'
     description: |
-      This field can only be used:
-      * If `IPProtocol` is one of TCP, UDP, or SCTP.
-      * By internal TCP/UDP load balancers, backend service-based network load
-      balancers, and internal and external protocol forwarding.
+      The `ports`, `portRange`, and `allPorts` fields are mutually exclusive.
+      Only packets addressed to ports in the specified range will be forwarded
+      to the backends configured with this forwarding rule.
 
-      This option should be set to TRUE when the Forwarding Rule
-      IPProtocol is set to L3_DEFAULT.
-
-      Set this field to true to allow packets addressed to any port or packets
+      The `allPorts` field has the following limitations:
+      * It requires that the forwarding rule `IPProtocol` be TCP, UDP, SCTP, or
+      L3_DEFAULT.
+      * It's applicable only to the following products: internal passthrough
+      Network Load Balancers, backend service-based external passthrough Network
+      Load Balancers, and internal and external protocol forwarding.
+      * Set this field to true to allow packets addressed to any port or packets
       lacking destination port information (for example, UDP fragments after the
       first fragment) to be forwarded to the backends configured with this
-      forwarding rule.
-
-      The `ports`, `port_range`, and
-      `allPorts` fields are mutually exclusive.
+      forwarding rule. The L3_DEFAULT protocol requires `allPorts` be set to
+      true.
   - !ruby/object:Api::Type::Enum
     name: 'networkTier'
     description: |

--- a/mmv1/products/compute/GlobalForwardingRule.yaml
+++ b/mmv1/products/compute/GlobalForwardingRule.yaml
@@ -423,24 +423,26 @@ properties:
   - !ruby/object:Api::Type::String
     name: 'portRange'
     description: |
-      This field can only be used:
-
-      * If `IPProtocol` is one of TCP, UDP, or SCTP.
-      * By backend service-based network load balancers, target pool-based
-      network load balancers, internal proxy load balancers, external proxy load
-      balancers, Traffic Director, external protocol forwarding, and Classic VPN.
-      Some products have restrictions on what ports can be used. See
+      The `portRange` field has the following limitations:
+      * It requires that the forwarding rule `IPProtocol` be TCP, UDP, or SCTP,
+      and
+      * It's applicable only to the following products: external passthrough
+      Network Load Balancers, internal and external proxy Network Load
+      Balancers, internal and external Application Load Balancers, external
+      protocol forwarding, and Classic VPN.
+      * Some products have restrictions on what ports can be used. See
       [port specifications](https://cloud.google.com/load-balancing/docs/forwarding-rule-concepts#port_specifications)
       for details.
 
+      For external forwarding rules, two or more forwarding rules cannot use the
+      same `[IPAddress, IPProtocol]` pair, and cannot have overlapping
+      `portRange`s.
 
-      * TargetHttpProxy: 80, 8080
-      * TargetHttpsProxy: 443
-      * TargetTcpProxy: 25, 43, 110, 143, 195, 443, 465, 587, 700, 993, 995,
-                        1883, 5222
-      * TargetSslProxy: 25, 43, 110, 143, 195, 443, 465, 587, 700, 993, 995,
-                        1883, 5222
-      * TargetVpnGateway: 500, 4500
+      For internal forwarding rules within the same VPC network, two or more
+      forwarding rules cannot use the same `[IPAddress, IPProtocol]` pair, and
+      cannot have overlapping `portRange`s.
+
+      @pattern: \d+(?:-\d+)?
     diff_suppress_func: 'tpgresource.PortRangeDiffSuppress'
     # This is a multi-resource resource reference (TargetHttp(s)Proxy,
     # TargetSslProxy, TargetTcpProxy, TargetVpnGateway, TargetPool,


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Update `ports`, `portRange`, and `allPorts` fields documentation on Global and Regional Forwarding Rules.

Part of  https://github.com/hashicorp/terraform-provider-google/issues/16241

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
