### PR TITLE
Add additional check to dangling cluster test

### DIFF
--- a/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
+++ b/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
@@ -611,65 +611,6 @@ func BootstrapServicePerimeterProjects(t *testing.T, desiredProjects int) []*clo
 	return projects
 }
 
-func RemoveContainerServiceAgentRoleFromContainerEngineRobot(t *testing.T, project *cloudresourcemanager.Project) {
-	config := BootstrapConfig(t)
-	if config == nil {
-		return
-	}
-
-	client := config.NewResourceManagerClient(config.UserAgent)
-	containerEngineRobot := fmt.Sprintf("serviceAccount:service-%d@container-engine-robot.iam.gserviceaccount.com", project.ProjectNumber)
-	getPolicyRequest := &cloudresourcemanager.GetIamPolicyRequest{}
-	policy, err := client.Projects.GetIamPolicy(project.ProjectId, getPolicyRequest).Do()
-	if err != nil {
-		t.Fatalf("error getting project iam policy: %v", err)
-	}
-	roleFound := false
-	changed := false
-	for _, binding := range policy.Bindings {
-		if binding.Role == "roles/container.serviceAgent" {
-			memberFound := false
-			for i, member := range binding.Members {
-				if member == containerEngineRobot {
-					binding.Members[i] = binding.Members[len(binding.Members)-1]
-					memberFound = true
-				}
-			}
-			if memberFound {
-				binding.Members = binding.Members[:len(binding.Members)-1]
-				changed = true
-			}
-		} else if binding.Role == "roles/editor" {
-			memberFound := false
-			for _, member := range binding.Members {
-				if member == containerEngineRobot {
-					memberFound = true
-					break
-				}
-			}
-			if !memberFound {
-				binding.Members = append(binding.Members, containerEngineRobot)
-				changed = true
-			}
-			roleFound = true
-		}
-	}
-	if !roleFound {
-		policy.Bindings = append(policy.Bindings, &cloudresourcemanager.Binding{
-			Members: []string{containerEngineRobot},
-			Role:    "roles/editor",
-		})
-		changed = true
-	}
-	if changed {
-		setPolicyRequest := &cloudresourcemanager.SetIamPolicyRequest{Policy: policy}
-		policy, err = client.Projects.SetIamPolicy(project.ProjectId, setPolicyRequest).Do()
-		if err != nil {
-			t.Fatalf("error setting project iam policy: %v", err)
-		}
-	}
-}
-
 // BootstrapProject will create or get a project named
 // "<projectIDPrefix><projectIDSuffix>" that will persist across test runs,
 // where projectIDSuffix is based off of getTestProjectFromEnv(). The reason

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -3659,13 +3659,32 @@ func TestAccContainerCluster_autoprovisioningDefaultsManagement(t *testing.T) {
 func TestAccContainerCluster_errorCleanDanglingCluster(t *testing.T) {
 	t.Parallel()
 
-	prefix := acctest.RandString(t, 10)
-	clusterName := fmt.Sprintf("tf-test-cluster-%s", prefix)
-	clusterNameError := fmt.Sprintf("tf-test-cluster-err-%s", prefix)
+	suffix := acctest.RandString(t, 10)
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", suffix)
+	clusterNameError := fmt.Sprintf("tf-test-cluster-err-%s", suffix)
+	clusterNameErrorWithTimeout := fmt.Sprintf("tf-test-cluster-timeout-%s", suffix)
 	containerNetName := fmt.Sprintf("tf-test-container-net-%s", acctest.RandString(t, 10))
 
 	initConfig := testAccContainerCluster_withInitialCIDR(containerNetName, clusterName)
-	overlapConfig := testAccContainerCluster_withCIDROverlap(initConfig, clusterNameError)
+	overlapConfig := testAccContainerCluster_withCIDROverlap(initConfig, clusterNameError, "")
+	overlapConfigWithTimeout := testAccContainerCluster_withCIDROverlap(initConfig, clusterNameErrorWithTimeout, "40s")
+
+	checkTaintApplied := func(st *terraform.State) error {
+		// Return an error if there is no tainted (i.e. marked for deletion) cluster.
+		ms := st.RootModule()
+		errCluster, ok := ms.Resources["google_container_cluster.cidr_error_overlap"]
+		if !ok {
+			var resourceNames []string
+			for rn := range ms.Resources {
+				resourceNames = append(resourceNames, rn)
+			}
+			return fmt.Errorf("could not find google_container_cluster.cidr_error_overlap in resources: %v", resourceNames)
+		}
+		if !errCluster.Primary.Tainted {
+			return fmt.Errorf("cluster with ID %s should be tainted, but is not", errCluster.Primary.ID)
+		}
+		return nil
+	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
@@ -3682,14 +3701,28 @@ func TestAccContainerCluster_errorCleanDanglingCluster(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
+				// First attempt to create the overlapping cluster with no timeout, this should fail and taint the resource.
 				Config:		   overlapConfig,
 				ExpectError: regexp.MustCompile("Error waiting for creating GKE cluster"),
 			},
-			// If tainted cluster won't be deleted, this step will return an error
 			{
-				Config:				      overlapConfig,
-				PlanOnly:			      true,
+				// Check that the tainted resource is in the config.
+				Config:             overlapConfig,
+				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
+				Check: checkTaintApplied,
+			},
+			{
+				// Next attempt to create the overlapping cluster with a 40s timeout. This will fail with a different error.
+				Config:		   overlapConfigWithTimeout,
+				ExpectError: regexp.MustCompile("timeout while waiting for state to become 'DONE'"),
+			},
+			{
+				// Check that the tainted resource is in the config.
+				Config:             overlapConfig,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+				Check: checkTaintApplied,
 			},
 		},
 	})
@@ -5467,7 +5500,6 @@ func TestAccContainerCluster_withEnablePrivateEndpointToggle(t *testing.T) {
 }
 
 func testAccContainerCluster_withEnablePrivateEndpoint(clusterName, flag, networkName, subnetworkName string) string {
-
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "uscentral1a" {
   location = "us-central1-a"
@@ -7979,7 +8011,7 @@ resource "google_container_cluster" "cidr_error_preempt" {
 `, containerNetName, clusterName)
 }
 
-func testAccContainerCluster_withCIDROverlap(initConfig, secondCluster string) string {
+func testAccContainerCluster_withCIDROverlap(initConfig, secondCluster, createTimeout string) string {
 	return fmt.Sprintf(`
   %s
 
@@ -7998,8 +8030,11 @@ resource "google_container_cluster" "cidr_error_overlap" {
     services_ipv4_cidr_block = "10.1.0.0/16"
   }
   deletion_protection = false
+  timeouts {
+    create = "%s"
+  }
 }
-`, initConfig, secondCluster)
+`, initConfig, secondCluster, createTimeout)
 }
 
 func testAccContainerCluster_withInvalidLocation(location string) string {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -3657,6 +3657,7 @@ func TestAccContainerCluster_autoprovisioningDefaultsManagement(t *testing.T) {
 // taints it, having Terraform clean it up during the next apply. This test
 // name is now inexact, but is being preserved to maintain the test history.
 func TestAccContainerCluster_errorCleanDanglingCluster(t *testing.T) {
+	acctest.SkipIfVcr(t) // skipped because the timeout step doesn't record operation GET interactions
 	t.Parallel()
 
 	suffix := acctest.RandString(t, 10)

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -3666,8 +3666,8 @@ func TestAccContainerCluster_errorCleanDanglingCluster(t *testing.T) {
 	containerNetName := fmt.Sprintf("tf-test-container-net-%s", acctest.RandString(t, 10))
 
 	initConfig := testAccContainerCluster_withInitialCIDR(containerNetName, clusterName)
-	overlapConfig := testAccContainerCluster_withCIDROverlap(initConfig, clusterNameError, "")
-	overlapConfigWithTimeout := testAccContainerCluster_withCIDROverlap(initConfig, clusterNameErrorWithTimeout, "40s")
+	overlapConfig := testAccContainerCluster_withCIDROverlap(initConfig, clusterNameError)
+	overlapConfigWithTimeout := testAccContainerCluster_withCIDROverlapWithTimeout(initConfig, clusterNameErrorWithTimeout, "40s")
 
 	checkTaintApplied := func(st *terraform.State) error {
 		// Return an error if there is no tainted (i.e. marked for deletion) cluster.
@@ -8011,9 +8011,33 @@ resource "google_container_cluster" "cidr_error_preempt" {
 `, containerNetName, clusterName)
 }
 
-func testAccContainerCluster_withCIDROverlap(initConfig, secondCluster, createTimeout string) string {
+func testAccContainerCluster_withCIDROverlap(initConfig, secondCluster string) string {
 	return fmt.Sprintf(`
-  %s
+%s
+
+resource "google_container_cluster" "cidr_error_overlap" {
+  name     = "%s"
+  location = "us-central1-a"
+
+  network    = google_compute_network.container_network.name
+  subnetwork = google_compute_subnetwork.container_subnetwork.name
+
+  initial_node_count = 1
+
+  networking_mode = "VPC_NATIVE"
+  ip_allocation_policy {
+    cluster_ipv4_cidr_block  = "10.0.0.0/16"
+    services_ipv4_cidr_block = "10.1.0.0/16"
+  }
+  deletion_protection = false
+}
+`, initConfig, secondCluster)
+}
+
+
+func testAccContainerCluster_withCIDROverlapWithTimeout(initConfig, secondCluster, createTimeout string) string {
+	return fmt.Sprintf(`
+%s
 
 resource "google_container_cluster" "cidr_error_overlap" {
   name     = "%s"


### PR DESCRIPTION
Also remove unused code which was needed for failed creation test

This additional check requires skipping VCR because the timeout is too short to record the necessary requests.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
