### PR TITLE
Enabling management of default Dialogflow resources without terraform import: `is_default_x` fields

### DIFF
--- a/mmv1/products/dialogflowcx/Flow.yaml
+++ b/mmv1/products/dialogflowcx/Flow.yaml
@@ -40,11 +40,22 @@ virtual_fields:
       The Default Start Flow cannot be deleted; deleting the `google_dialogflow_cx_flow` resource does nothing to the underlying GCP resources.
 examples:
   - !ruby/object:Provider::Terraform::Examples
+    name: 'dialogflowcx_flow_basic'
+    primary_resource_id: 'basic_flow'
+    vars:
+      agent_name: 'dialogflowcx-agent'
+  - !ruby/object:Provider::Terraform::Examples
     name: 'dialogflowcx_flow_full'
     primary_resource_id: 'basic_flow'
     vars:
       agent_name: 'dialogflowcx-agent'
       bucket_name: 'dialogflowcx-bucket'
+  - !ruby/object:Provider::Terraform::Examples
+    skip_docs: true
+    name: 'dialogflowcx_flow_default_start_flow'
+    primary_resource_id: 'default_start_flow'
+    vars:
+      agent_name: 'dialogflowcx-agent'
 skip_sweeper: true
 id_format: '{{parent}}/flows/{{name}}'
 import_format: ['{{parent}}/flows/{{name}}']

--- a/mmv1/products/dialogflowcx/Flow.yaml
+++ b/mmv1/products/dialogflowcx/Flow.yaml
@@ -38,6 +38,8 @@ virtual_fields:
     description: |
       Marks this as the [Default Start Flow](https://cloud.google.com/dialogflow/cx/docs/concept/flow#start) for an agent. When you create an agent, the Default Start Flow is created automatically.
       The Default Start Flow cannot be deleted; deleting the `google_dialogflow_cx_flow` resource does nothing to the underlying GCP resources.
+
+      ~> Avoid having multiple `google_dialogflow_cx_flow` resources linked to the same agent with `is_default_start_flow = true` because they will compete to control a single Default Start Flow resource in GCP.
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'dialogflowcx_flow_basic'

--- a/mmv1/products/dialogflowcx/Flow.yaml
+++ b/mmv1/products/dialogflowcx/Flow.yaml
@@ -27,10 +27,17 @@ timeouts: !ruby/object:Api::Timeouts
   update_minutes: 40
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/dialogflowcx_flow.go.erb
-  pre_create: templates/terraform/pre_create/dialogflow_set_location.go.erb
+  pre_create: templates/terraform/pre_create/dialogflowcx_set_location_skip_default_obj.go.erb
   pre_update: templates/terraform/pre_create/dialogflow_set_location.go.erb
-  pre_delete: templates/terraform/pre_create/dialogflow_set_location.go.erb
+  pre_delete: templates/terraform/pre_delete/dialogflowcx_set_location_skip_default_obj.go.erb
   pre_read: templates/terraform/pre_create/dialogflow_set_location.go.erb
+virtual_fields:
+  - !ruby/object:Api::Type::Boolean
+    name: is_default_start_flow
+    immutable: true
+    description: |
+      Marks this as the [Default Start Flow](https://cloud.google.com/dialogflow/cx/docs/concept/flow#start) for an agent. When you create an agent, the Default Start Flow is created automatically.
+      The Default Start Flow cannot be deleted; deleting the `google_dialogflow_cx_flow` resource does nothing to the underlying GCP resources.
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'dialogflowcx_flow_full'

--- a/mmv1/products/dialogflowcx/Intent.yaml
+++ b/mmv1/products/dialogflowcx/Intent.yaml
@@ -38,12 +38,16 @@ virtual_fields:
     description: |
       Marks this as the [Default Welcome Intent](https://cloud.google.com/dialogflow/cx/docs/concept/intent#welcome) for an agent. When you create an agent, a Default Welcome Intent is created automatically.
       The Default Welcome Intent cannot be deleted; deleting the `google_dialogflow_cx_intent` resource does nothing to the underlying GCP resources.
+
+      ~> Avoid having multiple `google_dialogflow_cx_intent` resources linked to the same agent with `is_default_welcome_intent = true` because they will compete to control a single Default Welcome Intent resource in GCP.
   - !ruby/object:Api::Type::Boolean
     name: is_default_negative_intent
     immutable: true
     description: |
       Marks this as the [Default Negative Intent](https://cloud.google.com/dialogflow/cx/docs/concept/intent#negative) for an agent. When you create an agent, a Default Negative Intent is created automatically.
       The Default Negative Intent cannot be deleted; deleting the `google_dialogflow_cx_intent` resource does nothing to the underlying GCP resources.
+
+      ~> Avoid having multiple `google_dialogflow_cx_intent` resources linked to the same agent with `is_default_negative_intent = true` because they will compete to control a single Default Negative Intent resource in GCP.
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'dialogflowcx_intent_full'

--- a/mmv1/products/dialogflowcx/Intent.yaml
+++ b/mmv1/products/dialogflowcx/Intent.yaml
@@ -50,6 +50,18 @@ examples:
     primary_resource_id: 'basic_intent'
     vars:
       agent_name: 'dialogflowcx-agent'
+  - !ruby/object:Provider::Terraform::Examples
+    skip_docs: true
+    name: 'dialogflowcx_intent_default_negative_intent'
+    primary_resource_id: 'default_negative_intent'
+    vars:
+      agent_name: 'dialogflowcx-agent'
+  - !ruby/object:Provider::Terraform::Examples
+    skip_docs: true
+    name: 'dialogflowcx_intent_default_welcome_intent'
+    primary_resource_id: 'default_welcome_intent'
+    vars:
+      agent_name: 'dialogflowcx-agent'
 skip_sweeper: true
 id_format: '{{parent}}/intents/{{name}}'
 import_format: ['{{parent}}/intents/{{name}}']

--- a/mmv1/products/dialogflowcx/Intent.yaml
+++ b/mmv1/products/dialogflowcx/Intent.yaml
@@ -27,10 +27,23 @@ timeouts: !ruby/object:Api::Timeouts
   update_minutes: 40
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/dialogflowcx_intent.go.erb
-  pre_create: templates/terraform/pre_create/dialogflow_set_location.go.erb
+  pre_create: templates/terraform/pre_create/dialogflowcx_set_location_skip_default_obj.go.erb
   pre_update: templates/terraform/pre_create/dialogflow_set_location.go.erb
-  pre_delete: templates/terraform/pre_create/dialogflow_set_location.go.erb
+  pre_delete: templates/terraform/pre_delete/dialogflowcx_set_location_skip_default_obj.go.erb
   pre_read: templates/terraform/pre_create/dialogflow_set_location.go.erb
+virtual_fields:
+  - !ruby/object:Api::Type::Boolean
+    name: is_default_welcome_intent
+    immutable: true
+    description: |
+      Marks this as the [Default Welcome Intent](https://cloud.google.com/dialogflow/cx/docs/concept/intent#welcome) for an agent. When you create an agent, a Default Welcome Intent is created automatically.
+      The Default Welcome Intent cannot be deleted; deleting the `google_dialogflow_cx_intent` resource does nothing to the underlying GCP resources.
+  - !ruby/object:Api::Type::Boolean
+    name: is_default_negative_intent
+    immutable: true
+    description: |
+      Marks this as the [Default Negative Intent](https://cloud.google.com/dialogflow/cx/docs/concept/intent#negative) for an agent. When you create an agent, a Default Negative Intent is created automatically.
+      The Default Negative Intent cannot be deleted; deleting the `google_dialogflow_cx_intent` resource does nothing to the underlying GCP resources.
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'dialogflowcx_intent_full'
@@ -141,9 +154,11 @@ properties:
       If the supplied value is negative, the intent is ignored in runtime detect intent requests.
   - !ruby/object:Api::Type::Boolean
     name: 'isFallback'
+    output: true
     description: |
       Indicates whether this is a fallback intent. Currently only default fallback intent is allowed in the agent, which is added upon agent creation.
       Adding training phrases to fallback intent is useful in the case of requests that are mistakenly matched, since training phrases assigned to fallback intents act as negative examples that triggers no-match event.
+      To manage the fallback intent, set `is_default_negative_intent = true`
   - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: |

--- a/mmv1/products/dialogflowcx/Intent.yaml
+++ b/mmv1/products/dialogflowcx/Intent.yaml
@@ -166,7 +166,6 @@ properties:
       If the supplied value is negative, the intent is ignored in runtime detect intent requests.
   - !ruby/object:Api::Type::Boolean
     name: 'isFallback'
-    output: true
     description: |
       Indicates whether this is a fallback intent. Currently only default fallback intent is allowed in the agent, which is added upon agent creation.
       Adding training phrases to fallback intent is useful in the case of requests that are mistakenly matched, since training phrases assigned to fallback intents act as negative examples that triggers no-match event.

--- a/mmv1/provider/terraform/virtual_fields.rb
+++ b/mmv1/provider/terraform/virtual_fields.rb
@@ -49,12 +49,17 @@ module Provider
       # The default value for the field (defaults to false)
       attr_reader :default_value
 
+      # If set to true, changes in the field's value require recreating the
+      # resource.
+      attr_reader :immutable
+
       def validate
         super
         check :name, type: String, required: true
         check :description, type: String, required: true
         check :type, type: Class, default: Api::Type::Boolean
         check :default_value, default: false
+        check :immutable, default: false
       end
     end
   end

--- a/mmv1/templates/terraform/custom_import/dialogflowcx_flow.go.erb
+++ b/mmv1/templates/terraform/custom_import/dialogflowcx_flow.go.erb
@@ -15,4 +15,9 @@ if err != nil {
 }
 d.SetId(id)
 
+// Set is_default_start_flow if the resource is actually the Default Start Flow
+if d.Get("name").(string) == "00000000-0000-0000-0000-000000000000" {
+    d.Set("is_default_start_flow", true)
+}
+
 return []*schema.ResourceData{d}, nil

--- a/mmv1/templates/terraform/custom_import/dialogflowcx_intent.go.erb
+++ b/mmv1/templates/terraform/custom_import/dialogflowcx_intent.go.erb
@@ -15,4 +15,12 @@
 	}
 	d.SetId(id)
 
+	// Set is_default_X if the resource is actually a Default Intent
+	if d.Get("name").(string) == "00000000-0000-0000-0000-000000000000" {
+		d.Set("is_default_welcome_intent", true)
+	}
+	if d.Get("name").(string) == "00000000-0000-0000-0000-000000000001" {
+		d.Set("is_default_negative_intent", true)
+	}
+
 	return []*schema.ResourceData{d}, nil

--- a/mmv1/templates/terraform/examples/dialogflowcx_flow_default_start_flow.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_flow_default_start_flow.tf.erb
@@ -1,0 +1,75 @@
+resource "google_dialogflow_cx_agent" "agent" {
+  display_name          = "<%= ctx[:vars]["agent_name"] %>"
+  location              = "global"
+  default_language_code = "en"
+  time_zone             = "America/New_York"
+}
+
+resource "google_dialogflow_cx_intent" "default_welcome_intent" {
+  parent                    = google_dialogflow_cx_agent.agent.id
+  is_default_welcome_intent = true
+  display_name              = "Default Welcome Intent"
+  priority                  = 1
+  training_phrases {
+    parts {
+      text = "Hello"
+    }
+    repeat_count = 1
+  }
+}
+
+
+resource "google_dialogflow_cx_flow" "<%= ctx[:primary_resource_id] %>" {
+  parent                = google_dialogflow_cx_agent.agent.id
+  is_default_start_flow = true
+  display_name          = "Default Start Flow"
+
+  nlu_settings {
+    classification_threshold = 0.3
+    model_type               = "MODEL_TYPE_STANDARD"
+  }
+
+  transition_routes {
+    intent = google_dialogflow_cx_intent.default_welcome_intent.id
+    trigger_fulfillment {
+      messages {
+        text {
+          text = ["Response to default welcome intent."]
+        }
+      }
+    }
+  }
+
+  event_handlers {
+    event = "custom-event"
+    trigger_fulfillment {
+      messages {
+        text {
+          text = ["This is a default flow."]
+        }
+      }
+    }
+  }
+
+  event_handlers {
+    event = "sys.no-match-default"
+    trigger_fulfillment {
+      messages {
+        text {
+          text = ["We've updated the default flow no-match response!"]
+        }
+      }
+    }
+  }
+
+  event_handlers {
+    event = "sys.no-input-default"
+    trigger_fulfillment {
+      messages {
+        text {
+          text = ["We've updated the default flow no-input response!"]
+        }
+      }
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/dialogflowcx_flow_default_start_flow.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_flow_default_start_flow.tf.erb
@@ -23,6 +23,7 @@ resource "google_dialogflow_cx_flow" "<%= ctx[:primary_resource_id] %>" {
   parent                = google_dialogflow_cx_agent.agent.id
   is_default_start_flow = true
   display_name          = "Default Start Flow"
+  description           = "A start flow created along with the agent"
 
   nlu_settings {
     classification_threshold = 0.3

--- a/mmv1/templates/terraform/examples/dialogflowcx_intent_default_negative_intent.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_intent_default_negative_intent.tf.erb
@@ -11,6 +11,7 @@ resource "google_dialogflow_cx_intent" "<%= ctx[:primary_resource_id] %>" {
   is_default_negative_intent = true
   display_name               = "Default Negative Intent"
   priority                   = 1
+  is_fallback                = true
   training_phrases {
      parts {
          text = "Never match this phrase"

--- a/mmv1/templates/terraform/examples/dialogflowcx_intent_default_negative_intent.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_intent_default_negative_intent.tf.erb
@@ -1,0 +1,20 @@
+resource "google_dialogflow_cx_agent" "agent" {
+  display_name          = "<%= ctx[:vars]["agent_name"] %>"
+  location              = "global"
+  default_language_code = "en"
+  time_zone             = "America/New_York"
+}
+
+
+resource "google_dialogflow_cx_intent" "<%= ctx[:primary_resource_id] %>" {
+  parent                     = google_dialogflow_cx_agent.agent.id
+  is_default_negative_intent = true
+  display_name               = "Default Negative Intent"
+  priority                   = 1
+  training_phrases {
+     parts {
+         text = "Never match this phrase"
+     }
+     repeat_count = 1
+  }
+}

--- a/mmv1/templates/terraform/examples/dialogflowcx_intent_default_welcome_intent.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_intent_default_welcome_intent.tf.erb
@@ -1,0 +1,20 @@
+resource "google_dialogflow_cx_agent" "agent" {
+  display_name          = "<%= ctx[:vars]["agent_name"] %>"
+  location              = "global"
+  default_language_code = "en"
+  time_zone             = "America/New_York"
+}
+
+
+resource "google_dialogflow_cx_intent" "<%= ctx[:primary_resource_id] %>" {
+  parent                    = google_dialogflow_cx_agent.agent.id
+  is_default_welcome_intent = true
+  display_name              = "Default Welcome Intent"
+  priority                  = 1
+  training_phrases {
+     parts {
+         text = "Hello"
+     }
+     repeat_count = 1
+  }
+}

--- a/mmv1/templates/terraform/pre_create/dialogflowcx_set_location_skip_default_obj.go.erb
+++ b/mmv1/templates/terraform/pre_create/dialogflowcx_set_location_skip_default_obj.go.erb
@@ -15,6 +15,7 @@ if parts := regexp.MustCompile(`locations\/([^\/]*)\/`).FindStringSubmatch(d.Get
 url = strings.Replace(url,"-dialogflow",fmt.Sprintf("%s-dialogflow",location),1)
 
 // if it's a default object Dialogflow creates for you, "Update" instead of "Create"
+// Note: below we try to access fields that aren't present in the resource, because this custom code is reused across multiple Dialogflow resources that contain different fields. When the field isn't present the boolean will be false.
 isDefaultStartFlow, _ := d.Get("is_default_start_flow").(bool)
 isDefaultWelcomeIntent, _ := d.Get("is_default_welcome_intent").(bool)
 isDefaultNegativeIntent, _ := d.Get("is_default_negative_intent").(bool)

--- a/mmv1/templates/terraform/pre_create/dialogflowcx_set_location_skip_default_obj.go.erb
+++ b/mmv1/templates/terraform/pre_create/dialogflowcx_set_location_skip_default_obj.go.erb
@@ -15,7 +15,7 @@ if parts := regexp.MustCompile(`locations\/([^\/]*)\/`).FindStringSubmatch(d.Get
 url = strings.Replace(url,"-dialogflow",fmt.Sprintf("%s-dialogflow",location),1)
 
 // if it's a default object Dialogflow creates for you, "Update" instead of "Create"
-// Note: below we try to access fields that aren't present in the resource, because this custom code is reused across multiple Dialogflow resources that contain different fields. When the field isn't present the boolean will be false.
+// Note: below we try to access fields that aren't present in the resource, because this custom code is reused across multiple Dialogflow resources that contain different fields. When the field isn't present, we deliberately ignore the error and the boolean is false.
 isDefaultStartFlow, _ := d.Get("is_default_start_flow").(bool)
 isDefaultWelcomeIntent, _ := d.Get("is_default_welcome_intent").(bool)
 isDefaultNegativeIntent, _ := d.Get("is_default_negative_intent").(bool)

--- a/mmv1/templates/terraform/pre_create/dialogflowcx_set_location_skip_default_obj.go.erb
+++ b/mmv1/templates/terraform/pre_create/dialogflowcx_set_location_skip_default_obj.go.erb
@@ -1,0 +1,41 @@
+
+// extract location from the parent
+location := ""
+
+if parts := regexp.MustCompile(`locations\/([^\/]*)\/`).FindStringSubmatch(d.Get("parent").(string)); parts != nil {
+    location = parts[1]
+} else {
+    return fmt.Errorf(
+        "Saw %s when the parent is expected to contains location %s",
+        d.Get("parent"),
+        "projects/{{project}}/locations/{{location}}/...",
+    )
+}
+
+url = strings.Replace(url,"-dialogflow",fmt.Sprintf("%s-dialogflow",location),1)
+
+// if it's a default object Dialogflow creates for you, "Update" instead of "Create"
+isDefaultStartFlow, _ := d.Get("is_default_start_flow").(bool)
+isDefaultWelcomeIntent, _ := d.Get("is_default_welcome_intent").(bool)
+isDefaultNegativeIntent, _ := d.Get("is_default_negative_intent").(bool)
+if isDefaultStartFlow || isDefaultWelcomeIntent || isDefaultNegativeIntent {
+    // hardcode the default object ID:
+    var defaultObjName string
+    if isDefaultStartFlow || isDefaultWelcomeIntent {
+        defaultObjName = "00000000-0000-0000-0000-000000000000"
+    }
+    if isDefaultNegativeIntent {
+        defaultObjName = "00000000-0000-0000-0000-000000000001"
+    }
+
+    // Store the ID
+    d.Set("name", defaultObjName)
+    id, err := tpgresource.ReplaceVars(d, config, "<%= id_format(object) -%>")
+    if err != nil {
+        return fmt.Errorf("Error constructing id: %s", err)
+    }
+    d.SetId(id)
+
+    // and defer to the Update method:
+    return resource<%= resource_name -%>Update(d, meta)
+}

--- a/mmv1/templates/terraform/pre_create/dialogflowcx_set_location_skip_default_obj.go.erb
+++ b/mmv1/templates/terraform/pre_create/dialogflowcx_set_location_skip_default_obj.go.erb
@@ -37,5 +37,6 @@ if isDefaultStartFlow || isDefaultWelcomeIntent || isDefaultNegativeIntent {
     d.SetId(id)
 
     // and defer to the Update method:
+    log.Printf("[DEBUG] Updating default <%= resource_name -%>")
     return resource<%= resource_name -%>Update(d, meta)
 }

--- a/mmv1/templates/terraform/pre_delete/dialogflowcx_set_location_skip_default_obj.go.erb
+++ b/mmv1/templates/terraform/pre_delete/dialogflowcx_set_location_skip_default_obj.go.erb
@@ -15,6 +15,7 @@ if parts := regexp.MustCompile(`locations\/([^\/]*)\/`).FindStringSubmatch(d.Get
 url = strings.Replace(url,"-dialogflow",fmt.Sprintf("%s-dialogflow",location),1)
 
 // if it's a default object Dialogflow creates for you, skip deletion
+// Note: below we try to access fields that aren't present in the resource, because this custom code is reused across multiple Dialogflow resources that contain different fields. When the field isn't present, we deliberately ignore the error and the boolean is false.
 isDefaultStartFlow, _ := d.Get("is_default_start_flow").(bool)
 isDefaultWelcomeIntent, _ := d.Get("is_default_welcome_intent").(bool)
 isDefaultNegativeIntent, _ := d.Get("is_default_negative_intent").(bool)

--- a/mmv1/templates/terraform/pre_delete/dialogflowcx_set_location_skip_default_obj.go.erb
+++ b/mmv1/templates/terraform/pre_delete/dialogflowcx_set_location_skip_default_obj.go.erb
@@ -1,0 +1,25 @@
+
+// extract location from the parent
+location := ""
+
+if parts := regexp.MustCompile(`locations\/([^\/]*)\/`).FindStringSubmatch(d.Get("parent").(string)); parts != nil {
+    location = parts[1]
+} else {
+    return fmt.Errorf(
+        "Saw %s when the parent is expected to contains location %s",
+        d.Get("parent"),
+        "projects/{{project}}/locations/{{location}}/...",
+    )
+}
+
+url = strings.Replace(url,"-dialogflow",fmt.Sprintf("%s-dialogflow",location),1)
+
+// if it's a default object Dialogflow creates for you, skip deletion
+isDefaultStartFlow, _ := d.Get("is_default_start_flow").(bool)
+isDefaultWelcomeIntent, _ := d.Get("is_default_welcome_intent").(bool)
+isDefaultNegativeIntent, _ := d.Get("is_default_negative_intent").(bool)
+if isDefaultStartFlow || isDefaultWelcomeIntent || isDefaultNegativeIntent {
+    // we can't delete these resources so do nothing
+    log.Printf("[DEBUG] Not deleting default <%= resource_name -%>")
+    return nil
+}

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -155,6 +155,9 @@ func Resource<%= resource_name -%>() *schema.Resource {
             "<%= field.name -%>": {
                 Type: <%= tf_type(field) -%>,
                 Optional: true,
+<%       if field.immutable -%>
+                ForceNew: true,
+<%       end -%>
 <%       unless field.default_value.nil? -%>
                 Default:  <%= go_literal(field.default_value) -%>,
 <%       end -%>

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
@@ -363,7 +363,8 @@ func TestAccDialogflowCXFlow_defaultStartFlow(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDialogflowCXFlow_defaultStartFlow(context),
+				// Note: this isn't actually a "create" test; it creates a resource in the TF state, but is actually importing the default object GCP has created, then updating it.
+				Config: testAccDialogflowCXFlow_defaultStartFlow_create(context),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_dialogflow_cx_flow.default_start_flow", "name", "00000000-0000-0000-0000-000000000000"),
 					resource.TestCheckResourceAttrPair(
@@ -372,11 +373,32 @@ func TestAccDialogflowCXFlow_defaultStartFlow(t *testing.T) {
 					),
 				),
 			},
+			{
+				ResourceName:      "google_dialogflow_cx_flow.default_start_flow",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// This is testing updating the default object without having to create it in the TF state first.
+				Config: testAccDialogflowCXFlow_defaultStartFlow_update(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_dialogflow_cx_flow.default_start_flow", "name", "00000000-0000-0000-0000-000000000000"),
+					resource.TestCheckResourceAttrPair(
+						"google_dialogflow_cx_flow.default_start_flow", "id",
+						"google_dialogflow_cx_agent.agent", "start_flow",
+					),
+				),
+			},
+			{
+				ResourceName:      "google_dialogflow_cx_flow.default_start_flow",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
 
-func testAccDialogflowCXFlow_defaultStartFlow(context map[string]interface{}) string {
+func testAccDialogflowCXFlow_defaultStartFlow_create(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_dialogflow_cx_agent" "agent" {
   display_name          = "tf-test-dialogflowcx-agent%{random_suffix}"
@@ -426,7 +448,7 @@ resource "google_dialogflow_cx_flow" "default_start_flow" {
     trigger_fulfillment {
       messages {
         text {
-          text = ["This is a default flow."]
+          text = ["Handle a custom event!"]
         }
       }
     }
@@ -437,7 +459,7 @@ resource "google_dialogflow_cx_flow" "default_start_flow" {
     trigger_fulfillment {
       messages {
         text {
-          text = ["We've updated the default flow no-match response!"]
+          text = ["This is the flow no-match response."]
         }
       }
     }
@@ -448,7 +470,79 @@ resource "google_dialogflow_cx_flow" "default_start_flow" {
     trigger_fulfillment {
       messages {
         text {
-          text = ["We've updated the default flow no-input response!"]
+          text = ["This is the flow no-input response."]
+        }
+      }
+    }
+  }
+}
+`, context)
+}
+
+func testAccDialogflowCXFlow_defaultStartFlow_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_dialogflow_cx_agent" "agent" {
+  display_name          = "tf-test-dialogflowcx-agent%{random_suffix}"
+  location              = "global"
+  default_language_code = "en"
+  time_zone             = "America/New_York"
+}
+
+resource "google_dialogflow_cx_intent" "default_welcome_intent" {
+  parent                    = google_dialogflow_cx_agent.agent.id
+  is_default_welcome_intent = true
+  display_name              = "Default Welcome Intent"
+  priority                  = 1
+  training_phrases {
+    parts {
+      text = "Hello"
+    }
+    repeat_count = 1
+  }
+}
+
+
+resource "google_dialogflow_cx_flow" "default_start_flow" {
+  parent                = google_dialogflow_cx_agent.agent.id
+  is_default_start_flow = true
+  display_name          = "Default Start Flow"
+  description           = "A start flow created along with the agent"
+
+  nlu_settings {
+    classification_threshold = 0.5
+    model_type               = "MODEL_TYPE_STANDARD"
+  }
+
+  transition_routes {
+    intent = google_dialogflow_cx_intent.default_welcome_intent.id
+    trigger_fulfillment {
+      messages {
+        text {
+          text = ["We can update the default welcome intent response!"]
+        }
+      }
+    }
+  }
+
+  // delete the custom-event handler to show we can
+
+  event_handlers {
+    event = "sys.no-match-default"
+    trigger_fulfillment {
+      messages {
+        text {
+          text = ["We an also update the no-match response!"]
+        }
+      }
+    }
+  }
+
+  event_handlers {
+    event = "sys.no-input-default"
+    trigger_fulfillment {
+      messages {
+        text {
+          text = ["The no-input response has been updated too!"]
         }
       }
     }

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
@@ -403,6 +403,7 @@ resource "google_dialogflow_cx_flow" "default_start_flow" {
   parent                = google_dialogflow_cx_agent.agent.id
   is_default_start_flow = true
   display_name          = "Default Start Flow"
+  description           = "A start flow created along with the agent"
 
   nlu_settings {
     classification_threshold = 0.3

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_intent_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_intent_test.go
@@ -152,17 +152,50 @@ func TestAccDialogflowCXIntent_defaultIntents(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDialogflowCXIntent_defaultIntents(context),
+				// Note: this isn't actually a "create" test; it creates resources in the TF state, but is actually importing the default objects GCP has created, then updating them.
+				Config: testAccDialogflowCXIntent_defaultIntents_create(context),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_dialogflow_cx_intent.default_negative_intent", "name", "00000000-0000-0000-0000-000000000001"),
 					resource.TestCheckResourceAttr("google_dialogflow_cx_intent.default_welcome_intent", "name", "00000000-0000-0000-0000-000000000000"),
 				),
 			},
+			{
+				ResourceName:            "google_dialogflow_cx_intent.default_negative_intent",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				ResourceName:            "google_dialogflow_cx_intent.default_welcome_intent",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				// This is testing updating the default objects without having to create them in the TF state first.
+				Config: testAccDialogflowCXIntent_defaultIntents_update(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_dialogflow_cx_intent.default_negative_intent", "name", "00000000-0000-0000-0000-000000000001"),
+					resource.TestCheckResourceAttr("google_dialogflow_cx_intent.default_welcome_intent", "name", "00000000-0000-0000-0000-000000000000"),
+				),
+			},
+			{
+				ResourceName:            "google_dialogflow_cx_intent.default_negative_intent",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				ResourceName:            "google_dialogflow_cx_intent.default_welcome_intent",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
 		},
 	})
 }
 
-func testAccDialogflowCXIntent_defaultIntents(context map[string]interface{}) string {
+func testAccDialogflowCXIntent_defaultIntents_create(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_dialogflow_cx_agent" "agent" {
   display_name          = "tf-test-dialogflowcx-agent%{random_suffix}"
@@ -195,6 +228,44 @@ resource "google_dialogflow_cx_intent" "default_welcome_intent" {
          text = "Hello"
      }
      repeat_count = 1
+  }
+}
+`, context)
+}
+
+func testAccDialogflowCXIntent_defaultIntents_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_dialogflow_cx_agent" "agent" {
+  display_name          = "tf-test-dialogflowcx-agent%{random_suffix}"
+  location              = "global"
+  default_language_code = "en"
+  time_zone             = "America/New_York"
+}
+
+resource "google_dialogflow_cx_intent" "default_negative_intent" {
+  parent                     = google_dialogflow_cx_agent.agent.id
+  is_default_negative_intent = true
+  display_name               = "Default Negative Intent"
+  priority                   = 1
+  is_fallback                = true
+  training_phrases {
+     parts {
+         text = "An updated phrase to never match."
+     }
+     repeat_count = 2
+  }
+}
+
+resource "google_dialogflow_cx_intent" "default_welcome_intent" {
+  parent                    = google_dialogflow_cx_agent.agent.id
+  is_default_welcome_intent = true
+  display_name              = "Default Welcome Intent"
+  priority                  = 1
+  training_phrases {
+     parts {
+         text = "An updated hello."
+     }
+     repeat_count = 2
   }
 }
 `, context)

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_intent_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_intent_test.go
@@ -176,6 +176,7 @@ resource "google_dialogflow_cx_intent" "default_negative_intent" {
   is_default_negative_intent = true
   display_name               = "Default Negative Intent"
   priority                   = 1
+  is_fallback                = true
   training_phrases {
      parts {
          text = "Never match this phrase"

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_intent_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_intent_test.go
@@ -139,3 +139,62 @@ func testAccDialogflowCXIntent_full(context map[string]interface{}) string {
     } 
 	  `, context)
 }
+
+func TestAccDialogflowCXIntent_defaultIntents(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDialogflowCXIntent_defaultIntents(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_dialogflow_cx_intent.default_negative_intent", "name", "00000000-0000-0000-0000-000000000001"),
+					resource.TestCheckResourceAttr("google_dialogflow_cx_intent.default_welcome_intent", "name", "00000000-0000-0000-0000-000000000000"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDialogflowCXIntent_defaultIntents(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_dialogflow_cx_agent" "agent" {
+  display_name          = "tf-test-dialogflowcx-agent%{random_suffix}"
+  location              = "global"
+  default_language_code = "en"
+  time_zone             = "America/New_York"
+}
+
+resource "google_dialogflow_cx_intent" "default_negative_intent" {
+  parent                     = google_dialogflow_cx_agent.agent.id
+  is_default_negative_intent = true
+  display_name               = "Default Negative Intent"
+  priority                   = 1
+  training_phrases {
+     parts {
+         text = "Never match this phrase"
+     }
+     repeat_count = 1
+  }
+}
+
+resource "google_dialogflow_cx_intent" "default_welcome_intent" {
+  parent                    = google_dialogflow_cx_agent.agent.id
+  is_default_welcome_intent = true
+  display_name              = "Default Welcome Intent"
+  priority                  = 1
+  training_phrases {
+     parts {
+         text = "Hello"
+     }
+     repeat_count = 1
+  }
+}
+`, context)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/16308, read that bug for more context 😅

An alternative version of https://github.com/GoogleCloudPlatform/magic-modules/pull/9359 because designing a good API is hard and I want someone else to make that decision 😅.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dialogflowcx: added `is_default_welcome_intent` and `is_default_negative_intent` fields to `google_dialogflow_cx_intent` resource to allow management of default intent resources via Terraform
```

```release-note:enhancement
dialogflowcx: added `is_default_start_flow` field to `google_dialogflow_cx_flow` resource to allow management of default flow resources via Terraform
```
