### PR TITLE
Fix edgecontainer cluster upgrade endpoint and update the machine configuration in internal test

### DIFF
--- a/mmv1/products/edgecontainer/Cluster.yaml
+++ b/mmv1/products/edgecontainer/Cluster.yaml
@@ -476,7 +476,7 @@ properties:
     default_from_api: true
     description: |
       The target cluster version. For example: "1.5.0".
-    update_url: 'projects/{{project}}/locations/{{region}}/instances/{{name}}:upgrade'
+    update_url: 'projects/{{project}}/locations/{{location}}/clusters/{{name}}:upgrade'
     update_verb: :POST
   - !ruby/object:Api::Type::Enum
     name: "releaseChannel"

--- a/mmv1/templates/terraform/examples/edgecontainer_local_control_plane_node_pool_internal.tf.erb
+++ b/mmv1/templates/terraform/examples/edgecontainer_local_control_plane_node_pool_internal.tf.erb
@@ -9,21 +9,21 @@ resource "google_edgecontainer_cluster" "cluster" {
   }
 
   networking {
-    cluster_ipv4_cidr_blocks = ["10.96.0.0/17"]
-    services_ipv4_cidr_blocks = ["10.0.0.0/21"]
+    cluster_ipv4_cidr_blocks = ["10.16.0.0/16"]
+    services_ipv4_cidr_blocks = ["10.17.0.0/16"]
   }
 
   fleet {
     project = "projects/${data.google_project.project.number}"
   }
 
-  external_load_balancer_ipv4_address_pools = ["10.100.68.100-10.100.68.102"]
+  external_load_balancer_ipv4_address_pools = ["172.17.34.97-172.17.34.99"]
 
   control_plane {
     local {
-      node_location = "us-central1-edge-den29"
+      node_location = "us-central1-edge-den25349"
       node_count = 1
-      machine_filter = "den29-06"
+      machine_filter = "den25349-01"
       shared_deployment_policy = "ALLOWED"
     }
   }
@@ -33,8 +33,8 @@ resource "google_edgecontainer_node_pool" "<%= ctx[:primary_resource_id] %>" {
   name = "nodepool-1"
   cluster = google_edgecontainer_cluster.cluster.name
   location = "us-central1"
-  node_location = "us-central1-edge-den29"
-  machine_filter = "NOT name:den29-01"
+  node_location = "us-central1-edge-den25349"
+  machine_filter = "den25349-02"
   node_count = 1
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
The change includes
1. Fix the cluster upgrade endpoint
2. Update the internal test machine configuration since we recently change the machine configuration.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
edgecontainer: fixed an issue where the update endpoint for `google_edgecontainer_cluster` was incorrect.
```
