### PR TITLE
feat(workflows): add user_env_vars field + tests

### DIFF
--- a/mmv1/products/workflows/Workflow.yaml
+++ b/mmv1/products/workflows/Workflow.yaml
@@ -41,6 +41,14 @@ examples:
       name: 'workflow'
       account_id: 'my-account'
     skip_import_test: true
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'workflow_beta'
+    primary_resource_id: 'example_beta'
+    vars:
+      name: 'workflow_beta'
+      account_id: 'my-account'
+    skip_import_test: true
+    min_version: 'beta'
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   extra_schema_entry: templates/terraform/extra_schema_entry/workflow.erb
   encoder: templates/terraform/encoders/workflow.go.erb
@@ -108,3 +116,8 @@ properties:
       The KMS key used to encrypt workflow and execution data.
 
       Format: projects/{project}/locations/{location}/keyRings/{keyRing}/cryptoKeys/{cryptoKey}
+  - !ruby/object:Api::Type::KeyValuePairs
+    name: 'userEnvVars'
+    min_version: beta
+    description: |
+      User-defined environment variables associated with this workflow revision. This map has a maximum length of 20. Each string can take up to 40KiB. Keys cannot be empty strings and cannot start with “GOOGLE” or “WORKFLOWS".

--- a/mmv1/templates/terraform/examples/workflow_beta.tf.erb
+++ b/mmv1/templates/terraform/examples/workflow_beta.tf.erb
@@ -1,0 +1,47 @@
+resource "google_service_account" "test_account" {
+  provider     = google-beta
+  account_id   = "<%= ctx[:vars]['account_id'] %>"
+  display_name = "Test Service Account"
+}
+
+resource "google_workflows_workflow" "<%= ctx[:primary_resource_id] %>" {
+  provider      = google-beta
+  name          = "<%= ctx[:vars]['name'] %>"
+  region        = "us-central1"
+  description   = "Magic"
+  service_account = google_service_account.test_account.id
+  labels = {
+    env = "test"
+  }
+  user_env_vars = {
+    foo = "BAR"
+  }
+  source_contents = <<-EOF
+  # This is a sample workflow. You can replace it with your source code.
+  #
+  # This workflow does the following:
+  # - reads current time and date information from an external API and stores
+  #   the response in currentTime variable
+  # - retrieves a list of Wikipedia articles related to the day of the week
+  #   from currentTime
+  # - returns the list of articles as an output of the workflow
+  #
+  # Note: In Terraform you need to escape the $$ or it will cause errors.
+
+  - getCurrentTime:
+      call: http.get
+      args:
+          url: https://timeapi.io/api/Time/current/zone?timeZone=Europe/Amsterdam
+      result: currentTime
+  - readWikipedia:
+      call: http.get
+      args:
+          url: https://en.wikipedia.org/w/api.php
+          query:
+              action: opensearch
+              search: $${currentTime.body.dayOfWeek}
+      result: wikiResult
+  - returnOutput:
+      return: $${wikiResult.body[1]}
+EOF
+}

--- a/mmv1/third_party/terraform/services/workflows/resource_workflows_workflow_test.go.erb
+++ b/mmv1/third_party/terraform/services/workflows/resource_workflows_workflow_test.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package workflows_test
 
 import (
@@ -211,3 +212,133 @@ EOF
 }
 `, workflowName, kmsKeyName)
 }
+
+<% unless version == 'ga' -%>
+func TestAccWorkflowsWorkflowBeta_update(t *testing.T) {
+	// custom test to test updating
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckWorkflowsWorkflowDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkflowsWorkflowBeta_full(context),
+			},
+			{
+				Config: testAccWorkflowsWorkflowBeta_update(context),
+			},
+		},
+	})
+}
+
+
+func testAccWorkflowsWorkflowBeta_full(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_service_account" "test_account" {
+  provider     = google-beta
+  account_id   = "tf-test-my-account%{random_suffix}"
+  display_name = "Test Service Account"
+}
+
+resource "google_workflows_workflow" "example_beta" {
+  provider      = google-beta
+  name          = "tf_test_workflow_beta%{random_suffix}"
+  region        = "us-central1"
+  description   = "Magic"
+  service_account = google_service_account.test_account.id
+  labels = {
+    env = "test"
+  }
+  user_env_vars = {
+    foo = "BAR"
+  }
+  source_contents = <<-EOF
+  # This is a sample workflow. You can replace it with your source code.
+  #
+  # This workflow does the following:
+  # - reads current time and date information from an external API and stores
+  #   the response in currentTime variable
+  # - retrieves a list of Wikipedia articles related to the day of the week
+  #   from currentTime
+  # - returns the list of articles as an output of the workflow
+  #
+  # Note: In Terraform you need to escape the $$ or it will cause errors.
+
+  - getCurrentTime:
+      call: http.get
+      args:
+          url: https://timeapi.io/api/Time/current/zone?timeZone=Europe/Amsterdam
+      result: currentTime
+  - readWikipedia:
+      call: http.get
+      args:
+          url: https://en.wikipedia.org/w/api.php
+          query:
+              action: opensearch
+              search: $${currentTime.body.dayOfWeek}
+      result: wikiResult
+  - returnOutput:
+      return: $${wikiResult.body[1]}
+EOF
+}
+`, context)
+}
+
+func testAccWorkflowsWorkflowBeta_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_service_account" "test_account" {
+  provider     = google-beta
+  account_id   = "tf-test-my-account%{random_suffix}"
+  display_name = "Test Service Account"
+}
+
+resource "google_workflows_workflow" "example_beta" {
+  provider      = google-beta
+  name          = "tf_test_workflow_beta%{random_suffix}"
+  region        = "us-central1"
+  description   = "Magic"
+  service_account = google_service_account.test_account.id
+  labels = {
+    env = "dev"
+  }
+  user_env_vars = {
+    bar = "FOO"
+  }
+  source_contents = <<-EOF
+  # This is a sample workflow. You can replace it with your source code.
+  #
+  # This workflow does the following:
+  # - reads current time and date information from an external API and stores
+  #   the response in currentTime variable
+  # - retrieves a list of Wikipedia articles related to the day of the week
+  #   from currentTime
+  # - returns the list of articles as an output of the workflow
+  #
+  # Note: In Terraform you need to escape the $$ or it will cause errors.
+
+  - getCurrentTime:
+      call: http.get
+      args:
+          url: https://timeapi.io/api/Time/current/zone?timeZone=Europe/Amsterdam
+      result: currentTime
+  - readWikipedia:
+      call: http.get
+      args:
+          url: https://en.wikipedia.org/w/api.php
+          query:
+              action: opensearch
+              search: $${currentTime.body.dayOfWeek}
+      result: wikiResult
+  - returnOutput:
+      return: $${wikiResult.body[1]}
+EOF
+}
+`, context)
+}
+<% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR:

- Modifies `google_workflows_workflow` to add `user_env_vars` field which is currently in preview. This allows users to set custom environment variables for Workflows
- Add tests (basic and update) as appropriate

Note that since `user_env_vars` is in preview ([see here](https://cloud.google.com/workflows/docs/use-environment-variables)), this new field will only be present in the beta provider

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/16341
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/15912

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
workflows: added field `user_env_vars` to `google_workflows_workflow` (beta)
```
