### PR TITLE
Add initiator_id metadata to dispatch events

### DIFF
--- a/.github/workflows/test-tgc.yml
+++ b/.github/workflows/test-tgc.yml
@@ -25,8 +25,8 @@ on:
       sha:
         description: "The commit SHA in magic-modules repository where the status result will be posted"
         required: true
-      initiator_id:
-        description: "Metadata about the caller who initiated the dispatch event"
+      caller_id:
+        description: "Identity of the workflow dispatch caller"
 
 concurrency:
   group: test-tgc-${{ github.event.inputs.owner }}-${{ github.event.inputs.repo }}-${{ github.event.inputs.branch }}

--- a/.github/workflows/test-tgc.yml
+++ b/.github/workflows/test-tgc.yml
@@ -25,6 +25,8 @@ on:
       sha:
         description: "The commit SHA in magic-modules repository where the status result will be posted"
         required: true
+      initiator_id:
+        description: "Metadata about the caller who initiated the dispatch event"
 
 concurrency:
   group: test-tgc-${{ github.event.inputs.owner }}-${{ github.event.inputs.repo }}-${{ github.event.inputs.branch }}

--- a/.github/workflows/test-tpg.yml
+++ b/.github/workflows/test-tpg.yml
@@ -25,6 +25,8 @@ on:
       sha:
         description: "The commit SHA in magic-modules repository where the status result will be posted"
         required: true
+      initiator_id:
+        description: "Metadata about the caller who initiated the dispatch event"
 
 concurrency:
   group: test-tpg-${{ github.event.inputs.owner }}-${{ github.event.inputs.repo }}-${{ github.event.inputs.branch }}

--- a/.github/workflows/test-tpg.yml
+++ b/.github/workflows/test-tpg.yml
@@ -25,8 +25,8 @@ on:
       sha:
         description: "The commit SHA in magic-modules repository where the status result will be posted"
         required: true
-      initiator_id:
-        description: "Metadata about the caller who initiated the dispatch event"
+      caller_id:
+        description: "Identity of the workflow dispatch caller"
 
 concurrency:
   group: test-tpg-${{ github.event.inputs.owner }}-${{ github.event.inputs.repo }}-${{ github.event.inputs.branch }}


### PR DESCRIPTION
Adding `initiator_id` to dispatch events. Going to use this to correlate event timing (completion time, etc) for dashboards.
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
