### PR TITLE
feat: added data source for bigquery dataset

### DIFF
--- a/mmv1/third_party/terraform/provider/provider.go.erb
+++ b/mmv1/third_party/terraform/provider/provider.go.erb
@@ -229,6 +229,7 @@ func DatasourceMapWithErrors() (map[string]*schema.Resource, error) {
 		"google_beyondcorp_app_connector":                  beyondcorp.DataSourceGoogleBeyondcorpAppConnector(),
 		"google_beyondcorp_app_gateway":                    beyondcorp.DataSourceGoogleBeyondcorpAppGateway(),
 		"google_billing_account":                           billing.DataSourceGoogleBillingAccount(),
+		"google_bigquery_dataset":          								bigquery.DataSourceGoogleBigqueryDataset(),
 		"google_bigquery_default_service_account":          bigquery.DataSourceGoogleBigqueryDefaultServiceAccount(),
 		"google_certificate_manager_certificate_map":       certificatemanager.DataSourceGoogleCertificateManagerCertificateMap(),
 		"google_cloudbuild_trigger":                        cloudbuild.DataSourceGoogleCloudBuildTrigger(),

--- a/mmv1/third_party/terraform/services/bigquery/data_source_google_bigquery_dataset.go
+++ b/mmv1/third_party/terraform/services/bigquery/data_source_google_bigquery_dataset.go
@@ -1,0 +1,46 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+package bigquery
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceGoogleBigqueryDataset() *schema.Resource {
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceBigQueryDataset().Schema)
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "dataset_id")
+	tpgresource.AddOptionalFieldsToSchema(dsSchema, "project")
+
+	return &schema.Resource{
+		Read:   dataSourceGoogleBigqueryDatasetRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceGoogleBigqueryDatasetRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+
+	dataset_id := d.Get("dataset_id").(string)
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return fmt.Errorf("Error fetching project: %s", err)
+	}
+
+	id := fmt.Sprintf("projects/%s/datasets/%s", project, dataset_id)
+	d.SetId(id)
+	err = resourceBigQueryDatasetRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
+}

--- a/mmv1/third_party/terraform/services/bigquery/data_source_google_bigquery_dataset_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/data_source_google_bigquery_dataset_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+package bigquery_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccDataSourceGoogleBigqueryDataset_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckBigQueryDatasetDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleBigqueryDataset_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceState("data.google_bigquery_dataset.bar", "google_bigquery_dataset.foo"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleBigqueryDataset_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+
+  resource "google_bigquery_dataset" "foo" {
+    dataset_id                  = "tf_test_ds_%{random_suffix}"
+    friendly_name               = "testing"
+    description                 = "This is a test description"
+    location                    = "US"
+    default_table_expiration_ms = 3600000
+  }
+
+  data "google_bigquery_dataset" "bar" {
+    dataset_id    = google_bigquery_dataset.foo.dataset_id
+  }
+`, context)
+}

--- a/mmv1/third_party/terraform/website/docs/d/bigquery_dataset.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/bigquery_dataset.html.markdown
@@ -1,0 +1,33 @@
+---
+subcategory: "BigQuery"
+description: |-
+  A datasource to retrieve information about a BigQuery dataset.
+---
+
+# `google_bigquery_dataset`
+
+Get information about a BigQuery dataset. For more information see
+the [official documentation](https://cloud.google.com/bigquery/docs)
+and [API](https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets).
+
+## Example Usage
+
+```hcl
+data "google_bigquery_dataset" "dataset" {
+  dataset_id = "my-bq-dataset"
+  project = "my-project"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `dataset_id` - (Required) The dataset ID.
+
+* `project` - (Optional) The ID of the project in which the resource belongs.
+    If it is not provided, the provider project is used.
+
+## Attributes Reference
+
+See [google_bigquery_dataset](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_dataset) resource for details of the available attributes.


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/5693. Adds new data source `google_bigquery_dataset`

```release-note:new-datasource
google_bigquery_dataset
```