### PR TITLE
Update guest_os_features in testAccComputeInstance_networkPerformance…

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -6026,9 +6026,12 @@ resource "google_compute_image" "foobar" {
   guest_os_features {
     type = "VIRTIO_SCSI_MULTIQUEUE"
   }
-	guest_os_features {
+  guest_os_features {
     type = "UEFI_COMPATIBLE"
-   }
+  }
+  guest_os_features {
+    type = "SEV_CAPABLE"
+  }
 }
 
 resource "google_compute_instance" "foobar" {


### PR DESCRIPTION
Fix testAccComputeInstance_networkPerformance test by adding new guest OS feature which were added in new Debian images.

This fixes https://github.com/hashicorp/terraform-provider-google/issues/15083

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
