### PR TITLE
Enabling management of default Dialogflow resources without terraform import: `name` field editable

### DIFF
--- a/mmv1/products/dialogflowcx/Flow.yaml
+++ b/mmv1/products/dialogflowcx/Flow.yaml
@@ -27,17 +27,28 @@ timeouts: !ruby/object:Api::Timeouts
   update_minutes: 40
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/dialogflowcx_flow.go.erb
-  pre_create: templates/terraform/pre_create/dialogflow_set_location.go.erb
+  pre_create: templates/terraform/pre_create/dialogflowcx_set_location_skip_default_obj.go.erb
   pre_update: templates/terraform/pre_create/dialogflow_set_location.go.erb
-  pre_delete: templates/terraform/pre_create/dialogflow_set_location.go.erb
+  pre_delete: templates/terraform/pre_delete/dialogflowcx_set_location_skip_default_obj.go.erb
   pre_read: templates/terraform/pre_create/dialogflow_set_location.go.erb
 examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'dialogflowcx_flow_basic'
+    primary_resource_id: 'basic_flow'
+    vars:
+      agent_name: 'dialogflowcx-agent'
   - !ruby/object:Provider::Terraform::Examples
     name: 'dialogflowcx_flow_full'
     primary_resource_id: 'basic_flow'
     vars:
       agent_name: 'dialogflowcx-agent'
       bucket_name: 'dialogflowcx-bucket'
+  - !ruby/object:Provider::Terraform::Examples
+    skip_docs: true
+    name: 'dialogflowcx_flow_default_start_flow'
+    primary_resource_id: 'default_start_flow'
+    vars:
+      agent_name: 'dialogflowcx-agent'
 skip_sweeper: true
 id_format: '{{parent}}/flows/{{name}}'
 import_format: ['{{parent}}/flows/{{name}}']
@@ -62,9 +73,11 @@ parameters:
 properties:
   - !ruby/object:Api::Type::String
     name: 'name'
-    output: true
+    default_from_api: true
+    immutable: true
     description: |
-      The unique identifier of the flow.
+      The unique identifier of the flow. You should not be setting it most of the time.
+      Setting it to the special value `00000000-0000-0000-0000-000000000000` marks this resource as the [Default Start Flow](https://cloud.google.com/dialogflow/cx/docs/concept/flow#start). When you create an agent, a Default Start Flow is created automatically. The Default Start Flow cannot be deleted; deleting the corresponding `google_dialogflow_cx_flow` resource does nothing to the underlying GCP resources.
       Format: projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/flows/<Flow ID>.
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
   - !ruby/object:Api::Type::String

--- a/mmv1/products/dialogflowcx/Flow.yaml
+++ b/mmv1/products/dialogflowcx/Flow.yaml
@@ -28,6 +28,7 @@ timeouts: !ruby/object:Api::Timeouts
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/dialogflowcx_flow.go.erb
   pre_create: templates/terraform/pre_create/dialogflowcx_set_location_skip_default_obj.go.erb
+  post_create: templates/terraform/post_create/dialogflowcx_set_name_and_id.go.erb
   pre_update: templates/terraform/pre_create/dialogflow_set_location.go.erb
   pre_delete: templates/terraform/pre_delete/dialogflowcx_set_location_skip_default_obj.go.erb
   pre_read: templates/terraform/pre_create/dialogflow_set_location.go.erb

--- a/mmv1/products/dialogflowcx/Intent.yaml
+++ b/mmv1/products/dialogflowcx/Intent.yaml
@@ -28,6 +28,7 @@ timeouts: !ruby/object:Api::Timeouts
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/dialogflowcx_intent.go.erb
   pre_create: templates/terraform/pre_create/dialogflowcx_set_location_skip_default_obj.go.erb
+  post_create: templates/terraform/post_create/dialogflowcx_set_name_and_id.go.erb
   pre_update: templates/terraform/pre_create/dialogflow_set_location.go.erb
   pre_delete: templates/terraform/pre_delete/dialogflowcx_set_location_skip_default_obj.go.erb
   pre_read: templates/terraform/pre_create/dialogflow_set_location.go.erb

--- a/mmv1/products/dialogflowcx/Intent.yaml
+++ b/mmv1/products/dialogflowcx/Intent.yaml
@@ -27,14 +27,26 @@ timeouts: !ruby/object:Api::Timeouts
   update_minutes: 40
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/dialogflowcx_intent.go.erb
-  pre_create: templates/terraform/pre_create/dialogflow_set_location.go.erb
+  pre_create: templates/terraform/pre_create/dialogflowcx_set_location_skip_default_obj.go.erb
   pre_update: templates/terraform/pre_create/dialogflow_set_location.go.erb
-  pre_delete: templates/terraform/pre_create/dialogflow_set_location.go.erb
+  pre_delete: templates/terraform/pre_delete/dialogflowcx_set_location_skip_default_obj.go.erb
   pre_read: templates/terraform/pre_create/dialogflow_set_location.go.erb
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'dialogflowcx_intent_full'
     primary_resource_id: 'basic_intent'
+    vars:
+      agent_name: 'dialogflowcx-agent'
+  - !ruby/object:Provider::Terraform::Examples
+    skip_docs: true
+    name: 'dialogflowcx_intent_default_negative_intent'
+    primary_resource_id: 'default_negative_intent'
+    vars:
+      agent_name: 'dialogflowcx-agent'
+  - !ruby/object:Provider::Terraform::Examples
+    skip_docs: true
+    name: 'dialogflowcx_intent_default_welcome_intent'
+    primary_resource_id: 'default_welcome_intent'
     vars:
       agent_name: 'dialogflowcx-agent'
 skip_sweeper: true
@@ -58,9 +70,12 @@ parameters:
 properties:
   - !ruby/object:Api::Type::String
     name: 'name'
-    output: true
+    default_from_api: true
+    immutable: true
     description: |
-      The unique identifier of the intent.
+      The unique identifier of the intent. You should not be setting it most of the time.
+      Setting it to the special value `00000000-0000-0000-0000-000000000000` marks this resource as the [Default Welcome Intent](https://cloud.google.com/dialogflow/cx/docs/concept/intent#welcome). When you create an agent, a Default Welcome Intent is created automatically. The Default Welcome Intent cannot be deleted; deleting the corresponding `google_dialogflow_cx_intent` resource does nothing to the underlying GCP resources.
+      Setting it to the special value `00000000-0000-0000-0000-000000000001` marks this resource as the [Default Negative Intent](https://cloud.google.com/dialogflow/cx/docs/concept/intent#negative). When you create an agent, a Default Negative Intent is created automatically. The Default Negative Intent cannot be deleted; deleting the corresponding `google_dialogflow_cx_intent` resource does nothing to the underlying GCP resources.
       Format: projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/intents/<Intent ID>.
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
   - !ruby/object:Api::Type::String
@@ -141,9 +156,11 @@ properties:
       If the supplied value is negative, the intent is ignored in runtime detect intent requests.
   - !ruby/object:Api::Type::Boolean
     name: 'isFallback'
+    output: true
     description: |
       Indicates whether this is a fallback intent. Currently only default fallback intent is allowed in the agent, which is added upon agent creation.
       Adding training phrases to fallback intent is useful in the case of requests that are mistakenly matched, since training phrases assigned to fallback intents act as negative examples that triggers no-match event.
+      To manage the fallback intent, set `name = "00000000-0000-0000-0000-000000000001"`.
   - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: |

--- a/mmv1/products/dialogflowcx/Intent.yaml
+++ b/mmv1/products/dialogflowcx/Intent.yaml
@@ -156,7 +156,6 @@ properties:
       If the supplied value is negative, the intent is ignored in runtime detect intent requests.
   - !ruby/object:Api::Type::Boolean
     name: 'isFallback'
-    output: true
     description: |
       Indicates whether this is a fallback intent. Currently only default fallback intent is allowed in the agent, which is added upon agent creation.
       Adding training phrases to fallback intent is useful in the case of requests that are mistakenly matched, since training phrases assigned to fallback intents act as negative examples that triggers no-match event.

--- a/mmv1/templates/terraform/examples/dialogflowcx_flow_default_start_flow.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_flow_default_start_flow.tf.erb
@@ -1,0 +1,76 @@
+resource "google_dialogflow_cx_agent" "agent" {
+  display_name          = "<%= ctx[:vars]["agent_name"] %>"
+  location              = "global"
+  default_language_code = "en"
+  time_zone             = "America/New_York"
+}
+
+resource "google_dialogflow_cx_intent" "default_welcome_intent" {
+  parent       = google_dialogflow_cx_agent.agent.id
+  name         = "00000000-0000-0000-0000-000000000000"
+  display_name = "Default Welcome Intent"
+  priority     = 1
+  training_phrases {
+    parts {
+      text = "Hello"
+    }
+    repeat_count = 1
+  }
+}
+
+
+resource "google_dialogflow_cx_flow" "<%= ctx[:primary_resource_id] %>" {
+  parent       = google_dialogflow_cx_agent.agent.id
+  name         = "00000000-0000-0000-0000-000000000000"
+  display_name = "Default Start Flow"
+  description  = "A start flow created along with the agent"
+
+  nlu_settings {
+    classification_threshold = 0.3
+    model_type               = "MODEL_TYPE_STANDARD"
+  }
+
+  transition_routes {
+    intent = google_dialogflow_cx_intent.default_welcome_intent.id
+    trigger_fulfillment {
+      messages {
+        text {
+          text = ["Response to default welcome intent."]
+        }
+      }
+    }
+  }
+
+  event_handlers {
+    event = "custom-event"
+    trigger_fulfillment {
+      messages {
+        text {
+          text = ["This is a default flow."]
+        }
+      }
+    }
+  }
+
+  event_handlers {
+    event = "sys.no-match-default"
+    trigger_fulfillment {
+      messages {
+        text {
+          text = ["We've updated the default flow no-match response!"]
+        }
+      }
+    }
+  }
+
+  event_handlers {
+    event = "sys.no-input-default"
+    trigger_fulfillment {
+      messages {
+        text {
+          text = ["We've updated the default flow no-input response!"]
+        }
+      }
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/dialogflowcx_intent_default_negative_intent.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_intent_default_negative_intent.tf.erb
@@ -1,0 +1,20 @@
+resource "google_dialogflow_cx_agent" "agent" {
+  display_name          = "<%= ctx[:vars]["agent_name"] %>"
+  location              = "global"
+  default_language_code = "en"
+  time_zone             = "America/New_York"
+}
+
+
+resource "google_dialogflow_cx_intent" "<%= ctx[:primary_resource_id] %>" {
+  parent       = google_dialogflow_cx_agent.agent.id
+  name         = "00000000-0000-0000-0000-000000000001"
+  display_name = "Default Negative Intent"
+  priority     = 1
+  training_phrases {
+    parts {
+      text = "Never match this phrase"
+    }
+    repeat_count = 1
+  }
+}

--- a/mmv1/templates/terraform/examples/dialogflowcx_intent_default_negative_intent.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_intent_default_negative_intent.tf.erb
@@ -11,6 +11,7 @@ resource "google_dialogflow_cx_intent" "<%= ctx[:primary_resource_id] %>" {
   name         = "00000000-0000-0000-0000-000000000001"
   display_name = "Default Negative Intent"
   priority     = 1
+  is_fallback  = true
   training_phrases {
     parts {
       text = "Never match this phrase"

--- a/mmv1/templates/terraform/examples/dialogflowcx_intent_default_welcome_intent.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_intent_default_welcome_intent.tf.erb
@@ -1,0 +1,20 @@
+resource "google_dialogflow_cx_agent" "agent" {
+  display_name          = "<%= ctx[:vars]["agent_name"] %>"
+  location              = "global"
+  default_language_code = "en"
+  time_zone             = "America/New_York"
+}
+
+
+resource "google_dialogflow_cx_intent" "<%= ctx[:primary_resource_id] %>" {
+  parent       = google_dialogflow_cx_agent.agent.id
+  name         = "00000000-0000-0000-0000-000000000000"
+  display_name = "Default Welcome Intent"
+  priority     = 1
+  training_phrases {
+    parts {
+      text = "Hello"
+    }
+    repeat_count = 1
+  }
+}

--- a/mmv1/templates/terraform/post_create/dialogflowcx_set_name_and_id.go.erb
+++ b/mmv1/templates/terraform/post_create/dialogflowcx_set_name_and_id.go.erb
@@ -1,0 +1,11 @@
+// "name" is not output-only so the code to set it doesn't get generated; do it ourselves:
+if err := d.Set("name", flatten<%= resource_name -%>Name(res["name"], d, config)); err != nil {
+    return fmt.Errorf(`Error setting computed identity field "name": %s`, err)
+}
+
+// Re-store the ID now
+id, err = tpgresource.ReplaceVars(d, config, "<%= id_format(object) -%>")
+if err != nil {
+    return fmt.Errorf("Error constructing id: %s", err)
+}
+d.SetId(id)

--- a/mmv1/templates/terraform/pre_create/dialogflowcx_set_location_skip_default_obj.go.erb
+++ b/mmv1/templates/terraform/pre_create/dialogflowcx_set_location_skip_default_obj.go.erb
@@ -1,0 +1,30 @@
+
+// extract location from the parent
+location := ""
+ 
+if parts := regexp.MustCompile(`locations\/([^\/]*)\/`).FindStringSubmatch(d.Get("parent").(string)); parts != nil {
+    location = parts[1]
+} else {
+    return fmt.Errorf(
+        "Saw %s when the parent is expected to contains location %s",
+        d.Get("parent"),
+        "projects/{{project}}/locations/{{location}}/...",
+    )
+}
+
+url = strings.Replace(url,"-dialogflow",fmt.Sprintf("%s-dialogflow",location),1)
+
+// if the user's set a name (e.g. for a default object) "Update" instead of "Create"
+objName, _ := d.Get("name").(string)
+if objName != "" {
+    // Store the ID
+    id, err := tpgresource.ReplaceVars(d, config, "<%= id_format(object) -%>")
+    if err != nil {
+        return fmt.Errorf("Error constructing id: %s", err)
+    }
+    d.SetId(id)
+
+    // and defer to the Update method:
+    log.Printf("[DEBUG] Updating default <%= resource_name -%>")
+    return resource<%= resource_name -%>Update(d, meta)
+}

--- a/mmv1/templates/terraform/pre_delete/dialogflowcx_set_location_skip_default_obj.go.erb
+++ b/mmv1/templates/terraform/pre_delete/dialogflowcx_set_location_skip_default_obj.go.erb
@@ -1,0 +1,23 @@
+
+// extract location from the parent
+location := ""
+ 
+if parts := regexp.MustCompile(`locations\/([^\/]*)\/`).FindStringSubmatch(d.Get("parent").(string)); parts != nil {
+    location = parts[1]
+} else {
+    return fmt.Errorf(
+        "Saw %s when the parent is expected to contains location %s",
+        d.Get("parent"),
+        "projects/{{project}}/locations/{{location}}/...",
+    )
+}
+
+url = strings.Replace(url,"-dialogflow",fmt.Sprintf("%s-dialogflow",location),1)
+
+// if it's a default object Dialogflow creates for you, skip deletion
+objName, _ := d.Get("name").(string)
+if objName == "00000000-0000-0000-0000-000000000000" || objName == "00000000-0000-0000-0000-000000000001" {
+    // we can't delete these resources so do nothing
+    log.Printf("[DEBUG] Not deleting default <%= resource_name -%>")
+    return nil
+}

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
@@ -350,3 +350,102 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
   }
 `, context)
 }
+
+func TestAccDialogflowCXFlow_defaultStartFlow(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDialogflowCXFlow_defaultStartFlow(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_dialogflow_cx_flow.default_start_flow", "name", "00000000-0000-0000-0000-000000000000"),
+					resource.TestCheckResourceAttrPair(
+						"google_dialogflow_cx_flow.default_start_flow", "id",
+						"google_dialogflow_cx_agent.agent", "start_flow",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccDialogflowCXFlow_defaultStartFlow(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_dialogflow_cx_agent" "agent" {
+  display_name          = "tf-test-dialogflowcx-agent%{random_suffix}"
+  location              = "global"
+  default_language_code = "en"
+  time_zone             = "America/New_York"
+}
+resource "google_dialogflow_cx_intent" "default_welcome_intent" {
+  parent       = google_dialogflow_cx_agent.agent.id
+  name         = "00000000-0000-0000-0000-000000000000"
+  display_name = "Default Welcome Intent"
+  priority     = 1
+  training_phrases {
+    parts {
+      text = "Hello"
+    }
+    repeat_count = 1
+  }
+}
+resource "google_dialogflow_cx_flow" "default_start_flow" {
+  parent       = google_dialogflow_cx_agent.agent.id
+  name         = "00000000-0000-0000-0000-000000000000"
+  display_name = "Default Start Flow"
+  description  = "A start flow created along with the agent"
+
+  nlu_settings {
+    classification_threshold = 0.3
+    model_type               = "MODEL_TYPE_STANDARD"
+  }
+  transition_routes {
+    intent = google_dialogflow_cx_intent.default_welcome_intent.id
+    trigger_fulfillment {
+      messages {
+        text {
+          text = ["Response to default welcome intent."]
+        }
+      }
+    }
+  }
+  event_handlers {
+    event = "custom-event"
+    trigger_fulfillment {
+      messages {
+        text {
+          text = ["This is a default flow."]
+        }
+      }
+    }
+  }
+  event_handlers {
+    event = "sys.no-match-default"
+    trigger_fulfillment {
+      messages {
+        text {
+          text = ["We've updated the default flow no-match response!"]
+        }
+      }
+    }
+  }
+  event_handlers {
+    event = "sys.no-input-default"
+    trigger_fulfillment {
+      messages {
+        text {
+          text = ["We've updated the default flow no-input response!"]
+        }
+      }
+    }
+  }
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_intent_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_intent_test.go
@@ -173,7 +173,7 @@ resource "google_dialogflow_cx_agent" "agent" {
 resource "google_dialogflow_cx_intent" "default_negative_intent" {
   parent       = google_dialogflow_cx_agent.agent.id
   name         = "00000000-0000-0000-0000-000000000001"
-  display_name = "Default Welcome Intent"
+  display_name = "Default Negative Intent"
   priority     = 1
   is_fallback  = true
   training_phrases {

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_intent_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_intent_test.go
@@ -139,3 +139,60 @@ func testAccDialogflowCXIntent_full(context map[string]interface{}) string {
     } 
 	  `, context)
 }
+
+func TestAccDialogflowCXIntent_defaultIntents(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDialogflowCXIntent_defaultIntents(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_dialogflow_cx_intent.default_negative_intent", "name", "00000000-0000-0000-0000-000000000001"),
+					resource.TestCheckResourceAttr("google_dialogflow_cx_intent.default_welcome_intent", "name", "00000000-0000-0000-0000-000000000000"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDialogflowCXIntent_defaultIntents(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_dialogflow_cx_agent" "agent" {
+  display_name          = "tf-test-dialogflowcx-agent%{random_suffix}"
+  location              = "global"
+  default_language_code = "en"
+  time_zone             = "America/New_York"
+}
+resource "google_dialogflow_cx_intent" "default_negative_intent" {
+  parent       = google_dialogflow_cx_agent.agent.id
+  name         = "00000000-0000-0000-0000-000000000001"
+  display_name = "Default Welcome Intent"
+  priority     = 1
+  training_phrases {
+     parts {
+         text = "Never match this phrase"
+     }
+     repeat_count = 1
+  }
+}
+resource "google_dialogflow_cx_intent" "default_welcome_intent" {
+  parent       = google_dialogflow_cx_agent.agent.id
+  name         = "00000000-0000-0000-0000-000000000000"
+  display_name = "Default Welcome Intent"
+  priority     = 1
+  training_phrases {
+     parts {
+         text = "Hello"
+     }
+     repeat_count = 1
+  }
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_intent_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_intent_test.go
@@ -175,6 +175,7 @@ resource "google_dialogflow_cx_intent" "default_negative_intent" {
   name         = "00000000-0000-0000-0000-000000000001"
   display_name = "Default Welcome Intent"
   priority     = 1
+  is_fallback  = true
   training_phrases {
      parts {
          text = "Never match this phrase"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/16308, read that bug for more context 😅

An alternative version of https://github.com/GoogleCloudPlatform/magic-modules/pull/9336 because designing a good API is hard and I want someone else to make that decision 😅.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dialogflowcx: changed `name` from an output-only attribute to an argument in the `google_dialogflow_cx_intent` resource
```

```release-note:enhancement
dialogflowcx: changed `name` from an output-only attribute to an argument in the `google_dialogflow_cx_flow` resource
```
