### PR TITLE
Fix the test TestAccTpuV2Vm_tpuV2VmFullExample

### DIFF
--- a/mmv1/products/tpuv2/Vm.yaml
+++ b/mmv1/products/tpuv2/Vm.yaml
@@ -59,6 +59,7 @@ examples:
     name: 'tpu_v2_vm_full'
     min_version: 'beta'
     primary_resource_id: 'tpu'
+    pull_external: true
     vars:
       vm_name: 'test-tpu'
       network_name: 'tpu-net'

--- a/mmv1/templates/terraform/examples/tpu_v2_vm_full.tf.erb
+++ b/mmv1/templates/terraform/examples/tpu_v2_vm_full.tf.erb
@@ -58,6 +58,8 @@ resource "google_tpu_v2_vm" "<%= ctx[:primary_resource_id] %>" {
   }
 
   tags = ["foo"]
+
+  depends_on = [time_sleep.wait_60_seconds]
 }
 
 resource "google_compute_subnetwork" "subnet" {
@@ -91,4 +93,11 @@ resource "google_compute_disk" "disk" {
   size  = 10
   type  = "pd-ssd"
   zone  = "us-central1-c"
+}
+
+# Wait after service account creation to limit eventual consistency errors.
+resource "time_sleep" "wait_60_seconds" {
+  depends_on = [google_service_account.sa]
+
+  create_duration = "60s"
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
fixes https://github.com/hashicorp/terraform-provider-google/issues/16147

An error is observed for the test `TestAccTpuV2Vm_tpuV2VmFullExample`

------- Stdout: -------
=== RUN   TestAccTpuV2Vm_tpuV2VmFullExample
=== PAUSE TestAccTpuV2Vm_tpuV2VmFullExample
=== CONT  TestAccTpuV2Vm_tpuV2VmFullExample
    vcr_utils.go:152: Step 1/2 error: Error running apply: exit status 1
        Error: Provider produced inconsistent result after apply
        When applying changes to google_service_account.sa, provider
        "provider[\"registry.terraform.io/hashicorp/google-beta\"]" produced an
        unexpected new value: Root resource was present, but now absent.
        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
--- FAIL: TestAccTpuV2Vm_tpuV2VmFullExample (92.96s)

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
