### PR TITLE
Object lock feature implementation for Storage

### DIFF
--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
@@ -256,7 +256,7 @@ func ResourceStorageBucket() *schema.Resource {
 				Description: `The bucket's Lifecycle Rules configuration.`,
 			},
 
-			"per_object_retention": {
+			"enable_object_retention": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    true,

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
@@ -602,7 +602,7 @@ func resourceStorageBucketCreate(d *schema.ResourceData, meta interface{}) error
 	err = transport_tpg.Retry(transport_tpg.RetryOptions{
 		RetryFunc: func() error {
 			insertCall := config.NewStorageClient(userAgent).Buckets.Insert(project, sb)
-			if d.Get("per_object_retention").(bool) {
+			if d.Get("enable_object_retention").(bool) {
 				insertCall.EnableObjectRetention(true)
 			}
 			res, err = insertCall.Do()
@@ -1641,7 +1641,7 @@ func setStorageBucket(d *schema.ResourceData, config *transport_tpg.Config, res 
 	if err := d.Set("logging", flattenBucketLogging(res.Logging)); err != nil {
 		return fmt.Errorf("Error setting logging: %s", err)
 	}
-	if err := d.Set("per_object_retention", flattenBucketObjectRetention(res.ObjectRetention)); err != nil {
+	if err := d.Set("enable_object_retention", flattenBucketObjectRetention(res.ObjectRetention)); err != nil {
 		return fmt.Errorf("Error setting object retention: %s", err)
 	}
 	if err := d.Set("versioning", flattenBucketVersioning(res.Versioning)); err != nil {

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
@@ -544,8 +544,6 @@ func resourceStorageBucketCreate(d *schema.ResourceData, meta interface{}) error
 	}
 	sb.Lifecycle = lifecycle
 
-	objectRetention := d.Get("per_object_retention").(bool)
-
 	if v, ok := d.GetOk("versioning"); ok {
 		sb.Versioning = expandBucketVersioning(v)
 	}
@@ -603,8 +601,11 @@ func resourceStorageBucketCreate(d *schema.ResourceData, meta interface{}) error
 
 	err = transport_tpg.Retry(transport_tpg.RetryOptions{
 		RetryFunc: func() error {
-			res, err = config.NewStorageClient(userAgent).Buckets.Insert(project,
-				sb).EnableObjectRetention(objectRetention).Do()
+			insertCall := config.NewStorageClient(userAgent).Buckets.Insert(project, sb)
+			if d.Get("per_object_retention").(bool) {
+				insertCall.EnableObjectRetention(true)
+			}
+			res, err = insertCall.Do()
 			return err
 		},
 	})

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
@@ -256,6 +256,22 @@ func ResourceStorageBucket() *schema.Resource {
 				Description: `The bucket's Lifecycle Rules configuration.`,
 			},
 
+			"per_object_retention": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:        schema.TypeBool,
+							Required:    true,
+							Description: `While set to true, enables each object in the bucket to have its own retention policy, which prevents deletion until stored for a specific length of time.`,
+						},
+					},
+				},
+				Description: `The bucket's object retention configuration.`,
+			}
+
 			"versioning": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -537,6 +553,10 @@ func resourceStorageBucketCreate(d *schema.ResourceData, meta interface{}) error
 	}
 	sb.Lifecycle = lifecycle
 
+	if v, ok := d.GetOk("per_object_retention"); ok {
+		sb.ObjectRetention = expandBucketObjectRetention(v)
+	}
+
 	if v, ok := d.GetOk("versioning"); ok {
 		sb.Versioning = expandBucketVersioning(v)
 	}
@@ -666,6 +686,12 @@ func resourceStorageBucketUpdate(d *schema.ResourceData, meta interface{}) error
 		sb.Billing = &storage.BucketBilling{
 			RequesterPays:   v.(bool),
 			ForceSendFields: []string{"RequesterPays"},
+		}
+	}
+
+	if d.HasChange("per_object_retention") {
+		if v, ok := d.GetOk("per_object_retention"); ok {
+			sb.ObjectRetention = expandBucketObjectRetention(v)
 		}
 	}
 
@@ -1119,6 +1145,37 @@ func flattenBucketRetentionPolicy(bucketRetentionPolicy *storage.BucketRetention
 
 	bucketRetentionPolicies = append(bucketRetentionPolicies, retentionPolicy)
 	return bucketRetentionPolicies
+}
+
+func expandBucketObjectRetention(configured interface{}) *storage.BucketObjectRetention {
+	objectRetentionList := configured.([]interface{})
+	if len(objectRetentionList) == 0 {
+		return nil
+	}
+
+	objectRetention := objectRetentionList[0].(map[string]interface{})
+
+	bucketObjectRetention := &storage.BucketObjectRetention{}
+
+	if objectRetention["enabled"].(bool) {
+		bucketObjectRetention.Mode = "Enabled"
+	}
+
+	return bucketObjectRetention
+}
+
+func flattenBucketObjectRetention(bucketObjectRetention *storage.BucketObjectRetention) []map[string]interface{} {
+	objectRetentionList := make([]map[string]interface{}, 0, 1)
+
+	if bucketObjectRetention == nil {
+		return objectRetentionList
+	}
+
+	objectRetention := map[string]interface{}{
+		"Mode": bucketVersioning.Mode,
+	}
+	objectRetentionList = append(objectRetentionList, objectRetention)
+	return objectRetentionList
 }
 
 func expandBucketVersioning(configured interface{}) *storage.BucketVersioning {
@@ -1619,6 +1676,9 @@ func setStorageBucket(d *schema.ResourceData, config *transport_tpg.Config, res 
 	}
 	if err := d.Set("logging", flattenBucketLogging(res.Logging)); err != nil {
 		return fmt.Errorf("Error setting logging: %s", err)
+	}
+	if err := d.Set("per_object_retention", flattenBucketObjectRetention(res.ObjectRetention)); err != nil {
+		return fmt.Errorf("Error setting object retention: %s", err)
 	}
 	if err := d.Set("versioning", flattenBucketVersioning(res.Versioning)); err != nil {
 		return fmt.Errorf("Error setting versioning: %s", err)

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
@@ -257,20 +257,11 @@ func ResourceStorageBucket() *schema.Resource {
 			},
 
 			"per_object_retention": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"enabled": {
-							Type:        schema.TypeBool,
-							Required:    true,
-							Description: `While set to true, enables each object in the bucket to have its own retention policy, which prevents deletion until stored for a specific length of time.`,
-						},
-					},
-				},
-				Description: `The bucket's object retention configuration.`,
-			}
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Enables each object in the bucket to have its own retention policy, which prevents deletion until stored for a specific length of time.`,
+			},
 
 			"versioning": {
 				Type:     schema.TypeList,
@@ -553,9 +544,7 @@ func resourceStorageBucketCreate(d *schema.ResourceData, meta interface{}) error
 	}
 	sb.Lifecycle = lifecycle
 
-	if v, ok := d.GetOk("per_object_retention"); ok {
-		sb.ObjectRetention = expandBucketObjectRetention(v)
-	}
+	objectRetention := d.Get("per_object_retention").(bool)
 
 	if v, ok := d.GetOk("versioning"); ok {
 		sb.Versioning = expandBucketVersioning(v)
@@ -614,7 +603,8 @@ func resourceStorageBucketCreate(d *schema.ResourceData, meta interface{}) error
 
 	err = transport_tpg.Retry(transport_tpg.RetryOptions{
 		RetryFunc: func() error {
-			res, err = config.NewStorageClient(userAgent).Buckets.Insert(project, sb).Do()
+			res, err = config.NewStorageClient(userAgent).Buckets.Insert(project,
+				sb).EnableObjectRetention(objectRetention).Do()
 			return err
 		},
 	})
@@ -686,12 +676,6 @@ func resourceStorageBucketUpdate(d *schema.ResourceData, meta interface{}) error
 		sb.Billing = &storage.BucketBilling{
 			RequesterPays:   v.(bool),
 			ForceSendFields: []string{"RequesterPays"},
-		}
-	}
-
-	if d.HasChange("per_object_retention") {
-		if v, ok := d.GetOk("per_object_retention"); ok {
-			sb.ObjectRetention = expandBucketObjectRetention(v)
 		}
 	}
 
@@ -1147,35 +1131,14 @@ func flattenBucketRetentionPolicy(bucketRetentionPolicy *storage.BucketRetention
 	return bucketRetentionPolicies
 }
 
-func expandBucketObjectRetention(configured interface{}) *storage.BucketObjectRetention {
-	objectRetentionList := configured.([]interface{})
-	if len(objectRetentionList) == 0 {
-		return nil
-	}
-
-	objectRetention := objectRetentionList[0].(map[string]interface{})
-
-	bucketObjectRetention := &storage.BucketObjectRetention{}
-
-	if objectRetention["enabled"].(bool) {
-		bucketObjectRetention.Mode = "Enabled"
-	}
-
-	return bucketObjectRetention
-}
-
-func flattenBucketObjectRetention(bucketObjectRetention *storage.BucketObjectRetention) []map[string]interface{} {
-	objectRetentionList := make([]map[string]interface{}, 0, 1)
-
+func flattenBucketObjectRetention(bucketObjectRetention *storage.BucketObjectRetention) bool {
 	if bucketObjectRetention == nil {
-		return objectRetentionList
+		return false
 	}
-
-	objectRetention := map[string]interface{}{
-		"Mode": bucketVersioning.Mode,
+	if bucketObjectRetention.Mode == "Enabled" {
+		return true
 	}
-	objectRetentionList = append(objectRetentionList, objectRetention)
-	return objectRetentionList
+	return false
 }
 
 func expandBucketVersioning(configured interface{}) *storage.BucketVersioning {

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
@@ -564,8 +564,6 @@ func expandObjectRetention(configured interface{}) *storage.ObjectRetention {
 	}
 	retention := retentions[0].(map[string]interface{})
 
-	mode := retention["mode"].(string)
-
 	objectRetention := &storage.ObjectRetention{
 		RetainUntilTime: retention["retain_until_time"].(string),
 		Mode:            retention["mode"].(string),

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
@@ -568,7 +568,7 @@ func expandObjectRetention(configured interface{}) *storage.ObjectRetention {
 
 	objectRetention := &storage.ObjectRetention{
 		RetainUntilTime: retention["retain_until_time"].(string),
-		Mode:            mode,
+		Mode:            retention["mode"].(string),
 	}
 
 	return objectRetention

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
@@ -217,7 +217,7 @@ func ResourceStorageBucketObject() *schema.Resource {
 				Description:   `Object level retention configuration.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"retain_until": {
+						"retain_until_time": {
 							Type:        schema.TypeString,
 							Required:    true,
 							Description: `Time in RFC 3339 (e.g. 2030-01-01T02:03:04Z) until which object retention protects this object.`,

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
@@ -235,6 +235,7 @@ func ResourceStorageBucketObject() *schema.Resource {
 			"event_based_hold": {
 				Type:        schema.TypeBool,
 				Optional:    true,
+				ConflictsWith: []string{"retention"},
 				Description: `Whether an object is under event-based hold. Event-based hold is a way to retain objects until an event occurs, which is signified by the hold's release (i.e. this value is set to false). After being released (set to false), such objects will be subject to bucket-level retention (if any).`,
 			},
 

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
@@ -486,7 +486,7 @@ func resourceStorageBucketObjectRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error setting media_link: %s", err)
 	}
 	if err := d.Set("retention", flattenObjectRetention(res.Retention)); err != nil {
-		return fmt.Errorf("Error setting lifecycle_rule: %s", err)
+		return fmt.Errorf("Error setting retention: %s", err)
 	}
 	if err := d.Set("event_based_hold", res.EventBasedHold); err != nil {
 		return fmt.Errorf("Error setting event_based_hold: %s", err)

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
@@ -390,6 +390,9 @@ func resourceStorageBucketObjectUpdate(d *schema.ResourceData, meta interface{})
 	if hasRetentionChanges {
 		if v, ok := d.GetOk("retention"); ok {
 			res.Retention = expandObjectRetention(v)
+		} else {
+			res.Retention = nil
+			res.NullFields = append(res.NullFields, "Retention")
 		}
 	}
 

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
@@ -6,14 +6,12 @@ import (
 	"io"
 	"log"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"crypto/sha256"
 	"encoding/base64"
@@ -223,20 +221,19 @@ func ResourceStorageBucketObject() *schema.Resource {
 							Description: `Time in RFC 3339 (e.g. 2030-01-01T02:03:04Z) until which object retention protects this object.`,
 						},
 						"mode": {
-							Type:         schema.TypeString,
-							Required:     true,
-							Description:  `The object retention mode. Supported values include: "UNLOCKED", "LOCKED".`,
-							ValidateFunc: validation.StringInSlice([]string{"UNLOCKED", "LOCKED"}, false),
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The object retention mode. Supported values include: "Unlocked", "Locked".`,
 						},
 					},
 				},
 			},
 
 			"event_based_hold": {
-				Type:        schema.TypeBool,
-				Optional:    true,
+				Type:          schema.TypeBool,
+				Optional:      true,
 				ConflictsWith: []string{"retention"},
-				Description: `Whether an object is under event-based hold. Event-based hold is a way to retain objects until an event occurs, which is signified by the hold's release (i.e. this value is set to false). After being released (set to false), such objects will be subject to bucket-level retention (if any).`,
+				Description:   `Whether an object is under event-based hold. Event-based hold is a way to retain objects until an event occurs, which is signified by the hold's release (i.e. this value is set to false). After being released (set to false), such objects will be subject to bucket-level retention (if any).`,
 			},
 
 			"temporary_hold": {
@@ -567,13 +564,10 @@ func expandObjectRetention(configured interface{}) *storage.ObjectRetention {
 	}
 	retention := retentions[0].(map[string]interface{})
 
-	mode := "Unlocked"
-	if retention["mode"].(string) == "LOCKED" {
-		mode = "Locked"
-	}
+	mode := retention["mode"].(string)
 
 	objectRetention := &storage.ObjectRetention{
-		RetainUntilTime: retention["retain_until"].(string),
+		RetainUntilTime: retention["retain_until_time"].(string),
 		Mode:            mode,
 	}
 
@@ -588,8 +582,8 @@ func flattenObjectRetention(objectRetention *storage.ObjectRetention) []map[stri
 	}
 
 	retention := map[string]interface{}{
-		"mode":         strings.ToUpper(objectRetention.Mode),
-		"retain_until": objectRetention.RetainUntilTime,
+		"mode":              objectRetention.Mode,
+		"retain_until_time": objectRetention.RetainUntilTime,
 	}
 
 	retentions = append(retentions, retention)

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object_test.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object_test.go
@@ -436,13 +436,13 @@ func TestAccStorageObject_retention(t *testing.T) {
 		CheckDestroy:             testAccStorageObjectDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testGoogleStorageBucketsObjectRetention(bucketName, "2040-01-01T02:03:04Z"),
+				Config: testGoogleStorageBucketsObjectRetention(bucketName, "2040-01-01T02:03:04.000Z"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleStorageObject(t, bucketName, objectName, dataMd5),
 				),
 			},
 			{
-				Config: testGoogleStorageBucketsObjectRetention(bucketName, "2040-01-02T02:03:04Z"),
+				Config: testGoogleStorageBucketsObjectRetention(bucketName, "2040-01-02T02:03:04.000Z"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleStorageObject(t, bucketName, objectName, dataMd5),
 				),

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object_test.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object_test.go
@@ -415,6 +415,48 @@ func TestAccStorageObject_holds(t *testing.T) {
 	})
 }
 
+func TestAccStorageObject_retention(t *testing.T) {
+	t.Parallel()
+
+	bucketName := acctest.TestBucketName(t)
+	data := []byte(content)
+	h := md5.New()
+	if _, err := h.Write(data); err != nil {
+		t.Errorf("error calculating md5: %v", err)
+	}
+	dataMd5 := base64.StdEncoding.EncodeToString(h.Sum(nil))
+	testFile := getNewTmpTestFile(t, "tf-test")
+	if err := ioutil.WriteFile(testFile.Name(), data, 0644); err != nil {
+		t.Errorf("error writing file: %v", err)
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccStorageObjectDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleStorageBucketsObjectRetention(bucketName, "2040-01-01T02:03:04Z"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleStorageObject(t, bucketName, objectName, dataMd5),
+				),
+			},
+			{
+				Config: testGoogleStorageBucketsObjectRetention(bucketName, "2040-01-02T02:03:04Z"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleStorageObject(t, bucketName, objectName, dataMd5),
+				),
+			},
+			{
+				Config: testGoogleStorageBucketsObjectRetentionDisabled(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleStorageObject(t, bucketName, objectName, dataMd5),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckGoogleStorageObject(t *testing.T, bucket, object, md5 string) resource.TestCheckFunc {
 	return testAccCheckGoogleStorageObjectWithEncryption(t, bucket, object, md5, "")
 }
@@ -644,6 +686,44 @@ resource "google_storage_bucket_object" "object" {
   }
 }
 `, bucketName, objectName, content, customerEncryptionKey)
+}
+
+func testGoogleStorageBucketsObjectRetention(bucketName string, retainUntil string) string {
+	return fmt.Sprintf(`
+resource "google_storage_bucket" "bucket" {
+  name                 = "%s"
+  location             = "US"
+  force_destroy        = true
+  per_object_retention = true
+}
+
+resource "google_storage_bucket_object" "object" {
+  name      = "%s"
+  bucket    = google_storage_bucket.bucket.name
+  content   = "%s"
+  retention {
+	mode         = "UNLOCKED"
+	retain_until = "%s"
+  }      
+}
+`, bucketName, objectName, content, retainUntil)
+}
+
+func testGoogleStorageBucketsObjectRetentionDisabled(bucketName string) string {
+	return fmt.Sprintf(`
+resource "google_storage_bucket" "bucket" {
+  name                 = "%s"
+  location             = "US"
+  force_destroy        = true
+  per_object_retention = true
+}
+
+resource "google_storage_bucket_object" "object" {
+  name      = "%s"
+  bucket    = google_storage_bucket.bucket.name
+  content   = "%s" 
+}
+`, bucketName, objectName, content, retainUntil)
 }
 
 func testGoogleStorageBucketsObjectHolds(bucketName string, eventBasedHold bool, temporaryHold bool) string {

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object_test.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 
@@ -430,8 +429,6 @@ func TestAccStorageObject_retention(t *testing.T) {
 	if err := ioutil.WriteFile(testFile.Name(), data, 0644); err != nil {
 		t.Errorf("error writing file: %v", err)
 	}
-	expire2Days := time.Now().UTC().Add(time.Hour * 48).Round(time.Millisecond).Format(time.RFC3339Nano)
-	expire3Days := time.Now().UTC().Add(time.Hour * 72).Round(time.Millisecond).Format(time.RFC3339Nano)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -439,13 +436,13 @@ func TestAccStorageObject_retention(t *testing.T) {
 		CheckDestroy:             testAccStorageObjectDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testGoogleStorageBucketsObjectRetention(bucketName, expire2Days),
+				Config: testGoogleStorageBucketsObjectRetention(bucketName, "2040-01-01T02:03:04.000Z"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleStorageObject(t, bucketName, objectName, dataMd5),
 				),
 			},
 			{
-				Config: testGoogleStorageBucketsObjectRetention(bucketName, expire3Days),
+				Config: testGoogleStorageBucketsObjectRetention(bucketName, "2040-01-02T02:03:04.000Z"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleStorageObject(t, bucketName, objectName, dataMd5),
 				),

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object_test.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object_test.go
@@ -723,7 +723,7 @@ resource "google_storage_bucket_object" "object" {
   bucket    = google_storage_bucket.bucket.name
   content   = "%s" 
 }
-`, bucketName, objectName, content, retainUntil)
+`, bucketName, objectName, content)
 }
 
 func testGoogleStorageBucketsObjectHolds(bucketName string, eventBasedHold bool, temporaryHold bool) string {

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
@@ -691,6 +691,47 @@ func TestAccStorageBucket_forceDestroyObjectDeleteError(t *testing.T) {
 	})
 }
 
+func TestAccStorageBucket_per_object_retention(t *testing.T) {
+	t.Parallel()
+
+	var bucket storage.Bucket
+	bucketName := fmt.Sprintf("tf-test-obloc-bucket-%d", acctest.RandInt(t))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccStorageBucketDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStorageBucket_per_object_retention(bucketName, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStorageBucketExists(
+						t, "google_storage_bucket.bucket", bucketName, &bucket),
+				),
+			},
+			{
+				ResourceName:            "google_storage_bucket.bucket",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+			{
+				Config: testAccStorageBucket_per_object_retention(bucketName, "false"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStorageBucketExists(
+						t, "google_storage_bucket.bucket", bucketName, &bucket),
+				),
+			},
+			{
+				ResourceName:            "google_storage_bucket.bucket",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+		},
+	})
+}
+
 func TestAccStorageBucket_versioning(t *testing.T) {
 	t.Parallel()
 
@@ -698,9 +739,9 @@ func TestAccStorageBucket_versioning(t *testing.T) {
 	bucketName := fmt.Sprintf("tf-test-acl-bucket-%d", acctest.RandInt(t))
 
 	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                    func() { acctest.AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:                testAccStorageBucketDestroyProducer(t),
+		CheckDestroy:             testAccStorageBucketDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStorageBucket_versioning(bucketName, "true"),
@@ -719,7 +760,7 @@ func TestAccStorageBucket_versioning(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
-						{
+			{
 				Config: testAccStorageBucket_versioning_empty(bucketName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStorageBucketExists(
@@ -736,7 +777,7 @@ func TestAccStorageBucket_versioning(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
-						{
+			{
 				Config: testAccStorageBucket_versioning(bucketName, "false"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStorageBucketExists(
@@ -753,7 +794,7 @@ func TestAccStorageBucket_versioning(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
-						{
+			{
 				Config: testAccStorageBucket_versioning_empty(bucketName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStorageBucketExists(
@@ -779,9 +820,9 @@ func TestAccStorageBucket_logging(t *testing.T) {
 
 	bucketName := fmt.Sprintf("tf-test-acl-bucket-%d", acctest.RandInt(t))
 	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                    func() { acctest.AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:                testAccStorageBucketDestroyProducer(t),
+		CheckDestroy:             testAccStorageBucketDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStorageBucket_logging(bucketName, "log-bucket"),
@@ -840,9 +881,9 @@ func TestAccStorageBucket_cors(t *testing.T) {
 	bucketName := fmt.Sprintf("tf-test-acl-bucket-%d", acctest.RandInt(t))
 
 	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                    func() { acctest.AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:                testAccStorageBucketDestroyProducer(t),
+		CheckDestroy:             testAccStorageBucketDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testGoogleStorageBucketsCors(bucketName),
@@ -872,9 +913,9 @@ func TestAccStorageBucket_defaultEventBasedHold(t *testing.T) {
 	bucketName := fmt.Sprintf("tf-test-acl-bucket-%d", acctest.RandInt(t))
 
 	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                    func() { acctest.AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:                testAccStorageBucketDestroyProducer(t),
+		CheckDestroy:             testAccStorageBucketDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStorageBucket_defaultEventBasedHold(bucketName),
@@ -1493,6 +1534,17 @@ resource "google_storage_bucket" "bucket" {
   }
 }
 `, bucketName)
+}
+
+func testAccStorageBucket_per_object_retention(bucketName string, enabled string) string {
+	return fmt.Sprintf(`
+resource "google_storage_bucket" "bucket" {
+  name                 = "%s"
+  location             = "US"
+  force_destroy        = "true"
+  per_object_retention = "%s"
+}
+`, bucketName, enabled)
 }
 
 func testAccStorageBucket_versioning(bucketName, enabled string) string {

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
@@ -691,7 +691,7 @@ func TestAccStorageBucket_forceDestroyObjectDeleteError(t *testing.T) {
 	})
 }
 
-func TestAccStorageBucket_per_object_retention(t *testing.T) {
+func TestAccStorageBucket_enable_object_retention(t *testing.T) {
 	t.Parallel()
 
 	var bucket storage.Bucket
@@ -703,7 +703,7 @@ func TestAccStorageBucket_per_object_retention(t *testing.T) {
 		CheckDestroy:             testAccStorageBucketDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStorageBucket_per_object_retention(bucketName, "true"),
+				Config: testAccStorageBucket_enable_object_retention(bucketName, "true"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStorageBucketExists(
 						t, "google_storage_bucket.bucket", bucketName, &bucket),
@@ -716,7 +716,7 @@ func TestAccStorageBucket_per_object_retention(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
-				Config: testAccStorageBucket_per_object_retention(bucketName, "false"),
+				Config: testAccStorageBucket_enable_object_retention(bucketName, "false"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStorageBucketExists(
 						t, "google_storage_bucket.bucket", bucketName, &bucket),
@@ -1536,13 +1536,13 @@ resource "google_storage_bucket" "bucket" {
 `, bucketName)
 }
 
-func testAccStorageBucket_per_object_retention(bucketName string, enabled string) string {
+func testAccStorageBucket_enable_object_retention(bucketName string, enabled string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
-  name                 = "%s"
-  location             = "US"
-  force_destroy        = "true"
-  per_object_retention = "%s"
+  name                    = "%s"
+  location                = "US"
+  force_destroy           = "true"
+  enable_object_retention = "%s"
 }
 `, bucketName, enabled)
 }

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
@@ -695,7 +695,7 @@ func TestAccStorageBucket_per_object_retention(t *testing.T) {
 	t.Parallel()
 
 	var bucket storage.Bucket
-	bucketName := fmt.Sprintf("tf-test-obloc-bucket-%d", acctest.RandInt(t))
+	bucketName := acctest.TestBucketName(t)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -120,6 +120,9 @@ The following arguments are supported:
 
 * `encryption` - (Optional) The bucket's encryption configuration. Structure is [documented below](#nested_encryption).
 
+* `per_object_retention` - (Optional, Default: false) Enables [object retention](https://cloud.google.com/storage/docs/object-lock) on a storage bucket.
+
+
 * `requester_pays` - (Optional, Default: false) Enables [Requester Pays](https://cloud.google.com/storage/docs/requester-pays) on a storage bucket.
 
 * `uniform_bucket_level_access` - (Optional, Default: false) Enables [Uniform bucket-level access](https://cloud.google.com/storage/docs/uniform-bucket-level-access) access to a bucket.

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -120,7 +120,7 @@ The following arguments are supported:
 
 * `encryption` - (Optional) The bucket's encryption configuration. Structure is [documented below](#nested_encryption).
 
-* `per_object_retention` - (Optional, Default: false) Enables [object retention](https://cloud.google.com/storage/docs/object-lock) on a storage bucket.
+* `enable_object_retention` - (Optional, Default: false) Enables [object retention](https://cloud.google.com/storage/docs/object-lock) on a storage bucket.
 
 
 * `requester_pays` - (Optional, Default: false) Enables [Requester Pays](https://cloud.google.com/storage/docs/requester-pays) on a storage bucket.

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
@@ -69,7 +69,7 @@ One of the following is required:
 * `customer_encryption` - (Optional) Enables object encryption with Customer-Supplied Encryption Key (CSEK). [Google [documentation about](#nested_customer_encryption) CSEK.](https://cloud.google.com/storage/docs/encryption/customer-supplied-keys)
     Structure is documented below.
 
-* `retention` - (Optional) The [object retention](http://cloud.google.com/storage/docs/object-lock) settings for the object. The retention settings allow an object to be retained until a provided date. Structure is documented below.
+* `retention` - (Optional) The [object retention](http://cloud.google.com/storage/docs/object-lock) settings for the object. The retention settings allow an object to be retained until a provided date. Structure is [documented below](#nested_retention).
 
 * `event_based_hold` - (Optional) Whether an object is under [event-based hold](https://cloud.google.com/storage/docs/object-holds#hold-types). Event-based hold is a way to retain objects until an event occurs, which is signified by the hold's release (i.e. this value is set to false). After being released (set to false), such objects will be subject to bucket-level retention (if any).
 

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
@@ -67,7 +67,7 @@ One of the following is required:
 * `content_type` - (Optional) [Content-Type](https://tools.ietf.org/html/rfc7231#section-3.1.1.5) of the object data. Defaults to "application/octet-stream" or "text/plain; charset=utf-8".
 
 * `customer_encryption` - (Optional) Enables object encryption with Customer-Supplied Encryption Key (CSEK). [Google [documentation about](#nested_customer_encryption) CSEK.](https://cloud.google.com/storage/docs/encryption/customer-supplied-keys)
-    Structure is documented below.
+    Structure is [documented below](#nested_customer_encryption).
 
 * `retention` - (Optional) The [object retention](http://cloud.google.com/storage/docs/object-lock) settings for the object. The retention settings allow an object to be retained until a provided date. Structure is [documented below](#nested_retention).
 

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
@@ -69,6 +69,8 @@ One of the following is required:
 * `customer_encryption` - (Optional) Enables object encryption with Customer-Supplied Encryption Key (CSEK). [Google [documentation about](#nested_customer_encryption) CSEK.](https://cloud.google.com/storage/docs/encryption/customer-supplied-keys)
     Structure is documented below.
 
+* `retention` - (Optional) The [object retention](http://cloud.google.com/storage/docs/object-lock) settings for the object. The retention settings allow an object to be retained until a provided date. Structure is documented below.
+
 * `event_based_hold` - (Optional) Whether an object is under [event-based hold](https://cloud.google.com/storage/docs/object-holds#hold-types). Event-based hold is a way to retain objects until an event occurs, which is signified by the hold's release (i.e. this value is set to false). After being released (set to false), such objects will be subject to bucket-level retention (if any).
 
 * `temporary_hold` - (Optional) Whether an object is under [temporary hold](https://cloud.google.com/storage/docs/object-holds#hold-types). While this flag is set to true, the object is protected against deletion and overwrites.
@@ -88,6 +90,14 @@ One of the following is required:
 * `encryption_algorithm` - (Optional) Encryption algorithm. Default: AES256
 
 * `encryption_key` - (Required) Base64 encoded Customer-Supplied Encryption Key.
+
+<a name="nested_retention"></a>The `retention` block supports:
+
+* `mode` - (Required) The retention policy mode. Either `Locked` or `Unlocked`.
+
+* `retain_until_time` - (Required) The time to retain the object until in RFC 3339 format, for example 2012-11-15T16:19:00.094Z.
+
+<a name>
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Adds support for the Object Lock feature, which allows for setting retention policies on objects. 

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
storage: added `retention` field to `google_storage_bucket_object` resource
```

```release-note:enhancement
storage: added `enable_object_retention` to `google_storage_bucket` resource
```
