### PR TITLE
update dcl version

### DIFF
--- a/mmv1/third_party/terraform/go.mod.erb
+++ b/mmv1/third_party/terraform/go.mod.erb
@@ -3,7 +3,7 @@ module github.com/hashicorp/terraform-provider-google
 go 1.19
 
 require (
-	cloud.google.com/go/bigtable v1.20.0
+	cloud.google.com/go/bigtable v1.19.0
 	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.55.0
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/davecgh/go-spew v1.1.1

--- a/mmv1/third_party/terraform/go.mod.erb
+++ b/mmv1/third_party/terraform/go.mod.erb
@@ -3,8 +3,8 @@ module github.com/hashicorp/terraform-provider-google
 go 1.19
 
 require (
-	cloud.google.com/go/bigtable v1.19.0
-	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.52.0
+	cloud.google.com/go/bigtable v1.20.0
+	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.55.0
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dnaeon/go-vcr v1.0.1

--- a/mmv1/third_party/terraform/go.sum
+++ b/mmv1/third_party/terraform/go.sum
@@ -17,6 +17,10 @@ cloud.google.com/go/longrunning v0.5.1/go.mod h1:spvimkwdz6SPWKEt/XBij79E9fiTkHS
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.52.0 h1:KswxXF4E5iWv2ggktqv265zOvwmXA3mgma3UQfYA4tU=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.52.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.54.0 h1:PUiaG5Xz1rzBU/GBO1OvyRz5O+Tog42Zg9+a/YFcpFc=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.54.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.55.0 h1:MTP0IDIztk36l8ubHkEcL6lWMG8Enqu9AP3E4MoBFg0=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.55.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=

--- a/mmv1/third_party/terraform/go.sum
+++ b/mmv1/third_party/terraform/go.sum
@@ -17,8 +17,6 @@ cloud.google.com/go/longrunning v0.5.1/go.mod h1:spvimkwdz6SPWKEt/XBij79E9fiTkHS
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.52.0 h1:KswxXF4E5iWv2ggktqv265zOvwmXA3mgma3UQfYA4tU=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.52.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
-github.com/GoogleCloudPlatform/declarative-resource-client-library v1.54.0 h1:PUiaG5Xz1rzBU/GBO1OvyRz5O+Tog42Zg9+a/YFcpFc=
-github.com/GoogleCloudPlatform/declarative-resource-client-library v1.54.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.55.0 h1:MTP0IDIztk36l8ubHkEcL6lWMG8Enqu9AP3E4MoBFg0=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.55.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=

--- a/tpgtools/api/assuredworkloads/samples/basic.workload.json
+++ b/tpgtools/api/assuredworkloads/samples/basic.workload.json
@@ -1,20 +1,22 @@
 {
   "organization": "{{org_id}}",
   "location": "{{region}}",
-  "displayName": "Workload Example",
+  "displayName": "{{display}}",
   "complianceRegime": "FEDRAMP_MODERATE",
   "billingAccount": "billingAccounts/{{billing_account}}",
   "labels": {
     "label-one": "value-one"
   },
   "provisionedResourcesParent": "folders/519620126891",
+  "violationNotificationsEnabled": true,
   "kmsSettings": {
     "nextRotationTime": "9999-10-02T15:01:23Z",
     "rotationPeriod": "10368000s"
   },
   "resourceSettings": [
     {
-      "resourceType": "CONSUMER_PROJECT"
+      "resourceType": "CONSUMER_FOLDER",
+      "displayName": "folder-display-name"
     },
     {
       "resourceType": "ENCRYPTION_KEYS_PROJECT"

--- a/tpgtools/api/assuredworkloads/samples/sovereign_controls.workload.json
+++ b/tpgtools/api/assuredworkloads/samples/sovereign_controls.workload.json
@@ -1,0 +1,27 @@
+{
+    "organization": "{{org_id}}",
+    "location": "europe-west9",
+    "displayName": "{{display}}",
+    "complianceRegime": "EU_REGIONS_AND_SUPPORT",
+    "billingAccount": "billingAccounts/{{billing_account}}",
+    "labels": {
+        "label-one": "value-one"
+    },
+    "enableSovereignControls": true,
+    "kmsSettings": {
+        "nextRotationTime": "9999-10-02T15:01:23Z",
+        "rotationPeriod": "10368000s"
+    },
+    "resourceSettings": [
+        {
+            "resourceType": "CONSUMER_FOLDER"
+        },
+        {
+            "resourceType": "ENCRYPTION_KEYS_PROJECT"
+        },
+        {
+            "resourceId": "{{ring}}",
+            "resourceType": "KEYRING"
+        }
+    ]
+}

--- a/tpgtools/api/assuredworkloads/samples/sovereign_controls_workload.yaml
+++ b/tpgtools/api/assuredworkloads/samples/sovereign_controls_workload.yaml
@@ -1,0 +1,31 @@
+# Copyright 2023 Google LLC. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: sovereign_controls_workload
+description: A Sovereign Controls test of the assuredworkloads api
+type: workload
+versions:
+- beta
+resource: samples/sovereign_controls.workload.json
+updates:
+- resource: samples/update_sovereign_controls.workload.json
+  dependencies: []
+variables:
+- name: billing_account
+  type: billing_account
+- name: display
+  type: resource_name
+- name: org_id
+  type: org_id
+- name: ring
+  type: resource_name

--- a/tpgtools/api/assuredworkloads/samples/update_sovereign_controls.workload.json
+++ b/tpgtools/api/assuredworkloads/samples/update_sovereign_controls.workload.json
@@ -1,0 +1,11 @@
+{
+    "name": "{{ref:__state__:name}}",
+    "organization": "{{org_id}}",
+    "location": "europe-west9",
+    "displayName": "updated-example",
+    "billingAccount": "billingAccounts/{{billing_account}}",
+    "complianceRegime": "EU_REGIONS_AND_SUPPORT",
+    "labels": {
+        "label-two": "value-two-eu-regions-and-support"
+    }
+}

--- a/tpgtools/api/orgpolicy/samples/organization_dry_run.policy.json
+++ b/tpgtools/api/orgpolicy/samples/organization_dry_run.policy.json
@@ -1,0 +1,13 @@
+{
+    "name": "organizations/{{org_id}}/policies/gcp.resourceLocations",
+    "parent": "organizations/{{org_id}}",
+    "dryRunSpec": {
+        "rules": [
+            {
+                "denyAll": true
+            }
+        ],
+        "reset": true,
+        "inheritFromParent": false
+    }
+}

--- a/tpgtools/api/orgpolicy/samples/organization_dry_run_policy.yaml
+++ b/tpgtools/api/orgpolicy/samples/organization_dry_run_policy.yaml
@@ -1,0 +1,26 @@
+# Copyright 2023 Google LLC. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: organization_dry_run_policy
+description: A test of an dry run policy for an organization
+type: policy
+versions:
+- ga
+- beta
+resource: samples/organization_dry_run.policy.json
+updates:
+- resource: samples/update_organization_dry_run.policy.json
+  dependencies: []
+variables:
+- name: org_id
+  type: org_id

--- a/tpgtools/api/orgpolicy/samples/update_organization_dry_run.policy.json
+++ b/tpgtools/api/orgpolicy/samples/update_organization_dry_run.policy.json
@@ -4,10 +4,8 @@
     "dryRunSpec": {
         "rules": [
             {
+                "allowAll": true,
                 "enforce": true
-            },
-            {
-                "allowAll": true
             }
         ],
         "reset": false,

--- a/tpgtools/api/orgpolicy/samples/update_organization_dry_run.policy.json
+++ b/tpgtools/api/orgpolicy/samples/update_organization_dry_run.policy.json
@@ -1,0 +1,16 @@
+{
+    "name": "organizations/{{org_id}}/policies/gcp.resourceLocations",
+    "parent": "organizations/{{org_id}}",
+    "dryRunSpec": {
+        "rules": [
+            {
+                "enforce": true
+            },
+            {
+                "allowAll": true
+            }
+        ],
+        "reset": false,
+        "inheritFromParent": true
+    }
+}

--- a/tpgtools/go.mod
+++ b/tpgtools/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	bitbucket.org/creachadair/stringset v0.0.11
-	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.52.0
+	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.55.0
 	github.com/golang/glog v1.1.2
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/hcl v1.0.0

--- a/tpgtools/go.sum
+++ b/tpgtools/go.sum
@@ -47,6 +47,8 @@ github.com/GoogleCloudPlatform/declarative-resource-client-library v1.51.0 h1:Yh
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.51.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.52.0 h1:KswxXF4E5iWv2ggktqv265zOvwmXA3mgma3UQfYA4tU=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.52.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.55.0 h1:MTP0IDIztk36l8ubHkEcL6lWMG8Enqu9AP3E4MoBFg0=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.55.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/tpgtools/overrides/assuredworkloads/beta/workload.yaml
+++ b/tpgtools/overrides/assuredworkloads/beta/workload.yaml
@@ -1,0 +1,12 @@
+- type: CUSTOM_SCHEMA_VALUES
+  field: enable_sovereign_controls
+  details:
+    required: false
+    optional: true
+    computed: true
+- type: CUSTOM_SCHEMA_VALUES
+  field: violation_notifications_enabled
+  details:
+    required: false
+    optional: true
+    computed: true

--- a/tpgtools/overrides/assuredworkloads/samples/workload/basic.tf.tmpl
+++ b/tpgtools/overrides/assuredworkloads/samples/workload/basic.tf.tmpl
@@ -9,7 +9,7 @@ resource "google_assured_workloads_workload" "primary" {
   organization = "{{org_id}}"
   location = "us-central1"
   resource_settings {
-    resource_type = "CONSUMER_FOLDER",
+    resource_type = "CONSUMER_FOLDER"
     display_name = "folder-display-name"
   }
   violation_notifications_enabled = true

--- a/tpgtools/overrides/assuredworkloads/samples/workload/basic.tf.tmpl
+++ b/tpgtools/overrides/assuredworkloads/samples/workload/basic.tf.tmpl
@@ -8,6 +8,11 @@ resource "google_assured_workloads_workload" "primary" {
   provisioned_resources_parent = google_folder.folder1.name
   organization = "{{org_id}}"
   location = "us-central1"
+  resource_settings {
+    resource_type = "CONSUMER_FOLDER",
+    display_name = "folder-display-name"
+  }
+  violation_notifications_enabled = true
 }
 
 resource "google_folder" "folder1" {

--- a/tpgtools/overrides/assuredworkloads/samples/workload/basic_update.tf.tmpl
+++ b/tpgtools/overrides/assuredworkloads/samples/workload/basic_update.tf.tmpl
@@ -9,7 +9,7 @@ resource "google_assured_workloads_workload" "primary" {
   organization = "{{org_id}}"
   location = "us-central1"
   resource_settings {
-    resource_type = "CONSUMER_FOLDER",
+    resource_type = "CONSUMER_FOLDER"
     display_name = "folder-display-name"
   }
   violation_notifications_enabled = true

--- a/tpgtools/overrides/assuredworkloads/samples/workload/basic_update.tf.tmpl
+++ b/tpgtools/overrides/assuredworkloads/samples/workload/basic_update.tf.tmpl
@@ -8,6 +8,11 @@ resource "google_assured_workloads_workload" "primary" {
   provisioned_resources_parent = google_folder.folder1.name
   organization = "{{org_id}}"
   location = "us-central1"
+  resource_settings {
+    resource_type = "CONSUMER_FOLDER",
+    display_name = "folder-display-name"
+  }
+  violation_notifications_enabled = true
 }
 
 resource "google_folder" "folder1" {

--- a/tpgtools/overrides/containeraws/samples/cluster/basic.tf.tmpl
+++ b/tpgtools/overrides/containeraws/samples/cluster/basic.tf.tmpl
@@ -8,6 +8,9 @@ resource "google_container_aws_cluster" "primary" {
     admin_users {
       username = "{{test_service_account}}"
     }
+    admin_groups {
+      group = "group@domain.com"
+    }
   }
 
   aws_region = "{{aws_region}}"

--- a/tpgtools/overrides/containeraws/samples/cluster/basic_update.tf.tmpl
+++ b/tpgtools/overrides/containeraws/samples/cluster/basic_update.tf.tmpl
@@ -8,6 +8,9 @@ resource "google_container_aws_cluster" "primary" {
     admin_users {
       username = "{{test_service_account}}"
     }
+    admin_groups {
+      group = "group@domain.com"
+    }
   }
 
   aws_region = "{{aws_region}}"

--- a/tpgtools/overrides/containerazure/samples/cluster/basic.tf.tmpl
+++ b/tpgtools/overrides/containerazure/samples/cluster/basic.tf.tmpl
@@ -8,6 +8,9 @@ resource "google_container_azure_cluster" "primary" {
     admin_users {
       username = "mmv2@google.com"
     }
+    admin_groups {
+      group = "group@domain.com"
+    }
   }
 
   azure_region = "westus2"

--- a/tpgtools/overrides/containerazure/samples/cluster/basic_update.tf.tmpl
+++ b/tpgtools/overrides/containerazure/samples/cluster/basic_update.tf.tmpl
@@ -8,6 +8,9 @@ resource "google_container_azure_cluster" "primary" {
     admin_users {
       username = "mmv2@google.com"
     }
+    admin_groups {
+      group = "group@domain.com"
+    }
   }
 
   azure_region = "westus2"

--- a/tpgtools/overrides/orgpolicy/beta/policy.yaml
+++ b/tpgtools/overrides/orgpolicy/beta/policy.yaml
@@ -7,3 +7,5 @@
   field: spec.rules.deny_all
 - type: ENUM_BOOL
   field: spec.rules.enforce
+- type: EXCLUDE
+  field: dry_run_spec

--- a/tpgtools/overrides/orgpolicy/policy.yaml
+++ b/tpgtools/overrides/orgpolicy/policy.yaml
@@ -7,5 +7,9 @@
   field: spec.rules.deny_all
 - type: ENUM_BOOL
   field: spec.rules.enforce
-- type: EXCLUDE
-  field: dry_run_spec
+- type: ENUM_BOOL
+  field: dry_run_spec.rules.allow_all
+- type: ENUM_BOOL
+  field: dry_run_spec.rules.deny_all
+- type: ENUM_BOOL
+  field: dry_run_spec.rules.enforce

--- a/tpgtools/overrides/orgpolicy/policy.yaml
+++ b/tpgtools/overrides/orgpolicy/policy.yaml
@@ -7,3 +7,5 @@
   field: spec.rules.deny_all
 - type: ENUM_BOOL
   field: spec.rules.enforce
+- type: EXCLUDE
+  field: dry_run_spec

--- a/tpgtools/overrides/orgpolicy/samples/policy/meta.yaml
+++ b/tpgtools/overrides/orgpolicy/samples/policy/meta.yaml
@@ -1,3 +1,8 @@
 ignore_read:
   - name
   - "spec.0.rules.0.condition.0.expression"
+# The feature for this sample is not ready
+test_hide:
+- organization_dry_run_policy.yaml
+doc_hide:
+- organization_dry_run_policy.yaml


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
upgrade DCL to `v1.55.0` (pending release note writing)

- `google_assured_workloads_workload` partner fields caused issues in DCL tests, so I did not include samples for them
- we have no `google_gke_hub_feature_membership` tests



<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
assuredworkloads: added `enable_sovereign_controls`, `partner`, `partner_permissions`, `violation_notifications_enabled`, and several other output-only fields to `google_assured_workloads_workloads`
```

```release-note:enhancement
containeraws: added `admin_groups` to `google_container_aws_cluster`
```

```release-note:enhancement
containerazure: added `admin_groups` to `google_container_azure_cluster`
```

```release-note:enhancement
gkehub: added `metrics_gcp_service_account_email` to `google_gke_hub_feature_membership`
```
