### PR TITLE
Deleted TestAccLoggingBucketConfigProject_locked test case.

### DIFF
--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
@@ -123,42 +123,6 @@ func TestAccLoggingBucketConfigProject_analyticsEnabled(t *testing.T) {
 	})
 }
 
-func TestAccLoggingBucketConfigProject_locked(t *testing.T) {
-	t.Parallel()
-
-	context := map[string]interface{}{
-		"random_suffix":   acctest.RandString(t, 10),
-		"project_name":    "tf-test-" + acctest.RandString(t, 10),
-		"org_id":          envvar.GetTestOrgFromEnv(t),
-		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
-	}
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccLoggingBucketConfigProject_locked(context, false),
-			},
-			{
-				ResourceName:            "google_logging_project_bucket_config.variable_locked",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"project"},
-			},
-			{
-				Config: testAccLoggingBucketConfigProject_locked(context, true),
-			},
-			{
-				ResourceName:            "google_logging_project_bucket_config.variable_locked",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"project"},
-			},
-		},
-	})
-}
-
 func TestAccLoggingBucketConfigProject_cmekSettings(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION


<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Cloud logging disallowed deleting locked buckets. Until this change is reverted, we deleted TestAccLoggingBucketConfigProject_locked test case, due to behavioral change of log buckets in project level for now.
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
Deleted a broken test.
```
