### PR TITLE
Add memcached-1.6.15 to the list of allowed memcache versions

### DIFF
--- a/mmv1/products/memcache/Instance.yaml
+++ b/mmv1/products/memcache/Instance.yaml
@@ -146,9 +146,10 @@ properties:
       The major version of Memcached software. If not provided, latest supported version will be used.
       Currently the latest supported major version is MEMCACHE_1_5. The minor version will be automatically
       determined by our system based on the latest supported minor version.
-    default_value: :MEMCACHE_1_5
+    default_value: :MEMCACHE_1_6_15
     values:
       - :MEMCACHE_1_5
+      - :MEMCACHE_1_6_15
   - !ruby/object:Api::Type::NestedObject
     name: nodeConfig
     description: |

--- a/mmv1/products/memcache/Instance.yaml
+++ b/mmv1/products/memcache/Instance.yaml
@@ -146,7 +146,7 @@ properties:
       The major version of Memcached software. If not provided, latest supported version will be used.
       Currently the latest supported major version is MEMCACHE_1_5. The minor version will be automatically
       determined by our system based on the latest supported minor version.
-    default_value: :MEMCACHE_1_6_15
+    default_value: :MEMCACHE_1_5
     values:
       - :MEMCACHE_1_5
       - :MEMCACHE_1_6_15

--- a/mmv1/products/memcache/Instance.yaml
+++ b/mmv1/products/memcache/Instance.yaml
@@ -150,6 +150,8 @@ properties:
     values:
       - :MEMCACHE_1_5
       - :MEMCACHE_1_6_15
+    update_url: 'projects/{{project}}/locations/{{region}}/instances/{{name}}:upgrade'
+    update_verb: :POST
   - !ruby/object:Api::Type::NestedObject
     name: nodeConfig
     description: |

--- a/mmv1/third_party/terraform/services/memcache/resource_memcache_instance_test.go
+++ b/mmv1/third_party/terraform/services/memcache/resource_memcache_instance_test.go
@@ -86,6 +86,8 @@ resource "google_memcache_instance" "test" {
       "max-item-size" = "8388608"
     }
   }
+
+  memcache_version = "MEMCACHE_1_6_15"
 }
 
 data "google_compute_network" "memcache_network" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add MEMCACHE_1_6_15 to the list of allowed memcached versions. This will also be
the default version.
Github issue - https://github.com/hashicorp/terraform-provider-google/issues/16191
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
memcache: added `MEMCACHE_1_6_15` as a possible value for `memcache_version` in `google_memcache_instance`
```
