### PR TITLE
Removed broken OICS link from handwritten resource docs

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/os_config_os_policy_assignment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/os_config_os_policy_assignment.html.markdown
@@ -20,12 +20,6 @@ To get more information about OSPolicyAssignment, see:
 *   How-to Guides
     *   [Official Documentation](https://cloud.google.com/compute/docs/os-configuration-management/create-os-policy-assignment)
 
-<div class = "oics-button" style="float: right; margin: 0 0 -15px">
-  <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=os_config_os_policy_assignment_basic&cloudshell_image=gcr.io%2Fgraphite-cloud-shell-images%2Fterraform%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
-    <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
-  </a>
-</div>
-
 ## Example Usage - Os Config Os Policy Assignment Basic
 
 ```hcl


### PR DESCRIPTION
Resolved https://github.com/hashicorp/terraform-provider-google/issues/16384

```release-note:none

```
