### PR TITLE
Improve cache for dispatch jobs

### DIFF
--- a/.github/workflows/test-tgc.yml
+++ b/.github/workflows/test-tgc.yml
@@ -40,22 +40,19 @@ jobs:
       with:
         repository: ${{ github.event.inputs.owner }}/${{ github.event.inputs.repo }}
         ref: ${{ github.event.inputs.branch }}
-        path: repo
         fetch-depth: 2
     - name: Cache Go modules and build cache
       uses: actions/cache@v3
       with:
         path: |
           ~/go/pkg/mod
-          ~/.cache/go-build
-        key: ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('repo/go.sum') }}
+        key: ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('repo/go.sum') }}
+          ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('go.sum') }}
           ${{ runner.os }}-test-${{ github.event.inputs.repo }}-
     - name: Check for Code Changes
       id: pull_request
       run: |
-        cd repo
         gofiles=$(git diff --name-only HEAD~1 | { grep -e "\.go$" -e "go.mod$" -e "go.sum$" || test $? = 1; })
         if [ -z "$gofiles" ]; then
           echo "has_changes=false" >> $GITHUB_OUTPUT
@@ -88,14 +85,12 @@ jobs:
     - name: Build Terraform Google Conversion
       if: ${{ !failure() && steps.pull_request.outputs.has_changes == 'true' }}
       run: |
-        cd repo
         go mod edit -replace github.com/hashicorp/terraform-provider-google-beta=github.com/${{ github.event.inputs.owner }}/terraform-provider-google-beta@${{ github.event.inputs.branch }}
         go mod tidy
         make build
     - name: Run Unit Tests
       if: ${{ !failure() && steps.pull_request.outputs.has_changes == 'true' }}
       run: |
-        cd repo
         make test
     - name: Post Result Status to Pull Request
       if: ${{ !cancelled() }}

--- a/.github/workflows/test-tgc.yml
+++ b/.github/workflows/test-tgc.yml
@@ -40,7 +40,7 @@ jobs:
       with:
         repository: ${{ github.event.inputs.owner }}/${{ github.event.inputs.repo }}
         ref: ${{ github.event.inputs.branch }}
-        path: tgc
+        path: repo
         fetch-depth: 2
     - name: Cache Go modules and build cache
       uses: actions/cache@v3
@@ -48,14 +48,14 @@ jobs:
         path: |
           ~/go/pkg/mod
           ~/.cache/go-build
-        key: ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('**/go.sum', 'google-beta/transport/**', 'google-beta/tpgresource/**', 'google-beta/acctest/**', 'google-beta/envvar/**', 'google-beta/sweeper/**', 'google-beta/verify/**') }}
+        key: ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('repo/go.sum', 'repo/google-beta/transport/**', 'repo/google-beta/tpgresource/**', 'repo/google-beta/acctest/**', 'repo/google-beta/envvar/**', 'repo/google-beta/sweeper/**', 'repo/google-beta/verify/**') }}
         restore-keys: |
-          ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('**/go.sum') }}
+          ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('repo/go.sum') }}
           ${{ runner.os }}-test-${{ github.event.inputs.repo }}-
     - name: Check for Code Changes
       id: pull_request
       run: |
-        cd tgc
+        cd repo
         gofiles=$(git diff --name-only HEAD~1 | { grep -e "\.go$" -e "go.mod$" -e "go.sum$" || test $? = 1; })
         if [ -z "$gofiles" ]; then
           echo "has_changes=false" >> $GITHUB_OUTPUT
@@ -88,14 +88,14 @@ jobs:
     - name: Build Terraform Google Conversion
       if: ${{ !failure() && steps.pull_request.outputs.has_changes == 'true' }}
       run: |
-        cd tgc
+        cd repo
         go mod edit -replace github.com/hashicorp/terraform-provider-google-beta=github.com/${{ github.event.inputs.owner }}/terraform-provider-google-beta@${{ github.event.inputs.branch }}
         go mod tidy
         make build
     - name: Run Unit Tests
       if: ${{ !failure() && steps.pull_request.outputs.has_changes == 'true' }}
       run: |
-        cd tgc
+        cd repo
         make test
     - name: Post Result Status to Pull Request
       if: ${{ !cancelled() }}

--- a/.github/workflows/test-tgc.yml
+++ b/.github/workflows/test-tgc.yml
@@ -48,7 +48,7 @@ jobs:
         path: |
           ~/go/pkg/mod
           ~/.cache/go-build
-        key: ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('repo/go.sum', 'repo/google-beta/transport/**', 'repo/google-beta/tpgresource/**', 'repo/google-beta/acctest/**', 'repo/google-beta/envvar/**', 'repo/google-beta/sweeper/**', 'repo/google-beta/verify/**') }}
+        key: ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('repo/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('repo/go.sum') }}
           ${{ runner.os }}-test-${{ github.event.inputs.repo }}-

--- a/.github/workflows/test-tgc.yml
+++ b/.github/workflows/test-tgc.yml
@@ -25,8 +25,6 @@ on:
       sha:
         description: "The commit SHA in magic-modules repository where the status result will be posted"
         required: true
-      caller_id:
-        description: "Identity of the workflow dispatch caller"
 
 concurrency:
   group: test-tgc-${{ github.event.inputs.owner }}-${{ github.event.inputs.repo }}-${{ github.event.inputs.branch }}
@@ -50,8 +48,9 @@ jobs:
         path: |
           ~/go/pkg/mod
           ~/.cache/go-build
-        key: ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('**/go.sum', 'google-beta/transport/**', 'google-beta/tpgresource/**', 'google-beta/acctest/**', 'google-beta/envvar/**', 'google-beta/sweeper/**', 'google-beta/verify/**') }}
         restore-keys: |
+          ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('**/go.sum') }}
           ${{ runner.os }}-test-${{ github.event.inputs.repo }}-
     - name: Check for Code Changes
       id: pull_request

--- a/.github/workflows/test-tpg.yml
+++ b/.github/workflows/test-tpg.yml
@@ -25,8 +25,6 @@ on:
       sha:
         description: "The commit SHA in magic-modules repository where the status result will be posted"
         required: true
-      caller_id:
-        description: "Identity of the workflow dispatch caller"
 
 concurrency:
   group: test-tpg-${{ github.event.inputs.owner }}-${{ github.event.inputs.repo }}-${{ github.event.inputs.branch }}
@@ -50,8 +48,9 @@ jobs:
         path: |
           ~/go/pkg/mod
           ~/.cache/go-build
-        key: ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('**/go.sum', 'google-beta/transport/**', 'google-beta/tpgresource/**', 'google-beta/acctest/**', 'google-beta/envvar/**', 'google-beta/sweeper/**', 'google-beta/verify/**') }}
         restore-keys: |
+          ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('**/go.sum') }}
           ${{ runner.os }}-test-${{ github.event.inputs.repo }}-
     - name: Check for Code Changes
       id: pull_request

--- a/.github/workflows/test-tpg.yml
+++ b/.github/workflows/test-tpg.yml
@@ -104,7 +104,7 @@ jobs:
       if: ${{ !failure() && steps.pull_request.outputs.has_changes == 'true' }}
       run: |
         cd repo
-        make testnolint TEST_ARGS="-p 4"
+        make testnolint TESTARGS="-p 4"
     - name: Lint Check
       if: ${{ !cancelled() && steps.pull_request.outputs.has_changes == 'true' }}
       run: |

--- a/.github/workflows/test-tpg.yml
+++ b/.github/workflows/test-tpg.yml
@@ -40,7 +40,7 @@ jobs:
       with:
         repository: ${{ github.event.inputs.owner }}/${{ github.event.inputs.repo }}
         ref: ${{ github.event.inputs.branch }}
-        path: provider
+        path: repo
         fetch-depth: 2
     - name: Cache Go modules and build cache
       uses: actions/cache@v3
@@ -48,14 +48,14 @@ jobs:
         path: |
           ~/go/pkg/mod
           ~/.cache/go-build
-        key: ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('**/go.sum', 'google-beta/transport/**', 'google-beta/tpgresource/**', 'google-beta/acctest/**', 'google-beta/envvar/**', 'google-beta/sweeper/**', 'google-beta/verify/**') }}
+        key: ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('repo/go.sum', 'repo/google-beta/transport/**', 'repo/google-beta/tpgresource/**', 'repo/google-beta/acctest/**', 'repo/google-beta/envvar/**', 'repo/google-beta/sweeper/**', 'repo/google-beta/verify/**') }}
         restore-keys: |
-          ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('**/go.sum') }}
+          ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('repo/go.sum') }}
           ${{ runner.os }}-test-${{ github.event.inputs.repo }}-
     - name: Check for Code Changes
       id: pull_request
       run: |
-        cd provider
+        cd repo
         gofiles=$(git diff --name-only HEAD~1 | { grep -e "\.go$" -e "go.mod$" -e "go.sum$" || test $? = 1; })
         if [ -z "$gofiles" ]; then
           echo "has_changes=false" >> $GITHUB_OUTPUT
@@ -88,22 +88,22 @@ jobs:
     - name: Build Provider
       if: ${{ !failure() && steps.pull_request.outputs.has_changes == 'true' }}
       run: |
-        cd provider
+        cd repo
         go build
     - name: Run Unit Tests
       if: ${{ !failure() && steps.pull_request.outputs.has_changes == 'true' }}
       run: |
-        cd provider
+        cd repo
         make testnolint
     - name: Lint Check
       if: ${{ !cancelled() && steps.pull_request.outputs.has_changes == 'true' }}
       run: |
-        cd provider
+        cd repo
         make lint
     - name: Documentation Check
       if: ${{ !cancelled() && steps.pull_request.outputs.has_changes == 'true' }}
       run: |
-        cd provider
+        cd repo
         make docscheck
     - name: Post Result Status to Pull Request
       if: ${{ !cancelled() }}

--- a/.github/workflows/test-tpg.yml
+++ b/.github/workflows/test-tpg.yml
@@ -94,7 +94,7 @@ jobs:
       if: ${{ !failure() && steps.pull_request.outputs.has_changes == 'true' }}
       run: |
         cd repo
-        make testnolint
+        make testnolint TEST_ARGS="-p 4"
     - name: Lint Check
       if: ${{ !cancelled() && steps.pull_request.outputs.has_changes == 'true' }}
       run: |

--- a/.github/workflows/test-tpg.yml
+++ b/.github/workflows/test-tpg.yml
@@ -40,7 +40,6 @@ jobs:
       with:
         repository: ${{ github.event.inputs.owner }}/${{ github.event.inputs.repo }}
         ref: ${{ github.event.inputs.branch }}
-        path: repo
         fetch-depth: 2
     - name: Cache Go modules and build cache
       uses: actions/cache@v3
@@ -48,24 +47,13 @@ jobs:
         path: |
           ~/go/pkg/mod
           ~/.cache/go-build
-        key: ${{ runner.os }}-test-${{ github.event.inputs.repo }}-
-          ${{
-            hashFiles(
-              'repo/go.sum',
-              'repo/google-beta/transport/**',
-              'repo/google-beta/tpgresource/**',
-              'repo/google-beta/acctest/**',
-              'repo/google-beta/envvar/**',
-              'repo/google-beta/sweeper/**',
-              'repo/google-beta/verify/**')
-          }}
+        key: ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{hashFiles('go.sum','google-beta/transport/**','google-beta/tpgresource/**','google-beta/acctest/**','google-beta/envvar/**','google-beta/sweeper/**','google-beta/verify/**') }}
         restore-keys: |
-          ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('repo/go.sum') }}
+          ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('go.sum') }}
           ${{ runner.os }}-test-${{ github.event.inputs.repo }}-
     - name: Check for Code Changes
       id: pull_request
       run: |
-        cd repo
         gofiles=$(git diff --name-only HEAD~1 | { grep -e "\.go$" -e "go.mod$" -e "go.sum$" || test $? = 1; })
         if [ -z "$gofiles" ]; then
           echo "has_changes=false" >> $GITHUB_OUTPUT
@@ -98,22 +86,18 @@ jobs:
     - name: Build Provider
       if: ${{ !failure() && steps.pull_request.outputs.has_changes == 'true' }}
       run: |
-        cd repo
         go build
     - name: Run Unit Tests
       if: ${{ !failure() && steps.pull_request.outputs.has_changes == 'true' }}
       run: |
-        cd repo
         make testnolint TESTARGS="-p 4"
     - name: Lint Check
       if: ${{ !cancelled() && steps.pull_request.outputs.has_changes == 'true' }}
       run: |
-        cd repo
         make lint
     - name: Documentation Check
       if: ${{ !cancelled() && steps.pull_request.outputs.has_changes == 'true' }}
       run: |
-        cd repo
         make docscheck
     - name: Post Result Status to Pull Request
       if: ${{ !cancelled() }}

--- a/.github/workflows/test-tpg.yml
+++ b/.github/workflows/test-tpg.yml
@@ -48,7 +48,17 @@ jobs:
         path: |
           ~/go/pkg/mod
           ~/.cache/go-build
-        key: ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('repo/go.sum', 'repo/google-beta/transport/**', 'repo/google-beta/tpgresource/**', 'repo/google-beta/acctest/**', 'repo/google-beta/envvar/**', 'repo/google-beta/sweeper/**', 'repo/google-beta/verify/**') }}
+        key: ${{ runner.os }}-test-${{ github.event.inputs.repo }}-
+          ${{
+            hashFiles(
+              'repo/go.sum',
+              'repo/google-beta/transport/**',
+              'repo/google-beta/tpgresource/**',
+              'repo/google-beta/acctest/**',
+              'repo/google-beta/envvar/**',
+              'repo/google-beta/sweeper/**',
+              'repo/google-beta/verify/**')
+          }}
         restore-keys: |
           ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('repo/go.sum') }}
           ${{ runner.os }}-test-${{ github.event.inputs.repo }}-


### PR DESCRIPTION
The cache isn't resulting the material improvements I was expecting. This is due to resource generation modifying shared packages. So any newly generated resource can't take advantage of existing cache
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
