### PR TITLE
Treat _Default & _Required Sinks same as buckets

### DIFF
--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
@@ -17,7 +18,7 @@ const nonUniqueWriterAccount = "serviceAccount:cloud-logs@system.gserviceaccount
 
 func ResourceLoggingProjectSink() *schema.Resource {
 	schm := &schema.Resource{
-		Create:        resourceLoggingProjectSinkCreate,
+		Create:        resourceLoggingProjectSinkAcquireOrCreate,
 		Read:          resourceLoggingProjectSinkRead,
 		Delete:        resourceLoggingProjectSinkDelete,
 		Update:        resourceLoggingProjectSinkUpdate,
@@ -49,7 +50,7 @@ func ResourceLoggingProjectSink() *schema.Resource {
 	return schm
 }
 
-func resourceLoggingProjectSinkCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceLoggingProjectSinkAcquireOrCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
 	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {
@@ -65,25 +66,32 @@ func resourceLoggingProjectSinkCreate(d *schema.ResourceData, meta interface{}) 
 	uniqueWriterIdentity := d.Get("unique_writer_identity").(bool)
 	customWriterIdentity := d.Get("custom_writer_identity").(string)
 
-	projectSinkCreateRequest := config.NewLoggingClient(userAgent).Projects.Sinks.Create(id.parent(), sink)
+	log.Printf("[DEBUG] Fetching logging bucket config: %#v", id)
 
-	// if custom-sa is specified, use it to write log and it requires uniqueWriterIdentity to be set as well
-	// otherwise set the uniqueWriter identity
-	if customWriterIdentity != "" {
-		projectSinkCreateRequest = projectSinkCreateRequest.UniqueWriterIdentity(uniqueWriterIdentity).CustomWriterIdentity(customWriterIdentity)
-	} else {
-		projectSinkCreateRequest = projectSinkCreateRequest.UniqueWriterIdentity(uniqueWriterIdentity)
+	res, _ := config.NewLoggingClient(userAgent).Projects.Sinks.Get(id.canonicalId()).Do()
+	if res == nil {
+		projectSinkCreateRequest := config.NewLoggingClient(userAgent).Projects.Sinks.Create(id.parent(), sink)
+
+		// if custom-sa is specified, use it to write log and it requires uniqueWriterIdentity to be set as well
+		// otherwise set the uniqueWriter identity
+		if customWriterIdentity != "" {
+			projectSinkCreateRequest = projectSinkCreateRequest.UniqueWriterIdentity(uniqueWriterIdentity).CustomWriterIdentity(customWriterIdentity)
+		} else {
+			projectSinkCreateRequest = projectSinkCreateRequest.UniqueWriterIdentity(uniqueWriterIdentity)
+		}
+
+		_, err = projectSinkCreateRequest.Do()
+
+		if err != nil {
+			return err
+		}
+
+		d.SetId(id.canonicalId())
+		return resourceLoggingProjectSinkRead(d, meta)
 	}
-
-	_, err = projectSinkCreateRequest.Do()
-
-	if err != nil {
-		return err
-	}
-
 	d.SetId(id.canonicalId())
 
-	return resourceLoggingProjectSinkRead(d, meta)
+	return resourceLoggingProjectSinkUpdate(d, meta)
 }
 
 // if bigquery_options is set unique_writer_identity must be true
@@ -175,6 +183,14 @@ func resourceLoggingProjectSinkUpdate(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceLoggingProjectSinkDelete(d *schema.ResourceData, meta interface{}) error {
+	name := d.Get("name")
+	for _, restrictedName := range []string{"_Required", "_Default"} {
+		if name == restrictedName {
+			log.Printf("[WARN] Default logging sinks cannot be deleted. Removing logging sinks config from state: %#v", d.Id())
+			return nil
+		}
+	}
+
 	config := meta.(*transport_tpg.Config)
 	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink.go
@@ -66,7 +66,7 @@ func resourceLoggingProjectSinkAcquireOrCreate(d *schema.ResourceData, meta inte
 	uniqueWriterIdentity := d.Get("unique_writer_identity").(bool)
 	customWriterIdentity := d.Get("custom_writer_identity").(string)
 
-	log.Printf("[DEBUG] Fetching logging bucket config: %#v", id)
+	log.Printf("[DEBUG] Fetching logging sink config: %#v", id)
 
 	res, _ := config.NewLoggingClient(userAgent).Projects.Sinks.Get(id.canonicalId()).Do()
 	if res == nil {
@@ -186,7 +186,7 @@ func resourceLoggingProjectSinkDelete(d *schema.ResourceData, meta interface{}) 
 	name := d.Get("name")
 	for _, restrictedName := range []string{"_Required", "_Default"} {
 		if name == restrictedName {
-			log.Printf("[WARN] Default logging sinks cannot be deleted. Removing logging sinks config from state: %#v", d.Id())
+			log.Print("[WARN] Default logging sinks cannot be deleted.")
 			return nil
 		}
 	}

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
@@ -535,7 +535,10 @@ resource "google_logging_project_sink" "custom_writer" {
   unique_writer_identity = true
   custom_writer_identity = "serviceAccount:${google_service_account.test-account1.email}"
 
-  depends_on = [google_logging_project_bucket_config.destination-bucket]
+  depends_on = [
+	google_logging_project_bucket_config.destination-bucket,
+	google_service_account_iam_member.loggingsa-customsa-binding,
+	]
 }
 `, project, project, org, billingId, serviceAccount, envvar.GetTestProjectFromEnv(), name, envvar.GetTestProjectFromEnv())
 }
@@ -589,7 +592,10 @@ resource "google_logging_project_sink" "custom_writer" {
   unique_writer_identity = true
   custom_writer_identity = "serviceAccount:${google_service_account.test-account2.email}"
 
-  depends_on = [google_logging_project_bucket_config.destination-bucket]
+  depends_on = [
+	google_logging_project_bucket_config.destination-bucket,
+	google_service_account_iam_member.loggingsa-customsa-binding,
+	]
 }
 `, project, project, org, billingId, serviceAccount, envvar.GetTestProjectFromEnv(), name, envvar.GetTestProjectFromEnv())
 }

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
@@ -33,6 +33,29 @@ func TestAccLoggingProjectSink_basic(t *testing.T) {
 	})
 }
 
+func TestAccLoggingProjectSink_default(t *testing.T) {
+	t.Parallel()
+
+	sinkName := "_Default"
+	bucketName := "tf-test-sink-bucket-" + acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckLoggingProjectSinkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingProjectSink_basic(sinkName, envvar.GetTestProjectFromEnv(), bucketName),
+			},
+			{
+				ResourceName:      "google_logging_project_sink.basic",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccLoggingProjectSink_described(t *testing.T) {
 	t.Parallel()
 

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_test.go
@@ -42,7 +42,6 @@ func TestAccLoggingProjectSink_default(t *testing.T) {
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckLoggingProjectSinkDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLoggingProjectSink_basic(sinkName, envvar.GetTestProjectFromEnv(), bucketName),

--- a/mmv1/third_party/terraform/services/logging/resource_logging_sink.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_sink.go
@@ -155,10 +155,11 @@ func expandResourceLoggingSinkForUpdate(d *schema.ResourceData) (sink *logging.L
 		Filter:          d.Get("filter").(string),
 		Disabled:        d.Get("disabled").(bool),
 		Description:     d.Get("description").(string),
-		ForceSendFields: []string{"Destination", "Filter", "Disabled"},
+		Exclusions:      expandLoggingSinkExclusions(d.Get("exclusions")),
+		ForceSendFields: []string{"Destination", "Filter", "Disabled", "Exclusions"},
 	}
 
-	updateFields := []string{}
+	updateFields := []string{"exclusions"}
 	if d.HasChange("destination") {
 		updateFields = append(updateFields, "destination")
 	}
@@ -170,10 +171,6 @@ func expandResourceLoggingSinkForUpdate(d *schema.ResourceData) (sink *logging.L
 	}
 	if d.HasChange("disabled") {
 		updateFields = append(updateFields, "disabled")
-	}
-	if d.HasChange("exclusions") {
-		sink.Exclusions = expandLoggingSinkExclusions(d.Get("exclusions"))
-		updateFields = append(updateFields, "exclusions")
 	}
 	if d.HasChange("bigquery_options") {
 		sink.BigqueryOptions = expandLoggingSinkBigqueryOptions(d.Get("bigquery_options"))

--- a/mmv1/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
@@ -18,7 +18,7 @@ Manages a project-level logging sink. For more information see:
 
 ~> **Note** You must [enable the Cloud Resource Manager API](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com)
 
-~> **Note:** Logging sinks are automatically created for a given project and cannot be deleted. Creating a resource of this type will acquire and update the resource that already exists at the desired location. These sinks cannot be removed so deleting this resource will remove the sink config from your terraform state but will leave the logging sink unchanged. The sinks that are currently automatically created are "_Default" and "_Required".
+~> **Note:** The `_Default` and `_Required` logging sinks are automatically created for a given project and cannot be deleted. Creating a resource of this type will acquire and update the resource that already exists at the desired location. These sinks cannot be removed so deleting this resource will remove the sink config from your terraform state but will leave the logging sink unchanged. The sinks that are currently automatically created are "_Default" and "_Required".
 
 
 ## Example Usage - Basic Sink
@@ -167,7 +167,7 @@ resource "google_logging_project_sink" "log-bucket" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the logging sink.
+* `name` - (Required) The name of the logging sink. Logging automatically creates two sinks: `_Required` and `_Default`.
 
 * `destination` - (Required) The destination of the sink (or, in other words, where logs are written to). Can be a
     Cloud Storage bucket, a PubSub topic, a BigQuery dataset or a Cloud Logging bucket . Examples:

--- a/mmv1/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
@@ -18,6 +18,9 @@ Manages a project-level logging sink. For more information see:
 
 ~> **Note** You must [enable the Cloud Resource Manager API](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com)
 
+~> **Note:** Logging sinks are automatically created for a given project and cannot be deleted. Creating a resource of this type will acquire and update the resource that already exists at the desired location. These sinks cannot be removed so deleting this resource will remove the sink config from your terraform state but will leave the logging sink unchanged. The sinks that are currently automatically created are "_Default" and "_Required".
+
+
 ## Example Usage - Basic Sink
 
 ```hcl


### PR DESCRIPTION
Fixes [terraform-provider-google#7811 ](https://github.com/hashicorp/terraform-provider-google/issues/7811)

The `google_logging_project_bucket_config` resource graciously handles the “_Default” bucket by acquiring and updating the resource that already exists at the desired location. This PR updates `google_logging_project_sink` to behave the same way.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
logging: `google_logging_project_sink` now will aqcuire and update the resource that already exists at the desired location. These buckets cannot be removed so deleting this resource will remove the bucket config from your terraform state but will leave the logging bucket unchanged.   
```
