### PR TITLE
Add fleet field to google_container_cluster resource 

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -106,12 +106,12 @@ var (
 		return false
 	})
 
-	suppressDiffForExsitingFleet = schema.SchemaDiffSuppressFunc(func(k, oldValue, newValue string, d *schema.ResourceData) bool {
-		o, n := d.GetChange("fleet.0.pre_registered")
-                suppress := !o.(bool) && !n.(bool)
-                log.Printf("[DEBUG] fleet suppress pre_registered old: %v, new: %v\n", o, n)
-		return false
-	})
+	// suppressDiffForExsitingFleet = schema.SchemaDiffSuppressFunc(func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+		// o, n := d.GetChange("fleet.0.pre_registered")
+                // suppress := !o.(bool) && !n.(bool)
+                // log.Printf("[DEBUG] fleet suppress pre_registered old: %v, new: %v\n", o, n)
+		// return false
+	// })
 )
 
 // This uses the node pool nodeConfig schema but sets
@@ -2057,7 +2057,6 @@ func ResourceContainerCluster() *schema.Resource {
 						"project": {
 							Type:              schema.TypeString,
 							Optional:          true,
-							DiffSuppressFunc:  suppressDiffForExsitingFleet,
 							Description:       `The Fleet host project of the cluster.`,
 						},
                                           	"membership": {
@@ -3949,19 +3948,20 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if d.HasChange("fleet") {
-		req := &container.UpdateClusterRequest{
-			Update: &container.ClusterUpdate{
-				DesiredFleet: expandFleet(d.Get("fleet")),
-			},
-		}
+		if fleet, ok := d.GetOk("fleet"); ok {
+			req := &container.UpdateClusterRequest{
+				Update: &container.ClusterUpdate{
+					DesiredFleet: expandFleet(fleet),
+				},
+			}
 
-		updateF := updateFunc(req, "updating GKE fleet config")
-		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
-			return err
+			updateF := updateFunc(req, "updating GKE fleet config")
+			// Call update serially.
+			if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+				return err
+			}
+			log.Printf("[INFO] GKE cluster %s fleet config has been updated", d.Id())
 		}
-
-		log.Printf("[INFO] GKE cluster %s fleet config has been updated", d.Id())
 	}
 
 	if d.HasChange("enable_k8s_beta_apis") {
@@ -6005,7 +6005,7 @@ func flattenFleet(c *container.Fleet) []map[string]interface{} {
                       "membership": c.Membership,
 		      "pre_registered": c.PreRegistered,
                 },
-        }       
+      }       
 }
 
 func flattenEnableK8sBetaApis(c *container.K8sBetaAPIConfig) []map[string]interface{} {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -2050,7 +2050,6 @@ func ResourceContainerCluster() *schema.Resource {
 						"project": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							Computed:     true,
 							Description:  `The Fleet host project of the cluster.`,
 						},
                                           	"membership": {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -3960,7 +3960,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			}
 		} else {
 			req.Update = &container.ClusterUpdate{
-				DesiredWorkloadIdentityConfig:  expandFleet(v),
+				DesiredFleet:  expandFleet(v),
 			}
 		}
 		log.Printf("[INFO] GKE cluster %s fleet config has been updated", d.Id())

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -2053,7 +2053,7 @@ func ResourceContainerCluster() *schema.Resource {
 				Optional:    true,
 				MaxItems:    1,
 				Description: `Fleet configuration of the cluster.`,
-				DiffSuppressFunc: suppressDiffForExsitingFleet,
+				DiffSuppressFunc: suppressDiffForPreRegisteredFleet,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"project": {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -3936,8 +3936,10 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			log.Printf("[INFO] GKE cluster %s Gateway API has been updated", d.Id())
 		}
 	}
-
+        log.Printf("[DEBUG] @ has change: %v", d.HasChange("fleet"))
+	log.Printf("[DEBUG] @@ fleet has change: %v", d.Get("fleet"))
 	if d.HasChange("fleet") {
+		log.Printf("[DEBUG] @@@ fleet has change: %v", d.Get("fleet"))
 		req := &container.UpdateClusterRequest{
 			Update: &container.ClusterUpdate{
 				DesiredFleet: expandFleet(d.Get("fleet")),

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -106,10 +106,12 @@ var (
 		return false
 	})
 
-	suppressDiffForExsitingFleet = schema.SchemaDiffSuppressFunc(func(k, oldValue, newValue string, d *schema.ResourceData) bool {
-		o, n := d.GetChange("fleet.0.pre_registered")
-                log.Printf("[DEBUG] fleet suppress pre_registered old: %v, new: %v\n", o, n)
-		return o.(bool)
+	suppressDiffForPreRegisteredFleet = schema.SchemaDiffSuppressFunc(func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+		if v, _ := d.Get("fleet.0.pre_registered").(bool); v {
+			log.Printf("[DEBUG] fleet suppress pre_registered: %v\n", v)
+			return true
+		}
+		return false
 	})
 )
 

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -3954,6 +3954,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 					DesiredFleet: expandFleet(fleet),
 				},
 			}
+                        log.Printf("[INFO] GKE cluster %s fleet config has been updated, fleet=%v, req=%v", fleet, req)
 
 			updateF := updateFunc(req, "updating GKE fleet config")
 			// Call update serially.

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -106,12 +106,11 @@ var (
 		return false
 	})
 
-	// suppressDiffForExsitingFleet = schema.SchemaDiffSuppressFunc(func(k, oldValue, newValue string, d *schema.ResourceData) bool {
-		// o, n := d.GetChange("fleet.0.pre_registered")
-                // suppress := !o.(bool) && !n.(bool)
-                // log.Printf("[DEBUG] fleet suppress pre_registered old: %v, new: %v\n", o, n)
-		// return false
-	// })
+	suppressDiffForExsitingFleet = schema.SchemaDiffSuppressFunc(func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+		o, n := d.GetChange("fleet.0.pre_registered")
+                log.Printf("[DEBUG] fleet suppress pre_registered old: %v, new: %v\n", o, n)
+		return o.(bool)
+	})
 )
 
 // This uses the node pool nodeConfig schema but sets
@@ -2052,6 +2051,7 @@ func ResourceContainerCluster() *schema.Resource {
 				Optional:    true,
 				MaxItems:    1,
 				Description: `Fleet configuration of the cluster.`,
+				DiffSuppressFunc: suppressDiffForExsitingFleet,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"project": {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -3955,7 +3955,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		if v, ok := d.GetOk("fleet"); !ok {
 			req.Update = &container.ClusterUpdate{
 				DesiredFleet: &container.Fleet{
-					Fleet: "",
+					Project: "",
 				},
 			}
 		} else {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -105,6 +105,13 @@ var (
 		}
 		return false
 	})
+
+	suppressDiffForExsitingFleet = schema.SchemaDiffSuppressFunc(func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+		o, n := d.GetChange("fleet.0.pre_registered")
+                suppress := !o.(bool) && !n.(bool)
+                log.Printf("[DEBUG] fleet suppress pre_registered old: %v, new: %v\n", o, n)
+		return false
+	})
 )
 
 // This uses the node pool nodeConfig schema but sets
@@ -2048,14 +2055,20 @@ func ResourceContainerCluster() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"project": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Description:  `The Fleet host project of the cluster.`,
+							Type:              schema.TypeString,
+							Optional:          true,
+							DiffSuppressFunc:  suppressDiffForExsitingFleet,
+							Description:       `The Fleet host project of the cluster.`,
 						},
                                           	"membership": {
                                                 	Type:             schema.TypeString,
                                                 	Computed:         true,
                                                 	Description:      `Full resource name of the registered fleet membership of the cluster.`,
+                                          	},
+                                          	"pre_registered": {
+                                                	Type:             schema.TypeBool,
+                                                	Computed:         true,
+                                                	Description:      `Whether the cluster has been registered via the fleet API.`,
                                           	},
 					},
 				},
@@ -3934,10 +3947,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			log.Printf("[INFO] GKE cluster %s Gateway API has been updated", d.Id())
 		}
 	}
-        log.Printf("[DEBUG] @ has change: %v", d.HasChange("fleet"))
-	log.Printf("[DEBUG] @@ fleet has change: %v", d.Get("fleet"))
+
 	if d.HasChange("fleet") {
-		log.Printf("[DEBUG] @@@ fleet has change: %v", d.Get("fleet"))
 		req := &container.UpdateClusterRequest{
 			Update: &container.ClusterUpdate{
 				DesiredFleet: expandFleet(d.Get("fleet")),
@@ -5992,6 +6003,7 @@ func flattenFleet(c *container.Fleet) []map[string]interface{} {
                 {
                       "project": c.Project,
                       "membership": c.Membership,
+		      "pre_registered": c.PreRegistered,
                 },
         }       
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -3963,6 +3963,11 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 				DesiredFleet:  expandFleet(v),
 			}
 		}
+		updateF := updateFunc(req, "updating GKE cluster fleet config")
+		// Call update serially.
+		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			return err
+		}
 		log.Printf("[INFO] GKE cluster %s fleet config has been updated", d.Id())
 	}
 

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -5158,15 +5158,12 @@ func expandGatewayApiConfig(configured interface{}) *container.GatewayAPIConfig 
 }
 
 func expandFleet(configured interface{}) *container.Fleet {
-        l := configured.([]interface{})
-        if len(l) == 0 || l[0] == nil {
-                return nil 
-        }       
+	l := configured.([]interface{})
+	v := &container.Fleet{}
 
-        config := l[0].(map[string]interface{})
-        return &container.Fleet{
-                Project: config["project"].(string),
-        }       
+	config := l[0].(map[string]interface{})
+	v.Project = config["project"].(string)
+	return v
 }  
 
 func expandEnableK8sBetaApis(configured interface{}, enabledAPIs []string) *container.K8sBetaAPIConfig {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -3938,21 +3938,19 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if d.HasChange("fleet") {
-		if fleet, ok := d.GetOk("fleet"); ok {
-			req := &container.UpdateClusterRequest{
-				Update: &container.ClusterUpdate{
-					DesiredFleet: expandFleet(fleet),
-				},
-			}
-
-			updateF := updateFunc(req, "updating GKE fleet config")
-			// Call update serially.
-			if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
-				return err
-			}
-
-			log.Printf("[INFO] GKE cluster %s fleet config has been updated", d.Id())
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				DesiredFleet: expandFleet(fleet),
+			},
 		}
+
+		updateF := updateFunc(req, "updating GKE fleet config")
+		// Call update serially.
+		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] GKE cluster %s fleet config has been updated", d.Id())
 	}
 
 	if d.HasChange("enable_k8s_beta_apis") {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -3948,17 +3948,20 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if d.HasChange("fleet") {
-		req := &container.UpdateClusterRequest{
-			Update: &container.ClusterUpdate{
-				DesiredFleet: expandFleet(d.Get("fleet")),
-			},
-		}
-		log.Printf("[INFO] GKE cluster %s fleet config has been updated, fleet=%v, req=%v", d.Get("fleet"), req)
-
-		updateF := updateFunc(req, "updating GKE fleet config")
-		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
-			return err
+		// Because GKE uses a non-RESTful update function, when removing the
+		// feature you need to specify a fairly full request body or it fails:
+		// "update": {"desiredFleet": {"project": ""}}
+		req := &container.UpdateClusterRequest{}
+		if v, ok := d.GetOk("fleet"); !ok {
+			req.Update = &container.ClusterUpdate{
+				DesiredFleet: &container.Fleet{
+					Fleet: "",
+				},
+			}
+		} else {
+			req.Update = &container.ClusterUpdate{
+				DesiredWorkloadIdentityConfig:  expandFleet(v),
+			}
 		}
 		log.Printf("[INFO] GKE cluster %s fleet config has been updated", d.Id())
 	}
@@ -5159,11 +5162,14 @@ func expandGatewayApiConfig(configured interface{}) *container.GatewayAPIConfig 
 
 func expandFleet(configured interface{}) *container.Fleet {
 	l := configured.([]interface{})
-	v := &container.Fleet{}
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
 
 	config := l[0].(map[string]interface{})
-	v.Project = config["project"].(string)
-	return v
+	return &container.Fleet{
+		Project: config["project"].(string),
+	}
 }  
 
 func expandEnableK8sBetaApis(configured interface{}, enabledAPIs []string) *container.K8sBetaAPIConfig {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -2040,6 +2040,28 @@ func ResourceContainerCluster() *schema.Resource {
 					},
 				},
 			},
+			"fleet": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				MaxItems:    1,
+				Description: `Fleet configuration of the cluster.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"project": {
+							Type:         schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description:  `The Fleet host project of the cluster.`,
+						},
+                                          	"membership": {
+                                                	Type:             schema.TypeString,
+                                                	Computed:         true,
+                                                	Description:      `Full resource name of the registered fleet membership of the cluster.`
+                                          	},
+					},
+				},
+			},
 		},
 	}
 }
@@ -2331,6 +2353,10 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 
 	if v, ok := d.GetOk("monitoring_config"); ok {
 		cluster.MonitoringConfig = expandMonitoringConfig(v)
+	}
+
+	if v, ok := d.GetOk("fleet"); ok {
+		cluster.Fleet = expandFleet(v)
 	}
 
 	if err := validateNodePoolAutoConfig(cluster); err != nil {
@@ -2786,6 +2812,9 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 	if err := d.Set("gateway_api_config", flattenGatewayApiConfig(cluster.NetworkConfig.GatewayApiConfig)); err != nil {
+		return err
+	}
+	if err := d.Set("fleet", flattenFleet(cluster.Fleet)); err != nil {
 		return err
 	}
 	if err := d.Set("enable_k8s_beta_apis", flattenEnableK8sBetaApis(cluster.EnableK8sBetaApis)); err != nil {
@@ -3905,6 +3934,24 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			}
 
 			log.Printf("[INFO] GKE cluster %s Gateway API has been updated", d.Id())
+		}
+	}
+
+	if d.HasChange("fleet") {
+		if fleet, ok := d.GetOk("fleet"); ok {
+			req := &container.UpdateClusterRequest{
+				Update: &container.ClusterUpdate{
+					DesiredFleet: expandFleet(fleet),
+				},
+			}
+
+			updateF := updateFunc(req, "updating GKE fleet config")
+			// Call update serially.
+			if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+				return err
+			}
+
+			log.Printf("[INFO] GKE cluster %s fleet config has been updated", d.Id())
 		}
 	}
 
@@ -5102,6 +5149,18 @@ func expandGatewayApiConfig(configured interface{}) *container.GatewayAPIConfig 
 	}
 }
 
+func expandFleet(configured interface{}) *container.Fleet {
+        l := configured.([]interface{})
+        if len(l) == 0 || l[0] == nil {
+                return nil 
+        }       
+
+        config := l[0].(map[string]interface{})
+        return &container.Fleet{
+                Project: config["project"].(string),
+        }       
+}  
+
 func expandEnableK8sBetaApis(configured interface{}, enabledAPIs []string) *container.K8sBetaAPIConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
@@ -5925,6 +5984,18 @@ func flattenGatewayApiConfig(c *container.GatewayAPIConfig) []map[string]interfa
 			"channel":        c.Channel,
 		},
 	}
+}
+
+func flattenFleet(c *container.Fleet) []map[string]interface{} {
+      if c == nil {
+                return nil
+      }         
+      return []map[string]interface{}{
+                {
+                      "project": c.Project,
+                      "membership": c.Membership,
+                },
+        }       
 }
 
 func flattenEnableK8sBetaApis(c *container.K8sBetaAPIConfig) []map[string]interface{} {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -2057,7 +2057,7 @@ func ResourceContainerCluster() *schema.Resource {
                                           	"membership": {
                                                 	Type:             schema.TypeString,
                                                 	Computed:         true,
-                                                	Description:      `Full resource name of the registered fleet membership of the cluster.`
+                                                	Description:      `Full resource name of the registered fleet membership of the cluster.`,
                                           	},
 					},
 				},

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -2045,13 +2045,15 @@ func ResourceContainerCluster() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				MaxItems:    1,
+				ConfigMode: schema.SchemaConfigModeAttr,
 				Description: `Fleet configuration of the cluster.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"project": {
 							Type:         schema.TypeString,
-							Optional:    true,
-							Computed:    true,
+							Optional:     true,
+							Computed:     true,
+							ConfigMode:   schema.SchemaConfigModeAttr,
 							Description:  `The Fleet host project of the cluster.`,
 						},
                                           	"membership": {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -3948,21 +3948,19 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if d.HasChange("fleet") {
-		if fleet, ok := d.GetOk("fleet"); ok {
-			req := &container.UpdateClusterRequest{
-				Update: &container.ClusterUpdate{
-					DesiredFleet: expandFleet(fleet),
-				},
-			}
-                        log.Printf("[INFO] GKE cluster %s fleet config has been updated, fleet=%v, req=%v", fleet, req)
-
-			updateF := updateFunc(req, "updating GKE fleet config")
-			// Call update serially.
-			if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
-				return err
-			}
-			log.Printf("[INFO] GKE cluster %s fleet config has been updated", d.Id())
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				DesiredFleet: expandFleet(d.Get("fleet")),
+			},
 		}
+		log.Printf("[INFO] GKE cluster %s fleet config has been updated, fleet=%v, req=%v", fleet, req)
+
+		updateF := updateFunc(req, "updating GKE fleet config")
+		// Call update serially.
+		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			return err
+		}
+		log.Printf("[INFO] GKE cluster %s fleet config has been updated", d.Id())
 	}
 
 	if d.HasChange("enable_k8s_beta_apis") {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -819,6 +819,7 @@ func ResourceContainerCluster() *schema.Resource {
 									"evaluation_mode": {
 											Type:          schema.TypeString,
 											Optional:      true,
+                     									Computed:      true,
 											ValidateFunc:  validation.StringInSlice([]string{"DISABLED", "PROJECT_SINGLETON_POLICY_ENFORCE"}, false),
 											Description:   "Mode of operation for Binary Authorization policy evaluation.",
 											ConflictsWith: []string{"binary_authorization.0.enabled"},

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -3940,7 +3940,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	if d.HasChange("fleet") {
 		req := &container.UpdateClusterRequest{
 			Update: &container.ClusterUpdate{
-				DesiredFleet: expandFleet(fleet),
+				DesiredFleet: expandFleet(d.Get("fleet")),
 			},
 		}
 

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -2043,9 +2043,7 @@ func ResourceContainerCluster() *schema.Resource {
 			"fleet": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				Computed:    true,
 				MaxItems:    1,
-				ConfigMode: schema.SchemaConfigModeAttr,
 				Description: `Fleet configuration of the cluster.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -2053,7 +2051,6 @@ func ResourceContainerCluster() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Computed:     true,
-							ConfigMode:   schema.SchemaConfigModeAttr,
 							Description:  `The Fleet host project of the cluster.`,
 						},
                                           	"membership": {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -3953,7 +3953,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 				DesiredFleet: expandFleet(d.Get("fleet")),
 			},
 		}
-		log.Printf("[INFO] GKE cluster %s fleet config has been updated, fleet=%v, req=%v", fleet, req)
+		log.Printf("[INFO] GKE cluster %s fleet config has been updated, fleet=%v, req=%v", d.Get("fleet"), req)
 
 		updateF := updateFunc(req, "updating GKE fleet config")
 		// Call update serially.

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -4252,8 +4252,7 @@ func TestAccContainerCluster_withFleetConfig(t *testing.T) {
 			},
 			{
 				Config:		testAccContainerCluster_withFleetConfig(clusterName, "random-project"),
-				ExpectError: regexp.MustCompile(`(1) changing existing fleet host project is not supported
-				(2) changing existing fleet membership is not supported.`),
+				ExpectError: regexp.MustCompile(`\n\t(1) changing existing fleet host project is not supported\n\t(2) changing existing fleet membership is not supported`),
 			},
 			{
 				Config: testAccContainerCluster_DisableFleet(clusterName),

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -4252,7 +4252,7 @@ func TestAccContainerCluster_withFleetConfig(t *testing.T) {
 			},
 			{
 				Config:		testAccContainerCluster_withFleetConfig(clusterName, "random-project"),
-				ExpectError: regexp.MustCompile(`\n\t(1) changing existing fleet host project is not supported\n\t(2) changing existing fleet membership is not supported`),
+				ExpectError: regexp.MustCompile(`changing existing fleet host project is not supported`),
 			},
 			{
 				Config: testAccContainerCluster_DisableFleet(clusterName),

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -4251,6 +4251,11 @@ func TestAccContainerCluster_withFleetConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
 			},
 			{
+				Config:		testAccContainerCluster_withFleetConfig(clusterName, "random-project"),
+				ExpectError: regexp.MustCompile(`(1) changing existing fleet host project is not supported
+				(2) changing existing fleet membership is not supported.`),
+			},
+			{
 				Config: testAccContainerCluster_DisableFleet(clusterName),
 			},
 			{
@@ -4281,7 +4286,7 @@ resource "google_container_cluster" "primary" {
 
 func testAccContainerCluster_DisableFleet(resource_name string) string {
 	return fmt.Sprintf(`
-resource "google_container_cluster" "with_security_posture_config" {
+resource "google_container_cluster" "primary" {
   name               = "%s"
   location           = "us-central1-a"
   initial_node_count = 1

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -4235,6 +4235,8 @@ func TestAccContainerCluster_withFleetConfig(t *testing.T) {
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
 	projectID := envvar.GetTestProjectFromEnv()
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -4242,7 +4244,7 @@ func TestAccContainerCluster_withFleetConfig(t *testing.T) {
 		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withFleetConfig(clusterName, projectID),
+				Config: testAccContainerCluster_withFleetConfig(clusterName, projectID, networkName, subnetworkName),
 			},
 			{
 				ResourceName:            "google_container_cluster.primary",
@@ -4250,11 +4252,20 @@ func TestAccContainerCluster_withFleetConfig(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
 			},
+			{
+				Config: testAccContainerCluster_DisableFleet(clusterName, networkName, subnetworkName),
+			},
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
 		},
 	})
 }
 
-func testAccContainerCluster_withFleetConfig(name, projectID string) string {
+func testAccContainerCluster_withFleetConfig(name, projectID, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
   name               = "%s"
@@ -4264,9 +4275,25 @@ resource "google_container_cluster" "primary" {
   fleet {
 	project = "%s"
   }
+
   deletion_protection = false
+  network    = "%s"
+  subnetwork    = "%s"
 }
-`, name, projectID)
+`, name, projectID, networkName, subnetworkName)
+}
+
+func testAccContainerCluster_DisableFleet(resource_name, networkName, subnetworkName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_security_posture_config" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  deletion_protection = false
+  network    = "%s"
+  subnetwork    = "%s"
+}
+`, resource_name, networkName, subnetworkName)
 }
 
 func testAccContainerCluster_SetSecurityPostureToStandard(resource_name, networkName, subnetworkName string) string {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -4235,8 +4235,6 @@ func TestAccContainerCluster_withFleetConfig(t *testing.T) {
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
 	projectID := envvar.GetTestProjectFromEnv()
-	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -4244,7 +4242,7 @@ func TestAccContainerCluster_withFleetConfig(t *testing.T) {
 		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withFleetConfig(clusterName, projectID, networkName, subnetworkName),
+				Config: testAccContainerCluster_withFleetConfig(clusterName, projectID),
 			},
 			{
 				ResourceName:            "google_container_cluster.primary",
@@ -4253,7 +4251,7 @@ func TestAccContainerCluster_withFleetConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_DisableFleet(clusterName, networkName, subnetworkName),
+				Config: testAccContainerCluster_DisableFleet(clusterName),
 			},
 			{
 				ResourceName:      "google_container_cluster.primary",
@@ -4265,7 +4263,7 @@ func TestAccContainerCluster_withFleetConfig(t *testing.T) {
 	})
 }
 
-func testAccContainerCluster_withFleetConfig(name, projectID, networkName, subnetworkName string) string {
+func testAccContainerCluster_withFleetConfig(name, projectID string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
   name               = "%s"
@@ -4277,23 +4275,19 @@ resource "google_container_cluster" "primary" {
   }
 
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
 }
-`, name, projectID, networkName, subnetworkName)
+`, name, projectID)
 }
 
-func testAccContainerCluster_DisableFleet(resource_name, networkName, subnetworkName string) string {
+func testAccContainerCluster_DisableFleet(resource_name string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_security_posture_config" {
   name               = "%s"
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
 }
-`, resource_name, networkName, subnetworkName)
+`, resource_name)
 }
 
 func testAccContainerCluster_SetSecurityPostureToStandard(resource_name, networkName, subnetworkName string) string {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -9169,4 +9169,3 @@ resource "google_container_cluster" "without_confidential_boot_disk" {
 `, clusterName, npName)
 }
 <% end -%>
-

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -4230,6 +4230,45 @@ func TestAccContainerCluster_withSecurityPostureConfig(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_withFleetConfig(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	projectID := envvar.GetTestProjectFromEnv()
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withFleetConfig(clusterName, projectID),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
+			},
+		},
+	})
+}
+
+func testAccContainerCluster_withFleetConfig(name, projectID string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+
+  fleet {
+	project = "%s"
+  }
+  deletion_protection = false
+}
+`, name, projectID)
+}
+
 func testAccContainerCluster_SetSecurityPostureToStandard(resource_name, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_security_posture_config" {
@@ -9130,3 +9169,4 @@ resource "google_container_cluster" "without_confidential_boot_disk" {
 `, clusterName, npName)
 }
 <% end -%>
+

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -378,6 +378,9 @@ subnetwork in which the cluster's instances are launched.
 * `security_posture_config` - (Optional)
 Enable/Disable Security Posture API features for the cluster. Structure is [documented below](#nested_security_posture_config).
 
+* `fleet` - (Optional)
+Fleet configuration for the cluster. Structure is [documented below](#nested_fleet).
+
 <a name="nested_default_snat_status"></a>The `default_snat_status` block supports
 
 *  `disabled` - (Required) Whether the cluster disables default in-node sNAT rules. In-node sNAT rules will be disabled when defaultSnatStatus is disabled.When disabled is set to false, default IP masquerade rules will be applied to the nodes to prevent sNAT on cluster internal traffic
@@ -1282,7 +1285,7 @@ linux_node_config {
 
 * `vulnerability_mode` - (Optional) Sets the mode of the Kubernetes security posture API's workload vulnerability scanning. Available options include `VULNERABILITY_DISABLED`, `VULNERABILITY_BASIC` and `VULNERABILITY_ENTERPRISE`.
 
-<a name="nested_security_posture_config"></a>The `fleet` block supports:
+<a name="nested_fleet"></a>The `fleet` block supports:
 
 * `project` - (Optional) The name of the Fleet host project where this cluster will be registered.
 
@@ -1330,7 +1333,7 @@ exported:
 
 * `node_config.0.effective_taints` - List of kubernetes taints applied to each node. Structure is [documented above](#nested_taint).
 
-* `fleet.0.membership` - The resource name of the fleet Membership resource associated to this cluster with format `projects/{{project}}/locations/{{location}}/memberships/{{name}}`. See the official doc for [fleet management]((https://cloud.google.com/kubernetes-engine/docs/fleets-overview)). 
+* `fleet.0.membership` - The resource name of the fleet Membership resource associated to this cluster with format `//gkehub.googleapis.com/projects/{{project}}/locations/{{location}}/memberships/{{name}}`. See the official doc for [fleet management](https://cloud.google.com/kubernetes-engine/docs/fleets-overview). 
 
 ## Timeouts
 

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1282,6 +1282,10 @@ linux_node_config {
 
 * `vulnerability_mode` - (Optional) Sets the mode of the Kubernetes security posture API's workload vulnerability scanning. Available options include `VULNERABILITY_DISABLED`, `VULNERABILITY_BASIC` and `VULNERABILITY_ENTERPRISE`.
 
+<a name="nested_security_posture_config"></a>The `fleet` block supports:
+
+* `project` - (Optional) The name of the Fleet host project where this cluster will be registered.
+
 
 ## Attributes Reference
 
@@ -1325,6 +1329,8 @@ exported:
 * `cluster_autoscaling.0.auto_provisioning_defaults.0.management.0.upgrade_options` - Specifies the [Auto Upgrade knobs](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/NodeManagement#AutoUpgradeOptions) for the node pool.
 
 * `node_config.0.effective_taints` - List of kubernetes taints applied to each node. Structure is [documented above](#nested_taint).
+
+* `fleet.0.membership` - The resource name of the fleet Membership resource associated to this cluster with format `projects/{{project}}/locations/{{location}}/memberships/{{name}}`. See the official doc for [fleet management]((https://cloud.google.com/kubernetes-engine/docs/fleets-overview)). 
 
 ## Timeouts
 


### PR DESCRIPTION
### Changes in this PR: 

- Support fleet field in `google_container_cluster` resource. Example usage: 
  - Set fleet config eg.`fleet {project = "my-project"}`.
  - Remove fleet config by removing the fleet block.
 
- Add DiffSuppressFunc for fleet field when `fleet.pre_registered = true`: 
  - Today Fleet config could be generated by server (and fleet.pre-registered will be true in this case). Suppress diff for this case. 

- Mark `binary_authorization.evaluation_mode` field as computed:
  -  When creating the cluster resource with fleet config, container API server will populate value for `binary_authorization.evaluation_mode`. So we need to mark this field as computed.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added `fleet` field to `google_container_cluster` resource
```

```release-note:enhancement
container: marked `binary_authorization.evaluation_mode` field as computed and optional in `google_container_cluster` resource
```
