### PR TITLE
Adding missing pingsCount, userLabels, and customContentType fields

### DIFF
--- a/mmv1/products/monitoring/UptimeCheckConfig.yaml
+++ b/mmv1/products/monitoring/UptimeCheckConfig.yaml
@@ -172,6 +172,15 @@ properties:
       - :STATIC_IP_CHECKERS
       - :VPC_CHECKERS
     default_from_api: true
+  - !ruby/object:Api::Type::KeyValuePairs
+    name: userLabels
+    description:
+      User-supplied key/value data to be used for organizing and
+      identifying the `UptimeCheckConfig` objects.
+      The field can contain up to 64 entries. Each key and value is limited to
+      63 Unicode characters or 128 bytes, whichever is smaller. Labels and
+      values can contain only lowercase letters, numerals, underscores, and
+      dashes. Keys must begin with a letter.
   - !ruby/object:Api::Type::NestedObject
     name: httpCheck
     description: Contains information needed to make an HTTP or HTTPS check.
@@ -193,6 +202,16 @@ properties:
         values:
           - :TYPE_UNSPECIFIED
           - :URL_ENCODED
+          - :USER_PROVIDED
+      - !ruby/object:Api::Type::String
+        name: customContentType
+        description:
+          A user provided content type header to use for the check. The invalid
+          configurations outlined in the `content_type` field apply to
+          custom_content_type`, as well as the following
+            1. `content_type` is `URL_ENCODED` and `custom_content_type` is set.
+            2. `content_type` is `USER_PROVIDED` and `custom_content_type` is not
+            set.
       - !ruby/object:Api::Type::NestedObject
         name: authInfo
         at_least_one_of:
@@ -330,6 +349,16 @@ properties:
                 - :STATUS_CLASS_4XX
                 - :STATUS_CLASS_5XX
                 - :STATUS_CLASS_ANY
+      - !ruby/object:Api::Type::NestedObject
+        name: pingConfig
+        description:
+          Contains information needed to add pings to an HTTP check.
+        properties:
+          - !ruby/object:Api::Type::Integer
+            name: pingsCount
+            required: true
+            description:
+              Number of ICMP pings. A maximum of 3 ICMP pings is currently supported.
   - !ruby/object:Api::Type::NestedObject
     name: tcpCheck
     description: Contains information needed to make a TCP check.
@@ -341,6 +370,16 @@ properties:
           The port to the page to run the check against. Will be combined with
           host (specified within the MonitoredResource) to construct the full
           URL.
+      - !ruby/object:Api::Type::NestedObject
+        name: pingConfig
+        description:
+          Contains information needed to add pings to a TCP check.
+        properties:
+          - !ruby/object:Api::Type::Integer
+            name: pingsCount
+            required: true
+            description:
+              Number of ICMP pings. A maximum of 3 ICMP pings is currently supported.
   - !ruby/object:Api::Type::NestedObject
     name: resourceGroup
     immutable: true

--- a/mmv1/templates/terraform/examples/uptime_check_config_http.tf.erb
+++ b/mmv1/templates/terraform/examples/uptime_check_config_http.tf.erb
@@ -1,13 +1,20 @@
 resource "google_monitoring_uptime_check_config" "<%= ctx[:primary_resource_id] %>" {
   display_name = "<%= ctx[:vars]["display_name"] %>"
   timeout      = "60s"
+  user_labels  = {
+    example-key = "example-value"
+  }
 
   http_check {
     path = "some-path"
     port = "8010"
     request_method = "POST"
-    content_type = "URL_ENCODED"
+    content_type = "USER_PROVIDED"
+    custom_content_type = "application/json"
     body = "Zm9vJTI1M0RiYXI="
+    ping_config {
+      pings_count = 1
+    }
   }
 
   monitored_resource {

--- a/mmv1/templates/terraform/examples/uptime_check_tcp.tf.erb
+++ b/mmv1/templates/terraform/examples/uptime_check_tcp.tf.erb
@@ -4,6 +4,9 @@ resource "google_monitoring_uptime_check_config" "<%= ctx[:primary_resource_id] 
 
   tcp_check {
     port = 888
+    ping_config {
+      pings_count = 2
+    }
   }
 
   resource_group {


### PR DESCRIPTION
Add fields present in the Uptime Check API that were missing from the corresponding terraform files.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/13001
Fixes https://github.com/hashicorp/terraform-provider-google/issues/14285
Fixes https://github.com/hashicorp/terraform-provider-google/issues/14724

```release-note:enhancement
monitoring: added `pings_count`, `user_labels`, and `custom_content_type` fields to `google_monitoring_uptime_check_config` resource
```
