### PR TITLE
[GKE Hub]: Add Fleet default cluster config

### DIFF
--- a/mmv1/products/gkehub2/Fleet.yaml
+++ b/mmv1/products/gkehub2/Fleet.yaml
@@ -49,7 +49,7 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: "gkehub_fleet_basic"
     skip_test: true
-    primary_resource_id: 'default'
+    primary_resource_id: "default"
 id_format: "projects/{{project}}/locations/global/fleets/default"
 import_format: ["projects/{{project}}/locations/global/fleets/default"]
 properties:
@@ -95,3 +95,25 @@ properties:
           - READY
           - DELETING
           - UPDATING
+  - !ruby/object:Api::Type::NestedObject
+    name: "defaultClusterConfig"
+    description: The default cluster configurations to apply across the fleet.
+    properties:
+      - !ruby/object:Api::Type::NestedObject
+        name: "securityPostureConfig"
+        description: Enable/Disable Security Posture features for the cluster.
+        properties:
+          - !ruby/object:Api::Type::Enum
+            name: "mode"
+            description: Sets which mode to use for Security Posture features.
+            values:
+              - DISABLED
+              - BASIC
+              - ENTERPRISE
+          - !ruby/object:Api::Type::Enum
+            name: "vulnerabilityMode"
+            description: Sets which mode to use for vulnerability scanning.
+            values:
+              - VULNERABILITY_DISABLED
+              - VULNERABILITY_BASIC
+              - VULNERABILITY_ENTERPRISE

--- a/mmv1/templates/terraform/examples/gkehub_fleet_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/gkehub_fleet_basic.tf.erb
@@ -1,3 +1,9 @@
 resource "google_gke_hub_fleet" "default" {
   display_name = "my production fleet"
+  default_cluster_config {
+    security_posture_config {
+      mode = "DISABLED"
+      vulnerability_mode = "VULNERABILITY_DISABLED"
+    }
+  }
 }

--- a/mmv1/templates/terraform/examples/gkehub_fleet_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/gkehub_fleet_basic.tf.erb
@@ -1,5 +1,6 @@
 resource "google_gke_hub_fleet" "default" {
   display_name = "my production fleet"
+  
   default_cluster_config {
     security_posture_config {
       mode = "DISABLED"

--- a/mmv1/templates/terraform/examples/gkehub_fleet_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/gkehub_fleet_basic.tf.erb
@@ -1,6 +1,5 @@
 resource "google_gke_hub_fleet" "default" {
   display_name = "my production fleet"
-  
   default_cluster_config {
     security_posture_config {
       mode = "DISABLED"

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_fleet_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_fleet_test.go.erb
@@ -57,7 +57,12 @@ func testAccGKEHub2Fleet_basic(context map[string]interface{}) string {
 resource "google_gke_hub_fleet" "default" {
   project = google_project.project.project_id
   display_name = "my production fleet"
-
+  default_cluster_config { 
+	security_posture_config {
+		mode = "DISABLED"
+		vulnerability_mode = "VULNERABILITY_DISABLED"
+	}
+  }
   depends_on = [time_sleep.wait_for_gkehub_enablement]
 }
 `, context)
@@ -68,7 +73,12 @@ func testAccGKEHub2Fleet_update(context map[string]interface{}) string {
 resource "google_gke_hub_fleet" "default" {
   project = google_project.project.project_id
   display_name = "my staging fleet"
-
+  default_cluster_config {
+	security_posture_config {
+		mode = "BASIC"
+		vulnerability_mode = "VULNERABILITY_BASIC"
+	}
+  }
   depends_on = [time_sleep.wait_for_gkehub_enablement]
 }
 `, context)
@@ -86,6 +96,12 @@ resource "google_project" "project" {
 resource "google_project_service" "gkehub" {
   project = google_project.project.project_id
   service = "gkehub.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "anthos" {
+  project = google_project.project.project_id
+  service = "anthos.googleapis.com"
   disable_on_destroy = false
 }
 


### PR DESCRIPTION
Adds new default cluster config fields to GKEHub resource "Fleet." 

b/296461330


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
GKEHub: added `defaultClusterConfig` to `Fleet` resource
```
