### PR TITLE
Fix the test TestAccTpuV2Vm_tpuV2VmBasicExample

### DIFF
--- a/mmv1/products/tpuv2/Vm.yaml
+++ b/mmv1/products/tpuv2/Vm.yaml
@@ -55,6 +55,17 @@ examples:
     primary_resource_id: 'tpu'
     vars:
       vm_name: 'test-tpu'
+    skip_test: true
+  # The purpose to have this test is to solve the issue
+  # "There is no more capacity in the zone"
+  # and not modify the documentation for the users
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'tpu_v2_vm_basic_test'
+    min_version: 'beta'
+    primary_resource_id: 'tpu'
+    vars:
+      vm_name: 'test-tpu'
+    skip_docs: true
   - !ruby/object:Provider::Terraform::Examples
     name: 'tpu_v2_vm_full'
     min_version: 'beta'

--- a/mmv1/templates/terraform/examples/tpu_v2_vm_basic_test.tf.erb
+++ b/mmv1/templates/terraform/examples/tpu_v2_vm_basic_test.tf.erb
@@ -1,0 +1,16 @@
+data "google_tpu_v2_runtime_versions" "available" {
+  provider = google-beta
+}
+
+resource "google_tpu_v2_vm" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+
+  name = "<%= ctx[:vars]["vm_name"] %>"
+  zone = "us-central1-c"
+
+  runtime_version = "tpu-vm-tf-2.13.0"
+
+  scheduling_config {
+    preemptible = true
+  }
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Try to fix the test `TestAccTpuV2Vm_tpuV2VmBasicExample`, which failed with the error

```
------- Stdout: -------
=== RUN   TestAccTpuV2Vm_tpuV2VmBasicExample
=== PAUSE TestAccTpuV2Vm_tpuV2VmBasicExample
=== CONT  TestAccTpuV2Vm_tpuV2VmBasicExample
    vcr_utils.go:152: Step 1/2 error: Error running apply: exit status 1
        Error: Error waiting to create Vm: Error waiting for Creating Vm: Error code 8, message: There is no more capacity in the zone "us-central1-c"; you can try in another zone where Cloud TPU Nodes are offered (see https://cloud.google.com/tpu/docs/regions) [EID: 0x9171da80a38afc2]
          with google_tpu_v2_vm.tpu,
          on terraform_plugin_test.tf line 6, in resource "google_tpu_v2_vm" "tpu":
           6: resource "google_tpu_v2_vm" "tpu" {
--- FAIL: TestAccTpuV2Vm_tpuV2VmBasicExample (31.10s)
FAIL
```

If the test still fails with the same reason after this change is merged, we need to  revert this change and consider other ways to address the capacity issue.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
