### PR TITLE
fix: remove unsupported config Cloud Spanner autoscaler configuraiton

### DIFF
--- a/mmv1/products/spanner/Instance.yaml
+++ b/mmv1/products/spanner/Instance.yaml
@@ -142,6 +142,7 @@ properties:
     exactly_one_of:
       - num_nodes
       - processing_units
+      - autoscaling_config
     default_from_api: true
   - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'

--- a/mmv1/products/spanner/Instance.yaml
+++ b/mmv1/products/spanner/Instance.yaml
@@ -134,6 +134,7 @@ properties:
     exactly_one_of:
       - num_nodes
       - processing_units
+      - autoscaling_config
   - !ruby/object:Api::Type::Integer
     name: 'processingUnits'
     description: |
@@ -164,6 +165,10 @@ properties:
       When autoscaling is enabled, num_nodes and processing_units are treated as,
       OUTPUT_ONLY fields and reflect the current compute capacity allocated to
       the instance.
+    exactly_one_of:
+      - num_nodes
+      - processing_units
+      - autoscaling_config
     properties:
       - !ruby/object:Api::Type::NestedObject
         name: 'autoscalingLimits'

--- a/mmv1/products/spanner/Instance.yaml
+++ b/mmv1/products/spanner/Instance.yaml
@@ -170,50 +170,17 @@ properties:
           Defines scale in controls to reduce the risk of response latency
           and outages due to abrupt scale-in events
         properties:
-          - !ruby/object:Api::Type::NestedObject
-            name: 'minLimit'
+          - !ruby/object:Api::Type::Integer
+            name: 'minProcessingUnits'
             description: |
-              Specifies the minimum compute capacity for the instance.
-            properties:
-              - !ruby/object:Api::Type::Integer
-                name: 'minNodes'
-                exactly_one_of:
-                  - min_nodes
-                  - min_processing_units
-                description: |
-                  Specifies minimum number of processing units allocated to the instance.
-                  If set, this number should be greater than or equal to 1.
-              - !ruby/object:Api::Type::Integer
-                name: 'minProcessingUnits'
-                exactly_one_of:
-                  - min_nodes
-                  - min_processing_units
-                description: |
-                  Specifies minimum number of processing units allocated to the instance.
-                  If set, this number should be multiples of 1000.
-          - !ruby/object:Api::Type::NestedObject
-            name: 'maxLimit'
+              Specifies minimum number of processing units allocated to the instance.
+              If set, this number should be multiples of 1000.
+          - !ruby/object:Api::Type::Integer
+            name: 'maxProcessingUnits'
             description: |
-              Specifies the maximum compute capacity for the instance.
-              The maximum compute capacity should be less than or equal to 10X the minimum compute capacity.
-            properties:
-              - !ruby/object:Api::Type::Integer
-                name: 'maxNodes'
-                exactly_one_of:
-                  - max_nodes
-                  - max_processing_units
-                description: |
-                  Specifies maximum number of nodes allocated to the instance.
-                  If set, this number should be greater than or equal to min_nodes.
-              - !ruby/object:Api::Type::Integer
-                name: 'maxProcessingUnits'
-                exactly_one_of:
-                  - max_nodes
-                  - max_processing_units
-                description: |
-                  Specifies maximum number of processing units allocated to the instance.
-                  If set, this number should be multiples of 1000 and be greater than or equal to
-                  min_processing_units.
+              Specifies maximum number of processing units allocated to the instance.
+              If set, this number should be multiples of 1000 and be greater than or equal to
+              min_processing_units.
       - !ruby/object:Api::Type::NestedObject
         name: 'autoscalingTargets'
         description: |

--- a/mmv1/templates/terraform/encoders/spanner_instance.go.erb
+++ b/mmv1/templates/terraform/encoders/spanner_instance.go.erb
@@ -1,5 +1,5 @@
-// Temp Logic to accommodate processing_units and num_nodes
-if obj["processingUnits"] == nil && obj["nodeCount"] == nil {
+// Temp Logic to accommodate autoscaling_config, processing_units and num_nodes
+if obj["processingUnits"] == nil && obj["nodeCount"] == nil && obj["autoscalingConfig"] == nil {
 	obj["nodeCount"] = 1
 }
 newObj := make(map[string]interface{})

--- a/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
+++ b/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
@@ -47,7 +47,7 @@ func TestAccSpannerInstance_noNodeCountSpecified(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccSpannerInstance_noNodeCountSpecified(idName),
-				ExpectError: regexp.MustCompile("one of `autoscaling_config,num_nodes,processing_units` must be specified"),
+				ExpectError: regexp.MustCompile(".*one of `autoscaling_config,num_nodes,processing_units` must be specified.*"),
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
+++ b/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
@@ -142,32 +142,6 @@ func TestAccSpannerInstance_virtualUpdate(t *testing.T) {
 	})
 }
 
-func TestAccSpannerInstance_basicWithAutoscalingUsingNodeConfig(t *testing.T) {
-	// Randomness
-	acctest.SkipIfVcr(t)
-	t.Parallel()
-
-	displayName := fmt.Sprintf("spanner-test-%s-dname", acctest.RandString(t, 10))
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckSpannerInstanceDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSpannerInstance_basicWithAutoscalerConfigUsingNodeAsConfigs(displayName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
-				),
-			},
-			{
-				ResourceName:      "google_spanner_instance.basic",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccSpannerInstance_basicWithAutoscalingUsingProcessingUnitConfig(t *testing.T) {
 	// Randomness
 	acctest.SkipIfVcr(t)
@@ -256,31 +230,6 @@ resource "google_spanner_instance" "basic" {
 `, name, name, virtual)
 }
 
-func testAccSpannerInstance_basicWithAutoscalerConfigUsingNodeAsConfigs(name string) string {
-	return fmt.Sprintf(`
-resource "google_spanner_instance" "basic" {
-  name         = "%s"
-  config       = "regional-us-central1"
-  display_name = "%s-dname"
-  num_nodes    = 1
-  autoscaling_config {
-    autoscaling_limits {
-      max_limit {
-        max_nodes            = 2
-      }
-      min_limit {
-        min_nodes            = 1
-      }
-    }
-    autoscaling_targets {
-      high_priority_cpu_utilization_percent = 65
-      storage_utilization_percent           = 95
-    }
-  }
-}
-`, name, name)
-}
-
 func testAccSpannerInstance_basicWithAutoscalerConfigUsingProcessingUnitsAsConfigs(name string) string {
 	return fmt.Sprintf(`
 resource "google_spanner_instance" "basic" {
@@ -290,12 +239,8 @@ resource "google_spanner_instance" "basic" {
   num_nodes    = 1
   autoscaling_config {
     autoscaling_limits {
-      max_limit {
-        max_processing_units            = 2000
-      }
-      min_limit {
-        min_processing_units            = 1000
-      }
+      max_processing_units            = 2000
+      min_processing_units            = 1000
     }
     autoscaling_targets {
       high_priority_cpu_utilization_percent = 65

--- a/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
+++ b/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
@@ -47,7 +47,7 @@ func TestAccSpannerInstance_noNodeCountSpecified(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccSpannerInstance_noNodeCountSpecified(idName),
-				ExpectError: regexp.MustCompile(".*one of `autoscaling_config,num_nodes,processing_units` must be specified.*"),
+				ExpectError: regexp.MustCompile(".*one of `autoscaling_config,num_nodes,processing_units`\nmust be specified.*"),
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
+++ b/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
@@ -47,7 +47,7 @@ func TestAccSpannerInstance_noNodeCountSpecified(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccSpannerInstance_noNodeCountSpecified(idName),
-				ExpectError: regexp.MustCompile("one of `num_nodes,processing_units` must be specified"),
+				ExpectError: regexp.MustCompile("one of `autoscaling_config,num_nodes,processing_units` must be specified"),
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
+++ b/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
@@ -143,8 +143,6 @@ func TestAccSpannerInstance_virtualUpdate(t *testing.T) {
 }
 
 func TestAccSpannerInstance_basicWithAutoscalingUsingProcessingUnitConfig(t *testing.T) {
-	// Randomness
-	acctest.SkipIfVcr(t)
 	t.Parallel()
 
 	displayName := fmt.Sprintf("spanner-test-%s-dname", acctest.RandString(t, 10))

--- a/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
+++ b/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
@@ -233,7 +233,7 @@ func testAccSpannerInstance_basicWithAutoscalerConfigUsingProcessingUnitsAsConfi
 resource "google_spanner_instance" "basic" {
   name         = "%s"
   config       = "regional-us-central1"
-  display_name = "%s-dname"
+  display_name = "%s"
   num_nodes    = 1
   autoscaling_config {
     autoscaling_limits {

--- a/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
+++ b/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
@@ -234,7 +234,6 @@ resource "google_spanner_instance" "basic" {
   name         = "%s"
   config       = "regional-us-central1"
   display_name = "%s"
-  num_nodes    = 1
   autoscaling_config {
     autoscaling_limits {
       max_processing_units            = 2000


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/16436

Removes unsupported minNodes, maxNodes, maxLimit and minLimit fields from Cloud Spanner autoscaling config object

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
Fixes https://github.com/hashicorp/terraform-provider-google/issues/16436
```
