### PR TITLE
specify the duration format for the Pub/Sub message retention duration

### DIFF
--- a/mmv1/products/pubsub/Topic.yaml
+++ b/mmv1/products/pubsub/Topic.yaml
@@ -147,4 +147,5 @@ properties:
       For instance, it allows any attached subscription to seek to a timestamp
       that is up to messageRetentionDuration in the past. If this field is not
       set, message retention is controlled by settings on individual subscriptions.
-      Cannot be more than 31 days or less than 10 minutes.
+      The rotation period has the format of a decimal number, followed by the
+      letter `s` (seconds). Cannot be more than 31 days or less than 10 minutes.


### PR DESCRIPTION
When passing a string that doesn't end with an `s`, get the error message

> Invalid value at 'topic.message_retention_duration' (type.googleapis.com/google.protobuf.Duration), Field 'messageRetentionDuration', Illegal duration format; duration must end with 's'

Made the wording similar to the [KMS key rotation period](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key#rotation_period) description.




<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
pubsub: clarified the expected format for the `message_retention_duration`
```
