### PR TITLE
Add client config and permissions to google_identity_platform_config

### DIFF
--- a/mmv1/products/identityplatform/Config.yaml
+++ b/mmv1/products/identityplatform/Config.yaml
@@ -277,6 +277,7 @@ properties:
         output: true
         description: |
           API key that can be used when making requests for this project.
+        sensitive: true
       - !ruby/object:Api::Type::String
         name: 'firebaseSubdomain'
         output: true

--- a/mmv1/products/identityplatform/Config.yaml
+++ b/mmv1/products/identityplatform/Config.yaml
@@ -254,3 +254,31 @@ properties:
             description: |
               Two letter unicode region codes to allow as defined by https://cldr.unicode.org/ The full list of these region codes is here: https://github.com/unicode-cldr/cldr-localenames-full/blob/master/main/en/territories.json
             item_type: Api::Type::String
+  - !ruby/object:Api::Type::NestedObject
+    name: 'client'
+    description: |
+      Options related to how clients making requests on behalf of a project should be configured.
+    properties:
+      - !ruby/object:Api::Type::NestedObject
+        name: 'permissions'
+        description: |
+          Configuration related to restricting a user's ability to affect their account.
+        properties:
+          - !ruby/object:Api::Type::Boolean
+            name: 'disabledUserSignup'
+            description: |
+              When true, end users cannot sign up for a new account on the associated project through any of our API methods
+          - !ruby/object:Api::Type::Boolean
+            name: 'disabledUserDeletion'
+            description: |
+              When true, end users cannot delete their account on the associated project through any of our API methods
+      - !ruby/object:Api::Type::String
+        name: 'apiKey'
+        output: true
+        description: |
+          API key that can be used when making requests for this project.
+      - !ruby/object:Api::Type::String
+        name: 'firebaseSubdomain'
+        output: true
+        description: |
+          Firebase subdomain.

--- a/mmv1/templates/terraform/examples/identity_platform_config_minimal.tf.erb
+++ b/mmv1/templates/terraform/examples/identity_platform_config_minimal.tf.erb
@@ -16,7 +16,12 @@ resource "google_project_service" "identitytoolkit" {
 
 resource "google_identity_platform_config" "default" {
   project = google_project.default.project_id
-  
+  client {
+    permissions {
+      disabled_user_deletion = false
+      disabled_user_signup   = true
+    }
+  }
   depends_on = [
     google_project_service.identitytoolkit
   ]


### PR DESCRIPTION
Add client config and permissions to google_identity_platform_config

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
`google_identity_platform_config`: Add Client config and Permissions
```

Reference: hashicorp/terraform-provider-google/issues/14194