### PR TITLE
Add custom domain config to Cloud Workstations cluster

### DIFF
--- a/mmv1/products/workstations/WorkstationCluster.yaml
+++ b/mmv1/products/workstations/WorkstationCluster.yaml
@@ -63,6 +63,12 @@ examples:
     primary_resource_id: "default"
     vars:
       workstation_cluster_name: "workstation-cluster-private"
+  - !ruby/object:Provider::Terraform::Examples
+    name: "workstation_cluster_custom_domain"
+    min_version: beta
+    primary_resource_id: "default"
+    vars:
+      workstation_cluster_name: "workstation-cluster-custom-domain"
 parameters:
   - !ruby/object:Api::Type::String
     name: "workstationClusterId"
@@ -90,7 +96,7 @@ properties:
     description: |
       The system-generated UID of the resource.
   - !ruby/object:Api::Type::KeyValueLabels
-    name: 'labels'
+    name: "labels"
     description:
       "Client-specified labels that are applied to the resource and that are
       also propagated to the underlying Compute Engine resources."
@@ -119,7 +125,7 @@ properties:
       Details can be found in the conditions field.
     output: true
   - !ruby/object:Api::Type::KeyValueAnnotations
-    name: 'annotations'
+    name: "annotations"
     description: "Client-specified annotations. This is distinct from labels."
   - !ruby/object:Api::Type::Fingerprint
     name: "etag"
@@ -163,6 +169,19 @@ properties:
         description: |
           Additional project IDs that are allowed to attach to the workstation cluster's service attachment.
           By default, the workstation cluster's project and the VPC host project (if different) are allowed.
+  - !ruby/object:Api::Type::NestedObject
+    name: "domainConfig"
+    min_version: beta
+    description: |
+      Configuration options for a custom domain.
+    properties:
+      - !ruby/object:Api::Type::String
+        name: "domain"
+        immutable: true
+        required: true
+        description: |
+          Domain used by Workstations for HTTP ingress.
+
   - !ruby/object:Api::Type::Array
     name: "conditions"
     description: |-

--- a/mmv1/templates/terraform/examples/workstation_cluster_custom_domain.tf.erb
+++ b/mmv1/templates/terraform/examples/workstation_cluster_custom_domain.tf.erb
@@ -1,0 +1,41 @@
+resource "google_workstations_workstation_cluster" "<%= ctx[:primary_resource_id] %>" {
+  provider               = google-beta
+  workstation_cluster_id = "<%= ctx[:vars]['workstation_cluster_name'] %>"
+  network                = google_compute_network.default.id
+  subnetwork             = google_compute_subnetwork.default.id
+  location               = "us-central1"
+
+  private_cluster_config {
+    enable_private_endpoint = true
+  }
+
+  domain_config {
+    domain = "workstations.example.com"
+  }
+
+  labels = {
+    "label" = "key"
+  }
+
+  annotations = {
+    label-one = "value-one"
+  }
+}
+
+data "google_project" "project" {
+  provider = google-beta
+}
+
+resource "google_compute_network" "default" {
+  provider                = google-beta
+  name                    = "<%= ctx[:vars]['workstation_cluster_name'] %>"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  provider = google-beta
+  name          = "<%= ctx[:vars]['workstation_cluster_name'] %>"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.default.name
+}


### PR DESCRIPTION
Add `domain_config` config for custom domain to workstations cluster. Field marked `min_version: beta` despite the resource being `min_version`'ed, in case the resource is promoted but the field is still only in beta (the field is in only in `v1beta`, not in `v1`).

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
workstations: add `domain_config` field to resource `google_workstations_workstation_cluster` (beta)
```
