### PR TITLE
Add data source for google_compute_region_disk

### DIFF
--- a/mmv1/third_party/terraform/provider/provider.go.erb
+++ b/mmv1/third_party/terraform/provider/provider.go.erb
@@ -256,6 +256,7 @@ func DatasourceMapWithErrors() (map[string]*schema.Resource, error) {
 		"google_compute_backend_bucket":                    compute.DataSourceGoogleComputeBackendBucket(),
 		"google_compute_default_service_account":           compute.DataSourceGoogleComputeDefaultServiceAccount(),
 		"google_compute_disk":        					    compute.DataSourceGoogleComputeDisk(),
+		"google_compute_region_disk":                       compute.DataSourceGoogleComputeRegionDisk(),
 		"google_compute_forwarding_rule":                   compute.DataSourceGoogleComputeForwardingRule(),
 		"google_compute_global_address":                    compute.DataSourceGoogleComputeGlobalAddress(),
 		"google_compute_global_forwarding_rule":            compute.DataSourceGoogleComputeGlobalForwardingRule(),

--- a/mmv1/third_party/terraform/provider/provider.go.erb
+++ b/mmv1/third_party/terraform/provider/provider.go.erb
@@ -255,7 +255,7 @@ func DatasourceMapWithErrors() (map[string]*schema.Resource, error) {
 		"google_compute_backend_service":                   compute.DataSourceGoogleComputeBackendService(),
 		"google_compute_backend_bucket":                    compute.DataSourceGoogleComputeBackendBucket(),
 		"google_compute_default_service_account":           compute.DataSourceGoogleComputeDefaultServiceAccount(),
-		"google_compute_disk":        					    compute.DataSourceGoogleComputeDisk(),
+		"google_compute_disk":                              compute.DataSourceGoogleComputeDisk(),
 		"google_compute_region_disk":                       compute.DataSourceGoogleComputeRegionDisk(),
 		"google_compute_forwarding_rule":                   compute.DataSourceGoogleComputeForwardingRule(),
 		"google_compute_global_address":                    compute.DataSourceGoogleComputeGlobalAddress(),

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_disk.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_disk.go
@@ -1,0 +1,46 @@
+package compute
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceGoogleComputeRegionDisk() *schema.Resource {
+
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceComputeRegionDisk().Schema)
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "name")
+	tpgresource.AddOptionalFieldsToSchema(dsSchema, "project")
+	tpgresource.AddOptionalFieldsToSchema(dsSchema, "region")
+
+	return &schema.Resource{
+		Read:   dataSourceGoogleComputeRegionDiskRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceGoogleComputeRegionDiskRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+
+	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/regions/{{region}}/disks/{{name}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+	err = resourceComputeRegionDiskRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if err := tpgresource.SetDataSourceLabels(d); err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
+}

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_disk_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_disk_test.go
@@ -1,0 +1,46 @@
+package compute_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccDataSourceGoogleComputeRegionDisk_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeDiskDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleComputeRegionDisk_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceState("data.google_compute_region_disk.foo", "google_compute_region_disk.foo"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleComputeRegionDisk_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_region_disk" "foo" {
+  name   = "tf-test-compute-disk-%{random_suffix}"
+  labels = {
+    my-label = "my-label-value"
+  }
+}
+
+data "google_compute_region_disk" "foo" {
+  name     = google_compute_region_disk.foo.name
+  project  = google_compute_region_disk.foo.project
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/website/docs/d/compute_region_disk.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_region_disk.html.markdown
@@ -1,0 +1,121 @@
+---
+subcategory: "Compute Engine"
+description: |-
+  Get information about a Google Compute Persistent disks.
+---
+
+# google\_compute\_region\_disk
+
+Get information about a Google Compute Regional Persistent disks.
+
+[the official documentation](https://cloud.google.com/compute/docs/disks) and its [API](https://cloud.google.com/compute/docs/reference/rest/v1/regionDisks).
+
+## Example Usage
+
+```hcl
+data "google_compute_region_disk" "disk" {
+  name    = "persistent-regional-disk"
+  project = "example"
+  region  = "us-central1"
+}
+
+resource "google_compute_instance" "default" {
+  # ...
+    
+  attached_disk {
+    source = data.google_compute_disk.disk.self_link
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of a specific disk.
+
+- - -
+
+* `region` - (Optional) A reference to the region where the disk resides.
+
+* `project` - (Optional) The ID of the project in which the resource belongs.
+    If it is not provided, the provider project is used.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `id` - an identifier for the resource with format `projects/{{project}}/zones/{{zone}}/disks/{{name}}`
+
+* `async_primary_disk` - A nested object resource Structure is [documented below](#nested_async_primary_disk).
+
+* `replica_zones` - URLs of the zones where the disk should be replicated to
+
+* `label_fingerprint` -
+  The fingerprint used for optimistic locking of this resource.  Used
+  internally during updates.
+
+* `creation_timestamp` -
+  Creation timestamp in RFC3339 text format.
+
+* `last_attach_timestamp` -
+  Last attach timestamp in RFC3339 text format.
+
+* `last_detach_timestamp` -
+  Last detach timestamp in RFC3339 text format.
+
+* `users` -
+  Links to the users of the disk (attached instances) in form:
+  project/zones/zone/instances/instance
+
+* `source_image_id` -
+  The ID value of the image used to create this disk. This value
+  identifies the exact image that was used to create this persistent
+  disk. For example, if you created the persistent disk from an image
+  that was later deleted and recreated under the same name, the source
+  image ID would identify the exact version of the image that was used.
+
+* `source_snapshot_id` -
+  The unique ID of the snapshot used to create this disk. This value
+  identifies the exact snapshot that was used to create this persistent
+  disk. For example, if you created the persistent disk from a snapshot
+  that was later deleted and recreated under the same name, the source
+  snapshot ID would identify the exact version of the snapshot that was
+  used.
+
+* `description` -
+  The optional description of this resource.
+
+* `labels` - All of labels (key/value pairs) present on the resource in GCP, including the labels configured through Terraform, other clients and services.
+
+* `size` -
+  Size of the persistent disk, specified in GB.
+
+* `physical_block_size_bytes` -
+  Physical block size of the persistent disk, in bytes.
+
+* `type` -
+  URL of the disk type resource describing which disk type to use to
+  create the disk.
+
+* `image` -
+  The image from which to initialize this disk.
+
+* `region` -
+  A reference to the region where the disk resides.
+
+* `source_image_encryption_key` -
+  The customer-supplied encryption key of the source image.
+
+* `snapshot` -
+  The source snapshot used to create this disk.
+
+* `source_snapshot_encryption_key` -
+  (Optional)
+  The customer-supplied encryption key of the source snapshot.
+
+* `self_link` - The URI of the created resource.
+
+<a name="nested_async_primary_disk"></a>The `async_primary_disk` block supports:
+
+* `disk` - Primary disk for asynchronous disk replication.

--- a/mmv1/third_party/terraform/website/docs/d/compute_region_disk.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_region_disk.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Compute Engine"
 description: |-
-  Get information about a Google Compute Persistent disks.
+  Get information about a Google Compute Regional Persistent disks.
 ---
 
 # google\_compute\_region\_disk
@@ -68,13 +68,6 @@ In addition to the arguments listed above, the following computed attributes are
   Links to the users of the disk (attached instances) in form:
   project/zones/zone/instances/instance
 
-* `source_image_id` -
-  The ID value of the image used to create this disk. This value
-  identifies the exact image that was used to create this persistent
-  disk. For example, if you created the persistent disk from an image
-  that was later deleted and recreated under the same name, the source
-  image ID would identify the exact version of the image that was used.
-
 * `source_snapshot_id` -
   The unique ID of the snapshot used to create this disk. This value
   identifies the exact snapshot that was used to create this persistent
@@ -98,14 +91,8 @@ In addition to the arguments listed above, the following computed attributes are
   URL of the disk type resource describing which disk type to use to
   create the disk.
 
-* `image` -
-  The image from which to initialize this disk.
-
 * `region` -
   A reference to the region where the disk resides.
-
-* `source_image_encryption_key` -
-  The customer-supplied encryption key of the source image.
 
 * `snapshot` -
   The source snapshot used to create this disk.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This change adds support for a data source for `google_compute_region_disk` .

Fixes https://github.com/hashicorp/terraform-provider-google/issues/16462

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
google_compute_region_disk
```
