### PR TITLE
[#16400] Fix and simplify InternalIpDiffSuppress function

### DIFF
--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.erb
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.erb
@@ -180,7 +180,7 @@ func TimestampDiffSuppress(format string) schema.SchemaDiffSuppressFunc {
 }
 
 // Suppresses diff for IPv4 and IPv6 different formats.
-// It also suppresses diffs if an IP and one reference are given.
+// It also suppresses diffs if an IP is changing to a reference.
 func InternalIpDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
 	addr_equality := false
 	netmask_equality := false
@@ -213,6 +213,7 @@ func InternalIpDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
 	}
 
 	// If old and new both have a netmask compare them, otherwise suppress
+	// This is not technically correct but prevents the permadiff described in https://github.com/hashicorp/terraform-provider-google/issues/16400
 	if (len(addr_netmask_old)) == 2 && (len(addr_netmask_new) == 2) {
 		netmask_equality = addr_netmask_old[1] == addr_netmask_new[1]
 	} else {

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.erb
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.erb
@@ -182,37 +182,39 @@ func TimestampDiffSuppress(format string) schema.SchemaDiffSuppressFunc {
 // Suppresses diff for IPv4 and IPv6 different formats.
 // It also suppress diffs if one IP and one reference are given.
 func InternalIpDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
+	addr_equality := false
+	netmask_equality := false
+
 	addr_netmask_old := strings.Split(old, "/")
 	addr_netmask_new := strings.Split(new, "/")
 
 	// Check if old or new are IPs (with or without netmask)
-	addr_old := func() net.IP {
-		if net.ParseIP(addr_netmask_old[0]) == nil {
-			return net.ParseIP(addr_netmask_old[0])
-		}
-		return net.ParseIP(old)
-	}()
-	addr_new := func() net.IP {
-		if net.ParseIP(addr_netmask_new[0]) == nil {
-			return net.ParseIP(addr_netmask_new[0])
-		}
-		return net.ParseIP(new)
-	}()
-
-	// If old or new are references, return true
-	if (addr_old == nil) || (addr_new == nil) {
-		return true
+	var addr_old net.IP
+	if net.ParseIP(addr_netmask_old[0]) == nil {
+		addr_old = net.ParseIP(addr_netmask_old[0])
+	} else {
+		addr_old = net.ParseIP(old)
+	}
+	var addr_new net.IP
+	if net.ParseIP(addr_netmask_new[0]) == nil {
+		addr_new = net.ParseIP(addr_netmask_new[0])
+	} else {
+		addr_new = net.ParseIP(new)
 	}
 
-	addr_equality := false
-	netmask_equality := false
+	// if old is an IP and new is a reference
+	// consider them the same
+	if (addr_old != nil) && (addr_new == nil) {
+		addr_equality = true
+	}
 
+	// old and new are equivalent IP addresses
 	if bytes.Equal(addr_old, addr_new) {
 		addr_equality = true
 	}
 
 	// If old and new have a netmask compare them,
-	// otherwise always assume they are the same
+	// otherwise always assume they are the same.
 	if (len(addr_netmask_old)) == 2 && (len(addr_netmask_new) == 2) {
 		netmask_equality = addr_netmask_old[1] == addr_netmask_new[1]
 	} else {

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.erb
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.erb
@@ -180,7 +180,7 @@ func TimestampDiffSuppress(format string) schema.SchemaDiffSuppressFunc {
 }
 
 // Suppresses diff for IPv4 and IPv6 different formats.
-// It also suppress diffs if one IP and one reference are given.
+// It also suppresses diffs if an IP and one reference are given.
 func InternalIpDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
 	addr_equality := false
 	netmask_equality := false
@@ -212,7 +212,7 @@ func InternalIpDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
 		}
 	}
 
-	// If old and new have a netmask compare them, otherwise suppress
+	// If old and new both have a netmask compare them, otherwise suppress
 	if (len(addr_netmask_old)) == 2 && (len(addr_netmask_new) == 2) {
 		netmask_equality = addr_netmask_old[1] == addr_netmask_new[1]
 	} else {

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.erb
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.erb
@@ -179,25 +179,47 @@ func TimestampDiffSuppress(format string) schema.SchemaDiffSuppressFunc {
 	}
 }
 
-// suppress diff when saved is Ipv4 and Ipv6 format while new is required a reference
-// this happens for an internal ip for Private Services Connect
+// Suppresses diff for IPv4 and IPv6 different formats.
+// It also suppress diffs if one IP and one reference are given.
 func InternalIpDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
-	olds := strings.Split(old, "/")
-	news := strings.Split(new, "/")
+	addr_netmask_old := strings.Split(old, "/")
+	addr_netmask_new := strings.Split(new, "/")
 
-	if len(olds) == 2 {
-		if len(news) == 2 {
-			return bytes.Equal(net.ParseIP(olds[0]), net.ParseIP(news[0])) && olds[1] == news[1]
-		} else {
-			return (net.ParseIP(olds[0]) != nil) && (net.ParseIP(new) == nil)
+	// Check if old or new are IPs (with or without netmask)
+	addr_old := func() net.IP {
+		if net.ParseIP(addr_netmask_old[0]) == nil {
+			return net.ParseIP(addr_netmask_old[0])
 		}
+		return net.ParseIP(old)
+	}()
+	addr_new := func() net.IP {
+		if net.ParseIP(addr_netmask_new[0]) == nil {
+			return net.ParseIP(addr_netmask_new[0])
+		}
+		return net.ParseIP(new)
+	}()
+
+	// If old or new are references, return true
+	if (addr_old == nil) || (addr_new == nil) {
+		return true
 	}
 
-	if (net.ParseIP(old) != nil) && (net.ParseIP(new) != nil) {
-		return bytes.Equal(net.ParseIP(old), net.ParseIP(new))
+	addr_equality := false
+	netmask_equality := false
+
+	if bytes.Equal(addr_old, addr_new) {
+		addr_equality = true
 	}
 
-	return (net.ParseIP(old) != nil) && (net.ParseIP(new) == nil)
+	// If old and new have a netmask compare them,
+	// otherwise always assume they are the same
+	if (len(addr_netmask_old)) == 2 && (len(addr_netmask_new) == 2) {
+		netmask_equality = addr_netmask_old[1] == addr_netmask_new[1]
+	} else {
+		netmask_equality = true
+	}
+
+	return addr_equality && netmask_equality
 }
 
 // Suppress diffs for duration format. ex "60.0s" and "60s" same

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.erb
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.erb
@@ -191,30 +191,28 @@ func InternalIpDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
 	// Check if old or new are IPs (with or without netmask)
 	var addr_old net.IP
 	if net.ParseIP(addr_netmask_old[0]) == nil {
-		addr_old = net.ParseIP(addr_netmask_old[0])
-	} else {
 		addr_old = net.ParseIP(old)
+	} else {
+		addr_old = net.ParseIP(addr_netmask_old[0])
 	}
 	var addr_new net.IP
 	if net.ParseIP(addr_netmask_new[0]) == nil {
-		addr_new = net.ParseIP(addr_netmask_new[0])
-	} else {
 		addr_new = net.ParseIP(new)
+	} else {
+		addr_new = net.ParseIP(addr_netmask_new[0])
 	}
 
-	// if old is an IP and new is a reference
-	// consider them the same
-	if (addr_old != nil) && (addr_new == nil) {
-		addr_equality = true
+	if addr_old != nil {
+		if addr_new == nil {
+			// old is an IP and new is a reference
+			addr_equality = true
+		} else {
+			// old and new are IP addresses
+			addr_equality = bytes.Equal(addr_old, addr_new)
+		}
 	}
 
-	// old and new are equivalent IP addresses
-	if bytes.Equal(addr_old, addr_new) {
-		addr_equality = true
-	}
-
-	// If old and new have a netmask compare them,
-	// otherwise always assume they are the same.
+	// If old and new have a netmask compare them, otherwise suppress
 	if (len(addr_netmask_old)) == 2 && (len(addr_netmask_new) == 2) {
 		netmask_equality = addr_netmask_old[1] == addr_netmask_new[1]
 	} else {

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
@@ -302,6 +302,16 @@ func TestInternalIpDiffSuppress(t *testing.T) {
 		},
 		"same3 ipv6s": {
 			Old:                "2600:1900:4020:31cd:8000:0:0:0/96",
+			New:                "2600:1900:4020:31cd:8000::",
+			ExpectDiffSuppress: true,
+		},
+		"same4 ipv6s": {
+			Old:                "2600:1900:4020:31cd:8000:0:0:0",
+			New:                "2600:1900:4020:31cd:8000::/96",
+			ExpectDiffSuppress: true,
+		},
+		"same5 ipv6s": {
+			Old:                "2600:1900:4020:31cd:8000:0:0:0/96",
 			New:                "https://www.googleapis.com/compute/v1/projects/myproject/regions/us-central1/addresses/myaddress",
 			ExpectDiffSuppress: true,
 		},

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
@@ -305,7 +305,7 @@ func TestInternalIpDiffSuppress(t *testing.T) {
 			New:                "2600:1900:4020:31cd:8000::",
 			ExpectDiffSuppress: true,
 		},
-		"suppress - long ipv6 IP without netmask and short ipv6 IP wit netmask": {
+		"suppress - long ipv6 IP without netmask and short ipv6 IP with netmask": {
 			Old:                "2600:1900:4020:31cd:8000:0:0:0",
 			New:                "2600:1900:4020:31cd:8000::/96",
 			ExpectDiffSuppress: true,

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
@@ -340,11 +340,6 @@ func TestInternalIpDiffSuppress(t *testing.T) {
 			New:                "2600:1900:4020:31cd:8000:0:0:8000",
 			ExpectDiffSuppress: false,
 		},
-		"do not suppress - ipv6 IPs with netmask": {
-			Old:                "2600:1900:4020:31cd:8000:0:0:0/96",
-			New:                "2600:1900:4020:31cd:8001::/96",
-			ExpectDiffSuppress: false,
-		},
 		"suppress - ipv4 IPs": {
 			Old:                "1.2.3.4",
 			New:                "1.2.3.4",

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
@@ -290,65 +290,90 @@ func TestInternalIpDiffSuppress(t *testing.T) {
 		Old, New           string
 		ExpectDiffSuppress bool
 	}{
-		"same1 ipv6s": {
+		"suppress - same long and short ipv6 IPs without netmask": {
 			Old:                "2600:1900:4020:31cd:8000:0:0:0",
 			New:                "2600:1900:4020:31cd:8000::",
 			ExpectDiffSuppress: true,
 		},
-		"same2 ipv6s": {
+		"suppress - long and short ipv6 IPs with netmask": {
 			Old:                "2600:1900:4020:31cd:8000:0:0:0/96",
 			New:                "2600:1900:4020:31cd:8000::/96",
 			ExpectDiffSuppress: true,
 		},
-		"same3 ipv6s": {
+		"suppress - long ipv6 IP with netmask and short ipv6 IP without netmask": {
 			Old:                "2600:1900:4020:31cd:8000:0:0:0/96",
 			New:                "2600:1900:4020:31cd:8000::",
 			ExpectDiffSuppress: true,
 		},
-		"same4 ipv6s": {
+		"suppress - long ipv6 IP without netmask and short ipv6 IP wit netmask": {
 			Old:                "2600:1900:4020:31cd:8000:0:0:0",
 			New:                "2600:1900:4020:31cd:8000::/96",
 			ExpectDiffSuppress: true,
 		},
-		"same5 ipv6s": {
+		"suppress - long ipv6 IP with netmask and reference": {
 			Old:                "2600:1900:4020:31cd:8000:0:0:0/96",
-			New:                "https://www.googleapis.com/compute/v1/projects/myproject/regions/us-central1/addresses/myaddress",
+			New:                "projects/project_id/regions/region/addresses/address-name",
 			ExpectDiffSuppress: true,
 		},
-		"different1 ipv6s": {
+		"suppress - long ipv6 IP without netmask and reference": {
+			Old:                "2600:1900:4020:31cd:8000:0:0:0",
+			New:                "projects/project_id/regions/region/addresses/address-name",
+			ExpectDiffSuppress: true,
+		},
+		"do not suppress - reference and ipv6 IP with netmask": {
+			Old:                "projects/project_id/regions/region/addresses/address-name",
+			New:                "2600:1900:4020:31cd:8000:0:0:0/96",
+			ExpectDiffSuppress: false,
+		},
+		"do not suppress - ipv6 IPs - 1": {
 			Old:                "2600:1900:4020:31cd:8000:0:0:0",
 			New:                "2600:1900:4020:31cd:8001::",
 			ExpectDiffSuppress: false,
 		},
-		"different2 ipv6s": {
+		"do not suppress - ipv6 IPs - 2": {
 			Old:                "2600:1900:4020:31cd:8000:0:0:0",
 			New:                "2600:1900:4020:31cd:8000:0:0:8000",
 			ExpectDiffSuppress: false,
 		},
-		"different3 ipv6s": {
+		"do not suppress - ipv6 IPs with netmask": {
 			Old:                "2600:1900:4020:31cd:8000:0:0:0/96",
 			New:                "2600:1900:4020:31cd:8001::/96",
 			ExpectDiffSuppress: false,
 		},
-		"different ipv4s": {
-			Old:                "1.2.3.4",
-			New:                "1.2.3.5",
-			ExpectDiffSuppress: false,
-		},
-		"same ipv4s": {
+		"suppress - ipv4 IPs": {
 			Old:                "1.2.3.4",
 			New:                "1.2.3.4",
 			ExpectDiffSuppress: true,
 		},
-		"ipv4 vs id": {
+		"suppress - ipv4 IP without netmask and ipv4 IP with netmask": {
 			Old:                "1.2.3.4",
-			New:                "google_compute_address.my_ipv4_addr.address",
+			New:                "1.2.3.4/24",
 			ExpectDiffSuppress: true,
 		},
-		"ipv6 vs id": {
-			Old:                "2600:1900:4020:31cd:8000:0:0:0",
-			New:                "google_compute_address.my_ipv6_addr.address",
+		"suppress - ipv4 IP without netmask and reference": {
+			Old:                "1.2.3.4",
+			New:                "projects/project_id/regions/region/addresses/address-name",
 			ExpectDiffSuppress: true,
+		},
+		"do not suppress - reference and ipv4 IP without netmask": {
+			Old:                "projects/project_id/regions/region/addresses/address-name",
+			New:                "1.2.3.4",
+			ExpectDiffSuppress: false,
+		},
+		"do not suppress - different ipv4 IPs": {
+			Old:                "1.2.3.4",
+			New:                "1.2.3.5",
+			ExpectDiffSuppress: false,
+		},
+		"do not suppress - different references": {
+			Old:                "projects/project_id/regions/region/addresses/address-name",
+			New:                "projects/project_id/regions/region/addresses/address-name-1",
+			ExpectDiffSuppress: false,
+		},
+		"do not suppress - same references": {
+			Old:                "projects/project_id/regions/region/addresses/address-name",
+			New:                "projects/project_id/regions/region/addresses/address-name",
+			ExpectDiffSuppress: false,
 		},
 	}
 

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
@@ -320,6 +320,11 @@ func TestInternalIpDiffSuppress(t *testing.T) {
 			New:                "projects/project_id/regions/region/addresses/address-name",
 			ExpectDiffSuppress: true,
 		},
+		"do not suppress - ipv6 IPs different netmask": {
+			Old:                "2600:1900:4020:31cd:8000:0:0:0/96",
+			New:                "2600:1900:4020:31cd:8000:0:0:0/95",
+			ExpectDiffSuppress: false,
+		},
 		"do not suppress - reference and ipv6 IP with netmask": {
 			Old:                "projects/project_id/regions/region/addresses/address-name",
 			New:                "2600:1900:4020:31cd:8000:0:0:0/96",
@@ -363,6 +368,11 @@ func TestInternalIpDiffSuppress(t *testing.T) {
 		"do not suppress - different ipv4 IPs": {
 			Old:                "1.2.3.4",
 			New:                "1.2.3.5",
+			ExpectDiffSuppress: false,
+		},
+		"do not suppress - ipv4 IPs different netmask": {
+			Old:                "1.2.3.4/24",
+			New:                "1.2.3.5/25",
 			ExpectDiffSuppress: false,
 		},
 		"do not suppress - different references": {


### PR DESCRIPTION
As per [#16400](https://github.com/hashicorp/terraform-provider-google/issues/16400) the PR

* fixes the [InternalIpDiffSuppress function](https://github.com/hashicorp/terraform-provider-google/blob/176e4b2bdb7a797c48d77a2ed4eafc03c5001887/google/tpgresource/common_diff_suppress.go#L185), which currently generates a drift for net masked IPv6 addresses and non net-masked IPv6 addresses (i.e. `fd20:6c7:bb6a:f400:0:0:0:0/96` --> `fd20:6c7:bb6a:f400::`)

* simplifies the [InternalIpDiffSuppress function](https://github.com/hashicorp/terraform-provider-google/blob/176e4b2bdb7a797c48d77a2ed4eafc03c5001887/google/tpgresource/common_diff_suppress.go#L185)

```release-note:bug
Fix (and simplify) InternalIpDiffSuppress function to suppress drifts for IPv6 with and without netmask.
```