### PR TITLE
Remove preview workarounds for Firestore databases

### DIFF
--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -69,15 +69,13 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'firestore_database'
     primary_resource_id: 'database'
-    pull_external: true
+    vars:
+      name: "example-database-id"
     test_env_vars:
-      org_id: :ORG_ID
-      billing_account: :BILLING_ACCT
+      project_id: :PROJECT_NAME
     ignore_read_extra:
       - project
       - etag
-    vars:
-      project_id: 'my-project'
   - !ruby/object:Provider::Terraform::Examples
     name: 'firestore_default_database_in_datastore_mode'
     primary_resource_id: 'datastore_mode_database'
@@ -91,19 +89,21 @@ examples:
       project_id: 'my-project'
   - !ruby/object:Provider::Terraform::Examples
     name: 'firestore_database_in_datastore_mode'
-    primary_resource_id: 'database'
-    pull_external: true
+    primary_resource_id: 'datastore_mode_database'
+    vars:
+      name: "example-database-id"
     test_env_vars:
-      org_id: :ORG_ID
-      billing_account: :BILLING_ACCT
+      project_id: :PROJECT_NAME
     ignore_read_extra:
       - project
       - etag
-    vars:
-      project_id: 'my-project'
   - !ruby/object:Provider::Terraform::Examples
     name: 'firestore_database_with_delete_protection'
     primary_resource_id: 'database'
+    vars:
+      name: "example-database-id"
+    test_env_vars:
+      project_id: :PROJECT_NAME
     skip_test: true
 properties:
   - !ruby/object:Api::Type::String

--- a/mmv1/templates/terraform/examples/firestore_database.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_database.tf.erb
@@ -1,32 +1,9 @@
-resource "google_project" "project" {
-  project_id      = "<%= ctx[:vars]['project_id'] %>"
-  name            = "<%= ctx[:vars]['project_id'] %>"
-  org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
-  billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>"
-}
-
-resource "time_sleep" "wait_60_seconds" {
-  depends_on = [google_project.project]
-
-  create_duration = "60s"
-}
-
-resource "google_project_service" "firestore" {
-  project = google_project.project.project_id
-  service = "firestore.googleapis.com"
-
-  # Needed for CI tests for permissions to propagate, should not be needed for actual usage
-  depends_on = [time_sleep.wait_60_seconds]
-}
-
 resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
-  project                           = google_project.project.project_id
-  name                              = "my-database"
+  project                           = "<%= ctx[:test_env_vars]['project_id'] %>"
+  name                              = "<%= ctx[:vars]['name']%>"
   location_id                       = "nam5"
   type                              = "FIRESTORE_NATIVE"
   concurrency_mode                  = "OPTIMISTIC"
   app_engine_integration_mode       = "DISABLED"
   point_in_time_recovery_enablement = "POINT_IN_TIME_RECOVERY_ENABLED"
-
-  depends_on = [google_project_service.firestore]
 }

--- a/mmv1/templates/terraform/examples/firestore_database_in_datastore_mode.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_database_in_datastore_mode.tf.erb
@@ -1,31 +1,9 @@
-resource "google_project" "project" {
-  project_id      = "<%= ctx[:vars]['project_id'] %>"
-  name            = "<%= ctx[:vars]['project_id'] %>"
-  org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
-  billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>"
-}
-
-resource "time_sleep" "wait_60_seconds" {
-  depends_on = [google_project.project]
-  create_duration = "60s"
-}
-
-resource "google_project_service" "firestore" {
-  project = google_project.project.project_id
-  service = "firestore.googleapis.com"
-
-  # Needed for CI tests for permissions to propagate, should not be needed for actual usage
-  depends_on = [time_sleep.wait_60_seconds]
-}
-
 resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
-  project                           = google_project.project.project_id
-  name                              = "datastore-mode-database"
+  project                           = "<%= ctx[:test_env_vars]['project_id'] %>"
+  name                              = "<%= ctx[:vars]['name']%>"
   location_id                       = "nam5"
   type                              = "DATASTORE_MODE"
   concurrency_mode                  = "OPTIMISTIC"
   app_engine_integration_mode       = "DISABLED"
   point_in_time_recovery_enablement = "POINT_IN_TIME_RECOVERY_ENABLED"
-
-  depends_on = [google_project_service.firestore]
 }

--- a/mmv1/templates/terraform/examples/firestore_database_with_delete_protection.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_database_with_delete_protection.tf.erb
@@ -1,6 +1,6 @@
 resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
-  project                           = google_project.project.project_id
-  name                              = "my-database"
+  project                           = "<%= ctx[:test_env_vars]['project_id'] %>"
+  name                              = "<%= ctx[:vars]['name']%>"
   location_id                       = "nam5"
   type                              = "FIRESTORE_NATIVE"
 
@@ -8,6 +8,4 @@ resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
   # To delete the database, first set this field to `DELETE_PROTECTION_DISABLED`, apply the changes.
   # Then delete the database resource and apply the changes again.
   delete_protection_state           = "DELETE_PROTECTION_ENABLED"
-
-  depends_on = [google_project_service.firestore]
 }

--- a/mmv1/third_party/terraform/services/firestore/resource_firestore_database_update_test.go.erb
+++ b/mmv1/third_party/terraform/services/firestore/resource_firestore_database_update_test.go.erb
@@ -13,8 +13,7 @@ import (
 func TestAccFirestoreDatabase_updateConcurrencyMode(t *testing.T) {
 	t.Parallel()
 
-	orgId := envvar.GetTestOrgFromEnv(t)
-	billingAccount := envvar.GetTestBillingAccountFromEnv(t)
+	projectId := envvar.GetTestProjectFromEnv()
 	randomSuffix := acctest.RandString(t, 10)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -25,19 +24,19 @@ func TestAccFirestoreDatabase_updateConcurrencyMode(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFirestoreDatabase_concurrencyMode(orgId, billingAccount, randomSuffix, "OPTIMISTIC"),
+				Config: testAccFirestoreDatabase_concurrencyMode(projectId, randomSuffix, "OPTIMISTIC"),
 			},
 			{
-				ResourceName:      "google_firestore_database.default",
+				ResourceName:      "google_firestore_database.database",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"etag", "project"},
 			},
 			{
-				Config: testAccFirestoreDatabase_concurrencyMode(orgId, billingAccount, randomSuffix, "PESSIMISTIC"),
+				Config: testAccFirestoreDatabase_concurrencyMode(projectId, randomSuffix, "PESSIMISTIC"),
 			},
 			{
-				ResourceName:      "google_firestore_database.default",
+				ResourceName:      "google_firestore_database.database",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"etag", "project"},
@@ -49,8 +48,7 @@ func TestAccFirestoreDatabase_updateConcurrencyMode(t *testing.T) {
 func TestAccFirestoreDatabase_updatePitrEnablement(t *testing.T) {
 	t.Parallel()
 
-	orgId := envvar.GetTestOrgFromEnv(t)
-	billingAccount := envvar.GetTestBillingAccountFromEnv(t)
+	projectId := envvar.GetTestProjectFromEnv()
 	randomSuffix := acctest.RandString(t, 10)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -61,19 +59,19 @@ func TestAccFirestoreDatabase_updatePitrEnablement(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFirestoreDatabase_pitrEnablement(orgId, billingAccount, randomSuffix, "POINT_IN_TIME_RECOVERY_ENABLED"),
+				Config: testAccFirestoreDatabase_pitrEnablement(projectId, randomSuffix, "POINT_IN_TIME_RECOVERY_ENABLED"),
 			},
 			{
-				ResourceName:      "google_firestore_database.default",
+				ResourceName:      "google_firestore_database.database",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"etag", "project"},
 			},
 			{
-				Config: testAccFirestoreDatabase_pitrEnablement(orgId, billingAccount, randomSuffix, "POINT_IN_TIME_RECOVERY_DISABLED"),
+				Config: testAccFirestoreDatabase_pitrEnablement(projectId, randomSuffix, "POINT_IN_TIME_RECOVERY_DISABLED"),
 			},
 			{
-				ResourceName:      "google_firestore_database.default",
+				ResourceName:      "google_firestore_database.database",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"etag", "project"},
@@ -85,8 +83,7 @@ func TestAccFirestoreDatabase_updatePitrEnablement(t *testing.T) {
 func TestAccFirestoreDatabase_updateDeleteProtectionState(t *testing.T) {
 	t.Parallel()
 
-	orgId := envvar.GetTestOrgFromEnv(t)
-	billingAccount := envvar.GetTestBillingAccountFromEnv(t)
+	projectId := envvar.GetTestProjectFromEnv()
 	randomSuffix := acctest.RandString(t, 10)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -97,19 +94,19 @@ func TestAccFirestoreDatabase_updateDeleteProtectionState(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFirestoreDatabase_deleteProtectionState(orgId, billingAccount, randomSuffix, "DELETE_PROTECTION_ENABLED"),
+				Config: testAccFirestoreDatabase_deleteProtectionState(projectId, randomSuffix, "DELETE_PROTECTION_ENABLED"),
 			},
 			{
-				ResourceName:      "google_firestore_database.default",
+				ResourceName:      "google_firestore_database.database",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"etag", "project"},
 			},
 			{
-				Config: testAccFirestoreDatabase_deleteProtectionState(orgId, billingAccount, randomSuffix, "DELETE_PROTECTION_DISABLED"),
+				Config: testAccFirestoreDatabase_deleteProtectionState(projectId, randomSuffix, "DELETE_PROTECTION_DISABLED"),
 			},
 			{
-				ResourceName:      "google_firestore_database.default",
+				ResourceName:      "google_firestore_database.database",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"etag", "project"},
@@ -118,75 +115,38 @@ func TestAccFirestoreDatabase_updateDeleteProtectionState(t *testing.T) {
 	})
 }
 
-func testAccFirestoreDatabase_basicDependencies(orgId, billingAccount string, randomSuffix string) string {
+func testAccFirestoreDatabase_concurrencyMode(projectId string, randomSuffix string, concurrencyMode string) string {
 	return fmt.Sprintf(`
-resource "google_project" "default" {
-  project_id      = "tf-test%s"
-  name            = "tf-test%s"
-  org_id          = "%s"
-  billing_account = "%s"
-}
-
-resource "time_sleep" "wait_60_seconds" {
-  depends_on = [google_project.default]
-
-  create_duration = "60s"
-}
-
-resource "google_project_service" "firestore" {
-  project = google_project.default.project_id
-  service = "firestore.googleapis.com"
-
-  # Needed for CI tests for permissions to propagate, should not be needed for actual usage
-  depends_on = [time_sleep.wait_60_seconds]
-}
-`, randomSuffix, randomSuffix, orgId, billingAccount)
-}
-
-func testAccFirestoreDatabase_concurrencyMode(orgId, billingAccount string, randomSuffix string, concurrencyMode string) string {
-	return testAccFirestoreDatabase_basicDependencies(orgId, billingAccount, randomSuffix) + fmt.Sprintf(`
-
-resource "google_firestore_database" "default" {
-  name             = "(default)"
+resource "google_firestore_database" "database" {
+  project          = "%s"
+  name             = "tf-test-%s"
   type             = "DATASTORE_MODE"
   location_id      = "nam5"
   concurrency_mode = "%s"
-
-  project = google_project.default.project_id
-
-  depends_on = [google_project_service.firestore]
 }
-`, concurrencyMode)
+`, projectId, randomSuffix, concurrencyMode)
 }
 
-func testAccFirestoreDatabase_pitrEnablement(orgId, billingAccount string, randomSuffix string, pointInTimeRecoveryEnablement string) string {
-	return testAccFirestoreDatabase_basicDependencies(orgId, billingAccount, randomSuffix) + fmt.Sprintf(`
-
-resource "google_firestore_database" "default" {
-  name                              = "(default)"
+func testAccFirestoreDatabase_pitrEnablement(projectId string, randomSuffix string, pointInTimeRecoveryEnablement string) string {
+	return fmt.Sprintf(`
+resource "google_firestore_database" "database" {
+  project                           = "%s"
+  name                              = "tf-test-%s"
   type                              = "DATASTORE_MODE"
   location_id                       = "nam5"
   point_in_time_recovery_enablement = "%s"
-
-  project = google_project.default.project_id
-
-  depends_on = [google_project_service.firestore]
 }
-`, pointInTimeRecoveryEnablement)
+`, projectId, randomSuffix, pointInTimeRecoveryEnablement)
 }
 
-func testAccFirestoreDatabase_deleteProtectionState(orgId, billingAccount string, randomSuffix string, deleteProtectionState string) string {
-	return testAccFirestoreDatabase_basicDependencies(orgId, billingAccount, randomSuffix) + fmt.Sprintf(`
-
-resource "google_firestore_database" "default" {
-  name                    = "(default)"
+func testAccFirestoreDatabase_deleteProtectionState(projectId string, randomSuffix string, deleteProtectionState string) string {
+	return fmt.Sprintf(`
+resource "google_firestore_database" "database" {
+  project                 = "%s"
+  name                    = "tf-test-%s"
   type                    = "DATASTORE_MODE"
   location_id             = "nam5"
   delete_protection_state = "%s"
-
-  project = google_project.default.project_id
-
-  depends_on = [google_project_service.firestore]
 }
-`, deleteProtectionState)
+`, projectId, randomSuffix, deleteProtectionState)
 }


### PR DESCRIPTION
To ease testing and make for better documentation, remove the in-band project creation from the (non-default) Firestore examples/tests.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
