### PR TITLE
mutate vsphere_config and add host_groups

### DIFF
--- a/mmv1/products/gkeonprem/VmwareNodePool.yaml
+++ b/mmv1/products/gkeonprem/VmwareNodePool.yaml
@@ -157,17 +157,14 @@ properties:
       - !ruby/object:Api::Type::NestedObject
         name: "vsphereConfig"
         description: Specifies the vSphere config for node pool.
-        output: true
         properties:
           - !ruby/object:Api::Type::String
             name: datastore
             description: The name of the vCenter datastore. Inherited from the user
               cluster.
-            output: true
           - !ruby/object:Api::Type::Array
             name: "tags"
             description: Tags to apply to VMs.
-            output: true
             item_type: !ruby/object:Api::Type::NestedObject
               properties:
                 - !ruby/object:Api::Type::String
@@ -178,6 +175,11 @@ properties:
                   name: "tag"
                   description: The Vsphere tag name.
                   output: true
+          - !ruby/object:Api::Type::Array
+            name: "hostGroups"
+            description: |
+              Vsphere host groups to apply to all VMs in the node pool
+            item_type: !ruby/object:Api::Type::String
       - !ruby/object:Api::Type::Boolean
         name: "enableLoadBalancer"
         description: |

--- a/mmv1/products/gkeonprem/VmwareNodePool.yaml
+++ b/mmv1/products/gkeonprem/VmwareNodePool.yaml
@@ -179,7 +179,7 @@ properties:
             name: "hostGroups"
             description: |
               Vsphere host groups to apply to all VMs in the node pool
-            item_type: !ruby/object:Api::Type::String
+            item_type: Api::Type::String
       - !ruby/object:Api::Type::Boolean
         name: "enableLoadBalancer"
         description: |

--- a/mmv1/products/gkeonprem/VmwareNodePool.yaml
+++ b/mmv1/products/gkeonprem/VmwareNodePool.yaml
@@ -170,11 +170,9 @@ properties:
                 - !ruby/object:Api::Type::String
                   name: "category"
                   description: The Vsphere tag category.
-                  output: true
                 - !ruby/object:Api::Type::String
                   name: "tag"
                   description: The Vsphere tag name.
-                  output: true
           - !ruby/object:Api::Type::Array
             name: "hostGroups"
             description: |

--- a/mmv1/templates/terraform/examples/gkeonprem_vmware_node_pool_full.tf.erb
+++ b/mmv1/templates/terraform/examples/gkeonprem_vmware_node_pool_full.tf.erb
@@ -58,6 +58,18 @@ resource "google_gkeonprem_vmware_node_pool" "<%= ctx[:primary_resource_id] %>" 
         effect = "NO_SCHEDULE"
     }
     labels = {}
+    vsphere_config {
+      datastore = "test-datastore"
+      tags {
+        category = "test-category-1"
+        tag = "tag-1"
+      }
+      tags {
+        category = "test-category-2"
+        tag = "tag-2"
+      }
+      host_groups = ["host1", "host2"]
+    }
     enable_load_balancer = true
   }
   node_pool_autoscaling {

--- a/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_vmware_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_vmware_node_pool_test.go.erb
@@ -105,6 +105,18 @@ func testAccGkeonpremVmwareNodePool_vmwareNodePoolUpdateStart(context map[string
             value = "value"
         }
         labels = {}
+        vsphere_config {
+          datastore = "test-datastore"
+          tags {
+            category = "test-category-1"
+            tag = "tag-1"
+          }
+          tags {
+            category = "test-category-2"
+            tag = "tag-2"
+          }
+          host_groups = ["host1", "host2"]
+        }
         enable_load_balancer = true
     }
     node_pool_autoscaling {
@@ -178,6 +190,18 @@ func testAccGkeonpremVmwareNodePool_vmwareNodePoolUpdate(context map[string]inte
             value = "value-updated"
         }
         labels = {}
+        vsphere_config {
+          datastore = "test-datastore-update"
+          tags {
+            category = "test-category-3"
+            tag = "tag-3"
+          }
+          tags {
+            category = "test-category-4"
+            tag = "tag-4"
+          }
+          host_groups = ["host3", "host4"]
+        }
         enable_load_balancer = false
     }
     node_pool_autoscaling {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
gkeonprem: set `vsphere_config` field as mutable and add `host_groups` subfield in `google_gkeonprem_vmware_node_pool` resource 
```
