### PR TITLE
Improves the documentation rendering for `google_monitoring_uptime_check_config`

### DIFF
--- a/mmv1/products/monitoring/UptimeCheckConfig.yaml
+++ b/mmv1/products/monitoring/UptimeCheckConfig.yaml
@@ -78,7 +78,7 @@ properties:
     output: true
     description:
       A unique resource name for this UptimeCheckConfig. The format is
-      projects/[PROJECT_ID]/uptimeCheckConfigs/[UPTIME_CHECK_ID].
+      `projects/[PROJECT_ID]/uptimeCheckConfigs/[UPTIME_CHECK_ID]`.
   - !ruby/object:Api::Type::String
     name: uptimeCheckId
     api_name: id
@@ -104,8 +104,8 @@ properties:
     required: true
     description:
       The maximum amount of time to wait for the request to complete (must be
-      between 1 and 60 seconds). Accepted formats
-      https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration
+      between 1 and 60 seconds). [See the accepted formats](
+      https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration)
   - !ruby/object:Api::Type::Array
     name: contentMatchers
     description:
@@ -167,7 +167,7 @@ properties:
     immutable: true
     description:
       The checker type to use for the check. If the monitored resource type is
-      servicedirectory_service, checkerType must be set to VPC_CHECKERS.
+      `servicedirectory_service`, `checker_type` must be set to `VPC_CHECKERS`.
     values:
       - :STATIC_IP_CHECKERS
       - :VPC_CHECKERS
@@ -190,7 +190,7 @@ properties:
         immutable: true
         description:
           The HTTP request method to use for the check. If set to
-          METHOD_UNSPECIFIED then requestMethod defaults to GET.
+          `METHOD_UNSPECIFIED` then `request_method` defaults to `GET`.
         default_value: :GET
         values:
           - :METHOD_UNSPECIFIED
@@ -246,8 +246,9 @@ properties:
           - http_check.0.mask_headers
         description:
           The port to the page to run the check against. Will be combined with
-          host (specified within the MonitoredResource) and path to construct
-          the full URL. Optional (defaults to 80 without SSL, or 443 with SSL).
+          `host` (specified within the [`monitored_resource`](#nested_monitored_resource))
+          and path to construct the full URL. Optional (defaults to 80 without
+          SSL, or 443 with SSL).
         default_from_api: true
       - !ruby/object:Api::Type::KeyValuePairs
         name: headers
@@ -262,11 +263,11 @@ properties:
           The list of headers to send as part of the uptime check request. If
           two headers have the same key and different values, they should be
           entered as a single header, with the value being a comma-separated
-          list of all the desired values as described at
-          https://www.w3.org/Protocols/rfc2616/rfc2616.txt (page 31). Entering
-          two separate headers with the same key in a Create call will cause the
-          first to be overwritten by the second. The maximum number of headers
-          allowed is 100.
+          list of all the desired values as described in
+          [RFC 2616 (page 31)](https://www.w3.org/Protocols/rfc2616/rfc2616.txt).
+          Entering two separate headers with the same key in a Create call will
+          cause the first to be overwritten by the second. The maximum number
+          of headers allowed is 100.
         default_from_api: true
       - !ruby/object:Api::Type::String
         name: path
@@ -281,8 +282,8 @@ properties:
         description:
           The path to the page to run the check against. Will be combined with
           the host (specified within the MonitoredResource) and port to
-          construct the full URL. If the provided path does not begin with "/",
-          a "/" will be prepended automatically. Optional (defaults to "/").
+          construct the full URL. If the provided path does not begin with `/`,
+          a `/` will be prepended automatically. Optional (defaults to `/`).
         diff_suppress_func: resourceMonitoringUptimeCheckConfigHttpCheckPathDiffSuppress
       - !ruby/object:Api::Type::Boolean
         name: useSsl
@@ -299,8 +300,8 @@ properties:
         description:
           Boolean specifying whether to include SSL certificate validation as a
           part of the Uptime check. Only applies to checks where
-          monitoredResource is set to uptime_url. If useSsl is false, setting
-          validateSsl to true has no effect.
+          `monitored_resource` is set to `uptime_url`. If `use_ssl` is `false`, setting
+          `validate_ssl` to `true` has no effect.
       - !ruby/object:Api::Type::Boolean
         name: maskHeaders
         at_least_one_of:
@@ -315,19 +316,19 @@ properties:
           Encryption should be specified for any headers related to
           authentication that you do not wish to be seen when retrieving the
           configuration. The server will be responsible for encrypting the
-          headers. On Get/List calls, if mask_headers is set to True then the
-          headers will be obscured with ******.
+          headers. On Get/List calls, if `mask_headers` is set to `true` then the
+          headers will be obscured with `******`.
       - !ruby/object:Api::Type::String
         name: body
         description:
-          The request body associated with the HTTP POST request. If contentType
-          is URL_ENCODED, the body passed in must be URL-encoded. Users can
-          provide a Content-Length header via the headers field or the API will
-          do so. If the requestMethod is GET and body is not empty, the API will
+          The request body associated with the HTTP POST request. If `content_type`
+          is `URL_ENCODED`, the body passed in must be URL-encoded. Users can
+          provide a `Content-Length` header via the `headers` field or the API will
+          do so. If the `request_method` is `GET` and `body` is not empty, the API will
           return an error. The maximum byte size is 1 megabyte. Note - As with
           all bytes fields JSON representations are base64 encoded. e.g.
-          "foo=bar" in URL-encoded form is "foo%3Dbar" and in base64 encoding is
-          "Zm9vJTI1M0RiYXI=".
+          `foo=bar` in URL-encoded form is `foo%3Dbar` and in base64 encoding is
+          `Zm9vJTI1M0RiYXI=`.
       - !ruby/object:Api::Type::Array
         name: acceptedResponseStatusCodes
         description:
@@ -368,7 +369,7 @@ properties:
         required: true
         description:
           The port to the page to run the check against. Will be combined with
-          host (specified within the MonitoredResource) to construct the full
+          host (specified within the `monitored_resource`) to construct the full
           URL.
       - !ruby/object:Api::Type::NestedObject
         name: pingConfig
@@ -416,12 +417,18 @@ properties:
   - !ruby/object:Api::Type::NestedObject
     name: monitoredResource
     immutable: true
-    description:
-      'The monitored resource
+    description: |
+      The [monitored resource]
       (https://cloud.google.com/monitoring/api/resources) associated with the
       configuration. The following monitored resource types are supported for
-      uptime checks:  uptime_url  gce_instance  gae_app  aws_ec2_instance
-      aws_elb_load_balancer  k8s_service  servicedirectory_service'
+      uptime checks:
+      * `aws_ec2_instance`
+      * `aws_elb_load_balancer`
+      * `gae_app
+      * `gce_instance`
+      * `k8s_service`
+      * `servicedirectory_service`
+      * `uptime_url`
     exactly_one_of:
       - monitored_resource
       - resource_group
@@ -433,13 +440,10 @@ properties:
         required: true
         description:
           The monitored resource type. This field must match the type field of a
-          MonitoredResourceDescriptor
-          (https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.monitoredResourceDescriptors#MonitoredResourceDescriptor)
+          [`MonitoredResourceDescriptor`](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.monitoredResourceDescriptors#MonitoredResourceDescriptor)
           object. For example, the type of a Compute Engine VM instance is
-          gce_instance. For a list of types, see Monitoring resource types
-          (https://cloud.google.com/monitoring/api/resources) and Logging
-          resource types
-          (https://cloud.google.com/logging/docs/api/v2/resource-list).
+          `gce_instance`. For a list of types, see [Monitoring resource types](https://cloud.google.com/monitoring/api/resources)
+          and [Logging resource types](https://cloud.google.com/logging/docs/api/v2/resource-list).
       - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         immutable: true
@@ -447,7 +451,7 @@ properties:
         description:
           Values for all of the labels listed in the associated monitored
           resource descriptor. For example, Compute Engine VM instances use the
-          labels "project_id", "instance_id", and "zone".
+          labels `project_id`, `instance_id`, and `zone`.
   - !ruby/object:Api::Type::NestedObject
     name: syntheticMonitor
     immutable: true


### PR DESCRIPTION
This improves the documentation rendering for `google_monitoring_uptime_check_config`


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
Improve documentation for `google_monitoring_uptime_check_config`
```
