### PR TITLE
Revert "Add client config and permissions to google_identity_platform_config"

### DIFF
--- a/mmv1/products/identityplatform/Config.yaml
+++ b/mmv1/products/identityplatform/Config.yaml
@@ -254,32 +254,3 @@ properties:
             description: |
               Two letter unicode region codes to allow as defined by https://cldr.unicode.org/ The full list of these region codes is here: https://github.com/unicode-cldr/cldr-localenames-full/blob/master/main/en/territories.json
             item_type: Api::Type::String
-  - !ruby/object:Api::Type::NestedObject
-    name: 'client'
-    description: |
-      Options related to how clients making requests on behalf of a project should be configured.
-    properties:
-      - !ruby/object:Api::Type::NestedObject
-        name: 'permissions'
-        description: |
-          Configuration related to restricting a user's ability to affect their account.
-        properties:
-          - !ruby/object:Api::Type::Boolean
-            name: 'disabledUserSignup'
-            description: |
-              When true, end users cannot sign up for a new account on the associated project through any of our API methods
-          - !ruby/object:Api::Type::Boolean
-            name: 'disabledUserDeletion'
-            description: |
-              When true, end users cannot delete their account on the associated project through any of our API methods
-      - !ruby/object:Api::Type::String
-        name: 'apiKey'
-        output: true
-        description: |
-          API key that can be used when making requests for this project.
-        sensitive: true
-      - !ruby/object:Api::Type::String
-        name: 'firebaseSubdomain'
-        output: true
-        description: |
-          Firebase subdomain.

--- a/mmv1/templates/terraform/examples/identity_platform_config_minimal.tf.erb
+++ b/mmv1/templates/terraform/examples/identity_platform_config_minimal.tf.erb
@@ -16,12 +16,7 @@ resource "google_project_service" "identitytoolkit" {
 
 resource "google_identity_platform_config" "default" {
   project = google_project.default.project_id
-  client {
-    permissions {
-      disabled_user_deletion = false
-      disabled_user_signup   = true
-    }
-  }
+  
   depends_on = [
     google_project_service.identitytoolkit
   ]


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#9417

We're going to need to revert this.. client is being returned by the API when not set by user.. resulting plan time diff 

```
=== CONT  TestAccIdentityPlatformConfig_identityPlatformConfigBasicExample
    vcr_utils.go:152: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        Terraform will perform the following actions:
          # google_identity_platform_config.default will be updated in-place
          ~ resource "google_identity_platform_config" "default" {
                id                         = "projects/---/config"
                name                       = "projects/---/config"
                # (3 unchanged attributes hidden)
              - client {
                }
                # (4 unchanged blocks hidden)
            }
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccIdentityPlatformConfig_identityPlatformConfigBasicExample (66.74s)
FAIL

```

TestAccIdentityPlatformConfig_identityPlatformConfigBasicExample and TestAccIdentityPlatformConfig_update are failing during VCR 

https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_Google_NightlyTests_GOOGLE_PACKAGE_IDENTITYPLATFORM/54816?hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildDeploymentsSection=false&expandBuildChangesSection=true&expandBuildTestsSection=true


```release-note:none
```
