### PR TITLE
cloudrunv2: remove beta from custom audiences

### DIFF
--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -248,7 +248,6 @@ properties:
           If True, indicates to use the default project's binary authorization policy. If False, binary authorization will be disabled.
   - !ruby/object:Api::Type::Array
     name: 'customAudiences'
-    min_version: beta
     description: |
       One or more custom audiences that you want this service to support. Specify each custom audience as the full URL in a string. The custom audiences are encoded in the token and used to authenticate requests.
       For more information, see https://cloud.google.com/run/docs/configuring/custom-audiences.

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.erb
@@ -668,7 +668,6 @@ resource "google_cloud_run_v2_service" "default" {
 `, context)
 }
 
-<% unless version == "ga" -%>
 func TestAccCloudRunV2Service_cloudrunv2ServiceCustomAudienceUpdate(t *testing.T) {
 	t.Parallel()
 
@@ -676,7 +675,7 @@ func TestAccCloudRunV2Service_cloudrunv2ServiceCustomAudienceUpdate(t *testing.T
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckCloudRunV2ServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -713,7 +712,6 @@ func TestAccCloudRunV2Service_cloudrunv2ServiceCustomAudienceUpdate(t *testing.T
 func testAccCloudRunV2Service_cloudRunServiceUpdateWithoutCustomAudience(serviceName string) string {
 	return fmt.Sprintf(`
 resource "google_cloud_run_v2_service" "default" {
-  provider     = google-beta
   name         = "%s"
   location     = "us-central1"
 
@@ -732,10 +730,8 @@ resource "google_cloud_run_v2_service" "default" {
 func testAccCloudRunV2Service_cloudRunServiceUpdateWithCustomAudience(serviceName string, customAudience string) string {
 	return fmt.Sprintf(`
 resource "google_cloud_run_v2_service" "default" {
-  provider         = google-beta
   name             = "%s"
   location         = "us-central1"
-  launch_stage     = "BETA"
   custom_audiences = ["%s"]
 
   template {
@@ -749,4 +745,3 @@ resource "google_cloud_run_v2_service" "default" {
 }
 `, serviceName, customAudience)
 }
-<% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Removes the Beta constraint from custom audiences in Cloud Run v2 as it is now at GA https://cloud.google.com/run/docs/release-notes#November_08_2023 

Fixes https://github.com/hashicorp/terraform-provider-google/issues/15234

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudrunv2: promoted the `custom_audiences` field on the `google_cloud_run_v2_service` resource to GA
```
