### PR TITLE
Fix `google_dataform_repository` resource's acceptance tests to have dynamic generated names for secrets

### DIFF
--- a/mmv1/products/dataform/Repository.yaml
+++ b/mmv1/products/dataform/Repository.yaml
@@ -36,6 +36,7 @@ examples:
       git_repository_name: 'my/repository'
       dataform_repository_name: 'dataform_repository'
       data: secret-data
+      secret_name: my-secret
   - !ruby/object:Provider::Terraform::Examples
     name: 'dataform_repository_ssh'
     primary_resource_id: dataform_respository
@@ -44,6 +45,7 @@ examples:
       git_repository_name: 'my/repository'
       dataform_repository_name: 'dataform_repository'
       data: secret-data
+      secret_name: my-secret
 parameters:
   - !ruby/object:Api::Type::String
     name: 'region'

--- a/mmv1/templates/terraform/examples/dataform_repository.tf.erb
+++ b/mmv1/templates/terraform/examples/dataform_repository.tf.erb
@@ -5,7 +5,7 @@ resource "google_sourcerepo_repository" "git_repository" {
 
 resource "google_secret_manager_secret" "secret" {
   provider = google-beta
-  secret_id = "secret"
+  secret_id = "<%= ctx[:vars]['secret_name'] %>"
 
   replication {
     auto {}

--- a/mmv1/templates/terraform/examples/dataform_repository_ssh.tf.erb
+++ b/mmv1/templates/terraform/examples/dataform_repository_ssh.tf.erb
@@ -5,7 +5,7 @@ resource "google_sourcerepo_repository" "git_repository" {
 
 resource "google_secret_manager_secret" "secret" {
   provider = google-beta
-  secret_id = "secret"
+  secret_id = "<%= ctx[:vars]['secret_name'] %>"
 
   replication {
     auto {}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->



This PR fixes acceptance tests that contain config for resources that will race to provision a secret called "secret"

Fixes https://github.com/hashicorp/terraform-provider-google/issues/16519

Currently this is causing an issue in this PR (https://github.com/GoogleCloudPlatform/magic-modules/pull/9457), where the bad test definitions are being used to generate IAM resource tests and result in [tests failing](https://github.com/GoogleCloudPlatform/magic-modules/pull/9457#issuecomment-1808280826) due to this error:


>Error: Error creating Secret: googleapi: Error 409: Secret [projects/[PROJECT_NUM]/secrets/secret] already exists.



<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
