### PR TITLE
Move endpoint default handling after TPC universe domain logic

### DIFF
--- a/mmv1/third_party/terraform/provider/provider.go.erb
+++ b/mmv1/third_party/terraform/provider/provider.go.erb
@@ -661,7 +661,6 @@ func ProviderConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 	if err != nil {
 		return nil, diag.FromErr(err)
 	}
-	transport_tpg.HandleDCLCustomEndpointDefaults(d)
 
 	config := transport_tpg.Config{
 		Project:             d.Get("project").(string),
@@ -754,6 +753,12 @@ func ProviderConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 			transport_tpg.DefaultBasePaths[key] = strings.ReplaceAll(basePath, "googleapis.com", config.UniverseDomain)
 		}
 	}
+
+	err = transport_tpg.SetEndpointDefaults(d)
+	if err != nil {
+		return nil, diag.FromErr(err)
+	}
+	transport_tpg.HandleDCLCustomEndpointDefaults(d)
 
 	// Given that impersonate_service_account is a secondary auth method, it has
 	// no conflicts to worry about. We pull the env var in a DefaultFunc.

--- a/mmv1/third_party/terraform/transport/config.go.erb
+++ b/mmv1/third_party/terraform/transport/config.go.erb
@@ -332,7 +332,10 @@ func HandleSDKDefaults(d *schema.ResourceData) error {
 			"CLOUDSDK_CORE_REQUEST_REASON",
 		}, nil))
 	}
+	return nil
+}
 
+func SetEndpointDefaults(d *schema.ResourceData) error {
 	// Generated Products
 	<% products.each do |product| -%>
 	if d.Get("<%= product[:definitions].name.underscore -%>_custom_endpoint") == "" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

splits off the default API endpoint half of [HandleSDKDefaults func](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/third_party/terraform/transport/config.go.erb#L278) into its own function and calls that new function after TPC universe domain is set. This allows the basepath defaults to use the new domain if set

The API custom/default endpoints are not used between when HandleSDKDefaults was called to after the TPC universe logic, so this reorder should be safe. HandleSDKDefaults is also not called anywhere else outside of the one use.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
provider: fixed an issue where universe domains would not overwrite API endpoints
```
