### PR TITLE
Revert project service data source to pre-5.0.0

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_project_service.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_project_service.go
@@ -28,13 +28,5 @@ func dataSourceGoogleProjectServiceRead(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Error constructing id: %s", err)
 	}
 	d.SetId(id)
-	err = resourceGoogleProjectServiceRead(d, meta)
-	if err != nil {
-		return err
-	}
-
-	if d.Id() == "" {
-		return fmt.Errorf("%s not found", id)
-	}
-	return nil
+	return resourceGoogleProjectServiceRead(d, meta)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fixes https://github.com/hashicorp/terraform-provider-google/issues/16515

This makes this particular data source an exception to the strategy outlined in https://github.com/hashicorp/terraform-provider-google/issues/12873.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
resourcemanager: made `data_source_google_project_service` no longer return an error when service is not enabled
```
