### PR TITLE
add `numberic_id` field into `google_compute_network.network` resource

### DIFF
--- a/mmv1/products/compute/Network.yaml
+++ b/mmv1/products/compute/Network.yaml
@@ -100,6 +100,13 @@ properties:
     required: true
     validation: !ruby/object:Provider::Terraform::Validation
       function: 'verify.ValidateGCEName'
+  - !ruby/object:Api::Type::String
+    name: 'numberic_id'
+    description: |
+      The unique identifier for the resource. This identifier is defined by the server.
+    output: true
+    validation: !ruby/object:Provider::Terraform::Validation
+      function: 'verify.ValidateGCEName'
   - !ruby/object:Api::Type::Boolean
     name: 'autoCreateSubnetworks'
     description: |


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR will fix an issue that relates to tag binding. Where it is only possible to use an id of a resource for binding rather than `name`. Because of the use of `id` within the terraform providers, `numeric_id` is used as a field which is the unique resource identifier for the resource.

 [marked as `id` in API documentation but will be named as `numeric_id` in provider](https://cloud.google.com/compute/docs/reference/rest/v1/networks#:~:text=%5BOutput%20Only%5D%20The%20unique%20identifier%20for%20the%20resource.%20This%20identifier%20is%20defined%20by%20the%20server.)


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
