### PR TITLE
cloudrunv2: ignore remote revision change if revision name omitted

### DIFF
--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -262,6 +262,7 @@ properties:
         name: 'revision'
         description: |-
           The unique name for the revision. If this field is omitted, it will be automatically generated based on the Service name.
+        custom_flatten: templates/terraform/custom_flatten/cloud_run_v2_service_revision.go.erb
       - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: |-

--- a/mmv1/templates/terraform/custom_flatten/cloud_run_v2_service_revision.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/cloud_run_v2_service_revision.go.erb
@@ -1,0 +1,6 @@
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+  if d.Get("template.0.revision") == "" {
+    return nil
+  }
+  return v
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR is a suggestion for a fix so services created with `google_cloud_run_v2_service` and later updated with `gcloud run deploy` with custom revision suffix will behave similar to how new revisions created with terraform or GCP console behaves when it comes to revision name. 

Fixes https://github.com/hashicorp/terraform-provider-google/issues/14569 that was closed without a fix

When deploying a new revision with revision suffix using `gcloud run deploy`, the new revision name will get returned by the api and `google_cloud_run_v2_service` wants to do an update (that would create another revision) with `template.revision` changed from the new revision name to `null` . (This does not happen when deploying a new revision with terraform, gcloud without suffix or GCP console). This PR makes it so if the revision name is omitted in the config, the returned revision name from the api is ignored and `template.revision` will remain `null` even if the latest revision was deployed with `gcloud` with custom revision suffix

Edit:
After sleeping on it i just realized this might probably not be a very good solution so closing this
Alternatively i could add a virtual field `autogenerate_revision_name` like in v1 that would do this instead
Or any other suggestion as this is kind of an annoyance in our pipeline that i want to get fixed

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode


-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudrunv2: ignore remote revision change in `google_cloud_run_v2_service` when automatically generating revision names
```
