### PR TITLE
revert build trigger to test

### DIFF
--- a/.github/workflows/downstreams.yml
+++ b/.github/workflows/downstreams.yml
@@ -4,8 +4,7 @@ permissions: read-all
 on:
   push:
     branches:
-      - main
-      - 'FEATURE-BRANCH-*'
+      - scott-test-*
 
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('commit-{0}', github.sha) }}


### PR DESCRIPTION
Looks like there is a failure on merge to check out the feature branches for this workflow.

https://github.com/GoogleCloudPlatform/magic-modules/pull/9351
https://github.com/GoogleCloudPlatform/magic-modules/actions/runs/6881979222/job/18719497116

Changing the trigger type to prototype.
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
