### PR TITLE
Add serviceDirectoryRegistrations message to resource google_compute_global_forwarding_rule

### DIFF
--- a/mmv1/products/compute/GlobalForwardingRule.yaml
+++ b/mmv1/products/compute/GlobalForwardingRule.yaml
@@ -503,11 +503,6 @@ properties:
           immutable: true
           default_from_api: true
         - !ruby/object:Api::Type::String
-          name: 'service'
-          description: |
-            Service Directory service to register the forwarding rule under.
-          immutable: true
-        - !ruby/object:Api::Type::String
           name: 'serviceDirectoryRegion'
           description: |
             [Optional] Service Directory region to register this global forwarding rule under.

--- a/mmv1/products/compute/GlobalForwardingRule.yaml
+++ b/mmv1/products/compute/GlobalForwardingRule.yaml
@@ -485,6 +485,37 @@ properties:
     update_url: 'projects/{{project}}/global/forwardingRules/{{name}}/setTarget'
     diff_suppress_func: 'tpgresource.CompareSelfLinkRelativePaths'
   - !ruby/object:Api::Type::Array
+    name: 'serviceDirectoryRegistrations'
+    description: |
+      Service Directory resources to register this forwarding rule with.
+
+      Currently, only supports a single Service Directory resource.
+    min_size: 0
+    max_size: 1
+    immutable: true
+    default_from_api: true
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties:
+        - !ruby/object:Api::Type::String
+          name: 'namespace'
+          description: |
+            Service Directory namespace to register the forwarding rule under.
+          immutable: true
+          default_from_api: true
+        - !ruby/object:Api::Type::String
+          name: 'service'
+          description: |
+            Service Directory service to register the forwarding rule under.
+          immutable: true
+        - !ruby/object:Api::Type::String
+          name: 'serviceDirectoryRegion'
+          description: |
+            [Optional] Service Directory region to register this global forwarding rule under.
+            Default to "us-central1". Only used for PSC for Google APIs. All PSC for
+            Google APIs Forwarding Rules on the same network should use the same Service
+            Directory region.
+          immutable: true
+  - !ruby/object:Api::Type::Array
     name: sourceIpRanges
     description: If not empty, this Forwarding Rule will only forward the traffic when the source IP address matches one of the IP addresses or CIDR ranges set here. Note that a Forwarding Rule can only have up to 64 source IP ranges, and this field can only be used with a regional Forwarding Rule whose scheme is EXTERNAL. Each sourceIpRange entry should be either an IP address (for example, 1.2.3.4) or a CIDR range (for example, 1.2.3.0/24).
     immutable: true

--- a/mmv1/templates/terraform/examples/private_service_connect_google_apis.tf.erb
+++ b/mmv1/templates/terraform/examples/private_service_connect_google_apis.tf.erb
@@ -38,5 +38,9 @@ resource "google_compute_global_forwarding_rule" "default" {
   network       = google_compute_network.network.id
   ip_address    = google_compute_global_address.default.id
   load_balancing_scheme = ""
+  service_directory_registrations {
+    namespace                 = "sd-namespace"
+    service_directory_region  = "europe-west3"
+  }
 }
 # [END compute_forwarding_rule_private_access]


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add `serviceDirectoryRegistrations` message to Global Forwarding Rule resource.
Fixes hashicorp/terraform-provider-google#9758 

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added field `service_directory_registrations` to resource `google_compute_global_forwarding_rule` 
```
