### PR TITLE
Add resource EventThreatDetectionCustomModule

### DIFF
--- a/mmv1/products/securitycenter/EventThreatDetectionCustomModule.yaml
+++ b/mmv1/products/securitycenter/EventThreatDetectionCustomModule.yaml
@@ -22,7 +22,7 @@ references: !ruby/object:Api::Resource::ReferenceLinks
     'Overview of custom modules for Event Threat Detection': 'https://cloud.google.com/security-command-center/docs/custom-modules-etd-overview'
   api: 'https://cloud.google.com/security-command-center/docs/reference/rest/v1/organizations.eventThreatDetectionSettings.customModules'
 base_url: 'organizations/{{organization}}/eventThreatDetectionSettings/customModules'
-self_link: 'organizations/{{organization}}/eventThreatDetectionSettings/customModules/{{module}}'
+self_link: 'organizations/{{organization}}/eventThreatDetectionSettings/customModules/{{name}}'
 mutex: 'organizations/{{organization}}/eventThreatDetectionSettings/customModules'
 update_verb: :PATCH
 update_mask: true

--- a/mmv1/products/securitycenter/EventThreatDetectionCustomModule.yaml
+++ b/mmv1/products/securitycenter/EventThreatDetectionCustomModule.yaml
@@ -30,13 +30,13 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: "scc_event_threat_detection_custom_module"
     primary_resource_id: "example"
+    # Has a handwritten update test
     skip_test: true
     vars:
       display_name: basic_custom_module
+      type: 'CONFIGURABLE_BAD_IP'
     test_env_vars:
       org_id: :ORG_ID
-    test_vars_overrides:
-      sleep: "true"
 
 parameters:
   - !ruby/object:Api::Type::String
@@ -50,7 +50,6 @@ parameters:
 properties:
   - !ruby/object:Api::Type::String
     name: 'name'
-    immutable: true
     output: true
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
     description: |
@@ -75,7 +74,6 @@ properties:
     description: |
       The state of enablement for the module at the given level of the hierarchy.
     values:
-      - :ENABLEMENT_STATE_UNSPECIFIED
       - :ENABLED
       - :DISABLED
   - !ruby/object:Api::Type::String
@@ -85,7 +83,6 @@ properties:
       Type for the module. e.g. CONFIGURABLE_BAD_IP.
   - !ruby/object:Api::Type::String
     name: 'displayName'
-    required: true
     description: |
       The human readable name to be displayed for the module.
   - !ruby/object:Api::Type::String

--- a/mmv1/products/securitycenter/EventThreatDetectionCustomModule.yaml
+++ b/mmv1/products/securitycenter/EventThreatDetectionCustomModule.yaml
@@ -53,7 +53,7 @@ properties:
     output: true
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
     description: |
-      Immutable. The resource name of the Event Threat Detection custom module.
+      The resource name of the Event Threat Detection custom module.
       Its format is "organizations/{organization}/eventThreatDetectionSettings/customModules/{module}".
   - !ruby/object:Api::Type::String
     name: 'config'

--- a/mmv1/products/securitycenter/EventThreatDetectionCustomModule.yaml
+++ b/mmv1/products/securitycenter/EventThreatDetectionCustomModule.yaml
@@ -78,9 +78,10 @@ properties:
       - :DISABLED
   - !ruby/object:Api::Type::String
     name: 'type'
+    immutable: true
     required: true
     description: |
-      Type for the module. e.g. CONFIGURABLE_BAD_IP.
+      Immutable. Type for the module. e.g. CONFIGURABLE_BAD_IP.
   - !ruby/object:Api::Type::String
     name: 'displayName'
     description: |

--- a/mmv1/products/securitycenter/EventThreatDetectionCustomModule.yaml
+++ b/mmv1/products/securitycenter/EventThreatDetectionCustomModule.yaml
@@ -1,0 +1,103 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'EventThreatDetectionCustomModule'
+description: |
+  Represents an instance of an Event Threat Detection custom module, including
+  its full module name, display name, enablement state, andlast updated time.
+  You can create a custom module at the organization level only.
+references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+    'Overview of custom modules for Event Threat Detection': 'https://cloud.google.com/security-command-center/docs/custom-modules-etd-overview'
+  api: 'https://cloud.google.com/security-command-center/docs/reference/rest/v1/organizations.eventThreatDetectionSettings.customModules'
+base_url: 'organizations/{{organization}}/eventThreatDetectionSettings/customModules'
+self_link: 'organizations/{{organization}}/eventThreatDetectionSettings/customModules/{{module}}'
+mutex: 'organizations/{{organization}}/eventThreatDetectionSettings/customModules'
+update_verb: :PATCH
+update_mask: true
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: "scc_event_threat_detection_custom_module"
+    primary_resource_id: "example"
+    skip_test: true
+    vars:
+      display_name: basic_custom_module
+    test_env_vars:
+      org_id: :ORG_ID
+    test_vars_overrides:
+      sleep: "true"
+
+parameters:
+  - !ruby/object:Api::Type::String
+    name: 'organization'
+    immutable: true
+    required: true
+    url_param_only: true
+    description: |
+      Numerical ID of the parent organization.
+
+properties:
+  - !ruby/object:Api::Type::String
+    name: 'name'
+    immutable: true
+    output: true
+    custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
+    description: |
+      Immutable. The resource name of the Event Threat Detection custom module. 
+      Its format is "organizations/{organization}/eventThreatDetectionSettings/customModules/{module}".
+  - !ruby/object:Api::Type::String
+    name: 'config'
+    required: true
+    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+    custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+    state_func:
+      'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+      return s }'
+    description: |
+      Config for the module. For the resident module, its config value is defined at this level. 
+      For the inherited module, its config value is inherited from the ancestor module.
+    validation: !ruby/object:Provider::Terraform::Validation
+      function: 'validation.StringIsJSON' 
+  - !ruby/object:Api::Type::Enum
+    name: 'enablementState'
+    required: true
+    description: |
+      The state of enablement for the module at the given level of the hierarchy.
+    values:
+      - :ENABLEMENT_STATE_UNSPECIFIED
+      - :ENABLED
+      - :DISABLED
+  - !ruby/object:Api::Type::String
+    name: 'type'
+    required: true
+    description: |
+      Type for the module. e.g. CONFIGURABLE_BAD_IP.
+  - !ruby/object:Api::Type::String
+    name: 'displayName'
+    required: true
+    description: |
+      The human readable name to be displayed for the module.
+  - !ruby/object:Api::Type::String
+    name: 'updateTime'
+    output: true
+    description: |
+      The time at which the custom module was last updated.
+
+      A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and
+      up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+  - !ruby/object:Api::Type::String
+    name: 'lastEditor'
+    output: true
+    description: |
+      The editor that last updated the custom module

--- a/mmv1/products/securitycenter/EventThreatDetectionCustomModule.yaml
+++ b/mmv1/products/securitycenter/EventThreatDetectionCustomModule.yaml
@@ -54,7 +54,7 @@ properties:
     output: true
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
     description: |
-      Immutable. The resource name of the Event Threat Detection custom module. 
+      Immutable. The resource name of the Event Threat Detection custom module.
       Its format is "organizations/{organization}/eventThreatDetectionSettings/customModules/{module}".
   - !ruby/object:Api::Type::String
     name: 'config'
@@ -65,10 +65,10 @@ properties:
       'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
       return s }'
     description: |
-      Config for the module. For the resident module, its config value is defined at this level. 
+      Config for the module. For the resident module, its config value is defined at this level.
       For the inherited module, its config value is inherited from the ancestor module.
     validation: !ruby/object:Provider::Terraform::Validation
-      function: 'validation.StringIsJSON' 
+      function: 'validation.StringIsJSON'
   - !ruby/object:Api::Type::Enum
     name: 'enablementState'
     required: true

--- a/mmv1/templates/terraform/examples/scc_event_threat_detection_custom_module.tf.erb
+++ b/mmv1/templates/terraform/examples/scc_event_threat_detection_custom_module.tf.erb
@@ -1,0 +1,18 @@
+resource "google_scc_event_threat_detection_custom_module" "<%= ctx[:primary_resource_id] %>" {
+  organization = "<%= ctx[:test_env_vars]['org_id'] %>"
+  display_name = "<%= ctx[:vars]['display_name'] %>"
+  enablement_state = "ENABLED"
+  type = "<%= ctx[:vars]['type'] %>"
+  description = "My Event Threat Detection Custom Module"
+  cofig = jsonencode({
+    "metadata": {
+      "severity": "LOW",
+      "description": "Flagged by Forcepoint as malicious",
+      "recommendation": "Contact the owner of the relevant project."
+    },
+    "ips": [
+      "192.0.2.1",
+      "192.0.2.0/24"
+    ]
+  })
+}

--- a/mmv1/third_party/terraform/services/securitycenter/resource_scc_event_threat_detection_custom_module_test.go
+++ b/mmv1/third_party/terraform/services/securitycenter/resource_scc_event_threat_detection_custom_module_test.go
@@ -18,7 +18,7 @@ func TestAccSecurityCenterEventThreatDetectionCustomModule(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"org_id":        envvar.GetTestOrgTargetFromEnv(t),
 		"random_suffix": acctest.RandString(t, 10),
 	}
 
@@ -75,12 +75,12 @@ func testAccSecurityCenterEventThreatDetectionCustomModule_sccOrganizationCustom
 	return acctest.Nprintf(`
 resource "google_scc_event_threat_detection_custom_module" "example" {
 	organization = "%{org_id}"
-	display_name = "tf_test_custom_module%{random_suffix}"
+	display_name = "tf_test_custom_module%{random_suffix}_updated"
 	enablement_state = "DISABLED"
 	type="CONFIGURABLE_BAD_IP"
 	config = <<EOF
               {"metadata": {
-				"severity": "LOW",
+				"severity": "MEDIUM",
 				"description": "Flagged by Forcepoint as malicious",
 				"recommendation": "Contact the owner of the relevant project."
 			  },

--- a/mmv1/third_party/terraform/services/securitycenter/resource_scc_event_threat_detection_custom_module_test.go
+++ b/mmv1/third_party/terraform/services/securitycenter/resource_scc_event_threat_detection_custom_module_test.go
@@ -25,7 +25,7 @@ func TestAccSecurityCenterEventThreatDetectionCustomModule(t *testing.T) {
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckSecurityCenterOrganizationCustomModuleDestroyProducer(t),
+		CheckDestroy:             testAccSecurityCenterEventThreatDetectionCustomModuleDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSecurityCenterEventThreatDetectionCustomModule_sccOrganizationCustomModuleExample(context),
@@ -124,7 +124,7 @@ func testAccSecurityCenterEventThreatDetectionCustomModuleDestroyProducer(t *tes
 				UserAgent: config.UserAgent,
 			})
 			if err == nil {
-				return fmt.Errorf("SecurityCenterOrganizationCustomModule still exists at %s", url)
+				return fmt.Errorf("EventThreatDetectionCustomModule still exists at %s", url)
 			}
 		}
 

--- a/mmv1/third_party/terraform/services/securitycenter/resource_scc_event_threat_detection_custom_module_test.go
+++ b/mmv1/third_party/terraform/services/securitycenter/resource_scc_event_threat_detection_custom_module_test.go
@@ -77,16 +77,15 @@ resource "google_scc_event_threat_detection_custom_module" "example" {
 	organization = "%{org_id}"
 	display_name = "tf_test_custom_module%{random_suffix}_updated"
 	enablement_state = "DISABLED"
-	type="CONFIGURABLE_BAD_IP"
+	type="CONFIGURABLE_BAD_DOMAIN"
 	config = <<EOF
               {"metadata": {
 				"severity": "MEDIUM",
 				"description": "Flagged by Forcepoint as malicious",
 				"recommendation": "Contact the owner of the relevant project."
 			  },
-			  "ips": [
-				"192.0.2.1",
-				"192.0.2.0/24"
+			  "domains": [
+				"example.com"
 			  ]}
             EOF
 }

--- a/mmv1/third_party/terraform/services/securitycenter/resource_scc_event_threat_detection_custom_module_test.go
+++ b/mmv1/third_party/terraform/services/securitycenter/resource_scc_event_threat_detection_custom_module_test.go
@@ -1,0 +1,133 @@
+package securitycenter_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func TestAccSecurityCenterEventThreatDetectionCustomModule(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecurityCenterOrganizationCustomModuleDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecurityCenterEventThreatDetectionCustomModule_sccOrganizationCustomModuleExample(context),
+			},
+			{
+				ResourceName:            "google_scc_event_threat_detection_custom_module.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"organization"},
+			},
+			{
+				Config: testAccSecurityCenterEventThreatDetectionCustomModule_sccOrganizationCustomModuleUpdate(context),
+			},
+			{
+				ResourceName:            "google_scc_event_threat_detection_custom_module.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"organization"},
+			},
+		},
+	})
+}
+
+func testAccSecurityCenterEventThreatDetectionCustomModule_sccOrganizationCustomModuleExample(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_scc_event_threat_detection_custom_module" "example" {
+	organization = "%{org_id}"
+	display_name = "tf_test_custom_module%{random_suffix}"
+	enablement_state = "ENABLED"
+	type="CONFIGURABLE_BAD_IP"
+	config = <<EOF
+              {"metadata": {
+				"severity": "LOW",
+				"description": "Flagged by Forcepoint as malicious",
+				"recommendation": "Contact the owner of the relevant project."
+			  },
+			  "ips": [
+				"192.0.2.1",
+				"192.0.2.0/24"
+			  ]}
+            EOF
+}
+`, context)
+}
+
+func testAccSecurityCenterEventThreatDetectionCustomModule_sccOrganizationCustomModuleUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_scc_event_threat_detection_custom_module" "example" {
+	organization = "%{org_id}"
+	display_name = "tf_test_custom_module%{random_suffix}"
+	enablement_state = "DISABLED"
+	type="CONFIGURABLE_BAD_IP"
+	config = <<EOF
+              {"metadata": {
+				"severity": "LOW",
+				"description": "Flagged by Forcepoint as malicious",
+				"recommendation": "Contact the owner of the relevant project."
+			  },
+			  "ips": [
+				"192.0.2.1",
+				"192.0.2.0/24"
+			  ]}
+            EOF
+}
+`, context)
+}
+
+func testAccSecurityCenterEventThreatDetectionCustomModuleDestroyProducer(t *testing.T) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		for name, rs := range s.RootModule().Resources {
+			if rs.Type != "google_scc_event_threat_detection_custom_module" {
+				continue
+			}
+			if strings.HasPrefix(name, "data.") {
+				continue
+			}
+
+			config := acctest.GoogleProviderConfig(t)
+
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{SecurityCenterBasePath}}organizations/{{organization}}/eventThreatDetectionSettings/customModules/{{name}}")
+			if err != nil {
+				return err
+			}
+
+			billingProject := ""
+
+			if config.BillingProject != "" {
+				billingProject = config.BillingProject
+			}
+
+			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				Project:   billingProject,
+				RawURL:    url,
+				UserAgent: config.UserAgent,
+			})
+			if err == nil {
+				return fmt.Errorf("SecurityCenterOrganizationCustomModule still exists at %s", url)
+			}
+		}
+
+		return nil
+	}
+}

--- a/mmv1/third_party/terraform/services/securitycenter/resource_scc_event_threat_detection_custom_module_test.go
+++ b/mmv1/third_party/terraform/services/securitycenter/resource_scc_event_threat_detection_custom_module_test.go
@@ -77,15 +77,15 @@ resource "google_scc_event_threat_detection_custom_module" "example" {
 	organization = "%{org_id}"
 	display_name = "tf_test_custom_module%{random_suffix}_updated"
 	enablement_state = "DISABLED"
-	type="CONFIGURABLE_BAD_DOMAIN"
+	type="CONFIGURABLE_BAD_IP"
 	config = <<EOF
               {"metadata": {
 				"severity": "MEDIUM",
 				"description": "Flagged by Forcepoint as malicious",
 				"recommendation": "Contact the owner of the relevant project."
 			  },
-			  "domains": [
-				"example.com"
+			  "ips": [
+				"192.0.2.1"
 			  ]}
             EOF
 }

--- a/mmv1/third_party/terraform/services/securitycenter/resource_scc_event_threat_detection_custom_module_test.go
+++ b/mmv1/third_party/terraform/services/securitycenter/resource_scc_event_threat_detection_custom_module_test.go
@@ -18,7 +18,7 @@ func TestAccSecurityCenterEventThreatDetectionCustomModule(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"org_id":        envvar.GetTestOrgTargetFromEnv(t),
+		"org_id":        envvar.GetTestOrgFromEnv(t),
 		"random_suffix": acctest.RandString(t, 10),
 	}
 


### PR DESCRIPTION
Related to b/306108528. Add support for https://cloud.google.com/security-command-center/docs/reference/rest/v1/organizations.eventThreatDetectionSettings.customModules.

Release Note Template for Downstream PRs (will be copied)

```release-note:new-resource
`google_scc_event_threat_detection_custom_module`
```
