### PR TITLE
promote Vmwareengine PC to GA

### DIFF
--- a/mmv1/products/vmwareengine/PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/PrivateCloud.yaml
@@ -13,7 +13,6 @@
 
 --- !ruby/object:Api::Resource
 name: 'PrivateCloud'
-min_version: beta
 base_url: 'projects/{{project}}/locations/{{location}}/privateClouds'
 self_link: 'projects/{{project}}/locations/{{location}}/privateClouds/{{name}}'
 delete_url: 'projects/{{project}}/locations/{{location}}/privateClouds/{{name}}?delay_hours=0'
@@ -55,7 +54,6 @@ examples:
     name: "vmware_engine_private_cloud_basic"
     config_path: "templates/terraform/examples/vmware_engine_private_cloud_basic.tf.erb"
     primary_resource_id: "vmw-engine-pc"
-    min_version: beta
     skip_test: true   # update tests will take care of create and update. PC creation is expensive and node reservation is required.
     vars:
       private_cloud_id: "sample-pc"
@@ -66,7 +64,6 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: "vmware_engine_private_cloud_full"
     config_path: "templates/terraform/examples/vmware_engine_private_cloud_full.tf.erb"
-    min_version: beta
     primary_resource_id: "vmw-engine-pc"
     skip_test: true   # update tests will take care of create and update. PC creation is expensive and node reservation is required.
     vars:
@@ -154,6 +151,12 @@ properties:
           as it does not support all features.
           * managementIpAddressLayoutVersion=2: Indicates the latest IP address layout
           used by all newly created private clouds. This version supports all current features.
+
+      - !ruby/object:Api::Type::String
+        name: 'dnsServerIp'
+        output: true
+        description: |
+          DNS Server IP of the Private Cloud.
 
   - !ruby/object:Api::Type::NestedObject
     name: 'managementCluster'

--- a/mmv1/templates/terraform/examples/vmware_engine_network_legacy.tf.erb
+++ b/mmv1/templates/terraform/examples/vmware_engine_network_legacy.tf.erb
@@ -1,5 +1,4 @@
 resource "google_vmwareengine_network" "<%= ctx[:primary_resource_id] %>" {
-  provider    = google-beta
   project     = google_project_service.acceptance.project
   name        = "<%= ctx[:test_env_vars]['location'] %>-default" #Legacy network IDs are in the format: {region-id}-default
   location    = "<%= ctx[:test_env_vars]['location'] %>"
@@ -9,7 +8,6 @@ resource "google_vmwareengine_network" "<%= ctx[:primary_resource_id] %>" {
 
 resource "google_project_service" "acceptance" {
   project  = google_project.acceptance.project_id
-  provider = google-beta
   service  = "vmwareengine.googleapis.com"
 
   # Needed for CI tests for permissions to propagate, should not be needed for actual usage
@@ -20,7 +18,6 @@ resource "google_project_service" "acceptance" {
 # so creating new project for isolation in CI.
 resource "google_project" "acceptance" {
   name            = "<%= ctx[:vars]['proj_id'] %>"
-  provider        = google-beta
   project_id      = "<%= ctx[:vars]['proj_id'] %>"
   org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
   billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>"

--- a/mmv1/templates/terraform/examples/vmware_engine_private_cloud_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/vmware_engine_private_cloud_basic.tf.erb
@@ -1,5 +1,4 @@
 resource "google_vmwareengine_private_cloud" "<%= ctx[:primary_resource_id] %>" {
-  provider    = google-beta
   location    = "<%= ctx[:test_env_vars]['region'] %>-a"
   name        = "<%= ctx[:vars]['private_cloud_id'] %>"
   description = "Sample test PC."
@@ -18,9 +17,8 @@ resource "google_vmwareengine_private_cloud" "<%= ctx[:primary_resource_id] %>" 
 }
 
 resource "google_vmwareengine_network" "pc-nw" {
-  provider    = google-beta
-  name        = "<%= ctx[:test_env_vars]['region'] %>-default"
-  location    = "<%= ctx[:test_env_vars]['region'] %>"
-  type        = "LEGACY"
+  name        = "<%= ctx[:vars]['network_id'] %>"
+  location    = "global"
+  type        = "STANDARD"
   description = "PC network description."
 }

--- a/mmv1/templates/terraform/examples/vmware_engine_private_cloud_full.tf.erb
+++ b/mmv1/templates/terraform/examples/vmware_engine_private_cloud_full.tf.erb
@@ -1,5 +1,4 @@
 resource "google_vmwareengine_private_cloud" "<%= ctx[:primary_resource_id] %>" {
-  provider    = google-beta
   location    = "<%= ctx[:test_env_vars]['region'] %>-a"
   name        = "<%= ctx[:vars]['private_cloud_id'] %>"
   description = "Sample test PC."
@@ -19,9 +18,7 @@ resource "google_vmwareengine_private_cloud" "<%= ctx[:primary_resource_id] %>" 
 }
 
 resource "google_vmwareengine_network" "pc-nw" {
-  provider    = google-beta
-  name        = "<%= ctx[:test_env_vars]['region'] %>-default"
-  location    = "<%= ctx[:test_env_vars]['region'] %>"
-  type        = "LEGACY"
+  name        = "<%= ctx[:vars]['network_id'] %>"
+  location    = "global"
+  type        = "STANDARD"
   description = "PC network description."
-}

--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
@@ -196,11 +196,12 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_vpc_access_connector":                      vpcaccess.DataSourceVPCAccessConnector(),
 	"google_redis_instance":                            redis.DataSourceGoogleRedisInstance(),
 	"google_vertex_ai_index":                           vertexai.DataSourceVertexAIIndex(),
-	"google_vmwareengine_network":                    	vmwareengine.DataSourceVmwareengineNetwork(),
 	<% unless version == 'ga' -%>
-	"google_vmwareengine_private_cloud": 								vmwareengine.DataSourceVmwareenginePrivateCloud(),
-	"google_vmwareengine_cluster": 											vmwareengine.DataSourceVmwareengineCluster(),
+	"google_vmwareengine_cluster":                      vmwareengine.DataSourceVmwareengineCluster(),
 	<% end -%>
+	"google_vmwareengine_network":                      vmwareengine.DataSourceVmwareengineNetwork(),
+	"google_vmwareengine_private_cloud":                vmwareengine.DataSourceVmwareenginePrivateCloud(),
+
 	// ####### END handwritten datasources ###########
 }
 

--- a/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_private_cloud.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_private_cloud.go
@@ -1,6 +1,5 @@
-<% autogen_exception -%>
 package vmwareengine
-<% unless version == 'ga' -%>
+
 import (
 	"fmt"
 
@@ -14,7 +13,6 @@ func DataSourceVmwareenginePrivateCloud() *schema.Resource {
 	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceVmwareenginePrivateCloud().Schema)
 	tpgresource.AddRequiredFieldsToSchema(dsSchema, "name", "location")
 	tpgresource.AddOptionalFieldsToSchema(dsSchema, "project")
-
 	return &schema.Resource{
 		Read:   dataSourceVmwareenginePrivateCloudRead,
 		Schema: dsSchema,
@@ -40,4 +38,3 @@ func dataSourceVmwareenginePrivateCloudRead(d *schema.ResourceData, meta interfa
 	}
 	return nil
 }
-<% end -%>

--- a/mmv1/third_party/terraform/website/docs/d/vmwareengine_private_cloud.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/vmwareengine_private_cloud.html.markdown
@@ -8,9 +8,6 @@ description: |-
 
 Use this data source to get details about a private cloud resource.
 
-~> **Warning:** This data source is in beta, and should be used with the terraform-provider-google-beta provider.
-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
-
 To get more information about private cloud, see:
 * [API documentation](https://cloud.google.com/vmware-engine/docs/reference/rest/v1/projects.locations.privateClouds)
 
@@ -18,7 +15,6 @@ To get more information about private cloud, see:
 
 ```hcl
 data "google_vmwareengine_private_cloud" "my_pc" {
-  provider = google-beta
   name     = "my-pc"
   location = "us-central1-a"
 }


### PR DESCRIPTION
Promoted the Private Cloud resource from Beta to GA

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
vmwareengine: promoted `google_vmwareengine_private_cloud` resource to GA
```
