### PR TITLE
Add Network Peering resource to Vmwareengine

### DIFF
--- a/mmv1/products/vmwareengine/NetworkPeering.yaml
+++ b/mmv1/products/vmwareengine/NetworkPeering.yaml
@@ -1,0 +1,172 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'NetworkPeering'
+base_url: 'projects/{{project}}/locations/global/networkPeering'
+self_link: 'projects/{{project}}/locations/global/networkPeerings/{{name}}'
+create_url: 'projects/{{project}}/locations/global/networkPeerings?networkPeeringId={{name}}'
+update_verb: :PATCH
+references: !ruby/object:Api::Resource::ReferenceLinks
+  api: 'https://cloud.google.com/compute/docs/reference/rest/v1/networks/addPeering'
+description: |
+  Represents a network peering resource. Network peerings are global resources.
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
+    path: "name"
+    base_url: "{{op_id}}"
+    wait_ms: 1000
+  result: !ruby/object:Api::OpAsync::Result
+    path: "response"
+  status: !ruby/object:Api::OpAsync::Status
+    path: "done"
+    complete: true
+    allowed:
+      - true
+      - false
+  error: !ruby/object:Api::OpAsync::Error
+    path: "error"
+    message: "message"
+
+import_format: ["projects/{{project}}/locations/global/networkPeerings/{{name}}"]
+autogen_async: true
+
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: "vmware_engine_network_peering_ven"
+    primary_resource_id: "vmw-engine-network-peering"
+    vars:
+      name: "sample-network-peering"
+    test_env_vars:
+      region: :REGION
+  - !ruby/object:Provider::Terraform::Examples
+    name: "vmware_engine_network_peering_standard"
+    primary_resource_id: "vmw-engine-network-peering"
+    vars:
+      name: "sample-network-peering"
+    test_env_vars:
+      region: :REGION
+
+parameters:
+  - !ruby/object:Api::Type::String
+    name: "name"
+    required: true
+    immutable: true
+    url_param_only: true
+    description: |
+      The ID of the Network Peering.
+
+properties:
+  - !ruby/object:Api::Type::Time
+    name: 'createTime'
+    output: true
+    description: |
+      Creation time of this resource.
+      A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and
+      up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+
+  - !ruby/object:Api::Type::Time
+    name: 'updateTime'
+    output: true
+    description: |
+      Last updated time of this resource.
+      A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine
+      fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+
+  - !ruby/object:Api::Type::String
+    name: 'peerNetwork'
+    required: true
+    description: |
+      The relative resource name of the network to peer with a standard VMware Engine network.
+      The provided network can be a consumer VPC network or another standard VMware Engine network.
+
+  - !ruby/object:Api::Type::Boolean
+    name: exportCustomRoutes
+    default_value: true
+    send_empty_value: true
+    description: |
+      True if custom routes are exported to the peered network; false otherwise.
+
+  - !ruby/object:Api::Type::Boolean
+    name: importCustomRoutes
+    default_value: true
+    send_empty_value: true
+    description: |
+      True if custom routes are imported from the peered network; false otherwise.
+
+  - !ruby/object:Api::Type::Boolean
+    name: exportCustomRoutesWithPublicIp
+    default_value: true
+    send_empty_value: true
+    description: |
+      True if all subnet routes with a public IP address range are exported; false otherwise.
+
+  - !ruby/object:Api::Type::Boolean
+    name: importCustomRoutesWithPublicIp
+    default_value: true
+    send_empty_value: true
+    description: |
+      True if custom routes are imported from the peered network; false otherwise.
+
+  - !ruby/object:Api::Type::String
+    name: 'state'
+    output: true
+    description: |
+      State of the network peering.
+      This field has a value of 'ACTIVE' when there's a matching configuration in the peer network.
+      New values may be added to this enum when appropriate.
+
+  - !ruby/object:Api::Type::String
+    name: 'stateDetails'
+    output: true
+    description: |
+      Details about the current state of the network peering.
+
+  - !ruby/object:Api::Type::Enum
+    name: 'peerNetworkType'
+    required: true
+    description: |
+      The type of the network to peer with the VMware Engine network.
+    values:
+      - :STANDARD
+      - :VMWARE_ENGINE_NETWORK
+      - :PRIVATE_SERVICES_ACCESS
+      - :NETAPP_CLOUD_VOLUMES
+      - :THIRD_PARTY_SERVICE
+      - :DELL_POWERSCALE
+
+  - !ruby/object:Api::Type::String
+    name: 'uid'
+    output: true
+    description: |
+      System-generated unique identifier for the resource.
+
+  - !ruby/object:Api::Type::String
+    name: 'vmwareEngineNetwork'
+    required: true
+    description: |
+      The relative resource name of the VMware Engine network. Specify the name in the following form:
+      projects/{project}/locations/{location}/vmwareEngineNetworks/{vmwareEngineNetworkId} where {project}
+      can either be a project number or a project ID.
+
+  - !ruby/object:Api::Type::String
+    name: 'description'
+    description: |
+      User-provided description for this network peering.
+
+  - !ruby/object:Api::Type::String
+    name: 'vmwareEngineNetworkCanonical'
+    output: true
+    description: |
+      The canonical name of the VMware Engine network in the form:
+      projects/{project_number}/locations/{location}/vmwareEngineNetworks/{vmwareEngineNetworkId}

--- a/mmv1/templates/terraform/examples/vmware_engine_network_peering_standard.tf.erb
+++ b/mmv1/templates/terraform/examples/vmware_engine_network_peering_standard.tf.erb
@@ -1,0 +1,15 @@
+resource "google_compute_network" "network-peering-vpc" {
+  name = "default-vpc"
+}
+resource "google_vmwareengine_network" "network-peering-standard-nw" {
+   name              = "default-standard-nw-np"
+   location          = "global"
+   type              = "STANDARD"
+}
+resource "google_vmwareengine_network_peering" "<%= ctx[:primary_resource_id] %>" {
+    name = "<%= ctx[:vars]['name'] %>"
+    description = "Sample description"
+    peer_network = google_compute_network.network-peering-vpc.id
+    peer_network_type = "STANDARD"
+    vmware_engine_network = google_vmwareengine_network.network-peering-standard-nw.id
+}

--- a/mmv1/templates/terraform/examples/vmware_engine_network_peering_ven.tf.erb
+++ b/mmv1/templates/terraform/examples/vmware_engine_network_peering_ven.tf.erb
@@ -1,0 +1,21 @@
+resource "google_vmwareengine_network" "network-peering-nw" {
+   name              = "default-np-nw"
+   location          = "global"
+   type              = "STANDARD"
+}
+resource "google_vmwareengine_network" "network-peering-peer-nw" {
+   name              = "peer-np-nw"
+   location          = "global"
+   type              = "STANDARD"
+}
+resource "google_vmwareengine_network_peering" "<%= ctx[:primary_resource_id] %>" {
+    name = "<%= ctx[:vars]['name'] %>"
+    description = "Sample description"
+    vmware_engine_network = google_vmwareengine_network.network-peering-nw.id
+    peer_network = google_vmwareengine_network.network-peering-peer-nw.id
+    peer_network_type = "VMWARE_ENGINE_NETWORK"
+    export_custom_routes = false
+    import_custom_routes = false
+    export_custom_routes_with_public_ip = false
+    import_custom_routes_with_public_ip = false
+}

--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
@@ -196,10 +196,13 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_vpc_access_connector":                      vpcaccess.DataSourceVPCAccessConnector(),
 	"google_redis_instance":                            redis.DataSourceGoogleRedisInstance(),
 	"google_vertex_ai_index":                           vertexai.DataSourceVertexAIIndex(),
-	"google_vmwareengine_network":                    	vmwareengine.DataSourceVmwareengineNetwork(),
 	<% unless version == 'ga' -%>
-	"google_vmwareengine_private_cloud": 								vmwareengine.DataSourceVmwareenginePrivateCloud(),
-	"google_vmwareengine_cluster": 											vmwareengine.DataSourceVmwareengineCluster(),
+	"google_vmwareengine_cluster":                      vmwareengine.DataSourceVmwareengineCluster(),
+	<% end -%>
+	"google_vmwareengine_network":                      vmwareengine.DataSourceVmwareengineNetwork(),
+	"google_vmwareengine_network_peering":              vmwareengine.DataSourceVmwareengineNetworkPeering(),
+	<% unless version == 'ga' -%>
+	"google_vmwareengine_private_cloud":                vmwareengine.DataSourceVmwareenginePrivateCloud(),
 	<% end -%>
 	// ####### END handwritten datasources ###########
 }

--- a/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_peering.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_peering.go
@@ -1,0 +1,40 @@
+package vmwareengine
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceVmwareengineNetworkPeering() *schema.Resource {
+
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceVmwareengineNetworkPeering().Schema)
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "name")
+	tpgresource.AddOptionalFieldsToSchema(dsSchema, "project")
+	return &schema.Resource{
+		Read:   dataSourceVmwareengineNetworkPeeringRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceVmwareengineNetworkPeeringRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+
+	// Store the ID now
+	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/locations/global/networkPeerings/{{name}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+	err = resourceVmwareengineNetworkPeeringRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
+}

--- a/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_peering_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_peering_test.go
@@ -1,0 +1,61 @@
+package vmwareengine_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccDataSourceVmwareengineNetworkPeering_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckVmwareengineNetworkPeeringDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVmwareengineNetworkPeering_ds(context),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores("data.google_vmwareengine_network_peering.ds", "google_vmwareengine_network_peering.vmw-engine-network-peering", map[string]struct{}{}),
+				),
+			},
+		},
+	})
+}
+
+func testAccVmwareengineNetworkPeering_ds(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_vmwareengine_network" "network-peering-nw" {
+	name              = "tf-test-sample-nw%{random_suffix}"
+	location          = "global"
+	type              = "STANDARD"
+}
+
+resource "google_vmwareengine_network" "network-peering-peer-nw" {
+	name              = "tf-test-peer-nw%{random_suffix}"
+	location          = "global"
+	type              = "STANDARD"
+}
+
+resource "google_vmwareengine_network_peering" "vmw-engine-network-peering" {
+	name = "tf-test-sample-network-peering%{random_suffix}"
+	description = "Sample description"
+	vmware_engine_network = google_vmwareengine_network.network-peering-nw.id
+	peer_network = google_vmwareengine_network.network-peering-peer-nw.id
+	peer_network_type = "VMWARE_ENGINE_NETWORK"
+}
+
+data "google_vmwareengine_network_peering" "ds" {
+	name = google_vmwareengine_network_peering.vmw-engine-network-peering.name
+	depends_on = [
+		google_vmwareengine_network_peering.vmw-engine-network-peering,
+	]
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_peering_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_peering_test.go
@@ -1,0 +1,67 @@
+package vmwareengine_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccVmwareengineNetworkPeering_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckVmwareengineNetworkPeeringDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVmwareengineNetworkPeering_config(context, "Sample description."),
+			},
+			{
+				ResourceName:            "google_vmwareengine_network_peering.vmw-engine-network-peering",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name"},
+			},
+			{
+				Config: testAccVmwareengineNetworkPeering_config(context, "Updated description."),
+			},
+			{
+				ResourceName:            "google_vmwareengine_network_peering.vmw-engine-network-peering",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name"},
+			},
+		},
+	})
+}
+
+func testAccVmwareengineNetworkPeering_config(context map[string]interface{}, description string) string {
+	context["description"] = description
+	return acctest.Nprintf(`
+resource "google_vmwareengine_network" "network-peering-nw" {
+	name              = "tf-test-sample-nw%{random_suffix}"
+	location          = "global"
+	type              = "STANDARD"
+}
+
+resource "google_vmwareengine_network" "network-peering-peer-nw" {
+	name              = "tf-test-peer-nw%{random_suffix}"
+	location          = "global"
+	type              = "STANDARD"
+}
+
+resource "google_vmwareengine_network_peering" "vmw-engine-network-peering" {
+	name = "tf-test-sample-network-peering%{random_suffix}"
+	description = "%{description}"
+	vmware_engine_network = google_vmwareengine_network.network-peering-nw.id
+	peer_network = google_vmwareengine_network.network-peering-peer-nw.id
+	peer_network_type = "VMWARE_ENGINE_NETWORK"
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/website/docs/d/vmwareengine_network_peering.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/vmwareengine_network_peering.html.markdown
@@ -1,0 +1,30 @@
+---
+subcategory: "Cloud VMware Engine"
+description: |-
+  Get information about a network peering.
+---
+
+# google\_vmwareengine\_network_peering
+
+Use this data source to get details about a network peering resource.
+
+To get more information about network peering, see:
+* [API documentation](https://cloud.google.com/vmware-engine/docs/reference/rest/v1/projects.locations.networkPeerings)
+
+## Example Usage
+
+```hcl
+data "google_vmwareengine_network_peering" "my_network_peering" {
+  name     = "my-network-peering"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the resource.
+
+## Attributes Reference
+
+See [google_vmwareengine_network_peering](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vmwareengine_network_peering#attributes-reference) resource for details of all the available attributes.


### PR DESCRIPTION
Added support for Network Peering resource and datasource.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_vmwareengine_network_peering`
```

```release-note:new-datasource
`google_vmwareengine_network_peering`
```