### PR TITLE
Adding a failing test/logs that illustrates problem with lifecycle age

### DIFF
--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
@@ -188,6 +188,7 @@ func ResourceStorageBucket() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"age": {
 										Type:        schema.TypeInt,
+										Default:     nil,
 										Optional:    true,
 										Description: `Minimum age of an object in days to satisfy this condition.`,
 									},
@@ -1242,7 +1243,9 @@ func flattenBucketLifecycleRuleCondition(condition *storage.BucketLifecycleRuleC
 		"matches_prefix":             tpgresource.ConvertStringArrToInterface(condition.MatchesPrefix),
 		"matches_suffix":             tpgresource.ConvertStringArrToInterface(condition.MatchesSuffix),
 	}
+	log.Printf("[DEBUG] flattening Age? %d\n\n", condition.Age)
 	if condition.Age != nil {
+		log.Printf("[DEBUG] flattening Age %d\n\n", *condition.Age)
 		ruleCondition["age"] = int(*condition.Age)
 	}
 	if condition.IsLive == nil {
@@ -1402,10 +1405,14 @@ func expandStorageBucketLifecycleRuleCondition(v interface{}) (*storage.BucketLi
 	condition := conditions[0].(map[string]interface{})
 	transformed := &storage.BucketLifecycleRuleCondition{}
 
-	if v, ok := condition["age"]; ok {
+	log.Printf("[DEBUG] expanding Age? %s\n\n", condition["age"])
+	if v, ok := condition["age"]; v != nil && ok {
+		log.Printf("[DEBUG] expanding Age %d\n\n", v)
 		age := int64(v.(int))
 		transformed.Age = &age
-		transformed.ForceSendFields = append(transformed.ForceSendFields, "Age")
+	} else {
+		log.Printf("[DEBUG] nil Age %d\n\n", v)
+		transformed.NullFields = append(transformed.NullFields, "Age")
 	}
 
 	if v, ok := condition["created_before"]; ok {

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
@@ -381,6 +381,65 @@ func TestAccStorageBucket_lifecycleRuleStateAny(t *testing.T) {
 	})
 }
 
+func TestAccStorageBucket_lifecycleRuleAge(t *testing.T) {
+	t.Parallel()
+
+	var bucket storage.Bucket
+	bucketName := fmt.Sprintf("tf-test-acc-bucket-%d", acctest.RandInt(t))
+	int64_10 := int64(10)
+	int64_0 := int64(0)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccStorageBucketDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStorageBucket_lifecycleRule_withAgeTen(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStorageBucketExists(
+						t, "google_storage_bucket.bucket", bucketName, &bucket),
+					testAccCheckStorageBucketLifecycleConditionAge(&int64_10, &bucket),
+				),
+			},
+			{
+				ResourceName:            "google_storage_bucket.bucket",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+			{
+				Config: testAccStorageBucket_lifecycleRule_withAgeNil(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStorageBucketExists(
+						t, "google_storage_bucket.bucket", bucketName, &bucket),
+					testAccCheckStorageBucketLifecycleConditionAge(nil, &bucket),
+				),
+			},
+			{
+				ResourceName:            "google_storage_bucket.bucket",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+			{
+				Config: testAccStorageBucket_lifecycleRule_withAgeZero(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStorageBucketExists(
+						t, "google_storage_bucket.bucket", bucketName, &bucket),
+					testAccCheckStorageBucketLifecycleConditionAge(&int64_0, &bucket),
+				),
+			},
+			{
+				ResourceName:            "google_storage_bucket.bucket",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+		},
+	})
+}
+
 func TestAccStorageBucket_storageClass(t *testing.T) {
 	t.Parallel()
 
@@ -1296,6 +1355,25 @@ func testAccCheckStorageBucketMissing(t *testing.T, bucketName string) resource.
 	}
 }
 
+func testAccCheckStorageBucketLifecycleConditionAge(expected *int64, b *storage.Bucket) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		actual := b.Lifecycle.Rule[0].Condition.Age
+		if expected == nil && b.Lifecycle.Rule[0].Condition.Age == nil {
+			return nil
+		}
+		if expected == nil {
+			return fmt.Errorf("expected condition Age to be unset, instead got %d", *actual)
+		}
+		if actual == nil {
+			return fmt.Errorf("expected condition Age to be %d, instead got nil (unset)", *expected)
+		}
+		if *expected != *actual {
+			return fmt.Errorf("expected condition Age to be %d, instead got %d", *expected, *actual)
+		}
+		return nil
+	}
+}
+
 func testAccCheckStorageBucketLifecycleConditionState(expected *bool, b *storage.Bucket) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		actual := b.Lifecycle.Rule[0].Condition.IsLive
@@ -1855,6 +1933,65 @@ resource "google_storage_bucket" "bucket" {
     condition {
       age        = 10
       with_state = "ANY"
+    }
+  }
+}
+`, bucketName)
+}
+
+func testAccStorageBucket_lifecycleRule_withAgeTen(bucketName string) string {
+	return fmt.Sprintf(`
+resource "google_storage_bucket" "bucket" {
+  name          = "%s"
+  location      = "US"
+  force_destroy = true
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      age        = 10
+      with_state = "ARCHIVED"
+    }
+  }
+}
+`, bucketName)
+}
+
+func testAccStorageBucket_lifecycleRule_withAgeNil(bucketName string) string {
+	return fmt.Sprintf(`
+resource "google_storage_bucket" "bucket" {
+  name          = "%s"
+  location      = "US"
+  force_destroy = true
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      with_state = "ARCHIVED"
+    }
+  }
+}
+`, bucketName)
+}
+
+func testAccStorageBucket_lifecycleRule_withAgeZero(bucketName string) string {
+	return fmt.Sprintf(`
+resource "google_storage_bucket" "bucket" {
+  name          = "%s"
+  location      = "US"
+  force_destroy = true
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+	  age        = 0
+      with_state = "ARCHIVED"
     }
   }
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This is related to https://github.com/hashicorp/terraform-provider-google/issues/14044

The issue appears to be caused by a confusion in the way Terraform handles config integer values as 0 vs `nil`. The API requires a `*int64` which only complicates matters because the conversion from the config to the API request could also be a problem as well.

This draft PR illustrates the problem by way of a failing test. I've tried a lot of different ways of resolving the issue within the bucket resource code but so far I haven't been able to come up with a fix.

From where I am now it seems like the central issue is that when converting the config to an API request, Terraform always sees `nil` values as 0, even after I changed the config for the `age` field to default to `nil`. Isolating the relevant changes you get something like this:

```
// in ResourceStorageBucket()
								Schema: map[string]*schema.Schema{
									"age": {
										Type:        schema.TypeInt,
										Default:     nil,
										Optional:    true,
										Description: `Minimum age of an object in days to satisfy this condition.`,
									},
...
// in expandStorageBucketLifecycleRuleCondition()
	log.Printf("[DEBUG] expanding Age? %s\n\n", condition["age"])
	if v, ok := condition["age"]; v != nil && ok {
		log.Printf("[DEBUG] expanding Age %d\n\n", v)
		age := int64(v.(int))
		transformed.Age = &age
	} else {
		log.Printf("[DEBUG] nil Age %d\n\n", v)
		transformed.NullFields = append(transformed.NullFields, "Age")
	}
```

When updating a bucket so that the lifecycle rule condition age is unset (i.e. `nil`) the logs always show the following:

```
2023/11/22 09:40:33 [DEBUG] expanding Age? %!s(int=0)

2023/11/22 09:40:33 [DEBUG] expanding Age 0
```

Obviously I would expect the value output here to be `nil` rather than 0, given that the age field is clearly both optional and nil by default.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
