### PR TITLE
Retry on firestore index create 409 with 'cross-transaction contention'

### DIFF
--- a/mmv1/products/firestore/Index.yaml
+++ b/mmv1/products/firestore/Index.yaml
@@ -16,6 +16,8 @@ name: 'Index'
 base_url: projects/{{project}}/databases/{{database}}/collectionGroups/{{collection}}/indexes
 self_link: '{{name}}'
 immutable: true
+error_retry_predicates:
+  ["transport_tpg.FirestoreIndex409CrossTransactionContetion"]
 description: |
   Cloud Firestore indexes enable simple and complex queries against documents in a database.
    This resource manages composite indexes and not single

--- a/mmv1/third_party/terraform/transport/error_retry_predicates.go
+++ b/mmv1/third_party/terraform/transport/error_retry_predicates.go
@@ -330,6 +330,16 @@ func FirestoreField409RetryUnderlyingDataChanged(err error) (bool, string) {
 	return false, ""
 }
 
+// relevant for firestore in datastore mode
+func FirestoreIndex409CrossTransactionContetion(err error) (bool, string) {
+	if gerr, ok := err.(*googleapi.Error); ok {
+		if gerr.Code == 409 && strings.Contains(gerr.Body, "Aborted due to cross-transaction contention") {
+			return true, "aborted due to cross-transaction contention - retrying"
+		}
+	}
+	return false, ""
+}
+
 func IapClient409Operation(err error) (bool, string) {
 	if gerr, ok := err.(*googleapi.Error); ok {
 		if gerr.Code == 409 && strings.Contains(strings.ToLower(gerr.Body), "operation was aborted") {

--- a/mmv1/third_party/terraform/transport/error_retry_predicates_test.go
+++ b/mmv1/third_party/terraform/transport/error_retry_predicates_test.go
@@ -181,3 +181,14 @@ func TestFirestoreField409_retryUnderlyingDataChanged(t *testing.T) {
 		t.Errorf("Error not detected as retryable")
 	}
 }
+
+func TestFirestoreIndex409_crossTransactionContetion(t *testing.T) {
+	err := googleapi.Error{
+		Code: 409,
+		Body: "Aborted due to cross-transaction contention",
+	}
+	isRetryable, _ := FirestoreIndex409CrossTransactionContetion(&err)
+	if !isRetryable {
+		t.Errorf("Error not detected as retryable")
+	}
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/16599

Retry firestore index create operation in case of `409` error with the text `Aborted due to cross-transaction contention`. This happened by creating multiple indexes..

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
firestore: retried resource creation for error 409 with the text "Aborted due to cross-transaction contention" in `google_firestore_index `
```
