### PR TITLE
Update Dockerfiles to Go 1.20

### DIFF
--- a/.ci/containers/build-environment/Dockerfile
+++ b/.ci/containers/build-environment/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Building Go dependencies
-FROM golang:1.19-bullseye AS builder
+FROM golang:1.20-bullseye AS builder
 
 # Set working directory
 WORKDIR /app
@@ -15,7 +15,7 @@ RUN go mod download
 FROM ruby:3.1-bullseye
 
 # golang
-COPY --from=golang:1.19-bullseye /usr/local/go /usr/local/go
+COPY --from=golang:1.20-bullseye /usr/local/go /usr/local/go
 ENV GOPATH /go
 ENV PATH /usr/local/go/bin:$PATH
 ENV PATH $GOPATH/bin:$PATH

--- a/.ci/containers/go-plus/Dockerfile
+++ b/.ci/containers/go-plus/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Download go module cache for builds
-FROM golang:1.19-bullseye AS builder
+FROM golang:1.20-bullseye AS builder
 ENV GOCACHE=/go/cache
 
 RUN apt-get update && apt-get install -y unzip
@@ -12,7 +12,7 @@ WORKDIR /app1/magic-modules-main/.ci/magician
 RUN go build -o /dev/null .
 
 # Stage 2: Creating the final image
-FROM golang:1.19-bullseye
+FROM golang:1.20-bullseye
 SHELL ["/bin/bash", "-c"]
 ENV GOCACHE=/go/cache
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR relates to https://github.com/GoogleCloudPlatform/magic-modules/pull/9506/files and updates Dockerfiles to Go 1.20

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
