### PR TITLE
[GKE Hub]: Add Fleet binary authorization config

### DIFF
--- a/mmv1/products/gkehub2/Fleet.yaml
+++ b/mmv1/products/gkehub2/Fleet.yaml
@@ -112,7 +112,6 @@ properties:
           - !ruby/object:Api::Type::Array
             name: "policyBindings"
             description: Binauthz policies that apply to this cluster.
-            output: false
             item_type: !ruby/object:Api::Type::NestedObject
               properties:
                 - !ruby/object:Api::Type::String

--- a/mmv1/products/gkehub2/Fleet.yaml
+++ b/mmv1/products/gkehub2/Fleet.yaml
@@ -131,7 +131,6 @@ properties:
             values:
               - DISABLED
               - BASIC
-              - ENTERPRISE
           - !ruby/object:Api::Type::Enum
             name: "vulnerabilityMode"
             description: Sets which mode to use for vulnerability scanning.

--- a/mmv1/products/gkehub2/Fleet.yaml
+++ b/mmv1/products/gkehub2/Fleet.yaml
@@ -100,6 +100,28 @@ properties:
     description: The default cluster configurations to apply across the fleet.
     properties:
       - !ruby/object:Api::Type::NestedObject
+        name: "binaryAuthorizationConfig"
+        description: Enable/Disable binary authorization features for the cluster.
+        properties:
+          - !ruby/object:Api::Type::Enum
+            name: "evaluationMode"
+            description: Mode of operation for binauthz policy evaluation.
+            values:
+              - DISABLED
+              - POLICY_BINDINGS
+          - !ruby/object:Api::Type::Array
+            name: "policyBindings"
+            description: Binauthz policies that apply to this cluster.
+            output: false
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: "name"
+                  description: |
+                    The relative resource name of the binauthz platform policy to audit. GKE
+                    platform policies have the following format:
+                    `projects/{project_number}/platforms/gke/policies/{policy_id}`.
+      - !ruby/object:Api::Type::NestedObject
         name: "securityPostureConfig"
         description: Enable/Disable Security Posture features for the cluster.
         properties:

--- a/mmv1/templates/terraform/examples/gkehub_fleet_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/gkehub_fleet_basic.tf.erb
@@ -1,5 +1,6 @@
 resource "google_gke_hub_fleet" "default" {
   display_name = "my production fleet"
+  
   default_cluster_config {
     security_posture_config {
       mode = "DISABLED"

--- a/mmv1/templates/terraform/examples/gkehub_fleet_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/gkehub_fleet_basic.tf.erb
@@ -1,6 +1,5 @@
 resource "google_gke_hub_fleet" "default" {
   display_name = "my production fleet"
-  
   default_cluster_config {
     security_posture_config {
       mode = "DISABLED"

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_fleet_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_fleet_test.go.erb
@@ -59,7 +59,7 @@ resource "google_gke_hub_fleet" "default" {
   display_name = "my production fleet"
   default_cluster_config { 
 	binary_authorization_config {
-		evaluationMode = "DISABLED"
+		evaluation_mode = "DISABLED"
 	}
 	security_posture_config {
 		mode = "DISABLED"
@@ -78,7 +78,7 @@ resource "google_gke_hub_fleet" "default" {
   display_name = "my staging fleet"
   default_cluster_config {
 	binary_authorization_config {
-		evaluationMode = "POLICY_BINDINGS"
+		evaluation_mode = "POLICY_BINDINGS"
 		policy_bindings = {
 			name = "projects/${google_project.project.project_id}/platforms/gke/policies/policy_id
 		}

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_fleet_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_fleet_test.go.erb
@@ -75,7 +75,7 @@ func testAccGKEHub2Fleet_update(context map[string]interface{}) string {
 	return gkeHubFleetProjectSetupForGA(context) + acctest.Nprintf(`
 resource "google_gke_hub_fleet" "default" {
   project = google_project.project.project_id
-  display_name = "my staging fleet"
+  display_name = "my updated fleet"
   default_cluster_config {
 	binary_authorization_config {
 		evaluation_mode = "POLICY_BINDINGS"

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_fleet_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_fleet_test.go.erb
@@ -48,6 +48,14 @@ func TestAccGKEHub2Fleet_gkehubFleetBasicExample_update(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccGKEHub2Fleet_removedDefaultClusterConfig(context),
+			},
+			{
+				ResourceName:      "google_gke_hub_fleet.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -88,6 +96,17 @@ resource "google_gke_hub_fleet" "default" {
 		vulnerability_mode = "VULNERABILITY_BASIC"
 	}
   }
+  depends_on = [time_sleep.wait_for_gkehub_enablement]
+}
+`, context)
+}
+
+func testAccGKEHub2Fleet_removedDefaultClusterConfig(context map[string]interface{}) string {
+	return gkeHubFleetProjectSetupForGA(context) + acctest.Nprintf(`
+resource "google_gke_hub_fleet" "default" {
+  project = google_project.project.project_id
+  display_name = "my updated fleet"
+
   depends_on = [time_sleep.wait_for_gkehub_enablement]
 }
 `, context)

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_fleet_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_fleet_test.go.erb
@@ -80,7 +80,7 @@ resource "google_gke_hub_fleet" "default" {
 	binary_authorization_config {
 		evaluation_mode = "POLICY_BINDINGS"
 		policy_bindings = {
-			name = "projects/${google_project.project.project_id}/platforms/gke/policies/policy_id
+			name = "projects/${google_project.project.project_id}/platforms/gke/policies/policy_id"
 		}
 	}
 	security_posture_config {

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_fleet_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_fleet_test.go.erb
@@ -79,7 +79,7 @@ resource "google_gke_hub_fleet" "default" {
   default_cluster_config {
 	binary_authorization_config {
 		evaluation_mode = "POLICY_BINDINGS"
-		policy_bindings = {
+		policy_bindings {
 			name = "projects/${google_project.project.project_id}/platforms/gke/policies/policy_id"
 		}
 	}

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_fleet_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_fleet_test.go.erb
@@ -58,6 +58,9 @@ resource "google_gke_hub_fleet" "default" {
   project = google_project.project.project_id
   display_name = "my production fleet"
   default_cluster_config { 
+	binary_authorization_config {
+		evaluationMode = "DISABLED"
+	}
 	security_posture_config {
 		mode = "DISABLED"
 		vulnerability_mode = "VULNERABILITY_DISABLED"
@@ -74,6 +77,12 @@ resource "google_gke_hub_fleet" "default" {
   project = google_project.project.project_id
   display_name = "my staging fleet"
   default_cluster_config {
+	binary_authorization_config {
+		evaluationMode = "POLICY_BINDINGS"
+		policy_bindings = {
+			name = "projects/${google_project.project.project_id}/platforms/gke/policies/policy_id
+		}
+	}
 	security_posture_config {
 		mode = "BASIC"
 		vulnerability_mode = "VULNERABILITY_BASIC"


### PR DESCRIPTION
Adds binary authorization fields to the default cluster config of the GKEHub resource "Fleet." 

b/296461330


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [ ] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
gkehub: added `binary_authorization_config` to `google_gke_hub_fleet`
```
