### PR TITLE
Promote Vmwareengine Cluster to GA

### DIFF
--- a/mmv1/products/vmwareengine/Cluster.yaml
+++ b/mmv1/products/vmwareengine/Cluster.yaml
@@ -14,7 +14,6 @@
 ---
 !ruby/object:Api::Resource
 name: "Cluster"
-min_version: beta
 base_url: "{{parent}}/clusters"
 create_url: "{{parent}}/clusters?clusterId={{name}}"
 self_link: "{{parent}}/clusters/{{name}}"
@@ -53,7 +52,6 @@ autogen_async: true
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: "vmware_engine_cluster_basic"
-    min_version: beta
     primary_resource_id: "vmw-engine-ext-cluster"
     skip_test: true   # update tests will take care of create and update. PC and cluster creation is expensive and node reservation is required.
     vars:
@@ -65,7 +63,6 @@ examples:
       region: :REGION
   - !ruby/object:Provider::Terraform::Examples
     name: "vmware_engine_cluster_full"
-    min_version: beta
     primary_resource_id: "vmw-ext-cluster"
     skip_test: true   # update tests will take care of create and update. PC and cluster creation is expensive and node reservation is required.
     vars:

--- a/mmv1/templates/terraform/examples/vmware_engine_cluster_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/vmware_engine_cluster_basic.tf.erb
@@ -1,5 +1,4 @@
 resource "google_vmwareengine_cluster" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
   name     = "<%= ctx[:vars]['name'] %>"
   parent   = google_vmwareengine_private_cloud.cluster-pc.id
   node_type_configs {
@@ -9,7 +8,6 @@ resource "google_vmwareengine_cluster" "<%= ctx[:primary_resource_id] %>" {
 }
 
 resource "google_vmwareengine_private_cloud" "cluster-pc" {
-  provider    = google-beta
   location    = "<%= ctx[:test_env_vars]['region'] %>-a"
   name        = "<%= ctx[:vars]['private_cloud_id'] %>"
   description = "Sample test PC."
@@ -28,9 +26,8 @@ resource "google_vmwareengine_private_cloud" "cluster-pc" {
 }
 
 resource "google_vmwareengine_network" "cluster-nw" {
-  provider    = google-beta
-  name        = "<%= ctx[:test_env_vars]['region'] %>-default"
-  location    = "<%= ctx[:test_env_vars]['region'] %>"
-  type        = "LEGACY"
+  name        = "<%= ctx[:vars]['network_id'] %>"
+  type        = "STANDARD"
+  location    = "global"
   description = "PC network description."
 }

--- a/mmv1/templates/terraform/examples/vmware_engine_cluster_full.tf.erb
+++ b/mmv1/templates/terraform/examples/vmware_engine_cluster_full.tf.erb
@@ -1,5 +1,4 @@
 resource "google_vmwareengine_cluster" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
   name     = "<%= ctx[:vars]['name'] %>"
   parent   = google_vmwareengine_private_cloud.cluster-pc.id
   node_type_configs {
@@ -10,7 +9,6 @@ resource "google_vmwareengine_cluster" "<%= ctx[:primary_resource_id] %>" {
 }
 
 resource "google_vmwareengine_private_cloud" "cluster-pc" {
-  provider    = google-beta
   location    = "<%= ctx[:test_env_vars]['region'] %>-a"
   name        = "<%= ctx[:vars]['private_cloud_id'] %>"
   description = "Sample test PC."
@@ -30,9 +28,8 @@ resource "google_vmwareengine_private_cloud" "cluster-pc" {
 }
 
 resource "google_vmwareengine_network" "cluster-nw" {
-  provider    = google-beta
-  name        = "<%= ctx[:test_env_vars]['region'] %>-default"
-  location    = "<%= ctx[:test_env_vars]['region'] %>"
-  type        = "LEGACY"
+  name        = "<%= ctx[:vars]['network_id'] %>"
+  type        = "STANDARD"
+  location    = "global"
   description = "PC network description."
 }

--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
@@ -199,9 +199,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_vpc_access_connector":                      vpcaccess.DataSourceVPCAccessConnector(),
 	"google_redis_instance":                            redis.DataSourceGoogleRedisInstance(),
 	"google_vertex_ai_index":                           vertexai.DataSourceVertexAIIndex(),
-	<% unless version == 'ga' -%>
 	"google_vmwareengine_cluster":                      vmwareengine.DataSourceVmwareengineCluster(),
-	<% end -%>
 	"google_vmwareengine_external_address":             vmwareengine.DataSourceVmwareengineExternalAddress(),
 	"google_vmwareengine_network":                      vmwareengine.DataSourceVmwareengineNetwork(),
 	"google_vmwareengine_network_peering":              vmwareengine.DataSourceVmwareengineNetworkPeering(),

--- a/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_cluster.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_cluster.go
@@ -1,6 +1,5 @@
-<% autogen_exception -%>
 package vmwareengine
-<% unless version == 'ga' -%>
+
 import (
 	"fmt"
 
@@ -38,4 +37,3 @@ func dataSourceVmwareengineClusterRead(d *schema.ResourceData, meta interface{})
 	}
 	return nil
 }
-<% end -%>

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_test.go
@@ -1,11 +1,9 @@
-<% autogen_exception -%>
 package vmwareengine_test
-<% unless version == 'ga' -%>
 
 import (
 	"fmt"
-	"testing"
 	"strings"
+	"testing"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
@@ -17,10 +15,11 @@ import (
 )
 
 func TestAccVmwareengineCluster_vmwareEngineClusterUpdate(t *testing.T) {
+	acctest.SkipIfVcr(t)
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"region":        	 "southamerica-west1", // using region with low node utilization.
+		"region":          "southamerica-west1", // using region with low node utilization.
 		"org_id":          envvar.GetTestOrgFromEnv(t),
 		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
 		"random_suffix":   acctest.RandString(t, 10),
@@ -28,14 +27,13 @@ func TestAccVmwareengineCluster_vmwareEngineClusterUpdate(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
-		CheckDestroy: testAccCheckVmwareengineClusterDestroyProducer(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckVmwareengineClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testVmwareEngineClusterConfig(context, 3),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores("data.google_vmwareengine_cluster.ds", "google_vmwareengine_cluster.vmw-engine-ext-cluster", map[string]struct{}{}),
-          acctest.CheckDataSourceStateMatchesResourceStateWithIgnores("data.google_vmwareengine_private_cloud.ds", "google_vmwareengine_private_cloud.cluster-pc", map[string]struct{}{}),
 				),
 			},
 			{
@@ -44,19 +42,19 @@ func TestAccVmwareengineCluster_vmwareEngineClusterUpdate(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"parent", "name"},
 			},
-      {
-        Config: testVmwareEngineClusterConfig(context, 4), // expand the cluster
-      },
-      {
+			{
+				Config: testVmwareEngineClusterConfig(context, 4), // expand the cluster
+			},
+			{
 				ResourceName:            "google_vmwareengine_cluster.vmw-engine-ext-cluster",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"parent", "name"},
 			},
 			{
-        Config: testVmwareEngineClusterConfig(context, 3), // shrink the cluster.
-      },
-      {
+				Config: testVmwareEngineClusterConfig(context, 3), // shrink the cluster.
+			},
+			{
 				ResourceName:            "google_vmwareengine_cluster.vmw-engine-ext-cluster",
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -67,11 +65,35 @@ func TestAccVmwareengineCluster_vmwareEngineClusterUpdate(t *testing.T) {
 }
 
 func testVmwareEngineClusterConfig(context map[string]interface{}, nodeCount int) string {
-	context["node_count"] = nodeCount;
+	context["node_count"] = nodeCount
 	return acctest.Nprintf(`
 
+resource "google_vmwareengine_network" "cluster-nw" {
+  name        = "tf-test-cluster-nw%{random_suffix}"
+  location    = "global"
+  type        = "STANDARD"
+  description = "PC network description."
+}
+
+resource "google_vmwareengine_private_cloud" "cluster-pc" {
+  location    = "%{region}-a"
+  name        = "tf-test-cluster-pc%{random_suffix}"
+  description = "Sample test PC."
+  network_config {
+    management_cidr       = "192.168.10.0/24"
+    vmware_engine_network = google_vmwareengine_network.cluster-nw.id
+  }
+
+  management_cluster {
+    cluster_id = "tf-test-mgmt-cluster%{random_suffix}"
+    node_type_configs {
+      node_type_id = "standard-72"
+      node_count   = 3
+    }
+  }
+}
+
 resource "google_vmwareengine_cluster" "vmw-engine-ext-cluster" {
-  provider = google-beta
   name = "tf-test-ext-cluster%{random_suffix}"
   parent =  google_vmwareengine_private_cloud.cluster-pc.id
   node_type_configs {
@@ -81,52 +103,13 @@ resource "google_vmwareengine_cluster" "vmw-engine-ext-cluster" {
   }
 }
 
-resource "google_vmwareengine_private_cloud" "cluster-pc" {
-  provider = google-beta
-  location = "%{region}-a"
-  name = "tf-test-sample-pc%{random_suffix}"
-  description = "Sample test PC."
-  network_config {
-    management_cidr = "192.168.30.0/24"
-    vmware_engine_network = google_vmwareengine_network.cluster-nw.id
-  }
-
-  management_cluster {
-    cluster_id = "tf-test-sample-mgmt-cluster%{random_suffix}"
-    node_type_configs {
-      node_type_id = "standard-72"
-      node_count   = 3
-			custom_core_count = 32
-    }
-  }
-}
-
-resource "google_vmwareengine_network" "cluster-nw" {
-  provider          = google-beta
-  name              = "%{region}-default"
-  location          = "%{region}"
-  type              = "LEGACY"
-  description       = "PC network description."
-}
-
 data "google_vmwareengine_cluster" ds {
   name = "tf-test-ext-cluster%{random_suffix}"
-	provider = google-beta
-	parent = google_vmwareengine_private_cloud.cluster-pc.id
-	depends_on = [
-    google_vmwareengine_cluster.vmw-engine-ext-cluster,
+  parent = google_vmwareengine_private_cloud.cluster-pc.id
+  depends_on = [
+	google_vmwareengine_cluster.vmw-engine-ext-cluster,
   ]
 }
-
-data "google_vmwareengine_private_cloud" ds {
-	location = "%{region}-a"
-	provider = google-beta
-  name = "tf-test-sample-pc%{random_suffix}"
-	depends_on = [
-   	google_vmwareengine_private_cloud.cluster-pc,
-  ]
-}
-
 `, context)
 }
 
@@ -168,5 +151,3 @@ func testAccCheckVmwareengineClusterDestroyProducer(t *testing.T) func(s *terraf
 		return nil
 	}
 }
-
-<% end -%>

--- a/mmv1/third_party/terraform/website/docs/d/vmwareengine_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/vmwareengine_cluster.html.markdown
@@ -8,9 +8,6 @@ description: |-
 
 Use this data source to get details about a cluster resource.
 
-~> **Warning:** This data source is in beta, and should be used with the terraform-provider-google-beta provider.
-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
-
 To get more information about private cloud cluster, see:
 * [API documentation](https://cloud.google.com/vmware-engine/docs/reference/rest/v1/projects.locations.privateClouds.clusters)
 
@@ -18,7 +15,6 @@ To get more information about private cloud cluster, see:
 
 ```hcl
 data "google_vmwareengine_cluster" "my_cluster" {
-  provider = google-beta
   name     = "my-cluster"
   parent   = "project/locations/us-west1-a/privateClouds/my-cloud"
 }


### PR DESCRIPTION
Promoted the cluster resource in vmwareengine to GA. 

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_vmwareengine_cluster` (GA only)
```
