### PR TITLE
Fix release notes link

### DIFF
--- a/tools/go-changelog/cmd/changelog-pr-body-check/main.go
+++ b/tools/go-changelog/cmd/changelog-pr-body-check/main.go
@@ -63,9 +63,7 @@ func main() {
 		case changelog.EntryErrorNotFound:
 			body := "Oops! It looks like no changelog entry is attached to" +
 				" this PR. Please include a release note block" +
-				" in the PR body, as described in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/:" +
-				"\n\n~~~\n```release-note:TYPE\nRelease note" +
-				"\n```\n~~~"
+				" in the PR body, as described in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/"
 			log.Fatal(body)
 		case changelog.EntryErrorUnknownTypes:
 			unknownTypes := err.Details["unknownTypes"].([]string)


### PR DESCRIPTION
The colon gets lumped in with the link and doesn't exist - seehttps://github.com/GoogleCloudPlatform/magic-modules/actions/runs/7053029330/job/19199293155?pr=9554 for an example

```release-note:none

```
