### PR TITLE
No pdcsi disable on create

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -2384,11 +2384,28 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		cluster.SecurityPostureConfig = expandSecurityPostureConfig(v)
 	}
 
+  needUpdateAfterCreate := false
+
 	// For now PSC based cluster don't support `enable_private_endpoint` on `create`, but only on `update` API call.
 	// If cluster is PSC based and enable_private_endpoint is set to true we will ignore it on `create` call and update cluster right after creation.
 	enablePrivateEndpointPSCCluster := isEnablePrivateEndpointPSCCluster(cluster)
 	if enablePrivateEndpointPSCCluster {
 		cluster.PrivateClusterConfig.EnablePrivateEndpoint = false
+		needUpdateAfterCreate = true
+	}
+
+	enablePDCSI := isEnablePDCSI(cluster);
+	if !enablePDCSI {
+		// GcePersistentDiskCsiDriver cannot be disabled at cluster create, only on cluster update. Ignore on create then update after creation.
+		// If pdcsi is disabled, the config should be defined. But we will be paranoid and double-check.
+		needUpdateAfterCreate = true
+		if cluster.AddonsConfig == nil {
+			cluster.AddonsConfig = &container.AddonsConfig{}
+		}
+		if cluster.AddonsConfig.GcePersistentDiskCsiDriverConfig == nil {
+			cluster.AddonsConfig.GcePersistentDiskCsiDriverConfig = &container.GcePersistentDiskCsiDriverConfig{}
+		}
+		cluster.AddonsConfig.GcePersistentDiskCsiDriverConfig.Enabled = true
 	}
 
 	req := &container.CreateClusterRequest{
@@ -2475,14 +2492,22 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
-	if enablePrivateEndpointPSCCluster {
+	if needUpdateAfterCreate {
 		name := containerClusterFullName(project, location, clusterName)
-		req := &container.UpdateClusterRequest{
-			Update: &container.ClusterUpdate{
-				DesiredEnablePrivateEndpoint: true,
-				ForceSendFields:              []string{"DesiredEnablePrivateEndpoint"},
-			},
+		update := &container.ClusterUpdate{}
+		if enablePrivateEndpointPSCCluster {
+			update.DesiredEnablePrivateEndpoint = true
+			update.ForceSendFields = append(update.ForceSendFields, "DesiredEnablePrivateEndpoint");
 		}
+		if !enablePDCSI {
+			update.DesiredAddonsConfig = &container.AddonsConfig{
+				GcePersistentDiskCsiDriverConfig: &container.GcePersistentDiskCsiDriverConfig{
+					Enabled: false,
+				},
+			}
+			update.ForceSendFields = append(update.ForceSendFields, "DesiredAddonsConfig.GcePersistentDiskCsiDriverConfig.Enabled");
+		}
+		req := &container.UpdateClusterRequest{Update: update}
 
 		err = transport_tpg.Retry(transport_tpg.RetryOptions{
 			RetryFunc: func() error {
@@ -2495,12 +2520,12 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 			},
 		})
 		if err != nil {
-			return errwrap.Wrapf("Error updating enable private endpoint: {{err}}", err)
+			return errwrap.Wrapf(fmt.Sprintf("Error updating cluster for %v: {{err}}", update.ForceSendFields), err)
 		}
 
 		err = ContainerOperationWait(config, op, project, location, "updating enable private endpoint", userAgent, d.Timeout(schema.TimeoutCreate))
 		if err != nil {
-			return errwrap.Wrapf("Error while waiting to enable private endpoint: {{err}}", err)
+			return errwrap.Wrapf(fmt.Sprintf("Error while waiting on cluster update for %v: {{err}}", update.ForceSendFields), err)
 		}
 	}
 
@@ -4933,6 +4958,13 @@ func isEnablePrivateEndpointPSCCluster(cluster *container.Cluster) bool {
 		return true
 	}
 	return false
+}
+
+func isEnablePDCSI(cluster *container.Cluster) bool {
+	if cluster.AddonsConfig == nil || cluster.AddonsConfig.GcePersistentDiskCsiDriverConfig == nil {
+		return true;	// PDCSI is enabled by default.
+	}
+	return cluster.AddonsConfig.GcePersistentDiskCsiDriverConfig.Enabled
 }
 
 func expandPrivateClusterConfig(configured interface{}) *container.PrivateClusterConfig {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -127,7 +127,6 @@ func TestAccContainerCluster_misc(t *testing.T) {
 }
 
 func TestAccContainerCluster_withAddons(t *testing.T) {
-	t.Skipf("Skipping test %s due to https://github.com/hashicorp/terraform-provider-google/issues/16114", t.Name())
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
@@ -4762,6 +4761,7 @@ resource "google_container_cluster" "primary" {
       enabled = true
     }
 <% end -%>
+	}
   deletion_protection = false
   network    = "%s"
   subnetwork    = "%s"


### PR DESCRIPTION
The PDCSI addon cannot be disabled on cluster creation.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/16114

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: fixed a bug where disable PDCSI addon `gce_persistent_disk_csi_driver_config ` during creation will result in permadiff in `google_container_cluster` resource
```
