### PR TITLE
Promoting GKE Autoscaling Profiles to GA

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -770,7 +770,6 @@ func ResourceContainerCluster() *schema.Resource {
 								},
 							},
 						},
-						<% unless version == 'ga' -%>
 						"autoscaling_profile": {
 							Type:             schema.TypeString,
 							Default:          "BALANCED",
@@ -779,7 +778,6 @@ func ResourceContainerCluster() *schema.Resource {
 							ValidateFunc:     validation.StringInSlice([]string{"BALANCED", "OPTIMIZE_UTILIZATION"}, false),
 							Description:      `Configuration options for the Autoscaling profile feature, which lets you choose whether the cluster autoscaler should optimize for resource utilization or resource availability when deciding to remove nodes from a cluster. Can be BALANCED or OPTIMIZE_UTILIZATION. Defaults to BALANCED.`,
 						},
-						<% end -%>
 					},
 				},
 			},
@@ -4558,9 +4556,7 @@ func expandClusterAutoscaling(configured interface{}, d *schema.ResourceData) *c
 	return &container.ClusterAutoscaling{
 		EnableNodeAutoprovisioning: config["enabled"].(bool),
 		ResourceLimits:             resourceLimits,
-		<% unless version == 'ga' -%>
 		AutoscalingProfile: config["autoscaling_profile"].(string),
-		<% end -%>
 		AutoprovisioningNodePoolDefaults: expandAutoProvisioningDefaults(config["auto_provisioning_defaults"], d),
 	}
 }
@@ -5795,9 +5791,7 @@ func flattenClusterAutoscaling(a *container.ClusterAutoscaling) []map[string]int
 	} else {
 		r["enabled"] = false
 	}
-	<% unless version == 'ga' -%>
 	r["autoscaling_profile"] = a.AutoscalingProfile
-	<% end -%>
 
 	return []map[string]interface{}{r}
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -6416,7 +6416,6 @@ resource "google_container_cluster" "with_node_pool" {
 `, cluster, nodePool, networkName, subnetworkName)
 }
 
-<% unless version == 'ga' -%>
 func testAccContainerCluster_withAutoscalingProfile(cluster, autoscalingProfile, networkName, subnetworkName string) string {
 	config := fmt.Sprintf(`
 resource "google_container_cluster" "autoscaling_with_profile" {
@@ -6435,7 +6434,6 @@ resource "google_container_cluster" "autoscaling_with_profile" {
 `, cluster, autoscalingProfile, networkName, subnetworkName)
 	return config
 }
-<% end -%>
 
 func testAccContainerCluster_autoprovisioning(cluster, networkName, subnetworkName string, autoprovisioning, withNetworkTag bool) string {
 	config := fmt.Sprintf(`

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -3244,10 +3244,6 @@ func TestAccContainerCluster_withSoleTenantGroup(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
-// consider merging this test with TestAccContainerCluster_nodeAutoprovisioningDefaults
-// once the feature is GA
-
 func TestAccContainerCluster_withAutoscalingProfile(t *testing.T) {
 	t.Parallel()
 	clusterName := fmt.Sprintf("cluster-test-%s", acctest.RandString(t, 10))
@@ -3303,6 +3299,8 @@ func TestAccContainerCluster_withInvalidAutoscalingProfile(t *testing.T) {
 		},
 	})
 }
+
+<% unless version == 'ga' -%>
 
 func TestAccContainerCluster_sharedVpc(t *testing.T) {
 	// Multiple fine-grained resources


### PR DESCRIPTION
Promoting GKE Autoscaling Profiles to GA in the provider, [being GA since 2021](https://cloud.google.com/kubernetes-engine/docs/release-notes#August_30_2021) 

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement 
container: promoted GKE Autoscaling Profiles to GA in the `cluster_autoscaling` block in `google_container_cluster`
```
