### PR TITLE
Add Subnet resource to Vmwareengine

### DIFF
--- a/mmv1/products/vmwareengine/Subnet.yaml
+++ b/mmv1/products/vmwareengine/Subnet.yaml
@@ -1,0 +1,168 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'Subnet'
+base_url: '{{parent}}/subnets'
+create_url: '{{parent}}/subnets/{{name}}?update_mask=ip_cidr_range'
+self_link: '{{parent}}/subnets/{{name}}'
+update_mask: true
+create_verb: :PATCH
+update_verb: :PATCH
+skip_delete: true
+references: !ruby/object:Api::Resource::ReferenceLinks
+  api: 'https://cloud.google.com/vmware-engine/docs/reference/rest/v1/projects.locations.privateClouds.subnets'
+description: |
+  Subnet in a private cloud. A Private Cloud contains two types of subnets: `management` subnets (such as vMotion) that
+  are read-only,and `userDefined`, which can also be updated. This resource should be used to read and update `userDefined`
+  subnets. To read `management` subnets, please utilize the subnet data source.
+async: !ruby/object:Api::OpAsync
+  actions: ['create', 'update']
+  operation: !ruby/object:Api::OpAsync::Operation
+    path: "name"
+    base_url: "{{op_id}}"
+    wait_ms: 1000
+  result: !ruby/object:Api::OpAsync::Result
+    path: "response"
+  status: !ruby/object:Api::OpAsync::Status
+    path: "done"
+    complete: true
+    allowed:
+      - true
+      - false
+  error: !ruby/object:Api::OpAsync::Error
+    path: "error"
+    message: "message"
+  include_project: true
+
+import_format: ["{{%parent}}/subnets/{{name}}"]
+id_format: "{{parent}}/subnets/{{name}}"
+autogen_async: true
+
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: "vmware_engine_subnet_user_defined"
+    skip_test: true   # update tests will take care of read and update. Parent PC creation is expensive and node reservation is required.
+    primary_resource_id: "vmw-engine-subnet"
+    vars:
+      private_cloud_id: "sample-pc"
+      management_cluster_id: "sample-mgmt-cluster"
+      network_id: "pc-nw"
+      subnet_id: "service-1"
+    test_env_vars:
+      region: :REGION
+
+parameters:
+  - !ruby/object:Api::Type::String
+    name: "parent"
+    immutable: true
+    required: true
+    url_param_only: true
+    description: |
+      The resource name of the private cloud to create a new subnet in.
+      Resource names are schemeless URIs that follow the conventions in https://cloud.google.com/apis/design/resource_names.
+      For example: projects/my-project/locations/us-west1-a/privateClouds/my-cloud
+
+  - !ruby/object:Api::Type::String
+    name: "name"
+    required: true
+    immutable: true
+    url_param_only: true
+    description: |
+      The ID of the subnet. For userDefined subnets, this name should be in the format of "service-n",
+      where n ranges from 1 to 5.
+
+properties:
+  - !ruby/object:Api::Type::Time
+    name: 'createTime'
+    output: true
+    description: |
+      Creation time of this resource.
+      A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and
+      up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+
+  - !ruby/object:Api::Type::Time
+    name: 'updateTime'
+    output: true
+    description: |
+      Last updated time of this resource.
+      A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine
+      fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+
+  - !ruby/object:Api::Type::String
+    name: 'ipCidrRange'
+    required: true
+    send_empty_value: true
+    description: |
+      The IP address range of the subnet in CIDR format.
+
+  - !ruby/object:Api::Type::String
+    name: 'gatewayIp'
+    output: true
+    description: |
+      The IP address of the gateway of this subnet. Must fall within the IP prefix defined above.
+
+  - !ruby/object:Api::Type::String
+    name: 'gatewayId'
+    output: true
+    description: |
+      The canonical identifier of the logical router that this subnet is attached to.
+
+  - !ruby/object:Api::Type::Array
+    name: 'dhcpAddressRanges'
+    output: true
+    description: |
+      DHCP address ranges.
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties:
+        - !ruby/object:Api::Type::String
+          name: 'firstAddress'
+          output: true
+          description: |
+            The first IP address of the range.
+        - !ruby/object:Api::Type::String
+          name: 'lastAddress'
+          output: true
+          description: |
+            The last IP address of the range.
+
+  - !ruby/object:Api::Type::String
+    name: 'type'
+    output: true
+    description: |
+      The type of the subnet.
+
+  - !ruby/object:Api::Type::Boolean
+    name: standardConfig
+    output: true
+    description: |
+      Whether the NSX-T configuration in the backend follows the standard configuration supported by Google Cloud.
+      If false, the subnet cannot be modified through Google Cloud, only through NSX-T directly.
+
+  - !ruby/object:Api::Type::String
+    name: 'state'
+    description: |
+      State of the subnet.
+    output: true
+
+  - !ruby/object:Api::Type::String
+    name: 'uid'
+    output: true
+    description: |
+      System-generated unique identifier for the resource.
+
+  - !ruby/object:Api::Type::Integer
+    name: 'vlanId'
+    output: true
+    description: |
+      VLAN ID of the VLAN on which the subnet is configured.

--- a/mmv1/templates/terraform/examples/vmware_engine_subnet_user_defined.tf.erb
+++ b/mmv1/templates/terraform/examples/vmware_engine_subnet_user_defined.tf.erb
@@ -1,0 +1,30 @@
+resource "google_vmwareengine_network" "subnet-nw" {
+  name        = "<%= ctx[:vars]['network_id'] %>"
+  location    = "global"
+  type        = "STANDARD"
+  description = "PC network description."
+}
+
+resource "google_vmwareengine_private_cloud" "subnet-pc" {
+  location    = "<%= ctx[:test_env_vars]['region'] %>-a"
+  name        = "<%= ctx[:vars]['private_cloud_id'] %>"
+  description = "Sample test PC."
+  network_config {
+    management_cidr       = "192.168.50.0/24"
+    vmware_engine_network = google_vmwareengine_network.subnet-nw.id
+  }
+
+  management_cluster {
+    cluster_id = "<%= ctx[:vars]['management_cluster_id'] %>"
+    node_type_configs {
+      node_type_id = "standard-72"
+      node_count   = 3
+    }
+  }
+}
+
+resource "google_vmwareengine_subnet" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['subnet_id'] %>"
+  parent =  google_vmwareengine_private_cloud.subnet-pc.id
+  ip_cidr_range = "192.168.100.0/26"
+}

--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
@@ -207,6 +207,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_vmwareengine_network_policy":               vmwareengine.DataSourceVmwareengineNetworkPolicy(),
 	"google_vmwareengine_nsx_credentials":              vmwareengine.DataSourceVmwareengineNsxCredentials(),
 	"google_vmwareengine_private_cloud":                vmwareengine.DataSourceVmwareenginePrivateCloud(),
+	"google_vmwareengine_subnet": 						vmwareengine.DataSourceVmwareengineSubnet(),
 
 	// ####### END handwritten datasources ###########
 }

--- a/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_subnet.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_subnet.go
@@ -1,0 +1,38 @@
+package vmwareengine
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceVmwareengineSubnet() *schema.Resource {
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceVmwareengineSubnet().Schema)
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "parent", "name")
+	return &schema.Resource{
+		Read:   dataSourceVmwareengineSubnetRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceVmwareengineSubnetRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+
+	// Store the ID now
+	id, err := tpgresource.ReplaceVars(d, config, "{{parent}}/subnets/{{name}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+	err = resourceVmwareengineSubnetRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
+}

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_subnet_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_subnet_test.go
@@ -1,0 +1,90 @@
+package vmwareengine_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccVmwareengineSubnet_vmwareEngineUserDefinedSubnetUpdate(t *testing.T) {
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"region":        "southamerica-west1", // using region with low node utilization.
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testVmwareEngineSubnetConfig(context, "192.168.1.0/26"),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores("data.google_vmwareengine_subnet.ds", "google_vmwareengine_subnet.vmw-engine-subnet", map[string]struct{}{}),
+				),
+			},
+			{
+				ResourceName:            "google_vmwareengine_subnet.vmw-engine-subnet",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parent", "name"},
+			},
+			{
+				Config: testVmwareEngineSubnetConfig(context, "192.168.2.0/26"),
+			},
+			{
+				ResourceName:            "google_vmwareengine_subnet.vmw-engine-subnet",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parent", "name"},
+			},
+		},
+	})
+}
+
+func testVmwareEngineSubnetConfig(context map[string]interface{}, ipCidrRange string) string {
+	context["ip_cidr_range"] = ipCidrRange
+	return acctest.Nprintf(`
+resource "google_vmwareengine_network" "subnet-nw" {
+  name        = "tf-test-subnet-nw%{random_suffix}"
+  location    = "global"
+  type        = "STANDARD"
+  description = "PC network description."
+}
+
+resource "google_vmwareengine_private_cloud" "subnet-pc" {
+  location    = "%{region}-a"
+  name        = "tf-test-subnet-pc%{random_suffix}"
+  description = "Sample test PC."
+  network_config {
+    management_cidr       = "192.168.0.0/24"
+    vmware_engine_network = google_vmwareengine_network.subnet-nw.id
+  }
+
+  management_cluster {
+    cluster_id = "tf-test-mgmt-cluster%{random_suffix}"
+    node_type_configs {
+      node_type_id = "standard-72"
+      node_count   = 3
+    }
+  }
+}
+
+resource "google_vmwareengine_subnet" "vmw-engine-subnet" {
+  name = "service-2"
+  parent =  google_vmwareengine_private_cloud.subnet-pc.id
+  ip_cidr_range = "%{ip_cidr_range}"
+}
+
+data "google_vmwareengine_subnet" ds {
+  name = "service-2"
+  parent = google_vmwareengine_private_cloud.subnet-pc.id
+  depends_on = [
+    google_vmwareengine_subnet.vmw-engine-subnet,
+  ]
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/website/docs/d/vmwareengine_subnet.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/vmwareengine_subnet.html.markdown
@@ -1,0 +1,34 @@
+---
+subcategory: "Cloud VMware Engine"
+description: |-
+  Get info about a private cloud subnet.
+---
+
+# google\_vmwareengine\_subnet
+
+Use this data source to get details about a subnet. Management subnets support only read operations and should be configured through this data source. User defined subnets can be configured using the resource as well as the datasource.
+
+To get more information about private cloud subnet, see:
+* [API documentation](https://cloud.google.com/vmware-engine/docs/reference/rest/v1/projects.locations.privateClouds.subnets)
+
+## Example Usage
+
+```hcl
+data "google_vmwareengine_subnet" "my_subnet" {
+  name     = "service-1"
+  parent   = "project/my-project/locations/us-west1-a/privateClouds/my-cloud"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the resource. 
+UserDefined subnets are named in the format of "service-n", where n ranges from 1 to 5. 
+Management subnets have arbitary names including "vmotion", "vsan", "system-management" etc. More details about subnet names can be found on the cloud console.
+* `parent` - (Required) The resource name of the private cloud that this subnet belongs.
+
+## Attributes Reference
+
+See [google_vmwareengine_subnet](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vmwareengine_subnet#attributes-reference) resource for details of all the available attributes.


### PR DESCRIPTION
Added Subnet resource and datasource to Vmwareengine. 

The subnet resource is a child of private cloud (PC), and they are created automatically during PC creation. They can only be read and updated (ip_cidr_range field) by the user. Hence, it is created here as a read and update only fine grained resource. 

Since the parent PC creation is expensive and node reservation is required, all tests are merged into the update test.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_vmwareengine_subnet`
```

```release-note:new-datasource
`google_vmwareengine_subnet`
```
