### PR TITLE
Upgrade DCL to v1.59.0

### DIFF
--- a/mmv1/third_party/terraform/go.mod.erb
+++ b/mmv1/third_party/terraform/go.mod.erb
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	cloud.google.com/go/bigtable v1.19.0
-	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.57.0
+	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.58.0
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dnaeon/go-vcr v1.0.1

--- a/mmv1/third_party/terraform/go.mod.erb
+++ b/mmv1/third_party/terraform/go.mod.erb
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	cloud.google.com/go/bigtable v1.19.0
-	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.58.0
+	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.59.0
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dnaeon/go-vcr v1.0.1

--- a/mmv1/third_party/terraform/go.sum
+++ b/mmv1/third_party/terraform/go.sum
@@ -17,6 +17,8 @@ cloud.google.com/go/longrunning v0.5.4/go.mod h1:zqNVncI0BOP8ST6XQD1+VcvuShMmq7+
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.57.0 h1:Rz/Jlnt195m9B8CJPQejuTbXaPCoB1w1QYQjD4oKHMk=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.57.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.58.0 h1:BePRfJS3N4ZNUzn+Z5vKMthuoitcvmD7Yw14X8BM60c=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.58.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=

--- a/mmv1/third_party/terraform/go.sum
+++ b/mmv1/third_party/terraform/go.sum
@@ -17,8 +17,8 @@ cloud.google.com/go/longrunning v0.5.4/go.mod h1:zqNVncI0BOP8ST6XQD1+VcvuShMmq7+
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.57.0 h1:Rz/Jlnt195m9B8CJPQejuTbXaPCoB1w1QYQjD4oKHMk=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.57.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
-github.com/GoogleCloudPlatform/declarative-resource-client-library v1.58.0 h1:BePRfJS3N4ZNUzn+Z5vKMthuoitcvmD7Yw14X8BM60c=
-github.com/GoogleCloudPlatform/declarative-resource-client-library v1.58.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.59.0 h1:jL4ac+IUrVftmfduFslaMXWj9ENuiXEiwZFw3U5ikUA=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.59.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=

--- a/tpgtools/api/recaptchaenterprise/samples/waf.key.json
+++ b/tpgtools/api/recaptchaenterprise/samples/waf.key.json
@@ -1,0 +1,21 @@
+{
+  "displayName": "display-name-one",
+  "project": "{{project}}",
+  "webSettings": {
+    "allowAllDomains": true,
+    "allowedDomains": [],
+    "integrationType": "INVISIBLE",
+    "challengeSecurityPreference": "USABILITY"
+  },
+  "wafSettings": {
+    "wafFeature": "CHALLENGE_PAGE",
+    "wafService": "CA"
+  },
+  "testingOptions": {
+    "testingScore": 0.5,
+    "testingChallenge": "NOCAPTCHA"
+  },
+  "labels": {
+    "label-one": "value-one"
+  }
+}

--- a/tpgtools/api/recaptchaenterprise/samples/waf_key.yaml
+++ b/tpgtools/api/recaptchaenterprise/samples/waf_key.yaml
@@ -1,0 +1,22 @@
+# Copyright 2023 Google LLC. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: waf_key
+description: A basic test of recaptcha enterprise key that includes WAF settings
+type: key
+versions:
+- ga
+resource: samples/waf.key.json
+variables:
+- name: project
+  type: project

--- a/tpgtools/go.mod
+++ b/tpgtools/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	bitbucket.org/creachadair/stringset v0.0.11
-	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.58.0
+	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.59.0
 	github.com/golang/glog v1.1.2
 	github.com/hashicorp/hcl v1.0.0
 	github.com/kylelemons/godebug v1.1.0

--- a/tpgtools/go.mod
+++ b/tpgtools/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	bitbucket.org/creachadair/stringset v0.0.11
-	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.57.0
+	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.58.0
 	github.com/golang/glog v1.1.2
 	github.com/hashicorp/hcl v1.0.0
 	github.com/kylelemons/godebug v1.1.0

--- a/tpgtools/go.sum
+++ b/tpgtools/go.sum
@@ -10,6 +10,8 @@ github.com/GoogleCloudPlatform/declarative-resource-client-library v1.57.0 h1:Rz
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.57.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.58.0 h1:BePRfJS3N4ZNUzn+Z5vKMthuoitcvmD7Yw14X8BM60c=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.58.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.59.0 h1:jL4ac+IUrVftmfduFslaMXWj9ENuiXEiwZFw3U5ikUA=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.59.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/tpgtools/go.sum
+++ b/tpgtools/go.sum
@@ -8,6 +8,8 @@ cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2Aawl
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.57.0 h1:Rz/Jlnt195m9B8CJPQejuTbXaPCoB1w1QYQjD4oKHMk=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.57.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.58.0 h1:BePRfJS3N4ZNUzn+Z5vKMthuoitcvmD7Yw14X8BM60c=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.58.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/tpgtools/overrides/containerazure/samples/nodepool/basic.tf.tmpl
+++ b/tpgtools/overrides/containerazure/samples/nodepool/basic.tf.tmpl
@@ -73,6 +73,10 @@ resource "google_container_azure_node_pool" "primary" {
       owner = "mmv2"
     }
 
+    labels = {
+      key_one = "label_one"
+    }
+
     vm_size = "Standard_DS2_v2"
   }
 

--- a/tpgtools/overrides/containerazure/samples/nodepool/basic_update.tf.tmpl
+++ b/tpgtools/overrides/containerazure/samples/nodepool/basic_update.tf.tmpl
@@ -74,6 +74,10 @@ resource "google_container_azure_node_pool" "primary" {
       owner = "mmv2"
     }
 
+    labels = {
+      key_two = "label_two"
+    }
+
     vm_size = "Standard_DS2_v2"
   }
 

--- a/tpgtools/overrides/containerazure/samples/nodepool/beta_basic.tf.tmpl
+++ b/tpgtools/overrides/containerazure/samples/nodepool/beta_basic.tf.tmpl
@@ -77,6 +77,10 @@ resource "google_container_azure_node_pool" "primary" {
       owner = "mmv2"
     }
 
+    labels = {
+      key_one = "label_one"
+    }
+
     vm_size = "Standard_DS2_v2"
 
     image_type = "ubuntu"

--- a/tpgtools/overrides/containerazure/samples/nodepool/beta_basic_update.tf.tmpl
+++ b/tpgtools/overrides/containerazure/samples/nodepool/beta_basic_update.tf.tmpl
@@ -78,6 +78,10 @@ resource "google_container_azure_node_pool" "primary" {
       owner = "mmv2"
     }
 
+    labels = {
+      key_two = "label_two"
+    }
+
     vm_size = "Standard_DS2_v2"
 
     image_type = "ubuntu"

--- a/tpgtools/overrides/orgpolicy/beta/policy.yaml
+++ b/tpgtools/overrides/orgpolicy/beta/policy.yaml
@@ -7,5 +7,9 @@
   field: spec.rules.deny_all
 - type: ENUM_BOOL
   field: spec.rules.enforce
-- type: EXCLUDE
-  field: dry_run_spec
+- type: ENUM_BOOL
+  field: dry_run_spec.rules.allow_all
+- type: ENUM_BOOL
+  field: dry_run_spec.rules.deny_all
+- type: ENUM_BOOL
+  field: dry_run_spec.rules.enforce

--- a/tpgtools/overrides/orgpolicy/samples/policy/dry_run_spec.tf.tmpl
+++ b/tpgtools/overrides/orgpolicy/samples/policy/dry_run_spec.tf.tmpl
@@ -14,15 +14,14 @@ resource "google_org_policy_policy" "primary" {
   name   = "organizations/{{org_id}}/policies/${google_org_policy_custom_constraint.constraint.name}"
   parent = "organizations/{{org_id}}"
 
-  inherit_from_parent = false
-  reset               = false
-
   spec {
     rules {
       enforce = "FALSE"
     }
   }
   dry_run_spec {
+    inherit_from_parent = false
+    reset               = false
     rules {
       enforce = "FALSE"
     }

--- a/tpgtools/overrides/orgpolicy/samples/policy/dry_run_spec.tf.tmpl
+++ b/tpgtools/overrides/orgpolicy/samples/policy/dry_run_spec.tf.tmpl
@@ -1,0 +1,30 @@
+resource "google_org_policy_custom_constraint" "constraint" {
+  name         = "custom.disableGkeAutoUpgrade%{random_suffix}"
+  parent       = "organizations/{{org_id}}"
+  display_name = "Disable GKE auto upgrade"
+  description  = "Only allow GKE NodePool resource to be created or updated if AutoUpgrade is not enabled where this custom constraint is enforced."
+
+  action_type    = "ALLOW"
+  condition      = "resource.management.autoUpgrade == false"
+  method_types   = ["CREATE"]
+  resource_types = ["container.googleapis.com/NodePool"]
+}
+
+resource "google_org_policy_policy" "primary" {
+  name   = "organizations/{{org_id}}/policies/${google_org_policy_custom_constraint.constraint.name}"
+  parent = "organizations/{{org_id}}"
+
+  inherit_from_parent = false
+  reset               = false
+
+  spec {
+    rules {
+      enforce = "FALSE"
+    }
+  }
+  dry_run_spec {
+    rules {
+      enforce = "FALSE"
+    }
+  }
+}

--- a/tpgtools/overrides/orgpolicy/samples/policy/dry_run_spec.yaml
+++ b/tpgtools/overrides/orgpolicy/samples/policy/dry_run_spec.yaml
@@ -1,0 +1,3 @@
+variables:
+  - name: "org_id"
+    type: "org_id"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

dry_run_spec.rules were not yet testable per service team

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
orgpolicy: added `dry_run_spec` to `google_org_policy_policy` (beta)
```
```release-note:enhancement
containerazure: added `config.labels` to `google_container_azure_node_pool`
```
```release-note:enhancement
recaptchaenterprise: added `waf_settings` to `google_recaptcha_enterprise_key`
```
