### PR TITLE
Build and test provider off main/feature

### DIFF
--- a/.github/workflows/build-downstream.yml
+++ b/.github/workflows/build-downstream.yml
@@ -17,7 +17,7 @@ jobs:
   generate-repository:
     runs-on: ubuntu-22.04
     env:
-      BASE_BRANCH: ${{ github.event.pull_request.base.ref || github.ref }}
+      BASE_BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout Repository

--- a/.github/workflows/downstreams.yml
+++ b/.github/workflows/downstreams.yml
@@ -4,7 +4,8 @@ permissions: read-all
 on:
   push:
     branches:
-      - scott-test-*
+      - main
+      - 'FEATURE-BRANCH-*'
 
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('commit-{0}', github.sha) }}


### PR DESCRIPTION

Original failure was due to using ref instead of ref_name
https://docs.github.com/en/actions/learn-github-actions/contexts#github-context

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
