### PR TITLE
Retry on firestore index create 409 with 'underlying data changed'

### DIFF
--- a/mmv1/products/firestore/Index.yaml
+++ b/mmv1/products/firestore/Index.yaml
@@ -17,7 +17,7 @@ base_url: projects/{{project}}/databases/{{database}}/collectionGroups/{{collect
 self_link: '{{name}}'
 immutable: true
 error_retry_predicates:
-  ["transport_tpg.FirestoreIndex409CrossTransactionContetion"]
+  ["transport_tpg.FirestoreIndex409Retry"]
 description: |
   Cloud Firestore indexes enable simple and complex queries against documents in a database.
    This resource manages composite indexes and not single

--- a/mmv1/third_party/terraform/transport/error_retry_predicates.go
+++ b/mmv1/third_party/terraform/transport/error_retry_predicates.go
@@ -331,10 +331,14 @@ func FirestoreField409RetryUnderlyingDataChanged(err error) (bool, string) {
 }
 
 // relevant for firestore in datastore mode
-func FirestoreIndex409CrossTransactionContetion(err error) (bool, string) {
-	if gerr, ok := err.(*googleapi.Error); ok {
-		if gerr.Code == 409 && strings.Contains(gerr.Body, "Aborted due to cross-transaction contention") {
+func FirestoreIndex409Retry(err error) (bool, string) {
+	if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 409 {
+		if strings.Contains(gerr.Body, "Aborted due to cross-transaction contention") {
 			return true, "aborted due to cross-transaction contention - retrying"
+		}
+
+		if strings.Contains(gerr.Body, "Please retry, underlying data changed") {
+			return true, "underlying data changed - retrying"
 		}
 	}
 	return false, ""

--- a/mmv1/third_party/terraform/transport/error_retry_predicates_test.go
+++ b/mmv1/third_party/terraform/transport/error_retry_predicates_test.go
@@ -187,7 +187,18 @@ func TestFirestoreIndex409_crossTransactionContetion(t *testing.T) {
 		Code: 409,
 		Body: "Aborted due to cross-transaction contention",
 	}
-	isRetryable, _ := FirestoreIndex409CrossTransactionContetion(&err)
+	isRetryable, _ := FirestoreIndex409Retry(&err)
+	if !isRetryable {
+		t.Errorf("Error not detected as retryable")
+	}
+}
+
+func TestFirestoreIndex409_retryUnderlyingDataChanged(t *testing.T) {
+	err := googleapi.Error{
+		Code: 409,
+		Body: "Please retry, underlying data changed",
+	}
+	isRetryable, _ := FirestoreIndex409Retry(&err)
 	if !isRetryable {
 		t.Errorf("Error not detected as retryable")
 	}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/16664

Retry firestore index create operation in case of `409` error with the text `Please retry, underlying data changed`. This happened by creating multiple indexes.
It is similar to https://github.com/GoogleCloudPlatform/magic-modules/pull/9515 that was merged recently.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
firestore: retried resource creation for error 409 with the text "Please retry, underlying data changed" in `google_firestore_index `
```
