### PR TITLE
Add ExternalAddress resource to Vmwareengine

### DIFF
--- a/mmv1/products/vmwareengine/ExternalAddress.yaml
+++ b/mmv1/products/vmwareengine/ExternalAddress.yaml
@@ -1,0 +1,125 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'ExternalAddress'
+base_url: '{{parent}}/externalAddresses'
+create_url: '{{parent}}/externalAddresses?externalAddressId={{name}}'
+self_link: '{{parent}}/externalAddresses/{{name}}'
+update_mask: true
+update_verb: :PATCH
+references: !ruby/object:Api::Resource::ReferenceLinks
+  api: 'https://cloud.google.com/vmware-engine/docs/reference/rest/v1/projects.locations.privateClouds.externalAddresses'
+description: |
+  An allocated external IP address and its corresponding internal IP address in a private cloud.
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
+    path: "name"
+    base_url: "{{op_id}}"
+    wait_ms: 1000
+    timeouts: !ruby/object:Api::Timeouts
+      insert_minutes: 40
+  result: !ruby/object:Api::OpAsync::Result
+    path: "response"
+  status: !ruby/object:Api::OpAsync::Status
+    path: "done"
+    complete: true
+    allowed:
+      - true
+      - false
+  error: !ruby/object:Api::OpAsync::Error
+    path: "error"
+    message: "message"
+  include_project: true
+
+import_format: ["{{%parent}}/externalAddresses/{{name}}"]
+id_format: "{{parent}}/externalAddresses/{{name}}"
+error_retry_predicates: ['transport_tpg.ExternalIpServiceNotActive']
+autogen_async: true
+
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: "vmware_engine_external_address_basic"
+    primary_resource_id: "vmw-engine-external-address"
+    skip_test: true   # update tests will take care of all CRUD tests. Parent PC creation is expensive and node reservation is required.
+    vars:
+      name: "sample-external-address"
+      network_id: "pc-nw"
+      private_cloud_id: "sample-pc"
+      management_cluster_id: "sample-mgmt-cluster"
+      network_policy_id: "sample-np"
+
+parameters:
+  - !ruby/object:Api::Type::String
+    name: "parent"
+    immutable: true
+    required: true
+    url_param_only: true
+    description: |
+      The resource name of the private cloud to create a new external address in.
+      Resource names are schemeless URIs that follow the conventions in https://cloud.google.com/apis/design/resource_names.
+      For example: projects/my-project/locations/us-west1-a/privateClouds/my-cloud
+
+  - !ruby/object:Api::Type::String
+    name: "name"
+    required: true
+    immutable: true
+    url_param_only: true
+    description: |
+      The ID of the external IP Address.
+
+properties:
+  - !ruby/object:Api::Type::Time
+    name: 'createTime'
+    output: true
+    description: |
+      Creation time of this resource.
+      A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and
+      up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+
+  - !ruby/object:Api::Type::Time
+    name: 'updateTime'
+    output: true
+    description: |
+      Last updated time of this resource.
+      A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine
+      fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+
+  - !ruby/object:Api::Type::String
+    name: 'internalIp'
+    required: true
+    description: |
+      The internal IP address of a workload VM.
+
+  - !ruby/object:Api::Type::String
+    name: 'externalIp'
+    output: true
+    description: |
+      The external IP address of a workload VM.
+
+  - !ruby/object:Api::Type::String
+    name: 'state'
+    description: |
+      State of the resource.
+    output: true
+
+  - !ruby/object:Api::Type::String
+    name: 'uid'
+    output: true
+    description: |
+      System-generated unique identifier for the resource.
+
+  - !ruby/object:Api::Type::String
+    name: 'description'
+    description: |
+      User-provided description for this resource.

--- a/mmv1/templates/terraform/examples/vmware_engine_external_address_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/vmware_engine_external_address_basic.tf.erb
@@ -1,0 +1,41 @@
+resource "google_vmwareengine_network" "external-address-nw" {
+  name        = "<%= ctx[:vars]['network_id'] %>"
+  location    = "global"
+  type        = "STANDARD"
+  description = "PC network description."
+}
+
+resource "google_vmwareengine_private_cloud" "external-address-pc" {
+  location    = "<%= ctx[:test_env_vars]['region'] %>-a"
+  name        = "<%= ctx[:vars]['private_cloud_id'] %>"
+  description = "Sample test PC."
+  network_config {
+    management_cidr       = "192.168.50.0/24"
+    vmware_engine_network = google_vmwareengine_network.external-address-nw.id
+  }
+
+  management_cluster {
+    cluster_id = "<%= ctx[:vars]['management_cluster_id'] %>"
+    node_type_configs {
+      node_type_id = "standard-72"
+      node_count   = 3
+    }
+  }
+}
+
+resource "google_vmwareengine_network_policy" "external-address-np" {
+  location = "<%= ctx[:test_env_vars]['region'] %>"
+  name = "<%= ctx[:vars]['network_policy_id'] %>"
+  edge_services_cidr = "192.168.30.0/26"
+  vmware_engine_network = google_vmwareengine_network.external-address-nw.id
+}
+
+resource "google_vmwareengine_external_address" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['name'] %>"
+  parent = google_vmwareengine_private_cloud.external-address-pc.id
+  internal_ip = "192.168.0.66"
+  description = "Sample description."
+  depends_on = [
+    google_vmwareengine_network_policy.external-address-np,
+  ]
+}

--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
@@ -202,6 +202,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	<% unless version == 'ga' -%>
 	"google_vmwareengine_cluster":                      vmwareengine.DataSourceVmwareengineCluster(),
 	<% end -%>
+	"google_vmwareengine_external_address":             vmwareengine.DataSourceVmwareengineExternalAddress(),
 	"google_vmwareengine_network":                      vmwareengine.DataSourceVmwareengineNetwork(),
 	"google_vmwareengine_network_peering":              vmwareengine.DataSourceVmwareengineNetworkPeering(),
 	"google_vmwareengine_network_policy":               vmwareengine.DataSourceVmwareengineNetworkPolicy(),

--- a/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_external_address.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_external_address.go
@@ -1,0 +1,39 @@
+package vmwareengine
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceVmwareengineExternalAddress() *schema.Resource {
+
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceVmwareengineExternalAddress().Schema)
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "parent", "name")
+	return &schema.Resource{
+		Read:   dataSourceVmwareengineExternalAddressRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceVmwareengineExternalAddressRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+
+	// Store the ID now
+	id, err := tpgresource.ReplaceVars(d, config, "{{parent}}/externalAddresses/{{name}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+	err = resourceVmwareengineExternalAddressRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
+}

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_address_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_address_test.go
@@ -1,0 +1,152 @@
+package vmwareengine_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func TestAccVmwareengineExternalAddress_vmwareEngineExternalAddressUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"region":        "southamerica-east1", // using region with low node utilization.
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckVmwareengineExternalAddressDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testVmwareEngineExternalAddressConfig(context, "description1", "192.168.0.66"),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores("data.google_vmwareengine_external_address.ds", "google_vmwareengine_external_address.vmw-engine-external-address", map[string]struct{}{}),
+				),
+			},
+			{
+				ResourceName:            "google_vmwareengine_external_address.vmw-engine-external-address",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parent", "name"},
+			},
+			{
+				Config: testVmwareEngineExternalAddressConfig(context, "description2", "192.168.0.67"),
+			},
+			{
+				ResourceName:            "google_vmwareengine_external_address.vmw-engine-external-address",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parent", "name"},
+			},
+		},
+	})
+}
+
+func testVmwareEngineExternalAddressConfig(context map[string]interface{}, description string, internalIp string) string {
+	context["internal_ip"] = internalIp
+	context["description"] = description
+	return acctest.Nprintf(`
+resource "google_vmwareengine_network" "external-address-nw" {
+  name        = "tf-test-sample-external-address-nw%{random_suffix}"
+  location    = "global"
+  type        = "STANDARD"
+  description = "PC network description."
+}
+
+resource "google_vmwareengine_private_cloud" "external-address-pc" {
+  location    = "%{region}-a"
+  name        = "tf-test-sample-external-address-pc%{random_suffix}"
+  description = "Sample test PC."
+  network_config {
+    management_cidr       = "192.168.1.0/24"
+    vmware_engine_network = google_vmwareengine_network.external-address-nw.id
+  }
+
+  management_cluster {
+    cluster_id = "tf-test-sample-external-address-cluster%{random_suffix}"
+    node_type_configs {
+      node_type_id = "standard-72"
+      node_count   = 3
+    }
+  }
+}
+
+resource "google_vmwareengine_network_policy" "external-address-np" {
+  location = "%{region}"
+  name = "tf-test-sample-external-address-np%{random_suffix}"
+  edge_services_cidr = "192.168.0.0/26"
+  vmware_engine_network = google_vmwareengine_network.external-address-nw.id
+	internet_access {
+    enabled = true
+  }
+  external_ip {
+    enabled = true
+  }
+}
+
+resource "google_vmwareengine_external_address" "vmw-engine-external-address" {
+  name = "tf-test-sample-external-address%{random_suffix}"
+  parent = google_vmwareengine_private_cloud.external-address-pc.id
+  internal_ip = "%{internal_ip}"
+  description = "%{description}"
+  depends_on = [
+    google_vmwareengine_network_policy.external-address-np,
+  ]
+}
+
+data "google_vmwareengine_external_address" "ds" {
+  name = google_vmwareengine_external_address.vmw-engine-external-address.name
+  parent = google_vmwareengine_private_cloud.external-address-pc.id
+  depends_on = [
+    google_vmwareengine_external_address.vmw-engine-external-address,
+  ]
+}
+`, context)
+}
+
+func testAccCheckVmwareengineExternalAddressDestroyProducer(t *testing.T) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		for name, rs := range s.RootModule().Resources {
+			if rs.Type != "google_vmwareengine_external_address" {
+				continue
+			}
+			if strings.HasPrefix(name, "data.") {
+				continue
+			}
+
+			config := acctest.GoogleProviderConfig(t)
+
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{VmwareengineBasePath}}{{parent}}/externalAddresses/{{name}}")
+			if err != nil {
+				return err
+			}
+
+			billingProject := ""
+
+			if config.BillingProject != "" {
+				billingProject = config.BillingProject
+			}
+
+			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				Project:   billingProject,
+				RawURL:    url,
+				UserAgent: config.UserAgent,
+			})
+			if err == nil {
+				return fmt.Errorf("VmwareengineExternalAddress still exists at %s", url)
+			}
+		}
+
+		return nil
+	}
+}

--- a/mmv1/third_party/terraform/transport/error_retry_predicates.go
+++ b/mmv1/third_party/terraform/transport/error_retry_predicates.go
@@ -517,3 +517,14 @@ func IsForbiddenIamServiceAccountRetryableError(opType string) RetryErrorPredica
 		return false, ""
 	}
 }
+
+// Retry the creation of `google_vmwareengine_external_address` resource if the network policy's
+// External IP field is not active yet.
+func ExternalIpServiceNotActive(err error) (bool, string) {
+	if gerr, ok := err.(*googleapi.Error); ok {
+		if gerr.Code == 400 && strings.Contains(gerr.Body, "External IP address network service is not active in the provided network policy") {
+			return true, "Waiting for external ip service to be enabled"
+		}
+	}
+	return false, ""
+}

--- a/mmv1/third_party/terraform/transport/error_retry_predicates_test.go
+++ b/mmv1/third_party/terraform/transport/error_retry_predicates_test.go
@@ -192,3 +192,14 @@ func TestFirestoreIndex409_crossTransactionContetion(t *testing.T) {
 		t.Errorf("Error not detected as retryable")
 	}
 }
+
+func TestExternalIpServiceNotActive(t *testing.T) {
+	err := googleapi.Error{
+		Code: 400,
+		Body: "External IP address network service is not active in the provided network policy",
+	}
+	isRetryable, _ := ExternalIpServiceNotActive(&err)
+	if !isRetryable {
+		t.Errorf("Error not detected as retryable")
+	}
+}

--- a/mmv1/third_party/terraform/website/docs/d/vmwareengine_external_address.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/vmwareengine_external_address.html.markdown
@@ -1,0 +1,32 @@
+---
+subcategory: "Cloud VMware Engine"
+description: |-
+  Get information about a external address.
+---
+
+# google\_vmwareengine\_external_address
+
+Use this data source to get details about a external address resource.
+
+To get more information about external address, see:
+* [API documentation](https://cloud.google.com/vmware-engine/docs/reference/rest/v1/projects.locations.privateClouds.externalAddresses)
+
+## Example Usage
+
+```hcl
+data "google_vmwareengine_external_address" "my_external_address" {
+  name     = "my-external-address"
+  parent   = "project/my-project/locations/us-west1-a/privateClouds/my-cloud"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the resource.
+* `parent` - (Required) The resource name of the private cloud that this cluster belongs.
+
+## Attributes Reference
+
+See [google_vmwareengine_external_address](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vmwareengine_external_address#attributes-reference) resource for details of all the available attributes.


### PR DESCRIPTION
Added ExternalAddress resource and datasource to Vmwareengine. 
External addresses are child resources of a Private Cloud (PC).

Since the parent PC creation is expensive and node reservation is required, all tests are merged into the update test.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_vmwareengine_external_address`
```

```release-note:new-datasource
`google_vmwareengine_external_address`
```
