### PR TITLE
Add rpo attribute to 'google_storage_bucket' resource

### DIFF
--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
@@ -465,6 +465,12 @@ func ResourceStorageBucket() *schema.Resource {
 				},
 				Description: `The bucket's custom location configuration, which specifies the individual regions that comprise a dual-region bucket. If the bucket is designated a single or multi-region, the parameters are empty.`,
 			},
+			"rpo": {
+				Type: schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: `Specifies the RPO setting of bucket. If set 'ASYNC_TURBO', The Turbo Replication will be enabled for the dual-region bucket. Value 'DEFAULT' will set RPO setting to default. Turbo Replication is only for buckets in dual-regions.See the docs for more details.`,
+			},
 			"public_access_prevention": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -595,6 +601,10 @@ func resourceStorageBucketCreate(d *schema.ResourceData, meta interface{}) error
 
 	if v, ok := d.GetOk("custom_placement_config"); ok {
 		sb.CustomPlacementConfig = expandBucketCustomPlacementConfig(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("rpo"); ok{
+		sb.Rpo = v.(string)
 	}
 
 	var res *storage.Bucket
@@ -758,6 +768,14 @@ func resourceStorageBucketUpdate(d *schema.ResourceData, meta interface{}) error
 
 	if d.HasChange("uniform_bucket_level_access") || d.HasChange("public_access_prevention") {
 		sb.IamConfiguration = expandIamConfiguration(d)
+	}
+
+	if d.HasChange("rpo") {
+		if v,ok := d.GetOk("rpo"); ok{
+			sb.Rpo = v.(string)
+		} else {
+			sb.NullFields = append(sb.NullFields, "Rpo")
+		}
 	}
 
 	res, err := config.NewStorageClient(userAgent).Buckets.Patch(d.Get("name").(string), sb).Do()
@@ -1671,7 +1689,13 @@ func setStorageBucket(d *schema.ResourceData, config *transport_tpg.Config, res 
 	if err := d.Set("custom_placement_config", flattenBucketCustomPlacementConfig(res.CustomPlacementConfig)); err != nil {
 		return fmt.Errorf("Error setting custom_placement_config: %s", err)
 	}
-
+	// Needs to hide rpo field for single-region buckets.
+	// Check the Rpo field from API response to determine whether bucket is in single region config or not.
+	if res.Rpo != "" {
+    if err := d.Set("rpo", res.Rpo); err != nil {
+      return fmt.Errorf("Error setting RPO setting : %s", err)
+    }
+	}
 	if res.IamConfiguration != nil && res.IamConfiguration.UniformBucketLevelAccess != nil {
 		if err := d.Set("uniform_bucket_level_access", res.IamConfiguration.UniformBucketLevelAccess.Enabled); err != nil {
 			return fmt.Errorf("Error setting uniform_bucket_level_access: %s", err)

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
@@ -178,6 +178,124 @@ func TestAccStorageBucket_dualLocation(t *testing.T) {
 	})
 }
 
+func TestAccStorageBucket_dualLocation_rpo(t *testing.T) {
+	t.Parallel()
+	bucketName := acctest.TestBucketName(t)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccStorageBucketDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStorageBucket_dualLocation(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"google_storage_bucket.bucket", "rpo", "DEFAULT"),
+				),
+			},
+			{
+				ResourceName:            "google_storage_bucket.bucket",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+			{
+				Config: testAccStorageBucket_dualLocation_rpo(bucketName,"ASYNC_TURBO"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"google_storage_bucket.bucket", "rpo", "ASYNC_TURBO"),
+				),
+			},
+			{
+				ResourceName:            "google_storage_bucket.bucket",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+			{
+				Config: testAccStorageBucket_dualLocation(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"google_storage_bucket.bucket", "rpo", "ASYNC_TURBO"),
+				),
+			},
+			{
+				ResourceName:            "google_storage_bucket.bucket",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+			{
+				Config: testAccStorageBucket_dualLocation_rpo(bucketName,"DEFAULT"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"google_storage_bucket.bucket", "rpo", "DEFAULT"),
+				),
+			},
+			{
+				ResourceName:            "google_storage_bucket.bucket",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+			{
+				Config: testAccStorageBucket_dualLocation(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"google_storage_bucket.bucket", "rpo", "DEFAULT"),
+				),
+			},
+			{
+				ResourceName:            "google_storage_bucket.bucket",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+		},
+	})
+}
+
+func TestAccStorageBucket_multiLocation_rpo(t *testing.T) {
+	t.Parallel()
+
+	bucketName := acctest.TestBucketName(t)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccStorageBucketDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStorageBucket_basic(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"google_storage_bucket.bucket", "rpo", "DEFAULT"),
+				),
+			},
+			{
+				ResourceName:            "google_storage_bucket.bucket",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+			{
+				Config: testAccStorageBucket_multiLocation_rpo(bucketName,"DEFAULT"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"google_storage_bucket.bucket", "rpo", "DEFAULT"),
+				),
+			},
+			{
+				ResourceName:            "google_storage_bucket.bucket",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+		},
+	})
+}
+
 func TestAccStorageBucket_customAttributes(t *testing.T) {
 	t.Parallel()
 
@@ -1402,6 +1520,31 @@ resource "google_storage_bucket" "bucket" {
   }
 }
 `, bucketName)
+}
+
+func testAccStorageBucket_dualLocation_rpo(bucketName string,rpo string) string {
+	return fmt.Sprintf(`
+resource "google_storage_bucket" "bucket" {
+  name          = "%s"
+  location      = "ASIA"
+  force_destroy = true
+  custom_placement_config {
+    data_locations = ["ASIA-EAST1", "ASIA-SOUTHEAST1"]
+  }
+  rpo = "%s"
+}
+`, bucketName,rpo)
+}
+
+func testAccStorageBucket_multiLocation_rpo(bucketName string,rpo string) string {
+	return fmt.Sprintf(`
+resource "google_storage_bucket" "bucket" {
+  name          = "%s"
+  location      = "ASIA"
+  force_destroy = true
+  rpo = "%s"
+}
+`, bucketName,rpo)
 }
 
 func testAccStorageBucket_customAttributes(bucketName string) string {

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -125,6 +125,8 @@ The following arguments are supported:
 
 * `requester_pays` - (Optional, Default: false) Enables [Requester Pays](https://cloud.google.com/storage/docs/requester-pays) on a storage bucket.
 
+* `rpo` - (Optional) RPO setting of the bucket. If set 'ASYNC_TURBO', The Turbo Replication will be enabled for the bucket. 'DEFAULT' value will set RPO setting to default RPO. **Note**: Turbo Replication is only for buckets in dual-regions (https://cloud.google.com/storage/docs/managing-turbo-replication). **Note**: If used with single-region bucket, It will throw an error.
+
 * `uniform_bucket_level_access` - (Optional, Default: false) Enables [Uniform bucket-level access](https://cloud.google.com/storage/docs/uniform-bucket-level-access) access to a bucket.
 
 * `public_access_prevention` - (Optional) Prevents public access to a bucket. Acceptable values are "inherited" or "enforced". If "inherited", the bucket uses [public access prevention](https://cloud.google.com/storage/docs/public-access-prevention). only if the bucket is subject to the public access prevention organization policy constraint. Defaults to "inherited".


### PR DESCRIPTION
Adds the rpo field to `google_storage_bucket` for bucket replication config.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
storage: added 'rpo' field to 'google_storage_bucket' resource.
```
