### PR TITLE
Fix permadiff that reorders  `stateful_external_ip` blocks on `google_compute_instance_group_manager` and `google_compute_region_instance_group_manager` resources

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
@@ -781,7 +781,7 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 	if err = d.Set("stateful_internal_ip", flattenStatefulPolicyStatefulInternalIps(manager.StatefulPolicy)); err != nil {
 		return fmt.Errorf("Error setting stateful_internal_ip in state: %s", err.Error())
 	}
-	if err = d.Set("stateful_external_ip", flattenStatefulPolicyStatefulExternalIps(manager.StatefulPolicy)); err != nil {
+	if err = d.Set("stateful_external_ip", flattenStatefulPolicyStatefulExternalIps(d, manager.StatefulPolicy)); err != nil {
 		return fmt.Errorf("Error setting stateful_external_ip in state: %s", err.Error())
 	}
 	if err := d.Set("fingerprint", manager.Fingerprint); err != nil {
@@ -1322,21 +1322,57 @@ func flattenStatefulPolicyStatefulInternalIps(statefulPolicy *compute.StatefulPo
 	return result
 }
 
-func flattenStatefulPolicyStatefulExternalIps(statefulPolicy *compute.StatefulPolicy) []map[string]interface{} {
+func flattenStatefulPolicyStatefulExternalIps(d *schema.ResourceData, statefulPolicy *compute.StatefulPolicy) []map[string]interface{} {
 	if statefulPolicy == nil || statefulPolicy.PreservedState == nil || statefulPolicy.PreservedState.ExternalIPs == nil {
 		return make([]map[string]interface{}, 0, 0)
 	}
-	result := make([]map[string]interface{}, 0, len(statefulPolicy.PreservedState.ExternalIPs))
+
+	initialResult := make([]map[string]interface{}, 0, len(statefulPolicy.PreservedState.ExternalIPs))
 	for interfaceName, externalIp := range statefulPolicy.PreservedState.ExternalIPs {
 		data := map[string]interface{}{
 			"interface_name": interfaceName,
 			"delete_rule": externalIp.AutoDelete,
 		}
 
-		result = append(result, data)
+		initialResult = append(initialResult, data)
 	}
-	return result
+
+	// statefulPolicy.PreservedState.ExternalIPs is affected by API-side reordering of external IPs, where ordering
+	// is done by the interface_name value. Below we intend to reorder the external IPs to match the order in the config.
+	// Any external IPs found from the API response that aren't in the config are appended to the end of the list.
+
+	val, ok := d.GetOk("stateful_external_ip")
+	configIpOrder := val.([]interface{})
+	if !ok || len(configIpOrder) == 0 {
+		return initialResult // return information from the API unchanged
+	}
+
+	order := map[string]int{} // record map of interface name to index
+	for i, el := range configIpOrder {
+		externalIp := el.(map[string]interface{})
+		name := externalIp["interface_name"].(string)
+		order[name] = i
+	}
+
+	orderedResult := make([]map[string]interface{}, len(configIpOrder))
+	unexpectedIps := []map[string]interface{}{}
+	for _, el := range initialResult {
+		name := el["interface_name"].(string)
+		index, found := order[name]
+		if !found {
+			unexpectedIps = append(unexpectedIps, el)
+			continue
+		}
+		orderedResult[index] = el // Put elements from API response in correct order
+	}
+	if len(unexpectedIps) > 0 {
+		// Additional IPs not in the config are appended to the end of the slice
+		orderedResult = append(orderedResult, unexpectedIps...)
+	}
+
+	return orderedResult
 }
+
 
 func flattenUpdatePolicy(updatePolicy *compute.InstanceGroupManagerUpdatePolicy) []map[string]interface{} {
 	results := []map[string]interface{}{}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
@@ -1324,55 +1324,45 @@ func flattenStatefulPolicyStatefulInternalIps(statefulPolicy *compute.StatefulPo
 
 func flattenStatefulPolicyStatefulExternalIps(d *schema.ResourceData, statefulPolicy *compute.StatefulPolicy) []map[string]interface{} {
 	if statefulPolicy == nil || statefulPolicy.PreservedState == nil || statefulPolicy.PreservedState.ExternalIPs == nil {
-		return make([]map[string]interface{}, 0, 0)
-	}
-
-	initialResult := make([]map[string]interface{}, 0, len(statefulPolicy.PreservedState.ExternalIPs))
-	for interfaceName, externalIp := range statefulPolicy.PreservedState.ExternalIPs {
-		data := map[string]interface{}{
-			"interface_name": interfaceName,
-			"delete_rule": externalIp.AutoDelete,
-		}
-
-		initialResult = append(initialResult, data)
+		return make([]map[string]interface{}, 0)
 	}
 
 	// statefulPolicy.PreservedState.ExternalIPs is affected by API-side reordering of external IPs, where ordering
-	// is done by the interface_name value. Below we intend to reorder the external IPs to match the order in the config.
-	// Any external IPs found from the API response that aren't in the config are appended to the end of the list.
+	// is done by the interface_name value.
+	// Below we intend to reorder the external IPs to match the order in the config.
+	// Also, data is converted from a map (client library's statefulPolicy.PreservedState.ExternalIPs) to a slice (stored in state).
+	// Any external IPs found from the API response that aren't in the config are appended to the end of the slice.
 
-	val, ok := d.GetOk("stateful_external_ip")
-	configIpOrder := val.([]interface{})
-	if !ok || len(configIpOrder) == 0 {
-		return initialResult // return information from the API unchanged
-	}
-
+	configIpOrder := d.Get("stateful_external_ip").([]interface{})
 	order := map[string]int{} // record map of interface name to index
 	for i, el := range configIpOrder {
 		externalIp := el.(map[string]interface{})
-		name := externalIp["interface_name"].(string)
-		order[name] = i
+		interfaceName := externalIp["interface_name"].(string)
+		order[interfaceName] = i
 	}
 
 	orderedResult := make([]map[string]interface{}, len(configIpOrder))
 	unexpectedIps := []map[string]interface{}{}
-	for _, el := range initialResult {
-		name := el["interface_name"].(string)
-		index, found := order[name]
+	for interfaceName, externalIp := range statefulPolicy.PreservedState.ExternalIPs {
+		data := map[string]interface{}{
+			"interface_name": interfaceName,
+			"delete_rule":    externalIp.AutoDelete,
+		}
+
+		index, found := order[interfaceName]
 		if !found {
-			unexpectedIps = append(unexpectedIps, el)
+			unexpectedIps = append(unexpectedIps, data)
 			continue
 		}
-		orderedResult[index] = el // Put elements from API response in correct order
+		orderedResult[index] = data // Put elements from API response in correct order
 	}
 	if len(unexpectedIps) > 0 {
-		// Additional IPs not in the config are appended to the end of the slice
+		// Additional IPs returned from API but not in the config are appended to the end of the slice
 		orderedResult = append(orderedResult, unexpectedIps...)
 	}
 
 	return orderedResult
 }
-
 
 func flattenUpdatePolicy(updatePolicy *compute.InstanceGroupManagerUpdatePolicy) []map[string]interface{} {
 	results := []map[string]interface{}{}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
@@ -778,7 +778,7 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 	if err = d.Set("stateful_disk", flattenStatefulPolicy(manager.StatefulPolicy)); err != nil {
 		return fmt.Errorf("Error setting stateful_disk in state: %s", err.Error())
 	}
-	if err = d.Set("stateful_internal_ip", flattenStatefulPolicyStatefulInternalIps(manager.StatefulPolicy)); err != nil {
+	if err = d.Set("stateful_internal_ip", flattenStatefulPolicyStatefulInternalIps(d, manager.StatefulPolicy)); err != nil {
 		return fmt.Errorf("Error setting stateful_internal_ip in state: %s", err.Error())
 	}
 	if err = d.Set("stateful_external_ip", flattenStatefulPolicyStatefulExternalIps(d, manager.StatefulPolicy)); err != nil {
@@ -1306,20 +1306,12 @@ func flattenStatefulPolicy(statefulPolicy *compute.StatefulPolicy) []map[string]
 	return result
 }
 
-func flattenStatefulPolicyStatefulInternalIps(statefulPolicy *compute.StatefulPolicy) []map[string]interface{} {
+func flattenStatefulPolicyStatefulInternalIps(d *schema.ResourceData, statefulPolicy *compute.StatefulPolicy) []map[string]interface{} {
 	if statefulPolicy == nil || statefulPolicy.PreservedState == nil || statefulPolicy.PreservedState.InternalIPs == nil {
 		return make([]map[string]interface{}, 0, 0)
 	}
-	result := make([]map[string]interface{}, 0, len(statefulPolicy.PreservedState.InternalIPs))
-	for interfaceName, internalIp := range statefulPolicy.PreservedState.InternalIPs {
-		data := map[string]interface{}{
-			"interface_name": interfaceName,
-			"delete_rule": internalIp.AutoDelete,
-		}
 
-		result = append(result, data)
-	}
-	return result
+	return flattenStatefulPolicyStatefulIps(d, "stateful_internal_ip", statefulPolicy.PreservedState.InternalIPs)
 }
 
 func flattenStatefulPolicyStatefulExternalIps(d *schema.ResourceData, statefulPolicy *compute.StatefulPolicy) []map[string]interface{} {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
@@ -1327,26 +1327,31 @@ func flattenStatefulPolicyStatefulExternalIps(d *schema.ResourceData, statefulPo
 		return make([]map[string]interface{}, 0)
 	}
 
-	// statefulPolicy.PreservedState.ExternalIPs is affected by API-side reordering of external IPs, where ordering
-	// is done by the interface_name value.
-	// Below we intend to reorder the external IPs to match the order in the config.
-	// Also, data is converted from a map (client library's statefulPolicy.PreservedState.ExternalIPs) to a slice (stored in state).
-	// Any external IPs found from the API response that aren't in the config are appended to the end of the slice.
+	return flattenStatefulPolicyStatefulIps(d, "stateful_external_ip", statefulPolicy.PreservedState.ExternalIPs)
+}
 
-	configIpOrder := d.Get("stateful_external_ip").([]interface{})
+func flattenStatefulPolicyStatefulIps(d *schema.ResourceData, ipfieldName string, ips map[string]compute.StatefulPolicyPreservedStateNetworkIp) []map[string]interface{} {
+
+	// statefulPolicy.PreservedState.ExternalIPs and statefulPolicy.PreservedState.InternalIPs are affected by API-side reordering
+	// of external/internal IPs, where ordering is done by the interface_name value.
+	// Below we intend to reorder the IPs to match the order in the config.
+	// Also, data is converted from a map (client library's statefulPolicy.PreservedState.ExternalIPs, or .InternalIPs) to a slice (stored in state).
+	// Any IPs found from the API response that aren't in the config are appended to the end of the slice.
+
+	configIpOrder := d.Get(ipfieldName).([]interface{})
 	order := map[string]int{} // record map of interface name to index
 	for i, el := range configIpOrder {
-		externalIp := el.(map[string]interface{})
-		interfaceName := externalIp["interface_name"].(string)
+		ip := el.(map[string]interface{})
+		interfaceName := ip["interface_name"].(string)
 		order[interfaceName] = i
 	}
 
 	orderedResult := make([]map[string]interface{}, len(configIpOrder))
 	unexpectedIps := []map[string]interface{}{}
-	for interfaceName, externalIp := range statefulPolicy.PreservedState.ExternalIPs {
+	for interfaceName, ip := range ips {
 		data := map[string]interface{}{
 			"interface_name": interfaceName,
-			"delete_rule":    externalIp.AutoDelete,
+			"delete_rule":    ip.AutoDelete,
 		}
 
 		index, found := order[interfaceName]
@@ -1354,7 +1359,7 @@ func flattenStatefulPolicyStatefulExternalIps(d *schema.ResourceData, statefulPo
 			unexpectedIps = append(unexpectedIps, data)
 			continue
 		}
-		orderedResult[index] = data // Put elements from API response in correct order
+		orderedResult[index] = data // Put elements from API response in order that matches the config
 	}
 
 	// Remove any nils from the ordered list. This can occur if the API doesn't include an interface present in the config.

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
@@ -1356,12 +1356,21 @@ func flattenStatefulPolicyStatefulExternalIps(d *schema.ResourceData, statefulPo
 		}
 		orderedResult[index] = data // Put elements from API response in correct order
 	}
-	if len(unexpectedIps) > 0 {
-		// Additional IPs returned from API but not in the config are appended to the end of the slice
-		orderedResult = append(orderedResult, unexpectedIps...)
+
+	// Remove any nils from the ordered list. This can occur if the API doesn't include an interface present in the config.
+	finalResult := []map[string]interface{}{}
+	for _, item := range orderedResult {
+		if item != nil {
+			finalResult = append(finalResult, item)
+		}
 	}
 
-	return orderedResult
+	if len(unexpectedIps) > 0 {
+		// Additional IPs returned from API but not in the config are appended to the end of the slice
+		finalResult = append(finalResult, unexpectedIps...)
+	}
+
+	return finalResult
 }
 
 func flattenUpdatePolicy(updatePolicy *compute.InstanceGroupManagerUpdatePolicy) []map[string]interface{} {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_internal_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_internal_test.go
@@ -1,7 +1,11 @@
 package compute
 
 import (
+	"reflect"
 	"testing"
+
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	"google.golang.org/api/compute/v1"
 )
 
 func TestInstanceGroupManager_parseUniqueId(t *testing.T) {
@@ -74,5 +78,157 @@ func TestInstanceGroupManager_convertUniqueId(t *testing.T) {
 		if actual != expected {
 			t.Fatalf("invalid return value by ConvertToUniqueIdWhenPresent for input %v; expected: %v, actual: %v", input, expected, actual)
 		}
+	}
+}
+
+func TestFlattenStatefulPolicyStatefulExternalIps(t *testing.T) {
+	cases := map[string]struct {
+		ConfigValues map[string]interface{}
+		ExternalIPs  map[string]compute.StatefulPolicyPreservedStateNetworkIp
+		Expected     []map[string]interface{}
+	}{
+		"Single external IP (nic0) in config and API-side": {
+			ConfigValues: map[string]interface{}{
+				"stateful_external_ip": []interface{}{
+					map[string]interface{}{
+						"interface_name": "nic0",
+						"delete_rule":    "NEVER",
+					},
+				},
+			},
+			ExternalIPs: map[string]compute.StatefulPolicyPreservedStateNetworkIp{
+				"nic0": {
+					AutoDelete: "NEVER",
+				},
+			},
+			Expected: []map[string]interface{}{
+				{
+					"interface_name": "nic0",
+					"delete_rule":    "NEVER",
+				},
+			},
+		},
+		"Two external IPs (nic0, nic1). Unordered in config and sorted API-side": {
+			ConfigValues: map[string]interface{}{
+				"stateful_external_ip": []interface{}{
+					map[string]interface{}{
+						"interface_name": "nic1",
+						"delete_rule":    "NEVER",
+					},
+					map[string]interface{}{
+						"interface_name": "nic0",
+						"delete_rule":    "NEVER",
+					},
+				},
+			},
+			ExternalIPs: map[string]compute.StatefulPolicyPreservedStateNetworkIp{
+				"nic0": {
+					AutoDelete: "NEVER",
+				},
+				"nic1": {
+					AutoDelete: "NEVER",
+				},
+			},
+			Expected: []map[string]interface{}{
+				{
+					"interface_name": "nic1",
+					"delete_rule":    "NEVER",
+				},
+				{
+					"interface_name": "nic0",
+					"delete_rule":    "NEVER",
+				},
+			},
+		},
+		"Two external IPs (nic0, nic1). Only nic0 in config and both stored API-side": {
+			ConfigValues: map[string]interface{}{
+				"stateful_external_ip": []interface{}{
+					map[string]interface{}{
+						"interface_name": "nic0",
+						"delete_rule":    "NEVER",
+					},
+				},
+			},
+			ExternalIPs: map[string]compute.StatefulPolicyPreservedStateNetworkIp{
+				"nic0": {
+					AutoDelete: "NEVER",
+				},
+				"nic1": {
+					AutoDelete: "NEVER",
+				},
+			},
+			Expected: []map[string]interface{}{
+				{
+					"interface_name": "nic0",
+					"delete_rule":    "NEVER",
+				},
+				{
+					"interface_name": "nic1",
+					"delete_rule":    "NEVER",
+				},
+			},
+		},
+		"Three external IPs (nic0, nic1, nic2). Only nic1, nic2 in config and all 3 stored API-side": {
+			ConfigValues: map[string]interface{}{
+				"stateful_external_ip": []interface{}{
+					map[string]interface{}{
+						"interface_name": "nic1",
+						"delete_rule":    "NEVER",
+					},
+					map[string]interface{}{
+						"interface_name": "nic2",
+						"delete_rule":    "NEVER",
+					},
+				},
+			},
+			ExternalIPs: map[string]compute.StatefulPolicyPreservedStateNetworkIp{
+				"nic0": {
+					AutoDelete: "NEVER",
+				},
+				"nic1": {
+					AutoDelete: "NEVER",
+				},
+				"nic2": {
+					AutoDelete: "NEVER",
+				},
+			},
+			Expected: []map[string]interface{}{
+				{
+					"interface_name": "nic1",
+					"delete_rule":    "NEVER",
+				},
+				{
+					"interface_name": "nic2",
+					"delete_rule":    "NEVER",
+				},
+				{
+					"interface_name": "nic0",
+					"delete_rule":    "NEVER",
+				},
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+
+			// Terraform config
+			schema := ResourceComputeRegionInstanceGroupManager().Schema
+			d := tpgresource.SetupTestResourceDataFromConfigMap(t, schema, tc.ConfigValues)
+
+			// API response
+			statefulPolicyPreservedState := compute.StatefulPolicyPreservedState{
+				ExternalIPs: tc.ExternalIPs,
+			}
+			statefulPolicy := compute.StatefulPolicy{
+				PreservedState: &statefulPolicyPreservedState,
+			}
+
+			output := flattenStatefulPolicyStatefulExternalIps(d, &statefulPolicy)
+
+			if !reflect.DeepEqual(tc.Expected, output) {
+				t.Fatalf("expected output to be %#v, but got %#v", tc.Expected, output)
+			}
+		})
 	}
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_internal_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_internal_test.go.erb
@@ -95,8 +95,8 @@ func TestFlattenStatefulPolicyStatefulExternalIps(t *testing.T) {
 	}{
 		"No external IPs in config nor API data": {
 			ConfigValues: map[string]interface{}{},
-			ExternalIPs: map[string]compute.StatefulPolicyPreservedStateNetworkIp{},
-			Expected: []map[string]interface{}{},
+			ExternalIPs:  map[string]compute.StatefulPolicyPreservedStateNetworkIp{},
+			Expected:     []map[string]interface{}{},
 		},
 		"Single external IP (nic0) in config and API data": {
 			ConfigValues: map[string]interface{}{
@@ -235,6 +235,38 @@ func TestFlattenStatefulPolicyStatefulExternalIps(t *testing.T) {
 				},
 				{
 					"interface_name": "nic0",
+					"delete_rule":    "NEVER",
+				},
+			},
+		},
+		"Three external IPs (nic0, nic1, nic2). Only nic0, nic2 in config and only nic1, nic2 stored in API data": {
+			ConfigValues: map[string]interface{}{
+				"stateful_external_ip": []interface{}{
+					map[string]interface{}{
+						"interface_name": "nic2",
+						"delete_rule":    "NEVER",
+					},
+					map[string]interface{}{
+						"interface_name": "nic0",
+						"delete_rule":    "NEVER",
+					},
+				},
+			},
+			ExternalIPs: map[string]compute.StatefulPolicyPreservedStateNetworkIp{
+				"nic1": {
+					AutoDelete: "NEVER",
+				},
+				"nic2": {
+					AutoDelete: "NEVER",
+				},
+			},
+			Expected: []map[string]interface{}{
+				{
+					"interface_name": "nic2",
+					"delete_rule":    "NEVER",
+				},
+				{
+					"interface_name": "nic1",
 					"delete_rule":    "NEVER",
 				},
 			},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_internal_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_internal_test.go.erb
@@ -87,27 +87,25 @@ func TestInstanceGroupManager_convertUniqueId(t *testing.T) {
 	}
 }
 
-func TestFlattenStatefulPolicyStatefulExternalIps(t *testing.T) {
+func TestFlattenStatefulPolicyStatefulIps(t *testing.T) {
 	cases := map[string]struct {
-		ConfigValues map[string]interface{}
-		ExternalIPs  map[string]compute.StatefulPolicyPreservedStateNetworkIp
+		ConfigValues []interface{}
+		Ips          map[string]compute.StatefulPolicyPreservedStateNetworkIp
 		Expected     []map[string]interface{}
 	}{
-		"No external IPs in config nor API data": {
-			ConfigValues: map[string]interface{}{},
-			ExternalIPs:  map[string]compute.StatefulPolicyPreservedStateNetworkIp{},
+		"No IPs in config nor API data": {
+			ConfigValues: []interface{}{},
+			Ips:          map[string]compute.StatefulPolicyPreservedStateNetworkIp{},
 			Expected:     []map[string]interface{}{},
 		},
-		"Single external IP (nic0) in config and API data": {
-			ConfigValues: map[string]interface{}{
-				"stateful_external_ip": []interface{}{
-					map[string]interface{}{
-						"interface_name": "nic0",
-						"delete_rule":    "NEVER",
-					},
+		"Single IP (nic0) in config and API data": {
+			ConfigValues: []interface{}{
+				map[string]interface{}{
+					"interface_name": "nic0",
+					"delete_rule":    "NEVER",
 				},
 			},
-			ExternalIPs: map[string]compute.StatefulPolicyPreservedStateNetworkIp{
+			Ips: map[string]compute.StatefulPolicyPreservedStateNetworkIp{
 				"nic0": {
 					AutoDelete: "NEVER",
 				},
@@ -119,20 +117,18 @@ func TestFlattenStatefulPolicyStatefulExternalIps(t *testing.T) {
 				},
 			},
 		},
-		"Two external IPs (nic0, nic1). Unordered in config and sorted in API data": {
-			ConfigValues: map[string]interface{}{
-				"stateful_external_ip": []interface{}{
-					map[string]interface{}{
-						"interface_name": "nic1",
-						"delete_rule":    "NEVER",
-					},
-					map[string]interface{}{
-						"interface_name": "nic0",
-						"delete_rule":    "NEVER",
-					},
+		"Two IPs (nic0, nic1). Unordered in config and sorted in API data": {
+			ConfigValues: []interface{}{
+				map[string]interface{}{
+					"interface_name": "nic1",
+					"delete_rule":    "NEVER",
+				},
+				map[string]interface{}{
+					"interface_name": "nic0",
+					"delete_rule":    "NEVER",
 				},
 			},
-			ExternalIPs: map[string]compute.StatefulPolicyPreservedStateNetworkIp{
+			Ips: map[string]compute.StatefulPolicyPreservedStateNetworkIp{
 				"nic0": {
 					AutoDelete: "NEVER",
 				},
@@ -151,16 +147,14 @@ func TestFlattenStatefulPolicyStatefulExternalIps(t *testing.T) {
 				},
 			},
 		},
-		"Two external IPs (nic0, nic1). Only nic0 in config and both stored in API data": {
-			ConfigValues: map[string]interface{}{
-				"stateful_external_ip": []interface{}{
-					map[string]interface{}{
-						"interface_name": "nic0",
-						"delete_rule":    "NEVER",
-					},
+		"Two IPs (nic0, nic1). Only nic0 in config and both stored in API data": {
+			ConfigValues: []interface{}{
+				map[string]interface{}{
+					"interface_name": "nic0",
+					"delete_rule":    "NEVER",
 				},
 			},
-			ExternalIPs: map[string]compute.StatefulPolicyPreservedStateNetworkIp{
+			Ips: map[string]compute.StatefulPolicyPreservedStateNetworkIp{
 				"nic0": {
 					AutoDelete: "NEVER",
 				},
@@ -179,9 +173,9 @@ func TestFlattenStatefulPolicyStatefulExternalIps(t *testing.T) {
 				},
 			},
 		},
-		"Two external IPs (nic0, nic1). None stored in config and both stored in API data": {
-			ConfigValues: map[string]interface{}{},
-			ExternalIPs: map[string]compute.StatefulPolicyPreservedStateNetworkIp{
+		"Two IPs (nic0, nic1). None stored in config and both stored in API data": {
+			ConfigValues: []interface{}{},
+			Ips: map[string]compute.StatefulPolicyPreservedStateNetworkIp{
 				"nic0": {
 					AutoDelete: "NEVER",
 				},
@@ -200,20 +194,18 @@ func TestFlattenStatefulPolicyStatefulExternalIps(t *testing.T) {
 				},
 			},
 		},
-		"Three external IPs (nic0, nic1, nic2). Only nic1, nic2 in config and all 3 stored in API data": {
-			ConfigValues: map[string]interface{}{
-				"stateful_external_ip": []interface{}{
-					map[string]interface{}{
-						"interface_name": "nic1",
-						"delete_rule":    "NEVER",
-					},
-					map[string]interface{}{
-						"interface_name": "nic2",
-						"delete_rule":    "NEVER",
-					},
+		"Three IPs (nic0, nic1, nic2). Only nic1, nic2 in config and all 3 stored in API data": {
+			ConfigValues: []interface{}{
+				map[string]interface{}{
+					"interface_name": "nic1",
+					"delete_rule":    "NEVER",
+				},
+				map[string]interface{}{
+					"interface_name": "nic2",
+					"delete_rule":    "NEVER",
 				},
 			},
-			ExternalIPs: map[string]compute.StatefulPolicyPreservedStateNetworkIp{
+			Ips: map[string]compute.StatefulPolicyPreservedStateNetworkIp{
 				"nic0": {
 					AutoDelete: "NEVER",
 				},
@@ -239,20 +231,18 @@ func TestFlattenStatefulPolicyStatefulExternalIps(t *testing.T) {
 				},
 			},
 		},
-		"Three external IPs (nic0, nic1, nic2). Only nic0, nic2 in config and only nic1, nic2 stored in API data": {
-			ConfigValues: map[string]interface{}{
-				"stateful_external_ip": []interface{}{
-					map[string]interface{}{
-						"interface_name": "nic2",
-						"delete_rule":    "NEVER",
-					},
-					map[string]interface{}{
-						"interface_name": "nic0",
-						"delete_rule":    "NEVER",
-					},
+		"Three IPs (nic0, nic1, nic2). Only nic0, nic2 in config and only nic1, nic2 stored in API data": {
+			ConfigValues: []interface{}{
+				map[string]interface{}{
+					"interface_name": "nic2",
+					"delete_rule":    "NEVER",
+				},
+				map[string]interface{}{
+					"interface_name": "nic0",
+					"delete_rule":    "NEVER",
 				},
 			},
-			ExternalIPs: map[string]compute.StatefulPolicyPreservedStateNetworkIp{
+			Ips: map[string]compute.StatefulPolicyPreservedStateNetworkIp{
 				"nic1": {
 					AutoDelete: "NEVER",
 				},
@@ -278,21 +268,31 @@ func TestFlattenStatefulPolicyStatefulExternalIps(t *testing.T) {
 
 			// Terraform config
 			schema := ResourceComputeRegionInstanceGroupManager().Schema
-			d := tpgresource.SetupTestResourceDataFromConfigMap(t, schema, tc.ConfigValues)
+			config := map[string]interface{}{
+				"stateful_external_ip": tc.ConfigValues,
+				"stateful_internal_ip": tc.ConfigValues,
+			}
+			d := tpgresource.SetupTestResourceDataFromConfigMap(t, schema, config)
 
 			// API response
 			statefulPolicyPreservedState := compute.StatefulPolicyPreservedState{
-				ExternalIPs: tc.ExternalIPs,
+				ExternalIPs: tc.Ips,
+				InternalIPs: tc.Ips,
 			}
 			statefulPolicy := compute.StatefulPolicy{
 				PreservedState: &statefulPolicyPreservedState,
 			}
 
-			output := flattenStatefulPolicyStatefulExternalIps(d, &statefulPolicy)
+			outputExternal := flattenStatefulPolicyStatefulExternalIps(d, &statefulPolicy)
+			if !reflect.DeepEqual(tc.Expected, outputExternal) {
+				t.Fatalf("expected external IPs output to be %#v, but got %#v", tc.Expected, outputExternal)
+			}
 
-			if !reflect.DeepEqual(tc.Expected, output) {
-				t.Fatalf("expected output to be %#v, but got %#v", tc.Expected, output)
+			outputInternal := flattenStatefulPolicyStatefulInternalIps(d, &statefulPolicy)
+			if !reflect.DeepEqual(tc.Expected, outputInternal) {
+				t.Fatalf("expected internal IPs output to be %#v, but got %#v", tc.Expected, outputInternal)
 			}
 		})
 	}
 }
+

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_internal_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_internal_test.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package compute
 
 import (
@@ -5,7 +6,12 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+
+<% if version == "ga" -%>
 	"google.golang.org/api/compute/v1"
+<% else -%>
+	compute "google.golang.org/api/compute/v0.beta"
+<% end -%>
 )
 
 func TestInstanceGroupManager_parseUniqueId(t *testing.T) {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_internal_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_internal_test.go.erb
@@ -93,7 +93,12 @@ func TestFlattenStatefulPolicyStatefulExternalIps(t *testing.T) {
 		ExternalIPs  map[string]compute.StatefulPolicyPreservedStateNetworkIp
 		Expected     []map[string]interface{}
 	}{
-		"Single external IP (nic0) in config and API-side": {
+		"No external IPs in config nor API data": {
+			ConfigValues: map[string]interface{}{},
+			ExternalIPs: map[string]compute.StatefulPolicyPreservedStateNetworkIp{},
+			Expected: []map[string]interface{}{},
+		},
+		"Single external IP (nic0) in config and API data": {
 			ConfigValues: map[string]interface{}{
 				"stateful_external_ip": []interface{}{
 					map[string]interface{}{
@@ -114,7 +119,7 @@ func TestFlattenStatefulPolicyStatefulExternalIps(t *testing.T) {
 				},
 			},
 		},
-		"Two external IPs (nic0, nic1). Unordered in config and sorted API-side": {
+		"Two external IPs (nic0, nic1). Unordered in config and sorted in API data": {
 			ConfigValues: map[string]interface{}{
 				"stateful_external_ip": []interface{}{
 					map[string]interface{}{
@@ -146,7 +151,7 @@ func TestFlattenStatefulPolicyStatefulExternalIps(t *testing.T) {
 				},
 			},
 		},
-		"Two external IPs (nic0, nic1). Only nic0 in config and both stored API-side": {
+		"Two external IPs (nic0, nic1). Only nic0 in config and both stored in API data": {
 			ConfigValues: map[string]interface{}{
 				"stateful_external_ip": []interface{}{
 					map[string]interface{}{
@@ -174,7 +179,28 @@ func TestFlattenStatefulPolicyStatefulExternalIps(t *testing.T) {
 				},
 			},
 		},
-		"Three external IPs (nic0, nic1, nic2). Only nic1, nic2 in config and all 3 stored API-side": {
+		"Two external IPs (nic0, nic1). None stored in config and both stored in API data": {
+			ConfigValues: map[string]interface{}{},
+			ExternalIPs: map[string]compute.StatefulPolicyPreservedStateNetworkIp{
+				"nic0": {
+					AutoDelete: "NEVER",
+				},
+				"nic1": {
+					AutoDelete: "NEVER",
+				},
+			},
+			Expected: []map[string]interface{}{
+				{
+					"interface_name": "nic0",
+					"delete_rule":    "NEVER",
+				},
+				{
+					"interface_name": "nic1",
+					"delete_rule":    "NEVER",
+				},
+			},
+		},
+		"Three external IPs (nic0, nic1, nic2). Only nic1, nic2 in config and all 3 stored in API data": {
 			ConfigValues: map[string]interface{}{
 				"stateful_external_ip": []interface{}{
 					map[string]interface{}{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_test.go.erb
@@ -342,7 +342,7 @@ func TestAccInstanceGroupManager_stateful(t *testing.T) {
 	target := fmt.Sprintf("tf-test-igm-%s", acctest.RandString(t, 10))
 	igm := fmt.Sprintf("tf-test-igm-%s", acctest.RandString(t, 10))
 	hck := fmt.Sprintf("tf-test-igm-%s", acctest.RandString(t, 10))
- 	network := fmt.Sprintf("tf-test-igm-%s", acctest.RandString(t, 10))
+	network := fmt.Sprintf("tf-test-igm-%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
@@ -768,7 +768,7 @@ func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta 
 	if err = d.Set("status", flattenStatus(manager.Status)); err != nil {
 		return fmt.Errorf("Error setting status in state: %s", err.Error())
 	}
-	if err = d.Set("stateful_internal_ip", flattenStatefulPolicyStatefulInternalIps(manager.StatefulPolicy)); err != nil {
+	if err = d.Set("stateful_internal_ip", flattenStatefulPolicyStatefulInternalIps(d, manager.StatefulPolicy)); err != nil {
 		return fmt.Errorf("Error setting stateful_internal_ip in state: %s", err.Error())
 	}
 	if err = d.Set("stateful_external_ip", flattenStatefulPolicyStatefulExternalIps(d, manager.StatefulPolicy)); err != nil {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
@@ -771,7 +771,7 @@ func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta 
 	if err = d.Set("stateful_internal_ip", flattenStatefulPolicyStatefulInternalIps(manager.StatefulPolicy)); err != nil {
 		return fmt.Errorf("Error setting stateful_internal_ip in state: %s", err.Error())
 	}
-	if err = d.Set("stateful_external_ip", flattenStatefulPolicyStatefulExternalIps(manager.StatefulPolicy)); err != nil {
+	if err = d.Set("stateful_external_ip", flattenStatefulPolicyStatefulExternalIps(d, manager.StatefulPolicy)); err != nil {
 		return fmt.Errorf("Error setting stateful_external_ip in state: %s", err.Error())
 	}
 	// If unset in state set to default value

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.erb
@@ -309,7 +309,7 @@ func TestAccRegionInstanceGroupManager_distributionPolicy(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"status"},
 			},
-      {
+			{
 				Config: testAccRegionInstanceGroupManager_distributionPolicyUpdate(template, igm, zones),
 			},
 			{
@@ -329,7 +329,7 @@ func TestAccRegionInstanceGroupManager_stateful(t *testing.T) {
 
 	template := fmt.Sprintf("tf-test-rigm-%s", acctest.RandString(t, 10))
 	igm := fmt.Sprintf("tf-test-rigm-%s", acctest.RandString(t, 10))
- 	network := fmt.Sprintf("tf-test-igm-%s", acctest.RandString(t, 10))
+	network := fmt.Sprintf("tf-test-igm-%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -362,6 +362,28 @@ func TestAccRegionInstanceGroupManager_stateful(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"status"},
+			},
+		},
+	})
+}
+
+func TestAccRegionInstanceGroupManager_APISideListRecordering(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"name": fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckRegionInstanceGroupManagerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			// {
+			// 	Config: testAccRegionInstanceGroupManager_statefulOrdered(context),
+			// },
+			{
+				Config: testAccRegionInstanceGroupManager_statefulUnordered(context),
 			},
 		},
 	})
@@ -1571,4 +1593,154 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
   }
 }
 `, network, template, igm)
+}
+
+func testAccRegionInstanceGroupManager_statefulOrdered(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+resource "google_compute_network" "igm-basic" {
+  name = "%{name}"
+}
+resource "google_compute_instance_template" "igm-basic" {
+  name           = "%{name}"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+    device_name  = "stateful-disk"
+  }
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    device_name  = "stateful-disk2"
+  }
+  network_interface {
+    network = "default"
+  }
+  network_interface {
+    network = google_compute_network.igm-basic.self_link
+  }
+}
+
+resource "google_compute_region_instance_group_manager" "igm-basic" {
+  description = "Terraform test instance group manager"
+  name        = "%{name}"
+
+  version {
+    instance_template = google_compute_instance_template.igm-basic.self_link
+    name              = "primary"
+  }
+
+  base_instance_name        = "tf-test-igm-basic"
+  region                    = "us-central1"
+  target_size               = 2
+  update_policy {
+    instance_redistribution_type = "NONE"
+    type                         = "OPPORTUNISTIC"
+    minimal_action               = "REPLACE"
+    max_surge_fixed              = 0
+    max_unavailable_fixed        = 6
+  }
+  stateful_disk {
+    device_name = "stateful-disk"
+    delete_rule = "NEVER"
+  }
+  stateful_internal_ip {
+    interface_name = "nic0"
+    delete_rule = "ON_PERMANENT_INSTANCE_DELETION"
+  }
+
+  stateful_external_ip {
+    interface_name = "nic0"
+    delete_rule = "NEVER"
+  }
+
+}
+`, context)
+}
+
+func testAccRegionInstanceGroupManager_statefulUnordered(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_network" "igm-basic" {
+  name = "%{name}"
+}
+
+resource "google_compute_instance_template" "igm-basic" {
+  name           = "%{name}"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+    device_name  = "stateful-disk"
+  }
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    device_name  = "stateful-disk2"
+  }
+  network_interface {
+    network = "default"
+  }
+  network_interface {
+    network = google_compute_network.igm-basic.self_link
+  }
+}
+
+resource "google_compute_region_instance_group_manager" "igm-basic" {
+  description = "Terraform test instance group manager"
+  name        = "%{name}"
+
+  version {
+    instance_template = google_compute_instance_template.igm-basic.self_link
+    name              = "primary"
+  }
+
+  base_instance_name        = "tf-test-igm-basic"
+  region                    = "us-central1"
+  target_size               = 2
+  update_policy {
+    instance_redistribution_type = "NONE"
+    type                         = "OPPORTUNISTIC"
+    minimal_action               = "REPLACE"
+    max_surge_fixed              = 0
+    max_unavailable_fixed        = 6
+  }
+  stateful_disk {
+    device_name = "stateful-disk"
+    delete_rule = "NEVER"
+  }
+
+  stateful_internal_ip {
+    interface_name = "nic0"
+    delete_rule = "ON_PERMANENT_INSTANCE_DELETION"
+  }
+
+  // stateful_external_ip blocks are intentionally out of lexical order (for interface_name)
+
+  stateful_external_ip {
+    interface_name = "nic1"
+    delete_rule = "NEVER"
+  }
+
+  stateful_external_ip {
+    interface_name = "nic0"
+    delete_rule = "NEVER"
+  }
+
+}
+`, context)
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.erb
@@ -1651,6 +1651,13 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
     delete_rule = "NEVER"
   }
 
+  // stateful_internal_ip blocks are intentionally out of lexical order (for interface_name)
+
+  stateful_internal_ip {
+    interface_name = "nic1"
+    delete_rule = "ON_PERMANENT_INSTANCE_DELETION"
+  }
+
   stateful_internal_ip {
     interface_name = "nic0"
     delete_rule = "ON_PERMANENT_INSTANCE_DELETION"

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.erb
@@ -379,9 +379,6 @@ func TestAccRegionInstanceGroupManager_APISideListRecordering(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckRegionInstanceGroupManagerDestroyProducer(t),
 		Steps: []resource.TestStep{
-			// {
-			// 	Config: testAccRegionInstanceGroupManager_statefulOrdered(context),
-			// },
 			{
 				Config: testAccRegionInstanceGroupManager_statefulUnordered(context),
 			},
@@ -1593,76 +1590,6 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
   }
 }
 `, network, template, igm)
-}
-
-func testAccRegionInstanceGroupManager_statefulOrdered(context map[string]interface{}) string {
-	return acctest.Nprintf(`
-data "google_compute_image" "my_image" {
-  family  = "debian-11"
-  project = "debian-cloud"
-}
-resource "google_compute_network" "igm-basic" {
-  name = "%{name}"
-}
-resource "google_compute_instance_template" "igm-basic" {
-  name           = "%{name}"
-  machine_type   = "e2-medium"
-  can_ip_forward = false
-  tags           = ["foo", "bar"]
-  disk {
-    source_image = data.google_compute_image.my_image.self_link
-    auto_delete  = true
-    boot         = true
-    device_name  = "stateful-disk"
-  }
-  disk {
-    source_image = data.google_compute_image.my_image.self_link
-    auto_delete  = true
-    device_name  = "stateful-disk2"
-  }
-  network_interface {
-    network = "default"
-  }
-  network_interface {
-    network = google_compute_network.igm-basic.self_link
-  }
-}
-
-resource "google_compute_region_instance_group_manager" "igm-basic" {
-  description = "Terraform test instance group manager"
-  name        = "%{name}"
-
-  version {
-    instance_template = google_compute_instance_template.igm-basic.self_link
-    name              = "primary"
-  }
-
-  base_instance_name        = "tf-test-igm-basic"
-  region                    = "us-central1"
-  target_size               = 2
-  update_policy {
-    instance_redistribution_type = "NONE"
-    type                         = "OPPORTUNISTIC"
-    minimal_action               = "REPLACE"
-    max_surge_fixed              = 0
-    max_unavailable_fixed        = 6
-  }
-  stateful_disk {
-    device_name = "stateful-disk"
-    delete_rule = "NEVER"
-  }
-  stateful_internal_ip {
-    interface_name = "nic0"
-    delete_rule = "ON_PERMANENT_INSTANCE_DELETION"
-  }
-
-  stateful_external_ip {
-    interface_name = "nic0"
-    delete_rule = "NEVER"
-  }
-
-}
-`, context)
 }
 
 func testAccRegionInstanceGroupManager_statefulUnordered(context map[string]interface{}) string {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Relates to (but doesn't close!) this issue : https://github.com/hashicorp/terraform-provider-google/issues/13430

This PR updates code related to `stateful_external_ip` blocks in the `google_compute_instance_group_manager` & `google_compute_region_instance_group_manager` resources to address a permadiff that proposes re-ordering those blocks. The root of this problem is that the API returns those blocks in a sorted order that doesn't match the user's config. The state will contain data returned from the API, so there's always a plan trying to return to the config-defined order.

Prior to this PR, the flattener function for `stateful_external_ip` blocks performs a conversion from a map (how the data from the API is presented by the compute Go client library) to an array (how the data is stored in state). 

This PR updates the flattener function to also re-order data returned by the API so it matches the user's Terraform configuration. This is achieved by passing the `schema.ResourceData` data for the resource into the flattener, to act as a source of information about the order of those fields in the user's config.


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed a permadiff that reordered `stateful_external_ip` and `stateful_internal_ip` blocks on `google_compute_instance_group_manager` and `google_compute_region_instance_group_manager` resources
```
