### PR TITLE
Remove default addition of IAP message in encoder and decoder, add new required `enabled` field and remove the previous required tags under IAP message for resource google_compute_backend_service and resource google_compute_region_backend_service

### DIFF
--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -745,14 +745,16 @@ properties:
     description: Settings for enabling Cloud Identity Aware Proxy
     send_empty_value: true
     properties:
+      - !ruby/object:Api::Type::Boolean
+        name: 'enabled'
+        required: true
+        description: Whether the serving infrastructure will authenticate and authorize all incoming requests.
       - !ruby/object:Api::Type::String
         name: 'oauth2ClientId'
-        required: true
         description: |
           OAuth2 Client ID for IAP
       - !ruby/object:Api::Type::String
         name: 'oauth2ClientSecret'
-        required: true
         description: |
           OAuth2 Client Secret for IAP
         send_empty_value: true

--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -754,14 +754,16 @@ properties:
     description: Settings for enabling Cloud Identity Aware Proxy
     send_empty_value: true
     properties:
+      - !ruby/object:Api::Type::Boolean
+        name: 'enabled'
+        required: true
+        description: Whether the serving infrastructure will authenticate and authorize all incoming requests.
       - !ruby/object:Api::Type::String
         name: 'oauth2ClientId'
-        required: true
         description: |
           OAuth2 Client ID for IAP
       - !ruby/object:Api::Type::String
         name: 'oauth2ClientSecret'
-        required: true
         description: |
           OAuth2 Client Secret for IAP
         send_empty_value: true

--- a/mmv1/templates/terraform/decoders/backend_service.go.erb
+++ b/mmv1/templates/terraform/decoders/backend_service.go.erb
@@ -12,18 +12,6 @@
 	# See the License for the specific language governing permissions and
 	# limitations under the License.
 -%>
-// We need to pretend IAP isn't there if it's disabled for Terraform to maintain
-// BC behaviour with the handwritten resource.
-v, ok :=  res["iap"]
-if !ok || v == nil {
-	delete(res, "iap")
-	return res, nil
-}
-m := v.(map[string]interface{})
-if ok && m["enabled"] == false {
-	delete(res, "iap")
-}
-
 // Requests with consistentHash will error for specific values of
 // localityLbPolicy. However, the API will not remove it if the backend
 // service is updated to from supporting to non-supporting localityLbPolicy

--- a/mmv1/templates/terraform/decoders/region_backend_service.go.erb
+++ b/mmv1/templates/terraform/decoders/region_backend_service.go.erb
@@ -12,22 +12,11 @@
 	# See the License for the specific language governing permissions and
 	# limitations under the License.
 -%>
-// We need to pretend IAP isn't there if it's disabled for Terraform to maintain
-// BC behaviour with the handwritten resource.
-v, ok :=  res["iap"]
-if !ok || v == nil {
-	delete(res, "iap")
-	return res, nil
-}
-m := v.(map[string]interface{})
-if ok && m["enabled"] == false {
-	delete(res, "iap")
-}
 
 <% unless version == 'ga' -%>
 // Since we add in a NONE subsetting policy, we need to remove it in some
 // cases for backwards compatibility with the config
-v, ok = res["subsetting"]
+v, ok := res["subsetting"]
 if ok && v != nil {
 	subsetting := v.(map[string]interface{})
 	policy, ok := subsetting["policy"]

--- a/mmv1/templates/terraform/encoders/backend_service.go.erb
+++ b/mmv1/templates/terraform/encoders/backend_service.go.erb
@@ -12,24 +12,6 @@
 	# See the License for the specific language governing permissions and
 	# limitations under the License.
 -%>
-// The BackendService API's Update / PUT API is badly formed and behaves like
-// a PATCH field for at least IAP. When sent a `null` `iap` field, the API
-// doesn't disable an existing field. To work around this, we need to emulate
-// the old Terraform behaviour of always sending the block (at both update and
-// create), and force sending each subfield as empty when the block isn't
-// present in config.
-
-iapVal := obj["iap"]
-if iapVal == nil {
-	data := map[string]interface{}{}
-	data["enabled"] = false
-	obj["iap"] = data
-} else {
-	iap := iapVal.(map[string]interface{})
-	iap["enabled"] = true
-	obj["iap"] = iap
-}
-
 backendsRaw, ok := obj["backends"]
 if !ok {
 	return obj, nil

--- a/mmv1/templates/terraform/encoders/region_backend_service.go.erb
+++ b/mmv1/templates/terraform/encoders/region_backend_service.go.erb
@@ -12,23 +12,6 @@
 	# See the License for the specific language governing permissions and
 	# limitations under the License.
 -%>
-// The RegionBackendService API's Update / PUT API is badly formed and behaves like
-// a PATCH field for at least IAP. When sent a `null` `iap` field, the API
-// doesn't disable an existing field. To work around this, we need to emulate
-// the old Terraform behaviour of always sending the block (at both update and
-// create), and force sending each subfield as empty when the block isn't
-// present in config.
-
-iapVal := obj["iap"]
-if iapVal == nil {
-	data := map[string]interface{}{}
-	data["enabled"] = false
-	obj["iap"] = data
-} else {
-	iap := iapVal.(map[string]interface{})
-	iap["enabled"] = true
-	obj["iap"] = iap
-}
 
 if d.Get("load_balancing_scheme").(string) == "EXTERNAL_MANAGED" || d.Get("load_balancing_scheme").(string) == "INTERNAL_MANAGED" {
 	return obj, nil

--- a/mmv1/templates/terraform/examples/backend_service_external_iap.tf.erb
+++ b/mmv1/templates/terraform/examples/backend_service_external_iap.tf.erb
@@ -3,6 +3,7 @@ resource "google_compute_backend_service" "<%= ctx[:primary_resource_id] %>" {
   protocol              = "HTTP"
   load_balancing_scheme = "EXTERNAL"
   iap {
+    enabled              = true
     oauth2_client_id     = "abc"
     oauth2_client_secret = "xyz"
   }

--- a/mmv1/templates/terraform/examples/region_backend_service_external_iap.tf.erb
+++ b/mmv1/templates/terraform/examples/region_backend_service_external_iap.tf.erb
@@ -4,6 +4,7 @@ resource "google_compute_region_backend_service" "<%= ctx[:primary_resource_id] 
   protocol              = "HTTP"
   load_balancing_scheme = "EXTERNAL"
   iap {
+    enabled              = true
     oauth2_client_id     = "abc"
     oauth2_client_secret = "xyz"
   }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.erb
@@ -125,23 +125,23 @@ func TestAccComputeBackendService_withBackendAndIAP(t *testing.T) {
 		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeBackendService_withBackendAndIAP(
+				Config: testAccComputeBackendService_withBackend(
 					serviceName, igName, itName, checkName, 10),
 			},
 			{
 				ResourceName:            "google_compute_backend_service.lipsum",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"iap.0.oauth2_client_secret"},
 			},
 			{
-				Config: testAccComputeBackendService_withBackend(
+				Config: testAccComputeBackendService_withBackendAndIAP(
 					serviceName, igName, itName, checkName, 10),
 			},
 			{
 				ResourceName:      "google_compute_backend_service.lipsum",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"iap.0.oauth2_client_secret"},
 			},
 		},
 	})
@@ -1266,6 +1266,7 @@ resource "google_compute_backend_service" "lipsum" {
   }
 
   iap {
+    enabled              = true
     oauth2_client_id     = "test"
     oauth2_client_secret = "test"
   }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.erb
@@ -263,6 +263,14 @@ func TestAccComputeRegionBackendService_withBackendAndIAP(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeRegionBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
+      {
+				Config: testAccComputeRegionBackendService_ilbBasic(backendName, checkName),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			{
 				Config: testAccComputeRegionBackendService_ilbBasicwithIAP(backendName, checkName),
 			},
@@ -271,14 +279,6 @@ func TestAccComputeRegionBackendService_withBackendAndIAP(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
         ImportStateVerifyIgnore: []string{"iap.0.oauth2_client_secret"},
-			},
-			{
-				Config: testAccComputeRegionBackendService_ilbBasic(backendName, checkName),
-			},
-			{
-				ResourceName:      "google_compute_region_backend_service.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})
@@ -1048,6 +1048,7 @@ resource "google_compute_region_backend_service" "foobar" {
   }
 
   iap {
+    enabled              = true
     oauth2_client_id     = "test"
     oauth2_client_secret = "test"
   }

--- a/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
@@ -113,3 +113,15 @@ Removed in favor of field `settings.ip_configuration.ssl_mode`.
 ### `schema_settings` no longer has a default value
 
 An empty value means the setting should be cleared.
+
+## Resource: `google_compute_backend_service`
+
+### `iap.enabled` is now required in the `iap` block
+
+To apply the IAP settings to the backend service, `true` needs to be set for `enabled` field.
+
+## Resource: `google_compute_region_backend_service`
+
+### `iap.enabled` is now required in the `iap` block
+
+To apply the IAP settings to the backend service, `true` needs to be set for `enabled` field.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes internal issue b/310147789
fixes https://github.com/hashicorp/terraform-provider-google/issues/17494
fixes https://github.com/hashicorp/terraform-provider-google/issues/16585

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed an issue regarding sending `enabled` field by default for null `iap` message in `google_compute_backend_service` and `google_compute_region_backend_service`
```

```release-note:breaking-change
compute: Add new required field `enabled` in `google_compute_backend_service` and `google_compute_region_backend_service`
```
