### PR TITLE
fix(kms): certificate chain type to array of strings

### DIFF
--- a/mmv1/products/kms/CryptoKeyVersion.yaml
+++ b/mmv1/products/kms/CryptoKeyVersion.yaml
@@ -104,15 +104,18 @@ properties:
         description: |
           The certificate chains needed to validate the attestation
         properties:
-          - !ruby/object:Api::Type::String
+          - !ruby/object:Api::Type::Array
+            item_type: Api::Type::String
             name: 'caviumCerts'
             description: |
               Cavium certificate chain corresponding to the attestation.
-          - !ruby/object:Api::Type::String
+          - !ruby/object:Api::Type::Array
+            item_type: Api::Type::String
             name: 'googleCardCerts'
             description: |
               Google card certificate chain corresponding to the attestation.
-          - !ruby/object:Api::Type::String
+          - !ruby/object:Api::Type::Array
+            item_type: Api::Type::String
             name: 'googlePartitionCerts'
             description: |
               Google partition certificate chain corresponding to the attestation.

--- a/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go
@@ -441,6 +441,35 @@ func TestAccKmsCryptoKeyVersion_basic(t *testing.T) {
 	})
 }
 
+func TestAccKmsCryptoKeyVersionWithSymmetricHSM(t *testing.T) {
+	t.Parallel()
+
+	projectId := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+	projectOrg := envvar.GetTestOrgFromEnv(t)
+	projectBillingAccount := envvar.GetTestBillingAccountFromEnv(t)
+	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	cryptoKeyName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleKmsCryptoKeyVersionWithSymmetricHSM(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
+			},
+			{
+				ResourceName:            "google_kms_crypto_key_version.crypto_key_version",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testGoogleKmsCryptoKeyVersion_removed(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
+			},
+		},
+	})
+}
+
 func TestAccKmsCryptoKeyVersion_skipInitialVersion(t *testing.T) {
 	t.Parallel()
 
@@ -735,6 +764,44 @@ resource "google_kms_crypto_key" "crypto_key" {
 	key_ring = google_kms_key_ring.key_ring.id
 	labels = {
 		key = "value"
+	}
+}
+
+resource "google_kms_crypto_key_version" "crypto_key_version" {
+	crypto_key = google_kms_crypto_key.crypto_key.id
+}
+`, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
+}
+
+func testGoogleKmsCryptoKeyVersionWithSymmetricHSM(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+	name            = "%s"
+	project_id      = "%s"
+	org_id          = "%s"
+	billing_account = "%s"
+}
+
+resource "google_project_service" "acceptance" {
+	project = google_project.acceptance.project_id
+	service = "cloudkms.googleapis.com"
+}
+
+resource "google_kms_key_ring" "key_ring" {
+	project  = google_project_service.acceptance.project
+	name     = "%s"
+	location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "crypto_key" {
+	name     = "%s"
+	key_ring = google_kms_key_ring.key_ring.id
+	labels = {
+		key = "value"
+	}
+	version_template {
+		algorithm        = "GOOGLE_SYMMETRIC_ENCRYPTION"
+		protection_level = "HSM"
 	}
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The response type for KeyOperationAttestation CertificateChains is an array of strings. This is also what documentation says. https://cloud.google.com/kms/docs/reference/rest/v1/KeyOperationAttestation#certificatechains 

However the provider spec for that property lists them as strings, so terraform will panic whenever a key version is created with HSM that uses these certificates as the types are mismatched. This PR fixes this so the type is an array of strings, as well as adding an  AccTest for HSM key version

Fixes https://github.com/hashicorp/terraform-provider-google/issues/13924

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
kms: fixed issue where `google_kms_crypto_key_version.attestation.cert_chains` properties were incorrectly set to type string
```
