### PR TITLE
Add remove_instance_on_destroy option to per-compute instance config resources

### DIFF
--- a/mmv1/products/compute/PerInstanceConfig.yaml
+++ b/mmv1/products/compute/PerInstanceConfig.yaml
@@ -101,7 +101,17 @@ virtual_fields:
       - :NONE
     default_value: :REPLACE
   - !ruby/object:Api::Type::Boolean
+    name: 'remove_instance_on_destroy'
+    conflicts:
+      - remove_instance_state_on_destroy
+    description: |
+      When true, deleting this config will immediately remove the underlying instance.
+      When false, deleting this config will use the behavior as determined by remove_instance_on_destroy.
+    default_value: false
+  - !ruby/object:Api::Type::Boolean
     name: 'remove_instance_state_on_destroy'
+    conflicts:
+      - remove_instance_on_destroy
     description: |
       When true, deleting this config will immediately remove any specified state from the underlying instance.
       When false, deleting this config will *not* immediately remove any state from the underlying instance.
@@ -110,7 +120,6 @@ virtual_fields:
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   encoder: templates/terraform/encoders/compute_per_instance_config.go.erb
   update_encoder: templates/terraform/update_encoder/compute_per_instance_config.go.erb
-  pre_delete: templates/terraform/pre_delete/compute_per_instance_config.go.erb
   post_update: templates/terraform/post_update/compute_per_instance_config.go.erb
   custom_delete: templates/terraform/custom_delete/per_instance_config.go.erb
 parameters:

--- a/mmv1/products/compute/RegionPerInstanceConfig.yaml
+++ b/mmv1/products/compute/RegionPerInstanceConfig.yaml
@@ -102,7 +102,17 @@ virtual_fields:
       - :NONE
     default_value: :REPLACE
   - !ruby/object:Api::Type::Boolean
+    name: 'remove_instance_on_destroy'
+    conflicts:
+      - remove_instance_state_on_destroy
+    description: |
+      When true, deleting this config will immediately remove the underlying instance.
+      When false, deleting this config will use the behavior as determined by remove_instance_on_destroy.
+    default_value: false
+  - !ruby/object:Api::Type::Boolean
     name: 'remove_instance_state_on_destroy'
+    conflicts:
+      - remove_instance_on_destroy
     description: |
       When true, deleting this config will immediately remove any specified state from the underlying instance.
       When false, deleting this config will *not* immediately remove any state from the underlying instance.
@@ -111,7 +121,6 @@ virtual_fields:
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   encoder: templates/terraform/encoders/compute_per_instance_config.go.erb
   update_encoder: templates/terraform/update_encoder/compute_per_instance_config.go.erb
-  pre_delete: templates/terraform/pre_delete/compute_per_instance_config.go.erb
   post_update: templates/terraform/post_update/compute_region_per_instance_config.go.erb
   custom_delete: templates/terraform/custom_delete/region_per_instance_config.go.erb
 parameters:

--- a/mmv1/templates/terraform/custom_delete/per_instance_config.go.erb
+++ b/mmv1/templates/terraform/custom_delete/per_instance_config.go.erb
@@ -10,14 +10,31 @@
 	transport_tpg.MutexStore.Lock(lockName)
 	defer transport_tpg.MutexStore.Unlock(lockName)
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/zones/{{zone}}/instanceGroupManagers/{{instance_group_manager}}/deletePerInstanceConfigs")
+	var url string
+	if d.Get("remove_instance_on_destroy").(bool) {
+		url, err = tpgresource.ReplaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/zones/{{zone}}/instanceGroupManagers/{{instance_group_manager}}/deleteInstances")
+	} else {
+		url, err = tpgresource.ReplaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/zones/{{zone}}/instanceGroupManagers/{{instance_group_manager}}/deletePerInstanceConfigs")
+	}
 	if err != nil {
 		return err
 	}
 
 	var obj map[string]interface{}
-	obj = map[string]interface{}{
-		"names": [1]string{d.Get("name").(string)},
+	if d.Get("remove_instance_on_destroy").(bool) {
+		// Instance name in deleteInstances request must include zone
+		instanceName, err := tpgresource.ReplaceVars(d, config, "zones/{{zone}}/instances/{{name}}")
+		if err != nil {
+			return err
+		}
+
+		obj = map[string]interface{}{
+			"instances": [1]string{instanceName},
+		}
+	} else {
+		obj = map[string]interface{}{
+			"names": [1]string{d.Get("name").(string)},
+		}
 	}
 	log.Printf("[DEBUG] Deleting PerInstanceConfig %q", d.Id())
 
@@ -42,8 +59,14 @@
 		return err
 	}
 
-	// Potentially delete the state managed by this config
-	if d.Get("remove_instance_state_on_destroy").(bool) {
+	if d.Get("remove_instance_on_destroy").(bool) {
+		err = transport_tpg.PollingWaitTime(resourceComputePerInstanceConfigInstancePollRead(d, meta, d.Get("name").(string)), PollCheckInstanceConfigInstanceDeleted, "Deleting PerInstanceConfig", d.Timeout(schema.TimeoutDelete), 1)
+		if err != nil {
+			return fmt.Errorf("Error waiting for instance delete on PerInstanceConfig %q: %s", d.Id(), err)
+		}
+	} else if d.Get("remove_instance_state_on_destroy").(bool) {
+		// Potentially delete the state managed by this config
+
 		// Instance name in applyUpdatesToInstances request must include zone
 		instanceName, err := tpgresource.ReplaceVars(d, config, "zones/{{zone}}/instances/{{name}}")
 		if err != nil {
@@ -85,7 +108,7 @@
 		err = transport_tpg.PollingWaitTime(resourceComputePerInstanceConfigPollRead(d, meta), PollCheckInstanceConfigDeleted, "Deleting PerInstanceConfig", d.Timeout(schema.TimeoutDelete), 1)
 		if err != nil {
 			return fmt.Errorf("Error waiting for delete on PerInstanceConfig %q: %s", d.Id(), err)
-		}		
+		}
 	}
 
 	log.Printf("[DEBUG] Finished deleting PerInstanceConfig %q: %#v", d.Id(), res)

--- a/mmv1/templates/terraform/custom_delete/region_per_instance_config.go.erb
+++ b/mmv1/templates/terraform/custom_delete/region_per_instance_config.go.erb
@@ -10,14 +10,31 @@
 	transport_tpg.MutexStore.Lock(lockName)
 	defer transport_tpg.MutexStore.Unlock(lockName)
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceGroupManagers/{{region_instance_group_manager}}/deletePerInstanceConfigs")
+	var url string
+	if d.Get("remove_instance_on_destroy").(bool) {
+		url, err = tpgresource.ReplaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceGroupManagers/{{region_instance_group_manager}}/deleteInstances")
+	} else {
+		url, err = tpgresource.ReplaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceGroupManagers/{{region_instance_group_manager}}/deletePerInstanceConfigs")
+	}
 	if err != nil {
 		return err
 	}
 
 	var obj map[string]interface{}
-	obj = map[string]interface{}{
-		"names": [1]string{d.Get("name").(string)},
+	if d.Get("remove_instance_on_destroy").(bool) {
+		// Instance name in deleteInstances request must include zone
+		instanceName, err := findInstanceName(d, config)
+		if err != nil {
+			return err
+		}
+
+		obj = map[string]interface{}{
+			"instances": [1]string{instanceName},
+		}
+	} else {
+		obj = map[string]interface{}{
+			"names": [1]string{d.Get("name").(string)},
+		}
 	}
 	log.Printf("[DEBUG] Deleting RegionPerInstanceConfig %q", d.Id())
 
@@ -42,8 +59,13 @@
 		return err
 	}
 
-	// Potentially delete the state managed by this config
-	if d.Get("remove_instance_state_on_destroy").(bool) {
+	if d.Get("remove_instance_on_destroy").(bool) {
+		err = transport_tpg.PollingWaitTime(resourceComputeRegionPerInstanceConfigInstancePollRead(d, meta, d.Get("name").(string)), PollCheckInstanceConfigInstanceDeleted, "Deleting RegionPerInstanceConfig", d.Timeout(schema.TimeoutDelete), 1)
+		if err != nil {
+			return fmt.Errorf("Error waiting for instance delete on RegionPerInstanceConfig %q: %s", d.Id(), err)
+		}
+	} else if d.Get("remove_instance_state_on_destroy").(bool) {
+		// Potentially delete the state managed by this config
 		// Instance name in applyUpdatesToInstances request must include zone
 		instanceName, err := findInstanceName(d, config)
 		if err != nil {
@@ -86,7 +108,7 @@
 		err = transport_tpg.PollingWaitTime(resourceComputeRegionPerInstanceConfigPollRead(d, meta), PollCheckInstanceConfigDeleted, "Deleting RegionPerInstanceConfig", d.Timeout(schema.TimeoutDelete), 1)
 		if err != nil {
 			return fmt.Errorf("Error waiting for delete on RegionPerInstanceConfig %q: %s", d.Id(), err)
-		}	
+		}
 	}
 
 	log.Printf("[DEBUG] Finished deleting RegionPerInstanceConfig %q: %#v", d.Id(), res)

--- a/mmv1/templates/terraform/pre_delete/compute_per_instance_config.go.erb
+++ b/mmv1/templates/terraform/pre_delete/compute_per_instance_config.go.erb
@@ -1,3 +1,0 @@
-obj = map[string]interface{}{
-	"names": [1]string{d.Get("name").(string)},
-} 

--- a/mmv1/templates/terraform/pre_delete/detach_disk.erb
+++ b/mmv1/templates/terraform/pre_delete/detach_disk.erb
@@ -56,7 +56,8 @@ if v, ok := readRes["users"].([]interface{}); ok {
 		err = ComputeOperationWaitTime(config, op, call.project,
 			fmt.Sprintf("Detaching disk from %s/%s/%s", call.project, call.zone, call.instance), userAgent, d.Timeout(schema.TimeoutDelete))
 		if err != nil {
-			if opErr, ok := err.(ComputeOperationError); ok && len(opErr.Errors) == 1 && opErr.Errors[0].Code == "RESOURCE_NOT_FOUND" {
+			var opErr ComputeOperationError
+			if errors.As(err, &opErr) && len(opErr.Errors) == 1 && opErr.Errors[0].Code == "RESOURCE_NOT_FOUND" {
 				log.Printf("[WARN] instance %q was deleted while awaiting detach", call.instance)
 				continue
 			}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_per_instance_config_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_per_instance_config_test.go.erb
@@ -170,6 +170,67 @@ func TestAccComputePerInstanceConfig_statefulIps(t *testing.T) {
 	})
 }
 
+func TestAccComputePerInstanceConfig_removeInstanceOnDestroy(t *testing.T) {
+	t.Parallel()
+
+	igmName := fmt.Sprintf("tf-test-igm-%s", acctest.RandString(t, 10))
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"igm_name":      igmName,
+		"config_name":   fmt.Sprintf("instance-%s", acctest.RandString(t, 10)),
+		"config_name2":  fmt.Sprintf("instance-%s", acctest.RandString(t, 10)),
+		"network":       fmt.Sprintf("tf-test-igm-%s", acctest.RandString(t, 10)),
+		"subnetwork":    fmt.Sprintf("tf-test-igm-%s", acctest.RandString(t, 10)),
+		"address1":      fmt.Sprintf("tf-test-igm-address%s", acctest.RandString(t, 10)),
+		"address2":      fmt.Sprintf("tf-test-igm-address%s", acctest.RandString(t, 10)),
+	}
+	igmId := fmt.Sprintf("projects/%s/zones/%s/instanceGroupManagers/%s",
+		envvar.GetTestProjectFromEnv(), envvar.GetTestZoneFromEnv(), igmName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputePerInstanceConfig_removeInstanceOnDestroyBefore(context),
+			},
+			{
+				ResourceName:            "google_compute_per_instance_config.config_one",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"remove_instance_on_destroy", "zone"},
+			},
+			{
+				ResourceName:            "google_compute_per_instance_config.config_two",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"remove_instance_on_destroy", "zone"},
+			},
+			{
+				Config: testAccComputePerInstanceConfig_removeInstanceOnDestroyAfter(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputePerInstanceConfigDestroyed(t, igmId, context["config_name"].(string)),
+					testAccCheckComputePerInstanceConfigInstanceDestroyed(t, igmId, context["config_name"].(string)),
+				),
+			},
+			{
+				ResourceName:            "google_compute_per_instance_config.config_two",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"remove_instance_on_destroy", "zone"},
+			},
+			{
+				// delete all configs
+				Config: testAccComputePerInstanceConfig_igm(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputePerInstanceConfigDestroyed(t, igmId, context["config_name2"].(string)),
+					testAccCheckComputePerInstanceConfigInstanceDestroyed(t, igmId, context["config_name2"].(string)),
+				),
+			},
+		},
+	})
+}
+
 func testAccComputePerInstanceConfig_statefulBasic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_per_instance_config" "default" {
@@ -340,6 +401,109 @@ resource "google_compute_instance_group_manager" "igm" {
 `, context)
 }
 
+func testAccComputePerInstanceConfig_removeInstanceOnDestroyBefore(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "default" {
+  name = "%{network}"
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "%{subnetwork}"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.default.id
+}
+
+resource "google_compute_address" "static_internal_ip" {
+  name         = "%{address1}"
+  address_type = "INTERNAL"
+}
+
+resource "google_compute_address" "static_external_ip" {
+  name         = "%{address2}"
+  address_type = "EXTERNAL"
+}
+
+resource "google_compute_per_instance_config" "config_one" {
+  instance_group_manager = google_compute_instance_group_manager.igm.name
+  name = "%{config_name}"
+  remove_instance_on_destroy = true
+  preserved_state {
+    metadata = {
+      asdf = "config-one"
+    }
+    disk {
+      device_name = "my-stateful-disk1"
+      source      = google_compute_disk.disk.id
+    }
+
+    disk {
+      device_name = "my-stateful-disk2"
+      source      = google_compute_disk.disk1.id
+    }
+    internal_ip {
+      ip_address {
+        address = google_compute_address.static_internal_ip.self_link
+      }
+      auto_delete    = "NEVER"
+      interface_name = "nic0"
+    }
+    external_ip {
+      ip_address {
+        address = google_compute_address.static_external_ip.self_link
+      }
+      auto_delete    = "NEVER"
+      interface_name = "nic0"
+    }
+  }
+}
+
+resource "google_compute_disk" "disk" {
+  name  = "test-disk-%{random_suffix}"
+  type  = "pd-ssd"
+  zone  = google_compute_instance_group_manager.igm.zone
+  image = "debian-8-jessie-v20170523"
+  physical_block_size_bytes = 4096
+}
+
+resource "google_compute_disk" "disk1" {
+  name  = "test-disk2-%{random_suffix}"
+  type  = "pd-ssd"
+  zone  = google_compute_instance_group_manager.igm.zone
+  image = "debian-cloud/debian-11"
+  physical_block_size_bytes = 4096
+}
+
+resource "google_compute_per_instance_config" "config_two" {
+	zone = google_compute_instance_group_manager.igm.zone
+	instance_group_manager = google_compute_instance_group_manager.igm.name
+	name = "%{config_name2}"
+	remove_instance_on_destroy = true
+	preserved_state {
+		metadata = {
+			asdf = "config-two"
+		}
+	}
+}
+`, context) + testAccComputePerInstanceConfig_igm(context)
+}
+
+func testAccComputePerInstanceConfig_removeInstanceOnDestroyAfter(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_per_instance_config" "config_two" {
+	zone = google_compute_instance_group_manager.igm.zone
+	instance_group_manager = google_compute_instance_group_manager.igm.name
+	name = "%{config_name2}"
+	remove_instance_on_destroy = true
+	preserved_state {
+		metadata = {
+			asdf = "config-two"
+		}
+	}
+}
+`, context) + testAccComputePerInstanceConfig_igm(context)
+}
+
 func testAccComputePerInstanceConfig_statefulIpsBasic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_network" "default" {
@@ -352,17 +516,17 @@ resource "google_compute_subnetwork" "default" {
   region        = "us-central1"
   network       = google_compute_network.default.id
 }
-	
+
 resource "google_compute_address" "static_internal_ip" {
   name         = "%{address1}"
   address_type = "INTERNAL"
 }
-	
+
 resource "google_compute_address" "static_external_ip" {
   name         = "%{address2}"
   address_type = "EXTERNAL"
 }
-	  
+
 resource "google_compute_per_instance_config" "default" {
   instance_group_manager = google_compute_instance_group_manager.igm.name
   name = "%{config_name}"
@@ -404,7 +568,7 @@ resource "google_compute_disk" "disk" {
   image = "debian-8-jessie-v20170523"
   physical_block_size_bytes = 4096
 }
-  
+
 resource "google_compute_disk" "disk1" {
   name  = "test-disk2-%{random_suffix}"
   type  = "pd-ssd"
@@ -427,17 +591,17 @@ resource "google_compute_subnetwork" "default" {
   region        = "us-central1"
   network       = google_compute_network.default.id
 }
-	
+
 resource "google_compute_address" "static_internal_ip" {
   name         = "%{address1}"
   address_type = "INTERNAL"
 }
-	
+
 resource "google_compute_address" "static_external_ip" {
   name         = "%{address2}"
   address_type = "EXTERNAL"
 }
-	  
+
 resource "google_compute_per_instance_config" "default" {
   instance_group_manager = google_compute_instance_group_manager.igm.name
   name = "%{config_name}"
@@ -479,7 +643,7 @@ resource "google_compute_disk" "disk" {
   image = "debian-8-jessie-v20170523"
   physical_block_size_bytes = 4096
 }
-  
+
 resource "google_compute_disk" "disk1" {
   name  = "test-disk2-%{random_suffix}"
   type  = "pd-ssd"
@@ -503,6 +667,48 @@ func testAccCheckComputePerInstanceConfigDestroyed(t *testing.T, igmId, configNa
 
 		return nil
 	}
+}
+
+// Checks that the instance with the given name was destroyed.
+func testAccCheckComputePerInstanceConfigInstanceDestroyed(t *testing.T, igmId, configName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		foundNames, err := testAccComputePerInstanceConfigListInstances(t, igmId)
+		if err != nil {
+			return fmt.Errorf("unable to confirm instance with name %s was destroyed: %v", configName, err)
+		}
+		if _, ok := foundNames[configName]; ok {
+			return fmt.Errorf("instance with name %s still exists", configName)
+		}
+
+		return nil
+	}
+}
+
+func testAccComputePerInstanceConfigListInstances(t *testing.T, igmId string) (map[string]struct{}, error) {
+	config := acctest.GoogleProviderConfig(t)
+
+	url := fmt.Sprintf("%s%s/listManagedInstances", config.ComputeBasePath, igmId)
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config: config,
+		Method: "POST",
+		RawURL: url,
+		UserAgent: config.UserAgent,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	v, ok := res["managedInstances"]
+	if !ok || v == nil {
+		return nil, nil
+	}
+	items := v.([]interface{})
+	instances := make(map[string]struct{})
+	for _, item := range items {
+		instance := item.(map[string]interface{})
+		instances[fmt.Sprintf("%v", instance["name"])] = struct{}{}
+	}
+	return instances, nil
 }
 
 func testAccComputePerInstanceConfigListNames(t *testing.T, igmId string) (map[string]struct{}, error) {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_per_instance_config_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_per_instance_config_test.go.erb
@@ -169,6 +169,67 @@ func TestAccComputeRegionPerInstanceConfig_statefulIps(t *testing.T) {
 	})
 }
 
+func TestAccComputeRegionPerInstanceConfig_removeInstanceOnDestroy(t *testing.T) {
+	t.Parallel()
+
+	rigmName := fmt.Sprintf("tf-test-rigm-%s", acctest.RandString(t, 10))
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"rigm_name":     rigmName,
+		"config_name":   fmt.Sprintf("instance-%s", acctest.RandString(t, 10)),
+		"config_name2":  fmt.Sprintf("instance-%s", acctest.RandString(t, 10)),
+		"network":       fmt.Sprintf("tf-test-rigm-%s", acctest.RandString(t, 10)),
+		"subnetwork":    fmt.Sprintf("tf-test-rigm-%s", acctest.RandString(t, 10)),
+		"address1":      fmt.Sprintf("tf-test-rigm-address%s", acctest.RandString(t, 10)),
+		"address2":      fmt.Sprintf("tf-test-rigm-address%s", acctest.RandString(t, 10)),
+	}
+	rigmId := fmt.Sprintf("projects/%s/regions/%s/instanceGroupManagers/%s",
+		envvar.GetTestProjectFromEnv(), envvar.GetTestRegionFromEnv(), rigmName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionPerInstanceConfig_removeInstanceOnDestroyBefore(context),
+			},
+			{
+				ResourceName:            "google_compute_region_per_instance_config.config_one",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"remove_instance_on_destroy", "zone"},
+			},
+			{
+				ResourceName:            "google_compute_region_per_instance_config.config_two",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"remove_instance_on_destroy", "zone"},
+			},
+			{
+				Config: testAccComputeRegionPerInstanceConfig_removeInstanceOnDestroyAfter(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionPerInstanceConfigDestroyed(t, rigmId, context["config_name"].(string)),
+					testAccCheckComputeRegionPerInstanceConfigInstanceDestroyed(t, rigmId, context["config_name"].(string)),
+				),
+			},
+			{
+				ResourceName:            "google_compute_region_per_instance_config.config_two",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"remove_instance_on_destroy", "zone"},
+			},
+			{
+				// delete all configs
+				Config: testAccComputeRegionPerInstanceConfig_rigm(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionPerInstanceConfigDestroyed(t, rigmId, context["config_name2"].(string)),
+					testAccCheckComputeRegionPerInstanceConfigInstanceDestroyed(t, rigmId, context["config_name2"].(string)),
+				),
+			},
+		},
+	})
+}
+
 func testAccComputeRegionPerInstanceConfig_statefulBasic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_region_per_instance_config" "default" {
@@ -347,6 +408,111 @@ resource "google_compute_region_instance_group_manager" "rigm" {
 `, context)
 }
 
+
+func testAccComputeRegionPerInstanceConfig_removeInstanceOnDestroyBefore(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "default" {
+  name = "%{network}"
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "%{subnetwork}"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.default.id
+}
+
+resource "google_compute_address" "static_internal_ip" {
+  name         = "%{address1}"
+  address_type = "INTERNAL"
+}
+
+resource "google_compute_address" "static_external_ip" {
+  name         = "%{address2}"
+  address_type = "EXTERNAL"
+}
+
+resource "google_compute_region_per_instance_config" "config_one" {
+  region = google_compute_region_instance_group_manager.rigm.region
+  region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
+  name = "%{config_name}"
+  remove_instance_on_destroy = true
+  preserved_state {
+    metadata = {
+      asdf = "config-one"
+    }
+    disk {
+      device_name = "my-stateful-disk1"
+      source      = google_compute_disk.disk.id
+    }
+
+    disk {
+      device_name = "my-stateful-disk2"
+      source      = google_compute_disk.disk1.id
+    }
+    internal_ip {
+      ip_address {
+				address = google_compute_address.static_internal_ip.self_link
+      }
+      auto_delete    = "NEVER"
+      interface_name = "nic0"
+    }
+    external_ip {
+      ip_address {
+        address = google_compute_address.static_external_ip.self_link
+      }
+      auto_delete    = "NEVER"
+      interface_name = "nic0"
+    }
+  }
+}
+
+resource "google_compute_disk" "disk" {
+  name  = "test-disk-%{random_suffix}"
+  type  = "pd-ssd"
+  zone  = "us-central1-c"
+  image = "debian-8-jessie-v20170523"
+  physical_block_size_bytes = 4096
+}
+
+resource "google_compute_disk" "disk1" {
+  name  = "test-disk2-%{random_suffix}"
+  type  = "pd-ssd"
+  zone  = "us-central1-c"
+  image = "debian-cloud/debian-11"
+  physical_block_size_bytes = 4096
+}
+
+resource "google_compute_region_per_instance_config" "config_two" {
+	region = google_compute_region_instance_group_manager.rigm.region
+	region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
+	name = "%{config_name2}"
+	remove_instance_on_destroy = true
+	preserved_state {
+		metadata = {
+			asdf = "config-two"
+		}
+	}
+}
+`, context) + testAccComputeRegionPerInstanceConfig_rigm(context)
+}
+
+func testAccComputeRegionPerInstanceConfig_removeInstanceOnDestroyAfter(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_region_per_instance_config" "config_two" {
+	region = google_compute_region_instance_group_manager.rigm.region
+	region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
+	name = "%{config_name2}"
+	remove_instance_on_destroy = true
+	preserved_state {
+		metadata = {
+			asdf = "config-two"
+		}
+	}
+}
+`, context) + testAccComputeRegionPerInstanceConfig_rigm(context)
+}
+
 func testAccComputeRegionPerInstanceConfig_statefulIpsBasic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_network" "default" {
@@ -508,6 +674,21 @@ func testAccCheckComputeRegionPerInstanceConfigDestroyed(t *testing.T, rigmId, c
 		}
 		if _, ok := foundNames[configName]; ok {
 			return fmt.Errorf("config with name %s still exists", configName)
+		}
+
+		return nil
+	}
+}
+
+// Checks that the instance with the given name was destroyed.
+func testAccCheckComputeRegionPerInstanceConfigInstanceDestroyed(t *testing.T, rigmId, configName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		foundNames, err := testAccComputePerInstanceConfigListInstances(t, rigmId)
+		if err != nil {
+			return fmt.Errorf("unable to confirm instance with name %s was destroyed: %v", configName, err)
+		}
+		if _, ok := foundNames[configName]; ok {
+			return fmt.Errorf("instance with name %s still exists", configName)
 		}
 
 		return nil

--- a/mmv1/third_party/terraform/services/compute/stateful_mig_polling.go
+++ b/mmv1/third_party/terraform/services/compute/stateful_mig_polling.go
@@ -47,6 +47,58 @@ func resourceComputePerInstanceConfigPollRead(d *schema.ResourceData, meta inter
 	}
 }
 
+// Deleting a PerInstanceConfig & the underlying instance needs both regular operation polling AND custom polling for deletion which is why this is not generated
+func resourceComputePerInstanceConfigInstancePollRead(d *schema.ResourceData, meta interface{}, instanceName string) transport_tpg.PollReadFunc {
+	return func() (map[string]interface{}, error) {
+		config := meta.(*transport_tpg.Config)
+		userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+		if err != nil {
+			return nil, err
+		}
+
+		url, err := tpgresource.ReplaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/zones/{{zone}}/instanceGroupManagers/{{instance_group_manager}}/listManagedInstances")
+		if err != nil {
+			return nil, err
+		}
+
+		url, err = transport_tpg.AddQueryParams(url, map[string]string{"filter": fmt.Sprintf("name=%q", instanceName)})
+		if err != nil {
+			return nil, err
+		}
+
+		project, err := tpgresource.GetProject(d, config)
+		if err != nil {
+			return nil, err
+		}
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: userAgent,
+		})
+		if err != nil {
+			return res, err
+		}
+
+		value, ok := res["managedInstances"]
+		if !ok || value == nil {
+			return nil, nil
+		}
+
+		managedInstances, ok := value.([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("expected list for value managedInstances. Actual value: %v", value)
+		}
+
+		if len(managedInstances) == 1 {
+			return managedInstances[0].(map[string]interface{}), nil
+		}
+
+		return nil, nil
+	}
+}
+
 // RegionPerInstanceConfig needs both regular operation polling AND custom polling for deletion which is why this is not generated
 func resourceComputeRegionPerInstanceConfigPollRead(d *schema.ResourceData, meta interface{}) transport_tpg.PollReadFunc {
 	return func() (map[string]interface{}, error) {
@@ -82,6 +134,58 @@ func resourceComputeRegionPerInstanceConfigPollRead(d *schema.ResourceData, meta
 
 		// Returns nil res if nested object is not found
 		return res, nil
+	}
+}
+
+// Deleting a RegionPerInstanceConfig & the underlying instance needs both regular operation polling AND custom polling for deletion which is why this is not generated
+func resourceComputeRegionPerInstanceConfigInstancePollRead(d *schema.ResourceData, meta interface{}, instanceName string) transport_tpg.PollReadFunc {
+	return func() (map[string]interface{}, error) {
+		config := meta.(*transport_tpg.Config)
+		userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+		if err != nil {
+			return nil, err
+		}
+
+		url, err := tpgresource.ReplaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceGroupManagers/{{region_instance_group_manager}}/listManagedInstances")
+		if err != nil {
+			return nil, err
+		}
+
+		url, err = transport_tpg.AddQueryParams(url, map[string]string{"filter": fmt.Sprintf("name=%q", instanceName)})
+		if err != nil {
+			return nil, err
+		}
+
+		project, err := tpgresource.GetProject(d, config)
+		if err != nil {
+			return nil, err
+		}
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: userAgent,
+		})
+		if err != nil {
+			return res, err
+		}
+
+		value, ok := res["managedInstances"]
+		if !ok || value == nil {
+			return nil, nil
+		}
+
+		managedInstances, ok := value.([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("expected list for value managedInstances. Actual value: %v", value)
+		}
+
+		if len(managedInstances) == 1 {
+			return managedInstances[0].(map[string]interface{}), nil
+		}
+
+		return nil, nil
 	}
 }
 
@@ -166,4 +270,23 @@ func PollCheckInstanceConfigDeleted(resp map[string]interface{}, respErr error) 
 		return transport_tpg.PendingStatusPollResult("Still deleting")
 	}
 	return transport_tpg.ErrorPollResult(fmt.Errorf("Expected PerInstanceConfig to be deleting but status is: %s", status))
+}
+
+func PollCheckInstanceConfigInstanceDeleted(resp map[string]interface{}, respErr error) transport_tpg.PollResult {
+	if respErr != nil {
+		return transport_tpg.ErrorPollResult(respErr)
+	}
+
+	// Nested object 404 appears as nil response
+	if resp == nil {
+		// Instance no longer exists
+		return transport_tpg.SuccessPollResult()
+	}
+
+	// Read status
+	status := resp["currentAction"].(string)
+	if status == "DELETING" {
+		return transport_tpg.PendingStatusPollResult("Still deleting")
+	}
+	return transport_tpg.ErrorPollResult(fmt.Errorf("Expected PerInstanceConfig instance to be deleting but status is: %s", status))
 }

--- a/mmv1/third_party/terraform/tpgresource/common_operation.go
+++ b/mmv1/third_party/terraform/tpgresource/common_operation.go
@@ -151,7 +151,7 @@ func OperationWait(w Waiter, activity string, timeout time.Duration, pollInterva
 	}
 	opRaw, err := c.WaitForState()
 	if err != nil {
-		return fmt.Errorf("Error waiting for %s: %s", activity, err)
+		return fmt.Errorf("Error waiting for %s: %w", activity, err)
 	}
 
 	err = w.SetOp(opRaw)


### PR DESCRIPTION
It's a bit counterintuitive that creating a per-instance config in an IGM spins up an instance but destroying it leaves the instance behind.

Also fixed a bug related to the operation to detach the disk from the instance failing due to the instance having been deleted. Other than the tests for the new per-instance config behavior, I was unable to devise an isolated test to trigger this issue.

Fixes hashicorp/terraform-provider-google#9042 & hashicorp/terraform-provider-google#16621.

```release-note:bug
compute: Add remove_instance_on_destroy option to per-instance config resources
```
