### PR TITLE
Remove use of `google_kms_crypto_key_iam_binding` resources in acceptance tests to reduce test failures related to missing permissions

### DIFF
--- a/mmv1/products/cloudfunctions2/Function.yaml
+++ b/mmv1/products/cloudfunctions2/Function.yaml
@@ -219,6 +219,7 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'cloudfunctions2_cmek'
     skip_docs: true # the example file is written in a repetitive way to help acc tests, so exclude
+    skip_vcr: true
     primary_resource_id: 'function'
     min_version: beta
     vars:

--- a/mmv1/products/cloudfunctions2/Function.yaml
+++ b/mmv1/products/cloudfunctions2/Function.yaml
@@ -218,6 +218,7 @@ examples:
       - 'build_config.0.source.0.storage_source.0.bucket'
   - !ruby/object:Provider::Terraform::Examples
     name: 'cloudfunctions2_cmek'
+    skip_docs: true # the example file is written in a repetitive way to help acc tests, so exclude
     primary_resource_id: 'function'
     min_version: beta
     vars:
@@ -239,6 +240,20 @@ examples:
     ignore_read_extra:
       - 'build_config.0.source.0.storage_source.0.object'
       - 'build_config.0.source.0.storage_source.0.bucket'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'cloudfunctions2_cmek_docs'
+    skip_test: true # this example file will cause IAM conflicts between tests if used to make a test
+    primary_resource_id: 'function'
+    min_version: beta
+    vars:
+      function: 'function-cmek'
+      bucket_name: 'gcf-source'
+      zip_path: 'function-source.zip'
+      kms_service_name: 'cloudkms.googleapis.com'
+      cmek-repo: 'cmek-repo'
+      unencoded-ar-repo: 'ar-repo'
+      kms_key_name: 'cmek-key'
+      project: 'my-project-name'
 iam_policy: !ruby/object:Api::Resource::IamPolicy
   parent_resource_attribute: 'cloud_function'
   method_name_separator: ':'

--- a/mmv1/products/metastore/Service.yaml
+++ b/mmv1/products/metastore/Service.yaml
@@ -66,6 +66,7 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'dataproc_metastore_service_cmek_test'
     skip_docs: true
+    skip_vcr: true
     primary_resource_id: 'default'
     vars:
       metastore_service_name: 'example-service'

--- a/mmv1/templates/terraform/examples/apigee_environment_type_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_environment_type_test.tf.erb
@@ -86,15 +86,13 @@ resource "google_project_service_identity" "apigee_sa" {
   service = google_project_service.apigee.service
 }
 
-resource "google_kms_crypto_key_iam_binding" "apigee_sa_keyuser" {
+resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
   provider = google-beta
 
   crypto_key_id = google_kms_crypto_key.apigee_key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  members = [
-    "serviceAccount:${google_project_service_identity.apigee_sa.email}",
-  ]
+  member = "serviceAccount:${google_project_service_identity.apigee_sa.email}"
 }
 
 resource "google_apigee_organization" "apigee_org" {
@@ -109,7 +107,7 @@ resource "google_apigee_organization" "apigee_org" {
   depends_on = [
     google_service_networking_connection.apigee_vpc_connection,
     google_project_service.apigee,
-    google_kms_crypto_key_iam_binding.apigee_sa_keyuser,
+    google_kms_crypto_key_iam_member.apigee_sa_keyuser,
   ]
 }
 

--- a/mmv1/templates/terraform/examples/apigee_instance_full.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_instance_full.tf.erb
@@ -38,13 +38,11 @@ resource "google_project_service_identity" "apigee_sa" {
   service  = google_project_service.apigee.service
 }
 
-resource "google_kms_crypto_key_iam_binding" "apigee_sa_keyuser" {
+resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
   crypto_key_id = google_kms_crypto_key.apigee_key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  members = [
-    "serviceAccount:${google_project_service_identity.apigee_sa.email}",
-  ]
+  member = "serviceAccount:${google_project_service_identity.apigee_sa.email}"
 }
 
 resource "google_apigee_organization" "apigee_org" {
@@ -57,7 +55,7 @@ resource "google_apigee_organization" "apigee_org" {
 
   depends_on = [
     google_service_networking_connection.apigee_vpc_connection,
-    google_kms_crypto_key_iam_binding.apigee_sa_keyuser,
+    google_kms_crypto_key_iam_member.apigee_sa_keyuser,
   ]
 }
 

--- a/mmv1/templates/terraform/examples/apigee_instance_full_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_instance_full_test.tf.erb
@@ -86,15 +86,13 @@ resource "google_project_service_identity" "apigee_sa" {
   service = google_project_service.apigee.service
 }
 
-resource "google_kms_crypto_key_iam_binding" "apigee_sa_keyuser" {
+resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
   provider = google-beta
 
   crypto_key_id = google_kms_crypto_key.apigee_key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  members = [
-    "serviceAccount:${google_project_service_identity.apigee_sa.email}",
-  ]
+  member = "serviceAccount:${google_project_service_identity.apigee_sa.email}"
 }
 
 resource "google_apigee_organization" "apigee_org" {
@@ -109,7 +107,7 @@ resource "google_apigee_organization" "apigee_org" {
 
   depends_on = [
     google_service_networking_connection.apigee_vpc_connection,
-    google_kms_crypto_key_iam_binding.apigee_sa_keyuser,
+    google_kms_crypto_key_iam_member.apigee_sa_keyuser,
   ]
 }
 

--- a/mmv1/templates/terraform/examples/apigee_nat_address_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_nat_address_basic.tf.erb
@@ -38,13 +38,11 @@ resource "google_project_service_identity" "apigee_sa" {
   service  = google_project_service.apigee.service
 }
 
-resource "google_kms_crypto_key_iam_binding" "apigee_sa_keyuser" {
+resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
   crypto_key_id = google_kms_crypto_key.apigee_key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  members = [
-    "serviceAccount:${google_project_service_identity.apigee_sa.email}",
-  ]
+  member = "serviceAccount:${google_project_service_identity.apigee_sa.email}"
 }
 
 resource "google_apigee_organization" "apigee_org" {
@@ -57,7 +55,7 @@ resource "google_apigee_organization" "apigee_org" {
 
   depends_on = [
     google_service_networking_connection.apigee_vpc_connection,
-    google_kms_crypto_key_iam_binding.apigee_sa_keyuser,
+    google_kms_crypto_key_iam_member.apigee_sa_keyuser,
   ]
 }
 

--- a/mmv1/templates/terraform/examples/apigee_organization_cloud_full.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_organization_cloud_full.tf.erb
@@ -38,13 +38,11 @@ resource "google_project_service_identity" "apigee_sa" {
   service  = google_project_service.apigee.service
 }
 
-resource "google_kms_crypto_key_iam_binding" "apigee_sa_keyuser" {
+resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
   crypto_key_id = google_kms_crypto_key.apigee_key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  members = [
-    "serviceAccount:${google_project_service_identity.apigee_sa.email}",
-  ]
+  member = "serviceAccount:${google_project_service_identity.apigee_sa.email}"
 }
 
 resource "google_apigee_organization" "org" {
@@ -57,6 +55,6 @@ resource "google_apigee_organization" "org" {
 
   depends_on = [
     google_service_networking_connection.apigee_vpc_connection,
-    google_kms_crypto_key_iam_binding.apigee_sa_keyuser,
+    google_kms_crypto_key_iam_member.apigee_sa_keyuser,
   ]
 }

--- a/mmv1/templates/terraform/examples/apigee_organization_cloud_full_disable_vpc_peering.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_organization_cloud_full_disable_vpc_peering.tf.erb
@@ -20,13 +20,11 @@ resource "google_project_service_identity" "apigee_sa" {
   service  = google_project_service.apigee.service
 }
 
-resource "google_kms_crypto_key_iam_binding" "apigee_sa_keyuser" {
+resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
   crypto_key_id = google_kms_crypto_key.apigee_key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  members = [
-    "serviceAccount:${google_project_service_identity.apigee_sa.email}",
-  ]
+  member = "serviceAccount:${google_project_service_identity.apigee_sa.email}"
 }
 
 resource "google_apigee_organization" "org" {
@@ -38,6 +36,6 @@ resource "google_apigee_organization" "org" {
   runtime_database_encryption_key_name = google_kms_crypto_key.apigee_key.id
 
   depends_on = [
-    google_kms_crypto_key_iam_binding.apigee_sa_keyuser,
+    google_kms_crypto_key_iam_member.apigee_sa_keyuser,
   ]
 }

--- a/mmv1/templates/terraform/examples/apigee_organization_cloud_full_disable_vpc_peering_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_organization_cloud_full_disable_vpc_peering_test.tf.erb
@@ -51,15 +51,13 @@ resource "google_project_service_identity" "apigee_sa" {
   service = google_project_service.apigee.service
 }
 
-resource "google_kms_crypto_key_iam_binding" "apigee_sa_keyuser" {
+resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
   provider = google-beta
 
   crypto_key_id = google_kms_crypto_key.apigee_key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  members = [
-    "serviceAccount:${google_project_service_identity.apigee_sa.email}",
-  ]
+  member = "serviceAccount:${google_project_service_identity.apigee_sa.email}"
 }
 
 resource "google_apigee_organization" "<%= ctx[:primary_resource_id] %>" {
@@ -84,6 +82,6 @@ resource "google_apigee_organization" "<%= ctx[:primary_resource_id] %>" {
   }
 
   depends_on = [
-    google_kms_crypto_key_iam_binding.apigee_sa_keyuser,
+    google_kms_crypto_key_iam_member.apigee_sa_keyuser,
   ]
 }

--- a/mmv1/templates/terraform/examples/apigee_organization_cloud_full_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_organization_cloud_full_test.tf.erb
@@ -86,15 +86,13 @@ resource "google_project_service_identity" "apigee_sa" {
   service = google_project_service.apigee.service
 }
 
-resource "google_kms_crypto_key_iam_binding" "apigee_sa_keyuser" {
+resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
   provider = google-beta
 
   crypto_key_id = google_kms_crypto_key.apigee_key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  members = [
-    "serviceAccount:${google_project_service_identity.apigee_sa.email}",
-  ]
+  member = "serviceAccount:${google_project_service_identity.apigee_sa.email}"
 }
 
 resource "google_apigee_organization" "<%= ctx[:primary_resource_id] %>" {
@@ -120,6 +118,6 @@ resource "google_apigee_organization" "<%= ctx[:primary_resource_id] %>" {
 
   depends_on = [
     google_service_networking_connection.apigee_vpc_connection,
-    google_kms_crypto_key_iam_binding.apigee_sa_keyuser,
+    google_kms_crypto_key_iam_member.apigee_sa_keyuser,
   ]
 }

--- a/mmv1/templates/terraform/examples/apigee_organization_retention_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_organization_retention_test.tf.erb
@@ -86,15 +86,13 @@ resource "google_project_service_identity" "apigee_sa" {
   service = google_project_service.apigee.service
 }
 
-resource "google_kms_crypto_key_iam_binding" "apigee_sa_keyuser" {
+resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
   provider = google-beta
 
   crypto_key_id = google_kms_crypto_key.apigee_key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  members = [
-    "serviceAccount:${google_project_service_identity.apigee_sa.email}",
-  ]
+  member = "serviceAccount:${google_project_service_identity.apigee_sa.email}"
 }
 
 resource "google_apigee_organization" "<%= ctx[:primary_resource_id] %>" {
@@ -110,7 +108,7 @@ resource "google_apigee_organization" "<%= ctx[:primary_resource_id] %>" {
   depends_on = [
     google_service_networking_connection.apigee_vpc_connection,
     google_project_service.apigee,
-    google_kms_crypto_key_iam_binding.apigee_sa_keyuser,
+    google_kms_crypto_key_iam_member.apigee_sa_keyuser,
   ]
 }
 

--- a/mmv1/templates/terraform/examples/cloudfunctions2_cmek.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudfunctions2_cmek.tf.erb
@@ -48,19 +48,24 @@ resource "google_artifact_registry_repository_iam_binding" "binding" {
   ]
 }
 
-resource "google_kms_crypto_key_iam_binding" "gcf_cmek_keyuser" {
+locals {
+  gcf_cmek_keyusers = {
+    1 = "serviceAccount:service-${data.google_project.project.number}@gcf-admin-robot.iam.gserviceaccount.com",
+    2 = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-artifactregistry.iam.gserviceaccount.com",
+    3 = "serviceAccount:service-${data.google_project.project.number}@gs-project-accounts.iam.gserviceaccount.com",
+    4 = "serviceAccount:service-${data.google_project.project.number}@serverless-robot-prod.iam.gserviceaccount.com",
+    5 = "serviceAccount:${google_project_service_identity.ea_sa.email}",
+  }
+}
+
+resource "google_kms_crypto_key_iam_member" "gcf_cmek_keyuser" {
   provider = google-beta
+  for_each = local.gcf_cmek_keyusers
 
   crypto_key_id = "<%= ctx[:vars]['kms_key_name'] %>"
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  members = [
-    "serviceAccount:service-${data.google_project.project.number}@gcf-admin-robot.iam.gserviceaccount.com",
-    "serviceAccount:service-${data.google_project.project.number}@gcp-sa-artifactregistry.iam.gserviceaccount.com",
-    "serviceAccount:service-${data.google_project.project.number}@gs-project-accounts.iam.gserviceaccount.com",
-    "serviceAccount:service-${data.google_project.project.number}@serverless-robot-prod.iam.gserviceaccount.com",
-    "serviceAccount:${google_project_service_identity.ea_sa.email}",
-  ]
+  member = each.value
 
   depends_on = [
     google_project_service_identity.ea_sa
@@ -75,7 +80,7 @@ resource "google_artifact_registry_repository" "encoded-ar-repo" {
   format = "DOCKER"
   kms_key_name = "<%= ctx[:vars]['kms_key_name'] %>"
   depends_on = [
-    google_kms_crypto_key_iam_binding.gcf_cmek_keyuser
+    google_kms_crypto_key_iam_member.gcf_cmek_keyuser
   ]
 }
 
@@ -107,7 +112,7 @@ resource "google_cloudfunctions2_function" "<%= ctx[:primary_resource_id] %>" {
   }
 
   depends_on = [
-    google_kms_crypto_key_iam_binding.gcf_cmek_keyuser
+    google_kms_crypto_key_iam_member.gcf_cmek_keyuser
   ]
 
 }

--- a/mmv1/templates/terraform/examples/cloudfunctions2_cmek.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudfunctions2_cmek.tf.erb
@@ -37,39 +37,58 @@ resource "google_artifact_registry_repository" "unencoded-ar-repo" {
   format = "DOCKER"
 }
 
-resource "google_artifact_registry_repository_iam_binding" "binding" {
+resource "google_artifact_registry_repository_iam_member" "member" {
   provider = google-beta
 
   location = google_artifact_registry_repository.encoded-ar-repo.location
   repository = google_artifact_registry_repository.encoded-ar-repo.name
   role = "roles/artifactregistry.admin"
-  members = [
-    "serviceAccount:service-${data.google_project.project.number}@gcf-admin-robot.iam.gserviceaccount.com",
-  ]
+  member = "serviceAccount:service-${data.google_project.project.number}@gcf-admin-robot.iam.gserviceaccount.com"
 }
 
-locals {
-  gcf_cmek_keyusers = {
-    1 = "serviceAccount:service-${data.google_project.project.number}@gcf-admin-robot.iam.gserviceaccount.com",
-    2 = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-artifactregistry.iam.gserviceaccount.com",
-    3 = "serviceAccount:service-${data.google_project.project.number}@gs-project-accounts.iam.gserviceaccount.com",
-    4 = "serviceAccount:service-${data.google_project.project.number}@serverless-robot-prod.iam.gserviceaccount.com",
-    5 = "serviceAccount:${google_project_service_identity.ea_sa.email}",
-  }
-}
-
-resource "google_kms_crypto_key_iam_member" "gcf_cmek_keyuser" {
+resource "google_kms_crypto_key_iam_member" "gcf_cmek_keyuser_1" {
   provider = google-beta
-  for_each = local.gcf_cmek_keyusers
 
   crypto_key_id = "<%= ctx[:vars]['kms_key_name'] %>"
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  member = each.value
+  member = "serviceAccount:service-${data.google_project.project.number}@gcf-admin-robot.iam.gserviceaccount.com"
+}
 
-  depends_on = [
-    google_project_service_identity.ea_sa
-  ]
+resource "google_kms_crypto_key_iam_member" "gcf_cmek_keyuser_2" {
+  provider = google-beta
+
+  crypto_key_id = "<%= ctx[:vars]['kms_key_name'] %>"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-artifactregistry.iam.gserviceaccount.com"
+}
+
+resource "google_kms_crypto_key_iam_member" "gcf_cmek_keyuser_3" {
+  provider = google-beta
+
+  crypto_key_id = "<%= ctx[:vars]['kms_key_name'] %>"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+  member = "serviceAccount:service-${data.google_project.project.number}@gs-project-accounts.iam.gserviceaccount.com"
+}
+
+resource "google_kms_crypto_key_iam_member" "gcf_cmek_keyuser_4" {
+  provider = google-beta
+
+  crypto_key_id = "<%= ctx[:vars]['kms_key_name'] %>"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+  member = "serviceAccount:service-${data.google_project.project.number}@serverless-robot-prod.iam.gserviceaccount.com"
+}
+
+resource "google_kms_crypto_key_iam_member" "gcf_cmek_keyuser_5" {
+  provider = google-beta
+
+  crypto_key_id = "<%= ctx[:vars]['kms_key_name'] %>"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+  member = "serviceAccount:${google_project_service_identity.ea_sa.email}"
 }
 
 resource "google_artifact_registry_repository" "encoded-ar-repo" {
@@ -79,8 +98,13 @@ resource "google_artifact_registry_repository" "encoded-ar-repo" {
   repository_id = "<%= ctx[:vars]['cmek-repo'] %>"
   format = "DOCKER"
   kms_key_name = "<%= ctx[:vars]['kms_key_name'] %>"
+
   depends_on = [
-    google_kms_crypto_key_iam_member.gcf_cmek_keyuser
+    google_kms_crypto_key_iam_member.gcf_cmek_keyuser_1,
+    google_kms_crypto_key_iam_member.gcf_cmek_keyuser_2,
+    google_kms_crypto_key_iam_member.gcf_cmek_keyuser_3,
+    google_kms_crypto_key_iam_member.gcf_cmek_keyuser_4,
+    google_kms_crypto_key_iam_member.gcf_cmek_keyuser_5,
   ]
 }
 
@@ -112,7 +136,10 @@ resource "google_cloudfunctions2_function" "<%= ctx[:primary_resource_id] %>" {
   }
 
   depends_on = [
-    google_kms_crypto_key_iam_member.gcf_cmek_keyuser
+    google_kms_crypto_key_iam_member.gcf_cmek_keyuser_1,
+    google_kms_crypto_key_iam_member.gcf_cmek_keyuser_2,
+    google_kms_crypto_key_iam_member.gcf_cmek_keyuser_3,
+    google_kms_crypto_key_iam_member.gcf_cmek_keyuser_4,
+    google_kms_crypto_key_iam_member.gcf_cmek_keyuser_5,
   ]
-
 }

--- a/mmv1/templates/terraform/examples/cloudfunctions2_cmek_docs.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudfunctions2_cmek_docs.tf.erb
@@ -1,0 +1,113 @@
+locals {
+  project = "<%= ctx[:vars]['project'] %>" # Google Cloud Platform Project ID
+}
+
+data "google_project" "project" {
+  provider = google-beta
+}
+
+resource "google_storage_bucket" "bucket" {
+  provider = google-beta
+
+  name     = "${local.project}-<%= ctx[:vars]['bucket_name'] %>"  # Every bucket name must be globally unique
+  location = "US"
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket_object" "object" {
+  provider = google-beta
+
+  name   = "function-source.zip"
+  bucket = google_storage_bucket.bucket.name
+  source = "<%= ctx[:vars]['zip_path'] %>"  # Add path to the zipped function source code
+}
+
+resource "google_project_service_identity" "ea_sa" {
+  provider = google-beta
+
+  project = data.google_project.project.project_id
+  service = "eventarc.googleapis.com"
+}
+
+resource "google_artifact_registry_repository" "unencoded-ar-repo" {
+  provider = google-beta
+
+  repository_id = "<%= ctx[:vars]['unencoded-ar-repo'] %>"
+  location = "us-central1"
+  format = "DOCKER"
+}
+
+resource "google_artifact_registry_repository_iam_binding" "binding" {
+  provider = google-beta
+
+  location = google_artifact_registry_repository.encoded-ar-repo.location
+  repository = google_artifact_registry_repository.encoded-ar-repo.name
+  role = "roles/artifactregistry.admin"
+  members = [
+    "serviceAccount:service-${data.google_project.project.number}@gcf-admin-robot.iam.gserviceaccount.com",
+  ]
+}
+
+resource "google_kms_crypto_key_iam_binding" "gcf_cmek_keyuser" {
+  provider = google-beta
+
+  crypto_key_id = "<%= ctx[:vars]['kms_key_name'] %>"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+  members = [
+    "serviceAccount:service-${data.google_project.project.number}@gcf-admin-robot.iam.gserviceaccount.com",
+    "serviceAccount:service-${data.google_project.project.number}@gcp-sa-artifactregistry.iam.gserviceaccount.com",
+    "serviceAccount:service-${data.google_project.project.number}@gs-project-accounts.iam.gserviceaccount.com",
+    "serviceAccount:service-${data.google_project.project.number}@serverless-robot-prod.iam.gserviceaccount.com",
+    "serviceAccount:${google_project_service_identity.ea_sa.email}",
+  ]
+
+  depends_on = [
+    google_project_service_identity.ea_sa
+  ]
+}
+
+resource "google_artifact_registry_repository" "encoded-ar-repo" {
+  provider = google-beta
+
+  location = "us-central1"
+  repository_id = "<%= ctx[:vars]['cmek-repo'] %>"
+  format = "DOCKER"
+  kms_key_name = "<%= ctx[:vars]['kms_key_name'] %>"
+  depends_on = [
+    google_kms_crypto_key_iam_binding.gcf_cmek_keyuser
+  ]
+}
+
+resource "google_cloudfunctions2_function" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+
+  name = "<%= ctx[:vars]['function'] %>"
+  location = "us-central1"
+  description = "CMEK function"
+  kms_key_name = "<%= ctx[:vars]['kms_key_name'] %>"
+
+  build_config {
+    runtime = "nodejs16"
+    entry_point = "helloHttp"  # Set the entry point
+    docker_repository = google_artifact_registry_repository.encoded-ar-repo.id
+
+    source {
+      storage_source {
+        bucket = google_storage_bucket.bucket.name
+        object = google_storage_bucket_object.object.name
+      }
+    }
+  }
+
+  service_config {
+    max_instance_count  = 1
+    available_memory    = "256M"
+    timeout_seconds     = 60
+  }
+
+  depends_on = [
+    google_kms_crypto_key_iam_binding.gcf_cmek_keyuser
+  ]
+
+}

--- a/mmv1/templates/terraform/examples/data_fusion_instance_cmek.tf.erb
+++ b/mmv1/templates/terraform/examples/data_fusion_instance_cmek.tf.erb
@@ -7,7 +7,7 @@ resource "google_data_fusion_instance" "<%= ctx[:primary_resource_id] %>" {
     key_reference = google_kms_crypto_key.crypto_key.id
   }
 
-  depends_on = [google_kms_crypto_key_iam_binding.crypto_key_binding]
+  depends_on = [google_kms_crypto_key_iam_member.crypto_key_member]
 }
 
 resource "google_kms_crypto_key" "crypto_key" {
@@ -20,13 +20,11 @@ resource "google_kms_key_ring" "key_ring" {
   location = "us-central1"
 }
 
-resource "google_kms_crypto_key_iam_binding" "crypto_key_binding" {
+resource "google_kms_crypto_key_iam_member" "crypto_key_member" {
   crypto_key_id = google_kms_crypto_key.crypto_key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  members = [
-    "serviceAccount:service-${data.google_project.project.number}@gcp-sa-datafusion.iam.gserviceaccount.com"
-  ]
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-datafusion.iam.gserviceaccount.com"
 }
 
 data "google_project" "project" {}

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_cmek_test.tf.erb
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_cmek_test.tf.erb
@@ -15,7 +15,10 @@ resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" 
     version = "3.1.2"
   }
 
-  depends_on = [google_kms_crypto_key_iam_binding.crypto_key_binding]
+  depends_on = [
+    google_kms_crypto_key_iam_member.crypto_key_member_1,
+    google_kms_crypto_key_iam_member.crypto_key_member_2,
+  ]
 }
 
 resource "google_kms_crypto_key" "crypto_key" {
@@ -30,12 +33,16 @@ resource "google_kms_key_ring" "key_ring" {
   location = "us-central1"
 }
 
-resource "google_kms_crypto_key_iam_binding" "crypto_key_binding" {
+resource "google_kms_crypto_key_iam_member" "crypto_key_member_1" {
   crypto_key_id = google_kms_crypto_key.crypto_key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  members = [
-    "serviceAccount:service-${data.google_project.project.number}@gcp-sa-metastore.iam.gserviceaccount.com",
-    "serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"
-  ]
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-metastore.iam.gserviceaccount.com"
+}
+
+resource "google_kms_crypto_key_iam_member" "crypto_key_member_2" {
+  crypto_key_id = google_kms_crypto_key.crypto_key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+  member = "serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"
 }

--- a/mmv1/templates/terraform/examples/privateca_certificate_authority_byo_key.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_authority_byo_key.tf.erb
@@ -3,21 +3,17 @@ resource "google_project_service_identity" "privateca_sa" {
   service = "privateca.googleapis.com"
 }
 
-resource "google_kms_crypto_key_iam_binding" "privateca_sa_keyuser_signerverifier" {
+resource "google_kms_crypto_key_iam_member" "privateca_sa_keyuser_signerverifier" {
   crypto_key_id = "<%= ctx[:vars]['kms_key_name'] %>"
   role          = "roles/cloudkms.signerVerifier"
 
-  members = [
-    "serviceAccount:${google_project_service_identity.privateca_sa.email}",
-  ]
+  member = "serviceAccount:${google_project_service_identity.privateca_sa.email}"
 }
 
-resource "google_kms_crypto_key_iam_binding" "privateca_sa_keyuser_viewer" {
+resource "google_kms_crypto_key_iam_member" "privateca_sa_keyuser_viewer" {
   crypto_key_id = "<%= ctx[:vars]['kms_key_name'] %>"
   role          = "roles/viewer"
-  members = [
-    "serviceAccount:${google_project_service_identity.privateca_sa.email}",
-  ]
+  member = "serviceAccount:${google_project_service_identity.privateca_sa.email}"
 }
 
 resource "google_privateca_certificate_authority" "<%= ctx[:primary_resource_id] %>" {
@@ -69,8 +65,8 @@ resource "google_privateca_certificate_authority" "<%= ctx[:primary_resource_id]
   }
 
   depends_on = [
-    google_kms_crypto_key_iam_binding.privateca_sa_keyuser_signerverifier,
-    google_kms_crypto_key_iam_binding.privateca_sa_keyuser_viewer,
+    google_kms_crypto_key_iam_member.privateca_sa_keyuser_signerverifier,
+    google_kms_crypto_key_iam_member.privateca_sa_keyuser_viewer,
   ]
 }
 # [END privateca_create_ca_byo_key]

--- a/mmv1/templates/terraform/examples/sql_instance_cmek.tf.erb
+++ b/mmv1/templates/terraform/examples/sql_instance_cmek.tf.erb
@@ -23,14 +23,12 @@ resource "google_kms_crypto_key" "key" {
 # [END cloud_sql_instance_key]
 
 # [START cloud_sql_instance_crypto_key]
-resource "google_kms_crypto_key_iam_binding" "crypto_key" {
+resource "google_kms_crypto_key_iam_member" "crypto_key" {
   provider      = google-beta
   crypto_key_id = google_kms_crypto_key.key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  members = [
-    "serviceAccount:${google_project_service_identity.gcp_sa_cloud_sql.email}",
-  ]
+  member = "serviceAccount:${google_project_service_identity.gcp_sa_cloud_sql.email}"
 }
 # [END cloud_sql_instance_crypto_key]
 

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_backup_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_backup_test.go
@@ -230,12 +230,10 @@ resource "google_kms_crypto_key" "key" {
   key_ring = google_kms_key_ring.keyring.id
 }
 
-resource "google_kms_crypto_key_iam_binding" "crypto_key" {
+resource "google_kms_crypto_key_iam_member" "crypto_key" {
   crypto_key_id = google_kms_crypto_key.key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  members = [
-	"serviceAccount:service-${data.google_project.project.number}@gcp-sa-alloydb.iam.gserviceaccount.com",
-  ]
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-alloydb.iam.gserviceaccount.com"
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_test.go
@@ -491,7 +491,7 @@ resource "google_alloydb_cluster" "default" {
   encryption_config {
     kms_key_name = google_kms_crypto_key.key.id
   }
-  depends_on = [google_kms_crypto_key_iam_binding.crypto_key]
+  depends_on = [google_kms_crypto_key_iam_member.crypto_key]
 }
 resource "google_compute_network" "default" {
   name = "tf-test-alloydb-cluster%{random_suffix}"
@@ -505,12 +505,10 @@ resource "google_kms_crypto_key" "key" {
   name     = "%{key_name}"
   key_ring = google_kms_key_ring.keyring.id
 }
-resource "google_kms_crypto_key_iam_binding" "crypto_key" {
+resource "google_kms_crypto_key_iam_member" "crypto_key" {
   crypto_key_id = google_kms_crypto_key.key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  members = [
-	"serviceAccount:service-${data.google_project.project.number}@gcp-sa-alloydb.iam.gserviceaccount.com",
-  ]
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-alloydb.iam.gserviceaccount.com"
 }
 `, context)
 }
@@ -582,7 +580,7 @@ resource "google_alloydb_cluster" "default" {
   lifecycle {
 	prevent_destroy = true
   }
-  depends_on = [google_kms_crypto_key_iam_binding.crypto_key]
+  depends_on = [google_kms_crypto_key_iam_member.crypto_key]
 }
 
 resource "google_compute_network" "default" {
@@ -601,12 +599,10 @@ resource "google_kms_crypto_key" "key" {
   key_ring = google_kms_key_ring.keyring.id
 }
 
-resource "google_kms_crypto_key_iam_binding" "crypto_key" {
+resource "google_kms_crypto_key_iam_member" "crypto_key" {
   crypto_key_id = google_kms_crypto_key.key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  members = [
-	"serviceAccount:service-${data.google_project.project.number}@gcp-sa-alloydb.iam.gserviceaccount.com",
-  ]
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-alloydb.iam.gserviceaccount.com"
 }
 `, context)
 }
@@ -632,9 +628,9 @@ resource "google_alloydb_cluster" "default" {
     }
   }
   lifecycle {
-	prevent_destroy = true
+    prevent_destroy = true
   }
-  depends_on = [google_kms_crypto_key_iam_binding.crypto_key]
+  depends_on = [google_kms_crypto_key_iam_member.crypto_key]
 }
 
 resource "google_compute_network" "default" {
@@ -654,24 +650,20 @@ resource "google_kms_crypto_key" "key" {
 }
 
 resource "google_kms_crypto_key" "key2" {
-	name     = "%{key_name}-2"
-	key_ring = google_kms_key_ring.keyring.id
+  name     = "%{key_name}-2"
+  key_ring = google_kms_key_ring.keyring.id
 }
 
-resource "google_kms_crypto_key_iam_binding" "crypto_key" {
+resource "google_kms_crypto_key_iam_member" "crypto_key" {
   crypto_key_id = google_kms_crypto_key.key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  members = [
-	"serviceAccount:service-${data.google_project.project.number}@gcp-sa-alloydb.iam.gserviceaccount.com",
-  ]
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-alloydb.iam.gserviceaccount.com"
 }
 
-resource "google_kms_crypto_key_iam_binding" "crypto_key2" {
-	crypto_key_id = google_kms_crypto_key.key2.id
-	role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-	members = [
-	  "serviceAccount:service-${data.google_project.project.number}@gcp-sa-alloydb.iam.gserviceaccount.com",
-	]
+resource "google_kms_crypto_key_iam_member" "crypto_key2" {
+  crypto_key_id = google_kms_crypto_key.key2.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-alloydb.iam.gserviceaccount.com"
 }
 `, context)
 }
@@ -696,7 +688,7 @@ resource "google_alloydb_cluster" "default" {
       retention_period = "510s"
     }
   }
-  depends_on = [google_kms_crypto_key_iam_binding.crypto_key]
+  depends_on = [google_kms_crypto_key_iam_member.crypto_key]
 }
 
 resource "google_compute_network" "default" {
@@ -720,20 +712,16 @@ resource "google_kms_crypto_key" "key2" {
 	key_ring = google_kms_key_ring.keyring.id
 }
 
-resource "google_kms_crypto_key_iam_binding" "crypto_key" {
+resource "google_kms_crypto_key_iam_member" "crypto_key" {
   crypto_key_id = google_kms_crypto_key.key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  members = [
-	"serviceAccount:service-${data.google_project.project.number}@gcp-sa-alloydb.iam.gserviceaccount.com",
-  ]
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-alloydb.iam.gserviceaccount.com"
 }
 
-resource "google_kms_crypto_key_iam_binding" "crypto_key2" {
-	crypto_key_id = google_kms_crypto_key.key2.id
-	role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-	members = [
-	  "serviceAccount:service-${data.google_project.project.number}@gcp-sa-alloydb.iam.gserviceaccount.com",
-	]
+resource "google_kms_crypto_key_iam_member" "crypto_key2" {
+  crypto_key_id = google_kms_crypto_key.key2.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-alloydb.iam.gserviceaccount.com"
 }
 `, context)
 }
@@ -1042,7 +1030,7 @@ resource "google_alloydb_cluster" "default" {
   lifecycle {
 	prevent_destroy = true
   }
-  depends_on = [google_kms_crypto_key_iam_binding.crypto_key]
+  depends_on = [google_kms_crypto_key_iam_member.crypto_key]
 }
 
 resource "google_compute_network" "default" {
@@ -1051,12 +1039,10 @@ resource "google_compute_network" "default" {
 
 data "google_project" "project" {}
 
-resource "google_kms_crypto_key_iam_binding" "crypto_key" {
+resource "google_kms_crypto_key_iam_member" "crypto_key" {
   crypto_key_id = "%{key_name}"
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  members = [
-    "serviceAccount:service-${data.google_project.project.number}@gcp-sa-alloydb.iam.gserviceaccount.com",
-  ]
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-alloydb.iam.gserviceaccount.com"
 }
 `, context)
 }
@@ -1074,7 +1060,7 @@ resource "google_alloydb_cluster" "default" {
       kms_key_name = "%{key_name}"
     }
   }
-  depends_on = [google_kms_crypto_key_iam_binding.crypto_key]
+  depends_on = [google_kms_crypto_key_iam_member.crypto_key]
 }
 
 resource "google_compute_network" "default" {
@@ -1083,12 +1069,10 @@ resource "google_compute_network" "default" {
 
 data "google_project" "project" {}
 
-resource "google_kms_crypto_key_iam_binding" "crypto_key" {
+resource "google_kms_crypto_key_iam_member" "crypto_key" {
 	crypto_key_id = "%{key_name}"
 	role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-	members = [
-	  "serviceAccount:service-${data.google_project.project.number}@gcp-sa-alloydb.iam.gserviceaccount.com",
-	]
+	members = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-alloydb.iam.gserviceaccount.com"
   }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_test.go
@@ -1072,7 +1072,7 @@ data "google_project" "project" {}
 resource "google_kms_crypto_key_iam_member" "crypto_key" {
 	crypto_key_id = "%{key_name}"
 	role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-	members = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-alloydb.iam.gserviceaccount.com"
+	member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-alloydb.iam.gserviceaccount.com"
   }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_secondary_cluster_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_secondary_cluster_test.go
@@ -519,7 +519,7 @@ resource "google_alloydb_cluster" "secondary" {
     kms_key_name = google_kms_crypto_key.key.id
   }
 
-  depends_on = [google_alloydb_instance.primary, google_kms_crypto_key_iam_binding.crypto_key]
+  depends_on = [google_alloydb_instance.primary, google_kms_crypto_key_iam_member.crypto_key]
 }
 
 data "google_project" "project" {}
@@ -538,12 +538,10 @@ resource "google_kms_crypto_key" "key" {
   key_ring = google_kms_key_ring.keyring.id
 }
 
-resource "google_kms_crypto_key_iam_binding" "crypto_key" {
+resource "google_kms_crypto_key_iam_member" "crypto_key" {
   crypto_key_id = google_kms_crypto_key.key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  members = [
-	"serviceAccount:service-${data.google_project.project.number}@gcp-sa-alloydb.iam.gserviceaccount.com",
-  ]
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-alloydb.iam.gserviceaccount.com"
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.erb
@@ -3650,6 +3650,10 @@ resource "google_compute_image" "image" {
     kms_key_self_link       = data.google_kms_crypto_key.key.id
     kms_key_service_account = google_service_account.test.email
   }
+
+  depends_on = [
+    google_kms_crypto_key_iam_member.crypto_key
+  ]
 }
 
 

--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
@@ -343,22 +343,18 @@ resource "google_kms_crypto_key" "key2" {
 	key_ring        = google_kms_key_ring.keyring.id
 }
 
-resource "google_kms_crypto_key_iam_binding" "crypto_key_binding1" {
+resource "google_kms_crypto_key_iam_member" "crypto_key_member1" {
 	crypto_key_id = google_kms_crypto_key.key1.id
 	role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 	
-	members = [
-		"serviceAccount:${data.google_logging_project_cmek_settings.cmek_settings.service_account_id}",
-	]
+	member = "serviceAccount:${data.google_logging_project_cmek_settings.cmek_settings.service_account_id}"
 }
 
-resource "google_kms_crypto_key_iam_binding" "crypto_key_binding2" {
+resource "google_kms_crypto_key_iam_member" "crypto_key_member2" {
 	crypto_key_id = google_kms_crypto_key.key2.id
 	role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 	
-	members = [
-		"serviceAccount:${data.google_logging_project_cmek_settings.cmek_settings.service_account_id}",
-	]
+	member = "serviceAccount:${data.google_logging_project_cmek_settings.cmek_settings.service_account_id}"
 }
 `, context), keyRingName, cryptoKeyName, cryptoKeyNameUpdate)
 }
@@ -378,7 +374,7 @@ resource "google_logging_project_bucket_config" "basic" {
 		kms_key_name = google_kms_crypto_key.key1.id
 	}
 
-	depends_on   = [google_kms_crypto_key_iam_binding.crypto_key_binding1]
+	depends_on   = [google_kms_crypto_key_iam_member.crypto_key_member1]
 }
 `, testAccLoggingBucketConfigProject_preCmekSettings(context, keyRingName, cryptoKeyName, cryptoKeyNameUpdate), bucketId)
 }
@@ -398,7 +394,7 @@ resource "google_logging_project_bucket_config" "basic" {
 		kms_key_name = google_kms_crypto_key.key2.id
 	}
 
-	depends_on   = [google_kms_crypto_key_iam_binding.crypto_key_binding2]
+	depends_on   = [google_kms_crypto_key_iam_member.crypto_key_member2]
 }
 `, testAccLoggingBucketConfigProject_preCmekSettings(context, keyRingName, cryptoKeyName, cryptoKeyNameUpdate), bucketId)
 }

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -3714,13 +3714,11 @@ resource "google_kms_crypto_key" "key" {
   key_ring = google_kms_key_ring.keyring.id
 }
 
-resource "google_kms_crypto_key_iam_binding" "crypto_key" {
+resource "google_kms_crypto_key_iam_member" "crypto_key" {
   crypto_key_id = google_kms_crypto_key.key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  members = [
-  "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloud-sql.iam.gserviceaccount.com",
-  ]
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloud-sql.iam.gserviceaccount.com"
 }
 
 resource "google_sql_database_instance" "master" {
@@ -3773,13 +3771,11 @@ resource "google_kms_crypto_key" "key" {
   key_ring = google_kms_key_ring.keyring.id
 }
 
-resource "google_kms_crypto_key_iam_binding" "crypto_key" {
+resource "google_kms_crypto_key_iam_member" "crypto_key" {
   crypto_key_id = google_kms_crypto_key.key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  members = [
-    "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloud-sql.iam.gserviceaccount.com",
-  ]
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloud-sql.iam.gserviceaccount.com"
 }
 
 resource "google_sql_database_instance" "master" {
@@ -3812,13 +3808,11 @@ resource "google_kms_crypto_key" "key-rep" {
   key_ring = google_kms_key_ring.keyring-rep.id
 }
 
-resource "google_kms_crypto_key_iam_binding" "crypto_key_rep" {
+resource "google_kms_crypto_key_iam_member" "crypto_key_rep" {
   crypto_key_id = google_kms_crypto_key.key-rep.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  members = [
-    "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloud-sql.iam.gserviceaccount.com",
-  ]
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloud-sql.iam.gserviceaccount.com"
 }
 
 resource "google_sql_database_instance" "replica" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Related to https://github.com/hashicorp/terraform-provider-google/issues/16687

We have a group of bootstrapped KMS keys in the test projects that can be used by acceptance tests but aren't created/deleted by tests.

Because these resources are reused by tests there is a chance that tests will conflict with each other when editing the IAM permissions on the resource.

In this PR I remove unnecessary use of `google_kms_crypto_key_iam_binding` so it's easier to identify instances when a test is affecting bootstrapped resources' IAM policies authoritatively.

An example I've identified that affects a bootstrapped KMS key is generated from the `mmv1/templates/terraform/examples/cloudfunctions2_cmek.tf.erb` file to make the generated test `TestAccCloudfunctions2function_cloudfunctions2CmekExample`

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
