### PR TITLE
Revert " add support for IAM Group authentication to google_sql_user"

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_user.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user.go
@@ -102,10 +102,8 @@ func ResourceSqlUser() *schema.Resource {
 				ForceNew:         true,
 				DiffSuppressFunc: tpgresource.EmptyOrDefaultStringSuppress("BUILT_IN"),
 				Description: `The user type. It determines the method to authenticate the user during login.
-                The default is the database's built-in user type. Flags include "BUILT_IN", "CLOUD_IAM_USER", "CLOUD_IAM_SERVICE_ACCOUNT",
-								"CLOUD_IAM_GROUP", "CLOUD_IAM_GROUP_USER" or "CLOUD_IAM_GROUP_SERVICE_ACCOUNT".`,
-				ValidateFunc: validation.StringInSlice([]string{"BUILT_IN", "CLOUD_IAM_USER", "CLOUD_IAM_SERVICE_ACCOUNT",
-					"CLOUD_IAM_GROUP", "CLOUD_IAM_GROUP_USER", "CLOUD_IAM_GROUP_SERVICE_ACCOUNT", ""}, false),
+                The default is the database's built-in user type. Flags include "BUILT_IN", "CLOUD_IAM_USER", or "CLOUD_IAM_SERVICE_ACCOUNT".`,
+				ValidateFunc: validation.StringInSlice([]string{"BUILT_IN", "CLOUD_IAM_USER", "CLOUD_IAM_SERVICE_ACCOUNT", ""}, false),
 			},
 			"sql_server_user_details": {
 				Type:     schema.TypeList,

--- a/mmv1/third_party/terraform/services/sql/resource_sql_user_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user_test.go
@@ -26,7 +26,6 @@ func TestAccSqlUser_mysql(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleSqlUserExists(t, "google_sql_user.user1"),
 					testAccCheckGoogleSqlUserExists(t, "google_sql_user.user2"),
-					testAccCheckGoogleSqlUserExists(t, "google_sql_user.user3"),
 				),
 			},
 			{
@@ -35,7 +34,6 @@ func TestAccSqlUser_mysql(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleSqlUserExists(t, "google_sql_user.user1"),
 					testAccCheckGoogleSqlUserExists(t, "google_sql_user.user2"),
-					testAccCheckGoogleSqlUserExists(t, "google_sql_user.user3"),
 				),
 			},
 			{
@@ -313,15 +311,6 @@ resource "google_sql_user" "user2" {
   instance = google_sql_database_instance.instance.name
   host     = "gmail.com"
   password = "hunter2"
-  type = "CLOUD_IAM_USER"
-}
-
-resource "google_sql_user" "user3" {
-  name     = "admin"
-  instance = google_sql_database_instance.instance.name
-  host     = "gmail.com"
-  password = "hunter3"
-  type = "CLOUD_IAM_GROUP"
 }
 `, instance, password)
 }

--- a/mmv1/third_party/terraform/website/docs/r/sql_user.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_user.html.markdown
@@ -72,24 +72,6 @@ resource "google_sql_user" "iam_service_account_user" {
   instance = google_sql_database_instance.main.name
   type     = "CLOUD_IAM_SERVICE_ACCOUNT"
 }
-
-resource "google_sql_user" "iam_group" {
-  name     = "group1@example.com"
-  instance = google_sql_database_instance.main.name
-  type     = "CLOUD_IAM_GROUP"
-}
-
-resource "google_sql_user" "iam_group_user" {
-  name     = "group_user1@example.com"
-  instance = google_sql_database_instance.main.name
-  type     = "CLOUD_IAM_GROUP_USER"
-}
-
-resource "google_sql_user" "iam_group_service_account_user" {
-  name     = "my-service-account@example.iam.gserviceaccount.com"
-  instance = google_sql_database_instance.main.name
-  type     = "CLOUD_IAM_GROUP_SERVICE_ACCOUNT"
-}
 ```
 
 ## Argument Reference
@@ -109,8 +91,7 @@ The following arguments are supported:
 
 * `type` - (Optional) The user type. It determines the method to authenticate the
     user during login. The default is the database's built-in user type. Flags
-    include "BUILT_IN", "CLOUD_IAM_USER", "CLOUD_IAM_SERVICE_ACCOUNT", 
-    "CLOUD_IAM_GROUP", "CLOUD_IAM_GROUP_USER" or "CLOUD_IAM_GROUP_SERVICE_ACCOUNT".
+    include "BUILT_IN", "CLOUD_IAM_USER", or "CLOUD_IAM_SERVICE_ACCOUNT".
 
 * `deletion_policy` - (Optional) The deletion policy for the user.
     Setting `ABANDON` allows the resource to be abandoned rather than deleted. This is useful


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#9578

Fixes https://github.com/hashicorp/terraform-provider-google/issues/16693

Tests were skipped in VCR so the inability to use these values yet was not noticed.

```release-note:none

```
