### PR TITLE
Add ExternalAccessRule to Vmwareengine

### DIFF
--- a/mmv1/products/vmwareengine/ExternalAccessRule.yaml
+++ b/mmv1/products/vmwareengine/ExternalAccessRule.yaml
@@ -1,0 +1,192 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'ExternalAccessRule'
+base_url: '{{parent}}/externalAccessRules'
+create_url: '{{parent}}/externalAccessRules?externalAccessRuleId={{name}}'
+self_link: '{{parent}}/externalAccessRules/{{name}}'
+update_mask: true
+update_verb: :PATCH
+references: !ruby/object:Api::Resource::ReferenceLinks
+  api: 'https://cloud.google.com/vmware-engine/docs/reference/rest/v1/projects.locations.networkPolicies.externalAccessRules'
+description: |
+  External access firewall rules for filtering incoming traffic destined to `ExternalAddress` resources.
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
+    path: "name"
+    base_url: "{{op_id}}"
+    wait_ms: 1000
+  result: !ruby/object:Api::OpAsync::Result
+    path: "response"
+  status: !ruby/object:Api::OpAsync::Status
+    path: "done"
+    complete: true
+    allowed:
+      - true
+      - false
+  error: !ruby/object:Api::OpAsync::Error
+    path: "error"
+    message: "message"
+  include_project: true
+import_format: ["{{%parent}}/externalAccessRules/{{name}}"]
+id_format: "{{parent}}/externalAccessRules/{{name}}"
+autogen_async: true
+
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: "vmware_engine_external_access_rule_basic"
+    primary_resource_id: "vmw-engine-external-access-rule"
+    skip_test: true   # update tests will take care of create and update. The test id dependent on PC creation, which is expensive and requires node reservation.
+    vars:
+      name: "sample-external-access-rule"
+      network_id: "sample-nw"
+      network_policy_id: "sample-np"
+    test_env_vars:
+      region: :REGION
+
+  - !ruby/object:Provider::Terraform::Examples
+    name: "vmware_engine_external_access_rule_full"
+    primary_resource_id: "vmw-engine-external-access-rule"
+    skip_test: true   # update tests will take care of create and update. The test id dependent on PC creation, which is expensive and requires node reservation.
+    vars:
+      name: "sample-external-access-rule"
+      network_id: "sample-nw"
+      network_policy_id: "sample-np"
+      private_cloud_id: "sample-pc"
+      management_cluster_id: "sample-mgmt-cluster"
+      external_address_id: "sample-ea"
+    test_env_vars:
+      region: :REGION
+
+parameters:
+  - !ruby/object:Api::Type::String
+    name: "parent"
+    immutable: true
+    required: true
+    url_param_only: true
+    description: |
+      The resource name of the network policy.
+      Resource names are schemeless URIs that follow the conventions in https://cloud.google.com/apis/design/resource_names.
+      For example: projects/my-project/locations/us-west1-a/networkPolicies/my-policy
+
+  - !ruby/object:Api::Type::String
+    name: "name"
+    required: true
+    immutable: true
+    url_param_only: true
+    description: |
+      The ID of the external access rule.
+
+properties:
+  - !ruby/object:Api::Type::Time
+    name: 'createTime'
+    output: true
+    description: |
+      Creation time of this resource.
+      A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and
+      up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+
+  - !ruby/object:Api::Type::Time
+    name: 'updateTime'
+    output: true
+    description: |
+      Last updated time of this resource.
+      A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine
+      fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+
+  - !ruby/object:Api::Type::String
+    name: 'description'
+    description: |
+      User-provided description for the external access rule.
+
+  - !ruby/object:Api::Type::Integer
+    name: 'priority'
+    required: true
+    description: |
+      External access rule priority, which determines the external access rule to use when multiple rules apply.
+
+  - !ruby/object:Api::Type::Enum
+    name: 'action'
+    required: true
+    description: |
+      The action that the external access rule performs.
+    values:
+      - :ALLOW
+      - :DENY
+
+  - !ruby/object:Api::Type::String
+    name: 'ipProtocol'
+    required: true
+    description: |
+      The IP protocol to which the external access rule applies.
+
+  - !ruby/object:Api::Type::Array
+    name: 'sourceIpRanges'
+    required: true
+    description: |
+      If source ranges are specified, the external access rule applies only to
+      traffic that has a source IP address in these ranges.
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties:
+        - !ruby/object:Api::Type::String
+          name: 'ipAddress'
+          description: |
+            A single IP address.
+        - !ruby/object:Api::Type::String
+          name: 'ipAddressRange'
+          description: |
+            An IP address range in the CIDR format.
+
+  - !ruby/object:Api::Type::Array
+    name: 'sourcePorts'
+    required: true
+    description: |
+      A list of source ports to which the external access rule applies.
+    item_type: Api::Type::String
+
+  - !ruby/object:Api::Type::Array
+    name: 'destinationIpRanges'
+    required: true
+    description: |
+      If destination ranges are specified, the external access rule applies only to
+      traffic that has a destination IP address in these ranges.
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties:
+        - !ruby/object:Api::Type::String
+          name: 'ipAddressRange'
+          description: |
+            An IP address range in the CIDR format.
+        - !ruby/object:Api::Type::String
+          name: 'externalAddress'
+          description: |
+            The name of an `ExternalAddress` resource.
+
+  - !ruby/object:Api::Type::Array
+    name: 'destinationPorts'
+    required: true
+    description: |
+      A list of destination ports to which the external access rule applies.
+    item_type: Api::Type::String
+
+  - !ruby/object:Api::Type::String
+    name: 'state'
+    description: |
+      State of the Cluster.
+    output: true
+
+  - !ruby/object:Api::Type::String
+    name: 'uid'
+    output: true
+    description: |
+      System-generated unique identifier for the resource.

--- a/mmv1/templates/terraform/examples/vmware_engine_external_access_rule_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/vmware_engine_external_access_rule_basic.tf.erb
@@ -1,0 +1,29 @@
+resource "google_vmwareengine_network" "external-access-rule-nw" {
+  name        = "<%= ctx[:vars]['network_id'] %>"
+  location    = "global"
+  type        = "STANDARD"
+  description = "PC network description."
+}
+
+resource "google_vmwareengine_network_policy" "external-access-rule-np" {
+  location = "<%= ctx[:test_env_vars]['region'] %>"
+  name = "<%= ctx[:vars]['network_policy_id'] %>"
+  edge_services_cidr = "192.168.30.0/26"
+  vmware_engine_network = google_vmwareengine_network.external-access-rule-nw.id
+}
+
+resource "google_vmwareengine_external_access_rule" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['name'] %>"
+  parent =  google_vmwareengine_network_policy.external-access-rule-np.id
+  priority = 101
+  action = "DENY"
+  ip_protocol = "TCP"
+  source_ip_ranges {
+    ip_address_range = "0.0.0.0/0"
+  }
+  source_ports = ["80"]
+  destination_ip_ranges {
+    ip_address_range = "0.0.0.0/0"
+  }
+  destination_ports = ["433"]
+}

--- a/mmv1/templates/terraform/examples/vmware_engine_external_access_rule_full.tf.erb
+++ b/mmv1/templates/terraform/examples/vmware_engine_external_access_rule_full.tf.erb
@@ -1,0 +1,54 @@
+resource "google_vmwareengine_network" "external-access-rule-nw" {
+  name        = "<%= ctx[:vars]['network_id'] %>"
+  location    = "global"
+  type        = "STANDARD"
+  description = "PC network description."
+}
+
+resource "google_vmwareengine_private_cloud" "external-access-rule-pc" {
+  location    = "<%= ctx[:test_env_vars]['region'] %>-a"
+  name        = "<%= ctx[:vars]['private_cloud_id'] %>"
+  description = "Sample test PC."
+  network_config {
+    management_cidr       = "192.168.50.0/24"
+    vmware_engine_network = google_vmwareengine_network.external-access-rule-nw.id
+  }
+
+  management_cluster {
+    cluster_id = "<%= ctx[:vars]['management_cluster_id'] %>"
+    node_type_configs {
+      node_type_id = "standard-72"
+      node_count   = 3
+    }
+  }
+}
+
+resource "google_vmwareengine_network_policy" "external-access-rule-np" {
+  location = "<%= ctx[:test_env_vars]['region'] %>"
+  name = "<%= ctx[:vars]['network_policy_id'] %>"
+  edge_services_cidr = "192.168.30.0/26"
+  vmware_engine_network = google_vmwareengine_network.external-access-rule-nw.id
+}
+
+resource "google_vmwareengine_external_address" "external-access-rule-ea" {
+    name = "<%= ctx[:vars]['external_address_id'] %>"
+    parent =  google_vmwareengine_private_cloud.external-access-rule-pc.id
+    internal_ip = "192.168.0.65"
+}
+
+resource "google_vmwareengine_external_access_rule" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['name'] %>"
+  parent =  google_vmwareengine_network_policy.external-access-rule-np.id
+  description = "Sample Description"
+  priority = 101
+  action = "ALLOW"
+  ip_protocol = "tcp"
+  source_ip_ranges {
+    ip_address_range = "0.0.0.0/0"
+  }
+  source_ports = ["80"]
+  destination_ip_ranges {
+    external_address = google_vmwareengine_external_address.external-access-rule-ea.id
+  }
+  destination_ports = ["433"]
+}

--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
@@ -187,6 +187,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_redis_instance":                            redis.DataSourceGoogleRedisInstance(),
 	"google_vertex_ai_index":                           vertexai.DataSourceVertexAIIndex(),
 	"google_vmwareengine_cluster":                      vmwareengine.DataSourceVmwareengineCluster(),
+	"google_vmwareengine_external_access_rule":         vmwareengine.DataSourceVmwareengineExternalAccessRule(),
 	"google_vmwareengine_external_address":             vmwareengine.DataSourceVmwareengineExternalAddress(),
 	"google_vmwareengine_network":                      vmwareengine.DataSourceVmwareengineNetwork(),
 	"google_vmwareengine_network_peering":              vmwareengine.DataSourceVmwareengineNetworkPeering(),

--- a/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_external_access_rule.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_external_access_rule.go
@@ -1,0 +1,39 @@
+package vmwareengine
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceVmwareengineExternalAccessRule() *schema.Resource {
+
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceVmwareengineExternalAccessRule().Schema)
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "parent", "name")
+	return &schema.Resource{
+		Read:   dataSourceVmwareengineExternalAccessRuleRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceVmwareengineExternalAccessRuleRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+
+	// Store the ID now
+	id, err := tpgresource.ReplaceVars(d, config, "{{parent}}/externalAccessRules/{{name}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+	err = resourceVmwareengineExternalAccessRuleRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
+}

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_access_rule_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_access_rule_test.go
@@ -1,0 +1,233 @@
+package vmwareengine_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccVmwareengineExternalAccessRule_vmwareEngineExternalAccessRuleUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"region":        "southamerica-west1", // using region with low node utilization.
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testVmwareEngineExternalAccessRuleCreateConfig(context),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores("data.google_vmwareengine_external_access_rule.ds", "google_vmwareengine_external_access_rule.vmw-engine-external-access-rule", map[string]struct{}{}),
+				),
+			},
+			{
+				ResourceName:            "google_vmwareengine_external_access_rule.vmw-engine-external-access-rule",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parent", "name"},
+			},
+			{
+				Config: testVmwareEngineExternalAccessRuleUpdateConfig(context),
+			},
+			{
+				ResourceName:            "google_vmwareengine_external_access_rule.vmw-engine-external-access-rule",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parent", "name"},
+			},
+		},
+	})
+}
+
+func testVmwareEngineExternalAccessRuleCreateConfig(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+
+resource "google_vmwareengine_network" "external-access-rule-nw" {
+  name        = "tf-test-sample-external-access-rule-nw-%{random_suffix}"
+  location    = "global"
+  type        = "STANDARD"
+}
+
+resource "google_vmwareengine_private_cloud" "external-access-rule-pc" {
+  location    = "%{region}-a"
+  name        = "tf-test-sample-external-access-rule-pc-%{random_suffix}"
+  type        = "TIME_LIMITED"
+  network_config {
+    management_cidr       = "192.168.1.0/24"
+    vmware_engine_network = google_vmwareengine_network.external-access-rule-nw.id
+  }
+
+  management_cluster {
+    cluster_id = "tf-test-sample-external-access-rule-cluster%{random_suffix}"
+    node_type_configs {
+      node_type_id = "standard-72"
+      node_count   = 1
+    }
+  }
+}
+
+resource "google_vmwareengine_network_policy" "external-access-rule-np" {
+  location = "%{region}"
+  name = "tf-test-sample-external-access-rule-np-%{random_suffix}"
+  edge_services_cidr = "192.168.0.0/26"
+  vmware_engine_network = google_vmwareengine_network.external-access-rule-nw.id
+	internet_access {
+    enabled = true
+  }
+  external_ip {
+    enabled = true
+  }
+}
+
+resource "google_vmwareengine_external_address" "external-access-rule-ea-one" {
+  name = "tf-test-sample-external-access-rule-ea-one%{random_suffix}"
+  parent =  google_vmwareengine_private_cloud.external-access-rule-pc.id
+  internal_ip = "192.168.0.74"
+  description = "Sample description."
+  depends_on = [
+    google_vmwareengine_network_policy.external-access-rule-np,
+  ]
+}
+
+resource "google_vmwareengine_external_address" "external-access-rule-ea-two" {
+  name = "tf-test-sample-external-access-rule-ea-two%{random_suffix}"
+  parent =  google_vmwareengine_private_cloud.external-access-rule-pc.id
+  internal_ip = "192.168.0.75"
+  description = "Sample description."
+  depends_on = [
+    google_vmwareengine_network_policy.external-access-rule-np,
+  ]
+}
+
+resource "google_vmwareengine_external_access_rule" "vmw-engine-external-access-rule" {
+  name = "tf-test-sample-external-access-rule%{random_suffix}"
+  parent =  google_vmwareengine_network_policy.external-access-rule-np.id
+  description = "description1"
+  priority = "101"
+  action = "ALLOW"
+  ip_protocol = "TCP"
+  source_ip_ranges {
+    ip_address_range = "0.0.0.0/0"
+  }
+  source_ports = ["80"]
+  destination_ip_ranges {
+    external_address = google_vmwareengine_external_address.external-access-rule-ea-one.id
+  }
+  destination_ip_ranges {
+    external_address = google_vmwareengine_external_address.external-access-rule-ea-two.id
+  }
+  destination_ports = ["433"]
+  depends_on = [
+    google_vmwareengine_external_address.external-access-rule-ea-one,
+    google_vmwareengine_external_address.external-access-rule-ea-two,
+  ]
+}
+
+data "google_vmwareengine_external_access_rule" "ds" {
+  name = google_vmwareengine_external_access_rule.vmw-engine-external-access-rule.name
+  parent = google_vmwareengine_network_policy.external-access-rule-np.id
+  depends_on = [
+    google_vmwareengine_external_access_rule.vmw-engine-external-access-rule,
+  ]
+}
+`, context)
+}
+
+func testVmwareEngineExternalAccessRuleUpdateConfig(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+
+resource "google_vmwareengine_network" "external-access-rule-nw" {
+  name        = "tf-test-sample-external-access-rule-nw-%{random_suffix}"
+  location    = "global"
+  type        = "STANDARD"
+}
+
+resource "google_vmwareengine_private_cloud" "external-access-rule-pc" {
+  location    = "%{region}-a"
+  name        = "tf-test-sample-external-access-rule-pc-%{random_suffix}"
+  type        = "TIME_LIMITED"
+  network_config {
+    management_cidr       = "192.168.1.0/24"
+    vmware_engine_network = google_vmwareengine_network.external-access-rule-nw.id
+  }
+
+  management_cluster {
+    cluster_id = "tf-test-sample-external-access-rule-cluster%{random_suffix}"
+    node_type_configs {
+      node_type_id = "standard-72"
+      node_count   = 1
+    }
+  }
+}
+
+resource "google_vmwareengine_network_policy" "external-access-rule-np" {
+  location = "%{region}"
+  name = "tf-test-sample-external-access-rule-np-%{random_suffix}"
+  edge_services_cidr = "192.168.0.0/26"
+  vmware_engine_network = google_vmwareengine_network.external-access-rule-nw.id
+	internet_access {
+    enabled = true
+  }
+  external_ip {
+    enabled = true
+  }
+}
+
+resource "google_vmwareengine_external_address" "external-access-rule-ea-one" {
+  name = "tf-test-sample-external-access-rule-ea-one%{random_suffix}"
+  parent =  google_vmwareengine_private_cloud.external-access-rule-pc.id
+  internal_ip = "192.168.0.74"
+  description = "Sample description."
+  depends_on = [
+    google_vmwareengine_network_policy.external-access-rule-np,
+  ]
+}
+
+resource "google_vmwareengine_external_address" "external-access-rule-ea-two" {
+  name = "tf-test-sample-external-access-rule-ea-two%{random_suffix}"
+  parent =  google_vmwareengine_private_cloud.external-access-rule-pc.id
+  internal_ip = "192.168.0.75"
+  description = "Sample description."
+  depends_on = [
+    google_vmwareengine_network_policy.external-access-rule-np,
+  ]
+}
+
+resource "google_vmwareengine_external_access_rule" "vmw-engine-external-access-rule" {
+  name = "tf-test-sample-external-access-rule%{random_suffix}"
+  parent =  google_vmwareengine_network_policy.external-access-rule-np.id
+  description = "description2"
+  priority = "102"
+  action = "DENY"
+  ip_protocol = "UDP"
+  source_ip_ranges {
+    ip_address = "192.168.40.1"
+  }
+  source_ip_ranges {
+    ip_address = "192.168.40.0"
+  }
+  source_ports = ["81", "82"]
+  destination_ip_ranges {
+    ip_address_range = "0.0.0.0/0"
+  }
+  destination_ports = ["435", "434"]
+  depends_on = [
+    google_vmwareengine_external_address.external-access-rule-ea-one,
+    google_vmwareengine_external_address.external-access-rule-ea-two,
+  ]
+}
+
+data "google_vmwareengine_external_access_rule" "ds" {
+  name = google_vmwareengine_external_access_rule.vmw-engine-external-access-rule.name
+  parent = google_vmwareengine_network_policy.external-access-rule-np.id
+  depends_on = [
+    google_vmwareengine_external_access_rule.vmw-engine-external-access-rule,
+  ]
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/website/docs/d/vmwareengine_external_access_rule.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/vmwareengine_external_access_rule.html.markdown
@@ -1,0 +1,32 @@
+---
+subcategory: "Cloud VMware Engine"
+description: |-
+  Get information about a external access rule.
+---
+
+# google\_vmwareengine\_external_access_rule
+
+Use this data source to get details about a external access rule resource.
+
+To get more information about external address, see:
+* [API documentation](https://cloud.google.com/vmware-engine/docs/reference/rest/v1/projects.locations.networkPolicies.externalAccessRules)
+
+## Example Usage
+
+```hcl
+data "google_vmwareengine_external_access_rule" "my_external_access_rule" {
+  name     = "my-external-access-rule"
+  parent   = "project/my-project/locations/us-west1-a/networkPolicies/my-network-policy"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the resource.
+* `parent` - (Required) The resource name of the network policy that this cluster belongs.
+
+## Attributes Reference
+
+See [google_vmwareengine_external_access_rule](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vmwareengine_external_access_rule#attributes-reference) resource for details of all the available attributes.


### PR DESCRIPTION
Added ExternalAccessRule resource and datasource to Vmwareengine. 
External access rules are dependent on external addresses, which are a child resource of Private Cloud (PC).

Since the parent PC creation is expensive and node reservation is required, all tests are merged into the update test.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_vmwareengine_external_access_rule`
```

```release-note:new-datasource
`google_vmwareengine_external_access_rule`
```
