### PR TITLE
Refactor magician structs

### DIFF
--- a/.ci/magician/cloudbuild/build_trigger.go
+++ b/.ci/magician/cloudbuild/build_trigger.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"os"
 
-	"google.golang.org/api/cloudbuild/v1"
+	cloudbuildv1 "google.golang.org/api/cloudbuild/v1"
 )
 
-func (cb cloudBuild) TriggerMMPresubmitRuns(commitSha string, substitutions map[string]string) error {
+func (cb *Client) TriggerMMPresubmitRuns(commitSha string, substitutions map[string]string) error {
 	presubmitTriggerId, ok := os.LookupEnv("GENERATE_DIFFS_TRIGGER")
 	if !ok {
 		return fmt.Errorf("did not provide GENERATE_DIFFS_TRIGGER environment variable")
@@ -24,12 +24,12 @@ func (cb cloudBuild) TriggerMMPresubmitRuns(commitSha string, substitutions map[
 
 func triggerCloudBuildRun(projectId, triggerId, repoName, commitSha string, substitutions map[string]string) error {
 	ctx := context.Background()
-	c, err := cloudbuild.NewService(ctx)
+	c, err := cloudbuildv1.NewService(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create Cloud Build service client: %s", err)
 	}
 
-	repoSource := &cloudbuild.RepoSource{
+	repoSource := &cloudbuildv1.RepoSource{
 		ProjectId:     projectId,
 		RepoName:      repoName,
 		CommitSha:     commitSha,

--- a/.ci/magician/cloudbuild/community.go
+++ b/.ci/magician/cloudbuild/community.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"os"
 
-	"google.golang.org/api/cloudbuild/v1"
+	cloudbuildv1 "google.golang.org/api/cloudbuild/v1"
 )
 
-func (cb cloudBuild) ApproveCommunityChecker(prNumber, commitSha string) error {
+func (cb *Client) ApproveCommunityChecker(prNumber, commitSha string) error {
 	buildId, err := getPendingBuildId(PROJECT_ID, commitSha)
 	if err != nil {
 		return err
@@ -26,7 +26,7 @@ func (cb cloudBuild) ApproveCommunityChecker(prNumber, commitSha string) error {
 	return nil
 }
 
-func (cb cloudBuild) GetAwaitingApprovalBuildLink(prNumber, commitSha string) (string, error) {
+func (cb *Client) GetAwaitingApprovalBuildLink(prNumber, commitSha string) (string, error) {
 	buildId, err := getPendingBuildId(PROJECT_ID, commitSha)
 	if err != nil {
 		return "", err
@@ -49,7 +49,7 @@ func getPendingBuildId(projectId, commitSha string) (string, error) {
 
 	ctx := context.Background()
 
-	c, err := cloudbuild.NewService(ctx)
+	c, err := cloudbuildv1.NewService(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -76,15 +76,15 @@ func getPendingBuildId(projectId, commitSha string) (string, error) {
 func approveBuild(projectId, buildId string) error {
 	ctx := context.Background()
 
-	c, err := cloudbuild.NewService(ctx)
+	c, err := cloudbuildv1.NewService(ctx)
 	if err != nil {
 		return err
 	}
 
 	name := fmt.Sprintf("projects/%s/builds/%s", projectId, buildId)
 
-	approveBuildRequest := &cloudbuild.ApproveBuildRequest{
-		ApprovalResult: &cloudbuild.ApprovalResult{
+	approveBuildRequest := &cloudbuildv1.ApproveBuildRequest{
+		ApprovalResult: &cloudbuildv1.ApprovalResult{
 			Decision: "APPROVED",
 		},
 	}

--- a/.ci/magician/cloudbuild/init.go
+++ b/.ci/magician/cloudbuild/init.go
@@ -1,14 +1,8 @@
 package cloudbuild
 
-type cloudBuild bool
-
-type CloudBuild interface {
-	ApproveCommunityChecker(prNumber, commitSha string) error
-	GetAwaitingApprovalBuildLink(prNumber, commitSha string) (string, error)
-	TriggerMMPresubmitRuns(commitSha string, substitutions map[string]string) error
+type Client struct {
 }
 
-func NewCloudBuildService() CloudBuild {
-	var x cloudBuild = true
-	return x
+func NewClient() *Client {
+	return &Client{}
 }

--- a/.ci/magician/cmd/community_checker.go
+++ b/.ci/magician/cmd/community_checker.go
@@ -12,17 +12,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type ccGithub interface {
-	GetPullRequest(prNumber string) (string, error)
-	GetUserType(user string) github.UserType
-	RemoveLabel(prNumber string, label string) error
-	PostBuildStatus(prNumber string, title string, state string, targetUrl string, commitSha string) error
-}
-
-type ccCloudbuild interface {
-	TriggerMMPresubmitRuns(commitSha string, substitutions map[string]string) error
-}
-
 // communityApprovalCmd represents the communityApproval command
 var communityApprovalCmd = &cobra.Command{
 	Use:   "community-checker",
@@ -63,13 +52,13 @@ var communityApprovalCmd = &cobra.Command{
 		baseBranch := args[5]
 		fmt.Println("Base Branch: ", baseBranch)
 
-		gh := github.NewGithubService()
-		cb := cloudbuild.NewCloudBuildService()
+		gh := github.NewClient()
+		cb := cloudbuild.NewClient()
 		execCommunityChecker(prNumber, commitSha, branchName, headRepoUrl, headBranch, baseBranch, gh, cb)
 	},
 }
 
-func execCommunityChecker(prNumber, commitSha, branchName, headRepoUrl, headBranch, baseBranch string, gh ccGithub, cb ccCloudbuild) {
+func execCommunityChecker(prNumber, commitSha, branchName, headRepoUrl, headBranch, baseBranch string, gh GithubClient, cb CloudbuildClient) {
 	substitutions := map[string]string{
 		"BRANCH_NAME":    branchName,
 		"_PR_NUMBER":     prNumber,

--- a/.ci/magician/cmd/community_checker.go
+++ b/.ci/magician/cmd/community_checker.go
@@ -13,7 +13,7 @@ import (
 )
 
 type ccGithub interface {
-	GetPullRequestAuthor(prNumber string) (string, error)
+	GetPullRequest(prNumber string) (string, error)
 	GetUserType(user string) github.UserType
 	RemoveLabel(prNumber string, label string) error
 	PostBuildStatus(prNumber string, title string, state string, targetUrl string, commitSha string) error
@@ -78,12 +78,13 @@ func execCommunityChecker(prNumber, commitSha, branchName, headRepoUrl, headBran
 		"_BASE_BRANCH":   baseBranch,
 	}
 
-	author, err := gh.GetPullRequestAuthor(prNumber)
+	pullRequest, err := gh.GetPullRequest(prNumber)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
+	author := pullRequest.User.Login
 	authorUserType := gh.GetUserType(author)
 	trusted := authorUserType == github.CoreContributorUserType || authorUserType == github.GooglerUserType
 

--- a/.ci/magician/cmd/community_checker_test.go
+++ b/.ci/magician/cmd/community_checker_test.go
@@ -8,7 +8,11 @@ import (
 
 func TestExecCommunityChecker_CoreContributorFlow(t *testing.T) {
 	gh := &mockGithub{
-		author:        "core_author",
+		pullRequest: github.PullRequest{
+			User: github.User{
+				Login: "core_author",
+			},
+		},
 		userType:      github.CoreContributorUserType,
 		calledMethods: make(map[string][][]any),
 	}
@@ -34,7 +38,11 @@ func TestExecCommunityChecker_CoreContributorFlow(t *testing.T) {
 
 func TestExecCommunityChecker_GooglerFlow(t *testing.T) {
 	gh := &mockGithub{
-		author:            "googler_author",
+		pullRequest: github.PullRequest{
+			User: github.User{
+				Login: "googler_author",
+			},
+		},
 		userType:          github.GooglerUserType,
 		calledMethods:     make(map[string][][]any),
 		firstReviewer:     "reviewer1",
@@ -61,7 +69,11 @@ func TestExecCommunityChecker_GooglerFlow(t *testing.T) {
 
 func TestExecCommunityChecker_AmbiguousUserFlow(t *testing.T) {
 	gh := &mockGithub{
-		author:            "ambiguous_author",
+		pullRequest: github.PullRequest{
+			User: github.User{
+				Login: "ambiguous_author",
+			},
+		},
 		userType:          github.CommunityUserType,
 		calledMethods:     make(map[string][][]any),
 		firstReviewer:     github.GetRandomReviewer(),

--- a/.ci/magician/cmd/interfaces.go
+++ b/.ci/magician/cmd/interfaces.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"magician/github"
+)
+
+type GithubClient interface {
+	GetPullRequest(prNumber string) (github.PullRequest, error)
+	GetPullRequestRequestedReviewer(prNumber string) (string, error)
+	GetPullRequestPreviousAssignedReviewers(prNumber string) ([]string, error)
+	GetUserType(user string) github.UserType
+	PostBuildStatus(prNumber, title, state, targetURL, commitSha string) error
+	PostComment(prNumber, comment string) error
+	RequestPullRequestReviewer(prNumber, assignee string) error
+	AddLabel(prNumber, label string) error
+	RemoveLabel(prNumber, label string) error
+	CreateWorkflowDispatchEvent(workflowFileName string, inputs map[string]any) error
+}
+
+type CloudbuildClient interface {
+	ApproveCommunityChecker(prNumber, commitSha string) error
+	GetAwaitingApprovalBuildLink(prNumber, commitSha string) (string, error)
+	TriggerMMPresubmitRuns(commitSha string, substitutions map[string]string) error
+}
+
+type ExecRunner interface {
+	GetCWD() string
+	Copy(src, dest string) error
+	RemoveAll(path string) error
+	PushDir(path string) error
+	PopDir() error
+	Run(name string, args, env []string) (string, error)
+	MustRun(name string, args, env []string) string
+}

--- a/.ci/magician/cmd/membership_checker.go
+++ b/.ci/magician/cmd/membership_checker.go
@@ -12,23 +12,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type mcGithub interface {
-	GetPullRequest(prNumber string) (string, error)
-	GetUserType(user string) github.UserType
-	GetPullRequestRequestedReviewer(prNumber string) (string, error)
-	GetPullRequestPreviousAssignedReviewers(prNumber string) ([]string, error)
-	RequestPullRequestReviewer(prNumber string, reviewer string) error
-	PostComment(prNumber string, comment string) error
-	AddLabel(prNumber string, label string) error
-	PostBuildStatus(prNumber string, title string, state string, targetUrl string, commitSha string) error
-}
-
-type mcCloudbuild interface {
-	ApproveCommunityChecker(prNumber, commitSha string) error
-	GetAwaitingApprovalBuildLink(prNumber, commitSha string) (string, error)
-	TriggerMMPresubmitRuns(commitSha string, substitutions map[string]string) error
-}
-
 // membershipCheckerCmd represents the membershipChecker command
 var membershipCheckerCmd = &cobra.Command{
 	Use:   "membership-checker",
@@ -77,13 +60,13 @@ var membershipCheckerCmd = &cobra.Command{
 		baseBranch := args[5]
 		fmt.Println("Base Branch: ", baseBranch)
 
-		gh := github.NewGithubService()
-		cb := cloudbuild.NewCloudBuildService()
+		gh := github.NewClient()
+		cb := cloudbuild.NewClient()
 		execMembershipChecker(prNumber, commitSha, branchName, headRepoUrl, headBranch, baseBranch, gh, cb)
 	},
 }
 
-func execMembershipChecker(prNumber, commitSha, branchName, headRepoUrl, headBranch, baseBranch string, gh mcGithub, cb mcCloudbuild) {
+func execMembershipChecker(prNumber, commitSha, branchName, headRepoUrl, headBranch, baseBranch string, gh GithubClient, cb CloudbuildClient) {
 	substitutions := map[string]string{
 		"BRANCH_NAME":    branchName,
 		"_PR_NUMBER":     prNumber,
@@ -92,7 +75,7 @@ func execMembershipChecker(prNumber, commitSha, branchName, headRepoUrl, headBra
 		"_BASE_BRANCH":   baseBranch,
 	}
 
-	author, err := gh.GetPullRequest(prNumber)
+	pullRequest, err := gh.GetPullRequest(prNumber)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/.ci/magician/cmd/membership_checker.go
+++ b/.ci/magician/cmd/membership_checker.go
@@ -13,7 +13,7 @@ import (
 )
 
 type mcGithub interface {
-	GetPullRequestAuthor(prNumber string) (string, error)
+	GetPullRequest(prNumber string) (string, error)
 	GetUserType(user string) github.UserType
 	GetPullRequestRequestedReviewer(prNumber string) (string, error)
 	GetPullRequestPreviousAssignedReviewers(prNumber string) ([]string, error)
@@ -92,12 +92,13 @@ func execMembershipChecker(prNumber, commitSha, branchName, headRepoUrl, headBra
 		"_BASE_BRANCH":   baseBranch,
 	}
 
-	author, err := gh.GetPullRequestAuthor(prNumber)
+	author, err := gh.GetPullRequest(prNumber)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
+	author := pullRequest.User.Login
 	authorUserType := gh.GetUserType(author)
 	trusted := authorUserType == github.CoreContributorUserType || authorUserType == github.GooglerUserType
 
@@ -116,7 +117,7 @@ func execMembershipChecker(prNumber, commitSha, branchName, headRepoUrl, headBra
 			os.Exit(1)
 		}
 
-		reviewersToRequest, newPrimaryReviewer := github.ChooseReviewers(firstRequestedReviewer, previouslyInvolvedReviewers)
+		reviewersToRequest, newPrimaryReviewer := github.ChooseCoreReviewers(firstRequestedReviewer, previouslyInvolvedReviewers)
 
 		for _, reviewer := range reviewersToRequest {
 			err = gh.RequestPullRequestReviewer(prNumber, reviewer)

--- a/.ci/magician/cmd/membership_checker_test.go
+++ b/.ci/magician/cmd/membership_checker_test.go
@@ -9,7 +9,11 @@ import (
 
 func TestExecMembershipChecker_CoreContributorFlow(t *testing.T) {
 	gh := &mockGithub{
-		author:        "core_author",
+		pullRequest: github.PullRequest{
+			User: github.User{
+				Login: "core_author",
+			},
+		},
 		userType:      github.CoreContributorUserType,
 		calledMethods: make(map[string][][]any),
 	}
@@ -43,7 +47,11 @@ func TestExecMembershipChecker_CoreContributorFlow(t *testing.T) {
 
 func TestExecMembershipChecker_GooglerFlow(t *testing.T) {
 	gh := &mockGithub{
-		author:            "googler_author",
+		pullRequest: github.PullRequest{
+			User: github.User{
+				Login: "googler_author",
+			},
+		},
 		userType:          github.GooglerUserType,
 		calledMethods:     make(map[string][][]any),
 		firstReviewer:     "reviewer1",
@@ -87,7 +95,11 @@ func TestExecMembershipChecker_GooglerFlow(t *testing.T) {
 
 func TestExecMembershipChecker_AmbiguousUserFlow(t *testing.T) {
 	gh := &mockGithub{
-		author:            "ambiguous_author",
+		pullRequest: github.PullRequest{
+			User: github.User{
+				Login: "ambiguous_author",
+			},
+		},
 		userType:          github.CommunityUserType,
 		calledMethods:     make(map[string][][]any),
 		firstReviewer:     github.GetRandomReviewer(),
@@ -139,7 +151,11 @@ func TestExecMembershipChecker_AmbiguousUserFlow(t *testing.T) {
 
 func TestExecMembershipChecker_CommentForNewPrimaryReviewer(t *testing.T) {
 	gh := &mockGithub{
-		author:            "googler_author",
+		pullRequest: github.PullRequest{
+			User: github.User{
+				Login: "googler_author",
+			},
+		},
 		userType:          github.GooglerUserType,
 		calledMethods:     make(map[string][][]any),
 		firstReviewer:     "",

--- a/.ci/magician/cmd/mock_github_test.go
+++ b/.ci/magician/cmd/mock_github_test.go
@@ -10,8 +10,8 @@ type mockGithub struct {
 	calledMethods     map[string][][]any
 }
 
-func (m *mockGithub) GetPullRequestAuthor(prNumber string) (string, error) {
-	m.calledMethods["GetPullRequestAuthor"] = append(m.calledMethods["GetPullRequestAuthor"], []any{prNumber})
+func (m *mockGithub) GetPullRequest(prNumber string) (string, error) {
+	m.calledMethods["GetPullRequest"] = append(m.calledMethods["GetPullRequest"], []any{prNumber})
 	return m.author, nil
 }
 

--- a/.ci/magician/cmd/mock_github_test.go
+++ b/.ci/magician/cmd/mock_github_test.go
@@ -3,16 +3,16 @@ package cmd
 import "magician/github"
 
 type mockGithub struct {
-	author            string
+	pullRequest       github.PullRequest
 	userType          github.UserType
 	firstReviewer     string
 	previousReviewers []string
 	calledMethods     map[string][][]any
 }
 
-func (m *mockGithub) GetPullRequest(prNumber string) (string, error) {
+func (m *mockGithub) GetPullRequest(prNumber string) (github.PullRequest, error) {
 	m.calledMethods["GetPullRequest"] = append(m.calledMethods["GetPullRequest"], []any{prNumber})
-	return m.author, nil
+	return m.pullRequest, nil
 }
 
 func (m *mockGithub) GetUserType(user string) github.UserType {
@@ -58,9 +58,4 @@ func (m *mockGithub) PostBuildStatus(prNumber string, title string, state string
 func (m *mockGithub) CreateWorkflowDispatchEvent(workflowFileName string, inputs map[string]any) error {
 	m.calledMethods["CreateWorkflowDispatchEvent"] = append(m.calledMethods["CreateWorkflowDispatchEvent"], []any{workflowFileName, inputs})
 	return nil
-}
-
-func (m *mockGithub) GetPullRequestLabelIDs(prNumber string) (map[int]struct{}, error) {
-	m.calledMethods["GetPullRequestLabelIDs"] = append(m.calledMethods["GetPullRequestLabelIDs"], []any{prNumber})
-	return nil, nil
 }

--- a/.ci/magician/cmd/test_tgc.go
+++ b/.ci/magician/cmd/test_tgc.go
@@ -21,7 +21,7 @@ var testTGCCmd = &cobra.Command{
 		commit := os.Getenv("COMMIT_SHA")
 		pr := os.Getenv("PR_NUMBER")
 
-		gh := github.NewGithubService()
+		gh := github.NewClient()
 
 		execTestTGC(commit, pr, gh)
 	},

--- a/.ci/magician/cmd/test_tpg.go
+++ b/.ci/magician/cmd/test_tpg.go
@@ -27,7 +27,7 @@ var testTPGCmd = &cobra.Command{
 		commit := os.Getenv("COMMIT_SHA")
 		pr := os.Getenv("PR_NUMBER")
 
-		gh := github.NewGithubService()
+		gh := github.NewClient()
 
 		execTestTPG(version, commit, pr, gh)
 	},

--- a/.ci/magician/exec/runner.go
+++ b/.ci/magician/exec/runner.go
@@ -12,47 +12,36 @@ import (
 	cp "github.com/otiai10/copy"
 )
 
-type actualRunner struct {
+type Runner struct {
 	cwd      string
 	dirStack *list.List
 }
 
-type Runner interface {
-	GetCWD() string
-	Copy(src, dest string) error
-	RemoveAll(path string) error
-	PushDir(path string) error
-	PopDir() error
-	WriteFile(name, data string) error
-	Run(name string, args, env []string) (string, error)
-	MustRun(name string, args, env []string) string
-}
-
-func NewRunner() (Runner, error) {
+func NewRunner() (*Runner, error) {
 	wd, err := os.Getwd()
 	if err != nil {
 		return nil, err
 	}
-	return &actualRunner{
+	return &Runner{
 		cwd:      wd,
 		dirStack: list.New(),
 	}, nil
 }
 
-func (ar *actualRunner) GetCWD() string {
+func (ar *Runner) GetCWD() string {
 	return ar.cwd
 }
 
-func (ar *actualRunner) Copy(src, dest string) error {
+func (ar *Runner) Copy(src, dest string) error {
 	return cp.Copy(ar.abs(src), ar.abs(dest))
 }
 
-func (ar *actualRunner) RemoveAll(path string) error {
+func (ar *Runner) RemoveAll(path string) error {
 	return os.RemoveAll(ar.abs(path))
 }
 
 // PushDir changes the directory for the runner to the desired path and saves the previous directory in the stack.
-func (ar *actualRunner) PushDir(path string) error {
+func (ar *Runner) PushDir(path string) error {
 	if ar.dirStack == nil {
 		return errors.New("attempted to push dir, but stack was nil")
 	}
@@ -62,7 +51,7 @@ func (ar *actualRunner) PushDir(path string) error {
 }
 
 // PopDir removes the most recently added directory from the stack and changes front to it.
-func (ar *actualRunner) PopDir() error {
+func (ar *Runner) PopDir() error {
 	if ar.dirStack == nil || ar.dirStack.Len() == 0 {
 		return errors.New("attempted to pop dir, but stack was nil or empty")
 	}
@@ -75,11 +64,11 @@ func (ar *actualRunner) PopDir() error {
 	return nil
 }
 
-func (ar *actualRunner) WriteFile(name, data string) error {
+func (ar *Runner) WriteFile(name, data string) error {
 	return os.WriteFile(ar.abs(name), []byte(data), 0644)
 }
 
-func (ar *actualRunner) Run(name string, args, env []string) (string, error) {
+func (ar *Runner) Run(name string, args, env []string) (string, error) {
 	cmd := exec.Command(name, args...)
 	cmd.Dir = ar.cwd
 	cmd.Env = append(os.Environ(), env...)
@@ -91,7 +80,7 @@ func (ar *actualRunner) Run(name string, args, env []string) (string, error) {
 	return string(out), nil
 }
 
-func (ar *actualRunner) MustRun(name string, args, env []string) string {
+func (ar *Runner) MustRun(name string, args, env []string) string {
 	out, err := ar.Run(name, args, env)
 	if err != nil {
 		log.Fatal(err)
@@ -99,7 +88,7 @@ func (ar *actualRunner) MustRun(name string, args, env []string) string {
 	return out
 }
 
-func (ar *actualRunner) abs(path string) string {
+func (ar *Runner) abs(path string) string {
 	if !filepath.IsAbs(path) {
 		return filepath.Join(ar.cwd, path)
 	}

--- a/.ci/magician/github/get.go
+++ b/.ci/magician/github/get.go
@@ -80,24 +80,3 @@ func (gh *Client) GetPullRequestPreviousAssignedReviewers(prNumber string) ([]st
 
 	return result, nil
 }
-
-func (gh *Client) GetPullRequestLabelIDs(prNumber string) (map[int]struct{}, error) {
-	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/%s/reviews", prNumber)
-
-	var labels []struct {
-		Label struct {
-			ID int `json:"id"`
-		} `json:"label"`
-	}
-
-	if _, err := utils.RequestCall(url, "GET", gh.token, &labels, nil); err != nil {
-		return nil, err
-	}
-
-	var result map[int]struct{}
-	for _, label := range labels {
-		result[label.Label.ID] = struct{}{}
-	}
-
-	return result, nil
-}

--- a/.ci/magician/github/get.go
+++ b/.ci/magician/github/get.go
@@ -5,21 +5,26 @@ import (
 	utils "magician/utility"
 )
 
-func (gh *github) GetPullRequestAuthor(prNumber string) (string, error) {
+type PullRequest struct {
+	User struct {
+		Login string `json:"login"`
+	} `json:"user"`
+	Labels []struct {
+		Name string
+	}
+}
+
+func (gh *github) GetPullRequest(prNumber string) (string, error) {
 	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/%s", prNumber)
 
-	var pullRequest struct {
-		User struct {
-			Login string `json:"login"`
-		} `json:"user"`
-	}
+	var pullRequest PullRequest
 
 	_, err := utils.RequestCall(url, "GET", gh.token, &pullRequest, nil)
 	if err != nil {
 		return "", err
 	}
 
-	return pullRequest.User.Login, nil
+	return pullRequest, nil
 }
 
 func (gh *github) GetPullRequestRequestedReviewer(prNumber string) (string, error) {

--- a/.ci/magician/github/get.go
+++ b/.ci/magician/github/get.go
@@ -5,29 +5,35 @@ import (
 	utils "magician/utility"
 )
 
+type User struct {
+	Login string `json:"login"`
+}
+
+type Label struct {
+	Name string `json:"name"`
+}
+
 type PullRequest struct {
 	User struct {
 		Login string `json:"login"`
 	} `json:"user"`
-	Labels []struct {
-		Name string
-	}
+	Labels []Label `json:"labels"`
 }
 
-func (gh *github) GetPullRequest(prNumber string) (string, error) {
+func (gh *Client) GetPullRequest(prNumber string) (PullRequest, error) {
 	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/%s", prNumber)
 
 	var pullRequest PullRequest
 
 	_, err := utils.RequestCall(url, "GET", gh.token, &pullRequest, nil)
 	if err != nil {
-		return "", err
+		return pullRequest, err
 	}
 
 	return pullRequest, nil
 }
 
-func (gh *github) GetPullRequestRequestedReviewer(prNumber string) (string, error) {
+func (gh *Client) GetPullRequestRequestedReviewer(prNumber string) (string, error) {
 	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/%s/requested_reviewers", prNumber)
 
 	var requestedReviewers struct {
@@ -48,7 +54,7 @@ func (gh *github) GetPullRequestRequestedReviewer(prNumber string) (string, erro
 	return requestedReviewers.Users[0].Login, nil
 }
 
-func (gh *github) GetPullRequestPreviousAssignedReviewers(prNumber string) ([]string, error) {
+func (gh *Client) GetPullRequestPreviousAssignedReviewers(prNumber string) ([]string, error) {
 	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/%s/reviews", prNumber)
 
 	var reviews []struct {
@@ -75,7 +81,7 @@ func (gh *github) GetPullRequestPreviousAssignedReviewers(prNumber string) ([]st
 	return result, nil
 }
 
-func (gh *github) GetPullRequestLabelIDs(prNumber string) (map[int]struct{}, error) {
+func (gh *Client) GetPullRequestLabelIDs(prNumber string) (map[int]struct{}, error) {
 	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/%s/reviews", prNumber)
 
 	var labels []struct {

--- a/.ci/magician/github/init.go
+++ b/.ci/magician/github/init.go
@@ -5,31 +5,17 @@ import (
 	"os"
 )
 
-// GithubService represents the service for GitHub interactions.
-type github struct {
+// Client for GitHub interactions.
+type Client struct {
 	token string
 }
 
-type GithubService interface {
-	GetPullRequestAuthor(prNumber string) (string, error)
-	GetPullRequestRequestedReviewer(prNumber string) (string, error)
-	GetPullRequestPreviousAssignedReviewers(prNumber string) ([]string, error)
-	GetPullRequestLabelIDs(prNumber string) (map[int]struct{}, error)
-	GetUserType(user string) UserType
-	PostBuildStatus(prNumber, title, state, targetURL, commitSha string) error
-	PostComment(prNumber, comment string) error
-	RequestPullRequestReviewer(prNumber, assignee string) error
-	AddLabel(prNumber, label string) error
-	RemoveLabel(prNumber, label string) error
-	CreateWorkflowDispatchEvent(workflowFileName string, inputs map[string]any) error
-}
-
-func NewGithubService() GithubService {
+func NewClient() *Client {
 	githubToken, ok := os.LookupEnv("GITHUB_TOKEN")
 	if !ok {
 		fmt.Println("Did not provide GITHUB_TOKEN environment variable")
 		os.Exit(1)
 	}
 
-	return &github{token: githubToken}
+	return &Client{token: githubToken}
 }

--- a/.ci/magician/github/membership.go
+++ b/.ci/magician/github/membership.go
@@ -56,7 +56,7 @@ func (ut UserType) String() string {
 	}
 }
 
-func (gh *github) GetUserType(user string) UserType {
+func (gh *Client) GetUserType(user string) UserType {
 	if isTeamMember(user, gh.token) {
 		fmt.Println("User is a team member")
 		return CoreContributorUserType

--- a/.ci/magician/github/reviewer_assignment.go
+++ b/.ci/magician/github/reviewer_assignment.go
@@ -14,7 +14,7 @@ var (
 )
 
 // Returns a list of users to request review from, as well as a new primary reviewer if this is the first run.
-func ChooseReviewers(firstRequestedReviewer string, previouslyInvolvedReviewers []string) (reviewersToRequest []string, newPrimaryReviewer string) {
+func ChooseCoreReviewers(firstRequestedReviewer string, previouslyInvolvedReviewers []string) (reviewersToRequest []string, newPrimaryReviewer string) {
 	hasPrimaryReviewer := false
 	newPrimaryReviewer = ""
 

--- a/.ci/magician/github/reviewer_assignment_test.go
+++ b/.ci/magician/github/reviewer_assignment_test.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-func TestChooseReviewers(t *testing.T) {
+func TestChooseCoreReviewers(t *testing.T) {
 	cases := map[string]struct {
 		FirstRequestedReviewer                           string
 		PreviouslyInvolvedReviewers                      []string
@@ -57,7 +57,7 @@ func TestChooseReviewers(t *testing.T) {
 		tc := tc
 		t.Run(tn, func(t *testing.T) {
 			t.Parallel()
-			reviewers, primaryReviewer := ChooseReviewers(tc.FirstRequestedReviewer, tc.PreviouslyInvolvedReviewers)
+			reviewers, primaryReviewer := ChooseCoreReviewers(tc.FirstRequestedReviewer, tc.PreviouslyInvolvedReviewers)
 			if tc.ExpectPrimaryReviewer && primaryReviewer == "" {
 				t.Error("wanted primary reviewer to be returned; got none")
 			}

--- a/.ci/magician/github/set.go
+++ b/.ci/magician/github/set.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 )
 
-func (gh *github) PostBuildStatus(prNumber, title, state, targetURL, commitSha string) error {
+func (gh *Client) PostBuildStatus(prNumber, title, state, targetURL, commitSha string) error {
 	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/%s", commitSha)
 
 	postBody := map[string]string{
@@ -25,7 +25,7 @@ func (gh *github) PostBuildStatus(prNumber, title, state, targetURL, commitSha s
 	return nil
 }
 
-func (gh *github) PostComment(prNumber, comment string) error {
+func (gh *Client) PostComment(prNumber, comment string) error {
 	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/%s/comments", prNumber)
 
 	body := map[string]string{
@@ -46,7 +46,7 @@ func (gh *github) PostComment(prNumber, comment string) error {
 	return nil
 }
 
-func (gh *github) RequestPullRequestReviewer(prNumber, assignee string) error {
+func (gh *Client) RequestPullRequestReviewer(prNumber, assignee string) error {
 	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/%s/requested_reviewers", prNumber)
 
 	body := map[string][]string{
@@ -68,7 +68,7 @@ func (gh *github) RequestPullRequestReviewer(prNumber, assignee string) error {
 	return nil
 }
 
-func (gh *github) AddLabel(prNumber, label string) error {
+func (gh *Client) AddLabel(prNumber, label string) error {
 	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/%s/labels", prNumber)
 
 	body := map[string][]string{
@@ -84,7 +84,7 @@ func (gh *github) AddLabel(prNumber, label string) error {
 
 }
 
-func (gh *github) RemoveLabel(prNumber, label string) error {
+func (gh *Client) RemoveLabel(prNumber, label string) error {
 	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/%s/labels/%s", prNumber, label)
 	_, err := utils.RequestCall(url, "DELETE", gh.token, nil, nil)
 
@@ -95,7 +95,7 @@ func (gh *github) RemoveLabel(prNumber, label string) error {
 	return nil
 }
 
-func (gh *github) CreateWorkflowDispatchEvent(workflowFileName string, inputs map[string]any) error {
+func (gh *Client) CreateWorkflowDispatchEvent(workflowFileName string, inputs map[string]any) error {
 	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/actions/workflows/%s/dispatches", workflowFileName)
 	resp, err := utils.RequestCall(url, "POST", gh.token, nil, map[string]any{
 		"ref":    "main",

--- a/.ci/magician/main.go
+++ b/.ci/magician/main.go
@@ -1,6 +1,5 @@
 /*
 Copyright © 2023 NAME HERE <EMAIL ADDRESS>
-
 */
 package main
 


### PR DESCRIPTION
Prep work for b/295224401. Made the following changes:

- Refactored to meet recommendations in go/go-style/decisions#interfaces and go/go-style/decisions#repetition
  - Also centralized the cmd package's interface definitions to reduce repeated code
- Standardized on GetPullRequest to replace GetPullRequestAuthor and GetPullRequestLabelIDs, since they both return pull request data - better to have a single method in case we need to use more than one part of the data at once.
   - This has the side effect of fixing override-breaking-change logic, which I believe was previously calling the wrong endpoint.

cc @ScottSuarez FYI
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
