### PR TITLE
Extract converter_factory and hcl_write from utils

### DIFF
--- a/mmv1/third_party/cai2hcl/common/converter.go
+++ b/mmv1/third_party/cai2hcl/common/converter.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v5/caiasset"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -11,9 +10,6 @@ type Converter interface {
 	// Convert turns assets into hcl blocks.
 	Convert(asset []*caiasset.Asset) ([]*HCLResourceBlock, error)
 }
-
-// Function initializing a converter from TF resource name and TF resource schema.
-type ConverterFactory = func(name string, schema map[string]*schema.Schema) Converter
 
 // HCLResourceBlock identifies the HCL block's labels and content.
 type HCLResourceBlock struct {

--- a/mmv1/third_party/cai2hcl/common/converter_factory.go
+++ b/mmv1/third_party/cai2hcl/common/converter_factory.go
@@ -1,0 +1,21 @@
+package common
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	tpg "github.com/hashicorp/terraform-provider-google-beta/google-beta/provider"
+)
+
+// Function initializing a converter from TF resource name and TF resource schema.
+type ConverterFactory = func(name string, schema map[string]*schema.Schema) Converter
+
+// Initializes map of converters.
+func CreateConverterMap(converterFactories map[string]ConverterFactory) map[string]Converter {
+	tpgProvider := tpg.Provider()
+
+	result := make(map[string]Converter, len(converterFactories))
+	for name, factory := range converterFactories {
+		result[name] = factory(name, tpgProvider.ResourcesMap[name].Schema)
+	}
+
+	return result
+}

--- a/mmv1/third_party/cai2hcl/common/hcl_write.go
+++ b/mmv1/third_party/cai2hcl/common/hcl_write.go
@@ -1,0 +1,55 @@
+package common
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func hclWriteBlock(val cty.Value, body *hclwrite.Body) error {
+	if val.IsNull() {
+		return nil
+	}
+	if !val.Type().IsObjectType() {
+		return fmt.Errorf("expect object type only, but type = %s", val.Type().FriendlyName())
+	}
+	it := val.ElementIterator()
+	for it.Next() {
+		objKey, objVal := it.Element()
+		if objVal.IsNull() {
+			continue
+		}
+		objValType := objVal.Type()
+		switch {
+		case objValType.IsObjectType():
+			newBlock := body.AppendNewBlock(objKey.AsString(), nil)
+			if err := hclWriteBlock(objVal, newBlock.Body()); err != nil {
+				return err
+			}
+		case objValType.IsCollectionType():
+			if objVal.LengthInt() == 0 {
+				continue
+			}
+			// Presumes map should not contain object type.
+			if !objValType.IsMapType() && objValType.ElementType().IsObjectType() {
+				listIterator := objVal.ElementIterator()
+				for listIterator.Next() {
+					_, listVal := listIterator.Element()
+					subBlock := body.AppendNewBlock(objKey.AsString(), nil)
+					if err := hclWriteBlock(listVal, subBlock.Body()); err != nil {
+						return err
+					}
+				}
+				continue
+			}
+			fallthrough
+		default:
+			if objValType.FriendlyName() == "string" && objVal.AsString() == "" {
+				continue
+			}
+			body.SetAttributeValue(objKey.AsString(), objVal)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Minor refactor of cai2hcl/ by extracting "hclwrite.go" and "converter_factory.go" from "utils.go".

```release-note:none
```
