### PR TITLE
Add type field to PrivateCloud in Vmwareengine

### DIFF
--- a/mmv1/products/vmwareengine/PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/PrivateCloud.yaml
@@ -20,7 +20,7 @@ create_url: 'projects/{{project}}/locations/{{location}}/privateClouds?privateCl
 update_verb: :PATCH
 references: !ruby/object:Api::Resource::ReferenceLinks
   api: 'https://cloud.google.com/vmware-engine/docs/reference/rest/v1/projects.locations.privateClouds'
-description: / Represents a private cloud resource. Private clouds are zonal resources.
+description: Represents a private cloud resource. Private clouds are zonal resources.
 error_abort_predicates: ['transport_tpg.Is429QuotaError']
 async: !ruby/object:Api::OpAsync
   operation: !ruby/object:Api::OpAsync::Operation
@@ -285,3 +285,14 @@ properties:
         name: 'fqdn'
         description: |-
           Fully qualified domain name of the appliance.
+
+  - !ruby/object:Api::Type::Enum
+    name: 'type'
+    description: |
+      Initial type of the private cloud.
+    immutable: true
+    ignore_read: true
+    values:
+      - :STANDARD
+      - :TIME_LIMITED
+    default_value: :STANDARD

--- a/mmv1/templates/terraform/examples/vmware_engine_private_cloud_full.tf.erb
+++ b/mmv1/templates/terraform/examples/vmware_engine_private_cloud_full.tf.erb
@@ -2,6 +2,7 @@ resource "google_vmwareengine_private_cloud" "<%= ctx[:primary_resource_id] %>" 
   location    = "<%= ctx[:test_env_vars]['region'] %>-a"
   name        = "<%= ctx[:vars]['private_cloud_id'] %>"
   description = "Sample test PC."
+  type        = "TIME_LIMITED"
   network_config {
     management_cidr       = "192.168.30.0/24"
     vmware_engine_network = google_vmwareengine_network.pc-nw.id
@@ -11,7 +12,7 @@ resource "google_vmwareengine_private_cloud" "<%= ctx[:primary_resource_id] %>" 
     cluster_id = "<%= ctx[:vars]['management_cluster_id'] %>"
     node_type_configs {
       node_type_id = "standard-72"
-      node_count   = 3
+      node_count   = 1
       custom_core_count = 32
     }
   }
@@ -22,3 +23,4 @@ resource "google_vmwareengine_network" "pc-nw" {
   location    = "global"
   type        = "STANDARD"
   description = "PC network description."
+}

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
@@ -27,7 +27,7 @@ func TestAccVmwareenginePrivateCloud_vmwareEnginePrivateCloudUpdate(t *testing.T
 		CheckDestroy:             testAccCheckVmwareenginePrivateCloudDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testPrivateCloudUpdateConfig(context, "description1", 3),
+				Config: testPrivateCloudUpdateConfig(context, "description1", 1),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores("data.google_vmwareengine_private_cloud.ds", "google_vmwareengine_private_cloud.vmw-engine-pc", map[string]struct{}{}),
 					testAccCheckGoogleVmwareengineNsxCredentialsMeta("data.google_vmwareengine_nsx_credentials.nsx-ds"),
@@ -78,6 +78,7 @@ resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
   location = "%{region}-a"
   name = "tf-test-sample-pc%{random_suffix}"
   description = "%{description}"
+  type = "TIME_LIMITED"
   network_config {
     management_cidr = "192.168.30.0/24"
     vmware_engine_network = google_vmwareengine_network.default-nw.id
@@ -104,6 +105,7 @@ data "google_vmwareengine_private_cloud" "ds" {
 data "google_vmwareengine_nsx_credentials" "nsx-ds" {
 	parent =  google_vmwareengine_private_cloud.vmw-engine-pc.id
 }
+
 data "google_vmwareengine_vcenter_credentials" "vcenter-ds" {
 	parent =  google_vmwareengine_private_cloud.vmw-engine-pc.id
 }


### PR DESCRIPTION
A private cloud can be of two types: TIME_LIMITED and STANDARD. The type field is immutable from the user's side but can be changed from the API backend when they upgrade to use 3 or more nodes, hence lifecycle.ignore_changes is used in the config. 

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
vmwareengine: added `type` field to `google_vmwareengine_private_cloud` resource
```