### PR TITLE
Add client, permissions, monitoring and mfa configs to google_identity_platform_config

### DIFF
--- a/mmv1/products/identityplatform/Config.yaml
+++ b/mmv1/products/identityplatform/Config.yaml
@@ -286,3 +286,54 @@ properties:
         description: |
           Firebase subdomain.
         default_from_api: true
+  - !ruby/object:Api::Type::NestedObject
+    name: 'mfa'
+    description: |
+      Options related to how clients making requests on behalf of a project should be configured.
+    ignore_read: true
+    properties:
+      - !ruby/object:Api::Type::Enum
+        name: 'state'
+        description: |
+          Whether MultiFactor Authentication has been enabled for this project.
+        values:
+          - :STATE_UNSPECIFIED
+          - :DISABLED
+          - :ENABLED
+          - :MANDATORY
+      - !ruby/object:Api::Type::Array
+        name: enabledProviders
+        description: |
+          A list of usable second factors for this project.
+        item_type: !ruby/object:Api::Type::Enum
+          name: 'undefined'
+          description: |
+            This field only has a name and description because of MM
+            limitations. It should not appear in downstreams.
+          values:
+            - :PROVIDER_UNSPECIFIED
+            - :PHONE_SMS
+      - !ruby/object:Api::Type::NestedObject
+        name: providerConfigs
+        description: |
+          A list of usable second factors for this project along with their configurations.
+          This field does not support phone based MFA, for that use the 'enabledProviders' field.
+        properties:
+          - !ruby/object:Api::Type::Enum
+            name: 'state'
+            description: |
+              Whether MultiFactor Authentication has been enabled for this project.
+            values:
+              - :STATE_UNSPECIFIED
+              - :DISABLED
+              - :ENABLED
+              - :MANDATORY
+          - !ruby/object:Api::Type::NestedObject
+            name: totpProviderConfig
+            description: |
+              TOTP MFA provider config for this project.
+            properties:
+              - !ruby/object:Api::Type::Integer
+                name: adjacentIntervals
+                description: |
+                  The allowed number of adjacent intervals that will be used for verification to avoid clock skew.

--- a/mmv1/products/identityplatform/Config.yaml
+++ b/mmv1/products/identityplatform/Config.yaml
@@ -258,6 +258,7 @@ properties:
     name: 'client'
     description: |
       Options related to how clients making requests on behalf of a project should be configured.
+    ignore_read: true
     properties:
       - !ruby/object:Api::Type::NestedObject
         name: 'permissions'
@@ -278,8 +279,10 @@ properties:
         description: |
           API key that can be used when making requests for this project.
         sensitive: true
+        default_from_api: true
       - !ruby/object:Api::Type::String
         name: 'firebaseSubdomain'
         output: true
         description: |
           Firebase subdomain.
+        default_from_api: true

--- a/mmv1/products/identityplatform/Config.yaml
+++ b/mmv1/products/identityplatform/Config.yaml
@@ -352,3 +352,18 @@ properties:
           The default cloud parent org or folder that the tenant project should be created under.
           The parent resource name should be in the format of "/", such as "folders/123" or "organizations/456".
           If the value is not set, the tenant will be created under the same organization or folder as the agent project.
+  - !ruby/object:Api::Type::NestedObject
+    name: 'monitoring'
+    description: |
+      Configuration related to monitoring project activity.
+    ignore_read: true
+    properties:
+      - !ruby/object:Api::Type::NestedObject
+        name: 'requestLogging'
+        description: |
+          Configuration for logging requests made to this project to Stackdriver Logging
+        properties:
+          - !ruby/object:Api::Type::Boolean
+            name: enabled
+            description: |
+              Whether logging is enabled for this project or not.

--- a/mmv1/products/identityplatform/Config.yaml
+++ b/mmv1/products/identityplatform/Config.yaml
@@ -254,3 +254,32 @@ properties:
             description: |
               Two letter unicode region codes to allow as defined by https://cldr.unicode.org/ The full list of these region codes is here: https://github.com/unicode-cldr/cldr-localenames-full/blob/master/main/en/territories.json
             item_type: Api::Type::String
+  - !ruby/object:Api::Type::NestedObject
+    name: 'client'
+    description: |
+      Options related to how clients making requests on behalf of a project should be configured.
+    properties:
+      - !ruby/object:Api::Type::NestedObject
+        name: 'permissions'
+        description: |
+          Configuration related to restricting a user's ability to affect their account.
+        properties:
+          - !ruby/object:Api::Type::Boolean
+            name: 'disabledUserSignup'
+            description: |
+              When true, end users cannot sign up for a new account on the associated project through any of our API methods
+          - !ruby/object:Api::Type::Boolean
+            name: 'disabledUserDeletion'
+            description: |
+              When true, end users cannot delete their account on the associated project through any of our API methods
+      - !ruby/object:Api::Type::String
+        name: 'apiKey'
+        output: true
+        description: |
+          API key that can be used when making requests for this project.
+        sensitive: true
+      - !ruby/object:Api::Type::String
+        name: 'firebaseSubdomain'
+        output: true
+        description: |
+          Firebase subdomain.

--- a/mmv1/products/identityplatform/Config.yaml
+++ b/mmv1/products/identityplatform/Config.yaml
@@ -337,3 +337,18 @@ properties:
                 name: adjacentIntervals
                 description: |
                   The allowed number of adjacent intervals that will be used for verification to avoid clock skew.
+  - !ruby/object:Api::Type::NestedObject
+    name: 'multiTenant'
+    description: |
+      Configuration related to multi-tenant functionality.
+    properties:
+      - !ruby/object:Api::Type::Boolean
+        name: 'allowTenants'
+        description: |
+          Whether this project can have tenants or not.
+      - !ruby/object:Api::Type::String
+        name: 'defaultTenantLocation'
+        description: |
+          The default cloud parent org or folder that the tenant project should be created under.
+          The parent resource name should be in the format of "/", such as "folders/123" or "organizations/456".
+          If the value is not set, the tenant will be created under the same organization or folder as the agent project.

--- a/mmv1/templates/terraform/examples/identity_platform_config_minimal.tf.erb
+++ b/mmv1/templates/terraform/examples/identity_platform_config_minimal.tf.erb
@@ -16,7 +16,12 @@ resource "google_project_service" "identitytoolkit" {
 
 resource "google_identity_platform_config" "default" {
   project = google_project.default.project_id
-  
+  client {
+    permissions {
+      disabled_user_deletion = false
+      disabled_user_signup   = true
+    }
+  }
   depends_on = [
     google_project_service.identitytoolkit
   ]


### PR DESCRIPTION
Add client, permissions, monitoring and mfa configs to `google_identity_platform_config`

For client this also fixes the diff that was introduced in #9417 and reverted in #9447

Fixes hashicorp/terraform-provider-google/issues/14192, hashicorp/terraform-provider-google/issues/15712, hashicorp/terraform-provider-google/issues/13326
Relates to: hashicorp/terraform-provider-google/issues/14194

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
Add client, permissions, monitoring and mfa configs to google_identity_platform_config
```


