### PR TITLE
[#16356] Add support for resource manager tags for google_compute_instance_template

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
@@ -1372,9 +1372,14 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 		ReservationAffinity:        reservationAffinity,
 	}
 
+	if _, ok := d.GetOk("effective_labels"); ok {
+		instanceProperties.Labels = tpgresource.ExpandEffectiveLabels(d)
+	}
+
 	if _, ok := d.GetOk("resource_manager_tags"); ok {
 		instanceProperties.ResourceManagerTags = tpgresource.ExpandStringMap(d, "resource_manager_tags")
 	}
+
 	var itName string
 	if v, ok := d.GetOk("name"); ok {
 		itName = v.(string)
@@ -1490,7 +1495,6 @@ func flattenDisk(disk *compute.AttachedDisk, configDisk map[string]any, defaultP
 		} else {
 			diskMap["disk_size_gb"] = disk.InitializeParams.DiskSizeGb
 		}
-
 		diskMap["resource_policies"] = disk.InitializeParams.ResourcePolicies
 		diskMap["resource_manager_tags"] = disk.InitializeParams.ResourceManagerTags
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
@@ -180,6 +180,15 @@ func ResourceComputeInstanceTemplate() *schema.Resource {
 							Description: `Indicates how many IOPS to provision for the disk. This sets the number of I/O operations per second that the disk can handle. Values must be between 10,000 and 120,000. For more details, see the [Extreme persistent disk documentation](https://cloud.google.com/compute/docs/disks/extreme-persistent-disk).`,
 						},
 
+						"resource_manager_tags": {
+							Type:         schema.TypeMap,
+							Optional:     true,
+							ForceNew:     true,
+							Elem:         &schema.Schema{Type: schema.TypeString},
+							Set:          schema.HashString,
+							Description:  `A map of resource manager tags. Resource manager tag keys and values have the same definition as resource manager tags. Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456. The field is ignored (both PUT & PATCH) when empty.`,
+						},
+
 						"source_image": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -614,6 +623,18 @@ Google Cloud KMS.`,
 				ForceNew:    true,
 				Computed:    true,
 				Description: `An instance template is a global resource that is not bound to a zone or a region. However, you can still specify some regional resources in an instance template, which restricts the template to the region where that resource resides. For example, a custom subnetwork resource is tied to a specific region. Defaults to the region of the Provider if no value is given.`,
+			},
+
+			"resource_manager_tags": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				ForceNew:    false,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         schema.HashString,
+				Description: `A map of resource manager tags.
+				Resource manager tag keys and values have the same definition as resource manager tags.
+				Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456.
+				The field is ignored (both PUT & PATCH) when empty.`,
 			},
 
 			"scheduling": {
@@ -1187,7 +1208,9 @@ func buildDisks(d *schema.ResourceData, config *transport_tpg.Config) ([]*comput
 			if v, ok := d.GetOk(prefix + ".provisioned_iops"); ok {
 				disk.InitializeParams.ProvisionedIops = int64(v.(int))
 			}
-
+			if _, ok := d.GetOk(prefix + ".resource_manager_tags"); ok {
+				disk.InitializeParams.ResourceManagerTags = tpgresource.ExpandStringMap(d, prefix + ".resource_manager_tags")
+			}
 			disk.InitializeParams.Labels = tpgresource.ExpandStringMap(d, prefix+".labels")
 
 			if v, ok := d.GetOk(prefix + ".source_image"); ok {
@@ -1210,7 +1233,6 @@ func buildDisks(d *schema.ResourceData, config *transport_tpg.Config) ([]*comput
 					disk.InitializeParams.SourceImageEncryptionKey.KmsKeyServiceAccount = v.(string)
 				}
 			}
-
 
 			if v, ok := d.GetOk(prefix + ".source_snapshot"); ok {
 				disk.InitializeParams.SourceSnapshot = v.(string)
@@ -1350,10 +1372,9 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 		ReservationAffinity:        reservationAffinity,
 	}
 
-	if _, ok := d.GetOk("effective_labels"); ok {
-		instanceProperties.Labels = tpgresource.ExpandEffectiveLabels(d)
+	if _, ok := d.GetOk("resource_manager_tags"); ok {
+		instanceProperties.ResourceManagerTags = tpgresource.ExpandStringMap(d, "resource_manager_tags")
 	}
-
 	var itName string
 	if v, ok := d.GetOk("name"); ok {
 		itName = v.(string)
@@ -1471,6 +1492,7 @@ func flattenDisk(disk *compute.AttachedDisk, configDisk map[string]any, defaultP
 		}
 
 		diskMap["resource_policies"] = disk.InitializeParams.ResourcePolicies
+		diskMap["resource_manager_tags"] = disk.InitializeParams.ResourceManagerTags
 	}
 
 	if disk.DiskEncryptionKey != nil {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.erb
@@ -1338,6 +1338,32 @@ func TestAccComputeInstanceTemplate_withLabels(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstanceTemplate_resourceManagerTags(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+	var instanceTemplateName = fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+    context := map[string]interface{}{
+		"project":       envvar.GetTestProjectFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+		"instance_name": instanceTemplateName,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceTemplate_resourceManagerTags(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceTemplateExists(
+						t, "google_compute_instance_template.foobar", &instanceTemplate)),
+			},
+		},
+	})
+}
+
 func testAccCheckComputeInstanceTemplateDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
@@ -3664,7 +3690,6 @@ resource "google_compute_image" "image" {
   ]
 }
 
-
 resource "google_compute_instance_template" "template" {
   name           = "tf-test-instance-template-%{random_suffix}"
   machine_type   = "e2-medium"
@@ -3686,6 +3711,51 @@ resource "google_compute_instance_template" "template" {
   depends_on = [
     google_kms_crypto_key_iam_member.crypto_key
   ]
+}
+`, context)
+}
+
+func testAccComputeInstanceTemplate_resourceManagerTags(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_tags_tag_key" "key" {
+  parent = "projects/%{project}"
+  short_name = "foobarbaz%{random_suffix}"
+  description = "For foo/bar resources."
+}
+
+resource "google_tags_tag_value" "value" {
+  parent = "tagKeys/${google_tags_tag_key.key.name}"
+  short_name = "foo%{random_suffix}"
+  description = "For foo resources."
+}
+
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name           = "%{instance_name}"
+  machine_type   = "e2-medium"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    disk_size_gb = 10
+    boot         = true
+
+    resource_manager_tags = {
+	  "tagKeys/${google_tags_tag_key.key.name}" = "tagValues/${google_tags_tag_value.value.name}"
+	}
+  }
+
+  resource_manager_tags = {
+    "tagKeys/${google_tags_tag_key.key.name}" = "tagValues/${google_tags_tag_value.value.name}"
+  }
+
+  network_interface {
+    network = "default"
+  }
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.erb
@@ -3735,8 +3735,8 @@ data "google_compute_image" "my_image" {
 }
 
 resource "google_compute_instance_template" "foobar" {
-  name           = "%{instance_name}"
-  machine_type   = "e2-medium"
+  name         = "%{instance_name}"
+  machine_type = "e2-medium"
 
   disk {
     source_image = data.google_compute_image.my_image.self_link
@@ -3745,8 +3745,8 @@ resource "google_compute_instance_template" "foobar" {
     boot         = true
 
     resource_manager_tags = {
-	  "tagKeys/${google_tags_tag_key.key.name}" = "tagValues/${google_tags_tag_value.value.name}"
-	}
+      "tagKeys/${google_tags_tag_key.key.name}" = "tagValues/${google_tags_tag_value.value.name}"
+    }
   }
 
   resource_manager_tags = {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.erb
@@ -159,6 +159,15 @@ func ResourceComputeRegionInstanceTemplate() *schema.Resource {
 							Description: `Indicates how many IOPS to provision for the disk. This sets the number of I/O operations per second that the disk can handle. Values must be between 10,000 and 120,000. For more details, see the [Extreme persistent disk documentation](https://cloud.google.com/compute/docs/disks/extreme-persistent-disk).`,
 						},
 
+						"resource_manager_tags": {
+							Type:         schema.TypeMap,
+							Optional:     true,
+							ForceNew:     true,
+							Elem:         &schema.Schema{Type: schema.TypeString},
+							Set:          schema.HashString,
+							Description:  `A map of resource manager tags. Resource manager tag keys and values have the same definition as resource manager tags. Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456. The field is ignored (both PUT & PATCH) when empty.`,
+						},
+
 						"source_image": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -576,6 +585,16 @@ Google Cloud KMS.`,
 				ForceNew:    true,
 				Computed:    true,
 				Description: `The ID of the project in which the resource belongs. If it is not provided, the provider project is used.`,
+			},
+
+			"resource_manager_tags": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				ForceNew:    false,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         schema.HashString,
+				Description: `A map of resource manager tags.
+				Resource manager tag keys and values have the same definition as resource manager tags. Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456. The field is ignored (both PUT & PATCH) when empty.`,
 			},
 
 			"scheduling": {
@@ -1051,6 +1070,10 @@ func resourceComputeRegionInstanceTemplateCreate(d *schema.ResourceData, meta in
 
 	if _, ok := d.GetOk("effective_labels"); ok {
 		instanceProperties.Labels = tpgresource.ExpandEffectiveLabels(d)
+	}
+
+	if _, ok := d.GetOk("resource_manager_tags"); ok {
+		instanceProperties.ResourceManagerTags = tpgresource.ExpandStringMap(d, "resource_manager_tags")
 	}
 
 	var itName string

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.erb
@@ -1146,6 +1146,32 @@ func TestAccComputeRegionInstanceTemplate_sourceImageEncryptionKey(t *testing.T)
 	})
 }
 
+func TestAccComputeRegionInstanceTemplate_resourceManagerTags(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+	var instanceTemplateName = fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+    context := map[string]interface{}{
+		"project":       envvar.GetTestProjectFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+		"instance_name": instanceTemplateName,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_resourceManagerTags(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.foobar", &instanceTemplate)),
+			},
+		},
+	})
+}
+
 func testAccCheckComputeRegionInstanceTemplateDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
@@ -3351,6 +3377,52 @@ resource "google_compute_region_instance_template" "template" {
   depends_on = [
     google_kms_crypto_key_iam_member.crypto_key
   ]
+}
+`, context)
+}
+
+func testAccComputeRegionInstanceTemplate_resourceManagerTags(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_tags_tag_key" "key" {
+  parent = "projects/%{project}"
+  short_name = "foobarbaz%{random_suffix}"
+  description = "For foo/bar resources."
+}
+
+resource "google_tags_tag_value" "value" {
+  parent = "tagKeys/${google_tags_tag_key.key.name}"
+  short_name = "foo%{random_suffix}"
+  description = "For foo resources."
+}
+
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "%{instance_name}"
+  machine_type = "e2-medium"
+  region       = "us-central1"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    disk_size_gb = 10
+    boot         = true
+
+    resource_manager_tags = {
+      "tagKeys/${google_tags_tag_key.key.name}" = "tagValues/${google_tags_tag_value.value.name}"
+    }
+  }
+
+  resource_manager_tags = {
+    "tagKeys/${google_tags_tag_key.key.name}" = "tagValues/${google_tags_tag_value.value.name}"
+  }
+
+  network_interface {
+    network = "default"
+  }
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -351,6 +351,8 @@ The following arguments are supported:
 * `reservation_affinity` - (Optional) Specifies the reservations that this instance can consume from.
     Structure is [documented below](#nested_reservation_affinity).
 
+* `resource_manager_tags` - (Optional) A set of key/value resource manager tag pairs to bind to the instances. Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456.
+
 * `scheduling` - (Optional) The scheduling strategy to use. More details about
     this configuration option are [detailed below](#nested_scheduling).
 
@@ -391,6 +393,8 @@ The following arguments are supported:
     sets the number of I/O operations per second that the disk can handle.
     Values must be between 10,000 and 120,000. For more details, see the
     [Extreme persistent disk documentation](https://cloud.google.com/compute/docs/disks/extreme-persistent-disk).
+
+* `resource_manager_tags` - (Optional) A set of key/value resource manager tag pairs to bind to this disk. Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456.
 
 * `source_image` - (Optional) The image from which to
     initialize this disk. This can be one of: the image's `self_link`,

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
@@ -355,6 +355,8 @@ The following arguments are supported:
 * `region` - (Optional) The Region in which the resource belongs.
     If region is not provided, the provider region is used.
 
+* `resource_manager_tags` - (Optional) A set of key/value resource manager tag pairs to bind to the instance. Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456.
+
 * `resource_policies` (Optional) -- A list of self_links of resource policies to attach to the instance. Modifying this list will cause the instance to recreate. Currently a max of 1 resource policy is supported.
 
 * `reservation_affinity` - (Optional) Specifies the reservations that this instance can consume from.
@@ -400,6 +402,8 @@ The following arguments are supported:
     sets the number of I/O operations per second that the disk can handle.
     Values must be between 10,000 and 120,000. For more details, see the
     [Extreme persistent disk documentation](https://cloud.google.com/compute/docs/disks/extreme-persistent-disk).
+
+* `resource_manager_tags` - (Optional) A set of key/value resource manager tag pairs to bind to this disk. Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456.
 
 * `source_image` - (Optional) The image from which to
     initialize this disk. This can be one of: the image's `self_link`,


### PR DESCRIPTION
Adds support for resource manager tags for google_compute_instance_template.

fixes https://github.com/hashicorp/terraform-provider-google/issues/16356
fixes https://github.com/hashicorp/terraform-provider-google/issues/15903
fixes https://github.com/hashicorp/terraform-provider-google/issues/12952

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `resource_manager_tags` and `disk.resource_manager_tags` for `google_compute_instance_template`
```

```release-note:enhancement
compute: added `resource_manager_tags` and `disk.resource_manager_tags` for `google_compute_region_instance_template`
```
