### PR TITLE
Add the clusterupgrade feature config for the fleet Feature resource. 

### DIFF
--- a/mmv1/products/gkehub2/Feature.yaml
+++ b/mmv1/products/gkehub2/Feature.yaml
@@ -108,6 +108,11 @@ examples:
     skip_test: true
     primary_resource_name: 'fmt.Sprintf("policycontroller")'
     primary_resource_id: 'feature'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'gkehub_feature_clusterupgrade'
+    skip_test: true
+    primary_resource_name: 'fmt.Sprint("clusterupgrade")'
+    primary_resource_id: 'feature'
 autogen_async: true
 # Skip sweeper gen since this is a child resource.
 skip_sweeper: true
@@ -195,6 +200,59 @@ properties:
                       - :MODE_UNSPECIFIED
                       - :COPY
                       - :MOVE
+      - !ruby/object:Api::Type::NestedObject
+        name: clusterupgrade
+        description: Clusterupgrade feature spec.
+        properties:
+          - !ruby/object:Api::Type::Array
+            name: 'upstreamFleets'
+            description: |
+              Specified if other fleet should be considered as a source of upgrades. Currently, at most one upstream fleet is allowed. The fleet name should be either fleet project number or id.
+            required: true
+            item_type: Api::Type::String
+          - !ruby/object:Api::Type::NestedObject
+            name: 'postConditions'
+            description: |
+              Post conditions to override for the specified upgrade.
+            required: true
+            default_from_api: true
+            properties:
+              - !ruby/object:Api::Type::String
+                name: 'soaking'
+                description: |
+                  Amount of time to "soak" after a rollout has been finished before marking it COMPLETE. Cannot exceed 30 days.
+                required: true
+          - !ruby/object:Api::Type::Array
+            name: 'gkeUpgradeOverrides'
+            description: |
+              Configuration overrides for individual upgrades.
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'upgrade'
+                  description: |
+                    Which upgrade to override.
+                  required: true
+                  properties:
+                    - !ruby/object:Api::Type::String
+                      name: 'name'
+                      description: |
+                        Name of the upgrade, e.g., "k8s_control_plane". It should be a valid upgrade name. It must not exceet 99 characters.
+                    - !ruby/object:Api::Type::String
+                      name: 'version'
+                      description: |
+                         Version of the upgrade, e.g., "1.22.1-gke.100". It should be a valid version. It must not exceet 99 characters.
+                - !ruby/object:Api::Type::NestedObject
+                    name: 'postConditions'
+                    description: |
+                      Post conditions to override for the specified upgrade.
+                    required: true
+                    properties:
+                      - !ruby/object:Api::Type::String
+                        name: 'soaking'
+                        description: |
+                          Amount of time to "soak" after a rollout has been finished before marking it COMPLETE. Cannot exceed 30 days.
+                        required: true
   - !ruby/object:Api::Type::NestedObject
     name: fleetDefaultMemberConfig
     description: Optional. Fleet Default Membership Configuration.

--- a/mmv1/templates/terraform/examples/gkehub_feature_clusterupgrade.tf.erb
+++ b/mmv1/templates/terraform/examples/gkehub_feature_clusterupgrade.tf.erb
@@ -1,0 +1,12 @@
+resource "google_gke_hub_feature" "feature" {
+  name = "clusterupgrade"
+  location = "global"
+  spec {
+    clusterupgrade {
+      upstream_fleets = []
+      post_conditions {
+        soaking = "60s"
+      }
+    }
+  }
+}

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go.erb
@@ -504,6 +504,119 @@ resource "google_gke_hub_feature" "feature" {
 `, context)
 }
 
+func TestAccGKEHubFeature_Clusterupgrade(t *testing.T) {
+	// VCR fails to handle batched project services
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix":   acctest.RandString(t, 10),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckGKEHubFeatureDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGKEHubFeature_Clusterupgrade(context),
+			},
+			{
+				ResourceName:            "google_gke_hub_feature.feature",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"project"},
+			},
+			{
+				Config: testAccGKEHubFeature_ClusterupgradeUpdate(context),
+			},
+			{
+				ResourceName:      "google_gke_hub_feature.feature",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccGKEHubFeature_Clusterupgrade(context map[string]interface{}) string {
+	return gkeHubFeatureProjectSetupForGA(context) + acctest.Nprintf(`
+resource "google_gke_hub_feature" "feature" {
+  name = "clusterupgrade"
+  location = "global"
+  spec {
+    clusterupgrade {
+      upstream_fleets = []
+      post_conditions {
+        soaking = "60s"
+      }
+    }
+  }
+  depends_on = [google_project_service.gkehub]
+  project = google_project.project.project_id
+}
+
+resource "google_gke_hub_feature" "feature_2" {
+  name = "clusterupgrade"
+  location = "global"
+  spec {
+    clusterupgrade {
+      upstream_fleets = []
+      post_conditions {
+        soaking = "60s"
+      }
+    }
+  }
+  depends_on = [google_project_service.gkehub_2]
+  project = google_project.project_2.project_id
+}
+`, context)
+}
+
+func testAccGKEHubFeature_ClusterupgradeUpdate(context map[string]interface{}) string {
+	return gkeHubFeatureProjectSetupForGA(context) + acctest.Nprintf(`
+resource "google_gke_hub_feature" "feature" {
+  name = "clusterupgrade"
+  location = "global"
+  spec {
+    clusterupgrade {
+      upstream_fleets = [tostring(google_project.project_2.number)]
+      post_conditions {
+        soaking = "120s"
+      }
+      gke_upgrade_overrides {
+        upgrade {
+          name = "k8s_control_plane"
+          version = "1.22.1-gke.100"
+        }
+        post_conditions {
+          soaking = "240s"
+        }
+      }
+    }
+  }
+  project = google_project.project.project_id
+}
+
+resource "google_gke_hub_feature" "feature_2" {
+  name = "clusterupgrade"
+  location = "global"
+  spec {
+    clusterupgrade {
+      upstream_fleets = []
+      post_conditions {
+        soaking = "60s"
+      }
+    }
+  }
+  depends_on = [google_project_service.gkehub_2]
+  project = google_project.project_2.project_id
+}
+`, context)
+}
+
 func TestAccGKEHubFeature_FleetDefaultMemberConfigPolicyController(t *testing.T) {
 	// VCR fails to handle batched project services
 	acctest.SkipIfVcr(t)
@@ -787,6 +900,31 @@ resource "google_project_service" "anthos" {
 
 resource "google_project_service" "gkehub" {
   project = google_project.project.project_id
+  service = "gkehub.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project" "project_2" {
+  name            = "tf-test-gkehub%{random_suffix}-2"
+  project_id      = "tf-test-gkehub%{random_suffix}-2"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
+}
+
+resource "google_project_service" "compute_2" {
+  project = google_project.project_2.project_id
+  service = "compute.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "container_2" {
+  project = google_project.project_2.project_id
+  service = "container.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "gkehub_2" {
+  project = google_project.project_2.project_id
   service = "gkehub.googleapis.com"
   disable_on_destroy = false
 }


### PR DESCRIPTION
Add the clusterupgrade feature config for the fleet Feature resource. Fixes https://github.com/hashicorp/terraform-provider-google/issues/16459

**Release Note Template for Downstream PRs (will be copied)**

```release-note:
gkehub2: added `clusterupgrade` feature config under the `google_gke_hub_feature` resource.
```
