### PR TITLE
Remove use of `google_kms_crypto_key_iam_binding` resource in tests, to make tests stable in overnight testing

### DIFF
--- a/mmv1/templates/terraform/examples/secure_source_manager_instance_cmek.tf.erb
+++ b/mmv1/templates/terraform/examples/secure_source_manager_instance_cmek.tf.erb
@@ -8,13 +8,11 @@ resource "google_kms_crypto_key" "crypto_key" {
   key_ring = google_kms_key_ring.key_ring.id
 }
 
-resource "google_kms_crypto_key_iam_binding" "crypto_key_binding" {
+resource "google_kms_crypto_key_iam_member" "crypto_key_binding" {
   crypto_key_id = google_kms_crypto_key.crypto_key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  members = [
-    "serviceAccount:service-${data.google_project.project.number}@gcp-sa-sourcemanager.iam.gserviceaccount.com"
-  ]
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-sourcemanager.iam.gserviceaccount.com"
 }
 
 resource "google_secure_source_manager_instance" "<%= ctx[:primary_resource_id] %>" {

--- a/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function_test.go.erb
@@ -1078,16 +1078,27 @@ resource "google_artifact_registry_repository_iam_binding" "binding" {
   ]
 }
 
-resource "google_kms_crypto_key_iam_binding" "gcf_cmek_keyuser" {
+resource "google_kms_crypto_key_iam_member" "gcf_cmek_keyuser_1" {
   crypto_key_id = "%s"
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  members = [
-    "serviceAccount:service-${data.google_project.project.number}@gcf-admin-robot.iam.gserviceaccount.com",
-    "serviceAccount:service-${data.google_project.project.number}@gcp-sa-artifactregistry.iam.gserviceaccount.com",
-    "serviceAccount:service-${data.google_project.project.number}@gs-project-accounts.iam.gserviceaccount.com",
-  ]
+  member = "serviceAccount:service-${data.google_project.project.number}@gcf-admin-robot.iam.gserviceaccount.com"
 }
+
+resource "google_kms_crypto_key_iam_member" "gcf_cmek_keyuser_2" {
+  crypto_key_id = "%s"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-artifactregistry.iam.gserviceaccount.com"
+}
+
+resource "google_kms_crypto_key_iam_member" "gcf_cmek_keyuser_3" {
+  crypto_key_id = "%s"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+  member = "serviceAccount:service-${data.google_project.project.number}@gs-project-accounts.iam.gserviceaccount.com"
+}
+
 
 resource "google_artifact_registry_repository" "encoded-ar-repo" {
   repository_id = "%s"
@@ -1095,7 +1106,9 @@ resource "google_artifact_registry_repository" "encoded-ar-repo" {
   location = "us-central1"
   format = "DOCKER"
   depends_on = [
-    google_kms_crypto_key_iam_binding.gcf_cmek_keyuser
+    google_kms_crypto_key_iam_binding.gcf_cmek_keyuser_1,
+    google_kms_crypto_key_iam_binding.gcf_cmek_keyuser_2,
+    google_kms_crypto_key_iam_binding.gcf_cmek_keyuser_3,
   ]
 }
 

--- a/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function_test.go.erb
@@ -1136,7 +1136,7 @@ resource "google_cloudfunctions_function" "function" {
   timeout               = 61
   entry_point           = "helloGET"
 }
-`, kmsKey, arRepoName, kmsKey, bucketName, zipFilePath, functionName, kmsKey)
+`, kmsKey, kmsKey, kmsKey, arRepoName, kmsKey, bucketName, zipFilePath, functionName, kmsKey)
 }
 <% end -%>
 

--- a/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function_test.go.erb
@@ -1106,9 +1106,9 @@ resource "google_artifact_registry_repository" "encoded-ar-repo" {
   location = "us-central1"
   format = "DOCKER"
   depends_on = [
-    google_kms_crypto_key_iam_binding.gcf_cmek_keyuser_1,
-    google_kms_crypto_key_iam_binding.gcf_cmek_keyuser_2,
-    google_kms_crypto_key_iam_binding.gcf_cmek_keyuser_3,
+    google_kms_crypto_key_iam_member.gcf_cmek_keyuser_1,
+    google_kms_crypto_key_iam_member.gcf_cmek_keyuser_2,
+    google_kms_crypto_key_iam_member.gcf_cmek_keyuser_3,
   ]
 }
 

--- a/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function_test.go.erb
@@ -295,7 +295,9 @@ func TestAccCloudFunctionsFunction_dockerRepository(t *testing.T) {
 
 <% unless version == "ga" -%>
 func TestAccCloudFunctionsFunction_cmek(t *testing.T) {
+	acctest.SkipIfVcr(t)
 	t.Parallel()
+
 	kmsKey := acctest.BootstrapKMSKeyInLocation(t, "us-central1")
 	funcResourceName := "google_cloudfunctions_function.function"
 	arRepoName := fmt.Sprintf("tf-cmek-test-docker-repository-%s", acctest.RandString(t, 10))

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -6905,12 +6905,10 @@ data "google_compute_image" "my_image" {
 
 data "google_project" "project" {}
 
-resource "google_kms_crypto_key_iam_binding" "crypto_key" {
+resource "google_kms_crypto_key_iam_member" "crypto_key" {
   crypto_key_id = "%{key_name}"
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  members = [
-    "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com",
-  ]
+  member = "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -6932,7 +6930,7 @@ resource "google_compute_instance" "foobar" {
   network_interface {
     network = "default"
   }
-  depends_on = [google_kms_crypto_key_iam_binding.crypto_key]
+  depends_on = [google_kms_crypto_key_iam_member.crypto_key]
 
 }
 `, context)

--- a/mmv1/third_party/terraform/services/spanner/resource_spanner_database_test.go.erb
+++ b/mmv1/third_party/terraform/services/spanner/resource_spanner_database_test.go.erb
@@ -642,7 +642,7 @@ resource "google_spanner_database" "database" {
 
   deletion_protection = false
 
-  depends_on = [google_kms_crypto_key_iam_binding.crypto-key-binding]
+  depends_on = [google_kms_crypto_key_iam_member.crypto-key-binding]
 }
 
 resource "google_kms_key_ring" "keyring" {
@@ -658,14 +658,12 @@ resource "google_kms_crypto_key" "example-key" {
   rotation_period = "100000s"
 }
 
-resource "google_kms_crypto_key_iam_binding" "crypto-key-binding" {
+resource "google_kms_crypto_key_iam_member" "crypto-key-binding" {
   provider      = google-beta
   crypto_key_id = google_kms_crypto_key.example-key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  members = [
-    "serviceAccount:${google_project_service_identity.ck_sa.email}",
-  ]
+  member = "serviceAccount:${google_project_service_identity.ck_sa.email}"
 }
 
 data "google_project" "project" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR will help address test failures like:
- https://github.com/hashicorp/terraform-provider-google/issues/16687
- https://github.com/hashicorp/terraform-provider-google/issues/13609

In this PR I remove `google_kms_crypto_key_iam_binding` from tests that use shared crypto keys. I have also removed that resource from tests that provision their own crypto keys to improve signal-to-noise when we need to solve this same problem again in future.

This PR stops these tests affecting shared crypto keys:
- TestAccCloudFunctionsFunction_cmek (beta)
- TestAccComputeInstance_confidentialHyperDiskBootDisk (beta)

---

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
