### PR TITLE
Ignore properties field during import test steps of generated `google_apigee_organization` acc test

### DIFF
--- a/mmv1/products/apigee/Organization.yaml
+++ b/mmv1/products/apigee/Organization.yaml
@@ -103,6 +103,8 @@ examples:
       beta
       # Resource creation race
     skip_vcr: true
+    ignore_read_extra:
+      - properties
   - !ruby/object:Provider::Terraform::Examples
     name: 'apigee_organization_cloud_full_disable_vpc_peering'
     skip_test:


### PR DESCRIPTION
Relates to https://github.com/hashicorp/terraform-provider-google/issues/16242

Accompanies https://github.com/GoogleCloudPlatform/magic-modules/pull/9257 - this PR added `ignore_read_extra` to related tests and I missed adding it to the test in this PR.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
