### PR TITLE
Only set enabled bool if evaluation mode is unspecified

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -4252,7 +4252,7 @@ func expandBinaryAuthorization(configured interface{}, legacy_enabled bool) *con
 		}
 	}
 	config := l[0].(map[string]interface{})
-        if config["evaluation_mode"].(string) == nil {
+        if config["evaluation_mode"].(string) == "" {
 		return &container.BinaryAuthorization{
 			Enabled:         config["enabled"].(bool),
                         ForceSendFields: []string{"Enabled"},

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -4252,8 +4252,13 @@ func expandBinaryAuthorization(configured interface{}, legacy_enabled bool) *con
 		}
 	}
 	config := l[0].(map[string]interface{})
+        if config["evaluation_mode"].(string) == nil {
+		return &container.BinaryAuthorization{
+			Enabled:         config["enabled"].(bool),
+                        ForceSendFields: []string{"Enabled"},
+		}
+
 	return &container.BinaryAuthorization{
-                Enabled:        config["enabled"].(bool),
                 EvaluationMode: config["evaluation_mode"].(string),
 	}
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Only set the binauthz enabled bool if evaluation mode is unspecified. This mirrors the API behavior.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/16759

```release-note:bug
container: fixed an issue in which migrating from the deprecated Binauthz enablement bool to the new evaluation mode enum inadvertently caused two cluster update events, instead of none.
```