### PR TITLE
Only set enabled bool if evaluation mode is unspecified

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -4856,8 +4856,13 @@ func expandBinaryAuthorization(configured interface{}) *container.BinaryAuthoriz
 		}
 	}
 	config := l[0].(map[string]interface{})
+        if config["evaluation_mode"] == "" {
+		return &container.BinaryAuthorization{
+			Enabled:         config["enabled"].(bool),
+			ForceSendFields: []string{"Enabled"},
+                      }
+        }
 	return &container.BinaryAuthorization{
-		Enabled:        config["enabled"].(bool),
 		EvaluationMode: config["evaluation_mode"].(string),
 	}
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -2201,7 +2201,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		PodSecurityPolicyConfig: expandPodSecurityPolicyConfig(d.Get("pod_security_policy_config")),
 <% end -%>
 		Autoscaling:             expandClusterAutoscaling(d.Get("cluster_autoscaling"), d),
-		BinaryAuthorization:     expandBinaryAuthorization(d.Get("binary_authorization"), false),
+		BinaryAuthorization:     expandBinaryAuthorization(d.Get("binary_authorization")),
 		Autopilot: &container.Autopilot{
 			Enabled:         d.Get("enable_autopilot").(bool),
 			WorkloadPolicyConfig: workloadPolicyConfig,
@@ -3026,16 +3026,11 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		log.Printf("[INFO] GKE cluster %s's master global access config has been updated to %v", d.Id(), config)
 	}
 
-	if d.HasChange("binary_authorization") || d.HasChange("enable_binary_authorization") {
-		req := &container.UpdateClusterRequest{}
-		if d.HasChange("enable_binary_authorization") {
-			req.Update = &container.ClusterUpdate{
-				DesiredBinaryAuthorization: expandBinaryAuthorization(d.Get("binary_authorization"), d.Get("enable_binary_authorization").(bool)),
-			}
-		} else {
-			req.Update = &container.ClusterUpdate{
-				DesiredBinaryAuthorization: expandBinaryAuthorization(d.Get("binary_authorization"), false),
-			}
+	if d.HasChange("binary_authorization") {
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				DesiredBinaryAuthorization: expandBinaryAuthorization(d.Get("binary_authorization")),
+			},
 		}
 
 		updateF := updateFunc(req, "updating GKE binary authorization")
@@ -4832,11 +4827,11 @@ func expandNotificationConfig(configured interface{}) *container.NotificationCon
 	}
 }
 
-func expandBinaryAuthorization(configured interface{}, legacy_enabled bool) *container.BinaryAuthorization {
+func expandBinaryAuthorization(configured interface{}) *container.BinaryAuthorization {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
 		return &container.BinaryAuthorization{
-			Enabled:         legacy_enabled,
+			Enabled:         false,
 			ForceSendFields: []string{"Enabled"},
 		}
 	}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -3031,11 +3031,11 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		if d.HasChange("enable_binary_authorization") {
 			req.Update = &container.ClusterUpdate{
 				DesiredBinaryAuthorization: expandBinaryAuthorization(d.Get("binary_authorization"), d.Get("enable_binary_authorization").(bool)),
-			},
+			}
 		} else {
 			req.Update = &container.ClusterUpdate{
 				DesiredBinaryAuthorization: expandBinaryAuthorization(d.Get("binary_authorization"), false),
-			},
+			}
 		}
 
 		updateF := updateFunc(req, "updating GKE binary authorization")

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -2988,22 +2988,6 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		log.Printf("[INFO] GKE cluster %s's autopilot workload policy config allow_net_admin has been set to %v", d.Id(), allowed)
 	}
 
-        if d.HasChange("binary_authorization") || d.HasChange("enable_binary_authorization") {
-		req := &container.UpdateClusterRequest{
-			Update: &container.ClusterUpdate{
-				DesiredBinaryAuthorization: expandBinaryAuthorization(d.Get("binary_authorization"), d.Get("enable_binary_authorization").(bool)),
-			},
-		}
-
-		updateF := updateFunc(req, "updating GKE binary authorization")
-		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
-			return err
-		}
-
-		log.Printf("[INFO] GKE cluster %s's binary authorization has been updated to %v", d.Id(), req.Update.DesiredBinaryAuthorization)
-	}
-
 	if d.HasChange("private_cluster_config.0.enable_private_endpoint") {
 		enabled := d.Get("private_cluster_config.0.enable_private_endpoint").(bool)
 		req := &container.UpdateClusterRequest{
@@ -3040,6 +3024,22 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 
 		log.Printf("[INFO] GKE cluster %s's master global access config has been updated to %v", d.Id(), config)
+	}
+
+        if d.HasChange("binary_authorization") || d.HasChange("enable_binary_authorization") {
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				DesiredBinaryAuthorization: expandBinaryAuthorization(d.Get("binary_authorization"), d.Get("enable_binary_authorization").(bool)),
+			},
+		}
+
+		updateF := updateFunc(req, "updating GKE binary authorization")
+		// Call update serially.
+		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] GKE cluster %s's binary authorization has been updated to %v", d.Id(), req.Update.DesiredBinaryAuthorization)
 	}
 
 	if d.HasChange("enable_shielded_nodes") {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -3026,7 +3026,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		log.Printf("[INFO] GKE cluster %s's master global access config has been updated to %v", d.Id(), config)
 	}
 
-        if d.HasChange("binary_authorization") || d.HasChange("enable_binary_authorization") {
+  if d.HasChange("binary_authorization") || d.HasChange("enable_binary_authorization") {
 		req := &container.UpdateClusterRequest{
 			Update: &container.ClusterUpdate{
 				DesiredBinaryAuthorization: expandBinaryAuthorization(d.Get("binary_authorization"), d.Get("enable_binary_authorization").(bool)),
@@ -4837,7 +4837,7 @@ func expandBinaryAuthorization(configured interface{}, legacy_enabled bool) *con
 	}
 	config := l[0].(map[string]interface{})
 	return &container.BinaryAuthorization{
-                Enabled:        config["enabled"].(bool),
+    Enabled:        config["enabled"].(bool),
 		EvaluationMode: config["evaluation_mode"].(string),
 	}
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -3026,7 +3026,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		log.Printf("[INFO] GKE cluster %s's master global access config has been updated to %v", d.Id(), config)
 	}
 
-  if d.HasChange("binary_authorization") || d.HasChange("enable_binary_authorization") {
+	if d.HasChange("binary_authorization") || d.HasChange("enable_binary_authorization") {
 		req := &container.UpdateClusterRequest{
 			Update: &container.ClusterUpdate{
 				DesiredBinaryAuthorization: expandBinaryAuthorization(d.Get("binary_authorization"), d.Get("enable_binary_authorization").(bool)),
@@ -4837,7 +4837,7 @@ func expandBinaryAuthorization(configured interface{}, legacy_enabled bool) *con
 	}
 	config := l[0].(map[string]interface{})
 	return &container.BinaryAuthorization{
-    Enabled:        config["enabled"].(bool),
+		Enabled:        config["enabled"].(bool),
 		EvaluationMode: config["evaluation_mode"].(string),
 	}
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -2201,7 +2201,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		PodSecurityPolicyConfig: expandPodSecurityPolicyConfig(d.Get("pod_security_policy_config")),
 <% end -%>
 		Autoscaling:             expandClusterAutoscaling(d.Get("cluster_autoscaling"), d),
-		BinaryAuthorization:     expandBinaryAuthorization(d.Get("binary_authorization")),
+		BinaryAuthorization:     expandBinaryAuthorization(d.Get("binary_authorization"), false),
 		Autopilot: &container.Autopilot{
 			Enabled:         d.Get("enable_autopilot").(bool),
 			WorkloadPolicyConfig: workloadPolicyConfig,
@@ -2988,24 +2988,10 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		log.Printf("[INFO] GKE cluster %s's autopilot workload policy config allow_net_admin has been set to %v", d.Id(), allowed)
 	}
 
-        if d.HasChange("binary_authorization") {
-                if d.HasChange("enable_binary_authorization") {
-                        // Only consider enabled bool if evaluation mode is unspecified.
-                        if d.Get("binary_authorization.0.evaluation_mode").(string) == "" {
-                                enabled := d.Get("enable_binary_authorization").(bool) || d.Get("binary_authorization.0.enabled").(bool)
-		                req := &container.UpdateClusterRequest{
-			                Update: &container.ClusterUpdate{
-				                DesiredBinaryAuthorization: &container.BinaryAuthorization{
-				 	                Enabled:         enabled,
-					                ForceSendFields: []string{"Enabled"},
-				                },
-			                },
-		                }
-                        }
-                }
+        if d.HasChange("binary_authorization") || d.HasChange("enable_binary_authorization") {
 		req := &container.UpdateClusterRequest{
 			Update: &container.ClusterUpdate{
-				DesiredBinaryAuthorization: expandBinaryAuthorization(d.Get("binary_authorization")),
+				DesiredBinaryAuthorization: expandBinaryAuthorization(d.Get("binary_authorization"), d.Get("enable_binary_authorization").(bool)),
 			},
 		}
 
@@ -3016,26 +3002,6 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 
 		log.Printf("[INFO] GKE cluster %s's binary authorization has been updated to %v", d.Id(), req.Update.DesiredBinaryAuthorization)
-	}
-
-	if d.HasChange("enable_binary_authorization") && !d.HasChange("binary_authorization"){
-		enabled := d.Get("enable_binary_authorization").(bool)
-		req := &container.UpdateClusterRequest{
-			Update: &container.ClusterUpdate{
-				DesiredBinaryAuthorization: &container.BinaryAuthorization{
-					Enabled:         enabled,
-					ForceSendFields: []string{"Enabled"},
-				},
-			},
-		}
-
-		updateF := updateFunc(req, "updating GKE binary authorization")
-		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
-			return err
-		}
-
-		log.Printf("[INFO] GKE cluster %s's binary authorization has been updated to %v", d.Id(), enabled)
 	}
 
 	if d.HasChange("private_cluster_config.0.enable_private_endpoint") {
@@ -4861,11 +4827,11 @@ func expandNotificationConfig(configured interface{}) *container.NotificationCon
 	}
 }
 
-func expandBinaryAuthorization(configured interface{}) *container.BinaryAuthorization {
+func expandBinaryAuthorization(configured interface{}, legacy_enabled bool) *container.BinaryAuthorization {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
 		return &container.BinaryAuthorization{
-			Enabled:         false,
+			Enabled:         legacy_enabled,
 			ForceSendFields: []string{"Enabled"},
 		}
 	}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -2988,7 +2988,37 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		log.Printf("[INFO] GKE cluster %s's autopilot workload policy config allow_net_admin has been set to %v", d.Id(), allowed)
 	}
 
-	if d.HasChange("enable_binary_authorization") {
+        if d.HasChange("binary_authorization") {
+                if d.HasChange("enable_binary_authorization") {
+                        // Only consider enabled bool if evaluation mode is unspecified.
+                        if d.Get("binary_authorization.0.evaluation_mode").(string) == "" {
+                                enabled := d.Get("enable_binary_authorization").(bool) || d.Get("binary_authorization.0.enabled").(bool)
+		                req := &container.UpdateClusterRequest{
+			                Update: &container.ClusterUpdate{
+				                DesiredBinaryAuthorization: &container.BinaryAuthorization{
+				 	                Enabled:         enabled,
+					                ForceSendFields: []string{"Enabled"},
+				                },
+			                },
+		                }
+                        }
+                }
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				DesiredBinaryAuthorization: expandBinaryAuthorization(d.Get("binary_authorization")),
+			},
+		}
+
+		updateF := updateFunc(req, "updating GKE binary authorization")
+		// Call update serially.
+		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] GKE cluster %s's binary authorization has been updated to %v", d.Id(), req.Update.DesiredBinaryAuthorization)
+	}
+
+	if d.HasChange("enable_binary_authorization") && !d.HasChange("binary_authorization"){
 		enabled := d.Get("enable_binary_authorization").(bool)
 		req := &container.UpdateClusterRequest{
 			Update: &container.ClusterUpdate{
@@ -3044,22 +3074,6 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 
 		log.Printf("[INFO] GKE cluster %s's master global access config has been updated to %v", d.Id(), config)
-	}
-
-    if d.HasChange("binary_authorization") {
-		req := &container.UpdateClusterRequest{
-			Update: &container.ClusterUpdate{
-				DesiredBinaryAuthorization: expandBinaryAuthorization(d.Get("binary_authorization")),
-			},
-		}
-
-		updateF := updateFunc(req, "updating GKE binary authorization")
-		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
-			return err
-		}
-
-		log.Printf("[INFO] GKE cluster %s's binary authorization has been updated to %v", d.Id(), req.Update.DesiredBinaryAuthorization)
 	}
 
 	if d.HasChange("enable_shielded_nodes") {
@@ -4856,13 +4870,8 @@ func expandBinaryAuthorization(configured interface{}) *container.BinaryAuthoriz
 		}
 	}
 	config := l[0].(map[string]interface{})
-        if config["evaluation_mode"] == "" {
-		return &container.BinaryAuthorization{
-			Enabled:         config["enabled"].(bool),
-			ForceSendFields: []string{"Enabled"},
-                      }
-        }
 	return &container.BinaryAuthorization{
+                Enabled:        config["enabled"].(bool),
 		EvaluationMode: config["evaluation_mode"].(string),
 	}
 }
@@ -4956,6 +4965,11 @@ func expandPrivateClusterConfig(configured interface{}) *container.PrivateCluste
 	if len(l) == 0 {
 		return nil
 	}
+	config := l[0].(map[string]interface{})
+	return &container.PrivateClusterConfig{
+		EnablePrivateEndpoint:      config["enable_private_endpoint"].(bool),
+		EnablePrivateNodes:         config["enable_private_nodes"].(bool),
+		MasterIpv4CidrBlock:        config["master_ipv4_cidr_block"].(string),
 	config := l[0].(map[string]interface{})
 	return &container.PrivateClusterConfig{
 		EnablePrivateEndpoint:      config["enable_private_endpoint"].(bool),
@@ -6393,10 +6407,5 @@ func containerClusterEnableK8sBetaApisCustomizeDiffFunc(d tpgresource.TerraformR
 		newAPIsSet := new.(*schema.Set)
 		for _, oldAPI := range oldAPIsSet.List() {
 			if !newAPIsSet.Contains(oldAPI) {
-				return d.ForceNew("enable_k8s_beta_apis.0.enabled_apis")
-			}
-		}
-	}
-
 	return nil
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -4970,11 +4970,6 @@ func expandPrivateClusterConfig(configured interface{}) *container.PrivateCluste
 		EnablePrivateEndpoint:      config["enable_private_endpoint"].(bool),
 		EnablePrivateNodes:         config["enable_private_nodes"].(bool),
 		MasterIpv4CidrBlock:        config["master_ipv4_cidr_block"].(string),
-	config := l[0].(map[string]interface{})
-	return &container.PrivateClusterConfig{
-		EnablePrivateEndpoint:      config["enable_private_endpoint"].(bool),
-		EnablePrivateNodes:         config["enable_private_nodes"].(bool),
-		MasterIpv4CidrBlock:        config["master_ipv4_cidr_block"].(string),
 		MasterGlobalAccessConfig:   expandPrivateClusterConfigMasterGlobalAccessConfig(config["master_global_access_config"]),
 		PrivateEndpointSubnetwork:  config["private_endpoint_subnetwork"].(string),
 		ForceSendFields:            []string{"EnablePrivateEndpoint", "EnablePrivateNodes", "MasterIpv4CidrBlock", "MasterGlobalAccessConfig"},
@@ -6407,5 +6402,10 @@ func containerClusterEnableK8sBetaApisCustomizeDiffFunc(d tpgresource.TerraformR
 		newAPIsSet := new.(*schema.Set)
 		for _, oldAPI := range oldAPIsSet.List() {
 			if !newAPIsSet.Contains(oldAPI) {
+				return d.ForceNew("enable_k8s_beta_apis.0.enabled_apis")
+			}
+		}
+	}
+
 	return nil
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -3026,7 +3026,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		log.Printf("[INFO] GKE cluster %s's master global access config has been updated to %v", d.Id(), config)
 	}
 
-	if d.HasChange("binary_authorization") {
+	if d.HasChange("binary_authorization") || d.HasChange("enable_binary_authorization") {
 		req := &container.UpdateClusterRequest{}
 		if d.HasChange("enable_binary_authorization") {
 			req.Update = &container.ClusterUpdate{

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -3026,10 +3026,15 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		log.Printf("[INFO] GKE cluster %s's master global access config has been updated to %v", d.Id(), config)
 	}
 
-	if d.HasChange("binary_authorization") || d.HasChange("enable_binary_authorization") {
-		req := &container.UpdateClusterRequest{
-			Update: &container.ClusterUpdate{
+	if d.HasChange("binary_authorization") {
+		req := &container.UpdateClusterRequest{}
+		if d.HasChange("enable_binary_authorization") {
+			req.Update = &container.ClusterUpdate{
 				DesiredBinaryAuthorization: expandBinaryAuthorization(d.Get("binary_authorization"), d.Get("enable_binary_authorization").(bool)),
+			},
+		} else {
+			req.Update = &container.ClusterUpdate{
+				DesiredBinaryAuthorization: expandBinaryAuthorization(d.Get("binary_authorization"), false),
 			},
 		}
 

--- a/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
@@ -636,7 +636,15 @@ resource "google_container_cluster" "primary" {
 
 ### `enable_binary_authorization` is now removed
 
-`enable_binary_authorization` has been removed in favor of `binary_authorization.enabled`.
+`enable_binary_authorization` has been removed in favor of `binary_authorization.evaluation_mode`.
+To enable Binary Authorization set evaluation mode to "PROJECT_SINGLETON_POLICY_ENFORCE",
+as shown in the example below, to disable it set evaluation mode to "DISABLED".
+
+```
+  binary_authorization {
+    evaluation_mode = "PROJECT_SINGLETON_POLICY_ENFORCE"
+  }
+```
 
 ### Default value of `network_policy.provider` is now removed
 

--- a/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
@@ -637,8 +637,8 @@ resource "google_container_cluster" "primary" {
 ### `enable_binary_authorization` is now removed
 
 `enable_binary_authorization` has been removed in favor of `binary_authorization.evaluation_mode`.
-To enable Binary Authorization set evaluation mode to "PROJECT_SINGLETON_POLICY_ENFORCE",
-as shown in the example below, to disable it set evaluation mode to "DISABLED".
+To enable Binary Authorization set evaluation mode to "PROJECT_SINGLETON_POLICY_ENFORCE"
+as shown in the example below, to disable it, set evaluation mode to "DISABLED".
 
 ```
   binary_authorization {

--- a/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_5_upgrade.html.markdown
@@ -637,8 +637,8 @@ resource "google_container_cluster" "primary" {
 ### `enable_binary_authorization` is now removed
 
 `enable_binary_authorization` has been removed in favor of `binary_authorization.evaluation_mode`.
-To enable Binary Authorization set evaluation mode to "PROJECT_SINGLETON_POLICY_ENFORCE"
-as shown in the example below, to disable it, set evaluation mode to "DISABLED".
+To enable Binary Authorization, set evaluation mode to "PROJECT_SINGLETON_POLICY_ENFORCE"
+as shown in the example below. To disable it, set evaluation mode to "DISABLED".
 
 ```
   binary_authorization {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Remove `enable_binary_authorization` conditional, this was missed in #8784. 

Fixes https://github.com/hashicorp/terraform-provider-google/issues/16759

```release-note:bug
container: fixed an issue in which migrating from the deprecated Binauthz enablement bool to the new evaluation mode enum inadvertently caused two cluster update events, instead of none.
```