### PR TITLE
Add missing IAM resources dependencies in `TestAccComputeRegionInstanceTemplate_sourceImageEncryptionKey`

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.erb
@@ -3255,6 +3255,10 @@ resource "google_compute_snapshot" "snapshot" {
     kms_key_self_link       = data.google_kms_crypto_key.key.id
     kms_key_service_account = google_service_account.test.email
   }
+
+  depends_on = [
+    google_kms_crypto_key_iam_member.crypto_key
+  ]
 }
 
 resource "google_compute_region_instance_template" "template" {
@@ -3275,6 +3279,10 @@ resource "google_compute_region_instance_template" "template" {
   network_interface {
     network = "default"
   }
+
+  depends_on = [
+    google_kms_crypto_key_iam_member.crypto_key
+  ]
 }
 `, context)
 }
@@ -3314,6 +3322,10 @@ resource "google_compute_image" "image" {
     kms_key_self_link       = data.google_kms_crypto_key.key.id
     kms_key_service_account = google_service_account.test.email
   }
+
+  depends_on = [
+    google_kms_crypto_key_iam_member.crypto_key
+  ]
 }
 
 
@@ -3335,6 +3347,10 @@ resource "google_compute_region_instance_template" "template" {
   network_interface {
     network = "default"
   }
+
+  depends_on = [
+    google_kms_crypto_key_iam_member.crypto_key
+  ]
 }
 `, context)
 }


### PR DESCRIPTION

Relates to this test failure: https://github.com/hashicorp/terraform-provider-google/issues/16687

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
