### PR TITLE
Revert "The version field should be under configmanagement instead of under oci"

### DIFF
--- a/mmv1/products/gkehub2/Feature.yaml
+++ b/mmv1/products/gkehub2/Feature.yaml
@@ -215,9 +215,6 @@ properties:
         name: configmanagement
         description: Config Management spec
         properties:
-          - !ruby/object:Api::Type::String
-            name: version
-            description: 'Version of ACM installed'
           - !ruby/object:Api::Type::NestedObject
             name: configSync
             description: 'ConfigSync configuration for the cluster'
@@ -274,6 +271,9 @@ properties:
                   - !ruby/object:Api::Type::String
                     name: syncWaitSecs
                     description: 'Period in seconds between consecutive syncs. Default: 15'
+                  - !ruby/object:Api::Type::String
+                    name: version
+                    description: 'Version of ACM installed'
       - !ruby/object:Api::Type::NestedObject
         name: policycontroller
         description: Policy Controller spec

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go.erb
@@ -460,7 +460,6 @@ resource "google_gke_hub_feature" "feature" {
   location = "global"
   fleet_default_member_config {
     configmanagement {
-      version = "1.16.0"
       config_sync {
         source_format = "hierarchy"
         git {
@@ -487,7 +486,6 @@ resource "google_gke_hub_feature" "feature" {
   location = "global"
   fleet_default_member_config {
     configmanagement {
-      version = "1.16.1"
       config_sync {
         source_format = "unstructured"
         oci {


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#9587

```release-note:bug
gkehub2: added field `version` under `configmanagement` instead of a child field `oci` in `google_gke_hub_feature` resource (revert)
```