### PR TITLE
Fix crash in containerattached when removing admin_groups or admin_users.

### DIFF
--- a/mmv1/templates/terraform/custom_flatten/containerattached_cluster_authorization_user.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/containerattached_cluster_authorization_user.go.erb
@@ -36,23 +36,27 @@
 //    ],
 // }
 func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
-    if v == nil {
-        return nil
-    }
+	if v == nil || len(v.(map[string]interface{})) == 0 {
+		return nil
+	}
 
-	orig := v.(map[string]interface{})["adminUsers"].([]interface{})
 	transformed := make(map[string][]string)
-	transformed["admin_users"] = make([]string, len(orig))
-	for i, u := range orig {
-		if u != nil {
-			transformed["admin_users"][i] = u.(map[string]interface{})["username"].(string)
+	if v.(map[string]interface{})["adminUsers"] != nil {
+		orig := v.(map[string]interface{})["adminUsers"].([]interface{})
+		transformed["admin_users"] = make([]string, len(orig))
+		for i, u := range orig {
+			if u != nil {
+				transformed["admin_users"][i] = u.(map[string]interface{})["username"].(string)
+			}
 		}
 	}
-	orig = v.(map[string]interface{})["adminGroups"].([]interface{})
-	transformed["admin_groups"] = make([]string, len(orig))
-	for i, u := range orig {
-		if u != nil {
-			transformed["admin_groups"][i] = u.(map[string]interface{})["group"].(string)
+	if v.(map[string]interface{})["adminGroups"] != nil {
+		orig := v.(map[string]interface{})["adminGroups"].([]interface{})
+		transformed["admin_groups"] = make([]string, len(orig))
+		for i, u := range orig {
+			if u != nil {
+				transformed["admin_groups"][i] = u.(map[string]interface{})["group"].(string)
+			}
 		}
 	}
 

--- a/mmv1/third_party/terraform/services/containerattached/resource_container_attached_cluster_update_test.go
+++ b/mmv1/third_party/terraform/services/containerattached/resource_container_attached_cluster_update_test.go
@@ -37,6 +37,24 @@ func TestAccContainerAttachedCluster_update(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"location", "annotations"},
 			},
+      {
+				Config: testAccContainerAttachedCluster_containerAttachedCluster_removeAuthorizationUsers(context),
+			},
+			{
+				ResourceName:            "google_container_attached_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "annotations"},
+			},
+      {
+				Config: testAccContainerAttachedCluster_containerAttachedCluster_removeAuthorizationGroups(context),
+			},
+			{
+				ResourceName:            "google_container_attached_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "annotations"},
+			},
 			{
 				Config: testAccContainerAttachedCluster_containerAttachedCluster_destroy(context),
 			},
@@ -155,6 +173,103 @@ resource "google_container_attached_cluster" "primary" {
 `, context)
 }
 
+func testAccContainerAttachedCluster_containerAttachedCluster_removeAuthorizationUsers(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+}
+
+data "google_container_attached_versions" "versions" {
+	location       = "us-west1"
+	project        = data.google_project.project.project_id
+}
+
+resource "google_container_attached_cluster" "primary" {
+  name     = "update%{random_suffix}"
+  project = data.google_project.project.project_id
+  location = "us-west1"
+  description = "Test cluster updated"
+  distribution = "aks"
+  annotations = {
+    label-one = "value-one"
+  label-two = "value-two"
+  }
+  authorization {
+    admin_groups = [ "group3@example.com"]
+  }
+  oidc_config {
+      issuer_url = "https://oidc.issuer.url"
+      jwks = base64encode("{\"keys\":[{\"use\":\"sig\",\"kty\":\"RSA\",\"kid\":\"testid\",\"alg\":\"RS256\",\"n\":\"somedata\",\"e\":\"AQAB\"}]}")
+  }
+  platform_version = data.google_container_attached_versions.versions.valid_versions[0]
+  fleet {
+    project = "projects/${data.google_project.project.number}"
+  }
+  monitoring_config {
+    managed_prometheus_config {}
+  }
+  binary_authorization {
+    evaluation_mode = "DISABLED"
+  }
+  proxy_config {
+    kubernetes_secret {
+      name = "new-proxy-config"
+      namespace = "custom-ns"
+    }
+  }
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+`, context)
+}
+
+func testAccContainerAttachedCluster_containerAttachedCluster_removeAuthorizationGroups(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+}
+
+data "google_container_attached_versions" "versions" {
+	location       = "us-west1"
+	project        = data.google_project.project.project_id
+}
+
+resource "google_container_attached_cluster" "primary" {
+  name     = "update%{random_suffix}"
+  project = data.google_project.project.project_id
+  location = "us-west1"
+  description = "Test cluster updated"
+  distribution = "aks"
+  annotations = {
+    label-one = "value-one"
+  label-two = "value-two"
+  }
+  oidc_config {
+      issuer_url = "https://oidc.issuer.url"
+      jwks = base64encode("{\"keys\":[{\"use\":\"sig\",\"kty\":\"RSA\",\"kid\":\"testid\",\"alg\":\"RS256\",\"n\":\"somedata\",\"e\":\"AQAB\"}]}")
+  }
+  platform_version = data.google_container_attached_versions.versions.valid_versions[0]
+  fleet {
+    project = "projects/${data.google_project.project.number}"
+  }
+  monitoring_config {
+    managed_prometheus_config {}
+  }
+  binary_authorization {
+    evaluation_mode = "DISABLED"
+  }
+  proxy_config {
+    kubernetes_secret {
+      name = "new-proxy-config"
+      namespace = "custom-ns"
+    }
+  }
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+`, context)
+}
+
 // Duplicate of testAccContainerAttachedCluster_containerAttachedCluster_update without lifecycle.prevent_destroy set
 // so the test can clean up the resource after the update.
 func testAccContainerAttachedCluster_containerAttachedCluster_destroy(context map[string]interface{}) string {
@@ -176,10 +291,6 @@ resource "google_container_attached_cluster" "primary" {
   annotations = {
     label-one = "value-one"
   label-two = "value-two"
-  }
-  authorization {
-    admin_users = [ "user2@example.com", "user3@example.com"]
-    admin_groups = [ "group3@example.com"]
   }
   oidc_config {
       issuer_url = "https://oidc.issuer.url"

--- a/mmv1/third_party/terraform/services/containerattached/resource_container_attached_cluster_update_test.go
+++ b/mmv1/third_party/terraform/services/containerattached/resource_container_attached_cluster_update_test.go
@@ -37,7 +37,7 @@ func TestAccContainerAttachedCluster_update(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"location", "annotations"},
 			},
-      {
+			{
 				Config: testAccContainerAttachedCluster_containerAttachedCluster_removeAuthorizationUsers(context),
 			},
 			{
@@ -46,7 +46,7 @@ func TestAccContainerAttachedCluster_update(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"location", "annotations"},
 			},
-      {
+			{
 				Config: testAccContainerAttachedCluster_containerAttachedCluster_removeAuthorizationGroups(context),
 			},
 			{


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/16784

Add checks to the custom flattener for the `authorization` field to ensure data is available before trying to use it.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
containerattached: fixed crash when updating a cluster to remove `admin_users` or `admin_groups`
```
