### PR TITLE
Add support of provisioned iops and throughput on boot disk.

### DIFF
--- a/mmv1/products/compute/Instance.yaml
+++ b/mmv1/products/compute/Instance.yaml
@@ -181,6 +181,28 @@ properties:
                 disks.source is required.  To create a disk with one of
                 the public operating system images, specify the image
                 by its family name.
+            - !ruby/object:Api::Type::Integer
+              name: 'provisionedIops'
+              description: |
+                Indicates how many IOPS to provision for the disk. This
+                sets the number of I/O operations per second that the
+                disk can handle. Values must be between 10,000 and 120,000.
+                Note: Updating currently is only supported for hyperdisk skus
+                via disk update api/gcloud without the need to delete and recreate
+                the disk, hyperdisk allows for an update of IOPS every
+                4 hours. To update your hyperdisk more frequently,
+                you'll need to manually delete and recreate it.
+            - !ruby/object:Api::Type::Integer
+              name: 'provisionedThroughput'
+              description: |
+                Indicates how much throughput to provision for the disk.
+                This sets the number of throughput mb per second that
+                the disk can handle. Values must be between 1 and 7,124.
+                Note: Updating currently is only supported for hyperdisk skus
+                via disk update api/gcloud without the need to delete and recreate
+                the disk, hyperdisk allows for an update of throughput every
+                4 hours. To update your hyperdisk more frequently,
+                you'll need to manually delete and recreate it.
             - !ruby/object:Api::Type::NestedObject
               name: 'sourceImageEncryptionKey'
               description: |

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
@@ -46,6 +46,8 @@ var (
 		"boot_disk.0.initialize_params.0.image",
 		"boot_disk.0.initialize_params.0.labels",
 		"boot_disk.0.initialize_params.0.resource_manager_tags",
+		"boot_disk.0.initialize_params.0.provisioned_iops",
+		"boot_disk.0.initialize_params.0.provisioned_throughput",
 <% unless version == 'ga' -%>
 		"boot_disk.0.initialize_params.0.enable_confidential_compute",
 <% end -%>
@@ -244,6 +246,27 @@ func ResourceComputeInstance() *schema.Resource {
 										ForceNew:     true,
 										Description:  `A map of resource manager tags. Resource manager tag keys and values have the same definition as resource manager tags. Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456. The field is ignored (both PUT & PATCH) when empty.`,
 									},
+									
+									"provisioned_iops": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										AtLeastOneOf: initializeParamsKeys,
+										Computed:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.IntBetween(10000, 120000),
+										Description:  `Indicates how many IOPS to provision for the disk. This sets the number of I/O operations per second that the disk can handle. Values must be between 10,000 and 120,000.`,
+									},
+
+									"provisioned_throughput": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										AtLeastOneOf: initializeParamsKeys,
+										Computed:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.IntBetween(1, 7124),
+										Description:  `Indicates how much throughput to provision for the disk. This sets the number of throughput mb per second that the disk can handle. Values must be between 1 and 7,124.`,
+									},
+
 <% unless version == 'ga' -%>
 									"enable_confidential_compute": {
 										Type:             schema.TypeBool,
@@ -2741,6 +2764,14 @@ func expandBootDisk(d *schema.ResourceData, config *transport_tpg.Config, projec
 			disk.InitializeParams.DiskSizeGb = int64(v.(int))
 		}
 
+		if v, ok := d.GetOk("boot_disk.0.initialize_params.0.provisioned_iops"); ok {
+			disk.InitializeParams.ProvisionedIops = int64(v.(int))
+		}
+
+		if v, ok := d.GetOk("boot_disk.0.initialize_params.0.provisioned_throughput"); ok {
+			disk.InitializeParams.ProvisionedThroughput = int64(v.(int))
+		}
+
 		<% unless version == 'ga' -%>
 		if v, ok := d.GetOk("boot_disk.0.initialize_params.0.enable_confidential_compute"); ok {
 			disk.InitializeParams.EnableConfidentialCompute = v.(bool)
@@ -2812,6 +2843,8 @@ func flattenBootDisk(d *schema.ResourceData, disk *compute.AttachedDisk, config 
 			"size":   diskDetails.SizeGb,
 			"labels": diskDetails.Labels,
 			"resource_manager_tags": d.Get("boot_disk.0.initialize_params.0.resource_manager_tags"),
+			"provisioned_iops": diskDetails.ProvisionedIops,
+			"provisioned_throughput": diskDetails.ProvisionedThroughput,
 <% unless version == 'ga' -%>
 			"enable_confidential_compute": diskDetails.EnableConfidentialCompute,
 <% end -%>

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -1827,6 +1827,29 @@ func TestAccComputeInstance_confidentialHyperDiskBootDisk(t *testing.T) {
 }
 <% end -%>
 
+func TestAccComputeInstance_hyperdiskBootDisk_provisioned_iops_throughput(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"instance_name":         fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"zone":                  "us-central1-a",
+		"provisioned_iops": 	 12000,
+		"provisioned_throughput": 200,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceHyperDiskBootDiskProvisionedIopsThroughput(context),
+			},
+			computeInstanceImportStep(context["zone"].(string), context["instance_name"].(string), []string{"allow_stopping_for_update"}),
+		},
+	})
+}
+
 func TestAccComputeInstance_enableDisplay(t *testing.T) {
 	t.Parallel()
 
@@ -6936,6 +6959,37 @@ resource "google_compute_instance" "foobar" {
 `, context)
 }
 <% end -%>
+
+func testAccComputeInstanceHyperDiskBootDiskProvisionedIopsThroughput(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family    = "ubuntu-2204-lts"
+  project   = "ubuntu-os-cloud"
+}
+
+data "google_project" "project" {}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%{instance_name}"
+  machine_type = "h3-standard-88"
+  zone         = "%{zone}"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+      provisioned_iops = %{provisioned_iops}
+      provisioned_throughput = %{provisioned_throughput}
+      type = "hyperdisk-balanced"
+      size = 100
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+`, context)
+}
 
 func testAccComputeInstance_enableDisplay(instance string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -249,6 +249,22 @@ is desired, you will need to modify your state file manually using
 
 * `resource_manager_tags` - (Optional) A tag is a key-value pair that can be attached to a Google Cloud resource. You can use tags to conditionally allow or deny policies based on whether a resource has a specific tag. This value is not returned by the API. In Terraform, this value cannot be updated and changing it will recreate the resource.
 
+* `provisioned_iops` - (Optional) Indicates how many IOPS to provision for the disk.
+    This sets the number of I/O operations per second that the disk can handle.
+    Values must be between 10,000 and 120,000. For more details,see the 
+    [Extreme persistent disk documentation](https://cloud.google.com/compute/docs/disks/extreme-persistent-disk).
+    Note: Updating currently is only supported for hyperdisk skus via disk update
+    api/gcloud without the need to delete and recreate the disk, hyperdisk allows
+    for an update of IOPS every 4 hours. To update your hyperdisk more frequently,
+    you'll need to manually delete and recreate it.
+
+* `provisioned_throughput` - (Optional) Indicates how much throughput to provision for the disk.
+    This sets the number of throughput mb per second that the disk can handle.
+    Values must be between 1 and 7,124. Note: Updating currently is only supported
+    for hyperdisk skus via disk update api/gcloud without the need to delete and
+    recreate the disk, hyperdisk allows for an update of throughput every 4 hours.
+    To update your hyperdisk more frequently, you'll need to manually delete and recreate it.
+
 <a name="nested_scratch_disk"></a>The `scratch_disk` block supports:
 
 * `interface` - (Required) The disk interface to use for attaching this disk; either SCSI or NVME.


### PR DESCRIPTION
Adding in Support for provisioned_iops and provisioned_throughput on boot_disk within initialize_params for google_compute_instance resource.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `provisioned_iops`and `provisioned_throughput` fields under `boot_disk.initialize_params` to `google_compute_instance` resource
```
