### PR TITLE
add primary key version

### DIFF
--- a/mmv1/products/kms/CryptoKey.yaml
+++ b/mmv1/products/kms/CryptoKey.yaml
@@ -89,8 +89,7 @@ properties:
     name: 'primary'
     description: |
       A copy of the primary CryptoKeyVersion that will be used by cryptoKeys.encrypt when this CryptoKey is given in EncryptRequest.name.
-      The CryptoKey's primary version can be updated via cryptoKeys.updatePrimaryVersion.
-      Keys with purpose ENCRYPT_DECRYPT may have a primary. For other keys, this field will be omitted.
+      Keys with purpose ENCRYPT_DECRYPT may have a primary. For other keys, this field will be unset.
     output: true
     properties:
       - !ruby/object:Api::Type::String

--- a/mmv1/products/kms/CryptoKey.yaml
+++ b/mmv1/products/kms/CryptoKey.yaml
@@ -85,6 +85,34 @@ properties:
     name: 'labels'
     description: |
       Labels with user-defined metadata to apply to this resource.
+  - !ruby/object:Api::Type::NestedObject
+    name: 'primary'
+    description: |
+      A copy of the primary CryptoKeyVersion that will be used by cryptoKeys.encrypt when this CryptoKey is given in EncryptRequest.name.
+      The CryptoKey's primary version can be updated via cryptoKeys.updatePrimaryVersion.
+      Keys with purpose ENCRYPT_DECRYPT may have a primary. For other keys, this field will be omitted.
+    output: true
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          The resource name for this CryptoKeyVersion.
+      - !ruby/object:Api::Type::Enum
+        name: 'state'
+        description: |
+          The current state of the CryptoKeyVersion.
+        values:
+          - :CRYPTO_KEY_VERSION_STATE_UNSPECIFIED
+          - :PENDING_GENERATION
+          - :ENABLED
+          - :DISABLED
+          - :DESTROYED
+          - :DESTROY_SCHEDULED
+          - :PENDING_IMPORT
+          - :IMPORT_FAILED
+          - :GENERATION_FAILED
+          - :PENDING_EXTERNAL_DESTRUCTION
+          - :EXTERNAL_DESTRUCTION_FAILED
   - !ruby/object:Api::Type::String
     name: 'purpose'
     description: |

--- a/mmv1/products/kms/CryptoKey.yaml
+++ b/mmv1/products/kms/CryptoKey.yaml
@@ -96,22 +96,12 @@ properties:
         name: 'name'
         description: |
           The resource name for this CryptoKeyVersion.
-      - !ruby/object:Api::Type::Enum
+        output: true
+      - !ruby/object:Api::Type::String
         name: 'state'
         description: |
           The current state of the CryptoKeyVersion.
-        values:
-          - :CRYPTO_KEY_VERSION_STATE_UNSPECIFIED
-          - :PENDING_GENERATION
-          - :ENABLED
-          - :DISABLED
-          - :DESTROYED
-          - :DESTROY_SCHEDULED
-          - :PENDING_IMPORT
-          - :IMPORT_FAILED
-          - :GENERATION_FAILED
-          - :PENDING_EXTERNAL_DESTRUCTION
-          - :EXTERNAL_DESTRUCTION_FAILED
+        output: true
   - !ruby/object:Api::Type::String
     name: 'purpose'
     description: |

--- a/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go
@@ -150,6 +150,10 @@ func TestAccKmsCryptoKey_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testGoogleKmsCryptoKey_basic(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_kms_crypto_key.crypto_key", "primary"),
+				),
+
 			},
 			{
 				ResourceName:            "google_kms_crypto_key.crypto_key",
@@ -172,7 +176,6 @@ func TestAccKmsCryptoKey_basic(t *testing.T) {
 					testAccCheckGoogleKmsCryptoKeyWasRemovedFromState("google_kms_crypto_key.crypto_key"),
 					testAccCheckGoogleKmsCryptoKeyVersionsDestroyed(t, projectId, location, keyRingName, cryptoKeyName),
 					testAccCheckGoogleKmsCryptoKeyRotationDisabled(t, projectId, location, keyRingName, cryptoKeyName),
-					resource.TestCheckResourceAttrSet("google_kms_crypto_key.crypto_key", "primary"),
 				),
 			},
 		},

--- a/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go
@@ -172,6 +172,7 @@ func TestAccKmsCryptoKey_basic(t *testing.T) {
 					testAccCheckGoogleKmsCryptoKeyWasRemovedFromState("google_kms_crypto_key.crypto_key"),
 					testAccCheckGoogleKmsCryptoKeyVersionsDestroyed(t, projectId, location, keyRingName, cryptoKeyName),
 					testAccCheckGoogleKmsCryptoKeyRotationDisabled(t, projectId, location, keyRingName, cryptoKeyName),
+					resource.TestCheckResourceAttrSet("google_kms_crypto_key.crypto_key", "primary"),
 				),
 			},
 		},

--- a/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go
@@ -151,7 +151,7 @@ func TestAccKmsCryptoKey_basic(t *testing.T) {
 			{
 				Config: testGoogleKmsCryptoKey_basic(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("google_kms_crypto_key.crypto_key", "primary.0"),
+					resource.TestCheckResourceAttrSet("google_kms_crypto_key.crypto_key", "primary.0.name"),
 				),
 			},
 			{

--- a/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go
@@ -153,7 +153,6 @@ func TestAccKmsCryptoKey_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("google_kms_crypto_key.crypto_key", "primary.0"),
 				),
-
 			},
 			{
 				ResourceName:            "google_kms_crypto_key.crypto_key",

--- a/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go
@@ -151,7 +151,7 @@ func TestAccKmsCryptoKey_basic(t *testing.T) {
 			{
 				Config: testGoogleKmsCryptoKey_basic(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("google_kms_crypto_key.crypto_key", "primary"),
+					resource.TestCheckResourceAttrSet("google_kms_crypto_key.crypto_key", "primary.0"),
 				),
 
 			},


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/5688

Add primary version attribute for crypto key resource as per https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys

Note: This only adds the `name` and `status` attributes of the version object, not the [complete version object](https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys.cryptoKeyVersions#CryptoKeyVersion), as my thinking was that these attributes are unlikely to be used and add unnecessary clutter, but I'm open to input on this. 

Allows primary version attributes to be referenced as an attribute of the crypto key as
```
resource "google_kms_crypto_key" "example-key" {
  name            = "crypto-key-example"
  key_ring        = <some keyring>
}

output "key_primary_version_name" {
  value = google_kms_crypto_key.example-key.primary[0].name
}

output "key_primary_version_state" {
  value = google_kms_crypto_key.example-key.primary[0].state
}
```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
Add output-only `primary` version attribute to `google_kms_crypto_key` resource

```
