### PR TITLE
bq analyticshub listing - add support for restrictedExportConfig

### DIFF
--- a/mmv1/products/bigqueryanalyticshub/Listing.yaml
+++ b/mmv1/products/bigqueryanalyticshub/Listing.yaml
@@ -53,6 +53,19 @@ examples:
       data_exchange_id: 'my_data_exchange'
       listing_id: 'my_listing'
       description: 'example data exchange'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'bigquery_analyticshub_listing_restricted'
+    primary_resource_id: 'listing'
+    primary_resource_name: "fmt.Sprintf(\"tf_test_my_data_exchange%s\",
+      context[\"\
+      random_suffix\"]), fmt.Sprintf(\"tf_test_my_listing%s\",
+      context[\"random_suffix\"\
+      ])"
+    region_override: 'US'
+    vars:
+      data_exchange_id: 'my_data_exchange'
+      listing_id: 'my_listing'
+      description: 'example data exchange'
 properties:
   - !ruby/object:Api::Type::String
     name: name
@@ -146,3 +159,15 @@ properties:
           projects/myproject/datasets/123
         required: true
         diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
+  - !ruby/object:Api::Type::NestedObject
+    name: restrictedExportConfig
+    description: if set, restricted export configuration will be propagated and enforced on the linked dataset.
+    properties:
+      - !ruby/object:Api::Type::Boolean
+        name: 'enabled'
+        description:
+          If true, enable restricted export.
+      - !ruby/object:Api::Type::Boolean
+        name: 'restrictQueryResult'
+        description:
+           If true, restrict export of query result derived from restricted linked dataset table.

--- a/mmv1/products/bigqueryanalyticshub/Listing.yaml
+++ b/mmv1/products/bigqueryanalyticshub/Listing.yaml
@@ -170,4 +170,4 @@ properties:
       - !ruby/object:Api::Type::Boolean
         name: 'restrictQueryResult'
         description:
-           If true, restrict export of query result derived from restricted linked dataset table.
+          If true, restrict export of query result derived from restricted linked dataset table.

--- a/mmv1/products/bigqueryanalyticshub/Listing.yaml
+++ b/mmv1/products/bigqueryanalyticshub/Listing.yaml
@@ -161,7 +161,7 @@ properties:
         diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
   - !ruby/object:Api::Type::NestedObject
     name: restrictedExportConfig
-    description: if set, restricted export configuration will be propagated and enforced on the linked dataset.
+    description: If set, restricted export configuration will be propagated and enforced on the linked dataset.
     properties:
       - !ruby/object:Api::Type::Boolean
         name: 'enabled'

--- a/mmv1/templates/terraform/examples/bigquery_analyticshub_listing_restricted.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_analyticshub_listing_restricted.tf.erb
@@ -1,0 +1,30 @@
+resource "google_bigquery_analytics_hub_data_exchange" "<%= ctx[:primary_resource_id] %>" {
+  location         = "US"
+  data_exchange_id = "<%= ctx[:vars]['data_exchange_id'] %>"
+  display_name     = "<%= ctx[:vars]['data_exchange_id'] %>"
+  description      = "<%= ctx[:vars]['description'] %>"
+}
+
+resource "google_bigquery_analytics_hub_listing" "<%= ctx[:primary_resource_id] %>" {
+  location         = "US"
+  data_exchange_id = google_bigquery_analytics_hub_data_exchange.<%= ctx[:primary_resource_id] %>.data_exchange_id
+  listing_id       = "<%= ctx[:vars]['listing_id'] %>"
+  display_name     = "<%= ctx[:vars]['listing_id'] %>"
+  description      = "<%= ctx[:vars]['description'] %>"
+
+  bigquery_dataset {
+    dataset = google_bigquery_dataset.<%= ctx[:primary_resource_id] %>.id
+  }
+
+  restricted_export_config {
+    enabled               = true
+    restrict_query_result = true
+  }
+}
+
+resource "google_bigquery_dataset" "<%= ctx[:primary_resource_id] %>" {
+  dataset_id                  = "<%= ctx[:vars]['listing_id'] %>"
+  friendly_name               = "<%= ctx[:vars]['listing_id'] %>"
+  description                 = "<%= ctx[:vars]['description'] %>"
+  location                    = "US"
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigqueryanalyticshub: added `restricted_export_config` field to `google_bigquery_analytics_hub_listing ` resource
```
