### PR TITLE
Disable test edgecontainer_local_control_plane_node_pool_internal

### DIFF
--- a/mmv1/products/edgecontainer/NodePool.yaml
+++ b/mmv1/products/edgecontainer/NodePool.yaml
@@ -67,11 +67,13 @@ examples:
   # to avoid leaking the machine name, and node location to public.
   # Skip the vcr test because as we only have limited machine resources and we don't want it run
   # in github presubmit test.
+  # TODO: enable the test when GDCE have extra prod rack for TF e2e testing.
   - !ruby/object:Provider::Terraform::Examples
     name: "edgecontainer_local_control_plane_node_pool_internal"
     primary_resource_id: "default"
     skip_docs: true
     skip_vcr: true
+    skip_test: true
 parameters:
   - !ruby/object:Api::Type::String
     name: "name"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to --> Disable test edgecontainer_local_control_plane_node_pool_internal issue raise in b/309602739 where gdce don't have enough prod machines for TF e2e testing.


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
