### PR TITLE
Ignore type lifecycle changes

### DIFF
--- a/mmv1/products/vmwareengine/PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/PrivateCloud.yaml
@@ -290,8 +290,10 @@ properties:
     name: 'type'
     description: |
       Initial type of the private cloud.
+
+      **Note:** Set `lifecycle.ignore_changes = [type]` when upgrading a TIME_LIMITED PC to STANDARD by increasing its node count.
+
     immutable: true
-    ignore_read: true
     values:
       - :STANDARD
       - :TIME_LIMITED

--- a/mmv1/templates/terraform/examples/vmware_engine_private_cloud_full.tf.erb
+++ b/mmv1/templates/terraform/examples/vmware_engine_private_cloud_full.tf.erb
@@ -16,6 +16,11 @@ resource "google_vmwareengine_private_cloud" "<%= ctx[:primary_resource_id] %>" 
       custom_core_count = 32
     }
   }
+
+  # Ignore changes to type for TIME_LIMITED Private Clouds
+  lifecycle {
+    ignore_changes = [type]
+  }
 }
 
 resource "google_vmwareengine_network" "pc-nw" {

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_address_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_address_test.go
@@ -16,7 +16,7 @@ func TestAccVmwareengineExternalAddress_vmwareEngineExternalAddressUpdate(t *tes
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"region":        "southamerica-east1", // using region with low node utilization.
+		"region":        "southamerica-west1", // using region with low node utilization.
 		"random_suffix": acctest.RandString(t, 10),
 	}
 

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
@@ -41,16 +41,7 @@ func TestAccVmwareenginePrivateCloud_vmwareEnginePrivateCloudUpdate(t *testing.T
 				ImportStateVerifyIgnore: []string{"location", "name", "update_time", "type"},
 			},
 			{
-				Config: testPrivateCloudUpdateConfig(context, "description2", 4), // Expand PC
-			},
-			{
-				ResourceName:            "google_vmwareengine_private_cloud.vmw-engine-pc",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "name", "update_time", "type"},
-			},
-			{
-				Config: testPrivateCloudUpdateConfig(context, "description2", 3), // Shrink PC
+				Config: testPrivateCloudUpdateConfig(context, "description2", 3), // Upgrade to STANDARD PC
 			},
 			{
 				ResourceName:            "google_vmwareengine_private_cloud.vmw-engine-pc",
@@ -90,6 +81,11 @@ resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
       node_count = "%{node_count}"
       custom_core_count = 32
     }
+  }
+
+  # Ignore changes to type for TIME_LIMITED Private Clouds
+  lifecycle {
+    ignore_changes = [type]
   }
 }
 


### PR DESCRIPTION
Ignore type lifecycle changes in case of a TIME_LIMITED PC

Setting `ignore_read:true` (#9608)  for Type raises the following error (#9656)
```
vcr_utils.go:152: Step 1/6 error: Check failed: Check 1/3 error: type is ; want TIME_LIMITED
```
Hence, instead using lifecycle.ignore_changes in case of a type modification on the Private Cloud resource. 

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
vmwareengine: added `lifecycle.ignore_changes` for `type` in examples of `google_vmwareengine_private_cloud` 
```
