### PR TITLE
Update more gke tests to use bootstrapped network

### DIFF
--- a/mmv1/products/gkebackup/BackupPlan.yaml
+++ b/mmv1/products/gkebackup/BackupPlan.yaml
@@ -45,8 +45,12 @@ examples:
       name: 'basic-plan'
       cluster_name: 'basic-cluster'
       deletion_protection: 'true'
+      network_name: 'default'
+      subnetwork_name: 'default'
     test_vars_overrides:
       deletion_protection: 'false'
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      subnetwork_name: 'acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       deletion_protection: 'false'
     test_env_vars:
@@ -58,8 +62,12 @@ examples:
       name: 'autopilot-plan'
       cluster_name: 'autopilot-cluster'
       deletion_protection: 'true'
+      network_name: 'default'
+      subnetwork_name: 'default'
     test_vars_overrides:
       deletion_protection: 'false'
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      subnetwork_name: 'acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       deletion_protection: 'false'
   - !ruby/object:Provider::Terraform::Examples
@@ -70,8 +78,12 @@ examples:
       cluster_name: 'cmek-cluster'
       key_name: 'backup-key'
       deletion_protection: 'true'
+      network_name: 'default'
+      subnetwork_name: 'default'
     test_vars_overrides:
       deletion_protection: 'false'
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      subnetwork_name: 'acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       deletion_protection: 'false'
     test_env_vars:
@@ -83,8 +95,12 @@ examples:
       name: 'full-plan'
       cluster_name: 'full-cluster'
       deletion_protection: 'true'
+      network_name: 'default'
+      subnetwork_name: 'default'
     test_vars_overrides:
       deletion_protection: 'false'
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      subnetwork_name: 'acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       deletion_protection: 'false'
     test_env_vars:

--- a/mmv1/products/gkebackup/RestorePlan.yaml
+++ b/mmv1/products/gkebackup/RestorePlan.yaml
@@ -43,11 +43,15 @@ examples:
       ])"
     vars:
       name: 'restore-all-ns'
+      network_name: 'default'
+      subnetwork_name: 'default'
     test_env_vars:
       project: :PROJECT_NAME
       deletion_protection: 'true'
     test_vars_overrides:
       deletion_protection: 'false'
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      subnetwork_name: 'acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       deletion_protection: 'false'
   - !ruby/object:Provider::Terraform::Examples
@@ -55,11 +59,15 @@ examples:
     primary_resource_id: 'rollback_ns'
     vars:
       name: 'rollback-ns'
+      network_name: 'default'
+      subnetwork_name: 'default'
     test_env_vars:
       project: :PROJECT_NAME
       deletion_protection: 'true'
     test_vars_overrides:
       deletion_protection: 'false'
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      subnetwork_name: 'acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       deletion_protection: 'false'
   - !ruby/object:Provider::Terraform::Examples
@@ -67,11 +75,15 @@ examples:
     primary_resource_id: 'rollback_app'
     vars:
       name: 'rollback-app'
+      network_name: 'default'
+      subnetwork_name: 'default'
     test_env_vars:
       project: :PROJECT_NAME
       deletion_protection: 'true'
     test_vars_overrides:
       deletion_protection: 'false'
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      subnetwork_name: 'acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       deletion_protection: 'false'
   - !ruby/object:Provider::Terraform::Examples
@@ -79,11 +91,15 @@ examples:
     primary_resource_id: 'all_cluster_resources'
     vars:
       name: 'all-groupkinds'
+      network_name: 'default'
+      subnetwork_name: 'default'
     test_env_vars:
       project: :PROJECT_NAME
       deletion_protection: 'true'
     test_vars_overrides:
       deletion_protection: 'false'
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      subnetwork_name: 'acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       deletion_protection: 'false'
   - !ruby/object:Provider::Terraform::Examples
@@ -91,11 +107,15 @@ examples:
     primary_resource_id: 'rename_ns'
     vars:
       name: 'rename-ns'
+      network_name: 'default'
+      subnetwork_name: 'default'
     test_env_vars:
       project: :PROJECT_NAME
       deletion_protection: 'true'
     test_vars_overrides:
       deletion_protection: 'false'
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      subnetwork_name: 'acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       deletion_protection: 'false'
   - !ruby/object:Provider::Terraform::Examples
@@ -103,11 +123,15 @@ examples:
     primary_resource_id: 'transform_rule'
     vars:
       name: 'transform-rule'
+      network_name: 'default'
+      subnetwork_name: 'default'
     test_env_vars:
       project: :PROJECT_NAME
       deletion_protection: 'true'
     test_vars_overrides:
       deletion_protection: 'false'
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      subnetwork_name: 'acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       deletion_protection: 'false'
 skip_sweeper: true

--- a/mmv1/products/gkehub/Membership.yaml
+++ b/mmv1/products/gkehub/Membership.yaml
@@ -61,7 +61,12 @@ examples:
     primary_resource_id: 'membership'
     vars:
       name: 'basic'
-      cluster_name: 'basiccluster'
+      cluster_name: 'basic-cluster'
+      network_name: 'default'
+      subnetwork_name: 'default'
+    test_vars_overrides:
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      subnetwork_name: 'acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     test_env_vars:
       project: :PROJECT_NAME
       location: :REGION
@@ -71,10 +76,14 @@ examples:
     primary_resource_id: 'membership'
     vars:
       name: 'basic'
-      cluster_name: 'basiccluster'
+      cluster_name: 'basic-cluster'
       deletion_protection: 'true'
+      network_name: 'default'
+      subnetwork_name: 'default'
     test_vars_overrides:
       deletion_protection: 'false'
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      subnetwork_name: 'acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       deletion_protection: 'false'
   - !ruby/object:Provider::Terraform::Examples
@@ -82,10 +91,14 @@ examples:
     primary_resource_id: 'membership'
     vars:
       name: 'basic'
-      cluster_name: 'basiccluster'
+      cluster_name: 'basic-cluster'
       deletion_protection: 'true'
+      network_name: 'default'
+      subnetwork_name: 'default'
     test_vars_overrides:
       deletion_protection: 'false'
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      subnetwork_name: 'acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       deletion_protection: 'false'
     test_env_vars:

--- a/mmv1/products/gkehub2/MembershipBinding.yaml
+++ b/mmv1/products/gkehub2/MembershipBinding.yaml
@@ -50,10 +50,14 @@ examples:
     primary_resource_name: "fmt.Sprintf(\"tf-test-membership%s\", context[\"random_suffix\"]), fmt.Sprintf(\"tf-test-membership-binding%s\", context[\"random_suffix\"])"
     primary_resource_id: "membership_binding"
     vars:
-      cluster_name: "basiccluster"
+      cluster_name: "basic-cluster"
       deletion_protection: 'true'
+      network_name: 'default'
+      subnetwork_name: 'default'
     test_vars_overrides:
       deletion_protection: 'false'
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      subnetwork_name: 'acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       deletion_protection: 'false'
     test_env_vars:

--- a/mmv1/products/gkehub2/MembershipRBACRoleBinding.yaml
+++ b/mmv1/products/gkehub2/MembershipRBACRoleBinding.yaml
@@ -50,10 +50,14 @@ examples:
     primary_resource_id: 'membership_rbac_role_binding'
     min_version: beta
     vars:
-      cluster_name: "basiccluster"
+      cluster_name: "basic-cluster"
       deletion_protection: 'true'
+      network_name: 'default'
+      subnetwork_name: 'default'
     test_vars_overrides:
       deletion_protection: 'false'
+      network_name: 'acctest.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      subnetwork_name: 'acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       deletion_protection: 'false'
     test_env_vars:

--- a/mmv1/templates/terraform/examples/gkebackup_backupplan_autopilot.tf.erb
+++ b/mmv1/templates/terraform/examples/gkebackup_backupplan_autopilot.tf.erb
@@ -13,6 +13,8 @@ resource "google_container_cluster" "primary" {
     }
   }
   deletion_protection  = "<%= ctx[:vars]['deletion_protection'] %>"
+  network       = "<%= ctx[:vars]['network_name'] %>"
+  subnetwork    = "<%= ctx[:vars]['subnetwork_name'] %>"
 }
 
 resource "google_gke_backup_backup_plan" "autopilot" {

--- a/mmv1/templates/terraform/examples/gkebackup_backupplan_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/gkebackup_backupplan_basic.tf.erb
@@ -11,6 +11,8 @@ resource "google_container_cluster" "primary" {
     }
   }
   deletion_protection  = "<%= ctx[:vars]['deletion_protection'] %>"
+  network       = "<%= ctx[:vars]['network_name'] %>"
+  subnetwork    = "<%= ctx[:vars]['subnetwork_name'] %>"
 }
 
 resource "google_gke_backup_backup_plan" "basic" {

--- a/mmv1/templates/terraform/examples/gkebackup_backupplan_cmek.tf.erb
+++ b/mmv1/templates/terraform/examples/gkebackup_backupplan_cmek.tf.erb
@@ -11,6 +11,8 @@ resource "google_container_cluster" "primary" {
     }
   }
   deletion_protection  = "<%= ctx[:vars]['deletion_protection'] %>"
+  network       = "<%= ctx[:vars]['network_name'] %>"
+  subnetwork    = "<%= ctx[:vars]['subnetwork_name'] %>"
 }
 
 resource "google_gke_backup_backup_plan" "cmek" {

--- a/mmv1/templates/terraform/examples/gkebackup_backupplan_full.tf.erb
+++ b/mmv1/templates/terraform/examples/gkebackup_backupplan_full.tf.erb
@@ -13,6 +13,7 @@ resource "google_container_cluster" "primary" {
   deletion_protection  = "<%= ctx[:vars]['deletion_protection'] %>"
   network       = "<%= ctx[:vars]['network_name'] %>"
   subnetwork    = "<%= ctx[:vars]['subnetwork_name'] %>"
+}
 
 resource "google_gke_backup_backup_plan" "full" {
   name = "<%= ctx[:vars]['name'] %>"

--- a/mmv1/templates/terraform/examples/gkebackup_backupplan_full.tf.erb
+++ b/mmv1/templates/terraform/examples/gkebackup_backupplan_full.tf.erb
@@ -11,7 +11,8 @@ resource "google_container_cluster" "primary" {
     }
   }
   deletion_protection  = "<%= ctx[:vars]['deletion_protection'] %>"
-}
+  network       = "<%= ctx[:vars]['network_name'] %>"
+  subnetwork    = "<%= ctx[:vars]['subnetwork_name'] %>"
 
 resource "google_gke_backup_backup_plan" "full" {
   name = "<%= ctx[:vars]['name'] %>"

--- a/mmv1/templates/terraform/examples/gkebackup_restoreplan_all_cluster_resources.tf.erb
+++ b/mmv1/templates/terraform/examples/gkebackup_restoreplan_all_cluster_resources.tf.erb
@@ -11,6 +11,8 @@ resource "google_container_cluster" "primary" {
     }
   }
   deletion_protection  = "<%= ctx[:vars]['deletion_protection'] %>"
+  network       = "<%= ctx[:vars]['network_name'] %>"
+  subnetwork    = "<%= ctx[:vars]['subnetwork_name'] %>"
 }
 
 resource "google_gke_backup_backup_plan" "basic" {

--- a/mmv1/templates/terraform/examples/gkebackup_restoreplan_all_namespaces.tf.erb
+++ b/mmv1/templates/terraform/examples/gkebackup_restoreplan_all_namespaces.tf.erb
@@ -11,6 +11,8 @@ resource "google_container_cluster" "primary" {
     }
   }
   deletion_protection  = "<%= ctx[:vars]['deletion_protection'] %>"
+  network       = "<%= ctx[:vars]['network_name'] %>"
+  subnetwork    = "<%= ctx[:vars]['subnetwork_name'] %>"
 }
 
 resource "google_gke_backup_backup_plan" "basic" {

--- a/mmv1/templates/terraform/examples/gkebackup_restoreplan_protected_application.tf.erb
+++ b/mmv1/templates/terraform/examples/gkebackup_restoreplan_protected_application.tf.erb
@@ -11,6 +11,8 @@ resource "google_container_cluster" "primary" {
     }
   }
   deletion_protection  = "<%= ctx[:vars]['deletion_protection'] %>"
+  network       = "<%= ctx[:vars]['network_name'] %>"
+  subnetwork    = "<%= ctx[:vars]['subnetwork_name'] %>"
 }
 
 resource "google_gke_backup_backup_plan" "basic" {

--- a/mmv1/templates/terraform/examples/gkebackup_restoreplan_rename_namespace.tf.erb
+++ b/mmv1/templates/terraform/examples/gkebackup_restoreplan_rename_namespace.tf.erb
@@ -11,6 +11,8 @@ resource "google_container_cluster" "primary" {
     }
   }
   deletion_protection  = "<%= ctx[:vars]['deletion_protection'] %>"
+  network       = "<%= ctx[:vars]['network_name'] %>"
+  subnetwork    = "<%= ctx[:vars]['subnetwork_name'] %>"
 }
 
 resource "google_gke_backup_backup_plan" "basic" {

--- a/mmv1/templates/terraform/examples/gkebackup_restoreplan_rollback_namespace.tf.erb
+++ b/mmv1/templates/terraform/examples/gkebackup_restoreplan_rollback_namespace.tf.erb
@@ -11,6 +11,8 @@ resource "google_container_cluster" "primary" {
     }
   }
   deletion_protection  = "<%= ctx[:vars]['deletion_protection'] %>"
+  network       = "<%= ctx[:vars]['network_name'] %>"
+  subnetwork    = "<%= ctx[:vars]['subnetwork_name'] %>"
 }
 
 resource "google_gke_backup_backup_plan" "basic" {

--- a/mmv1/templates/terraform/examples/gkebackup_restoreplan_second_transformation.tf.erb
+++ b/mmv1/templates/terraform/examples/gkebackup_restoreplan_second_transformation.tf.erb
@@ -11,6 +11,8 @@ resource "google_container_cluster" "primary" {
     }
   }
   deletion_protection  = "<%= ctx[:vars]['deletion_protection'] %>"
+  network       = "<%= ctx[:vars]['network_name'] %>"
+  subnetwork    = "<%= ctx[:vars]['subnetwork_name'] %>"
 }
 
 resource "google_gke_backup_backup_plan" "basic" {

--- a/mmv1/templates/terraform/examples/gkehub_membership_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/gkehub_membership_basic.tf.erb
@@ -3,6 +3,8 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection  = "<%= ctx[:vars]['deletion_protection'] %>"
+  network       = "<%= ctx[:vars]['network_name'] %>"
+  subnetwork    = "<%= ctx[:vars]['subnetwork_name'] %>"
 }
 
 resource "google_gke_hub_membership" "membership" {

--- a/mmv1/templates/terraform/examples/gkehub_membership_binding_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/gkehub_membership_binding_basic.tf.erb
@@ -3,6 +3,8 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection  = "<%= ctx[:vars]['deletion_protection'] %>"
+  network       = "<%= ctx[:vars]['network_name'] %>"
+  subnetwork    = "<%= ctx[:vars]['subnetwork_name'] %>"
 }
 
 resource "google_gke_hub_membership" "membership" {

--- a/mmv1/templates/terraform/examples/gkehub_membership_issuer.tf.erb
+++ b/mmv1/templates/terraform/examples/gkehub_membership_issuer.tf.erb
@@ -6,6 +6,8 @@ resource "google_container_cluster" "primary" {
     workload_pool = "<%= ctx[:test_env_vars]['project'] %>.svc.id.goog"
   }
   deletion_protection  = "<%= ctx[:vars]['deletion_protection'] %>"
+  network       = "<%= ctx[:vars]['network_name'] %>"
+  subnetwork    = "<%= ctx[:vars]['subnetwork_name'] %>"
 }
 
 resource "google_gke_hub_membership" "membership" {

--- a/mmv1/templates/terraform/examples/gkehub_membership_rbac_role_binding_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/gkehub_membership_rbac_role_binding_basic.tf.erb
@@ -4,6 +4,8 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection  = "<%= ctx[:vars]['deletion_protection'] %>"
+  network       = "<%= ctx[:vars]['network_name'] %>"
+  subnetwork    = "<%= ctx[:vars]['subnetwork_name'] %>"
 }
 
 resource "google_gke_hub_membership" "membership" {

--- a/mmv1/templates/terraform/examples/gkehub_membership_regional.tf.erb
+++ b/mmv1/templates/terraform/examples/gkehub_membership_regional.tf.erb
@@ -3,6 +3,8 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection = false
+  network       = "<%= ctx[:vars]['network_name'] %>"
+  subnetwork    = "<%= ctx[:vars]['subnetwork_name'] %>"
 }
 
 resource "google_gke_hub_membership" "membership" {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -175,13 +175,16 @@ func TestAccContainerCluster_withAddons(t *testing.T) {
 func TestAccContainerCluster_withDeletionProtection(t *testing.T) {
 	t.Parallel()
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withDeletionProtection(clusterName, "false"),
+				Config: testAccContainerCluster_withDeletionProtection(clusterName, networkName, subnetworkName, "false"),
 			},
 			{
 				ResourceName:            "google_container_cluster.primary",
@@ -190,15 +193,15 @@ func TestAccContainerCluster_withDeletionProtection(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_withDeletionProtection(clusterName, "true"),
+				Config: testAccContainerCluster_withDeletionProtection(clusterName, networkName, subnetworkName, "true"),
 			},
 			{
-				Config: testAccContainerCluster_withDeletionProtection(clusterName, "true"),
+				Config: testAccContainerCluster_withDeletionProtection(clusterName, networkName, subnetworkName, "true"),
 				Destroy:     true,
 				ExpectError: regexp.MustCompile("Cannot destroy cluster because deletion_protection is set to true. Set it to false to proceed with cluster deletion."),
 			},
 			{
-				Config: testAccContainerCluster_withDeletionProtection(clusterName, "false"),
+				Config: testAccContainerCluster_withDeletionProtection(clusterName, networkName, subnetworkName, "false"),
 			},
 		},
 	})
@@ -2064,6 +2067,8 @@ func TestAccContainerCluster_withNodePoolNamePrefix(t *testing.T) {
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 	npNamePrefix := "tf-test-np-"
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -2072,7 +2077,7 @@ func TestAccContainerCluster_withNodePoolNamePrefix(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withNodePoolNamePrefix(clusterName, npNamePrefix),
+				Config: testAccContainerCluster_withNodePoolNamePrefix(clusterName, npNamePrefix, networkName, subnetworkName),
 			},
 			{
 				ResourceName:			 "google_container_cluster.with_node_pool_name_prefix",
@@ -2800,6 +2805,8 @@ func TestAccContainerCluster_withShieldedNodes(t *testing.T) {
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
@@ -2807,7 +2814,7 @@ func TestAccContainerCluster_withShieldedNodes(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withShieldedNodes(clusterName, true),
+				Config: testAccContainerCluster_withShieldedNodes(clusterName, networkName, subnetworkName, true),
 			},
 			{
 				ResourceName:		 "google_container_cluster.with_shielded_nodes",
@@ -2816,7 +2823,7 @@ func TestAccContainerCluster_withShieldedNodes(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_withShieldedNodes(clusterName, false),
+				Config: testAccContainerCluster_withShieldedNodes(clusterName, networkName, subnetworkName, false),
 			},
 			{
 				ResourceName:		 "google_container_cluster.with_shielded_nodes",
@@ -3369,6 +3376,8 @@ func TestAccContainerCluster_withBinaryAuthorizationEvaluationModeAutopilot(t *t
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
@@ -3376,7 +3385,7 @@ func TestAccContainerCluster_withBinaryAuthorizationEvaluationModeAutopilot(t *t
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withBinaryAuthorizationEvaluationMode(clusterName, true, "PROJECT_SINGLETON_POLICY_ENFORCE"),
+				Config: testAccContainerCluster_withBinaryAuthorizationEvaluationMode(clusterName, true, "PROJECT_SINGLETON_POLICY_ENFORCE", networkName, subnetworkName),
 			},
 			{
 				ResourceName:		 "google_container_cluster.with_binary_authorization_evaluation_mode",
@@ -3385,7 +3394,7 @@ func TestAccContainerCluster_withBinaryAuthorizationEvaluationModeAutopilot(t *t
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_withBinaryAuthorizationEvaluationMode(clusterName, true, "DISABLED"),
+				Config: testAccContainerCluster_withBinaryAuthorizationEvaluationMode(clusterName, true, "DISABLED", networkName, subnetworkName),
 			},
 			{
 				ResourceName:		 "google_container_cluster.with_binary_authorization_evaluation_mode",
@@ -3401,6 +3410,8 @@ func TestAccContainerCluster_withBinaryAuthorizationEvaluationModeClassic(t *tes
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
@@ -3408,7 +3419,7 @@ func TestAccContainerCluster_withBinaryAuthorizationEvaluationModeClassic(t *tes
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withBinaryAuthorizationEvaluationMode(clusterName, false, "PROJECT_SINGLETON_POLICY_ENFORCE"),
+				Config: testAccContainerCluster_withBinaryAuthorizationEvaluationMode(clusterName, false, "PROJECT_SINGLETON_POLICY_ENFORCE", networkName, subnetworkName),
 			},
 			{
 				ResourceName:		 "google_container_cluster.with_binary_authorization_evaluation_mode",
@@ -3417,7 +3428,7 @@ func TestAccContainerCluster_withBinaryAuthorizationEvaluationModeClassic(t *tes
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_withBinaryAuthorizationEvaluationMode(clusterName, false, "DISABLED"),
+				Config: testAccContainerCluster_withBinaryAuthorizationEvaluationMode(clusterName, false, "DISABLED", networkName, subnetworkName),
 			},
 			{
 				ResourceName:		 "google_container_cluster.with_binary_authorization_evaluation_mode",
@@ -3904,6 +3915,8 @@ func TestAccContainerCluster_withAdvancedDatapath(t *testing.T) {
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.AccTestPreCheck(t) },
@@ -3911,7 +3924,7 @@ func TestAccContainerCluster_withAdvancedDatapath(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withDatapathProvider(clusterName, "ADVANCED_DATAPATH"),
+				Config: testAccContainerCluster_withDatapathProvider(clusterName, "ADVANCED_DATAPATH", networkName, subnetworkName),
 			},
 			{
 				ResourceName:        "google_container_cluster.primary",
@@ -4301,7 +4314,7 @@ func TestAccContainerCluster_withFleetConfig(t *testing.T) {
 		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withFleetConfig(clusterName, projectID),
+				Config: testAccContainerCluster_withFleetConfig(clusterName, projectID, networkName, subnetworkName),
 			},
 			{
 				ResourceName:            "google_container_cluster.primary",
@@ -4310,7 +4323,7 @@ func TestAccContainerCluster_withFleetConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
 			},
 			{
-				Config:		testAccContainerCluster_withFleetConfig(clusterName, "random-project"),
+				Config:		testAccContainerCluster_withFleetConfig(clusterName, "random-project", networkName, subnetworkName),
 				ExpectError: regexp.MustCompile(`changing existing fleet host project is not supported`),
 			},
 			{
@@ -4378,19 +4391,23 @@ resource "google_container_cluster" "primary" {
   }
 
   deletion_protection = false
+  network    = "%s"
+  subnetwork    = "%s"
 }
-`, name, projectID)
+`, name, projectID, networkName, subnetworkName)
 }
 
-func testAccContainerCluster_DisableFleet(resource_name string) string {
+func testAccContainerCluster_DisableFleet(resource_name, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
   name               = "%s"
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection = false
+  network    = "%s"
+  subnetwork    = "%s"
 }
-`, resource_name)
+`, resource_name, networkName, subnetworkName)
 }
 
 func testAccContainerCluster_withIncompatibleMasterVersionNodeVersion(name string) string {
@@ -4482,13 +4499,16 @@ func TestAccContainerCluster_autopilot_net_admin(t *testing.T) {
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_autopilot_net_admin(clusterName, true),
+				Config: testAccContainerCluster_autopilot_net_admin(clusterName, networkName, subnetworkName, true),
 			},
 			{
 				ResourceName:      "google_container_cluster.primary",
@@ -4497,7 +4517,7 @@ func TestAccContainerCluster_autopilot_net_admin(t *testing.T) {
 				ImportStateVerifyIgnore:	[]string{"min_master_version", "deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_autopilot_net_admin(clusterName, false),
+				Config: testAccContainerCluster_autopilot_net_admin(clusterName, networkName, subnetworkName, false),
 			},
 			{
 				ResourceName:      "google_container_cluster.primary",
@@ -4506,7 +4526,7 @@ func TestAccContainerCluster_autopilot_net_admin(t *testing.T) {
 				ImportStateVerifyIgnore:	[]string{"min_master_version", "deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_autopilot_net_admin(clusterName, true),
+				Config: testAccContainerCluster_autopilot_net_admin(clusterName, networkName, subnetworkName, true),
 			},
 			{
 				ResourceName:      "google_container_cluster.primary",
@@ -5175,7 +5195,7 @@ resource "google_container_cluster" "with_network_policy_enabled" {
 `, clusterName, networkName, subnetworkName)
 }
 
-func testAccContainerCluster_withDeletionProtection(clusterName string, deletionProtection string) string {
+func testAccContainerCluster_withDeletionProtection(clusterName, networkName, subnetworkName, deletionProtection string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
   name               = "%s"
@@ -5183,8 +5203,10 @@ resource "google_container_cluster" "primary" {
   initial_node_count = 1
 
   deletion_protection = %s
+  network    = "%s"
+  subnetwork    = "%s"
 }
-`, clusterName, deletionProtection)
+`, clusterName, deletionProtection, networkName, subnetworkName)
 }
 
 func testAccContainerCluster_withReleaseChannelEnabled(clusterName, channel, networkName, subnetworkName string) string {
@@ -7064,7 +7086,7 @@ resource "google_container_cluster" "with_node_pool" {
 `, cluster, nodePool, networkName, subnetworkName)
 }
 
-func testAccContainerCluster_withNodePoolNamePrefix(cluster, npPrefix string) string {
+func testAccContainerCluster_withNodePoolNamePrefix(cluster, npPrefix, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_node_pool_name_prefix" {
   name     = "%s"
@@ -7075,8 +7097,10 @@ resource "google_container_cluster" "with_node_pool_name_prefix" {
     node_count  = 2
   }
   deletion_protection = false
+  network    = "%s"
+  subnetwork    = "%s"
 }
-`, cluster, npPrefix)
+`, cluster, npPrefix, networkName, subnetworkName)
 }
 
 func testAccContainerCluster_withNodePoolMultiple(cluster, npPrefix, networkName, subnetworkName string) string {
@@ -7788,7 +7812,7 @@ resource "google_container_cluster" "with_private_cluster" {
 `, clusterName, masterGlobalAccessEnabled, networkName, subnetworkName)
 }
 
-func testAccContainerCluster_withShieldedNodes(clusterName string, enabled bool) string {
+func testAccContainerCluster_withShieldedNodes(clusterName, networkName, subnetworkName string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_shielded_nodes" {
   name               = "%s"
@@ -7797,8 +7821,10 @@ resource "google_container_cluster" "with_shielded_nodes" {
 
   enable_shielded_nodes = %v
   deletion_protection = false
+  network    = "%s"
+  subnetwork    = "%s"
 }
-`, clusterName, enabled)
+`, clusterName, enabled, networkName, subnetworkName)
 }
 
 func testAccContainerCluster_withWorkloadIdentityConfigEnabled(projectID, clusterName, networkName, subnetworkName string) string {
@@ -7980,7 +8006,7 @@ resource "google_container_cluster" "with_binary_authorization_enabled_bool" {
 `, clusterName, enabled, networkName, subnetworkName)
 }
 
-func testAccContainerCluster_withBinaryAuthorizationEvaluationMode(clusterName string, autopilot_enabled bool, evaluation_mode string) string {
+func testAccContainerCluster_withBinaryAuthorizationEvaluationMode(clusterName string, autopilot_enabled bool, evaluation_mode, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_binary_authorization_evaluation_mode" {
   name               = "%s"
@@ -7994,8 +8020,10 @@ resource "google_container_cluster" "with_binary_authorization_evaluation_mode" 
     evaluation_mode = "%s"
   }
   deletion_protection = false
+  network    = "%s"
+  subnetwork    = "%s"
 }
-`, clusterName, autopilot_enabled, evaluation_mode)
+`, clusterName, autopilot_enabled, evaluation_mode, networkName, subnetworkName)
 }
 
 func testAccContainerCluster_withFlexiblePodCIDR(containerNetName string, clusterName string) string {
@@ -8274,7 +8302,7 @@ resource "google_container_cluster" "primary" {
 `, kmsData.KeyRing.Name, kmsData.CryptoKey.Name, clusterName, networkName, subnetworkName)
 }
 
-func testAccContainerCluster_withDatapathProvider(clusterName, datapathProvider string) string {
+func testAccContainerCluster_withDatapathProvider(clusterName, datapathProvider, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
   name               = "%s"
@@ -8289,8 +8317,10 @@ resource "google_container_cluster" "primary" {
     channel = "RAPID"
   }
   deletion_protection = false
+  network    = "%s"
+  subnetwork    = "%s"
 }
-`, clusterName, datapathProvider)
+`, clusterName, datapathProvider, networkName, subnetworkName)
 }
 
 func testAccContainerCluster_withMasterAuthorizedNetworksDisabled(containerNetName string, clusterName string) string {
@@ -9013,7 +9043,7 @@ resource "google_container_cluster" "primary" {
 }`, name)
 }
 
-func testAccContainerCluster_autopilot_net_admin(name string, enabled bool) string {
+func testAccContainerCluster_autopilot_net_admin(name, networkName, subnetworkName string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
   name             = "%s"
@@ -9022,7 +9052,10 @@ resource "google_container_cluster" "primary" {
   allow_net_admin  = %t
   min_master_version = 1.27
   deletion_protection = false
-}`, name, enabled)
+  network    = "%s"
+  subnetwork    = "%s"
+}
+`, name, enabled, networkName, subnetworkName)
 }
 
 
@@ -9181,6 +9214,8 @@ func TestAccContainerCluster_withConfidentialBootDisk(t *testing.T) {
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
 	npName := fmt.Sprintf("tf-test-node-pool-%s", acctest.RandString(t, 10))
 	kms := acctest.BootstrapKMSKeyInLocation(t, "us-central1")
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
 	if acctest.BootstrapPSARole(t, "service-", "compute-system", "roles/cloudkms.cryptoKeyEncrypterDecrypter") {
 		t.Fatal("Stopping the test because a role was added to the policy.")
@@ -9192,7 +9227,7 @@ func TestAccContainerCluster_withConfidentialBootDisk(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withConfidentialBootDisk(clusterName, npName, kms.CryptoKey.Name),
+				Config: testAccContainerCluster_withConfidentialBootDisk(clusterName, npName, kms.CryptoKey.Name, networkName, subnetworkName),
 			},
 			{
 				ResourceName:            "google_container_cluster.with_confidential_boot_disk",
@@ -9204,31 +9239,33 @@ func TestAccContainerCluster_withConfidentialBootDisk(t *testing.T) {
 	})
 }
 
-func testAccContainerCluster_withConfidentialBootDisk(clusterName, npName, kmsKeyName string) string {
+func testAccContainerCluster_withConfidentialBootDisk(clusterName, npName, kmsKeyName, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_confidential_boot_disk" {
- name               = "%s"
- location           = "us-central1-a"
- release_channel {
- channel = "RAPID"
+  name               = "%s"
+  location           = "us-central1-a"
+  release_channel {
+  channel = "RAPID"
 }
- node_pool {
-  name = "%s"
-  initial_node_count = 1
-  node_config {
-  oauth_scopes = [
-    "https://www.googleapis.com/auth/cloud-platform",
-   ]
-  image_type = "COS_CONTAINERD"
-  boot_disk_kms_key = "%s"
-  machine_type = "n2-standard-2"
-  enable_confidential_storage = true
-  disk_type = "hyperdisk-balanced"
+  node_pool {
+    name = "%s"
+    initial_node_count = 1
+    node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+    ]
+    image_type = "COS_CONTAINERD"
+    boot_disk_kms_key = "%s"
+    machine_type = "n2-standard-2"
+    enable_confidential_storage = true
+    disk_type = "hyperdisk-balanced"
   }
 }
- deletion_protection = false
+  deletion_protection = false
+  network    = "%s"
+  subnetwork    = "%s"
 }
-`, clusterName, npName, kmsKeyName)
+`, clusterName, npName, kmsKeyName, networkName, subnetworkName)
 }
 
 func TestAccContainerCluster_withConfidentialBootDiskNodeConfig(t *testing.T) {
@@ -9236,6 +9273,8 @@ func TestAccContainerCluster_withConfidentialBootDiskNodeConfig(t *testing.T) {
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
 	kms := acctest.BootstrapKMSKeyInLocation(t, "us-central1")
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
 	if acctest.BootstrapPSARole(t, "service-", "compute-system", "roles/cloudkms.cryptoKeyEncrypterDecrypter") {
 		t.Fatal("Stopping the test because a role was added to the policy.")
@@ -9247,7 +9286,7 @@ func TestAccContainerCluster_withConfidentialBootDiskNodeConfig(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withConfidentialBootDiskNodeConfig(clusterName, kms.CryptoKey.Name),
+				Config: testAccContainerCluster_withConfidentialBootDiskNodeConfig(clusterName, kms.CryptoKey.Name, networkName, subnetworkName),
 			},
 			{
 				ResourceName:            "google_container_cluster.with_confidential_boot_disk_node_config",
@@ -9259,28 +9298,30 @@ func TestAccContainerCluster_withConfidentialBootDiskNodeConfig(t *testing.T) {
 	})
 }
 
-func testAccContainerCluster_withConfidentialBootDiskNodeConfig(clusterName, kmsKeyName string) string {
+func testAccContainerCluster_withConfidentialBootDiskNodeConfig(clusterName, kmsKeyName, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_confidential_boot_disk_node_config" {
- name               = "%s"
- location           = "us-central1-a"
- initial_node_count = 1
- release_channel {
-   channel = "RAPID"
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  release_channel {
+    channel = "RAPID"
   }
- node_config {
-  oauth_scopes = [
-    "https://www.googleapis.com/auth/cloud-platform",
-  ]
- image_type = "COS_CONTAINERD"
- boot_disk_kms_key = "%s"
- machine_type = "n2-standard-2"
- enable_confidential_storage = true
- disk_type = "hyperdisk-balanced"
- }
-deletion_protection = false
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+    ]
+    image_type = "COS_CONTAINERD"
+    boot_disk_kms_key = "%s"
+    machine_type = "n2-standard-2"
+    enable_confidential_storage = true
+    disk_type = "hyperdisk-balanced"
+  }
+  deletion_protection = false
+  network    = "%s"
+  subnetwork    = "%s"
 }
-`, clusterName, kmsKeyName)
+`, clusterName, kmsKeyName, networkName, subnetworkName)
 }
 
 func TestAccContainerCluster_withoutConfidentialBootDisk(t *testing.T) {
@@ -9288,6 +9329,8 @@ func TestAccContainerCluster_withoutConfidentialBootDisk(t *testing.T) {
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
 	npName := fmt.Sprintf("tf-test-cluster-nodepool-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
@@ -9295,7 +9338,7 @@ func TestAccContainerCluster_withoutConfidentialBootDisk(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withoutConfidentialBootDisk(clusterName, npName),
+				Config: testAccContainerCluster_withoutConfidentialBootDisk(clusterName, npName, networkName, subnetworkName),
 			},
 			{
 				ResourceName:            "google_container_cluster.without_confidential_boot_disk",
@@ -9306,30 +9349,32 @@ func TestAccContainerCluster_withoutConfidentialBootDisk(t *testing.T) {
 		},
 	})
 }
-func testAccContainerCluster_withoutConfidentialBootDisk(clusterName string, npName string) string {
+func testAccContainerCluster_withoutConfidentialBootDisk(clusterName, npName, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "without_confidential_boot_disk" {
- name               = "%s"
- location           = "us-central1-a"
- release_channel {
-   channel = "RAPID"
+  name               = "%s"
+  location           = "us-central1-a"
+  release_channel {
+    channel = "RAPID"
   }
- node_pool {
-  name = "%s"
-  initial_node_count = 1
-  node_config {
-  oauth_scopes = [
-   "https://www.googleapis.com/auth/cloud-platform",
-  ]
-  image_type = "COS_CONTAINERD"
-  machine_type = "n2-standard-2"
-  enable_confidential_storage = false
-  disk_type = "pd-balanced"
+  node_pool {
+    name = "%s"
+    initial_node_count = 1
+    node_config {
+      oauth_scopes = [
+       "https://www.googleapis.com/auth/cloud-platform",
+      ]
+      image_type = "COS_CONTAINERD"
+      machine_type = "n2-standard-2"
+      enable_confidential_storage = false
+      disk_type = "pd-balanced"
+    }
   }
+  deletion_protection = false
+  network    = "%s"
+  subnetwork    = "%s"
 }
- deletion_protection = false
-}
-`, clusterName, npName)
+`, clusterName, npName, networkName, subnetworkName)
 }
 <% end -%>
 

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -4306,6 +4306,8 @@ func TestAccContainerCluster_withFleetConfig(t *testing.T) {
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 	projectID := envvar.GetTestProjectFromEnv()
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -4327,7 +4329,7 @@ func TestAccContainerCluster_withFleetConfig(t *testing.T) {
 				ExpectError: regexp.MustCompile(`changing existing fleet host project is not supported`),
 			},
 			{
-				Config: testAccContainerCluster_DisableFleet(clusterName),
+				Config: testAccContainerCluster_DisableFleet(clusterName, networkName, subnetworkName),
 			},
 			{
 				ResourceName:      "google_container_cluster.primary",
@@ -4379,7 +4381,7 @@ func TestAccContainerCluster_withWorkloadALTSConfig(t *testing.T) {
 }
 <% end -%>
 
-func testAccContainerCluster_withFleetConfig(name, projectID string) string {
+func testAccContainerCluster_withFleetConfig(name, projectID, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
   name               = "%s"

--- a/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_backup_plan_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_backup_plan_test.go.erb
@@ -14,10 +14,10 @@ func TestAccGKEBackupBackupPlan_update(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"project":       envvar.GetTestProjectFromEnv(),
-		"random_suffix": acctest.RandString(t, 10),
-		"network_name" := acctest.BootstrapSharedTestNetwork(t, "gke-cluster"),
-		"subnetwork_name" := acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster")),
+		"project":         envvar.GetTestProjectFromEnv(),
+		"random_suffix":   acctest.RandString(t, 10),
+		"network_name":    acctest.BootstrapSharedTestNetwork(t, "gke-cluster"),
+		"subnetwork_name": acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster")),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_backup_plan_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_backup_plan_test.go.erb
@@ -16,6 +16,8 @@ func TestAccGKEBackupBackupPlan_update(t *testing.T) {
 	context := map[string]interface{}{
 		"project":       envvar.GetTestProjectFromEnv(),
 		"random_suffix": acctest.RandString(t, 10),
+		"network_name" := acctest.BootstrapSharedTestNetwork(t, "gke-cluster"),
+		"subnetwork_name" := acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster")),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -55,21 +57,23 @@ resource "google_container_cluster" "primary" {
     workload_pool = "%{project}.svc.id.goog"
   }
   addons_config {
-	gke_backup_agent_config {
-	  enabled = true
-	}
+    gke_backup_agent_config {
+      enabled = true
+    }
   }
   deletion_protection = false
+  network       = "%{network_name}"
+  subnetwork    = "%{subnetwork_name}"
 }
-	
+
 resource "google_gke_backup_backup_plan" "backupplan" {
   name = "tf-test-testplan%{random_suffix}"
   cluster = google_container_cluster.primary.id
   location = "us-central1"
   backup_config {
-	include_volume_data = false
-	include_secrets = false
-	all_namespaces = true
+    include_volume_data = false
+    include_secrets = false
+    all_namespaces = true
   }
   labels = {
     "some-key-1": "some-value-1"
@@ -88,11 +92,13 @@ resource "google_container_cluster" "primary" {
     workload_pool = "%{project}.svc.id.goog"
   }
   addons_config {
-	gke_backup_agent_config {
-	  enabled = true
-	}
+    gke_backup_agent_config {
+      enabled = true
+    }
   }
   deletion_protection = false
+  network       = "%{network_name}"
+  subnetwork    = "%{subnetwork_name}"
 }
 	
 resource "google_gke_backup_backup_plan" "backupplan" {
@@ -100,24 +106,24 @@ resource "google_gke_backup_backup_plan" "backupplan" {
   cluster = google_container_cluster.primary.id
   location = "us-central1"
   retention_policy {
-	backup_delete_lock_days = 30
-	backup_retain_days = 180
+    backup_delete_lock_days = 30
+    backup_retain_days = 180
   }
   backup_schedule {
     cron_schedule = "0 9 * * 1"
   }
   backup_config {
-	include_volume_data = true
-	include_secrets = true
-	selected_applications {
-	  namespaced_names {
-	    name = "app1"
-	    namespace = "ns1"
-	  }
-	  namespaced_names {
-	    name = "app2"
-	    namespace = "ns2"
-	  }
+    include_volume_data = true
+    include_secrets = true
+    selected_applications {
+      namespaced_names {
+        name = "app1"
+        namespace = "ns1"
+      }
+      namespaced_names {
+        name = "app2"
+        namespace = "ns2"
+      }
     }
   }
   labels = {

--- a/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.erb
@@ -325,8 +325,8 @@ func TestAccGKEHubFeatureMembership_gkehubFeatureAcmAllFields(t *testing.T) {
 		"random_suffix":   acctest.RandString(t, 10),
 		"org_id":          envvar.GetTestOrgFromEnv(t),
 		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
-		"network_name" := acctest.BootstrapSharedTestNetwork(t, "gke-cluster"),
-		"subnetwork_name" := acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster")),
+		"network_name" :   acctest.BootstrapSharedTestNetwork(t, "gke-cluster"),
+		"subnetwork_name": acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster")),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -777,8 +777,8 @@ func TestAccGKEHubFeatureMembership_gkehubFeatureMesh(t *testing.T) {
 		"random_suffix":   acctest.RandString(t, 10),
 		"org_id":          envvar.GetTestOrgFromEnv(t),
 		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
-		"network_name" := acctest.BootstrapSharedTestNetwork(t, "gke-cluster"),
-		"subnetwork_name" := acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster")),
+		"network_name":    acctest.BootstrapSharedTestNetwork(t, "gke-cluster"),
+		"subnetwork_name": acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster")),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.erb
@@ -325,6 +325,8 @@ func TestAccGKEHubFeatureMembership_gkehubFeatureAcmAllFields(t *testing.T) {
 		"random_suffix":   acctest.RandString(t, 10),
 		"org_id":          envvar.GetTestOrgFromEnv(t),
 		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
+		"network_name" := acctest.BootstrapSharedTestNetwork(t, "gke-cluster"),
+		"subnetwork_name" := acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster")),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -388,6 +390,8 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection = false
+  network       = "%{network_name}"
+  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub]
 }
 
@@ -454,6 +458,8 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection = false
+  network       = "%{network_name}"
+  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub]
 }
 
@@ -521,6 +527,8 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection = false
+  network       = "%{network_name}"
+  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub, google_project_service.acm]
 }
 
@@ -769,6 +777,8 @@ func TestAccGKEHubFeatureMembership_gkehubFeatureMesh(t *testing.T) {
 		"random_suffix":   acctest.RandString(t, 10),
 		"org_id":          envvar.GetTestOrgFromEnv(t),
 		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
+		"network_name" := acctest.BootstrapSharedTestNetwork(t, "gke-cluster"),
+		"subnetwork_name" := acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster")),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -821,6 +831,8 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection = false
+  network       = "%{network_name}"
+  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.container, google_project_service.gkehub]
 }
 
@@ -874,6 +886,8 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection = false
+  network       = "%{network_name}"
+  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.container, google_project_service.gkehub]
 }
 
@@ -926,6 +940,8 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection = false
+  network       = "%{network_name}"
+  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.container, google_project_service.gkehub]
 }
 
@@ -978,6 +994,8 @@ resource "google_container_cluster" "primary" {
   initial_node_count = 1
   project = google_project.project.project_id
   deletion_protection = false
+  network       = "%{network_name}"
+  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.container, google_project_service.container, google_project_service.gkehub]
 }
 
@@ -987,6 +1005,8 @@ resource "google_container_cluster" "secondary" {
   initial_node_count = 1
   project = google_project.project.project_id
   deletion_protection = false
+  network       = "%{network_name}"
+  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.container, google_project_service.container, google_project_service.gkehub]
 }
 
@@ -996,6 +1016,8 @@ resource "google_container_cluster" "tertiary" {
   initial_node_count = 1
   project = google_project.project.project_id
   deletion_protection = false
+  network       = "%{network_name}"
+  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.container, google_project_service.container, google_project_service.gkehub]
 }
 
@@ -1006,6 +1028,8 @@ resource "google_container_cluster" "quarternary" {
   initial_node_count = 1
   project = google_project.project.project_id
   deletion_protection = false
+  network       = "%{network_name}"
+  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.container, google_project_service.container, google_project_service.gkehub]
 }
 
@@ -1080,6 +1104,8 @@ resource "google_container_cluster" "container_acmoci" {
   network = google_compute_network.testnetwork.self_link
   project = google_project.project.project_id
   deletion_protection = false
+  network       = "%{network_name}"
+  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.container, google_project_service.container, google_project_service.gkehub]
 }
 

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go.erb
@@ -208,6 +208,8 @@ func TestAccGKEHubFeature_gkehubFeatureMciUpdate(t *testing.T) {
 		"random_suffix":   acctest.RandString(t, 10),
 		"org_id":          envvar.GetTestOrgFromEnv(t),
 		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
+		"network_name" :   acctest.BootstrapSharedTestNetwork(t, "gke-cluster"),
+		"subnetwork_name": acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster")),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -246,6 +248,8 @@ resource "google_container_cluster" "primary" {
   initial_node_count = 1
   project = google_project.project.project_id
   deletion_protection = false
+  network       = "%{network_name}"
+  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub]
 }
 
@@ -255,6 +259,8 @@ resource "google_container_cluster" "secondary" {
   initial_node_count = 1
   project = google_project.project.project_id
   deletion_protection = false
+  network       = "%{network_name}"
+  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub]
 }
 
@@ -299,6 +305,8 @@ resource "google_container_cluster" "primary" {
   initial_node_count = 1
   project = google_project.project.project_id
   deletion_protection = false
+  network       = "%{network_name}"
+  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub]
 }
 
@@ -308,6 +316,8 @@ resource "google_container_cluster" "secondary" {
   initial_node_count = 1
   project = google_project.project.project_id
   deletion_protection = false
+  network       = "%{network_name}"
+  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub]
 }
 

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_membership_binding_test.go
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_membership_binding_test.go
@@ -13,11 +13,11 @@ func TestAccGKEHub2MembershipBinding_gkehubMembershipBindingBasicExample_update(
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"project":       envvar.GetTestProjectFromEnv(),
-		"location":      envvar.GetTestRegionFromEnv(),
-		"random_suffix": acctest.RandString(t, 10),
-		"network_name" := acctest.BootstrapSharedTestNetwork(t, "gke-cluster"),
-		"subnetwork_name" := acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster")),
+		"project":         envvar.GetTestProjectFromEnv(),
+		"location":        envvar.GetTestRegionFromEnv(),
+		"random_suffix":   acctest.RandString(t, 10),
+		"network_name":    acctest.BootstrapSharedTestNetwork(t, "gke-cluster"),
+		"subnetwork_name": acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster")),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_membership_binding_test.go
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_membership_binding_test.go
@@ -16,6 +16,8 @@ func TestAccGKEHub2MembershipBinding_gkehubMembershipBindingBasicExample_update(
 		"project":       envvar.GetTestProjectFromEnv(),
 		"location":      envvar.GetTestRegionFromEnv(),
 		"random_suffix": acctest.RandString(t, 10),
+		"network_name" := acctest.BootstrapSharedTestNetwork(t, "gke-cluster"),
+		"subnetwork_name" := acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster")),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -51,6 +53,8 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection = false
+  network       = "%{network_name}"
+  subnetwork    = "%{subnetwork_name}"
 }
 
 resource "google_gke_hub_membership" "example" {
@@ -93,6 +97,8 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection = false
+  network       = "%{network_name}"
+  subnetwork    = "%{subnetwork_name}"
 }
 
 resource "google_gke_hub_membership" "example" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Bootstrap a dedicated network used in GKE cluster to avoid traffic to the default network

Previous PRs: https://github.com/GoogleCloudPlatform/magic-modules/pull/9265, https://github.com/GoogleCloudPlatform/magic-modules/pull/9348

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
