### PR TITLE
Adding md5auth key to bgp router peer

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go
@@ -329,7 +329,7 @@ func TestAccComputeRouterPeer_UpdateMd5AuthenticationKey(t *testing.T) {
 	t.Parallel()
 
 	routerName := fmt.Sprintf("tf-test-router-%s", acctest.RandString(t, 10))
-	resourceName := "google_compute_router_peer.foobar"
+	resourceName := "google_compute_router_peer.foobar1"
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
 package compute_test
 
 import (
@@ -303,6 +305,7 @@ func TestAccComputeRouterPeer_AddMd5AuthenticationKey(t *testing.T) {
 	t.Parallel()
 
 	routerName := fmt.Sprintf("tf-test-router-%s", acctest.RandString(t, 10))
+	resourceName := "google_compute_router_peer.foobar"
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
@@ -310,23 +313,11 @@ func TestAccComputeRouterPeer_AddMd5AuthenticationKey(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccComputeRouterPeerWithMd5AuthKey(routerName),
-				Check: testAccCheckComputeRouterPeerExists(
-					t, "google_compute_router_peer.foobar"),
-			},
-			{
-				ResourceName:      "google_compute_router_peer.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccComputeRouterPeerBasic(routerName),
-				Check: testAccCheckComputeRouterPeerExists(
-					t, "google_compute_router_peer.foobar"),
-			},
-			{
-				ResourceName:      "google_compute_router_peer.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "md5_authentication_key.#", "1"), // Check for one element in the list
+					resource.TestCheckResourceAttr(resourceName, "md5_authentication_key.0.name", fmt.Sprintf("%s-peer-key", routerName)),
+					resource.TestCheckResourceAttr(resourceName, "md5_authentication_key.0.key", fmt.Sprintf("%s-peer-key-value", routerName)),
+				),
 			},
 		},
 	})
@@ -344,23 +335,19 @@ func TestAccComputeRouterPeer_UpdateMd5AuthenticationKey(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccComputeRouterPeerWithMd5AuthKey(routerName),
-				Check: testAccCheckComputeRouterPeerExists(
-					t, "google_compute_router_peer.foobar"),
-			},
-			{
-				ResourceName:      "google_compute_router_peer.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "md5_authentication_key.#", "1"), // Check for one element in the list
+					resource.TestCheckResourceAttr(resourceName, "md5_authentication_key.0.name", fmt.Sprintf("%s-peer-key", routerName)),
+					resource.TestCheckResourceAttr(resourceName, "md5_authentication_key.0.key", fmt.Sprintf("%s-peer-key-value", routerName)),
+				),
 			},
 			{
 				Config: testAccComputeRouterPeerWithMd5AuthKeyUpdate(routerName),
-				Check: testAccCheckComputeRouterPeerExists(
-					t, resourceName),
-			},
-			{
-				ResourceName:      "google_compute_router_peer.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "md5_authentication_key.#", "1"), // Check for one element in the list
+					resource.TestCheckResourceAttr(resourceName, "md5_authentication_key.0.name", fmt.Sprintf("%s-peer-key", routerName)),
+					resource.TestCheckResourceAttr(resourceName, "md5_authentication_key.0.key", fmt.Sprintf("%s-peer-key-value-1", routerName)),
+				),
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go
@@ -303,7 +303,6 @@ func TestAccComputeRouterPeer_AddMd5AuthenticationKey(t *testing.T) {
 	t.Parallel()
 
 	routerName := fmt.Sprintf("tf-test-router-%s", acctest.RandString(t, 10))
-
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
@@ -354,7 +353,7 @@ func TestAccComputeRouterPeer_UpdateMd5AuthenticationKey(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeRouterPeerWithMd5AuthKey(routerName),
+				Config: testAccComputeRouterPeerWithMd5AuthKeyUpdate(routerName),
 				Check: testAccCheckComputeRouterPeerExists(
 					t, resourceName),
 			},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
 package compute_test
 
 import (
@@ -306,7 +304,7 @@ func TestAccComputeRouterPeer_AddMd5AuthenticationKey(t *testing.T) {
 
 	routerName := fmt.Sprintf("tf-test-router-%s", acctest.RandString(t, 10))
 	resourceName1 := "google_compute_router_peer.foobar"
-	resourceName2 := "google_compute_router_peer.foobar2"
+	resourceName2 := "google_compute_router_peer.foobar1"
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
@@ -316,11 +314,11 @@ func TestAccComputeRouterPeer_AddMd5AuthenticationKey(t *testing.T) {
 				Config: testAccComputeRouterPeerWithMd5AuthKey(routerName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName1, "md5_authentication_key.#", "1"), // Check for one element in the list
-					resource.TestCheckResourceAttr(resourceName1, "md5_authentication_key.0.name", fmt.Sprintf("%s-peer1-key", routerName)),
-					resource.TestCheckResourceAttr(resourceName1, "md5_authentication_key.0.key", fmt.Sprintf("%s-peer1-key-value", routerName)),
+					resource.TestCheckResourceAttr(resourceName1, "md5_authentication_key.0.name", fmt.Sprintf("%s-peer-key", routerName)),
+					resource.TestCheckResourceAttr(resourceName1, "md5_authentication_key.0.key", fmt.Sprintf("%s-peer-key-value", routerName)),
 					resource.TestCheckResourceAttr(resourceName2, "md5_authentication_key.#", "1"), // Check for one element in the list
-					resource.TestCheckResourceAttr(resourceName2, "md5_authentication_key.0.name", fmt.Sprintf("%s-peer3-key", routerName)),
-					resource.TestCheckResourceAttr(resourceName2, "md5_authentication_key.0.key", fmt.Sprintf("%s-peer3-key-value", routerName)),
+					resource.TestCheckResourceAttr(resourceName2, "md5_authentication_key.0.name", fmt.Sprintf("%s-peer1-key", routerName)),
+					resource.TestCheckResourceAttr(resourceName2, "md5_authentication_key.0.key", fmt.Sprintf("%s-peer1-key-value", routerName)),
 				),
 			},
 		},
@@ -656,7 +654,8 @@ func testAccComputeRouterPeerWithMd5AuthKey(routerName string) string {
       google_compute_router_peer.foobar
     ]
   }
-`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
+`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName,
+		routerName)
 }
 
 func testAccComputeRouterPeerWithMd5AuthKeyUpdate(routerName string) string {
@@ -763,7 +762,8 @@ func testAccComputeRouterPeerWithMd5AuthKeyUpdate(routerName string) string {
       google_compute_router_peer.foobar
     ]
   }
-`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
+`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName,
+		routerName)
 }
 
 func testAccComputeRouterPeerKeepRouter(routerName string) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go
@@ -299,6 +299,74 @@ func TestAccComputeRouterPeer_EnableDisableIpv6(t *testing.T) {
 	})
 }
 
+func TestAccComputeRouterPeer_AddMd5AuthenticationKey(t *testing.T) {
+	t.Parallel()
+
+	routerName := fmt.Sprintf("tf-test-router-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRouterPeerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRouterPeerWithMd5AuthKey(routerName),
+				Check: testAccCheckComputeRouterPeerExists(
+					t, "google_compute_router_peer.foobar"),
+			},
+			{
+				ResourceName:      "google_compute_router_peer.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterPeerBasic(routerName),
+				Check: testAccCheckComputeRouterPeerExists(
+					t, "google_compute_router_peer.foobar"),
+			},
+			{
+				ResourceName:      "google_compute_router_peer.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRouterPeer_UpdateMd5AuthenticationKey(t *testing.T) {
+	t.Parallel()
+
+	routerName := fmt.Sprintf("tf-test-router-%s", acctest.RandString(t, 10))
+	resourceName := "google_compute_router_peer.foobar"
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRouterPeerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRouterPeerWithMd5AuthKey(routerName),
+				Check: testAccCheckComputeRouterPeerExists(
+					t, "google_compute_router_peer.foobar"),
+			},
+			{
+				ResourceName:      "google_compute_router_peer.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterPeerWithMd5AuthKey(routerName),
+				Check: testAccCheckComputeRouterPeerExists(
+					t, resourceName),
+			},
+			{
+				ResourceName:      "google_compute_router_peer.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckComputeRouterPeerDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
@@ -492,6 +560,160 @@ resource "google_compute_router_peer" "foobar" {
   interface                 = google_compute_router_interface.foobar.name
 }
 `, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
+}
+
+func testAccComputeRouterPeerWithMd5AuthKey(routerName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  name = "%s-net"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "foobar" {
+  name          = "%s-subnet"
+  network       = google_compute_network.foobar.self_link
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+}
+
+resource "google_compute_address" "foobar" {
+  name   = "%s"
+  region = google_compute_subnetwork.foobar.region
+}
+
+resource "google_compute_ha_vpn_gateway" "foobar" {
+  name    = "%s-gateway"
+  network = google_compute_network.foobar.self_link
+  region  = google_compute_subnetwork.foobar.region
+}
+
+resource "google_compute_external_vpn_gateway" "external_gateway" {
+  name            = "%s-external-gateway"
+  redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
+  description     = "An externally managed VPN gateway"
+  interface {
+    id         = 0
+    ip_address = "8.8.8.8"
+  }
+}
+
+resource "google_compute_router" "foobar" {
+  name    = "%s"
+  region  = google_compute_subnetwork.foobar.region
+  network = google_compute_network.foobar.self_link
+  bgp {
+    asn = 64514
+  }
+}
+
+resource "google_compute_vpn_tunnel" "foobar" {
+  name               = "%s"
+  region             = google_compute_subnetwork.foobar.region
+  vpn_gateway = google_compute_ha_vpn_gateway.foobar.id
+  peer_external_gateway           = google_compute_external_vpn_gateway.external_gateway.id
+  peer_external_gateway_interface = 0  
+  shared_secret      = "unguessable"
+  router             = google_compute_router.foobar.name
+  vpn_gateway_interface           = 0
+}
+
+resource "google_compute_router_interface" "foobar" {
+  name       = "%s"
+  router     = google_compute_router.foobar.name
+  region     = google_compute_router.foobar.region
+  vpn_tunnel = google_compute_vpn_tunnel.foobar.name
+}
+
+resource "google_compute_router_peer" "foobar" {
+  name                      = "%s-peer"
+  router                    = google_compute_router.foobar.name
+  region                    = google_compute_router.foobar.region
+  peer_asn                  = 65515
+  advertised_route_priority = 100
+  interface                 = google_compute_router_interface.foobar.name
+  md5_authentication_key {
+    name = "%s-peer-key"
+    key = "%s-peer-key-value"
+  }
+}
+`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
+}
+
+func testAccComputeRouterPeerWithMd5AuthKeyUpdate(routerName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  name = "%s-net"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "foobar" {
+  name          = "%s-subnet"
+  network       = google_compute_network.foobar.self_link
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+}
+
+resource "google_compute_address" "foobar" {
+  name   = "%s"
+  region = google_compute_subnetwork.foobar.region
+}
+
+resource "google_compute_ha_vpn_gateway" "foobar" {
+  name    = "%s-gateway"
+  network = google_compute_network.foobar.self_link
+  region  = google_compute_subnetwork.foobar.region
+}
+
+resource "google_compute_external_vpn_gateway" "external_gateway" {
+  name            = "%s-external-gateway"
+  redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
+  description     = "An externally managed VPN gateway"
+  interface {
+    id         = 0
+    ip_address = "8.8.8.8"
+  }
+}
+
+resource "google_compute_router" "foobar" {
+  name    = "%s"
+  region  = google_compute_subnetwork.foobar.region
+  network = google_compute_network.foobar.self_link
+  bgp {
+    asn = 64514
+  }
+}
+
+resource "google_compute_vpn_tunnel" "foobar" {
+  name               = "%s"
+  region             = google_compute_subnetwork.foobar.region
+  vpn_gateway = google_compute_ha_vpn_gateway.foobar.id
+  peer_external_gateway           = google_compute_external_vpn_gateway.external_gateway.id
+  peer_external_gateway_interface = 0  
+  shared_secret      = "unguessable"
+  router             = google_compute_router.foobar.name
+  vpn_gateway_interface           = 0
+}
+
+resource "google_compute_router_interface" "foobar" {
+  name       = "%s"
+  router     = google_compute_router.foobar.name
+  region     = google_compute_router.foobar.region
+  vpn_tunnel = google_compute_vpn_tunnel.foobar.name
+}
+
+resource "google_compute_router_peer" "foobar" {
+  name                      = "%s-peer"
+  router                    = google_compute_router.foobar.name
+  region                    = google_compute_router.foobar.region
+  peer_asn                  = 65515
+  advertised_route_priority = 100
+  interface                 = google_compute_router_interface.foobar.name
+  md5_authentication_key {
+    name = "%s-peer-key"
+    key = "%s-peer-key-value-1"
+  }
+}
+`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
 }
 
 func testAccComputeRouterPeerKeepRouter(routerName string) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go
@@ -577,12 +577,6 @@ func testAccComputeRouterPeerWithMd5AuthKey(routerName string) string {
     region  = google_compute_subnetwork.foobar.region
   }
   
-  resource "google_compute_ha_vpn_gateway" "foobar1" {
-    name    = "%s-gateway1"
-    network = google_compute_network.foobar.self_link
-    region  = google_compute_subnetwork.foobar.region
-  }
-  
   resource "google_compute_external_vpn_gateway" "external_gateway" {
     name            = "%s-external-gateway"
     redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
@@ -613,22 +607,12 @@ func testAccComputeRouterPeerWithMd5AuthKey(routerName string) string {
     vpn_gateway_interface           = 0
   }
   
-  resource "google_compute_vpn_tunnel" "foobar1" {
-    name               = "%s1"
-    region             = google_compute_subnetwork.foobar.region
-    vpn_gateway = google_compute_ha_vpn_gateway.foobar1.id
-    peer_external_gateway           = google_compute_external_vpn_gateway.external_gateway.id
-    peer_external_gateway_interface = 0  
-    shared_secret      = "unguessable"
-    router             = google_compute_router.foobar.name
-    vpn_gateway_interface           = 0
-  }
-  
   resource "google_compute_router_interface" "foobar" {
     name       = "%s"
     router     = google_compute_router.foobar.name
     region     = google_compute_router.foobar.region
     vpn_tunnel = google_compute_vpn_tunnel.foobar.name
+    ip_range = "169.254.3.1/30"
   }
   
   resource "google_compute_router_interface" "foobar1" {
@@ -636,51 +620,43 @@ func testAccComputeRouterPeerWithMd5AuthKey(routerName string) string {
     router     = google_compute_router.foobar.name
     region     = google_compute_router.foobar.region
     vpn_tunnel = google_compute_vpn_tunnel.foobar.name
-  }
-  
-  resource "google_compute_router_interface" "foobar2" {
-    name       = "%s2"
-    router     = google_compute_router.foobar.name
-    region     = google_compute_router.foobar.region
-    vpn_tunnel = google_compute_vpn_tunnel.foobar1.name
+    ip_range = "169.254.4.1/30"
+    depends_on = [
+      google_compute_router_interface.foobar
+    ]
   }
   
   resource "google_compute_router_peer" "foobar" {
-    name                      = "%s-peer1"
+    name                      = "%s-peer"
     router                    = google_compute_router.foobar.name
     region                    = google_compute_router.foobar.region
     peer_asn                  = 65515
     advertised_route_priority = 100
     interface                 = google_compute_router_interface.foobar.name
+    peer_ip_address           = "169.254.3.2"
     md5_authentication_key {
-      name = "%s-peer1-key"
-      key = "%s-peer1-key-value"
+      name = "%s-peer-key"
+      key = "%s-peer-key-value"
     }
   }
   
   resource "google_compute_router_peer" "foobar1" {
-    name                      = "%s-peer2"
+    name                      = "%s-peer1"
     router                    = google_compute_router.foobar.name
     region                    = google_compute_router.foobar.region
     peer_asn                  = 65516
     advertised_route_priority = 100
     interface                 = google_compute_router_interface.foobar1.name
-  }
-  
-  resource "google_compute_router_peer" "foobar2" {
-    name                      = "%s-peer3"
-    router                    = google_compute_router.foobar.name
-    region                    = google_compute_router.foobar.region
-    peer_asn                  = 65517
-    advertised_route_priority = 100
-    interface                 = google_compute_router_interface.foobar2.name
+    peer_ip_address           = "169.254.4.2"
     md5_authentication_key {
-      name = "%s-peer3-key"
-      key = "%s-peer3-key-value"
+      name = "%s-peer1-key"
+      key = "%s-peer1-key-value"
     }
+    depends_on = [
+      google_compute_router_peer.foobar
+    ]
   }
-`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName,
-		routerName, routerName, routerName, routerName, routerName, routerName)
+`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
 }
 
 func testAccComputeRouterPeerWithMd5AuthKeyUpdate(routerName string) string {
@@ -708,12 +684,6 @@ func testAccComputeRouterPeerWithMd5AuthKeyUpdate(routerName string) string {
     region  = google_compute_subnetwork.foobar.region
   }
   
-  resource "google_compute_ha_vpn_gateway" "foobar1" {
-    name    = "%s-gateway1"
-    network = google_compute_network.foobar.self_link
-    region  = google_compute_subnetwork.foobar.region
-  }
-  
   resource "google_compute_external_vpn_gateway" "external_gateway" {
     name            = "%s-external-gateway"
     redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
@@ -744,22 +714,12 @@ func testAccComputeRouterPeerWithMd5AuthKeyUpdate(routerName string) string {
     vpn_gateway_interface           = 0
   }
   
-  resource "google_compute_vpn_tunnel" "foobar1" {
-    name               = "%s1"
-    region             = google_compute_subnetwork.foobar.region
-    vpn_gateway = google_compute_ha_vpn_gateway.foobar1.id
-    peer_external_gateway           = google_compute_external_vpn_gateway.external_gateway.id
-    peer_external_gateway_interface = 0  
-    shared_secret      = "unguessable"
-    router             = google_compute_router.foobar.name
-    vpn_gateway_interface           = 0
-  }
-  
   resource "google_compute_router_interface" "foobar" {
     name       = "%s"
     router     = google_compute_router.foobar.name
     region     = google_compute_router.foobar.region
     vpn_tunnel = google_compute_vpn_tunnel.foobar.name
+    ip_range = "169.254.3.1/30"
   }
   
   resource "google_compute_router_interface" "foobar1" {
@@ -767,51 +727,43 @@ func testAccComputeRouterPeerWithMd5AuthKeyUpdate(routerName string) string {
     router     = google_compute_router.foobar.name
     region     = google_compute_router.foobar.region
     vpn_tunnel = google_compute_vpn_tunnel.foobar.name
-  }
-  
-  resource "google_compute_router_interface" "foobar2" {
-    name       = "%s2"
-    router     = google_compute_router.foobar.name
-    region     = google_compute_router.foobar.region
-    vpn_tunnel = google_compute_vpn_tunnel.foobar1.name
+    ip_range = "169.254.4.1/30"
+    depends_on = [
+      google_compute_router_interface.foobar
+    ]
   }
   
   resource "google_compute_router_peer" "foobar" {
-    name                      = "%s-peer1"
+    name                      = "%s-peer"
     router                    = google_compute_router.foobar.name
     region                    = google_compute_router.foobar.region
     peer_asn                  = 65515
     advertised_route_priority = 100
     interface                 = google_compute_router_interface.foobar.name
+    peer_ip_address           = "169.254.3.2"
     md5_authentication_key {
-      name = "%s-peer1-key"
-      key = "%s-peer1-key-value-changed"
+      name = "%s-peer-key"
+      key = "%s-peer-key-value"
     }
   }
   
   resource "google_compute_router_peer" "foobar1" {
-    name                      = "%s-peer2"
+    name                      = "%s-peer1"
     router                    = google_compute_router.foobar.name
     region                    = google_compute_router.foobar.region
     peer_asn                  = 65516
     advertised_route_priority = 100
     interface                 = google_compute_router_interface.foobar1.name
-  }
-  
-  resource "google_compute_router_peer" "foobar2" {
-    name                      = "%s-peer3"
-    router                    = google_compute_router.foobar.name
-    region                    = google_compute_router.foobar.region
-    peer_asn                  = 65517
-    advertised_route_priority = 100
-    interface                 = google_compute_router_interface.foobar2.name
+    peer_ip_address           = "169.254.4.2"
     md5_authentication_key {
-      name = "%s-peer3-key"
-      key = "%s-peer3-key-value"
+      name = "%s-peer1-key"
+      key = "%s-peer1-key-value-changed"
     }
+    depends_on = [
+      google_compute_router_peer.foobar
+    ]
   }
-`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName,
-		routerName, routerName, routerName, routerName, routerName, routerName)
+`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
 }
 
 func testAccComputeRouterPeerKeepRouter(routerName string) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go
@@ -305,7 +305,8 @@ func TestAccComputeRouterPeer_AddMd5AuthenticationKey(t *testing.T) {
 	t.Parallel()
 
 	routerName := fmt.Sprintf("tf-test-router-%s", acctest.RandString(t, 10))
-	resourceName := "google_compute_router_peer.foobar"
+	resourceName1 := "google_compute_router_peer.foobar"
+	resourceName2 := "google_compute_router_peer.foobar2"
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
@@ -314,9 +315,12 @@ func TestAccComputeRouterPeer_AddMd5AuthenticationKey(t *testing.T) {
 			{
 				Config: testAccComputeRouterPeerWithMd5AuthKey(routerName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "md5_authentication_key.#", "1"), // Check for one element in the list
-					resource.TestCheckResourceAttr(resourceName, "md5_authentication_key.0.name", fmt.Sprintf("%s-peer-key", routerName)),
-					resource.TestCheckResourceAttr(resourceName, "md5_authentication_key.0.key", fmt.Sprintf("%s-peer-key-value", routerName)),
+					resource.TestCheckResourceAttr(resourceName1, "md5_authentication_key.#", "1"), // Check for one element in the list
+					resource.TestCheckResourceAttr(resourceName1, "md5_authentication_key.0.name", fmt.Sprintf("%s-peer1-key", routerName)),
+					resource.TestCheckResourceAttr(resourceName1, "md5_authentication_key.0.key", fmt.Sprintf("%s-peer1-key-value", routerName)),
+					resource.TestCheckResourceAttr(resourceName2, "md5_authentication_key.#", "1"), // Check for one element in the list
+					resource.TestCheckResourceAttr(resourceName2, "md5_authentication_key.0.name", fmt.Sprintf("%s-peer3-key", routerName)),
+					resource.TestCheckResourceAttr(resourceName2, "md5_authentication_key.0.key", fmt.Sprintf("%s-peer3-key-value", routerName)),
 				),
 			},
 		},
@@ -337,16 +341,16 @@ func TestAccComputeRouterPeer_UpdateMd5AuthenticationKey(t *testing.T) {
 				Config: testAccComputeRouterPeerWithMd5AuthKey(routerName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "md5_authentication_key.#", "1"), // Check for one element in the list
-					resource.TestCheckResourceAttr(resourceName, "md5_authentication_key.0.name", fmt.Sprintf("%s-peer-key", routerName)),
-					resource.TestCheckResourceAttr(resourceName, "md5_authentication_key.0.key", fmt.Sprintf("%s-peer-key-value", routerName)),
+					resource.TestCheckResourceAttr(resourceName, "md5_authentication_key.0.name", fmt.Sprintf("%s-peer1-key", routerName)),
+					resource.TestCheckResourceAttr(resourceName, "md5_authentication_key.0.key", fmt.Sprintf("%s-peer1-key-value", routerName)),
 				),
 			},
 			{
 				Config: testAccComputeRouterPeerWithMd5AuthKeyUpdate(routerName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "md5_authentication_key.#", "1"), // Check for one element in the list
-					resource.TestCheckResourceAttr(resourceName, "md5_authentication_key.0.name", fmt.Sprintf("%s-peer-key", routerName)),
-					resource.TestCheckResourceAttr(resourceName, "md5_authentication_key.0.key", fmt.Sprintf("%s-peer-key-value-1", routerName)),
+					resource.TestCheckResourceAttr(resourceName, "md5_authentication_key.0.name", fmt.Sprintf("%s-peer1-key", routerName)),
+					resource.TestCheckResourceAttr(resourceName, "md5_authentication_key.0.key", fmt.Sprintf("%s-peer1-key-value-changed", routerName)),
 				),
 			},
 		},
@@ -550,156 +554,264 @@ resource "google_compute_router_peer" "foobar" {
 
 func testAccComputeRouterPeerWithMd5AuthKey(routerName string) string {
 	return fmt.Sprintf(`
-resource "google_compute_network" "foobar" {
-  name = "%s-net"
-  auto_create_subnetworks = false
-}
-
-resource "google_compute_subnetwork" "foobar" {
-  name          = "%s-subnet"
-  network       = google_compute_network.foobar.self_link
-  ip_cidr_range = "10.0.0.0/16"
-  region        = "us-central1"
-}
-
-resource "google_compute_address" "foobar" {
-  name   = "%s"
-  region = google_compute_subnetwork.foobar.region
-}
-
-resource "google_compute_ha_vpn_gateway" "foobar" {
-  name    = "%s-gateway"
-  network = google_compute_network.foobar.self_link
-  region  = google_compute_subnetwork.foobar.region
-}
-
-resource "google_compute_external_vpn_gateway" "external_gateway" {
-  name            = "%s-external-gateway"
-  redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
-  description     = "An externally managed VPN gateway"
-  interface {
-    id         = 0
-    ip_address = "8.8.8.8"
+  resource "google_compute_network" "foobar" {
+    name = "%s-net"
+    auto_create_subnetworks = false
   }
-}
-
-resource "google_compute_router" "foobar" {
-  name    = "%s"
-  region  = google_compute_subnetwork.foobar.region
-  network = google_compute_network.foobar.self_link
-  bgp {
-    asn = 64514
+  
+  resource "google_compute_subnetwork" "foobar" {
+    name          = "%s-subnet"
+    network       = google_compute_network.foobar.self_link
+    ip_cidr_range = "10.0.0.0/16"
+    region        = "us-central1"
   }
-}
-
-resource "google_compute_vpn_tunnel" "foobar" {
-  name               = "%s"
-  region             = google_compute_subnetwork.foobar.region
-  vpn_gateway = google_compute_ha_vpn_gateway.foobar.id
-  peer_external_gateway           = google_compute_external_vpn_gateway.external_gateway.id
-  peer_external_gateway_interface = 0  
-  shared_secret      = "unguessable"
-  router             = google_compute_router.foobar.name
-  vpn_gateway_interface           = 0
-}
-
-resource "google_compute_router_interface" "foobar" {
-  name       = "%s"
-  router     = google_compute_router.foobar.name
-  region     = google_compute_router.foobar.region
-  vpn_tunnel = google_compute_vpn_tunnel.foobar.name
-}
-
-resource "google_compute_router_peer" "foobar" {
-  name                      = "%s-peer"
-  router                    = google_compute_router.foobar.name
-  region                    = google_compute_router.foobar.region
-  peer_asn                  = 65515
-  advertised_route_priority = 100
-  interface                 = google_compute_router_interface.foobar.name
-  md5_authentication_key {
-    name = "%s-peer-key"
-    key = "%s-peer-key-value"
+  
+  resource "google_compute_address" "foobar" {
+    name   = "%s"
+    region = google_compute_subnetwork.foobar.region
   }
-}
-`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
+  
+  resource "google_compute_ha_vpn_gateway" "foobar" {
+    name    = "%s-gateway"
+    network = google_compute_network.foobar.self_link
+    region  = google_compute_subnetwork.foobar.region
+  }
+  
+  resource "google_compute_ha_vpn_gateway" "foobar1" {
+    name    = "%s-gateway1"
+    network = google_compute_network.foobar.self_link
+    region  = google_compute_subnetwork.foobar.region
+  }
+  
+  resource "google_compute_external_vpn_gateway" "external_gateway" {
+    name            = "%s-external-gateway"
+    redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
+    description     = "An externally managed VPN gateway"
+    interface {
+      id         = 0
+      ip_address = "8.8.8.8"
+    }
+  }
+  
+  resource "google_compute_router" "foobar" {
+    name    = "%s"
+    region  = google_compute_subnetwork.foobar.region
+    network = google_compute_network.foobar.self_link
+    bgp {
+      asn = 64514
+    }
+  }
+  
+  resource "google_compute_vpn_tunnel" "foobar" {
+    name               = "%s"
+    region             = google_compute_subnetwork.foobar.region
+    vpn_gateway = google_compute_ha_vpn_gateway.foobar.id
+    peer_external_gateway           = google_compute_external_vpn_gateway.external_gateway.id
+    peer_external_gateway_interface = 0  
+    shared_secret      = "unguessable"
+    router             = google_compute_router.foobar.name
+    vpn_gateway_interface           = 0
+  }
+  
+  resource "google_compute_vpn_tunnel" "foobar1" {
+    name               = "%s1"
+    region             = google_compute_subnetwork.foobar.region
+    vpn_gateway = google_compute_ha_vpn_gateway.foobar1.id
+    peer_external_gateway           = google_compute_external_vpn_gateway.external_gateway.id
+    peer_external_gateway_interface = 0  
+    shared_secret      = "unguessable"
+    router             = google_compute_router.foobar.name
+    vpn_gateway_interface           = 0
+  }
+  
+  resource "google_compute_router_interface" "foobar" {
+    name       = "%s"
+    router     = google_compute_router.foobar.name
+    region     = google_compute_router.foobar.region
+    vpn_tunnel = google_compute_vpn_tunnel.foobar.name
+  }
+  
+  resource "google_compute_router_interface" "foobar1" {
+    name       = "%s1"
+    router     = google_compute_router.foobar.name
+    region     = google_compute_router.foobar.region
+    vpn_tunnel = google_compute_vpn_tunnel.foobar.name
+  }
+  
+  resource "google_compute_router_interface" "foobar2" {
+    name       = "%s2"
+    router     = google_compute_router.foobar.name
+    region     = google_compute_router.foobar.region
+    vpn_tunnel = google_compute_vpn_tunnel.foobar1.name
+  }
+  
+  resource "google_compute_router_peer" "foobar" {
+    name                      = "%s-peer1"
+    router                    = google_compute_router.foobar.name
+    region                    = google_compute_router.foobar.region
+    peer_asn                  = 65515
+    advertised_route_priority = 100
+    interface                 = google_compute_router_interface.foobar.name
+    md5_authentication_key {
+      name = "%s-peer1-key"
+      key = "%s-peer1-key-value"
+    }
+  }
+  
+  resource "google_compute_router_peer" "foobar1" {
+    name                      = "%s-peer2"
+    router                    = google_compute_router.foobar.name
+    region                    = google_compute_router.foobar.region
+    peer_asn                  = 65516
+    advertised_route_priority = 100
+    interface                 = google_compute_router_interface.foobar1.name
+  }
+  
+  resource "google_compute_router_peer" "foobar2" {
+    name                      = "%s-peer3"
+    router                    = google_compute_router.foobar.name
+    region                    = google_compute_router.foobar.region
+    peer_asn                  = 65517
+    advertised_route_priority = 100
+    interface                 = google_compute_router_interface.foobar2.name
+    md5_authentication_key {
+      name = "%s-peer3-key"
+      key = "%s-peer3-key-value"
+    }
+  }
+`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName,
+		routerName, routerName, routerName, routerName, routerName, routerName)
 }
 
 func testAccComputeRouterPeerWithMd5AuthKeyUpdate(routerName string) string {
 	return fmt.Sprintf(`
-resource "google_compute_network" "foobar" {
-  name = "%s-net"
-  auto_create_subnetworks = false
-}
-
-resource "google_compute_subnetwork" "foobar" {
-  name          = "%s-subnet"
-  network       = google_compute_network.foobar.self_link
-  ip_cidr_range = "10.0.0.0/16"
-  region        = "us-central1"
-}
-
-resource "google_compute_address" "foobar" {
-  name   = "%s"
-  region = google_compute_subnetwork.foobar.region
-}
-
-resource "google_compute_ha_vpn_gateway" "foobar" {
-  name    = "%s-gateway"
-  network = google_compute_network.foobar.self_link
-  region  = google_compute_subnetwork.foobar.region
-}
-
-resource "google_compute_external_vpn_gateway" "external_gateway" {
-  name            = "%s-external-gateway"
-  redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
-  description     = "An externally managed VPN gateway"
-  interface {
-    id         = 0
-    ip_address = "8.8.8.8"
+  resource "google_compute_network" "foobar" {
+    name = "%s-net"
+    auto_create_subnetworks = false
   }
-}
-
-resource "google_compute_router" "foobar" {
-  name    = "%s"
-  region  = google_compute_subnetwork.foobar.region
-  network = google_compute_network.foobar.self_link
-  bgp {
-    asn = 64514
+  
+  resource "google_compute_subnetwork" "foobar" {
+    name          = "%s-subnet"
+    network       = google_compute_network.foobar.self_link
+    ip_cidr_range = "10.0.0.0/16"
+    region        = "us-central1"
   }
-}
-
-resource "google_compute_vpn_tunnel" "foobar" {
-  name               = "%s"
-  region             = google_compute_subnetwork.foobar.region
-  vpn_gateway = google_compute_ha_vpn_gateway.foobar.id
-  peer_external_gateway           = google_compute_external_vpn_gateway.external_gateway.id
-  peer_external_gateway_interface = 0  
-  shared_secret      = "unguessable"
-  router             = google_compute_router.foobar.name
-  vpn_gateway_interface           = 0
-}
-
-resource "google_compute_router_interface" "foobar" {
-  name       = "%s"
-  router     = google_compute_router.foobar.name
-  region     = google_compute_router.foobar.region
-  vpn_tunnel = google_compute_vpn_tunnel.foobar.name
-}
-
-resource "google_compute_router_peer" "foobar" {
-  name                      = "%s-peer"
-  router                    = google_compute_router.foobar.name
-  region                    = google_compute_router.foobar.region
-  peer_asn                  = 65515
-  advertised_route_priority = 100
-  interface                 = google_compute_router_interface.foobar.name
-  md5_authentication_key {
-    name = "%s-peer-key"
-    key = "%s-peer-key-value-1"
+  
+  resource "google_compute_address" "foobar" {
+    name   = "%s"
+    region = google_compute_subnetwork.foobar.region
   }
-}
-`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
+  
+  resource "google_compute_ha_vpn_gateway" "foobar" {
+    name    = "%s-gateway"
+    network = google_compute_network.foobar.self_link
+    region  = google_compute_subnetwork.foobar.region
+  }
+  
+  resource "google_compute_ha_vpn_gateway" "foobar1" {
+    name    = "%s-gateway1"
+    network = google_compute_network.foobar.self_link
+    region  = google_compute_subnetwork.foobar.region
+  }
+  
+  resource "google_compute_external_vpn_gateway" "external_gateway" {
+    name            = "%s-external-gateway"
+    redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
+    description     = "An externally managed VPN gateway"
+    interface {
+      id         = 0
+      ip_address = "8.8.8.8"
+    }
+  }
+  
+  resource "google_compute_router" "foobar" {
+    name    = "%s"
+    region  = google_compute_subnetwork.foobar.region
+    network = google_compute_network.foobar.self_link
+    bgp {
+      asn = 64514
+    }
+  }
+  
+  resource "google_compute_vpn_tunnel" "foobar" {
+    name               = "%s"
+    region             = google_compute_subnetwork.foobar.region
+    vpn_gateway = google_compute_ha_vpn_gateway.foobar.id
+    peer_external_gateway           = google_compute_external_vpn_gateway.external_gateway.id
+    peer_external_gateway_interface = 0  
+    shared_secret      = "unguessable"
+    router             = google_compute_router.foobar.name
+    vpn_gateway_interface           = 0
+  }
+  
+  resource "google_compute_vpn_tunnel" "foobar1" {
+    name               = "%s1"
+    region             = google_compute_subnetwork.foobar.region
+    vpn_gateway = google_compute_ha_vpn_gateway.foobar1.id
+    peer_external_gateway           = google_compute_external_vpn_gateway.external_gateway.id
+    peer_external_gateway_interface = 0  
+    shared_secret      = "unguessable"
+    router             = google_compute_router.foobar.name
+    vpn_gateway_interface           = 0
+  }
+  
+  resource "google_compute_router_interface" "foobar" {
+    name       = "%s"
+    router     = google_compute_router.foobar.name
+    region     = google_compute_router.foobar.region
+    vpn_tunnel = google_compute_vpn_tunnel.foobar.name
+  }
+  
+  resource "google_compute_router_interface" "foobar1" {
+    name       = "%s1"
+    router     = google_compute_router.foobar.name
+    region     = google_compute_router.foobar.region
+    vpn_tunnel = google_compute_vpn_tunnel.foobar.name
+  }
+  
+  resource "google_compute_router_interface" "foobar2" {
+    name       = "%s2"
+    router     = google_compute_router.foobar.name
+    region     = google_compute_router.foobar.region
+    vpn_tunnel = google_compute_vpn_tunnel.foobar1.name
+  }
+  
+  resource "google_compute_router_peer" "foobar" {
+    name                      = "%s-peer1"
+    router                    = google_compute_router.foobar.name
+    region                    = google_compute_router.foobar.region
+    peer_asn                  = 65515
+    advertised_route_priority = 100
+    interface                 = google_compute_router_interface.foobar.name
+    md5_authentication_key {
+      name = "%s-peer1-key"
+      key = "%s-peer1-key-value-changed"
+    }
+  }
+  
+  resource "google_compute_router_peer" "foobar1" {
+    name                      = "%s-peer2"
+    router                    = google_compute_router.foobar.name
+    region                    = google_compute_router.foobar.region
+    peer_asn                  = 65516
+    advertised_route_priority = 100
+    interface                 = google_compute_router_interface.foobar1.name
+  }
+  
+  resource "google_compute_router_peer" "foobar2" {
+    name                      = "%s-peer3"
+    router                    = google_compute_router.foobar.name
+    region                    = google_compute_router.foobar.region
+    peer_asn                  = 65517
+    advertised_route_priority = 100
+    interface                 = google_compute_router_interface.foobar2.name
+    md5_authentication_key {
+      name = "%s-peer3-key"
+      key = "%s-peer3-key-value"
+    }
+  }
+`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName,
+		routerName, routerName, routerName, routerName, routerName, routerName)
 }
 
 func testAccComputeRouterPeerKeepRouter(routerName string) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	"github.com/hashicorp/terraform-provider-google/google/verify"
-
 )
 
 func ipv6RepresentationDiffSuppress(_, old, new string, d *schema.ResourceData) bool {
@@ -282,6 +281,29 @@ or deleted.`,
 				Computed: true,
 				ForceNew: true,
 			},
+			"md5_authentication_key": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Description: `Present if MD5 authentication is enabled for the peering. Must be the name
+of one of the entries in the Router.md5_authentication_keys. The field must comply with RFC1035.`,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"md5_authentication_key_name": {
+							Type:     schema.TypeString,
+							Required: true,
+							Description: `[REQUIRED] Name used to identify the key.
+Must be unique within a router. Must be referenced by exactly one bgpPeer. Must comply with RFC1035.`,
+						},
+						"md5_authentication_key_value": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `Value of the key.`,
+							Sensitive:   true,
+						},
+					},
+				},
+			},
 		},
 		UseJSONNumber: true,
 	}
@@ -384,6 +406,19 @@ func resourceComputeRouterBgpPeerCreate(d *schema.ResourceData, meta interface{}
 		return err
 	} else if v, ok := d.GetOkExists("peer_ipv6_nexthop_address"); !tpgresource.IsEmptyValue(reflect.ValueOf(peerIpv6NexthopAddressProp)) && (ok || !reflect.DeepEqual(v, peerIpv6NexthopAddressProp)) {
 		obj["peerIpv6NexthopAddress"] = peerIpv6NexthopAddressProp
+	}
+	md5AuthenticationKeyProp, err := expandNestedComputeRouterBgpPeerMd5AuthenticationKey(d.Get("md5_authentication_key"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("md5_authentication_key"); !tpgresource.IsEmptyValue(reflect.ValueOf(md5AuthenticationKeyProp)) && (ok || !reflect.DeepEqual(v, md5AuthenticationKeyProp)) {
+		/*some manual handling is required here as the parent cloud router object has a different layout for keyName and keyValue.
+		bgpPeer blocks in cloud router only specify the keyName to be used and the cloudRouter object has another block called
+		md5AuthenticationKeys which is an array which specify all the keys (name and value). The constraint here is that a key must
+		be used by exactly one bgpPeer to be considered valid.
+		*/
+		md5AuthenticationKeyName := md5AuthenticationKeyProp.(map[string]interface{})["md5AuthenticationKeyName"]
+		obj["md5AuthenticationKeyName"] = md5AuthenticationKeyName
+		obj["md5AuthenticationKey"] = md5AuthenticationKeyProp
 	}
 
 	lockName, err := tpgresource.ReplaceVars(d, config, "router/{{region}}/{{router}}")
@@ -552,6 +587,9 @@ func resourceComputeRouterBgpPeerRead(d *schema.ResourceData, meta interface{}) 
 	if err := d.Set("peer_ipv6_nexthop_address", flattenNestedComputeRouterBgpPeerPeerIpv6NexthopAddress(res["peerIpv6NexthopAddress"], d, config)); err != nil {
 		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
 	}
+	if err := d.Set("md5_authentication_key", flattenNestedComputeRouterBgpPeerMd5AuthenticationKey(res["md5AuthenticationKeyName"], d, config)); err != nil {
+		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
+	}
 
 	return nil
 }
@@ -649,6 +687,19 @@ func resourceComputeRouterBgpPeerUpdate(d *schema.ResourceData, meta interface{}
 		return err
 	} else if v, ok := d.GetOkExists("peer_ipv6_nexthop_address"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, peerIpv6NexthopAddressProp)) {
 		obj["peerIpv6NexthopAddress"] = peerIpv6NexthopAddressProp
+	}
+	md5AuthenticationKeyProp, err := expandNestedComputeRouterBgpPeerMd5AuthenticationKey(d.Get("md5_authentication_key"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("md5_authentication_key"); !tpgresource.IsEmptyValue(reflect.ValueOf(md5AuthenticationKeyProp)) && (ok || !reflect.DeepEqual(v, md5AuthenticationKeyProp)) {
+		/*some manual handling is required here as the parent cloud router object has a different layout for keyName and keyValue.
+		bgpPeer blocks in cloud router only specify the keyName to be used and the cloudRouter object has another block called
+		md5AuthenticationKeys which is an array which specify all the keys (name and value). The constraint here is that a key must
+		be used by exactly one bgpPeer to be considered valid.
+		*/
+		md5AuthenticationKeyName := md5AuthenticationKeyProp.(map[string]interface{})["md5AuthenticationKeyName"]
+		obj["md5AuthenticationKeyName"] = md5AuthenticationKeyName
+		obj["md5AuthenticationKey"] = md5AuthenticationKeyProp
 	}
 
 	lockName, err := tpgresource.ReplaceVars(d, config, "router/{{region}}/{{router}}")
@@ -881,6 +932,16 @@ func flattenNestedComputeRouterBgpPeerManagementType(v interface{}, d *schema.Re
 	return v
 }
 
+func flattenNestedComputeRouterBgpPeerMd5AuthenticationKey(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return nil
+	}
+
+	transformed := make(map[string]interface{})
+	transformed["md5AuthenticationKeyName"] = v
+	return []interface{}{transformed}
+}
+
 func flattenNestedComputeRouterBgpPeerBfd(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	if v == nil {
 		return nil
@@ -900,6 +961,7 @@ func flattenNestedComputeRouterBgpPeerBfd(v interface{}, d *schema.ResourceData,
 		flattenNestedComputeRouterBgpPeerBfdMultiplier(original["multiplier"], d, config)
 	return []interface{}{transformed}
 }
+
 func flattenNestedComputeRouterBgpPeerBfdSessionInitializationMode(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	return v
 }
@@ -1095,6 +1157,40 @@ func expandNestedComputeRouterBgpPeerBfd(v interface{}, d tpgresource.TerraformR
 	return transformed, nil
 }
 
+func expandNestedComputeRouterBgpPeerMd5AuthenticationKey(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+	transformed := make(map[string]interface{})
+
+	transformedMd5AuthenticationKeyName, err := expandNestedComputeRouterBgpPeerMd5AuthenticationKeyMd5AuthenticationKeyName(original["md5_authentication_key_name"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedMd5AuthenticationKeyName); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		transformed["md5AuthenticationKeyName"] = transformedMd5AuthenticationKeyName
+	}
+
+	transformedMd5AuthenticationKeyValue, err := expandNestedComputeRouterBgpPeerMd5AuthenticationKeyMd5AuthenticationKeyValue(original["md5_authentication_key_value"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedMd5AuthenticationKeyValue); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		transformed["md5AuthenticationKeyValue"] = transformedMd5AuthenticationKeyValue
+	}
+
+	return transformed, nil
+}
+
+func expandNestedComputeRouterBgpPeerMd5AuthenticationKeyMd5AuthenticationKeyName(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandNestedComputeRouterBgpPeerMd5AuthenticationKeyMd5AuthenticationKeyValue(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
 func expandNestedComputeRouterBgpPeerBfdSessionInitializationMode(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
 	return v, nil
 }
@@ -1194,12 +1290,12 @@ func resourceComputeRouterBgpPeerFindNestedObjectInList(d *schema.ResourceData, 
 // PatchCreateEncoder handles creating request data to PATCH parent resource
 // with list including new object.
 func resourceComputeRouterBgpPeerPatchCreateEncoder(d *schema.ResourceData, meta interface{}, obj map[string]interface{}) (map[string]interface{}, error) {
-	currItems, err := resourceComputeRouterBgpPeerListForPatch(d, meta)
+	currBgpPeerItems, currMd5AuthenticationKeys, err := resourceComputeRouterBgpPeerListForPatch(d, meta)
 	if err != nil {
 		return nil, err
 	}
 
-	_, found, err := resourceComputeRouterBgpPeerFindNestedObjectInList(d, meta, currItems)
+	_, found, err := resourceComputeRouterBgpPeerFindNestedObjectInList(d, meta, currBgpPeerItems)
 	if err != nil {
 		return nil, err
 	}
@@ -1209,9 +1305,24 @@ func resourceComputeRouterBgpPeerPatchCreateEncoder(d *schema.ResourceData, meta
 		return nil, fmt.Errorf("Unable to create RouterBgpPeer, existing object already found: %+v", found)
 	}
 
+	var res map[string]interface{}
+
 	// Return list with the resource to create appended
-	res := map[string]interface{}{
-		"bgpPeers": append(currItems, obj),
+	val, ok := obj["md5AuthenticationKey"]
+
+	if ok {
+		kvp := val.(map[string]interface{})
+		res = map[string]interface{}{
+			"bgpPeers":              append(currBgpPeerItems, obj),
+			"md5AuthenticationKeys": append(currMd5AuthenticationKeys, kvp),
+		}
+
+		//we need to remove this key from the object as it not a part of bgpRouterPeer
+		delete(obj, "md5AuthenticationKey")
+	} else {
+		res = map[string]interface{}{
+			"bgpPeers": append(currBgpPeerItems, obj),
+		}
 	}
 
 	return res, nil
@@ -1220,12 +1331,12 @@ func resourceComputeRouterBgpPeerPatchCreateEncoder(d *schema.ResourceData, meta
 // PatchUpdateEncoder handles creating request data to PATCH parent resource
 // with list including updated object.
 func resourceComputeRouterBgpPeerPatchUpdateEncoder(d *schema.ResourceData, meta interface{}, obj map[string]interface{}) (map[string]interface{}, error) {
-	items, err := resourceComputeRouterBgpPeerListForPatch(d, meta)
+	bgpPeerItems, md5AuthenticationKeys, err := resourceComputeRouterBgpPeerListForPatch(d, meta)
 	if err != nil {
 		return nil, err
 	}
 
-	idx, item, err := resourceComputeRouterBgpPeerFindNestedObjectInList(d, meta, items)
+	idx, item, err := resourceComputeRouterBgpPeerFindNestedObjectInList(d, meta, bgpPeerItems)
 	if err != nil {
 		return nil, err
 	}
@@ -1235,15 +1346,32 @@ func resourceComputeRouterBgpPeerPatchUpdateEncoder(d *schema.ResourceData, meta
 		return nil, fmt.Errorf("Unable to update RouterBgpPeer %q - not found in list", d.Id())
 	}
 
+	var kvp map[string]interface{}
+	val, ok := obj["md5AuthenticationKey"]
+	if ok {
+		kvp = val.(map[string]interface{})
+		//remove key from this map as it not needed here
+		delete(obj, "md5AuthenticationKey")
+	}
+
 	// Merge new object into old.
 	for k, v := range obj {
 		item[k] = v
 	}
-	items[idx] = item
+	bgpPeerItems[idx] = item
+
+	var res map[string]interface{}
 
 	// Return list with new item added
-	res := map[string]interface{}{
-		"bgpPeers": items,
+	if ok {
+		res = map[string]interface{}{
+			"bgpPeers":              append(bgpPeerItems, obj),
+			"md5AuthenticationKeys": append(md5AuthenticationKeys, kvp),
+		}
+	} else {
+		res = map[string]interface{}{
+			"bgpPeers": bgpPeerItems,
+		}
 	}
 
 	return res, nil
@@ -1252,7 +1380,7 @@ func resourceComputeRouterBgpPeerPatchUpdateEncoder(d *schema.ResourceData, meta
 // PatchDeleteEncoder handles creating request data to PATCH parent resource
 // with list excluding object to delete.
 func resourceComputeRouterBgpPeerPatchDeleteEncoder(d *schema.ResourceData, meta interface{}, obj map[string]interface{}) (map[string]interface{}, error) {
-	currItems, err := resourceComputeRouterBgpPeerListForPatch(d, meta)
+	currItems, _, err := resourceComputeRouterBgpPeerListForPatch(d, meta)
 	if err != nil {
 		return nil, err
 	}
@@ -1276,20 +1404,20 @@ func resourceComputeRouterBgpPeerPatchDeleteEncoder(d *schema.ResourceData, meta
 
 // ListForPatch handles making API request to get parent resource and
 // extracting list of objects.
-func resourceComputeRouterBgpPeerListForPatch(d *schema.ResourceData, meta interface{}) ([]interface{}, error) {
+func resourceComputeRouterBgpPeerListForPatch(d *schema.ResourceData, meta interface{}) ([]interface{}, []interface{}, error) {
 	config := meta.(*transport_tpg.Config)
 	url, err := tpgresource.ReplaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/routers/{{router}}")
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	project, err := tpgresource.GetProject(d, config)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
@@ -1300,19 +1428,36 @@ func resourceComputeRouterBgpPeerListForPatch(d *schema.ResourceData, meta inter
 		UserAgent: userAgent,
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var v interface{}
 	var ok bool
+	var ls, keys []interface{}
+	var lsOk, keysOk bool
 
 	v, ok = res["bgpPeers"]
 	if ok && v != nil {
-		ls, lsOk := v.([]interface{})
+		ls, lsOk = v.([]interface{})
 		if !lsOk {
-			return nil, fmt.Errorf(`expected list for nested field "bgpPeers"`)
+			return nil, nil, fmt.Errorf(`expected list for nested field "bgpPeers"`)
 		}
-		return ls, nil
 	}
-	return nil, nil
+	v, ok = res["md5AuthenticationKeys"]
+	if ok && v != nil {
+		keys, keysOk = v.([]interface{})
+		if !keysOk {
+			return nil, nil, fmt.Errorf(`expected list for nested field "md5AuthenticationKeys"`)
+		}
+	}
+
+	if lsOk && keysOk {
+		return ls, keys, nil
+	} else if !lsOk && keysOk {
+		return nil, keys, nil
+	} else if lsOk && !keysOk {
+		return ls, nil, nil
+	} else {
+		return nil, nil, nil
+	}
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
@@ -289,13 +289,13 @@ of one of the entries in the Router.md5_authentication_keys. The field must comp
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"md5_authentication_key_name": {
+						"name": {
 							Type:     schema.TypeString,
 							Required: true,
 							Description: `[REQUIRED] Name used to identify the key.
 Must be unique within a router. Must be referenced by exactly one bgpPeer. Must comply with RFC1035.`,
 						},
-						"md5_authentication_key_value": {
+						"key": {
 							Type:        schema.TypeString,
 							Required:    true,
 							Description: `Value of the key.`,
@@ -416,7 +416,7 @@ func resourceComputeRouterBgpPeerCreate(d *schema.ResourceData, meta interface{}
 		md5AuthenticationKeys which is an array which specify all the keys (name and value). The constraint here is that a key must
 		be used by exactly one bgpPeer to be considered valid.
 		*/
-		md5AuthenticationKeyName := md5AuthenticationKeyProp.(map[string]interface{})["md5AuthenticationKeyName"]
+		md5AuthenticationKeyName := md5AuthenticationKeyProp.(map[string]interface{})["name"]
 		obj["md5AuthenticationKeyName"] = md5AuthenticationKeyName
 		obj["md5AuthenticationKey"] = md5AuthenticationKeyProp
 	}
@@ -697,7 +697,7 @@ func resourceComputeRouterBgpPeerUpdate(d *schema.ResourceData, meta interface{}
 		md5AuthenticationKeys which is an array which specify all the keys (name and value). The constraint here is that a key must
 		be used by exactly one bgpPeer to be considered valid.
 		*/
-		md5AuthenticationKeyName := md5AuthenticationKeyProp.(map[string]interface{})["md5AuthenticationKeyName"]
+		md5AuthenticationKeyName := md5AuthenticationKeyProp.(map[string]interface{})["name"]
 		obj["md5AuthenticationKeyName"] = md5AuthenticationKeyName
 		obj["md5AuthenticationKey"] = md5AuthenticationKeyProp
 	}
@@ -938,7 +938,9 @@ func flattenNestedComputeRouterBgpPeerMd5AuthenticationKey(v interface{}, d *sch
 	}
 
 	transformed := make(map[string]interface{})
-	transformed["md5AuthenticationKeyName"] = v
+	transformed["name"] = v
+	//key value is not returned as it is a sensitive field
+	transformed["key"] = nil
 	return []interface{}{transformed}
 }
 
@@ -1166,18 +1168,18 @@ func expandNestedComputeRouterBgpPeerMd5AuthenticationKey(v interface{}, d tpgre
 	original := raw.(map[string]interface{})
 	transformed := make(map[string]interface{})
 
-	transformedMd5AuthenticationKeyName, err := expandNestedComputeRouterBgpPeerMd5AuthenticationKeyMd5AuthenticationKeyName(original["md5_authentication_key_name"], d, config)
+	transformedMd5AuthenticationKeyName, err := expandNestedComputeRouterBgpPeerMd5AuthenticationKeyMd5AuthenticationKeyName(original["name"], d, config)
 	if err != nil {
 		return nil, err
 	} else if val := reflect.ValueOf(transformedMd5AuthenticationKeyName); val.IsValid() && !tpgresource.IsEmptyValue(val) {
-		transformed["md5AuthenticationKeyName"] = transformedMd5AuthenticationKeyName
+		transformed["name"] = transformedMd5AuthenticationKeyName
 	}
 
-	transformedMd5AuthenticationKeyValue, err := expandNestedComputeRouterBgpPeerMd5AuthenticationKeyMd5AuthenticationKeyValue(original["md5_authentication_key_value"], d, config)
+	transformedMd5AuthenticationKeyValue, err := expandNestedComputeRouterBgpPeerMd5AuthenticationKeyMd5AuthenticationKeyValue(original["key"], d, config)
 	if err != nil {
 		return nil, err
 	} else if val := reflect.ValueOf(transformedMd5AuthenticationKeyValue); val.IsValid() && !tpgresource.IsEmptyValue(val) {
-		transformed["md5AuthenticationKeyValue"] = transformedMd5AuthenticationKeyValue
+		transformed["key"] = transformedMd5AuthenticationKeyValue
 	}
 
 	return transformed, nil

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
@@ -499,6 +499,8 @@ func resourceComputeRouterBgpPeerRead(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
+	log.Printf("[DEBUG] Reading RouterBgpPeerobject - %#v", d.Get("md5_authentication_key"))
+
 	url, err := tpgresource.ReplaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/routers/{{router}}")
 	if err != nil {
 		return err
@@ -946,11 +948,15 @@ func flattenNestedComputeRouterBgpPeerMd5AuthenticationKey(v interface{}, d *sch
 	if v == nil {
 		return nil
 	}
-
+	originalKeyValue := d.Get("md5_authentication_key").([]interface{})
 	transformed := make(map[string]interface{})
 	transformed["name"] = v
+	log.Printf("[DEBUG] originalKeyValue - %#v)", originalKeyValue)
 	//key value is not returned as it is a sensitive field
-	transformed["key"] = nil
+	if len(originalKeyValue) != 0 {
+		transformed["key"] = originalKeyValue[0].(map[string]interface{})["key"]
+		log.Printf("[DEBUG] transformed key value - %#v)", transformed["key"])
+	}
 	return []interface{}{transformed}
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
@@ -484,7 +484,12 @@ func resourceComputeRouterBgpPeerCreate(d *schema.ResourceData, meta interface{}
 
 	log.Printf("[DEBUG] Finished creating RouterBgpPeer %q: %#v", d.Id(), res)
 
-	return resourceComputeRouterBgpPeerRead(d, meta)
+	err = resourceComputeRouterBgpPeerRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	return d.Set("md5_authentication_key", md5AuthenticationKeyProp)
 }
 
 func resourceComputeRouterBgpPeerRead(d *schema.ResourceData, meta interface{}) error {
@@ -750,7 +755,12 @@ func resourceComputeRouterBgpPeerUpdate(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	return resourceComputeRouterBgpPeerRead(d, meta)
+	err = resourceComputeRouterBgpPeerRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	return d.Set("md5_authentication_key", []interface{}{md5AuthenticationKeyProp})
 }
 
 func resourceComputeRouterBgpPeerDelete(d *schema.ResourceData, meta interface{}) error {
@@ -1338,6 +1348,9 @@ func resourceComputeRouterBgpPeerPatchUpdateEncoder(d *schema.ResourceData, meta
 		return nil, err
 	}
 
+	log.Printf("[DEBUG] inside UpdateEncoder - bgpPeerItems:  %+v, md5AuthenticationKeys - %+v", bgpPeerItems, md5AuthenticationKeys)
+	log.Printf("[DEBUG] inside UpdateEncoder - obj:  %+v", obj)
+
 	idx, item, err := resourceComputeRouterBgpPeerFindNestedObjectInList(d, meta, bgpPeerItems)
 	if err != nil {
 		return nil, err
@@ -1348,32 +1361,54 @@ func resourceComputeRouterBgpPeerPatchUpdateEncoder(d *schema.ResourceData, meta
 		return nil, fmt.Errorf("Unable to update RouterBgpPeer %q - not found in list", d.Id())
 	}
 
-	var kvp map[string]interface{}
+	var md5AuthenticationKey map[string]interface{}
+	var deletedKeyName interface{}
+	var wasPresent bool
 	val, ok := obj["md5AuthenticationKey"]
 	if ok {
-		kvp = val.(map[string]interface{})
+		md5AuthenticationKey = val.(map[string]interface{})
 		//remove key from this map as it not needed here
 		delete(obj, "md5AuthenticationKey")
+	} else {
+		//check if key used to be present
+		deletedKeyName, wasPresent = item["md5AuthenticationKeyName"]
+		if wasPresent {
+			delete(item, "md5AuthenticationKeyName")
+		}
 	}
 
-	// Merge new object into old.
+	//merging the bgpRouterPeer objects
 	for k, v := range obj {
 		item[k] = v
 	}
+	log.Printf("[DEBUG] UpdateEncoder - sending new object to be updated %#v", item)
+
+	//merging the md5AuthenticationKeys objects
+	isKeyNew := true
+	log.Printf("[DEBUG] UpdateEncoder - currentMd5AuthenticationKeys %#v", md5AuthenticationKeys)
+	for i, val := range md5AuthenticationKeys {
+		key := val.(map[string]interface{})
+		if key["name"] == md5AuthenticationKey["name"] {
+			key = md5AuthenticationKey
+			md5AuthenticationKeys[i] = key
+			isKeyNew = false
+		}
+
+		if key["name"] == deletedKeyName {
+			//if the key was deleted, then remove it from the parent router object as well
+			md5AuthenticationKeys = append(md5AuthenticationKeys[:i], md5AuthenticationKeys[i+1:]...)
+			log.Printf("[DEBUG] deleting unused key from parent object ,md5AuthenticationKeys - %+v", md5AuthenticationKeys)
+		}
+
+	}
 	bgpPeerItems[idx] = item
+	if isKeyNew {
+		md5AuthenticationKeys = append(md5AuthenticationKeys, md5AuthenticationKey)
+	}
 
-	var res map[string]interface{}
-
-	// Return list with new item added
-	if ok {
-		res = map[string]interface{}{
-			"bgpPeers":              append(bgpPeerItems, obj),
-			"md5AuthenticationKeys": append(md5AuthenticationKeys, kvp),
-		}
-	} else {
-		res = map[string]interface{}{
-			"bgpPeers": bgpPeerItems,
-		}
+	res := map[string]interface{}{
+		"bgpPeers":              bgpPeerItems,
+		"md5AuthenticationKeys": md5AuthenticationKeys,
 	}
 
 	return res, nil
@@ -1382,7 +1417,7 @@ func resourceComputeRouterBgpPeerPatchUpdateEncoder(d *schema.ResourceData, meta
 // PatchDeleteEncoder handles creating request data to PATCH parent resource
 // with list excluding object to delete.
 func resourceComputeRouterBgpPeerPatchDeleteEncoder(d *schema.ResourceData, meta interface{}, obj map[string]interface{}) (map[string]interface{}, error) {
-	currItems, _, err := resourceComputeRouterBgpPeerListForPatch(d, meta)
+	currItems, md5AuthenticationKeys, err := resourceComputeRouterBgpPeerListForPatch(d, meta)
 	if err != nil {
 		return nil, err
 	}
@@ -1396,9 +1431,19 @@ func resourceComputeRouterBgpPeerPatchDeleteEncoder(d *schema.ResourceData, meta
 		return nil, tpgresource.Fake404("nested", "ComputeRouterBgpPeer")
 	}
 
+	//if the removed bgp peer has some md5AuthKey associated with it, then remove the key from the router parent object as well
+	keyName := item["md5AuthenticationKeyName"]
+	for i, val := range md5AuthenticationKeys {
+		key := val.(map[string]interface{})
+		if key["name"] == keyName {
+			md5AuthenticationKeys = append(md5AuthenticationKeys[:i], md5AuthenticationKeys[i+1:]...)
+		}
+	}
+
 	updatedItems := append(currItems[:idx], currItems[idx+1:]...)
 	res := map[string]interface{}{
-		"bgpPeers": updatedItems,
+		"bgpPeers":              updatedItems,
+		"md5AuthenticationKeys": md5AuthenticationKeys,
 	}
 
 	return res, nil

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
@@ -484,12 +484,12 @@ func resourceComputeRouterBgpPeerCreate(d *schema.ResourceData, meta interface{}
 
 	log.Printf("[DEBUG] Finished creating RouterBgpPeer %q: %#v", d.Id(), res)
 
-	err = resourceComputeRouterBgpPeerRead(d, meta)
+	err = d.Set("md5_authentication_key", []interface{}{md5AuthenticationKeyProp})
 	if err != nil {
 		return err
 	}
 
-	return d.Set("md5_authentication_key", []interface{}{md5AuthenticationKeyProp})
+	return resourceComputeRouterBgpPeerRead(d, meta)
 }
 
 func resourceComputeRouterBgpPeerRead(d *schema.ResourceData, meta interface{}) error {
@@ -498,8 +498,6 @@ func resourceComputeRouterBgpPeerRead(d *schema.ResourceData, meta interface{}) 
 	if err != nil {
 		return err
 	}
-
-	log.Printf("[DEBUG] Reading RouterBgpPeerobject - %#v", d.Get("md5_authentication_key"))
 
 	url, err := tpgresource.ReplaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/routers/{{router}}")
 	if err != nil {
@@ -757,12 +755,12 @@ func resourceComputeRouterBgpPeerUpdate(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	err = resourceComputeRouterBgpPeerRead(d, meta)
+	err = d.Set("md5_authentication_key", []interface{}{md5AuthenticationKeyProp})
 	if err != nil {
 		return err
 	}
 
-	return d.Set("md5_authentication_key", []interface{}{md5AuthenticationKeyProp})
+	return resourceComputeRouterBgpPeerRead(d, meta)
 }
 
 func resourceComputeRouterBgpPeerDelete(d *schema.ResourceData, meta interface{}) error {
@@ -951,11 +949,9 @@ func flattenNestedComputeRouterBgpPeerMd5AuthenticationKey(v interface{}, d *sch
 	originalKeyValue := d.Get("md5_authentication_key").([]interface{})
 	transformed := make(map[string]interface{})
 	transformed["name"] = v
-	log.Printf("[DEBUG] originalKeyValue - %#v)", originalKeyValue)
 	//key value is not returned as it is a sensitive field
 	if len(originalKeyValue) != 0 {
 		transformed["key"] = originalKeyValue[0].(map[string]interface{})["key"]
-		log.Printf("[DEBUG] transformed key value - %#v)", transformed["key"])
 	}
 	return []interface{}{transformed}
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
@@ -489,7 +489,7 @@ func resourceComputeRouterBgpPeerCreate(d *schema.ResourceData, meta interface{}
 		return err
 	}
 
-	return d.Set("md5_authentication_key", md5AuthenticationKeyProp)
+	return d.Set("md5_authentication_key", []interface{}{md5AuthenticationKeyProp})
 }
 
 func resourceComputeRouterBgpPeerRead(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adding md5Authenctication key field for BGPRouterPeer resource. Related to b/260899743

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `md5_authentication_key` to `google_compute_router_peer`
```
