### PR TITLE
Fix with18TbScratchDisk test by replacing it with with24TbScratchDisk

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.erb
@@ -2374,7 +2374,7 @@ data "google_compute_image" "my_image" {
 
 resource "google_compute_instance_template" "foobar" {
   name           = "tf-test-instance-template-%s"
-  machine_type   = "n2-standard-16"
+  machine_type   = "n2-standard-64"
   can_ip_forward = false
   disk {
     source_image = data.google_compute_image.my_image.name


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Part of https://github.com/hashicorp/terraform-provider-google/issues/16057 . TestAccComputeInstanceTemplate_withScratchDisk was already fixed.

TestAccComputeInstanceTemplate_with18TbScratchDisk is fixed by replacing to 24Tb Local SSDs and different machine type. Also applied the same fix to TestAccComputeInstance_with18TbScratchDisk but it's skipped right now (tested locally).

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
