### PR TITLE
Soft delete feature implementation for storage

### DIFF
--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
@@ -482,6 +482,35 @@ func ResourceStorageBucket() *schema.Resource {
 				Computed:    true,
 				Description: `Prevents public access to a bucket.`,
 			},
+			"soft_delete_policy": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Computed:    true,
+				Description: `The bucket's soft delete policy, which defines the period of time that soft-deleted objects will be retained, and cannot be permanently deleted. If it is not provided, by default Google Cloud Storage sets this to default soft delete policy`,
+				Elem : &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"retention_duration_seconds": {
+							Type:        schema.TypeInt,
+							Default:     604800,
+							Optional:    true,
+							ValidateFunc: func(val any, key string) (warns []string, errs []error) {
+								 v := val.(int)
+								 if v < 604800 || v > 7776000 {
+									 errs = append(errs, fmt.Errorf("%q must be between 604800 and 7776000 inclusive, got: %d", key, v))
+								 }
+								 return
+							 },
+							Description: `The duration in seconds that soft-deleted objects in the bucket will be retained and cannot be permanently deleted. Default value is 604800. The value must be in between 604800 and 7776000.`,
+						},
+						"effective_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Server-determined value that indicates the time from which the policy, or one with a greater retention, was effective. This value is in RFC 3339 format.`,
+						},
+					},
+				},
+			},
 		},
 		UseJSONNumber: true,
 	}
@@ -610,6 +639,10 @@ func resourceStorageBucketCreate(d *schema.ResourceData, meta interface{}) error
 
 	if v, ok := d.GetOk("rpo"); ok{
 		sb.Rpo = v.(string)
+	}
+
+	if v, ok := d.GetOk("soft_delete_policy"); ok {
+		sb.SoftDeletePolicy = expandBucketSoftDeletePolicy(v.([]interface{}))
 	}
 
 	var res *storage.Bucket
@@ -780,6 +813,12 @@ func resourceStorageBucketUpdate(d *schema.ResourceData, meta interface{}) error
 			sb.Rpo = v.(string)
 		} else {
 			sb.NullFields = append(sb.NullFields, "Rpo")
+		}
+	}
+
+	if d.HasChange("soft_delete_policy") {
+		if v, ok := d.GetOk("soft_delete_policy"); ok {
+			sb.SoftDeletePolicy = expandBucketSoftDeletePolicy(v.([]interface{}))
 		}
 	}
 
@@ -1163,6 +1202,31 @@ func flattenBucketObjectRetention(bucketObjectRetention *storage.BucketObjectRet
 		return true
 	}
 	return false
+}
+
+func expandBucketSoftDeletePolicy(configured interface{}) *storage.BucketSoftDeletePolicy{
+	configuredSoftDeletePolicies := configured.([]interface{})
+	if len(configuredSoftDeletePolicies) == 0 {
+		return nil
+	}
+	configuredSoftDeletePolicy := configuredSoftDeletePolicies[0].(map[string]interface{})
+	softDeletePolicy := &storage.BucketSoftDeletePolicy{
+		RetentionDurationSeconds: int64(configuredSoftDeletePolicy["retention_duration_seconds"].(int)),
+	}
+	return softDeletePolicy
+}
+
+func flattenBucketSoftDeletePolicy(softDeletePolicy *storage.BucketSoftDeletePolicy) []map[string]interface{} {
+	policies := make([]map[string]interface{}, 0, 1)
+	if softDeletePolicy == nil {
+		return policies
+	}
+	policy := map[string]interface{}{
+		 "retention_duration_seconds": softDeletePolicy.RetentionDurationSeconds,
+		 "effective_time":             softDeletePolicy.EffectiveTime,
+	}
+	policies = append(policies, policy)
+	return policies
 }
 
 func expandBucketVersioning(configured interface{}) *storage.BucketVersioning {
@@ -1716,6 +1780,9 @@ func setStorageBucket(d *schema.ResourceData, config *transport_tpg.Config, res 
 			return fmt.Errorf("Error setting RPO setting : %s", err)
 		}
 	}
+	if err := d.Set("soft_delete_policy", flattenBucketSoftDeletePolicy(res.SoftDeletePolicy)); err != nil {
+  	return fmt.Errorf("Error setting soft_delete_policy: %s", err)
+  }
 	if res.IamConfiguration != nil && res.IamConfiguration.UniformBucketLevelAccess != nil {
 		if err := d.Set("uniform_bucket_level_access", res.IamConfiguration.UniformBucketLevelAccess.Enabled); err != nil {
 			return fmt.Errorf("Error setting uniform_bucket_level_access: %s", err)

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
@@ -1338,6 +1338,36 @@ func TestAccStorageBucket_retentionPolicyLocked(t *testing.T) {
 	})
 }
 
+func TestAccStorageBucket_SoftDeletePolicy(t *testing.T) {
+	t.Parallel()
+
+	var bucket storage.Bucket
+	bucketName := fmt.Sprintf("tf-test-acc-bucket-%d", acctest.RandInt(t))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccStorageBucketDestroyProducer(t),
+	Steps: []resource.TestStep{
+			{
+				Config: testAccStorageBucket_SoftDeletePolicy(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStorageBucketExists(
+						t, "google_storage_bucket.bucket", bucketName, &bucket),
+					resource.TestCheckResourceAttr(
+						"google_storage_bucket.bucket", "soft_delete_policy.0.retention_duration_seconds", "7776000"),
+				),
+			},
+			{
+				ResourceName:            "google_storage_bucket.bucket",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+		},
+	})
+}
+
 func testAccCheckStorageBucketExists(t *testing.T, n string, bucketName string, bucket *storage.Bucket) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -2245,6 +2275,21 @@ resource "google_storage_bucket" "bucket" {
 }
 `, bucketName)
 }
+
+func testAccStorageBucket_SoftDeletePolicy(bucketName string) string {
+	return fmt.Sprintf(`
+resource "google_storage_bucket" "bucket" {
+	name          = "%s"
+	location      = "US"
+	force_destroy = true
+
+	soft_delete_policy {
+		retention_duration_seconds = 7776000
+	}
+}
+`, bucketName)
+}
+
 
 func testAccStorageBucket_websiteNoAttributes(bucketName string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -133,6 +133,8 @@ The following arguments are supported:
 
 * `custom_placement_config` - (Optional) The bucket's custom location configuration, which specifies the individual regions that comprise a dual-region bucket. If the bucket is designated a single or multi-region, the parameters are empty. Structure is [documented below](#nested_custom_placement_config).
 
+* `soft_delete_policy` -  (Optional) The bucket's soft delete policy, which defines the period of time that soft-deleted objects will be retained, and cannot be permanently deleted. If it is not provided, by default Google Cloud Storage sets this to default soft delete policy. Structure is [documented below](#nested_soft_delete_policy).
+
 <a name="nested_lifecycle_rule"></a>The `lifecycle_rule` block supports:
 
 * `action` - (Required) The Lifecycle Rule's action configuration. A single block of this type is supported. Structure is [documented below](#nested_action).
@@ -232,6 +234,12 @@ The following arguments are supported:
 <a name="nested_custom_placement_config"></a>The `custom_placement_config` block supports:
 
 * `data_locations` - (Required) The list of individual regions that comprise a dual-region bucket. See [Cloud Storage bucket locations](https://cloud.google.com/storage/docs/dual-regions#availability) for a list of acceptable regions. **Note**: If any of the data_locations changes, it will [recreate the bucket](https://cloud.google.com/storage/docs/locations#key-concepts).
+
+<a name="nested_soft_delete_policy"></a>The `soft_delete_policy` block supports:
+
+* `retention_duration_seconds` - (Required) The duration in seconds that soft-deleted objects in the bucket will be retained and cannot be permanently deleted. Default value is 604800. The value must be in between 604800(7 days) and 7776000(90 days).
+
+* `effective_time` - (Read Only) Server-determined value that indicates the time from which the policy, or one with a greater retention, was effective. This value is in RFC 3339 format.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Adds support for Soft Delete feature, which allows setting soft delete policy on 'google_storage_bucket' resource.


**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
storage: added 'soft_delete_policy' to 'google_storage_bucket' resource
```
