### PR TITLE
Use new scoped down magician token for downstream-builder

### DIFF
--- a/.ci/gcb-push-downstream.yml
+++ b/.ci/gcb-push-downstream.yml
@@ -187,9 +187,10 @@ options:
     machineType: 'N1_HIGHCPU_32'
 
 
+logsBucket: 'gs://cloudbuild-downstream-builder-logs'
 availableSecrets:
   secretManager:
-    - versionName: projects/673497134629/secrets/github-magician-token/versions/latest
+    - versionName: projects/673497134629/secrets/github-classic--repo-workflow/versions/latest
       env: GITHUB_TOKEN
     - versionName: projects/673497134629/secrets/ci-test-project/versions/latest
       env: GOOGLE_PROJECT


### PR DESCRIPTION
I [tested this](https://pantheon.corp.google.com/cloud-build/builds;region=global/d31685d6-98a2-406e-a3ca-4500a31b6a5d;step=3?e=13802955&mods=logs_tg_staging&project=graphite-docker-images) within a [new trigger](https://pantheon.corp.google.com/cloud-build/triggers;region=global/edit/241a6833-4048-498f-82ff-a720c4d44338?project=graphite-docker-images) against a [different branch](https://github.com/GoogleCloudPlatform/magic-modules/blob/scott-downstream-builder-test/.ci/gcb-push-downstream.yml). 

Migrates this trigger to use a specific bucket and scoped down token. Will switch SA after this is merged since the SA doesn't have broad access to buckets thus cannot access the current default Cloud build logs bucket.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
