### PR TITLE
Standardized pull request reviewer functions to return lists of User structs

### DIFF
--- a/.ci/magician/cmd/community_checker_test.go
+++ b/.ci/magician/cmd/community_checker_test.go
@@ -58,10 +58,10 @@ func TestExecCommunityChecker_GooglerFlow(t *testing.T) {
 				Login: "googler_author",
 			},
 		},
-		userType:          github.GooglerUserType,
-		calledMethods:     make(map[string][][]any),
-		firstReviewer:     "reviewer1",
-		previousReviewers: []string{github.GetRandomReviewer(), "reviewer3"},
+		userType:           github.GooglerUserType,
+		calledMethods:      make(map[string][][]any),
+		requestedReviewers: []github.User{github.User{Login: "reviewer1"}},
+		previousReviewers:  []github.User{github.User{Login: github.GetRandomReviewer()}, github.User{Login: "reviewer3"}},
 	}
 	cb := &mockCloudBuild{
 		calledMethods: make(map[string][][]any),
@@ -89,10 +89,10 @@ func TestExecCommunityChecker_AmbiguousUserFlow(t *testing.T) {
 				Login: "ambiguous_author",
 			},
 		},
-		userType:          github.CommunityUserType,
-		calledMethods:     make(map[string][][]any),
-		firstReviewer:     github.GetRandomReviewer(),
-		previousReviewers: []string{github.GetRandomReviewer(), "reviewer3"},
+		userType:           github.CommunityUserType,
+		calledMethods:      make(map[string][][]any),
+		requestedReviewers: []github.User{github.User{Login: github.GetRandomReviewer()}},
+		previousReviewers:  []github.User{github.User{Login: github.GetRandomReviewer()}, github.User{Login: "reviewer3"}},
 	}
 	cb := &mockCloudBuild{
 		calledMethods: make(map[string][][]any),

--- a/.ci/magician/cmd/interfaces.go
+++ b/.ci/magician/cmd/interfaces.go
@@ -21,8 +21,8 @@ import (
 
 type GithubClient interface {
 	GetPullRequest(prNumber string) (github.PullRequest, error)
-	GetPullRequestRequestedReviewer(prNumber string) (string, error)
-	GetPullRequestPreviousAssignedReviewers(prNumber string) ([]string, error)
+	GetPullRequestRequestedReviewers(prNumber string) ([]github.User, error)
+	GetPullRequestPreviousReviewers(prNumber string) ([]github.User, error)
 	GetUserType(user string) github.UserType
 	PostBuildStatus(prNumber, title, state, targetURL, commitSha string) error
 	PostComment(prNumber, comment string) error

--- a/.ci/magician/cmd/membership_checker.go
+++ b/.ci/magician/cmd/membership_checker.go
@@ -100,19 +100,19 @@ func execMembershipChecker(prNumber, commitSha, branchName, headRepoUrl, headBra
 	if authorUserType != github.CoreContributorUserType {
 		fmt.Println("Not core contributor - assigning reviewer")
 
-		firstRequestedReviewer, err := gh.GetPullRequestRequestedReviewer(prNumber)
+		requestedReviewers, err := gh.GetPullRequestRequestedReviewers(prNumber)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		}
 
-		previouslyInvolvedReviewers, err := gh.GetPullRequestPreviousAssignedReviewers(prNumber)
+		previousReviewers, err := gh.GetPullRequestPreviousReviewers(prNumber)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		}
 
-		reviewersToRequest, newPrimaryReviewer := github.ChooseCoreReviewers(firstRequestedReviewer, previouslyInvolvedReviewers)
+		reviewersToRequest, newPrimaryReviewer := github.ChooseCoreReviewers(requestedReviewers, previousReviewers)
 
 		for _, reviewer := range reviewersToRequest {
 			err = gh.RequestPullRequestReviewer(prNumber, reviewer)

--- a/.ci/magician/cmd/membership_checker_test.go
+++ b/.ci/magician/cmd/membership_checker_test.go
@@ -67,10 +67,10 @@ func TestExecMembershipChecker_GooglerFlow(t *testing.T) {
 				Login: "googler_author",
 			},
 		},
-		userType:          github.GooglerUserType,
-		calledMethods:     make(map[string][][]any),
-		firstReviewer:     "reviewer1",
-		previousReviewers: []string{github.GetRandomReviewer(), "reviewer3"},
+		userType:           github.GooglerUserType,
+		calledMethods:      make(map[string][][]any),
+		requestedReviewers: []github.User{github.User{Login: "reviewer1"}},
+		previousReviewers:  []github.User{github.User{Login: github.GetRandomReviewer()}, github.User{Login: "reviewer3"}},
 	}
 	cb := &mockCloudBuild{
 		calledMethods: make(map[string][][]any),
@@ -115,10 +115,10 @@ func TestExecMembershipChecker_AmbiguousUserFlow(t *testing.T) {
 				Login: "ambiguous_author",
 			},
 		},
-		userType:          github.CommunityUserType,
-		calledMethods:     make(map[string][][]any),
-		firstReviewer:     github.GetRandomReviewer(),
-		previousReviewers: []string{github.GetRandomReviewer(), "reviewer3"},
+		userType:           github.CommunityUserType,
+		calledMethods:      make(map[string][][]any),
+		requestedReviewers: []github.User{github.User{Login: github.GetRandomReviewer()}},
+		previousReviewers:  []github.User{github.User{Login: github.GetRandomReviewer()}, github.User{Login: "reviewer3"}},
 	}
 	cb := &mockCloudBuild{
 		calledMethods: make(map[string][][]any),
@@ -171,10 +171,10 @@ func TestExecMembershipChecker_CommentForNewPrimaryReviewer(t *testing.T) {
 				Login: "googler_author",
 			},
 		},
-		userType:          github.GooglerUserType,
-		calledMethods:     make(map[string][][]any),
-		firstReviewer:     "",
-		previousReviewers: []string{"reviewer3"},
+		userType:           github.GooglerUserType,
+		calledMethods:      make(map[string][][]any),
+		requestedReviewers: []github.User{},
+		previousReviewers:  []github.User{github.User{Login: "reviewer3"}},
 	}
 	cb := &mockCloudBuild{
 		calledMethods: make(map[string][][]any),

--- a/.ci/magician/cmd/mock_github_test.go
+++ b/.ci/magician/cmd/mock_github_test.go
@@ -18,11 +18,11 @@ package cmd
 import "magician/github"
 
 type mockGithub struct {
-	pullRequest       github.PullRequest
-	userType          github.UserType
-	firstReviewer     string
-	previousReviewers []string
-	calledMethods     map[string][][]any
+	pullRequest        github.PullRequest
+	userType           github.UserType
+	requestedReviewers []github.User
+	previousReviewers  []github.User
+	calledMethods      map[string][][]any
 }
 
 func (m *mockGithub) GetPullRequest(prNumber string) (github.PullRequest, error) {
@@ -35,13 +35,13 @@ func (m *mockGithub) GetUserType(user string) github.UserType {
 	return m.userType
 }
 
-func (m *mockGithub) GetPullRequestRequestedReviewer(prNumber string) (string, error) {
-	m.calledMethods["GetPullRequestRequestedReviewer"] = append(m.calledMethods["GetPullRequestRequestedReviewer"], []any{prNumber})
-	return m.firstReviewer, nil
+func (m *mockGithub) GetPullRequestRequestedReviewers(prNumber string) ([]github.User, error) {
+	m.calledMethods["GetPullRequestRequestedReviewers"] = append(m.calledMethods["GetPullRequestRequestedReviewers"], []any{prNumber})
+	return m.requestedReviewers, nil
 }
 
-func (m *mockGithub) GetPullRequestPreviousAssignedReviewers(prNumber string) ([]string, error) {
-	m.calledMethods["GetPullRequestPreviousAssignedReviewers"] = append(m.calledMethods["GetPullRequestPreviousAssignedReviewers"], []any{prNumber})
+func (m *mockGithub) GetPullRequestPreviousReviewers(prNumber string) ([]github.User, error) {
+	m.calledMethods["GetPullRequestPreviousReviewers"] = append(m.calledMethods["GetPullRequestPreviousReviewers"], []any{prNumber})
 	return m.previousReviewers, nil
 }
 

--- a/.ci/magician/github/get.go
+++ b/.ci/magician/github/get.go
@@ -29,9 +29,7 @@ type Label struct {
 }
 
 type PullRequest struct {
-	User struct {
-		Login string `json:"login"`
-	} `json:"user"`
+	User   User    `json:"user"`
 	Labels []Label `json:"labels"`
 }
 
@@ -48,34 +46,26 @@ func (gh *Client) GetPullRequest(prNumber string) (PullRequest, error) {
 	return pullRequest, nil
 }
 
-func (gh *Client) GetPullRequestRequestedReviewer(prNumber string) (string, error) {
+func (gh *Client) GetPullRequestRequestedReviewers(prNumber string) ([]User, error) {
 	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/%s/requested_reviewers", prNumber)
 
 	var requestedReviewers struct {
-		Users []struct {
-			Login string `json:"login"`
-		} `json:"users"`
+		Users []User `json:"users"`
 	}
 
 	_, err := utils.RequestCall(url, "GET", gh.token, &requestedReviewers, nil)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	if requestedReviewers.Users == nil || len(requestedReviewers.Users) == 0 {
-		return "", nil
-	}
-
-	return requestedReviewers.Users[0].Login, nil
+	return requestedReviewers.Users, nil
 }
 
-func (gh *Client) GetPullRequestPreviousAssignedReviewers(prNumber string) ([]string, error) {
+func (gh *Client) GetPullRequestPreviousReviewers(prNumber string) ([]User, error) {
 	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/%s/reviews", prNumber)
 
 	var reviews []struct {
-		User struct {
-			Login string `json:"login"`
-		} `json:"user"`
+		User User `json:"user"`
 	}
 
 	_, err := utils.RequestCall(url, "GET", gh.token, &reviews, nil)
@@ -83,14 +73,14 @@ func (gh *Client) GetPullRequestPreviousAssignedReviewers(prNumber string) ([]st
 		return nil, err
 	}
 
-	previousAssignedReviewers := map[string]struct{}{}
+	previousAssignedReviewers := map[string]User{}
 	for _, review := range reviews {
-		previousAssignedReviewers[review.User.Login] = struct{}{}
+		previousAssignedReviewers[review.User.Login] = review.User
 	}
 
-	result := []string{}
-	for key := range previousAssignedReviewers {
-		result = append(result, key)
+	result := []User{}
+	for _, user := range previousAssignedReviewers {
+		result = append(result, user)
 	}
 
 	return result, nil

--- a/.ci/magician/github/reviewer_assignment.go
+++ b/.ci/magician/github/reviewer_assignment.go
@@ -29,18 +29,21 @@ var (
 )
 
 // Returns a list of users to request review from, as well as a new primary reviewer if this is the first run.
-func ChooseCoreReviewers(firstRequestedReviewer string, previouslyInvolvedReviewers []string) (reviewersToRequest []string, newPrimaryReviewer string) {
+func ChooseCoreReviewers(requestedReviewers, previousReviewers []User) (reviewersToRequest []string, newPrimaryReviewer string) {
 	hasPrimaryReviewer := false
 	newPrimaryReviewer = ""
 
-	if firstRequestedReviewer != "" {
-		hasPrimaryReviewer = true
+	for _, reviewer := range requestedReviewers {
+		if IsTeamReviewer(reviewer.Login) {
+			hasPrimaryReviewer = true
+			break
+		}
 	}
 
-	for _, reviewer := range previouslyInvolvedReviewers {
-		if IsTeamReviewer(reviewer) {
+	for _, reviewer := range previousReviewers {
+		if IsTeamReviewer(reviewer.Login) {
 			hasPrimaryReviewer = true
-			reviewersToRequest = append(reviewersToRequest, reviewer)
+			reviewersToRequest = append(reviewersToRequest, reviewer.Login)
 		}
 	}
 

--- a/.ci/magician/github/reviewer_assignment_test.go
+++ b/.ci/magician/github/reviewer_assignment_test.go
@@ -26,45 +26,50 @@ import (
 
 func TestChooseCoreReviewers(t *testing.T) {
 	cases := map[string]struct {
-		FirstRequestedReviewer                           string
-		PreviouslyInvolvedReviewers                      []string
+		RequestedReviewers                               []User
+		PreviousReviewers                                []User
 		ExpectReviewersFromList, ExpectSpecificReviewers []string
 		ExpectPrimaryReviewer                            bool
 	}{
 		"no previous review requests assigns new reviewer from team": {
-			FirstRequestedReviewer:      "",
-			PreviouslyInvolvedReviewers: []string{},
-			ExpectReviewersFromList:     utils.Removes(reviewerRotation, onVacationReviewers),
-			ExpectPrimaryReviewer:       true,
+			RequestedReviewers:      []User{},
+			PreviousReviewers:       []User{},
+			ExpectReviewersFromList: utils.Removes(reviewerRotation, onVacationReviewers),
+			ExpectPrimaryReviewer:   true,
 		},
-		"first requested reviewer means that primary reviewer was already selected": {
-			FirstRequestedReviewer:      "foobar",
-			PreviouslyInvolvedReviewers: []string{},
-			ExpectPrimaryReviewer:       false,
+		"requested reviewer from team means that primary reviewer was already selected": {
+			RequestedReviewers:    []User{User{Login: reviewerRotation[0]}},
+			PreviousReviewers:     []User{},
+			ExpectPrimaryReviewer: false,
+		},
+		"requested off-team reviewer does not mean that primary reviewer was already selected": {
+			RequestedReviewers:    []User{User{Login: "foobar"}},
+			PreviousReviewers:     []User{},
+			ExpectPrimaryReviewer: true,
 		},
 		"previously involved team member reviewers should have review requested and mean that primary reviewer was already selected": {
-			FirstRequestedReviewer:      "",
-			PreviouslyInvolvedReviewers: []string{reviewerRotation[0]},
-			ExpectSpecificReviewers:     []string{reviewerRotation[0]},
-			ExpectPrimaryReviewer:       false,
+			RequestedReviewers:      []User{},
+			PreviousReviewers:       []User{User{Login: reviewerRotation[0]}},
+			ExpectSpecificReviewers: []string{reviewerRotation[0]},
+			ExpectPrimaryReviewer:   false,
 		},
 		"previously involved reviewers that are not team members are ignored": {
-			FirstRequestedReviewer:      "",
-			PreviouslyInvolvedReviewers: []string{"foobar"},
-			ExpectReviewersFromList:     utils.Removes(reviewerRotation, onVacationReviewers),
-			ExpectPrimaryReviewer:       true,
+			RequestedReviewers:      []User{},
+			PreviousReviewers:       []User{User{Login: "foobar"}},
+			ExpectReviewersFromList: utils.Removes(reviewerRotation, onVacationReviewers),
+			ExpectPrimaryReviewer:   true,
 		},
 		"only previously involved team member reviewers will have review requested": {
-			FirstRequestedReviewer:      "",
-			PreviouslyInvolvedReviewers: []string{reviewerRotation[0], "foobar", reviewerRotation[1]},
-			ExpectSpecificReviewers:     []string{reviewerRotation[0], reviewerRotation[1]},
-			ExpectPrimaryReviewer:       false,
+			RequestedReviewers:      []User{},
+			PreviousReviewers:       []User{User{Login: reviewerRotation[0]}, User{Login: "foobar"}, User{Login: reviewerRotation[1]}},
+			ExpectSpecificReviewers: []string{reviewerRotation[0], reviewerRotation[1]},
+			ExpectPrimaryReviewer:   false,
 		},
 		"primary reviewer will not have review requested even if other team members previously reviewed": {
-			FirstRequestedReviewer:      reviewerRotation[1],
-			PreviouslyInvolvedReviewers: []string{reviewerRotation[0]},
-			ExpectSpecificReviewers:     []string{reviewerRotation[0]},
-			ExpectPrimaryReviewer:       false,
+			RequestedReviewers:      []User{User{Login: reviewerRotation[1]}},
+			PreviousReviewers:       []User{User{Login: reviewerRotation[0]}},
+			ExpectSpecificReviewers: []string{reviewerRotation[0]},
+			ExpectPrimaryReviewer:   false,
 		},
 	}
 
@@ -72,7 +77,7 @@ func TestChooseCoreReviewers(t *testing.T) {
 		tc := tc
 		t.Run(tn, func(t *testing.T) {
 			t.Parallel()
-			reviewers, primaryReviewer := ChooseCoreReviewers(tc.FirstRequestedReviewer, tc.PreviouslyInvolvedReviewers)
+			reviewers, primaryReviewer := ChooseCoreReviewers(tc.RequestedReviewers, tc.PreviousReviewers)
 			if tc.ExpectPrimaryReviewer && primaryReviewer == "" {
 				t.Error("wanted primary reviewer to be returned; got none")
 			}


### PR DESCRIPTION
This PR makes the github client align more closely with the GitHub API by having functions for requested reviewers and previous reviewers which return lists of API users. The big difference is that the previous reviewers are extracted from the list of previous reviews and deduplicated.

This change makes it possible to easily fetch all the requested reviewers, not just the latest one.

I also modified ChooseCoreReviewers to explicitly check for a requestedReviewer from the team instead of assuming that any requested reviewer will be a team member. This should be slightly clearer and slightly more correct in terms of the behavior we want.

This is prework for b/295224401, which will need to use similar logic to check if a service team member has already reviewed a PR.

@trodge @ScottSuarez FYI

```release-note:none

```
