### PR TITLE
chore: do not show sensitive certificate details in Terraform cmd out…

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.erb
@@ -775,11 +775,12 @@ is set to true. Defaults to ZONAL.`,
 			},
 
 			"replica_configuration": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
+				Type:       schema.TypeList,
+				Optional:   true,
+				MaxItems:   1,
 				// Returned from API on all replicas
-				Computed: true,
+				Computed:   true,
+				Sensitive:  true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"ca_certificate": {
@@ -787,7 +788,6 @@ is set to true. Defaults to ZONAL.`,
 							Optional:     true,
 							ForceNew:     true,
 							AtLeastOneOf: replicaConfigurationKeys,
-							Sensitive:    true,
 							Description:  `PEM representation of the trusted CA's x509 certificate.`,
 						},
 						"client_certificate": {
@@ -795,7 +795,6 @@ is set to true. Defaults to ZONAL.`,
 							Optional:     true,
 							ForceNew:     true,
 							AtLeastOneOf: replicaConfigurationKeys,
-							Sensitive:    true,
 							Description:  `PEM representation of the replica's x509 certificate.`,
 						},
 						"client_key": {
@@ -803,7 +802,6 @@ is set to true. Defaults to ZONAL.`,
 							Optional:     true,
 							ForceNew:     true,
 							AtLeastOneOf: replicaConfigurationKeys,
-							Sensitive:    true,
 							Description:  `PEM representation of the replica's private key. The corresponding public key in encoded in the client_certificate.`,
 						},
 						"connect_retry_interval": {

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.erb
@@ -787,6 +787,7 @@ is set to true. Defaults to ZONAL.`,
 							Optional:     true,
 							ForceNew:     true,
 							AtLeastOneOf: replicaConfigurationKeys,
+							Sensitive:    true,
 							Description:  `PEM representation of the trusted CA's x509 certificate.`,
 						},
 						"client_certificate": {
@@ -794,6 +795,7 @@ is set to true. Defaults to ZONAL.`,
 							Optional:     true,
 							ForceNew:     true,
 							AtLeastOneOf: replicaConfigurationKeys,
+							Sensitive:    true,
 							Description:  `PEM representation of the replica's x509 certificate.`,
 						},
 						"client_key": {
@@ -801,6 +803,7 @@ is set to true. Defaults to ZONAL.`,
 							Optional:     true,
 							ForceNew:     true,
 							AtLeastOneOf: replicaConfigurationKeys,
+							Sensitive:    true,
 							Description:  `PEM representation of the replica's private key. The corresponding public key in encoded in the client_certificate.`,
 						},
 						"connect_retry_interval": {
@@ -865,8 +868,9 @@ is set to true. Defaults to ZONAL.`,
 				Description: `The configuration for replication.`,
 			},
 			"server_ca_cert": {
-				Type:     schema.TypeList,
-				Computed: true,
+				Type:       schema.TypeList,
+				Computed:   true,
+				Sensitive:  true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"cert": {

--- a/mmv1/third_party/terraform/services/sql/resource_sql_ssl_cert.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_ssl_cert.go
@@ -56,6 +56,7 @@ func ResourceSqlSslCert() *schema.Resource {
 			"cert": {
 				Type:        schema.TypeString,
 				Computed:    true,
+				Sensitive:   true,
 				Description: `The actual certificate data for this client certificate.`,
 			},
 
@@ -87,6 +88,7 @@ func ResourceSqlSslCert() *schema.Resource {
 			"server_ca_cert": {
 				Type:        schema.TypeString,
 				Computed:    true,
+				Sensitive:   true,
 				Description: `The CA cert of the server this client cert was generated from.`,
 			},
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Mark some certificate-related information as sensitive so that they wouldn't be shown in the Terraform cmd output like `terraform destroy`.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
sql: update `replica_configuration`, `ca_cert`, and `server_ca_cert` fields to be flagged sensitive in `google_sql_instance` and `google_sql_ssl_cert` resources
```
