### PR TITLE
Update OrganizationSecurityPolicy.yaml

### DIFF
--- a/mmv1/products/compute/OrganizationSecurityPolicy.yaml
+++ b/mmv1/products/compute/OrganizationSecurityPolicy.yaml
@@ -18,6 +18,9 @@ base_url: 'locations/global/securityPolicies?parentId={{parent}}'
 self_link: 'locations/global/securityPolicies/{{policy_id}}'
 create_url: 'locations/global/securityPolicies?parentId={{parent}}'
 update_verb: :PATCH
+deprecation_message: >-
+  `google_compute_organizationsecuritypolicy` is deprecated and will be removed in the next major release
+  of the provider. Use `google_compute_firewall_policy` instead.
 description: |
   Organization security policies are used to control incoming/outgoing traffic.
 references: !ruby/object:Api::Resource::ReferenceLinks

--- a/mmv1/products/compute/OrganizationSecurityPolicy.yaml
+++ b/mmv1/products/compute/OrganizationSecurityPolicy.yaml
@@ -19,7 +19,7 @@ self_link: 'locations/global/securityPolicies/{{policy_id}}'
 create_url: 'locations/global/securityPolicies?parentId={{parent}}'
 update_verb: :PATCH
 deprecation_message: >-
-  `google_compute_organizationsecuritypolicy` is deprecated and will be removed in the next major release
+  `google_compute_organizationsecuritypolicy` is deprecated and will be removed in a future major release
   of the provider. Use `google_compute_firewall_policy` instead.
 description: |
   Organization security policies are used to control incoming/outgoing traffic.


### PR DESCRIPTION
Fixed https://github.com/hashicorp/terraform-provider-google/issues/14896

Add a deprecation message indicating that the current resource OrganizationSecurityPolicy will be deprecated in favor of  FirewallPolicy resource.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:deprecation
compute: deprecated `google_compute_organization_security_policy`. Use `google_compute_firewall_policy` instead.
```
