### PR TITLE
fix gke tests

### DIFF
--- a/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.erb
@@ -325,8 +325,6 @@ func TestAccGKEHubFeatureMembership_gkehubFeatureAcmAllFields(t *testing.T) {
 		"random_suffix":   acctest.RandString(t, 10),
 		"org_id":          envvar.GetTestOrgFromEnv(t),
 		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
-		"network_name" :   acctest.BootstrapSharedTestNetwork(t, "gke-cluster"),
-		"subnetwork_name": acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster")),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -390,8 +388,6 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection = false
-  network       = "%{network_name}"
-  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub]
 }
 
@@ -458,8 +454,6 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection = false
-  network       = "%{network_name}"
-  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub]
 }
 
@@ -527,8 +521,6 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection = false
-  network       = "%{network_name}"
-  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub, google_project_service.acm]
 }
 
@@ -777,8 +769,6 @@ func TestAccGKEHubFeatureMembership_gkehubFeatureMesh(t *testing.T) {
 		"random_suffix":   acctest.RandString(t, 10),
 		"org_id":          envvar.GetTestOrgFromEnv(t),
 		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
-		"network_name":    acctest.BootstrapSharedTestNetwork(t, "gke-cluster"),
-		"subnetwork_name": acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster")),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -831,8 +821,6 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection = false
-  network       = "%{network_name}"
-  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.container, google_project_service.gkehub]
 }
 
@@ -886,8 +874,6 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection = false
-  network       = "%{network_name}"
-  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.container, google_project_service.gkehub]
 }
 
@@ -940,8 +926,6 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection = false
-  network       = "%{network_name}"
-  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.container, google_project_service.gkehub]
 }
 
@@ -994,8 +978,6 @@ resource "google_container_cluster" "primary" {
   initial_node_count = 1
   project = google_project.project.project_id
   deletion_protection = false
-  network       = "%{network_name}"
-  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.container, google_project_service.container, google_project_service.gkehub]
 }
 
@@ -1005,8 +987,6 @@ resource "google_container_cluster" "secondary" {
   initial_node_count = 1
   project = google_project.project.project_id
   deletion_protection = false
-  network       = "%{network_name}"
-  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.container, google_project_service.container, google_project_service.gkehub]
 }
 
@@ -1016,8 +996,6 @@ resource "google_container_cluster" "tertiary" {
   initial_node_count = 1
   project = google_project.project.project_id
   deletion_protection = false
-  network       = "%{network_name}"
-  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.container, google_project_service.container, google_project_service.gkehub]
 }
 
@@ -1028,8 +1006,6 @@ resource "google_container_cluster" "quarternary" {
   initial_node_count = 1
   project = google_project.project.project_id
   deletion_protection = false
-  network       = "%{network_name}"
-  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.container, google_project_service.container, google_project_service.gkehub]
 }
 
@@ -1104,8 +1080,6 @@ resource "google_container_cluster" "container_acmoci" {
   network = google_compute_network.testnetwork.self_link
   project = google_project.project.project_id
   deletion_protection = false
-  network       = "%{network_name}"
-  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.container, google_project_service.container, google_project_service.gkehub]
 }
 

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go.erb
@@ -208,8 +208,6 @@ func TestAccGKEHubFeature_gkehubFeatureMciUpdate(t *testing.T) {
 		"random_suffix":   acctest.RandString(t, 10),
 		"org_id":          envvar.GetTestOrgFromEnv(t),
 		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
-		"network_name" :   acctest.BootstrapSharedTestNetwork(t, "gke-cluster"),
-		"subnetwork_name": acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster")),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -248,8 +246,6 @@ resource "google_container_cluster" "primary" {
   initial_node_count = 1
   project = google_project.project.project_id
   deletion_protection = false
-  network       = "%{network_name}"
-  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub]
 }
 
@@ -259,8 +255,6 @@ resource "google_container_cluster" "secondary" {
   initial_node_count = 1
   project = google_project.project.project_id
   deletion_protection = false
-  network       = "%{network_name}"
-  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub]
 }
 
@@ -305,8 +299,6 @@ resource "google_container_cluster" "primary" {
   initial_node_count = 1
   project = google_project.project.project_id
   deletion_protection = false
-  network       = "%{network_name}"
-  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub]
 }
 
@@ -316,8 +308,6 @@ resource "google_container_cluster" "secondary" {
   initial_node_count = 1
   project = google_project.project.project_id
   deletion_protection = false
-  network       = "%{network_name}"
-  subnetwork    = "%{subnetwork_name}"
   depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub]
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Revert some changes in https://github.com/GoogleCloudPlatform/magic-modules/pull/9664, as these tests are wrapped in new projects and don't need + can't find the bootstrapped network. Tests failed in nightly currently with error `Error 400: Network "tf-bootstrap-net-gke-cluster" does not exist.`

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
