### PR TITLE
Move container building to a YAML file and specify a service account

### DIFF
--- a/.ci/gcb-build-container.yml
+++ b/.ci/gcb-build-container.yml
@@ -1,0 +1,15 @@
+---
+# substitutions:
+#   _IMAGE_NAME: 'gcr.io/graphite-docker-images/bash-plus:latest'
+#   _DIRECTORY: '.ci/containers/bash-plus'
+
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', '$_IMAGE_NAME', '.']
+    dir: '$_DIRECTORY'
+
+images:
+  - '$_IMAGE_NAME'
+
+logsBucket: 'gs://cloudbuild-container-builder-logs'
+


### PR DESCRIPTION
Apart of the security improvements to our [continuous integration system](https://docs.google.com/document/d/1VvYtYJueYHttB57ZWSPI9ymUJMaTVj7t89tl4DkgBuc/edit?resourcekey=0-n_zdVUEhOJu8RJLF5ZAtdQ). 

We are moving these operations to a YAML file and specifying a bucket that the logs can be written to :) 
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
