### PR TITLE
In-place update `labels` and `terraform_labels` fields in immutable resources

### DIFF
--- a/mmv1/api/resource.rb
+++ b/mmv1/api/resource.rb
@@ -472,10 +472,6 @@ module Api
     end
 
     def add_labels_fields(props, parent, labels)
-      # The effective_labels field is used to write to API, instead of the labels field.
-      labels.ignore_write = true
-      labels.description = "#{labels.description}\n\n#{get_labels_field_note(labels.name)}"
-
       @custom_diff ||= []
       if parent.nil? || parent.flatten_object
         @custom_diff.append('tpgresource.SetLabelsDiff')
@@ -483,8 +479,15 @@ module Api
         @custom_diff.append('tpgresource.SetMetadataLabelsDiff')
       end
 
-      props << build_terraform_labels_field('labels', labels)
+      props << build_terraform_labels_field('labels', parent, labels)
       props << build_effective_labels_field('labels', labels)
+
+      # The effective_labels field is used to write to API, instead of the labels field.
+      labels.ignore_write = true
+      labels.description = "#{labels.description}\n\n#{get_labels_field_note(labels.name)}"
+      return unless parent.nil?
+
+      labels.immutable = false
     end
 
     def add_annotations_fields(props, parent, annotations)
@@ -521,9 +524,15 @@ module Api
       )
     end
 
-    def build_terraform_labels_field(name, labels)
+    def build_terraform_labels_field(name, parent, labels)
       description = "The combination of #{name} configured directly on the resource
  and default #{name} configured on the provider."
+
+      immutable = if parent.nil?
+                    false
+                  else
+                    labels.immutable
+                  end
 
       Api::Type::KeyValueTerraformLabels.new(
         name: "terraform#{name.capitalize}",
@@ -533,8 +542,16 @@ module Api
         min_version: labels.field_min_version,
         ignore_write: true,
         update_url: labels.update_url,
-        immutable: labels.immutable
+        immutable:
       )
+    end
+
+    # Check if the resource has root "labels" field
+    def root_labels?
+      root_properties.each do |p|
+        return true if p.is_a? Api::Type::KeyValueLabels
+      end
+      false
     end
 
     # Return labels fields that should be added to ImportStateVerifyIgnore

--- a/mmv1/api/type.rb
+++ b/mmv1/api/type.rb
@@ -47,7 +47,7 @@ module Api
       # For nested fields, this only applies at the current level. This means
       # it should be explicitly added to each field that needs the ForceNew
       # behavior.
-      attr_reader :immutable
+      attr_accessor :immutable
 
       # url_param_only will not send the field in the resource body and will
       # not attempt to read the field from the API response.

--- a/mmv1/provider/terraform.rb
+++ b/mmv1/provider/terraform.rb
@@ -545,13 +545,21 @@ module Provider
     end
 
     def force_new?(property, resource)
-      ((!property.output || property.is_a?(Api::Type::KeyValueEffectiveLabels)) &&
-        (property.immutable || (resource.immutable && property.update_url.nil? &&
-                              property.immutable.nil? &&
-                            (property.parent.nil? ||
-                             force_new?(property.parent, resource))))) ||
+      (
+        (!property.output || property.is_a?(Api::Type::KeyValueEffectiveLabels)) &&
+        (property.immutable ||
+          (resource.immutable && property.update_url.nil? && property.immutable.nil? &&
+            (property.parent.nil? ||
+              (force_new?(property.parent, resource) &&
+               !(property.parent.flatten_object && property.is_a?(Api::Type::KeyValueLabels))
+              )
+            )
+          )
+        )
+      ) ||
         (property.is_a?(Api::Type::KeyValueTerraformLabels) &&
-          !updatable?(resource, resource.all_user_properties))
+          !updatable?(resource, resource.all_user_properties) && !resource.root_labels?
+        )
     end
 
     # Returns tuples of (fieldName, list of update masks) for

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -57,7 +57,7 @@ func Resource<%= object.resource_name -%>() *schema.Resource {
     return &schema.Resource{
         Create: resource<%= object.resource_name -%>Create,
         Read: resource<%= object.resource_name -%>Read,
-<%  if updatable?(object,  object.all_user_properties) -%>
+<%  if updatable?(object, object.all_user_properties) || object.root_labels? -%>
         Update: resource<%= object.resource_name -%>Update,
 <%  end -%>
         Delete: resource<%= object.resource_name -%>Delete,
@@ -70,7 +70,7 @@ func Resource<%= object.resource_name -%>() *schema.Resource {
 
         Timeouts: &schema.ResourceTimeout {
             Create: schema.DefaultTimeout(<%= object.timeouts.insert_minutes -%> * time.Minute),
-<%  if updatable?(object, object.all_user_properties) -%>
+<%  if updatable?(object, object.all_user_properties) || object.root_labels? -%>
             Update: schema.DefaultTimeout(<%= object.timeouts.update_minutes -%> * time.Minute),
 <%  end -%>
             Delete: schema.DefaultTimeout(<%= object.timeouts.delete_minutes -%> * time.Minute),
@@ -973,7 +973,12 @@ if len(updateMask) > 0 {
     return resource<%= object.resource_name -%>Read(d, meta)
 <%  end # if custom_update -%>
 }
-<%  end # if updatable? -%>
+<% elsif object.root_labels? # if updatable? -%>
+func resource<%= object.resource_name -%>Update(d *schema.ResourceData, meta interface{}) error {
+    // Only the root field "labels" and "terraform_labels" are mutable
+    return resource<%= object.resource_name -%>Read(d, meta)
+}
+<%  end -%>
 
 func resource<%= object.resource_name -%>Delete(d *schema.ResourceData, meta interface{}) error {
 <%  if object.async&.is_a?(Api::OpAsync) && object.async.include_project && object.async&.allow?('delete') -%>

--- a/mmv1/templates/terraform/resource.html.markdown.erb
+++ b/mmv1/templates/terraform/resource.html.markdown.erb
@@ -179,7 +179,7 @@ This resource provides the following
 [Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options:
 
 - `create` - Default is <%= timeouts.insert_minutes -%> minutes.
-<% if updatable?(object, properties) -%>
+<% if updatable?(object, properties) || object.root_labels? -%>
 - `update` - Default is <%= timeouts.update_minutes -%> minutes.
 <% end -%>
 - `delete` - Default is <%= timeouts.delete_minutes -%> minutes.

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job.go.erb
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job.go.erb
@@ -155,7 +155,6 @@ func ResourceDataprocJob() *schema.Resource {
 				**Note**: This field is non-authoritative, and will only manage the labels present in your configuration.
 				Please refer to the field 'effective_labels' for all of the labels present on the resource.`,
 				Optional:    true,
-				ForceNew:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 

--- a/tpgtools/property.go
+++ b/tpgtools/property.go
@@ -906,6 +906,7 @@ func createPropertiesFromSchema(schema *openapi.Schema, typeFetcher *TypeFetcher
 
 			if p.IsResourceLabels() {
 				props = append(props, build_terraform_labels_field(p, resource, parent))
+				p.ForceNew = false
 			}
 		}
 
@@ -969,7 +970,6 @@ func build_terraform_labels_field(p Property, resource *Resource, parent *Proper
 		resource:    resource,
 		parent:      parent,
 		Computed:    true,
-		ForceNew:    p.ForceNew, // Add ForceNew property if labels field has it
 		PackageName: p.PackageName,
 		StateSetter: &stateSetter,
 	}

--- a/tpgtools/resource.go
+++ b/tpgtools/resource.go
@@ -291,6 +291,16 @@ func (r Resource) Updatable() bool {
 	return false
 }
 
+// The resource has other mutable fields, besides "labels" and "terraform_labels" fields
+func (r Resource) HasMutableNonLabelsFields() bool {
+	for _, p := range r.SchemaProperties() {
+		if !p.IsResourceLabels() && p.Name() != "terraform_labels" && !p.ForceNew && !(!p.Optional && p.Computed) {
+			return true
+		}
+	}
+	return false
+}
+
 // Objects are properties with sub-properties
 func (r Resource) Objects() (props []Property) {
 	for _, v := range r.Properties {

--- a/tpgtools/templates/resource.go.tmpl
+++ b/tpgtools/templates/resource.go.tmpl
@@ -413,6 +413,7 @@ func resource{{$.PathType}}Read(d *schema.ResourceData, meta interface{}) error 
 
 {{- if $.Updatable }}
 func resource{{$.PathType}}Update(d *schema.ResourceData, meta interface{}) error {
+{{- if $.HasMutableNonLabelsFields }}
 	config := meta.(*transport_tpg.Config)
 
 {{- range $v := .Properties }}
@@ -490,6 +491,10 @@ func resource{{$.PathType}}Update(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	log.Printf("[DEBUG] Finished creating {{$.DCLTitle}} %q: %#v", d.Id(), res)
+
+{{- else }}
+	// Only the root field "labels" and "terraform_labels" are mutable
+{{- end }}
 
 	return resource{{$.PathType}}Read(d, meta)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

For immutable resources, add update method and remove ForceNew from `labels` and `terraform_labels` fields, so these two fields will be updated in place.

This change applied to all of the immutable resources with immutable `terraform_labels` and immutable `labels` fields
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
provider: added support for in-place update for `labels` and `terraform_labels` fields in immutable resources

```
