### PR TITLE
Removed usage of labeler.LabelData due to a soak period being required

### DIFF
--- a/.ci/magician/cmd/request_service_reviewers.go
+++ b/.ci/magician/cmd/request_service_reviewers.go
@@ -45,6 +45,11 @@ var requestServiceReviewersCmd = &cobra.Command{
 	},
 }
 
+// TODO: Switch to labeler.LabelData after a soak period.
+type LabelData struct {
+	Team string `yaml:"team,omitempty"`
+}
+
 func execRequestServiceReviewers(prNumber string, gh GithubClient, enrolledTeamsYaml []byte) {
 	pullRequest, err := gh.GetPullRequest(prNumber)
 	if err != nil {
@@ -52,7 +57,7 @@ func execRequestServiceReviewers(prNumber string, gh GithubClient, enrolledTeams
 		os.Exit(1)
 	}
 
-	enrolledTeams := make(map[string]labeler.LabelData)
+	enrolledTeams := make(map[string]LabelData)
 	if err := yaml.Unmarshal(enrolledTeamsYaml, &enrolledTeams); err != nil {
 		fmt.Printf("Error unmarshalling enrolled teams yaml: %s", err)
 		os.Exit(1)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
https://github.com/GoogleCloudPlatform/magic-modules/pull/9703 for more context - it didn't work because folks don't have the yaml change available until after they're already running it. But we can just re-define a LabelData struct in .ci, which _will_ get caught, and which will resolve the issue for now.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
