### PR TITLE
Fixed a problem in which only ConfigId was calculated first when the API parameter was set to Known After Apply

### DIFF
--- a/mmv1/third_party/terraform/services/servicemanagement/resource_endpoints_service.go
+++ b/mmv1/third_party/terraform/services/servicemanagement/resource_endpoints_service.go
@@ -157,6 +157,10 @@ func predictServiceId(_ context.Context, d *schema.ResourceDiff, meta interface{
 	if !d.HasChange("openapi_config") && !d.HasChange("grpc_config") && !d.HasChange("protoc_output_base64") {
 		return nil
 	}
+	if !d.NewValueKnown("openapi_config") || !d.NewValueKnown("grpc_config") || !d.NewValueKnown("protoc_output_base64") {
+		d.SetNewComputed("config_id")
+		return nil
+	}
 	baseDate := time.Now().Format("2006-01-02")
 	oldConfigId := d.Get("config_id").(string)
 	if match, err := regexp.MatchString(`\d\d\d\d-\d\d-\d\dr\d*`, oldConfigId); !match || err != nil {

--- a/mmv1/third_party/terraform/services/servicemanagement/resource_endpoints_service_test.go
+++ b/mmv1/third_party/terraform/services/servicemanagement/resource_endpoints_service_test.go
@@ -58,6 +58,30 @@ func TestAccEndpointsService_grpc(t *testing.T) {
 	})
 }
 
+func TestAccEndpointsService_grpcNotPreComputeConfigId(t *testing.T) {
+	t.Parallel()
+	prj := envvar.GetTestProjectFromEnv()
+	parent := fmt.Sprintf("projects/%s", prj)
+	description := acctest.RandString(t, 100)
+	serviceId := "tf-test" + acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckEndpointServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointsService_grpcNotPreComputeConfigId(serviceId, envvar.GetTestProjectFromEnv(), parent, description),
+				Check:  testAccCheckEndpointExistsByName(t, serviceId),
+			},
+			{
+				Config: testAccEndpointsService_grpcNotPreComputeConfigId(serviceId, envvar.GetTestProjectFromEnv(), parent, description),
+				Check:  testAccCheckEndpointExistsByName(t, serviceId),
+			},
+		},
+	})
+}
+
 func testAccEndpointsService_basic(serviceId, project, rev string) string {
 	return fmt.Sprintf(`
 resource "google_endpoints_service" "endpoints_service" {
@@ -127,6 +151,41 @@ EOF
   protoc_output_base64 = filebase64("test-fixtures/test_api_descriptor.pb")
 }
 `, serviceId, project)
+}
+
+func testAccEndpointsService_grpcNotPreComputeConfigId(serviceId, project, parent, description string) string {
+	return fmt.Sprintf(`
+resource "google_tags_tag_key" "key1" {
+  parent      = "%[3]s"
+  short_name  = "endpoints-service-test-1"
+  description = "%[4]s"
+}
+
+resource "google_tags_tag_key" "key2" {
+  parent      = "%[3]s"
+  short_name  = "endpoints-service-test-2"
+  lifecycle {
+    replace_triggered_by = [google_tags_tag_key.key1.description]
+  }
+}
+
+resource "google_endpoints_service" "endpoints_service" {
+  service_name = "%[1]s.endpoints.%[2]s.cloud.goog"
+  project      = "%[2]s"
+  grpc_config  = <<EOF
+type: google.api.Service
+config_version: 3
+name: %[1]s.endpoints.%[2]s.cloud.goog
+title: Test ${google_tags_tag_key.key2.namespaced_name}
+usage:
+  rules:
+  - selector: endpoints.examples.bookstore.Bookstore.ListShelves
+    allow_unregistered_calls: true
+EOF
+
+  protoc_output_base64 = filebase64("test-fixtures/test_api_descriptor.pb")
+}
+`, serviceId, project, parent, description)
 }
 
 func testAccCheckEndpointExistsByName(t *testing.T, serviceId string) resource.TestCheckFunc {

--- a/mmv1/third_party/terraform/services/servicemanagement/resource_endpoints_service_test.go
+++ b/mmv1/third_party/terraform/services/servicemanagement/resource_endpoints_service_test.go
@@ -58,11 +58,10 @@ func TestAccEndpointsService_grpc(t *testing.T) {
 	})
 }
 
-func TestAccEndpointsService_grpcNotPreComputeConfigId(t *testing.T) {
+func TestAccEndpointsService_grpcNotPreComputeConfigIdByGrpcConfig(t *testing.T) {
 	t.Parallel()
 	prj := envvar.GetTestProjectFromEnv()
 	parent := fmt.Sprintf("projects/%s", prj)
-	description := acctest.RandString(t, 100)
 	serviceId := "tf-test" + acctest.RandString(t, 10)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -71,11 +70,34 @@ func TestAccEndpointsService_grpcNotPreComputeConfigId(t *testing.T) {
 		CheckDestroy:             testAccCheckEndpointServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEndpointsService_grpcNotPreComputeConfigId(serviceId, envvar.GetTestProjectFromEnv(), parent, description),
+				Config: testAccEndpointsService_grpcNotPreComputeConfigIdByGrpcConfig(serviceId, envvar.GetTestProjectFromEnv(), parent, "1"),
 				Check:  testAccCheckEndpointExistsByName(t, serviceId),
 			},
 			{
-				Config: testAccEndpointsService_grpcNotPreComputeConfigId(serviceId, envvar.GetTestProjectFromEnv(), parent, description),
+				Config: testAccEndpointsService_grpcNotPreComputeConfigIdByGrpcConfig(serviceId, envvar.GetTestProjectFromEnv(), parent, "2"),
+				Check:  testAccCheckEndpointExistsByName(t, serviceId),
+			},
+		},
+	})
+}
+
+func TestAccEndpointsService_openapiNotPreComputeConfigId(t *testing.T) {
+	t.Parallel()
+	prj := envvar.GetTestProjectFromEnv()
+	parent := fmt.Sprintf("projects/%s", prj)
+	serviceId := "tf-test" + acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckEndpointServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEndpointsService_openapiNotPreComputeConfigId(serviceId, envvar.GetTestProjectFromEnv(), parent, "1"),
+				Check:  testAccCheckEndpointExistsByName(t, serviceId),
+			},
+			{
+				Config: testAccEndpointsService_openapiNotPreComputeConfigId(serviceId, envvar.GetTestProjectFromEnv(), parent, "2"),
 				Check:  testAccCheckEndpointExistsByName(t, serviceId),
 			},
 		},
@@ -153,17 +175,17 @@ EOF
 `, serviceId, project)
 }
 
-func testAccEndpointsService_grpcNotPreComputeConfigId(serviceId, project, parent, description string) string {
+func testAccEndpointsService_grpcNotPreComputeConfigIdByGrpcConfig(serviceId, project, parent, description string) string {
 	return fmt.Sprintf(`
 resource "google_tags_tag_key" "key1" {
   parent      = "%[3]s"
-  short_name  = "endpoints-service-test-1"
+  short_name  = "endpoints-%[1]s-1"
   description = "%[4]s"
 }
 
 resource "google_tags_tag_key" "key2" {
   parent      = "%[3]s"
-  short_name  = "endpoints-service-test-2"
+  short_name  = "endpoints-%[1]s-2"
   lifecycle {
     replace_triggered_by = [google_tags_tag_key.key1.description]
   }
@@ -185,6 +207,71 @@ EOF
 
   protoc_output_base64 = filebase64("test-fixtures/test_api_descriptor.pb")
 }
+`, serviceId, project, parent, description)
+}
+
+func testAccEndpointsService_openapiNotPreComputeConfigId(serviceId, project, parent, description string) string {
+	return fmt.Sprintf(`
+resource "google_tags_tag_key" "key1" {
+  parent      = "%[3]s"
+  short_name  = "endpoints-%[1]s-1"
+  description = "%[4]s"
+}
+
+resource "google_tags_tag_key" "key2" {
+  parent      = "%[3]s"
+  short_name  = "endpoints-%[1]s-2"
+  lifecycle {
+    replace_triggered_by = [google_tags_tag_key.key1.description]
+  }
+}
+resource "google_endpoints_service" "endpoints_service" {
+  service_name   = "%[1]s.endpoints.%[2]s.cloud.goog"
+  project        = "%[2]s"
+  openapi_config = <<EOF
+swagger: "2.0"
+info:
+  description: "${google_tags_tag_key.key2.namespaced_name}"
+  title: "Endpoints Example, rev. 1"
+  version: "1.0.0"
+host: "%[1]s.endpoints.%[2]s.cloud.goog"
+basePath: "/"
+consumes:
+- "application/json"
+produces:
+- "application/json"
+schemes:
+- "https"
+paths:
+  "/echo":
+    post:
+      description: "Echo back a given message."
+      operationId: "echo"
+      produces:
+      - "application/json"
+      responses:
+        200:
+          description: "Echo"
+          schema:
+            $ref: "#/definitions/echoMessage"
+      parameters:
+      - description: "Message to echo"
+        in: body
+        name: message
+        required: true
+        schema:
+          $ref: "#/definitions/echoMessage"
+      security:
+      - api_key: []
+definitions:
+  echoMessage:
+    properties:
+      message:
+        type: "string"
+EOF
+
+}
+
 `, serviceId, project, parent, description)
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

If certain attributes such as protoc_output_base64 are modified, the config_id is pre-computed, but if these attributes are (known after apply) at plan time and there is no diff as a result of apply, the plan result will not match, Error: Provider produced inconsistent final plan.
Therefore, if these attributes are modified and their values are non-deterministic, the config_id is now also calculated at apply time.

The added test case has the dependency endpoints <- key2 <- key1, and the attribute of key2 is used in grpc_config of endpoints.
If the attribute of key2 referenced in endpoints is known after apply for some reason, and as a result there is no diff in the attribute of key2, only the config_id will be changed, but in that case it will not be applied and ` Provider produced inconsistent final plan` error happened.

As a specific case, we have confirmed the occurrence of this problem in the product code in cases where grpc-config, protoc-descriptor, etc. are obtained through multiple resources such as local_file, etc. and external files obtained by null_resource.

I have [closed P/R](https://github.com/GoogleCloudPlatform/magic-modules/pull/8853) and newly opened because discovering that the previous P/R had many incorrect modified source code, corrections, tests, etc.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/11776
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
servicemanagement: fixed issue in `google_endpoints_service` where an inconsistent plan would be created when certain fields had computed values 
```
