### PR TITLE
Add data source for Google Cloud Filestore Instance.

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
@@ -118,6 +118,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_container_registry_repository":             containeranalysis.DataSourceGoogleContainerRepo(),
 	"google_dataproc_metastore_service":                dataprocmetastore.DataSourceDataprocMetastoreService(),
 	"google_datastream_static_ips":                     datastream.DataSourceGoogleDatastreamStaticIps(),
+	"google_filestore_instance":                        filestore.DataSourceGoogleFilestoreInstance(),
 	"google_iam_policy":                                resourcemanager.DataSourceGoogleIamPolicy(),
 	"google_iam_role":                                  resourcemanager.DataSourceGoogleIamRole(),
 	"google_iam_testable_permissions":                  resourcemanager.DataSourceGoogleIamTestablePermissions(),

--- a/mmv1/third_party/terraform/services/filestore/data_source_filestore_instance.go
+++ b/mmv1/third_party/terraform/services/filestore/data_source_filestore_instance.go
@@ -1,0 +1,59 @@
+package filestore
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceGoogleFilestoreInstance() *schema.Resource {
+	// Generate datasource schema from resource
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceFilestoreInstance().Schema)
+
+	// Set 'Required' schema elements
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "name")
+
+	// Set 'Optional' schema elements
+	tpgresource.AddOptionalFieldsToSchema(dsSchema, "project", "location")
+
+	return &schema.Resource{
+		Read:   dataSourceGoogleFilestoreInstanceRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceGoogleFilestoreInstanceRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	
+	location, err := tpgresource.GetLocation(d, config)
+	if err != nil {
+		return err
+	}
+	
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return err
+	}
+	
+	id := fmt.Sprintf("projects/%s/locations/%s/instances/%s", project, location, d.Get("name").(string))
+	if err != nil {
+		return err
+	}
+	d.SetId(id)
+
+	err = resourceFilestoreInstanceRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if err := tpgresource.SetDataSourceLabels(d); err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
+}

--- a/mmv1/third_party/terraform/services/filestore/data_source_filestore_instance.go
+++ b/mmv1/third_party/terraform/services/filestore/data_source_filestore_instance.go
@@ -26,17 +26,17 @@ func DataSourceGoogleFilestoreInstance() *schema.Resource {
 
 func dataSourceGoogleFilestoreInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
-	
+
 	location, err := tpgresource.GetLocation(d, config)
 	if err != nil {
 		return err
 	}
-	
+
 	project, err := tpgresource.GetProject(d, config)
 	if err != nil {
 		return err
 	}
-	
+
 	id := fmt.Sprintf("projects/%s/locations/%s/instances/%s", project, location, d.Get("name").(string))
 	if err != nil {
 		return err

--- a/mmv1/third_party/terraform/services/filestore/data_source_filestore_instance_test.go
+++ b/mmv1/third_party/terraform/services/filestore/data_source_filestore_instance_test.go
@@ -1,0 +1,52 @@
+package filestore_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccFilestoreInstanceDatasource_basic(t *testing.T) {
+	t.Parallel()
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFilestoreInstanceDatasourceConfig(acctest.RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceState("data.google_filestore_instance.filestore", "google_filestore_instance.filestore"),
+				),
+			},
+		},
+	})
+}
+
+func testAccFilestoreInstanceDatasourceConfig(suffix string) string {
+	return fmt.Sprintf(`
+resource "google_filestore_instance" "filestore" {
+  name        = "tf-instance-%s"
+  location    = "us-central1-b"
+  tier        = "BASIC_HDD"
+  description = "A basic filestore instance created during testing."
+
+  file_shares {
+    capacity_gb = 1536
+    name        = "share"
+  }
+
+  networks {
+    network = "default"
+    modes   = ["MODE_IPV4"]
+  }
+}
+
+data "google_filestore_instance" "filestore" {
+  name = google_filestore_instance.filestore.name
+  location = "us-central1-b"
+}
+`, suffix)
+}

--- a/mmv1/third_party/terraform/website/docs/d/filestore_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/filestore_instance.html.markdown
@@ -1,0 +1,48 @@
+---
+subcategory: "Filestore"
+description: |-
+  Get information about a Google Cloud Filestore instance.
+---
+
+# google\_filestore\_instance
+
+Get info about a Google Cloud Filestore instance.
+
+## Example Usage
+
+```tf
+data "google_filestore_instance" "my_instance" {
+  name = "my-filestore-instance"
+}
+
+output "instance_ip_addresses" {
+  value = data.google_filestore_instance.my_instance.networks.ip_addresses
+}
+
+output "instance_connect_mode" {
+  value = data.google_filestore_instance.my_instance.networks.connect_mode
+}
+
+output "instance_file_share_name" {
+  value = data.google_filestore_instance.my_instance.file_shares.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of a Filestore instance.
+
+- - -
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+* `location` - (Optional) The name of the location of the instance. This 
+    can be a region for ENTERPRISE tier instances. If it is not provided, 
+    the provider region or zone is used.
+
+## Attributes Reference
+
+See [google_filestore_instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/filestore_instance) resource for details of the available attributes.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This PR adds a data source for GCP Filestore Instances. This data source is particularly important because connections to Filestore instances require use of the instance IP address which is non-deterministic and generated when the instance is created. 

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
`google_filestore_instance`
```
