### PR TITLE
added default value for minPortsPerVM field at "google_compute_router_nat"

### DIFF
--- a/mmv1/products/compute/RouterNat.yaml
+++ b/mmv1/products/compute/RouterNat.yaml
@@ -236,7 +236,8 @@ properties:
   - !ruby/object:Api::Type::Integer
     name: minPortsPerVm
     description: |
-      Minimum number of ports allocated to a VM from this NAT.
+      Minimum number of ports allocated to a VM from this NAT. Defaults to 64 for static port allocation and 32 dynamic port allocation if not set.
+    default_value: 64
   - !ruby/object:Api::Type::Integer
     name: maxPortsPerVm
     description: |


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
