### PR TITLE
Refactor `networkName` in TestAccComputeNetwork_*

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_test.go.erb
@@ -22,6 +22,8 @@ func TestAccComputeNetwork_explicitAutoSubnet(t *testing.T) {
 	t.Parallel()
 
 	var network compute.Network
+	suffixName := acctest.RandString(t, 10)
+    networkName := fmt.Sprintf("tf-test-network-basic-%s", suffixName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -29,7 +31,7 @@ func TestAccComputeNetwork_explicitAutoSubnet(t *testing.T) {
 		CheckDestroy:             testAccCheckComputeNetworkDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeNetwork_basic(acctest.RandString(t, 10)),
+				Config: testAccComputeNetwork_basic(networkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeNetworkExists(
 						t, "google_compute_network.bar", &network),
@@ -50,6 +52,8 @@ func TestAccComputeNetwork_customSubnet(t *testing.T) {
 	t.Parallel()
 
 	var network compute.Network
+	suffixName := acctest.RandString(t, 10)
+    networkName := fmt.Sprintf("tf-test-network-custom-sn-%s", suffixName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -57,7 +61,7 @@ func TestAccComputeNetwork_customSubnet(t *testing.T) {
 		CheckDestroy:             testAccCheckComputeNetworkDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeNetwork_custom_subnet(acctest.RandString(t, 10)),
+				Config: testAccComputeNetwork_custom_subnet(networkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeNetworkExists(
 						t, "google_compute_network.baz", &network),
@@ -78,7 +82,8 @@ func TestAccComputeNetwork_routingModeAndUpdate(t *testing.T) {
 	t.Parallel()
 
 	var network compute.Network
-	networkName := acctest.RandString(t, 10)
+	suffixName := acctest.RandString(t, 10)
+    networkName := fmt.Sprintf("tf-test-network-routing-mode-%s", suffixName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -121,7 +126,7 @@ func TestAccComputeNetwork_numericId(t *testing.T) {
 		CheckDestroy:             testAccCheckComputeNetworkDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeNetwork_basic(suffixName),
+				Config: testAccComputeNetwork_basic(networkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("google_compute_network.bar", "numeric_id",regexp.MustCompile("^\\d{1,}$")),
 					resource.TestCheckResourceAttr("google_compute_network.bar", "id", networkId),
@@ -140,6 +145,8 @@ func TestAccComputeNetwork_default_routing_mode(t *testing.T) {
 	t.Parallel()
 
 	var network compute.Network
+	suffixName := acctest.RandString(t, 10)
+    networkName := fmt.Sprintf("tf-test-network-network-default-routes-%s", suffixName)
 
 	expectedRoutingMode := "REGIONAL"
 
@@ -149,7 +156,7 @@ func TestAccComputeNetwork_default_routing_mode(t *testing.T) {
 		CheckDestroy:             testAccCheckComputeNetworkDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeNetwork_basic(acctest.RandString(t, 10)),
+				Config: testAccComputeNetwork_basic(networkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeNetworkExists(
 						t, "google_compute_network.bar", &network),
@@ -165,6 +172,8 @@ func TestAccComputeNetwork_networkDeleteDefaultRoute(t *testing.T) {
 	t.Parallel()
 
 	var network compute.Network
+	suffixName := acctest.RandString(t, 10)
+    networkName := fmt.Sprintf("tf-test-network-network-default-routes-%s", suffixName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -172,7 +181,7 @@ func TestAccComputeNetwork_networkDeleteDefaultRoute(t *testing.T) {
 		CheckDestroy:             testAccCheckComputeNetworkDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeNetwork_deleteDefaultRoute(acctest.RandString(t, 10)),
+				Config: testAccComputeNetwork_deleteDefaultRoute(networkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeNetworkExists(
 						t, "google_compute_network.bar", &network),
@@ -189,7 +198,8 @@ func TestAccComputeNetwork_networkFirewallPolicyEnforcementOrderAndUpdate(t *tes
 
 	var network compute.Network
 	var updatedNetwork compute.Network
-	networkName := acctest.RandString(t, 10)
+	suffixName := acctest.RandString(t, 10)
+    networkName := fmt.Sprintf("tf-test-network-firewall-policy-enforcement-order-%s", suffixName)
 
 	defaultNetworkFirewallPolicyEnforcementOrder := "AFTER_CLASSIC_FIREWALL"
 	explicitNetworkFirewallPolicyEnforcementOrder := "BEFORE_CLASSIC_FIREWALL"
@@ -401,56 +411,56 @@ func testAccCheckComputeNetworkWasUpdated(newNetwork *compute.Network, oldNetwor
         }
 }
 
-func testAccComputeNetwork_basic(suffix string) string {
+func testAccComputeNetwork_basic(networkName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "bar" {
-  name                    = "tf-test-network-basic-%s"
+  name                    = "%s"
   auto_create_subnetworks = true
 }
-`, suffix)
+`, networkName)
 }
 
-func testAccComputeNetwork_custom_subnet(suffix string) string {
+func testAccComputeNetwork_custom_subnet(networkName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "baz" {
-  name                    = "tf-test-network-custom-sn-%s"
+  name                    = "%s"
   auto_create_subnetworks = false
 }
-`, suffix)
+`, networkName)
 }
 
-func testAccComputeNetwork_routing_mode(network, routingMode string) string {
+func testAccComputeNetwork_routing_mode(networkName, routingMode string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "acc_network_routing_mode" {
-  name         = "tf-test-network-routing-mode-%s"
+  name         = "%s"
   routing_mode = "%s"
 }
-`, network, routingMode)
+`, networkName, routingMode)
 }
 
-func testAccComputeNetwork_deleteDefaultRoute(suffix string) string {
+func testAccComputeNetwork_deleteDefaultRoute(networkName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "bar" {
-  name                            = "tf-test-network-delete-default-routes-%s"
+  name                            = "%s"
   delete_default_routes_on_create = true
   auto_create_subnetworks         = false
 }
-`, suffix)
+`, networkName)
 }
 
-func testAccComputeNetwork_networkFirewallPolicyEnforcementOrderDefault(network string) string {
+func testAccComputeNetwork_networkFirewallPolicyEnforcementOrderDefault(networkName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "acc_network_firewall_policy_enforcement_order" {
-  name = "tf-test-network-firewall-policy-enforcement-order-%s"
+  name = "%s"
 }
-`, network)
+`, networkName)
 }
 
-func testAccComputeNetwork_networkFirewallPolicyEnforcementOrderUpdate(network, order string) string {
+func testAccComputeNetwork_networkFirewallPolicyEnforcementOrderUpdate(networkName, order string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "acc_network_firewall_policy_enforcement_order" {
-  name                                      = "tf-test-network-firewall-policy-enforcement-order-%s"
+  name                                      = "%s"
   network_firewall_policy_enforcement_order = "%s"
 }
-`, network, order)
+`, networkName, order)
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_test.go.erb
@@ -117,8 +117,8 @@ func TestAccComputeNetwork_numericId(t *testing.T) {
 	t.Parallel()
 	suffixName := acctest.RandString(t, 10)
 	networkName := fmt.Sprintf("tf-test-network-basic-%s", suffixName)
-    projectId := envvar.GetTestProjectFromEnv()
-    networkId := fmt.Sprintf("projects/%v/global/networks/%v", projectId, networkName)
+	projectId := envvar.GetTestProjectFromEnv()
+	networkId := fmt.Sprintf("projects/%v/global/networks/%v", projectId, networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_test.go.erb
@@ -23,7 +23,7 @@ func TestAccComputeNetwork_explicitAutoSubnet(t *testing.T) {
 
 	var network compute.Network
 	suffixName := acctest.RandString(t, 10)
-    networkName := fmt.Sprintf("tf-test-network-basic-%s", suffixName)
+	networkName := fmt.Sprintf("tf-test-network-basic-%s", suffixName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -53,7 +53,7 @@ func TestAccComputeNetwork_customSubnet(t *testing.T) {
 
 	var network compute.Network
 	suffixName := acctest.RandString(t, 10)
-    networkName := fmt.Sprintf("tf-test-network-custom-sn-%s", suffixName)
+	networkName := fmt.Sprintf("tf-test-network-custom-sn-%s", suffixName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -83,7 +83,7 @@ func TestAccComputeNetwork_routingModeAndUpdate(t *testing.T) {
 
 	var network compute.Network
 	suffixName := acctest.RandString(t, 10)
-    networkName := fmt.Sprintf("tf-test-network-routing-mode-%s", suffixName)
+	networkName := fmt.Sprintf("tf-test-network-routing-mode-%s", suffixName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -116,7 +116,7 @@ func TestAccComputeNetwork_routingModeAndUpdate(t *testing.T) {
 func TestAccComputeNetwork_numericId(t *testing.T) {
 	t.Parallel()
 	suffixName := acctest.RandString(t, 10)
-    networkName := fmt.Sprintf("tf-test-network-basic-%s", suffixName)
+	networkName := fmt.Sprintf("tf-test-network-basic-%s", suffixName)
     projectId := envvar.GetTestProjectFromEnv()
     networkId := fmt.Sprintf("projects/%v/global/networks/%v", projectId, networkName)
 
@@ -146,7 +146,7 @@ func TestAccComputeNetwork_default_routing_mode(t *testing.T) {
 
 	var network compute.Network
 	suffixName := acctest.RandString(t, 10)
-    networkName := fmt.Sprintf("tf-test-network-network-default-routes-%s", suffixName)
+	networkName := fmt.Sprintf("tf-test-network-network-default-routes-%s", suffixName)
 
 	expectedRoutingMode := "REGIONAL"
 
@@ -173,7 +173,7 @@ func TestAccComputeNetwork_networkDeleteDefaultRoute(t *testing.T) {
 
 	var network compute.Network
 	suffixName := acctest.RandString(t, 10)
-    networkName := fmt.Sprintf("tf-test-network-network-default-routes-%s", suffixName)
+	networkName := fmt.Sprintf("tf-test-network-network-default-routes-%s", suffixName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -199,7 +199,7 @@ func TestAccComputeNetwork_networkFirewallPolicyEnforcementOrderAndUpdate(t *tes
 	var network compute.Network
 	var updatedNetwork compute.Network
 	suffixName := acctest.RandString(t, 10)
-    networkName := fmt.Sprintf("tf-test-network-firewall-policy-enforcement-order-%s", suffixName)
+	networkName := fmt.Sprintf("tf-test-network-firewall-policy-enforcement-order-%s", suffixName)
 
 	defaultNetworkFirewallPolicyEnforcementOrder := "AFTER_CLASSIC_FIREWALL"
 	explicitNetworkFirewallPolicyEnforcementOrder := "BEFORE_CLASSIC_FIREWALL"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Refactored the use of `networkName` in TestAccComputeNetwork_

This is mentioned in a comment from a separate PR [here](https://github.com/GoogleCloudPlatform/magic-modules/pull/9473#discussion_r1414435609)

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
