### PR TITLE
Dataflow Flex Templates - allow usage of launch options

### DIFF
--- a/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job.go.erb
+++ b/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job.go.erb
@@ -74,6 +74,12 @@ func ResourceDataflowFlexTemplateJob() *schema.Resource {
 				Description: `Only applicable when updating a pipeline. Map of transform name prefixes of the job to be replaced with the corresponding name prefixes of the new job.`,
 			},
 
+			"launch_options": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Description: `Options to be used to configure Flex Template launcher instance.`,
+			},
+
 			"on_delete": {
 				Type:         schema.TypeString,
 				ValidateFunc: validation.StringInSlice([]string{"cancel", "drain"}, false),
@@ -278,12 +284,15 @@ func resourceDataflowFlexTemplateJobCreate(d *schema.ResourceData, meta interfac
 		return err
 	}
 
+	launchOptions := tpgresource.ExpandStringMap(d, "launch_options")
+
 	request := dataflow.LaunchFlexTemplateRequest{
 		LaunchParameter: &dataflow.LaunchFlexTemplateParameter{
 			ContainerSpecGcsPath: d.Get("container_spec_gcs_path").(string),
 			JobName:              d.Get("name").(string),
 			Parameters:           updatedParameters,
 			Environment:          &env,
+			LaunchOptions:        launchOptions,
 		},
 	}
 

--- a/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job_migrate.go.erb
+++ b/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job_migrate.go.erb
@@ -40,6 +40,12 @@ func resourceDataflowFlexTemplateJobResourceV0() *schema.Resource {
 				Description: `Only applicable when updating a pipeline. Map of transform name prefixes of the job to be replaced with the corresponding name prefixes of the new job.`,
 			},
 
+			"launch_options": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Description: `Options to be used to configure Flex Template launcher instance.`,
+			},
+
 			"on_delete": {
 				Type:         schema.TypeString,
 				ValidateFunc: validation.StringInSlice([]string{"cancel", "drain"}, false),


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Allow passing `launch_options` when using Terraform to manage Flex Templates, to allow customizing specific things such as `ft_vm_source_image` and `ft_launch_timeout_secs` when required by the customer.


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
Add optional launch_options to dataflow_flex_template_job
```
