### PR TITLE
Reduce VCR recording runtime after package split

### DIFF
--- a/.ci/scripts/go-plus/gcb-terraform-vcr-tester/test_terraform_vcr.sh
+++ b/.ci/scripts/go-plus/gcb-terraform-vcr-tester/test_terraform_vcr.sh
@@ -141,9 +141,13 @@ if [[ "$run_full_VCR" = true ]]; then
 
   test_exit_code=$?
 else
+  # clear GOOGLE_TEST_DIRECTORY list
+  GOOGLE_TEST_DIRECTORY=()
   affected_services_comment="<ul>"
   for service in "${!affected_services[@]}"
   do
+    # append affected service package path
+    GOOGLE_TEST_DIRECTORY+=("./google-beta/services/$service")
     echo "run VCR tests in $service"
     TF_LOG=DEBUG TF_LOG_PATH_MASK=$local_path/testlog/replaying/%s.log TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google-beta/services/$service -parallel $ACCTEST_PARALLELISM -v -run=TestAcc -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google-beta/version.ProviderVersion=acc" >> replaying_test.log # append logs into file
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

I've observed some significant recording runtime increases, especially for large size of affected tests, after [VCR split](https://github.com/GoogleCloudPlatform/magic-modules/pull/9392). 

Example PR: https://github.com/GoogleCloudPlatform/magic-modules/pull/9666
Before VCR split: ~20 mins for recording https://github.com/GoogleCloudPlatform/magic-modules/pull/9666#issuecomment-1864704896
After VCR split: ~2 hours for recording https://github.com/GoogleCloudPlatform/magic-modules/pull/9666#issuecomment-1869402132

What I suspect is, even though VCR split only changed how we run tests in the REPLAYING mode, it skips package compiling for all non-affected services and therefore it needs to compile them (probably multiple times) in the RECORDING mode (previously using compilation cache from the REPLAYING)
Given how we enable the parallelism in RECORDING and the lower size of it due to the limitation of Terraform log setup, it needs much more total compilation time and therefore leads to the long RECORDING runtime.

To resolve this issue, since we've known what packages are affected and needed to run tests against, we can only loop through these packages and run failed tests against them. 

Testing: https://github.com/GoogleCloudPlatform/magic-modules/pull/9717#issuecomment-1870656968: recording mode took ~2.5h for 12 `TestAccComputeFirewall*` and after apply the change in this PR, it takes only ~10 minutes https://github.com/GoogleCloudPlatform/magic-modules/pull/9721#issuecomment-1870663908.

 
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
