### PR TITLE
Update edgecontainer cluster/node-pool timeout

### DIFF
--- a/mmv1/products/edgecontainer/Cluster.yaml
+++ b/mmv1/products/edgecontainer/Cluster.yaml
@@ -32,9 +32,9 @@ async: !ruby/object:Api::OpAsync
     base_url: '{{op_id}}'
     wait_ms: 1000
     timeouts: !ruby/object:Api::Timeouts
-      insert_minutes: 60
-      update_minutes: 60
-      delete_minutes: 60
+      insert_minutes: 480
+      update_minutes: 480
+      delete_minutes: 480
   result: !ruby/object:Api::OpAsync::Result
     path: 'response'
   status: !ruby/object:Api::OpAsync::Status

--- a/mmv1/products/edgecontainer/NodePool.yaml
+++ b/mmv1/products/edgecontainer/NodePool.yaml
@@ -32,9 +32,9 @@ async: !ruby/object:Api::OpAsync
     base_url: "{{op_id}}"
     wait_ms: 1000
     timeouts: !ruby/object:Api::Timeouts
-      insert_minutes: 60
-      update_minutes: 60
-      delete_minutes: 60
+      insert_minutes: 480
+      update_minutes: 480
+      delete_minutes: 480
   result: !ruby/object:Api::OpAsync::Result
     path: "response"
   status: !ruby/object:Api::OpAsync::Status


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Updating the edgecontainer cluster/node-pool operation timeout, since now the LCP cluster enabled the Edge OS pinning which can take one hr per machine.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
edgecontainer: increased default timeout on `google_edgecontainer_cluster`, `google_edgecontainer_node_pool` to 480m from 60m
```
