### PR TITLE
Add error handling for ALREADY_EXISTS in IAM CreateServiceAccount call

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iam/v1"
 )
 
@@ -82,6 +83,12 @@ func ResourceGoogleServiceAccount() *schema.Resource {
 				Computed:    true,
 				Description: `The Identity of the service account in the form 'serviceAccount:{email}'. This value is often used to refer to the service account in order to grant IAM permissions.`,
 			},
+			"ignore_create_already_exists": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    false,
+				Description: `If set to true, skip service account creation if a service account with the same email already exists.`,
+			},
 		},
 		UseJSONNumber: true,
 	}
@@ -114,7 +121,11 @@ func resourceGoogleServiceAccountCreate(d *schema.ResourceData, meta interface{}
 
 	sa, err = config.NewIamClient(userAgent).Projects.ServiceAccounts.Create("projects/"+project, r).Do()
 	if err != nil {
-		return fmt.Errorf("Error creating service account: %s", err)
+		gerr, ok := err.(*googleapi.Error)
+		alreadyExists := ok && gerr.Code == 409 && d.Get("ignore_create_already_exists").(bool)
+		if !alreadyExists {
+			return fmt.Errorf("Error creating service account: %s", err)
+		}
 	}
 
 	d.SetId(sa.Name)

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account_test.go
@@ -54,6 +54,16 @@ func TestAccServiceAccount_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			// Test creating a service account that already exists.
+			{
+				Config: testAccServiceAccountIgnoreCreateAlreadyExists(accountId, displayName, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"google_service_account.acceptance", "project", project),
+					resource.TestCheckResourceAttr(
+						"google_service_account.acceptance", "member", "serviceAccount:"+expectedEmail),
+				),
+			},
 			// The second step updates the service account
 			{
 				Config: testAccServiceAccountBasic(accountId, displayName2, desc2),
@@ -162,6 +172,17 @@ resource "google_service_account" "acceptance" {
   account_id   = "%v"
   display_name = "%v"
   description  = "%v"
+}
+`, account, name, desc)
+}
+
+func testAccServiceAccountIgnoreCreateAlreadyExists(account, name, desc string) string {
+	return fmt.Sprintf(`
+resource "google_service_account" "acceptance" {
+  account_id   = "%v"
+  display_name = "%v"
+  description  = "%v"
+  ignore_create_already_exists = true
 }
 `, account, name, desc)
 }

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account_test.go
@@ -54,16 +54,6 @@ func TestAccServiceAccount_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			// Test creating a service account that already exists.
-			{
-				Config: testAccServiceAccountIgnoreCreateAlreadyExists(accountId, displayName, desc),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"google_service_account.acceptance", "project", project),
-					resource.TestCheckResourceAttr(
-						"google_service_account.acceptance", "member", "serviceAccount:"+expectedEmail),
-				),
-			},
 			// The second step updates the service account
 			{
 				Config: testAccServiceAccountBasic(accountId, displayName2, desc2),
@@ -93,6 +83,47 @@ func TestAccServiceAccount_basic(t *testing.T) {
 				ResourceName:      "google_service_account.acceptance",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Test the option to ignore ALREADY_EXISTS error from creating a service account.
+func TestAccServiceAccount_createIgnoreAlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	accountId := "a" + acctest.RandString(t, 10)
+	displayName := "Terraform Test"
+	desc := "test description"
+	project := envvar.GetTestProjectFromEnv()
+	expectedEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", accountId, project)
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			// The first step creates a basic service account
+			{
+				Config: testAccServiceAccountBasic(accountId, displayName, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"google_service_account.acceptance", "project", project),
+					resource.TestCheckResourceAttr(
+						"google_service_account.acceptance", "member", "serviceAccount:"+expectedEmail),
+				),
+			},
+			{
+				ResourceName:      "google_service_account.acceptance",
+				ImportStateId:     fmt.Sprintf("projects/%s/serviceAccounts/%s", project, expectedEmail),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// The second step creates a new resource that duplicates with the existing service account.
+			{
+				Config: testAccServiceAccountCreateIgnoreAlreadyExists(accountId, displayName, desc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"google_service_account.duplicate", "member", "serviceAccount:"+expectedEmail),
+				),
 			},
 		},
 	})
@@ -176,15 +207,20 @@ resource "google_service_account" "acceptance" {
 `, account, name, desc)
 }
 
-func testAccServiceAccountIgnoreCreateAlreadyExists(account, name, desc string) string {
+func testAccServiceAccountCreateIgnoreAlreadyExists(account, name, desc string) string {
 	return fmt.Sprintf(`
 resource "google_service_account" "acceptance" {
   account_id   = "%v"
   display_name = "%v"
   description  = "%v"
-  ignore_create_already_exists = true
 }
-`, account, name, desc)
+resource "google_service_account" "duplicate" {
+  account_id   = "%v"
+  display_name = "%v"
+  description  = "%v"
+  create_ignore_already_exists = true
+}
+`, account, name, desc, account, name, desc)
 }
 
 func testAccServiceAccountWithProject(project, account, name string) string {

--- a/mmv1/third_party/terraform/website/docs/r/google_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_service_account.html.markdown
@@ -51,6 +51,8 @@ The following arguments are supported:
 * `project` - (Optional) The ID of the project that the service account will be created in.
     Defaults to the provider project configuration.
 
+* `create_ignore_already_exists` - (Optional) If set to true, skip service account creation if a service account with the same email already exists.
+
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are


### PR DESCRIPTION
Introduce an optional resource argument to Google Cloud IAM Service Account. If `ignore_create_already_exists` is set to true, resource creation would succeed if response error is 409 ALREADY_EXISTS.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/16185
Fixes https://github.com/hashicorp/terraform-provider-google/issues/10193

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:note
iam: introducde an optional resource argument to Google Cloud IAM Service Account. If `ignore_create_already_exists` is set to true, resource creation would succeed if response error is 409 ALREADY_EXISTS.
```
