### PR TITLE
Remove resource_definition

### DIFF
--- a/mmv1/provider/terraform/custom_code.rb
+++ b/mmv1/provider/terraform/custom_code.rb
@@ -34,12 +34,7 @@ module Provider
       # resource's Resource.Schema map.  They should be formatted as
       # entries in the map, e.g. `"foo": &schema.Schema{ ... },`.
       attr_reader :extra_schema_entry
-      # Resource definition code is inserted below everything else
-      # in the resource's Resource {...} definition.  This may be useful
-      # for things like a MigrateState / SchemaVersion pair.
-      # This is likely to be used rarely and may be removed if all its
-      # use cases are covered in other ways.
-      attr_reader :resource_definition
+
       # ====================
       # Encoders & Decoders
       # ====================
@@ -132,7 +127,6 @@ module Provider
         super
 
         check :extra_schema_entry, type: String
-        check :resource_definition, type: String
         check :encoder, type: String
         check :update_encoder, type: String
         check :decoder, type: String

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -144,8 +144,6 @@ func Resource<%= resource_name -%>() *schema.Resource {
         DeprecationMessage: "<%= object.deprecation_message -%>",
 <% end -%>
 
-<%= lines(compile(pwd + '/' + object.custom_code.resource_definition)) if object.custom_code.resource_definition -%>
-
         Schema: map[string]*schema.Schema{
 <%  order_properties(properties).each do |prop| -%>
 <%=       lines(build_schema_property(prop, object, pwd)) -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The usage of `resource_definition` is removed in the PR https://github.com/GoogleCloudPlatform/magic-modules/pull/9553 a couple weeks ago. In this PR, remove it thoroughly.

There should be no generated diffs.


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
