### PR TITLE
Move business logic to provider class

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
@@ -4,24 +4,9 @@ package provider
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-<% products.each do |product|
-	product_definition = product[:definitions]
-	if version == 'ga'
-		some_resource_in_ga = false
-		product_definition.objects.each do |object|
-			if !object.exclude && !object.not_in_version?(product_definition.version_obj_or_closest(version))
-				some_resource_in_ga = true
-				break
-			end
-		end
-
-		if some_resource_in_ga -%>
-			"github.com/hashicorp/terraform-provider-google/google/services/<%= product[:definitions].name.downcase -%>"
+	<% get_mmv1_services_in_version(products, version).each do |service|  -%>
+	  "github.com/hashicorp/terraform-provider-google/google/services/<%= service -%>"
 	<% end -%>
-<% else -%>
-		"github.com/hashicorp/terraform-provider-google/google/services/<%= product[:definitions].name.downcase -%>"
-	<% end -%>
-<% end -%>
 
 	"github.com/hashicorp/terraform-provider-google/google/services/composer"
 	"github.com/hashicorp/terraform-provider-google/google/services/container"
@@ -217,27 +202,13 @@ var handwrittenDatasources = map[string]*schema.Resource{
 var generatedIAMDatasources = map[string]*schema.Resource{
 	// ####### START generated IAM datasources ###########
 	<%
-	products.each do |product|
-		product_definition = product[:definitions]
-		service = product_definition.name.downcase
-		config = product[:overrides]
-		sorted =  product_definition.objects.sort_by { |obj| obj.name }
-		sorted.each do |object|
-		next if object.exclude || object.not_in_version?(product_definition.version_obj_or_closest(version))
-		tf_product = (object.__product.legacy_name || product_definition.name).underscore
-		terraform_name = object.legacy_name || "google_#{tf_product}_#{object.name.underscore}"
+	resources_for_version.each do |object|
+		unless object[:iam_class_name].nil?
 	-%>
+	"<%= object[:terraform_name] -%>_iam_policy":               tpgiamresource.DataSourceIamPolicy(<%= object[:iam_class_name] -%>IamSchema, <%= object[:iam_class_name] -%>IamUpdaterProducer),
 	<%
-	iam_policy = object&.iam_policy
-	unless iam_policy.nil? || iam_policy.exclude ||
-		(iam_policy.min_version && iam_policy.min_version < version)
-		iam_class_name = product_definition.name + object.name
-	-%>
-	"<%= terraform_name -%>_iam_policy":               tpgiamresource.DataSourceIamPolicy(<%= service -%>.<%= iam_class_name -%>IamSchema, <%= service -%>.<%= iam_class_name -%>IamUpdaterProducer),
-	<%
-	end # unless iam_policy.nil? || iam_policy.exclude
-	end   # product_definition.objects.each do
-	end     # products.each do
+		end
+	end
 	-%>
 	// ####### END generated IAM datasources ###########
 }
@@ -266,53 +237,26 @@ var handwrittenIAMDatasources = map[string]*schema.Resource{
 	// ####### END non-generated IAM datasources ###########
 }
 
-<%
-resource_count = 0
-iam_resource_count = 0
-products.each do |product|
-	product_definition = product[:definitions]
-	product_definition.objects.reject { |r| r.exclude || r.not_in_version?(product_definition.version_obj_or_closest(version)) }.each do |object|
-		resource_count += 1 unless object&.exclude_resource
-		iam_policy = object&.iam_policy
-		unless iam_policy.nil? || iam_policy.exclude
-			iam_resource_count += 3
-		end
-	end
-end
--%>
-
 // Resources
 // Generated resources: <%= resource_count %>
 // Generated IAM resources: <%= iam_resource_count %>
 // Total generated resources: <%= resource_count + iam_resource_count %>
 var generatedResources = map[string]*schema.Resource{
-	<%
-	products.each do |product|
-	product_definition = product[:definitions]
-	service = product_definition.name.downcase
-	config = product[:overrides]
-	sorted =  product_definition.objects.sort_by { |obj| obj.name }
-	sorted.each do |object|
-		next if object.exclude || object.not_in_version?(product_definition.version_obj_or_closest(version))
-		tf_product = (object.__product.legacy_name || product_definition.name).underscore
-		terraform_name = object.legacy_name || "google_#{tf_product}_#{object.name.underscore}"
-	-%>
-	<% 	unless object&.exclude_resource -%>
-		"<%= terraform_name -%>": <%= service -%>.Resource<%= product_definition.name + object.name -%>(),
+	<% resources_for_version.each do |object| -%>
+	<% 	unless object[:resource_name].nil? -%>
+		"<%= object[:terraform_name] -%>": <%= object[:resource_name] -%>(),
 	<%  end -%>
 	<%
-		iam_policy = object&.iam_policy
-		unless iam_policy.nil? || iam_policy.exclude ||
-			(iam_policy.min_version && iam_policy.min_version < version)
-		  iam_class_name = product_definition.name + object.name
+	    unless object[:iam_class_name].nil?
 	-%>
-		"<%= terraform_name -%>_iam_binding":              tpgiamresource.ResourceIamBinding(<%= service -%>.<%= iam_class_name -%>IamSchema, <%= service -%>.<%= iam_class_name -%>IamUpdaterProducer, <%= service -%>.<%= iam_class_name -%>IdParseFunc),
-		"<%= terraform_name -%>_iam_member":               tpgiamresource.ResourceIamMember(<%= service -%>.<%= iam_class_name -%>IamSchema, <%= service -%>.<%= iam_class_name -%>IamUpdaterProducer, <%= service -%>.<%= iam_class_name -%>IdParseFunc),
-		"<%= terraform_name -%>_iam_policy":               tpgiamresource.ResourceIamPolicy(<%= service -%>.<%= iam_class_name -%>IamSchema, <%= service -%>.<%= iam_class_name -%>IamUpdaterProducer, <%= service -%>.<%= iam_class_name -%>IdParseFunc),
+		"<%= object[:terraform_name] -%>_iam_binding":              tpgiamresource.ResourceIamBinding(<%= object[:iam_class_name] -%>IamSchema, <%= object[:iam_class_name] -%>IamUpdaterProducer, <%= object[:iam_class_name] -%>IdParseFunc),
+		"<%= object[:terraform_name] -%>_iam_member":               tpgiamresource.ResourceIamMember(<%= object[:iam_class_name] -%>IamSchema, <%= object[:iam_class_name] -%>IamUpdaterProducer, <%= object[:iam_class_name] -%>IdParseFunc),
+		"<%= object[:terraform_name] -%>_iam_policy":               tpgiamresource.ResourceIamPolicy(<%= object[:iam_class_name] -%>IamSchema, <%= object[:iam_class_name] -%>IamUpdaterProducer, <%= object[:iam_class_name] -%>IdParseFunc),
 	<%
-	end # unless iam_policy.nil? || iam_policy.exclude
-	end   # product_definition.objects.each do
-	end     # products.each do
+	    end # unless object[:iam_class_name].nil?
+	-%>
+	<%
+	end     # resources_for_version.each do
 	-%>
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Move some business logic for generating resources from [mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb) to provider class

No diffs are generated.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
