### PR TITLE
Remove `firestore_default_database` Test

### DIFF
--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -55,20 +55,6 @@ import_format:
   - '{{name}}'
 examples:
   - !ruby/object:Provider::Terraform::Examples
-    name: 'firestore_default_database'
-    primary_resource_id: 'database'
-    pull_external: true
-    vars:
-      delete_protection_state: "DELETE_PROTECTION_ENABLED"
-    test_env_vars:
-      project_id: :PROJECT_NAME
-    test_vars_overrides:
-      delete_protection_state: '"DELETE_PROTECTION_DISABLED"'
-    ignore_read_extra:
-      - project
-      - etag
-      - deletion_policy
-  - !ruby/object:Provider::Terraform::Examples
     name: 'firestore_database'
     primary_resource_id: 'database'
     vars:

--- a/mmv1/templates/terraform/examples/firestore_default_database.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_default_database.tf.erb
@@ -1,8 +1,0 @@
-resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
-  project                 = "<%= ctx[:test_env_vars]['project_id'] %>"
-  name                    = "(default)"
-  location_id             = "nam5"
-  type                    = "FIRESTORE_NATIVE"
-  delete_protection_state = "<%= ctx[:vars]['delete_protection_state'] %>"
-  deletion_policy         = "DELETE"
-}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes #16723

With how the test is reacting to creating a firestore database with name set to `(default)`. I propose to remove the default test unless something can be done internally to allow the creation of a `firestore_database` with the name set to `(default)` in terraform.

Users can create a database with the name set to `(default)` but are unable to through the provider.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
