### PR TITLE
Add support for gcsfuse volumes to cloudrun v1 in beta

### DIFF
--- a/mmv1/products/cloudrun/Service.yaml
+++ b/mmv1/products/cloudrun/Service.yaml
@@ -861,8 +861,10 @@ properties:
                           required: true
                           description: |-
                             Unique name representing the type of file system to be created. Cloud Run supports the following values:
-                              * gcsfuse.run.googleapis.com: Mount a Google Cloud Storage bucket using GCSFuse
-                        - !ruby/object:Api::Type::String
+                              * gcsfuse.run.googleapis.com: Mount a Google Cloud Storage bucket using GCSFuse. This driver requires the
+                                run.googleapis.com/execution-environment annotation to be set to "gen2" and 
+                                run.googleapis.com/launch-stage set to "BETA" or "ALPHA".
+                        - !ruby/object:Api::Type::Boolean
                           name: 'readOnly'
                           default_from_api: true
                           description: |-
@@ -872,7 +874,7 @@ properties:
                           description: |-
                             Driver-specific attributes. The following options are supported for available drivers:
                               * gcsfuse.run.googleapis.com
-                                * bucketName: the name of the Cloud Storage Bucket that backs this volume. The Cloud Run Service identity must have access to this bucket.
+                                * bucketName: The name of the Cloud Storage Bucket that backs this volume. The Cloud Run Service identity must have access to this bucket.
               - !ruby/object:Api::Type::Enum
                 name: servingState
                 deprecation_message: >-

--- a/mmv1/products/cloudrun/Service.yaml
+++ b/mmv1/products/cloudrun/Service.yaml
@@ -850,6 +850,29 @@ properties:
                           name: 'sizeLimit'
                           description: |-
                             Limit on the storage usable by this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. This field's values are of the 'Quantity' k8s type: https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/. The default is nil which means that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes/#emptydir.
+                    - !ruby/object:Api::Type::NestedObject
+                      name: csi
+                      description: |-
+                        A filesystem specified by the Container Storage Interface (CSI).
+                      min_version: beta
+                      properties:
+                        - !ruby/object:Api::Type::String
+                          name: 'driver'
+                          required: true
+                          description: |-
+                            Unique name representing the type of file system to be created. Cloud Run supports the following values:
+                              * gcsfuse.run.googleapis.com: Mount a Google Cloud Storage bucket using GCSFuse
+                        - !ruby/object:Api::Type::String
+                          name: 'readOnly'
+                          default_from_api: true
+                          description: |-
+                            If true, all mounts created from this volume will be read-only.
+                        - !ruby/object:Api::Type::KeyValuePairs
+                          name: 'volumeAttributes'
+                          description: |-
+                            Driver-specific attributes. The following options are supported for available drivers:
+                              * gcsfuse.run.googleapis.com
+                                * bucketName: the name of the Cloud Storage Bucket that backs this volume. The Cloud Run Service identity must have access to this bucket.
               - !ruby/object:Api::Type::Enum
                 name: servingState
                 deprecation_message: >-

--- a/mmv1/products/cloudrun/Service.yaml
+++ b/mmv1/products/cloudrun/Service.yaml
@@ -862,7 +862,7 @@ properties:
                           description: |-
                             Unique name representing the type of file system to be created. Cloud Run supports the following values:
                               * gcsfuse.run.googleapis.com: Mount a Google Cloud Storage bucket using GCSFuse. This driver requires the
-                                run.googleapis.com/execution-environment annotation to be set to "gen2" and 
+                                run.googleapis.com/execution-environment annotation to be set to "gen2" and
                                 run.googleapis.com/launch-stage set to "BETA" or "ALPHA".
                         - !ruby/object:Api::Type::Boolean
                           name: 'readOnly'

--- a/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.erb
@@ -1052,6 +1052,7 @@ func TestAccCloudRunService_csiVolume(t *testing.T) {
 func testAccCloudRunService_cloudRunServiceWithEmptyDirVolume(name, project string) string {
 	return fmt.Sprintf(`
 resource "google_cloud_run_service" "default" {
+  provider = google-beta
   name     = "%s"
   location = "us-central1"
 
@@ -1091,6 +1092,7 @@ resource "google_cloud_run_service" "default" {
 func testAccCloudRunService_cloudRunServiceUpdateWithGcsVolume(name, project string) string {
 	return fmt.Sprintf(`
 resource "google_cloud_run_service" "default" {
+  provider = google-beta
   name     = "%s"
   location = "us-central1"
 
@@ -1120,6 +1122,7 @@ resource "google_cloud_run_service" "default" {
         name = "vol1"
         csi {
           driver = "gcsfuse.run.googleapis.com"
+          read_only = true
           volume_attributes = {
             bucketName = "gcp-public-data-landsat"
           }

--- a/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.erb
@@ -1013,3 +1013,128 @@ resource "google_cloud_run_service" "default" {
 }
 
 <% end -%>
+
+<% unless version == 'ga' -%>
+
+func TestAccCloudRunService_csiVolume(t *testing.T) {
+	t.Parallel()
+
+	project := envvar.GetTestProjectFromEnv()
+	name := "tftest-cloudrun-" + acctest.RandString(t, 6)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudRunService_cloudRunServiceWithEmptyDirVolume(name, project),
+			},
+			{
+				ResourceName:            "google_cloud_run_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "metadata.0.annotations", "metadata.0.labels", "metadata.0.terraform_labels", "status.0.conditions"},
+			},
+			{
+				Config: testAccCloudRunService_cloudRunServiceUpdateWithGcsVolume(name, project,),
+			},
+			{
+				ResourceName:            "google_cloud_run_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "metadata.0.annotations", "metadata.0.labels", "metadata.0.terraform_labels", "status.0.conditions"},
+                              },
+                        },
+      })
+    }
+
+
+func testAccCloudRunService_cloudRunServiceWithEmptyDirVolume(name, project string) string {
+	return fmt.Sprintf(`
+resource "google_cloud_run_service" "default" {
+  name     = "%s"
+  location = "us-central1"
+
+  metadata {
+    namespace = "%s"
+    annotations = {
+      generated-by = "magic-modules"
+      "run.googleapis.com/launch-stage" = "BETA"
+    }
+  }
+
+  template {
+    spec {
+      containers {
+        image = "gcr.io/cloudrun/hello"
+        volume_mounts {
+          name = "vol1"
+          mount_path = "/mnt/vol1"
+        }
+      }
+      volumes {
+        name = "vol1"
+        empty_dir { size_limit = "256Mi" }
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      metadata.0.annotations,
+    ]
+  }
+}
+`, name, project)
+}
+
+func testAccCloudRunService_cloudRunServiceUpdateWithGcsVolume(name, project string) string {
+	return fmt.Sprintf(`
+resource "google_cloud_run_service" "default" {
+  name     = "%s"
+  location = "us-central1"
+
+  metadata {
+    namespace = "%s"
+    annotations = {
+      generated-by = "magic-modules"
+      "run.googleapis.com/launch-stage" = "BETA"
+    }
+  }
+
+  template {
+    metadata {
+      annotations = {
+        "run.googleapis.com/execution-environment" = "gen2"
+      }
+    }
+    spec {
+      containers {
+        image = "gcr.io/cloudrun/hello"
+        volume_mounts {
+          name = "vol1"
+          mount_path = "/mnt/vol1"
+        }
+      }
+      volumes {
+        name = "vol1"
+        csi {
+          driver = "gcsfuse.run.googleapis.com"
+          volume_attributes = {
+            bucketName = "gcp-public-data-landsat"
+          }
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      metadata.0.annotations,
+    ]
+  }
+}
+`, name, project)
+}
+
+<% end -%>

--- a/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.erb
@@ -1024,7 +1024,7 @@ func TestAccCloudRunService_csiVolume(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCloudRunService_cloudRunServiceWithEmptyDirVolume(name, project),


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add support for mounting GCS volumes in Cloud Run v1 Services, in the beta provider.

This is a new feature in Cloud Run. Support is added to cloudrunv2 in #9746

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudrun: added `template.spec.volumes.csi` field to `google_cloud_run_service` to support mounting Cloud Storage buckets using GCSFuse (beta)
```
