### PR TITLE
[#16195] Allow users to update `google_forwarding_rule` `description` in place

### DIFF
--- a/mmv1/products/compute/ForwardingRule.yaml
+++ b/mmv1/products/compute/ForwardingRule.yaml
@@ -263,6 +263,8 @@ properties:
     description: |
       An optional description of this resource. Provide this property when
       you create the resource.
+    update_verb: :PATCH
+    update_url: projects/{{project}}/regions/{{region}}/forwardingRules/{{name}}
   # This is a multi-resource resource reference (Address, GlobalAddress)
   - !ruby/object:Api::Type::String
     name: 'IPAddress'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_forwarding_rule_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_forwarding_rule_test.go.erb
@@ -347,7 +347,7 @@ resource "google_compute_target_pool" "bar-tp" {
 }
 
 resource "google_compute_forwarding_rule" "foobar" {
-  description = "Resource created for Terraform acceptance testing"
+  description = "Updated resource created for Terraform acceptance testing"
   ip_protocol = "UDP"
   name        = "%s"
   port_range  = "80-81"


### PR DESCRIPTION
Allows users to update `google_forwarding_rule` `description` in place.

fixes [hashicorp/terraform-provider-google/issues/16195](https://github.com/hashicorp/terraform-provider-google/issues/16195)

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: allow users to update `google_forwarding_rule` `description` in place
```
