### PR TITLE
Add NetworkSecurity AddressGroup IAM support

### DIFF
--- a/mmv1/products/networksecurity/ProjectAddressGroup.yaml
+++ b/mmv1/products/networksecurity/ProjectAddressGroup.yaml
@@ -13,7 +13,7 @@
 
 --- !ruby/object:Api::Resource
 name: "ProjectAddressGroup"
-legacy_name: "AddressGroup"
+legacy_name: 'google_network_security_address_group'
 base_url: "projects/{{project}}/locations/{{location}}/addressGroups"
 self_link: "projects/{{project}}/locations/{{location}}/addressGroups/{{name}}"
 # This resource is only used to generate IAM resources. They do not correspond to real

--- a/mmv1/products/networksecurity/ProjectAddressGroup.yaml
+++ b/mmv1/products/networksecurity/ProjectAddressGroup.yaml
@@ -13,6 +13,7 @@
 
 --- !ruby/object:Api::Resource
 name: "ProjectAddressGroup"
+legacy_name: "AddressGroup"
 base_url: "projects/{{project}}/locations/{{location}}/addressGroups"
 self_link: "projects/{{project}}/locations/{{location}}/addressGroups/{{name}}"
 # This resource is only used to generate IAM resources. They do not correspond to real
@@ -61,5 +62,4 @@ properties:
     required: true
     description: |
       The location of the gateway security policy.
-      The default value is `global`.
     url_param_only: true

--- a/mmv1/products/networksecurity/ProjectAddressGroup.yaml
+++ b/mmv1/products/networksecurity/ProjectAddressGroup.yaml
@@ -1,12 +1,12 @@
 # Copyright 2024 Google Inc.
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the License is distributed on an 'AS IS' BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.

--- a/mmv1/products/networksecurity/ProjectAddressGroup.yaml
+++ b/mmv1/products/networksecurity/ProjectAddressGroup.yaml
@@ -1,0 +1,63 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: "ProjectAddressGroup"
+base_url: "projects/{{project}}/locations/{{location}}/addressGroups"
+self_link: "projects/{{project}}/locations/{{location}}/addressGroups/{{name}}"
+# This resource is only used to generate IAM resources. They do not correspond to real
+# GCP resources, and should not be used to generate anything other than IAM support.
+# IAM resources for AddressGroup are moved to a separate configuration because the AddressGroup 
+# resourcesupports both organization and project levels, 
+# but IAM support exists only on the project level Address Groups
+description: |
+  Only used to generate IAM resources for project level address groups
+exclude_tgc: true
+exclude_resource: true
+iam_policy: !ruby/object:Api::Resource::IamPolicy
+  method_name_separator: ':'
+  parent_resource_type: 'google_network_security_address_group'
+  parent_resource_attribute: "name"
+  base_url: "projects/{{project}}/locations/{{location}}/addressGroups/{{name}}"
+  example_config_body: 'templates/terraform/iam/example_config_body/networksecurity_project_address_group.tf.erb'
+  import_format: 
+    [
+      'projects/{{project}}/locations/{{location}}/addressGroups/{{name}}',
+      '{{project}}/{{location}}/{{name}}',
+      '{{location}}/{{name}}',
+      '{{name}}'
+    ]
+id_format: 'projects/{{project}}/locations/{{location}}/addressGroups/{{name}}'
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: "network_security_address_groups_basic"
+    primary_resource_id: "default"
+    vars:
+      resource_name: "my-project-address-group"
+    test_env_vars:
+      project: :PROJECT_NAME
+properties:
+  - !ruby/object:Api::Type::String
+    name: "name"
+    required: true
+    url_param_only: true  
+    description: |
+      Name of the AddressGroup resource.
+  - !ruby/object:Api::Type::String
+    name: "location"
+    required: true
+    description: |
+      The location of the gateway security policy.
+      The default value is `global`.
+    url_param_only: true
+

--- a/mmv1/products/networksecurity/ProjectAddressGroup.yaml
+++ b/mmv1/products/networksecurity/ProjectAddressGroup.yaml
@@ -17,27 +17,30 @@ base_url: "projects/{{project}}/locations/{{location}}/addressGroups"
 self_link: "projects/{{project}}/locations/{{location}}/addressGroups/{{name}}"
 # This resource is only used to generate IAM resources. They do not correspond to real
 # GCP resources, and should not be used to generate anything other than IAM support.
-# IAM resources for AddressGroup are moved to a separate configuration because the AddressGroup 
-# resourcesupports both organization and project levels, 
+# IAM resources for AddressGroup are moved to a separate configuration because the AddressGroup
+# resourcesupports both organization and project levels,
 # but IAM support exists only on the project level Address Groups
 description: |
   Only used to generate IAM resources for project level address groups
 exclude_tgc: true
 exclude_resource: true
 iam_policy: !ruby/object:Api::Resource::IamPolicy
-  method_name_separator: ':'
-  parent_resource_type: 'google_network_security_address_group'
+  method_name_separator: ":"
+  allowed_iam_role: 'roles/compute.networkAdmin'
+  parent_resource_type: "google_network_security_address_group"
   parent_resource_attribute: "name"
+  skip_import_test: true
   base_url: "projects/{{project}}/locations/{{location}}/addressGroups/{{name}}"
-  example_config_body: 'templates/terraform/iam/example_config_body/networksecurity_project_address_group.tf.erb'
-  import_format: 
+  iam_conditions_request_type: null
+  example_config_body: "templates/terraform/iam/example_config_body/networksecurity_project_address_group.tf.erb"
+  import_format:
     [
-      'projects/{{project}}/locations/{{location}}/addressGroups/{{name}}',
-      '{{project}}/{{location}}/{{name}}',
-      '{{location}}/{{name}}',
-      '{{name}}'
+      "projects/{{project}}/locations/{{location}}/addressGroups/{{name}}",
+      "{{project}}/{{location}}/{{name}}",
+      "{{location}}/{{name}}",
+      "{{name}}",
     ]
-id_format: 'projects/{{project}}/locations/{{location}}/addressGroups/{{name}}'
+id_format: "projects/{{project}}/locations/{{location}}/addressGroups/{{name}}"
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: "network_security_address_groups_basic"
@@ -50,7 +53,7 @@ properties:
   - !ruby/object:Api::Type::String
     name: "name"
     required: true
-    url_param_only: true  
+    url_param_only: true
     description: |
       Name of the AddressGroup resource.
   - !ruby/object:Api::Type::String
@@ -60,4 +63,3 @@ properties:
       The location of the gateway security policy.
       The default value is `global`.
     url_param_only: true
-

--- a/mmv1/products/networksecurity/ProjectAddressGroup.yaml
+++ b/mmv1/products/networksecurity/ProjectAddressGroup.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google Inc.
+# Copyright 2023 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/mmv1/templates/terraform/iam/example_config_body/networksecurity_project_address_group.tf.erb
+++ b/mmv1/templates/terraform/iam/example_config_body/networksecurity_project_address_group.tf.erb
@@ -1,3 +1,3 @@
-project = %{project}
+project = "%{project}"
 location = google_network_security_address_group.default.location
 name = google_network_security_address_group.default.name

--- a/mmv1/templates/terraform/iam/example_config_body/networksecurity_project_address_group.tf.erb
+++ b/mmv1/templates/terraform/iam/example_config_body/networksecurity_project_address_group.tf.erb
@@ -1,0 +1,3 @@
+project = %{project}
+location = google_network_security_address_group.default.location
+name = google_network_security_address_group.default.name


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add NetworkSecurity AddressGroup IAM support, 
Note, only project level AddressGroups have support for IAM Policies, while the upstream resource `google_network_security_address_group` is implemented to support both org and project parents. Hence the implementation is deviating from the normal flow.


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_network_security_address_group_iam_*`
```
