### PR TITLE
Reduce node_count in `TestAccVmwareengine*` tests

### DIFF
--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_test.go
@@ -88,7 +88,7 @@ resource "google_vmwareengine_private_cloud" "cluster-pc" {
     cluster_id = "tf-test-mgmt-cluster%{random_suffix}"
     node_type_configs {
       node_type_id = "standard-72"
-      node_count   = 3
+      node_count   = 1
     }
   }
 }
@@ -99,7 +99,7 @@ resource "google_vmwareengine_cluster" "vmw-engine-ext-cluster" {
   node_type_configs {
     node_type_id = "standard-72"
     node_count   = %{node_count}
-		custom_core_count = 32
+    custom_core_count = 32
   }
 }
 

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_address_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_address_test.go
@@ -74,7 +74,7 @@ resource "google_vmwareengine_private_cloud" "external-address-pc" {
     cluster_id = "tf-test-sample-external-address-cluster%{random_suffix}"
     node_type_configs {
       node_type_id = "standard-72"
-      node_count   = 3
+      node_count   = 1
     }
   }
 }

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_subnet_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_subnet_test.go
@@ -68,7 +68,7 @@ resource "google_vmwareengine_private_cloud" "subnet-pc" {
     cluster_id = "tf-test-mgmt-cluster%{random_suffix}"
     node_type_configs {
       node_type_id = "standard-72"
-      node_count   = 3
+      node_count   = 1
     }
   }
 }


### PR DESCRIPTION
This PR reduces the number of VMware engine private cloud nodes provisioned in this test.
See https://github.com/hashicorp/terraform-provider-google/issues/16911#issuecomment-1879203209 for context


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
