### PR TITLE
Fix issue due to Secure Web Proxy recreation due to not setting addresses field

### DIFF
--- a/mmv1/products/networkservices/Gateway.yaml
+++ b/mmv1/products/networkservices/Gateway.yaml
@@ -170,6 +170,7 @@ properties:
   - !ruby/object:Api::Type::Array
     name: 'addresses'
     immutable: true
+    default_from_api: true
     description: |
       Zero or one IPv4-address on which the Gateway will receive the traffic. When no address is provided,
       an IP from the subnetwork is allocated This field only applies to gateways of type 'SECURE_WEB_GATEWAY'.

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_gateway_test.go
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_gateway_test.go
@@ -81,7 +81,7 @@ func TestAccNetworkServicesGateway_networkServicesGatewaySecureWebProxyWithoutAd
 		CheckDestroy:             testAccCheckNetworkServicesGatewayDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetworkServicesGateway_networkServicesGatewaySecureWebProxyWithoutAddresses(context, true),
+				Config: testAccNetworkServicesGateway_networkServicesGatewaySecureWebProxy(context, false),
 			},
 			{
 				ResourceName:            "google_network_services_gateway.default",
@@ -93,7 +93,7 @@ func TestAccNetworkServicesGateway_networkServicesGatewaySecureWebProxyWithoutAd
 	})
 }
 
-func testAccNetworkServicesGateway_networkServicesGatewaySecureWebProxyWithoutAddresses(context map[string]interface{}, withAddresses bool) string {
+func testAccNetworkServicesGateway_networkServicesGatewaySecureWebProxy(context map[string]interface{}, withAddresses bool) string {
 	config := ""
 	config += acctest.Nprintf(`
 resource "google_certificate_manager_certificate" "default" {

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_gateway_test.go
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_gateway_test.go
@@ -63,9 +63,110 @@ resource "google_network_services_gateway" "foobar" {
   description = "update description"
   labels      = {
     foo = "bar"
-  } 
+  }
 }
 `, gatewayName)
+}
+
+func TestAccNetworkServicesGateway_networkServicesGatewaySecureWebProxyWithoutAddresses(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckNetworkServicesGatewayDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkServicesGateway_networkServicesGatewaySecureWebProxyWithoutAddresses(context, true),
+			},
+			{
+				ResourceName:            "google_network_services_gateway.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "location", "delete_swg_autogen_router_on_destroy", "labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccNetworkServicesGateway_networkServicesGatewaySecureWebProxyWithoutAddresses(context map[string]interface{}, withAddresses bool) string {
+	config := ""
+	config += acctest.Nprintf(`
+resource "google_certificate_manager_certificate" "default" {
+  name        = "tf-test-my-certificate-%{random_suffix}"
+  location    = "us-central1"
+  self_managed {
+    pem_certificate = file("test-fixtures/cert.pem")
+    pem_private_key = file("test-fixtures/private-key.pem")
+  }
+}
+
+resource "google_compute_network" "default" {
+  name                    = "tf-test-my-network-%{random_suffix}"
+  routing_mode            = "REGIONAL"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "tf-test-my-subnetwork-name-%{random_suffix}"
+  purpose       = "PRIVATE"
+  ip_cidr_range = "10.128.0.0/20"
+  region        = "us-central1"
+  network       = google_compute_network.default.id
+  role          = "ACTIVE"
+}
+
+resource "google_compute_subnetwork" "proxyonlysubnet" {
+  name          = "tf-test-my-proxy-only-subnetwork-%{random_suffix}"
+  purpose       = "REGIONAL_MANAGED_PROXY"
+  ip_cidr_range = "192.168.0.0/23"
+  region        = "us-central1"
+  network       = google_compute_network.default.id
+  role          = "ACTIVE"
+}
+
+resource "google_network_security_gateway_security_policy" "default" {
+  name        = "tf-test-my-policy-name-%{random_suffix}"
+  location    = "us-central1"
+}
+
+resource "google_network_security_gateway_security_policy_rule" "default" {
+  name                    = "tf-test-my-policyrule-name-%{random_suffix}"
+  location                = "us-central1"
+  gateway_security_policy = google_network_security_gateway_security_policy.default.name
+  enabled                 = true
+  priority                = 1
+  session_matcher         = "host() == 'example.com'"
+  basic_profile           = "ALLOW"
+}
+
+resource "google_network_services_gateway" "default" {
+  name                                 = "tf-test-my-gateway-%{random_suffix}"
+  location                             = "us-central1"`, context)
+
+	if withAddresses {
+		config += `
+  addresses                            = ["10.128.0.99"]`
+	}
+
+	config += acctest.Nprintf(`
+  type                                 = "SECURE_WEB_GATEWAY"
+  ports                                = [443]
+  scope                                = "tf-test-my-default-scope-%{random_suffix}"
+  certificate_urls                     = [google_certificate_manager_certificate.default.id]
+  gateway_security_policy              = google_network_security_gateway_security_policy.default.id
+  network                              = google_compute_network.default.id
+  subnetwork                           = google_compute_subnetwork.default.id
+  delete_swg_autogen_router_on_destroy = true
+  depends_on                           = [google_compute_subnetwork.proxyonlysubnet]
+  }
+`, context)
+
+	return config
 }
 
 // TODO(#14600): Enable the test once the api allows to update the fields for secure web gateway type.
@@ -359,12 +460,12 @@ resource "google_network_security_gateway_security_policy_rule" "default" {
   name                    = "%s"
   location                = "us-west1"
   gateway_security_policy = google_network_security_gateway_security_policy.default.name
-  enabled                 = true  
+  enabled                 = true
   priority                = 1
   session_matcher         = "host() == 'example.com'"
   basic_profile           = "ALLOW"
 }
-	  
+
 resource "google_network_services_gateway" "gateway1" {
   name                                 = "%s"
   location                             = "us-west1"
@@ -453,12 +554,12 @@ resource "google_network_security_gateway_security_policy_rule" "default" {
   name                    = "%s"
   location                = "us-west1"
   gateway_security_policy = google_network_security_gateway_security_policy.default.name
-  enabled                 = true  
+  enabled                 = true
   priority                = 1
   session_matcher         = "host() == 'example.com'"
   basic_profile           = "ALLOW"
 }
-	  
+
 resource "google_network_services_gateway" "gateway1" {
   name                                 = "%s"
   location                             = "us-west1"
@@ -575,12 +676,12 @@ resource "google_network_security_gateway_security_policy_rule" "default" {
   name                    = "%s"
   location                = "us-west2"
   gateway_security_policy = google_network_security_gateway_security_policy.default.name
-  enabled                 = true  
+  enabled                 = true
   priority                = 1
   session_matcher         = "host() == 'example.com'"
   basic_profile           = "ALLOW"
 }
-	  
+
 resource "google_network_services_gateway" "gateway1" {
   name                                 = "%s"
   location                             = "us-west2"
@@ -684,12 +785,12 @@ resource "google_network_security_gateway_security_policy_rule" "default" {
   name                    = "%s"
   location                = "us-west2"
   gateway_security_policy = google_network_security_gateway_security_policy.default.name
-  enabled                 = true  
+  enabled                 = true
   priority                = 1
   session_matcher         = "host() == 'example.com'"
   basic_profile           = "ALLOW"
 }
-	  
+
 resource "google_network_services_gateway" "gateway1" {
   name                                 = "%s"
   location                             = "us-west2"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/16922

This PR adds the default_from_api label so whenever the 'adresses' field is not set, the TF states saves the value auto set by the API. The integration tests test both cases with and without 'addresses' field.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
networkservices: fixed a perma-diff on `addresses` in `google_network_services_gateway`
```
