### PR TITLE
Support replica materialized view in resource_bigquery_table in the beta provider

### DIFF
--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package bigquery
 
 import (
@@ -528,7 +529,7 @@ func ResourceBigQueryTable() *schema.Resource {
 							Default:      "NONE",
 							Description:  `The compression type of the data source. Valid values are "NONE" or "GZIP".`,
 						},
-						// Schema: Optional] The schema for the  data.
+						// Schema: Optional] The schema for the data.
 						// Schema is required for CSV and JSON formats if autodetect is not on.
 						// Schema is disallowed for Google Cloud Bigtable, Cloud Datastore backups, Avro, Iceberg, ORC, and Parquet formats.
 						"schema": {
@@ -887,7 +888,7 @@ func ResourceBigQueryTable() *schema.Resource {
 							Type:        schema.TypeInt,
 							Default:     1800000,
 							Optional:    true,
-							Description: `Specifies maximum frequency at which this materialized view will be refreshed. The default is 1800000`,
+							Description: `Specifies maximum frequency at which this materialized view will be refreshed. The default is 1800000.`,
 						},
 
 						"allow_non_incremental_definition": {
@@ -1250,6 +1251,40 @@ func ResourceBigQueryTable() *schema.Resource {
 					},
 				},
 			},
+			<% unless version == 'ga' -%>
+			// TableReplicationInfo: [Optional] Replication info of a table created using `AS REPLICA` DDL like: `CREATE MATERIALIZED VIEW mv1 AS REPLICA OF src_mv`.
+			"table_replication_info": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: `Replication info of a table created using "AS REPLICA" DDL like: "CREATE MATERIALIZED VIEW mv1 AS REPLICA OF src_mv".`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"source_project_id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The ID of the source project."`,
+						},
+						"source_dataset_id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The ID of the source dataset."`,
+						},
+						"source_table_id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The ID of the source materialized view."`,
+						},
+						"replication_interval_ms": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Computed:    true,
+							Description: `The interval at which the source materialized view is polled for updates."`,
+						},
+					},
+				},
+			},
+			<% end -%>
 		},
 		UseJSONNumber: true,
 	}
@@ -1386,9 +1421,51 @@ func resourceBigQueryTableCreate(d *schema.ResourceData, meta interface{}) error
 
 	datasetID := d.Get("dataset_id").(string)
 
+	<% unless version == 'ga' -%>
+	if v, ok := d.GetOk("table_replication_info"); ok {
+		if table.Schema != nil || table.View != nil || table.MaterializedView != nil {
+			return errors.New("Schema, view, or materialized view cannot be specified when table replication info is present")
+		}
+
+		replicationDDL := fmt.Sprintf("CREATE MATERIALIZED VIEW %s.%s.%s", d.Get("project").(string), d.Get("dataset_id").(string), d.Get("table_id").(string))
+
+		tableReplicationInfo := expandTableReplicationInfo(v)
+		replicationIntervalMs := tableReplicationInfo["replication_interval_ms"].(int64)
+		if replicationIntervalMs > 0 {
+			replicationIntervalSeconds := replicationIntervalMs / 1000
+			replicationDDL = fmt.Sprintf("%s OPTIONS(replication_interval_seconds=%d)", replicationDDL, replicationIntervalSeconds)
+		}
+
+		replicationDDL = fmt.Sprintf("%s AS REPLICA OF %s.%s.%s", replicationDDL, tableReplicationInfo["source_project_id"], tableReplicationInfo["source_dataset_id"], tableReplicationInfo["source_table_id"])
+		useLegacySQL := false
+
+		req := &bigquery.QueryRequest{
+			Query:        replicationDDL,
+			UseLegacySql: &useLegacySQL,
+		}
+
+		log.Printf("[INFO] Creating a replica materialized view with DDL: '%s'", replicationDDL)
+
+		_, err := config.NewBigQueryClient(userAgent).Jobs.Query(project, req).Do()
+
+		id := fmt.Sprintf("projects/%s/datasets/%s/tables/%s", project, datasetID, d.Get("table_id").(string))
+		if err != nil {
+			if deleteErr := resourceBigQueryTableDelete(d, meta); deleteErr != nil {
+				log.Printf("[INFO] Unable to clean up table %s: %s", id, deleteErr)
+			}
+			return err
+		}
+
+		log.Printf("[INFO] BigQuery table %s has been created", id)
+		d.SetId(id)
+
+		return resourceBigQueryTableRead(d, meta)
+	}
+
+	<% end -%>
 	if table.View != nil && table.Schema != nil {
 
-		log.Printf("[INFO] Removing schema from table definition because big query does not support setting schema on view creation")
+		log.Printf("[INFO] Removing schema from table definition because BigQuery does not support setting schema on view creation")
 		schemaBack := table.Schema
 		table.Schema = nil
 
@@ -1408,7 +1485,7 @@ func resourceBigQueryTableCreate(d *schema.ResourceData, meta interface{}) error
 			return err
 		}
 
-		log.Printf("[INFO] BigQuery table %s has been update with schema", res.Id)
+		log.Printf("[INFO] BigQuery table %s has been updated with schema", res.Id)
 	} else {
 		log.Printf("[INFO] Creating BigQuery table: %s", table.TableReference.TableId)
 
@@ -1597,10 +1674,44 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	<% unless version == 'ga' -%>
+	// Get API fields for TableReplicationInfo not available in the client library yet.
+	url, err := tpgresource.ReplaceVars(d, config, "{{BigQueryBasePath}}projects/{{project}}/datasets/{{dataset_id}}/tables/{{table_id}}")
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Reading BigQuery table through API: %s", url)
+
+	getRes, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
+	if err != nil {
+		return err
+	}
+
+	if v, ok := getRes["tableReplicationInfo"]; ok {
+		tableReplicationInfo := flattenTableReplicationInfo(v.(map[string]interface{}))
+
+		if err := d.Set("table_replication_info", tableReplicationInfo); err != nil {
+			return fmt.Errorf("Error setting table replication info: %s", err)
+		}
+	}
+
+  <% end -%>
 	return nil
 }
 
 func resourceBigQueryTableUpdate(d *schema.ResourceData, meta interface{}) error {
+	<% unless version == 'ga' -%>
+	if d.Get("table_replication_info") != nil {
+		return errors.New("Table replication info is not supported in update")
+	}
+
+	<% end -%>
 	config := meta.(*transport_tpg.Config)
 	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {
@@ -2387,6 +2498,58 @@ func flattenTableConstraints(edc *bigquery.TableConstraints) []map[string]interf
 	return []map[string]interface{}{result}
 }
 
+<% unless version == 'ga' -%>
+func expandTableReplicationInfo(cfg interface{}) map[string]interface{} {
+	raw := cfg.([]interface{})[0].(map[string]interface{})
+
+	result := map[string]interface{}{}
+
+	if v, ok := raw["source_project_id"]; ok {
+		result["source_project_id"] = v.(string)
+	}
+
+	if v, ok := raw["source_dataset_id"]; ok {
+		result["source_dataset_id"] = v.(string)
+	}
+
+	if v, ok := raw["source_table_id"]; ok {
+		result["source_table_id"] = v.(string)
+	}
+
+	if v, ok := raw["replication_interval_ms"]; ok {
+		result["replication_interval_ms"] = int64(v.(int))
+	}
+
+	return result
+}
+
+func flattenTableReplicationInfo(tableReplicationInfo map[string]interface{}) []map[string]interface{} {
+	result := map[string]interface{}{}
+
+	if v, ok := tableReplicationInfo["sourceTable"]; ok {
+		sourceTable := v.(map[string]interface{})
+		if v, ok := sourceTable["projectId"]; ok {
+			result["source_project_id"] = v.(string)
+		}
+		if v, ok := sourceTable["datasetId"]; ok {
+			result["source_dataset_id"] = v.(string)
+		}
+		if v, ok := sourceTable["tableId"]; ok {
+			result["source_table_id"] = v.(string)
+		}
+	}
+
+	if v, ok := tableReplicationInfo["replicationIntervalMs"]; ok {
+		replicationIntervalMs := v.(string)
+		if i, err := strconv.Atoi(replicationIntervalMs); err == nil {
+			result["replication_interval_ms"] = int64(i)
+		}
+	}
+
+	return []map[string]interface{}{result}
+}
+
+<% end -%>
 func resourceBigQueryTableImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.erb
@@ -1263,23 +1263,27 @@ func ResourceBigQueryTable() *schema.Resource {
 						"source_project_id": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: `The ID of the source project."`,
+							ForceNew:    true,
+							Description: `The ID of the source project.`,
 						},
 						"source_dataset_id": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: `The ID of the source dataset."`,
+							ForceNew:    true,
+							Description: `The ID of the source dataset.`,
 						},
 						"source_table_id": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: `The ID of the source materialized view."`,
+							ForceNew:    true,
+							Description: `The ID of the source materialized view.`,
 						},
 						"replication_interval_ms": {
 							Type:        schema.TypeInt,
+							Default:     300000,
 							Optional:    true,
-							Computed:    true,
-							Description: `The interval at which the source materialized view is polled for updates."`,
+							ForceNew:    true,
+							Description: `The interval at which the source materialized view is polled for updates. The default is 300000.`,
 						},
 					},
 				},
@@ -1706,14 +1710,6 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceBigQueryTableUpdate(d *schema.ResourceData, meta interface{}) error {
-	<% unless version == 'ga' -%>
-	if v, ok := d.GetOk("table_replication_info"); ok {
-		if len(v.([]interface{})) > 0 {
-			return errors.New("Table replication info is not supported in update")
-		}
-	}
-
-	<% end -%>
 	config := meta.(*transport_tpg.Config)
 	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.erb
@@ -1707,8 +1707,10 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceBigQueryTableUpdate(d *schema.ResourceData, meta interface{}) error {
 	<% unless version == 'ga' -%>
-	if d.Get("table_replication_info") != nil {
-		return errors.New("Table replication info is not supported in update")
+	if v, ok := d.GetOk("table_replication_info"); ok {
+		if len(v.([]interface{})) > 0 {
+			return errors.New("Table replication info is not supported in update")
+		}
 	}
 
 	<% end -%>

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.erb
@@ -529,7 +529,7 @@ func ResourceBigQueryTable() *schema.Resource {
 							Default:      "NONE",
 							Description:  `The compression type of the data source. Valid values are "NONE" or "GZIP".`,
 						},
-						// Schema: Optional] The schema for the data.
+						// Schema: [Optional] The schema for the data.
 						// Schema is required for CSV and JSON formats if autodetect is not on.
 						// Schema is disallowed for Google Cloud Bigtable, Cloud Datastore backups, Avro, Iceberg, ORC, and Parquet formats.
 						"schema": {

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.erb
@@ -1256,6 +1256,7 @@ func ResourceBigQueryTable() *schema.Resource {
 			"table_replication_info": {
 				Type:        schema.TypeList,
 				Optional:    true,
+				ForceNew:    true,
 				MaxItems:    1,
 				Description: `Replication info of a table created using "AS REPLICA" DDL like: "CREATE MATERIALIZED VIEW mv1 AS REPLICA OF src_mv".`,
 				Elem: &schema.Resource{
@@ -1679,7 +1680,7 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	<% unless version == 'ga' -%>
-	// Get API fields for TableReplicationInfo not available in the client library yet.
+	// TODO: Update when the Get API fields for TableReplicationInfo are available in the client library.
 	url, err := tpgresource.ReplaceVars(d, config, "{{BigQueryBasePath}}projects/{{project}}/datasets/{{dataset_id}}/tables/{{table_id}}")
 	if err != nil {
 		return err

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
@@ -1459,12 +1459,14 @@ func TestAccBigQueryTable_TableReplicationInfo_WithoutReplicationInterval(t *tes
 
 	sourceDatasetID := fmt.Sprintf("tf_test_source_dataset_%s", acctest.RandString(t, 10))
 	sourceTableID := fmt.Sprintf("tf_test_source_table_%s", acctest.RandString(t, 10))
-	sourceMVJobID := fmt.Sprintf("tf_test_create_source_mv_job_%s", acctest.RandString(t, 10))
 	sourceMVID := fmt.Sprintf("tf_test_source_mv_%s", acctest.RandString(t, 10))
 	replicaDatasetID := fmt.Sprintf("tf_test_replica_dataset_%s", acctest.RandString(t, 10))
 	replicaMVID := fmt.Sprintf("tf_test_replica_mv_%s", acctest.RandString(t, 10))
-	replicationIntervalExpr := ""
+	sourceTableJobID := fmt.Sprintf("tf_test_create_source_table_job_%s", acctest.RandString(t, 10))
+	sourceMVJobID := fmt.Sprintf("tf_test_create_source_mv_job_%s", acctest.RandString(t, 10))
+	dropTableJobID := fmt.Sprintf("tf_test_drop_table_job_%s", acctest.RandString(t, 10))
 	dropMVJobID := fmt.Sprintf("tf_test_drop_source_mv_job_%s", acctest.RandString(t, 10))
+	replicationIntervalExpr := ""
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -1475,7 +1477,7 @@ func TestAccBigQueryTable_TableReplicationInfo_WithoutReplicationInterval(t *tes
 		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVJobID, sourceMVID, replicaDatasetID, replicaMVID, replicationIntervalExpr, dropMVJobID),
+				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVID, replicaDatasetID, replicaMVID, sourceTableJobID, sourceMVJobID, dropTableJobID, dropMVJobID, replicationIntervalExpr),
 			},
 			{
 				ResourceName:            "google_bigquery_table.replica_mv",
@@ -1494,12 +1496,14 @@ func TestAccBigQueryTable_TableReplicationInfo_WithReplicationInterval(t *testin
 
 	sourceDatasetID := fmt.Sprintf("tf_test_source_dataset_%s", acctest.RandString(t, 10))
 	sourceTableID := fmt.Sprintf("tf_test_source_table_%s", acctest.RandString(t, 10))
-	sourceMVJobID := fmt.Sprintf("tf_test_create_source_mv_job_%s", acctest.RandString(t, 10))
 	sourceMVID := fmt.Sprintf("tf_test_source_mv_%s", acctest.RandString(t, 10))
 	replicaDatasetID := fmt.Sprintf("tf_test_replica_dataset_%s", acctest.RandString(t, 10))
 	replicaMVID := fmt.Sprintf("tf_test_replica_mv_%s", acctest.RandString(t, 10))
-	replicationIntervalExpr := "replication_interval_ms = 600000"
+	sourceTableJobID := fmt.Sprintf("tf_test_create_source_table_job_%s", acctest.RandString(t, 10))
+	sourceMVJobID := fmt.Sprintf("tf_test_create_source_mv_job_%s", acctest.RandString(t, 10))
+	dropTableJobID := fmt.Sprintf("tf_test_drop_table_job_%s", acctest.RandString(t, 10))
 	dropMVJobID := fmt.Sprintf("tf_test_drop_source_mv_job_%s", acctest.RandString(t, 10))
+	replicationIntervalExpr := "replication_interval_ms = 600000"
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -1510,7 +1514,7 @@ func TestAccBigQueryTable_TableReplicationInfo_WithReplicationInterval(t *testin
 		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVJobID, sourceMVID, replicaDatasetID, replicaMVID, replicationIntervalExpr, dropMVJobID),
+				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVID, replicaDatasetID, replicaMVID, sourceTableJobID, sourceMVJobID, dropTableJobID, dropMVJobID, replicationIntervalExpr),
 			},
 			{
 				ResourceName:            "google_bigquery_table.replica_mv",
@@ -1529,13 +1533,15 @@ func TestAccBigQueryTable_TableReplicationInfo_Update(t *testing.T) {
 
 	sourceDatasetID := fmt.Sprintf("tf_test_source_dataset_%s", acctest.RandString(t, 10))
 	sourceTableID := fmt.Sprintf("tf_test_source_table_%s", acctest.RandString(t, 10))
-	sourceMVJobID := fmt.Sprintf("tf_test_create_source_mv_job_%s", acctest.RandString(t, 10))
 	sourceMVID := fmt.Sprintf("tf_test_source_mv_%s", acctest.RandString(t, 10))
 	replicaDatasetID := fmt.Sprintf("tf_test_replica_dataset_%s", acctest.RandString(t, 10))
 	replicaMVID := fmt.Sprintf("tf_test_replica_mv_%s", acctest.RandString(t, 10))
+	sourceTableJobID := fmt.Sprintf("tf_test_create_source_table_job_%s", acctest.RandString(t, 10))
+	sourceMVJobID := fmt.Sprintf("tf_test_create_source_mv_job_%s", acctest.RandString(t, 10))
+	dropTableJobID := fmt.Sprintf("tf_test_drop_table_job_%s", acctest.RandString(t, 10))
+	dropMVJobID := fmt.Sprintf("tf_test_drop_source_mv_job_%s", acctest.RandString(t, 10))
 	replicationIntervalExprOld := ""
 	replicationIntervalExprNew := "replication_interval_ms = 600000"
-	dropMVJobID := fmt.Sprintf("tf_test_drop_source_mv_job_%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -1546,7 +1552,7 @@ func TestAccBigQueryTable_TableReplicationInfo_Update(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVJobID, sourceMVID, replicaDatasetID, replicaMVID, replicationIntervalExprOld, dropMVJobID),
+				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVID, replicaDatasetID, replicaMVID, sourceTableJobID, sourceMVJobID, dropTableJobID, dropMVJobID, replicationIntervalExprOld),
 			},
 			{
 				ResourceName:            "google_bigquery_table.replica_mv",
@@ -1555,7 +1561,7 @@ func TestAccBigQueryTable_TableReplicationInfo_Update(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVJobID, sourceMVID, replicaDatasetID, replicaMVID, replicationIntervalExprNew, dropMVJobID),
+				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVID, replicaDatasetID, replicaMVID, sourceTableJobID, sourceMVJobID, dropTableJobID, dropMVJobID, replicationIntervalExprNew),
 				ExpectError: regexp.MustCompile("Table replication info is not supported in update"),
 			},
 		},
@@ -3786,7 +3792,7 @@ resource "google_bigquery_table" "test" {
 `, datasetID, tableID)
 }
 
-func testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVJobID, sourceMVID, replicaDatasetID, replicaMVID, replicationIntervalExpr, dropMVJobID string) string {
+func testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVID, replicaDatasetID, replicaMVID, sourceTableJobID, sourceMVJobID, dropTableJobID, dropMVJobID, replicationIntervalExpr string) string {
 	return fmt.Sprintf(`
 resource "google_bigquery_dataset" "source" {
   provider = google-beta
@@ -3795,23 +3801,26 @@ resource "google_bigquery_dataset" "source" {
   location = "aws-us-east-1"
 }
 
-resource "google_bigquery_table" "source_table" {
+resource "google_bigquery_job" "source_table_job" {
   provider = google-beta
 
-  deletion_protection = false
-  table_id   = "%s"
-  dataset_id = google_bigquery_dataset.source.dataset_id
-  external_data_configuration {
-    connection_id   = "bigquerytestdefault.aws-us-east-1.e2e_ccmv_tf_test"
-    autodetect      = true
-		metadata_cache_mode = "AUTOMATIC"
-    source_format = "PARQUET"
-    source_uris = [
-      "s3://bq-testing/parquet/all_types.parquet",
-    ]
+  job_id = "%s"
+
+  location = "aws-us-east-1"
+  query {
+    query = "CREATE EXTERNAL TABLE %s.%s WITH CONNECTION ` + "`bigquerytestdefault.aws-us-east-1.e2e_ccmv_tf_test`" + ` OPTIONS (format = \"PARQUET\", uris = [\"s3://bq-testing/parquet/all_types.parquet\"], max_staleness = INTERVAL \"10:00:0\" HOUR TO SECOND, metadata_cache_mode = \"MANUAL\")"
+    use_legacy_sql = false
+    create_disposition = ""
+    write_disposition = ""
   }
-  max_staleness = "0-0 0 10:0:0"
- }
+
+  depends_on = [google_bigquery_dataset.source]
+}
+
+resource "time_sleep" "wait_10_seconds_for_source_table_job" {
+  depends_on = [google_bigquery_job.source_table_job]
+  create_duration = "10s"
+}
 
 resource "google_bigquery_job" "source_mv_job" {
   provider = google-beta
@@ -3826,10 +3835,10 @@ resource "google_bigquery_job" "source_mv_job" {
     write_disposition = ""
   }
 
-  depends_on = [google_bigquery_table.source_table]
+  depends_on = [time_sleep.wait_10_seconds_for_source_table_job]
 }
 
-resource "time_sleep" "wait_10_seconds" {
+resource "time_sleep" "wait_10_seconds_for_source_mv_job" {
   depends_on = [google_bigquery_job.source_mv_job]
   create_duration = "10s"
 }
@@ -3844,7 +3853,7 @@ resource "google_bigquery_dataset_access" "access" {
     table_id   = "%s"
   }
 
-  depends_on = [time_sleep.wait_10_seconds]
+  depends_on = [time_sleep.wait_10_seconds_for_source_mv_job]
 }
 
 resource "google_bigquery_dataset" "replica" {
@@ -3887,11 +3896,33 @@ resource "google_bigquery_job" "drop_source_mv_job" {
   depends_on = [google_bigquery_table.replica_mv]
 }
 
-resource "time_sleep" "wait_10_seconds_last" {
+resource "time_sleep" "wait_10_seconds_for_drop_source_mv_job" {
   depends_on = [google_bigquery_job.drop_source_mv_job]
   create_duration = "10s"
 }
-`, sourceDatasetID, sourceTableID, sourceMVJobID, sourceDatasetID, sourceMVID, sourceDatasetID, sourceTableID, projectID, sourceMVID, replicaDatasetID, replicaMVID, projectID, sourceMVID, replicationIntervalExpr, dropMVJobID, sourceDatasetID, sourceMVID)
+
+resource "google_bigquery_job" "drop_source_table_job" {
+  provider = google-beta
+
+  project = "bigquerytestdefault"
+  job_id = "%s"
+
+  location = "aws-us-east-1"
+  query {
+    query = "DROP TABLE %s.%s"
+    use_legacy_sql = false
+    create_disposition = ""
+    write_disposition = ""
+  }
+
+  depends_on = [google_bigquery_table.replica_mv]
+}
+
+resource "time_sleep" "wait_10_seconds_for_drop_source_table_job" {
+  depends_on = [google_bigquery_job.drop_source_table_job]
+  create_duration = "10s"
+}
+`, sourceDatasetID, sourceTableJobID, sourceDatasetID, sourceTableID, sourceMVJobID, sourceDatasetID, sourceMVID, sourceDatasetID, sourceTableID, projectID, sourceMVID, replicaDatasetID, replicaMVID, projectID, sourceMVID, replicationIntervalExpr, dropMVJobID, sourceDatasetID, sourceMVID, dropTableJobID, sourceDatasetID, sourceTableID)
 }
 
 <% end -%>

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
@@ -1521,46 +1521,6 @@ func TestAccBigQueryTable_TableReplicationInfo_WithReplicationInterval(t *testin
 	})
 }
 
-func TestAccBigQueryTable_TableReplicationInfo_Update(t *testing.T) {
-	t.Parallel()
-
-	projectID := envvar.GetTestProjectFromEnv()
-
-	sourceDatasetID := fmt.Sprintf("tf_test_source_dataset_%s", acctest.RandString(t, 10))
-	sourceTableID := fmt.Sprintf("tf_test_source_table_%s", acctest.RandString(t, 10))
-	sourceMVID := fmt.Sprintf("tf_test_source_mv_%s", acctest.RandString(t, 10))
-	replicaDatasetID := fmt.Sprintf("tf_test_replica_dataset_%s", acctest.RandString(t, 10))
-	replicaMVID := fmt.Sprintf("tf_test_replica_mv_%s", acctest.RandString(t, 10))
-	sourceMVJobID := fmt.Sprintf("tf_test_create_source_mv_job_%s", acctest.RandString(t, 10))
-	dropMVJobID := fmt.Sprintf("tf_test_drop_source_mv_job_%s", acctest.RandString(t, 10))
-	replicationIntervalExprOld := ""
-	replicationIntervalExprNew := "replication_interval_ms = 600000"
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
-		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
-		ExternalProviders:        map[string]resource.ExternalProvider{
-			"time": {},
-		},
-		Steps: []resource.TestStep{
-			{
-				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVID, replicaDatasetID, replicaMVID, sourceMVJobID, dropMVJobID, replicationIntervalExprOld),
-			},
-			{
-				ResourceName:            "google_bigquery_table.replica_mv",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"deletion_protection"},
-			},
-			{
-				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVID, replicaDatasetID, replicaMVID, sourceMVJobID, dropMVJobID, replicationIntervalExprNew),
-				ExpectError: regexp.MustCompile("Table replication info is not supported in update"),
-			},
-		},
-	})
-}
-
 <% end -%>
 func testAccCheckBigQueryExtData(t *testing.T, expectedQuoteChar string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -1894,7 +1854,7 @@ resource "google_bigquery_table" "test" {
     hive_partitioning_options {
       mode = "AUTO"
       source_uri_prefix = "gs://${google_storage_bucket.test.name}/"
-	    require_partition_filter = true
+      require_partition_filter = true
     }
 
   }
@@ -1934,7 +1894,7 @@ resource "google_bigquery_table" "test" {
     hive_partitioning_options {
       mode = "CUSTOM"
       source_uri_prefix = "gs://${google_storage_bucket.test.name}/{key1:STRING}"
-	    require_partition_filter = true
+      require_partition_filter = true
     }
 
     schema = <<EOH
@@ -3140,49 +3100,49 @@ resource "google_bigquery_table" "test" {
 }
 
 func testAccBigQueryTableFromBigtable(context map[string]interface{}) string {
-	return acctest.Nprintf(`
-	resource "google_bigtable_instance" "instance" {
-		name = "tf-test-bigtable-inst-%{random_suffix}"
-		cluster {
-			cluster_id = "tf-test-bigtable-%{random_suffix}"
-			zone       = "us-central1-b"
-		}
-		instance_type = "DEVELOPMENT"
-		deletion_protection = false
-	}
-	resource "google_bigtable_table" "table" {
-		name          = "%{random_suffix}"
-		instance_name = google_bigtable_instance.instance.name
-		column_family {
-			family = "cf-%{random_suffix}-first"
-		}
-		column_family {
-			family = "cf-%{random_suffix}-second"
-		}
-	}
-	resource "google_bigquery_table" "table" {
-		deletion_protection = false
-		dataset_id = google_bigquery_dataset.dataset.dataset_id
-		table_id   = "tf_test_bigtable_%{random_suffix}"
-		external_data_configuration {
-		  autodetect            = true
-		  source_format         = "BIGTABLE"
-		  ignore_unknown_values = true
-		  source_uris = [
-			"https://googleapis.com/bigtable/${google_bigtable_table.table.id}",
-		  ]
-		}
-	}
-	resource "google_bigquery_dataset" "dataset" {
-		dataset_id                  = "tf_test_ds_%{random_suffix}"
-		friendly_name               = "test"
-		description                 = "This is a test description"
-		location                    = "EU"
-		default_table_expiration_ms = 3600000
-		labels = {
-		  env = "default"
-		}
-	}
+  return acctest.Nprintf(`
+resource "google_bigtable_instance" "instance" {
+  name = "tf-test-bigtable-inst-%{random_suffix}"
+  cluster {
+    cluster_id = "tf-test-bigtable-%{random_suffix}"
+    zone       = "us-central1-b"
+  }
+  instance_type = "DEVELOPMENT"
+  deletion_protection = false
+}
+resource "google_bigtable_table" "table" {
+  name          = "%{random_suffix}"
+  instance_name = google_bigtable_instance.instance.name
+  column_family {
+    family = "cf-%{random_suffix}-first"
+  }
+  column_family {
+    family = "cf-%{random_suffix}-second"
+  }
+}
+resource "google_bigquery_table" "table" {
+  deletion_protection = false
+  dataset_id = google_bigquery_dataset.dataset.dataset_id
+  table_id   = "tf_test_bigtable_%{random_suffix}"
+  external_data_configuration {
+    autodetect            = true
+    source_format         = "BIGTABLE"
+    ignore_unknown_values = true
+    source_uris = [
+    "https://googleapis.com/bigtable/${google_bigtable_table.table.id}",
+    ]
+  }
+}
+resource "google_bigquery_dataset" "dataset" {
+  dataset_id                  = "tf_test_ds_%{random_suffix}"
+  friendly_name               = "test"
+  description                 = "This is a test description"
+  location                    = "EU"
+  default_table_expiration_ms = 3600000
+  labels = {
+    env = "default"
+  }
+}
 `, context)
 }
 

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package bigquery_test
 
 import (
@@ -1431,6 +1432,7 @@ func TestAccBigQueryTable_invalidSchemas(t *testing.T) {
 	})
 }
 
+<% unless version == 'ga' -%>
 func TestAccBigQueryTable_TableReplicationInfo_ConflictsWithView(t *testing.T) {
 	t.Parallel()
 
@@ -1439,7 +1441,7 @@ func TestAccBigQueryTable_TableReplicationInfo_ConflictsWithView(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -1457,32 +1459,106 @@ func TestAccBigQueryTable_TableReplicationInfo_WithoutReplicationInterval(t *tes
 
 	sourceDatasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
 	sourceTableID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
-	connectionID := "bigquerytestdefault.aws-us-east-1.wjchen_replica_mv_tf_connection"
-	sourceURI := "s3://bq-testing/mmiaolin-test/large_orders/*.parquet"
+	connectionID := "bigquerytestdefault.aws-us-east-1.e2e_ccmv_tf_test"
+	sourceURI := "s3://bq-testing/parquet/all_types.parquet"
 	// Has to follow google sql IntervalValue encoding
 	maxStaleness := "0-0 0 10:0:0"
 	sourceMaterializedViewID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
 	destinationDatasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
 	replicaMaterializedViewID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	replicationIntervalExpression := "" // replication_interval_ms = 600000
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigQueryTableWithReplicationInfoNoReplicationInterval(projectID, sourceDatasetID, sourceTableID, connectionID, sourceURI, maxStaleness, sourceMaterializedViewID, destinationDatasetID, replicaMaterializedViewID),
+				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, connectionID, sourceURI, maxStaleness, sourceMaterializedViewID, destinationDatasetID, replicaMaterializedViewID, replicationIntervalExpression),
 			},
 			{
 				ResourceName:            "google_bigquery_table.replica_mv",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"schema", "external_data_configuration.0.schema", "encryption_configuration", "deletion_protection"},
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
 	})
 }
 
+func TestAccBigQueryTable_TableReplicationInfo_WithReplicationInterval(t *testing.T) {
+	t.Parallel()
+
+	projectID := envvar.GetTestProjectFromEnv()
+
+	sourceDatasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	sourceTableID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	connectionID := "bigquerytestdefault.aws-us-east-1.e2e_ccmv_tf_test"
+	sourceURI := "s3://bq-testing/parquet/all_types.parquet"
+	// Has to follow google sql IntervalValue encoding
+	maxStaleness := "0-0 0 10:0:0"
+	sourceMaterializedViewID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	destinationDatasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	replicaMaterializedViewID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	replicationIntervalExpression := "replication_interval_ms = 600000"
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, connectionID, sourceURI, maxStaleness, sourceMaterializedViewID, destinationDatasetID, replicaMaterializedViewID, replicationIntervalExpression),
+			},
+			{
+				ResourceName:            "google_bigquery_table.replica_mv",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+func TestAccBigQueryTable_TableReplicationInfo_Update(t *testing.T) {
+	t.Parallel()
+
+	projectID := envvar.GetTestProjectFromEnv()
+
+	sourceDatasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	sourceTableID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	connectionID := "bigquerytestdefault.aws-us-east-1.e2e_ccmv_tf_test"
+	sourceURI := "s3://bq-testing/parquet/all_types.parquet"
+	// Has to follow google sql IntervalValue encoding
+	maxStaleness := "0-0 0 10:0:0"
+	sourceMaterializedViewID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	destinationDatasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	replicaMaterializedViewID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	replicationIntervalExpressionOld := ""
+	replicationIntervalExpressionNew := "replication_interval_ms = 600000"
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, connectionID, sourceURI, maxStaleness, sourceMaterializedViewID, destinationDatasetID, replicaMaterializedViewID, replicationIntervalExpressionOld),
+			},
+			{
+				ResourceName:            "google_bigquery_table.replica_mv",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config:      testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, connectionID, sourceURI, maxStaleness, sourceMaterializedViewID, destinationDatasetID, replicaMaterializedViewID, replicationIntervalExpressionNew),
+				ExpectError: regexp.MustCompile("Table replication info is not supported in update"),
+			},
+		},
+	})
+}
+<% end -%>
 func testAccCheckBigQueryExtData(t *testing.T, expectedQuoteChar string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		for _, rs := range s.RootModule().Resources {
@@ -3678,13 +3754,18 @@ resource "google_bigquery_table" "test" {
 `, datasetID, tableID, schema)
 }
 
+<% unless version == 'ga' -%>
 func testAccBigQueryTableWithReplicationInfoAndView(datasetID, tableID string) string {
 	return fmt.Sprintf(`
 resource "google_bigquery_dataset" "test" {
+  provider = google-beta
+
   dataset_id = "%s"
 }
 
 resource "google_bigquery_table" "test" {
+  provider = google-beta
+
   deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
@@ -3701,14 +3782,18 @@ resource "google_bigquery_table" "test" {
 `, datasetID, tableID)
 }
 
-func testAccBigQueryTableWithReplicationInfoNoReplicationInterval(projectID, sourceDatasetID, sourceTableID, connectionID, sourceURI, maxStaleness, sourceMaterializedViewID, destinationDatasetID, replicaMaterializedViewID string) string {
+func testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, connectionID, sourceURI, maxStaleness, sourceMaterializedViewID, destinationDatasetID, replicaMaterializedViewID, replicationIntervalExpression string) string {
 	return fmt.Sprintf(`
 resource "google_bigquery_dataset" "source" {
+  provider = google-beta
+
   dataset_id = "%s"
   location = "aws-us-east-1"
 }
 
 resource "google_bigquery_table" "source_table" {
+  provider = google-beta
+
   deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.source.dataset_id
@@ -3722,10 +3807,11 @@ resource "google_bigquery_table" "source_table" {
     ]
   }
   max_staleness = "%s"
-	encryption_configuration {}
  }
 
 resource "google_bigquery_table" "source_mv" {
+  provider = google-beta
+
   deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.source.dataset_id
@@ -3735,10 +3821,12 @@ resource "google_bigquery_table" "source_mv" {
   }
 	max_staleness = "%s"
 
-	depends_on = ["google_bigquery_table.source_table"]
+  depends_on = ["google_bigquery_table.source_table"]
 }
 
 resource "google_bigquery_dataset_access" "access" {
+  provider = google-beta
+
   dataset_id    = google_bigquery_dataset.source.dataset_id
   view {
     project_id = "%s"
@@ -3748,6 +3836,8 @@ resource "google_bigquery_dataset_access" "access" {
 }
 
 resource "google_bigquery_dataset" "destination" {
+  provider = google-beta
+
   dataset_id = "%s"
   location = "us"
 }
@@ -3764,11 +3854,12 @@ resource "google_bigquery_table" "replica_mv" {
     source_project_id = "%s"
     source_dataset_id = google_bigquery_table.source_mv.dataset_id
     source_table_id = google_bigquery_table.source_mv.table_id
-    #replication_interval_ms = 600000
+    %s
   }
 }
-`, sourceDatasetID, sourceTableID, connectionID, sourceURI, maxStaleness, sourceMaterializedViewID, sourceDatasetID, sourceTableID, maxStaleness, projectID, destinationDatasetID, replicaMaterializedViewID, projectID)
+`, sourceDatasetID, sourceTableID, connectionID, sourceURI, maxStaleness, sourceMaterializedViewID, sourceDatasetID, sourceTableID, maxStaleness, projectID, destinationDatasetID, replicaMaterializedViewID, projectID, replicationIntervalExpression)
 }
+<% end -%>
 
 var TEST_CSV = `lifelock,LifeLock,,web,Tempe,AZ,1-May-07,6850000,USD,b
 lifelock,LifeLock,,web,Tempe,AZ,1-Oct-06,6000000,USD,a

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
@@ -1457,24 +1457,25 @@ func TestAccBigQueryTable_TableReplicationInfo_WithoutReplicationInterval(t *tes
 
 	projectID := envvar.GetTestProjectFromEnv()
 
-	sourceDatasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
-	sourceTableID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
-	connectionID := "bigquerytestdefault.aws-us-east-1.e2e_ccmv_tf_test"
-	sourceURI := "s3://bq-testing/parquet/all_types.parquet"
-	// Has to follow google sql IntervalValue encoding
-	maxStaleness := "0-0 0 10:0:0"
-	sourceMaterializedViewID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
-	destinationDatasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
-	replicaMaterializedViewID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
-	replicationIntervalExpression := "" // replication_interval_ms = 600000
+	sourceDatasetID := fmt.Sprintf("tf_test_source_dataset_%s", acctest.RandString(t, 10))
+	sourceTableID := fmt.Sprintf("tf_test_source_table_%s", acctest.RandString(t, 10))
+	sourceMVJobID := fmt.Sprintf("tf_test_create_source_mv_job_%s", acctest.RandString(t, 10))
+	sourceMVID := fmt.Sprintf("tf_test_source_mv_%s", acctest.RandString(t, 10))
+	replicaDatasetID := fmt.Sprintf("tf_test_replica_dataset_%s", acctest.RandString(t, 10))
+	replicaMVID := fmt.Sprintf("tf_test_replica_mv_%s", acctest.RandString(t, 10))
+	replicationIntervalExpr := ""
+	dropMVJobID := fmt.Sprintf("tf_test_drop_source_mv_job_%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ExternalProviders:        map[string]resource.ExternalProvider{
+			"time": {},
+		},
 		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, connectionID, sourceURI, maxStaleness, sourceMaterializedViewID, destinationDatasetID, replicaMaterializedViewID, replicationIntervalExpression),
+				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVJobID, sourceMVID, replicaDatasetID, replicaMVID, replicationIntervalExpr, dropMVJobID),
 			},
 			{
 				ResourceName:            "google_bigquery_table.replica_mv",
@@ -1491,24 +1492,25 @@ func TestAccBigQueryTable_TableReplicationInfo_WithReplicationInterval(t *testin
 
 	projectID := envvar.GetTestProjectFromEnv()
 
-	sourceDatasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
-	sourceTableID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
-	connectionID := "bigquerytestdefault.aws-us-east-1.e2e_ccmv_tf_test"
-	sourceURI := "s3://bq-testing/parquet/all_types.parquet"
-	// Has to follow google sql IntervalValue encoding
-	maxStaleness := "0-0 0 10:0:0"
-	sourceMaterializedViewID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
-	destinationDatasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
-	replicaMaterializedViewID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
-	replicationIntervalExpression := "replication_interval_ms = 600000"
+	sourceDatasetID := fmt.Sprintf("tf_test_source_dataset_%s", acctest.RandString(t, 10))
+	sourceTableID := fmt.Sprintf("tf_test_source_table_%s", acctest.RandString(t, 10))
+	sourceMVJobID := fmt.Sprintf("tf_test_create_source_mv_job_%s", acctest.RandString(t, 10))
+	sourceMVID := fmt.Sprintf("tf_test_source_mv_%s", acctest.RandString(t, 10))
+	replicaDatasetID := fmt.Sprintf("tf_test_replica_dataset_%s", acctest.RandString(t, 10))
+	replicaMVID := fmt.Sprintf("tf_test_replica_mv_%s", acctest.RandString(t, 10))
+	replicationIntervalExpr := "replication_interval_ms = 600000"
+	dropMVJobID := fmt.Sprintf("tf_test_drop_source_mv_job_%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ExternalProviders:        map[string]resource.ExternalProvider{
+			"time": {},
+		},
 		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, connectionID, sourceURI, maxStaleness, sourceMaterializedViewID, destinationDatasetID, replicaMaterializedViewID, replicationIntervalExpression),
+				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVJobID, sourceMVID, replicaDatasetID, replicaMVID, replicationIntervalExpr, dropMVJobID),
 			},
 			{
 				ResourceName:            "google_bigquery_table.replica_mv",
@@ -1525,25 +1527,26 @@ func TestAccBigQueryTable_TableReplicationInfo_Update(t *testing.T) {
 
 	projectID := envvar.GetTestProjectFromEnv()
 
-	sourceDatasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
-	sourceTableID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
-	connectionID := "bigquerytestdefault.aws-us-east-1.e2e_ccmv_tf_test"
-	sourceURI := "s3://bq-testing/parquet/all_types.parquet"
-	// Has to follow google sql IntervalValue encoding
-	maxStaleness := "0-0 0 10:0:0"
-	sourceMaterializedViewID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
-	destinationDatasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
-	replicaMaterializedViewID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
-	replicationIntervalExpressionOld := ""
-	replicationIntervalExpressionNew := "replication_interval_ms = 600000"
+	sourceDatasetID := fmt.Sprintf("tf_test_source_dataset_%s", acctest.RandString(t, 10))
+	sourceTableID := fmt.Sprintf("tf_test_source_table_%s", acctest.RandString(t, 10))
+	sourceMVJobID := fmt.Sprintf("tf_test_create_source_mv_job_%s", acctest.RandString(t, 10))
+	sourceMVID := fmt.Sprintf("tf_test_source_mv_%s", acctest.RandString(t, 10))
+	replicaDatasetID := fmt.Sprintf("tf_test_replica_dataset_%s", acctest.RandString(t, 10))
+	replicaMVID := fmt.Sprintf("tf_test_replica_mv_%s", acctest.RandString(t, 10))
+	replicationIntervalExprOld := ""
+	replicationIntervalExprNew := "replication_interval_ms = 600000"
+	dropMVJobID := fmt.Sprintf("tf_test_drop_source_mv_job_%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
+		ExternalProviders:        map[string]resource.ExternalProvider{
+			"time": {},
+		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, connectionID, sourceURI, maxStaleness, sourceMaterializedViewID, destinationDatasetID, replicaMaterializedViewID, replicationIntervalExpressionOld),
+				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVJobID, sourceMVID, replicaDatasetID, replicaMVID, replicationIntervalExprOld, dropMVJobID),
 			},
 			{
 				ResourceName:            "google_bigquery_table.replica_mv",
@@ -1552,7 +1555,7 @@ func TestAccBigQueryTable_TableReplicationInfo_Update(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config:      testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, connectionID, sourceURI, maxStaleness, sourceMaterializedViewID, destinationDatasetID, replicaMaterializedViewID, replicationIntervalExpressionNew),
+				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVJobID, sourceMVID, replicaDatasetID, replicaMVID, replicationIntervalExprNew, dropMVJobID),
 				ExpectError: regexp.MustCompile("Table replication info is not supported in update"),
 			},
 		},
@@ -3783,7 +3786,7 @@ resource "google_bigquery_table" "test" {
 `, datasetID, tableID)
 }
 
-func testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, connectionID, sourceURI, maxStaleness, sourceMaterializedViewID, destinationDatasetID, replicaMaterializedViewID, replicationIntervalExpression string) string {
+func testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVJobID, sourceMVID, replicaDatasetID, replicaMVID, replicationIntervalExpr, dropMVJobID string) string {
 	return fmt.Sprintf(`
 resource "google_bigquery_dataset" "source" {
   provider = google-beta
@@ -3799,30 +3802,34 @@ resource "google_bigquery_table" "source_table" {
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.source.dataset_id
   external_data_configuration {
-    connection_id   = "%s"
+    connection_id   = "bigquerytestdefault.aws-us-east-1.e2e_ccmv_tf_test"
     autodetect      = true
 		metadata_cache_mode = "AUTOMATIC"
     source_format = "PARQUET"
     source_uris = [
-      "%s",
+      "s3://bq-testing/parquet/all_types.parquet",
     ]
   }
-  max_staleness = "%s"
+  max_staleness = "0-0 0 10:0:0"
  }
 
-resource "google_bigquery_table" "source_mv" {
-  provider = google-beta
+ resource "google_bigquery_job" "source_mv_job" {
+  job_id = "%s"
 
-  deletion_protection = false
-  table_id   = "%s"
-  dataset_id = google_bigquery_dataset.source.dataset_id
-
-  materialized_view {
-    query = "SELECT * FROM %s.%s"
+  location = "aws-us-east-1"
+  query {
+    query = "CREATE MATERIALIZED VIEW %s.%s OPTIONS(max_staleness=INTERVAL \"10:00:0\" HOUR TO SECOND) AS SELECT * FROM %s.%s"
+    use_legacy_sql = false
+    create_disposition = ""
+    write_disposition = ""
   }
-  max_staleness = "%s"
 
-  depends_on = ["google_bigquery_table.source_table"]
+  depends_on = [google_bigquery_table.source_table]
+}
+
+resource "time_sleep" "wait_10_seconds" {
+  depends_on = [google_bigquery_job.source_mv_job]
+  create_duration = "10s"
 }
 
 resource "google_bigquery_dataset_access" "access" {
@@ -3831,12 +3838,14 @@ resource "google_bigquery_dataset_access" "access" {
   dataset_id    = google_bigquery_dataset.source.dataset_id
   view {
     project_id = "%s"
-    dataset_id = google_bigquery_table.source_mv.dataset_id
-    table_id   = google_bigquery_table.source_mv.table_id
+    dataset_id = google_bigquery_dataset.source.dataset_id
+    table_id   = "%s"
   }
+
+  depends_on = [time_sleep.wait_10_seconds]
 }
 
-resource "google_bigquery_dataset" "destination" {
+resource "google_bigquery_dataset" "replica" {
   provider = google-beta
 
   dataset_id = "%s"
@@ -3846,19 +3855,39 @@ resource "google_bigquery_dataset" "destination" {
 resource "google_bigquery_table" "replica_mv" {
   provider = google-beta
 
-  depends_on = [google_bigquery_dataset_access.access]
-
   deletion_protection = false
-  dataset_id = google_bigquery_dataset.destination.dataset_id
+  dataset_id = google_bigquery_dataset.replica.dataset_id
   table_id   = "%s"
   table_replication_info {
     source_project_id = "%s"
-    source_dataset_id = google_bigquery_table.source_mv.dataset_id
-    source_table_id = google_bigquery_table.source_mv.table_id
+    source_dataset_id = google_bigquery_dataset.source.dataset_id
+    source_table_id = "%s"
     %s
   }
+
+  depends_on = [google_bigquery_dataset_access.access]
 }
-`, sourceDatasetID, sourceTableID, connectionID, sourceURI, maxStaleness, sourceMaterializedViewID, sourceDatasetID, sourceTableID, maxStaleness, projectID, destinationDatasetID, replicaMaterializedViewID, projectID, replicationIntervalExpression)
+
+resource "google_bigquery_job" "drop_source_mv_job" {
+  project = "bigquerytestdefault"
+  job_id = "%s"
+
+  location = "aws-us-east-1"
+  query {
+    query = "DROP MATERIALIZED VIEW %s.%s"
+    use_legacy_sql = false
+    create_disposition = ""
+    write_disposition = ""
+  }
+
+  depends_on = [google_bigquery_table.replica_mv]
+}
+
+resource "time_sleep" "wait_10_seconds_last" {
+  depends_on = [google_bigquery_job.drop_source_mv_job]
+  create_duration = "10s"
+}
+`, sourceDatasetID, sourceTableID, sourceMVJobID, sourceDatasetID, sourceMVID, sourceDatasetID, sourceTableID, projectID, sourceMVID, replicaDatasetID, replicaMVID, projectID, sourceMVID, replicationIntervalExpr, dropMVJobID, sourceDatasetID, sourceMVID)
 }
 
 <% end -%>

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
@@ -1459,14 +1459,12 @@ func TestAccBigQueryTable_TableReplicationInfo_WithoutReplicationInterval(t *tes
 
 	sourceDatasetID := fmt.Sprintf("tf_test_source_dataset_%s", acctest.RandString(t, 10))
 	sourceTableID := fmt.Sprintf("tf_test_source_table_%s", acctest.RandString(t, 10))
+	sourceMVJobID := fmt.Sprintf("tf_test_create_source_mv_job_%s", acctest.RandString(t, 10))
 	sourceMVID := fmt.Sprintf("tf_test_source_mv_%s", acctest.RandString(t, 10))
 	replicaDatasetID := fmt.Sprintf("tf_test_replica_dataset_%s", acctest.RandString(t, 10))
 	replicaMVID := fmt.Sprintf("tf_test_replica_mv_%s", acctest.RandString(t, 10))
-	sourceTableJobID := fmt.Sprintf("tf_test_create_source_table_job_%s", acctest.RandString(t, 10))
-	sourceMVJobID := fmt.Sprintf("tf_test_create_source_mv_job_%s", acctest.RandString(t, 10))
-	dropTableJobID := fmt.Sprintf("tf_test_drop_table_job_%s", acctest.RandString(t, 10))
-	dropMVJobID := fmt.Sprintf("tf_test_drop_source_mv_job_%s", acctest.RandString(t, 10))
 	replicationIntervalExpr := ""
+	dropMVJobID := fmt.Sprintf("tf_test_drop_source_mv_job_%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -1477,7 +1475,7 @@ func TestAccBigQueryTable_TableReplicationInfo_WithoutReplicationInterval(t *tes
 		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVID, replicaDatasetID, replicaMVID, sourceTableJobID, sourceMVJobID, dropTableJobID, dropMVJobID, replicationIntervalExpr),
+				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVJobID, sourceMVID, replicaDatasetID, replicaMVID, replicationIntervalExpr, dropMVJobID),
 			},
 			{
 				ResourceName:            "google_bigquery_table.replica_mv",
@@ -1496,14 +1494,12 @@ func TestAccBigQueryTable_TableReplicationInfo_WithReplicationInterval(t *testin
 
 	sourceDatasetID := fmt.Sprintf("tf_test_source_dataset_%s", acctest.RandString(t, 10))
 	sourceTableID := fmt.Sprintf("tf_test_source_table_%s", acctest.RandString(t, 10))
+	sourceMVJobID := fmt.Sprintf("tf_test_create_source_mv_job_%s", acctest.RandString(t, 10))
 	sourceMVID := fmt.Sprintf("tf_test_source_mv_%s", acctest.RandString(t, 10))
 	replicaDatasetID := fmt.Sprintf("tf_test_replica_dataset_%s", acctest.RandString(t, 10))
 	replicaMVID := fmt.Sprintf("tf_test_replica_mv_%s", acctest.RandString(t, 10))
-	sourceTableJobID := fmt.Sprintf("tf_test_create_source_table_job_%s", acctest.RandString(t, 10))
-	sourceMVJobID := fmt.Sprintf("tf_test_create_source_mv_job_%s", acctest.RandString(t, 10))
-	dropTableJobID := fmt.Sprintf("tf_test_drop_table_job_%s", acctest.RandString(t, 10))
-	dropMVJobID := fmt.Sprintf("tf_test_drop_source_mv_job_%s", acctest.RandString(t, 10))
 	replicationIntervalExpr := "replication_interval_ms = 600000"
+	dropMVJobID := fmt.Sprintf("tf_test_drop_source_mv_job_%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -1514,7 +1510,7 @@ func TestAccBigQueryTable_TableReplicationInfo_WithReplicationInterval(t *testin
 		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVID, replicaDatasetID, replicaMVID, sourceTableJobID, sourceMVJobID, dropTableJobID, dropMVJobID, replicationIntervalExpr),
+				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVJobID, sourceMVID, replicaDatasetID, replicaMVID, replicationIntervalExpr, dropMVJobID),
 			},
 			{
 				ResourceName:            "google_bigquery_table.replica_mv",
@@ -1533,15 +1529,13 @@ func TestAccBigQueryTable_TableReplicationInfo_Update(t *testing.T) {
 
 	sourceDatasetID := fmt.Sprintf("tf_test_source_dataset_%s", acctest.RandString(t, 10))
 	sourceTableID := fmt.Sprintf("tf_test_source_table_%s", acctest.RandString(t, 10))
+	sourceMVJobID := fmt.Sprintf("tf_test_create_source_mv_job_%s", acctest.RandString(t, 10))
 	sourceMVID := fmt.Sprintf("tf_test_source_mv_%s", acctest.RandString(t, 10))
 	replicaDatasetID := fmt.Sprintf("tf_test_replica_dataset_%s", acctest.RandString(t, 10))
 	replicaMVID := fmt.Sprintf("tf_test_replica_mv_%s", acctest.RandString(t, 10))
-	sourceTableJobID := fmt.Sprintf("tf_test_create_source_table_job_%s", acctest.RandString(t, 10))
-	sourceMVJobID := fmt.Sprintf("tf_test_create_source_mv_job_%s", acctest.RandString(t, 10))
-	dropTableJobID := fmt.Sprintf("tf_test_drop_table_job_%s", acctest.RandString(t, 10))
-	dropMVJobID := fmt.Sprintf("tf_test_drop_source_mv_job_%s", acctest.RandString(t, 10))
 	replicationIntervalExprOld := ""
 	replicationIntervalExprNew := "replication_interval_ms = 600000"
+	dropMVJobID := fmt.Sprintf("tf_test_drop_source_mv_job_%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -1552,7 +1546,7 @@ func TestAccBigQueryTable_TableReplicationInfo_Update(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVID, replicaDatasetID, replicaMVID, sourceTableJobID, sourceMVJobID, dropTableJobID, dropMVJobID, replicationIntervalExprOld),
+				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVJobID, sourceMVID, replicaDatasetID, replicaMVID, replicationIntervalExprOld, dropMVJobID),
 			},
 			{
 				ResourceName:            "google_bigquery_table.replica_mv",
@@ -1561,7 +1555,7 @@ func TestAccBigQueryTable_TableReplicationInfo_Update(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVID, replicaDatasetID, replicaMVID, sourceTableJobID, sourceMVJobID, dropTableJobID, dropMVJobID, replicationIntervalExprNew),
+				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVJobID, sourceMVID, replicaDatasetID, replicaMVID, replicationIntervalExprNew, dropMVJobID),
 				ExpectError: regexp.MustCompile("Table replication info is not supported in update"),
 			},
 		},
@@ -3792,7 +3786,7 @@ resource "google_bigquery_table" "test" {
 `, datasetID, tableID)
 }
 
-func testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVID, replicaDatasetID, replicaMVID, sourceTableJobID, sourceMVJobID, dropTableJobID, dropMVJobID, replicationIntervalExpr string) string {
+func testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVJobID, sourceMVID, replicaDatasetID, replicaMVID, replicationIntervalExpr, dropMVJobID string) string {
 	return fmt.Sprintf(`
 resource "google_bigquery_dataset" "source" {
   provider = google-beta
@@ -3801,26 +3795,23 @@ resource "google_bigquery_dataset" "source" {
   location = "aws-us-east-1"
 }
 
-resource "google_bigquery_job" "source_table_job" {
+resource "google_bigquery_table" "source_table" {
   provider = google-beta
 
-  job_id = "%s"
-
-  location = "aws-us-east-1"
-  query {
-    query = "CREATE EXTERNAL TABLE %s.%s WITH CONNECTION ` + "`bigquerytestdefault.aws-us-east-1.e2e_ccmv_tf_test`" + ` OPTIONS (format = \"PARQUET\", uris = [\"s3://bq-testing/parquet/all_types.parquet\"], max_staleness = INTERVAL \"10:00:0\" HOUR TO SECOND, metadata_cache_mode = \"MANUAL\")"
-    use_legacy_sql = false
-    create_disposition = ""
-    write_disposition = ""
+  deletion_protection = false
+  table_id   = "%s"
+  dataset_id = google_bigquery_dataset.source.dataset_id
+  external_data_configuration {
+    connection_id   = "bigquerytestdefault.aws-us-east-1.e2e_ccmv_tf_test"
+    autodetect      = true
+		metadata_cache_mode = "AUTOMATIC"
+    source_format = "PARQUET"
+    source_uris = [
+      "s3://bq-testing/parquet/all_types.parquet",
+    ]
   }
-
-  depends_on = [google_bigquery_dataset.source]
-}
-
-resource "time_sleep" "wait_10_seconds_for_source_table_job" {
-  depends_on = [google_bigquery_job.source_table_job]
-  create_duration = "10s"
-}
+  max_staleness = "0-0 0 10:0:0"
+ }
 
 resource "google_bigquery_job" "source_mv_job" {
   provider = google-beta
@@ -3835,10 +3826,10 @@ resource "google_bigquery_job" "source_mv_job" {
     write_disposition = ""
   }
 
-  depends_on = [time_sleep.wait_10_seconds_for_source_table_job]
+  depends_on = [google_bigquery_table.source_table]
 }
 
-resource "time_sleep" "wait_10_seconds_for_source_mv_job" {
+resource "time_sleep" "wait_10_seconds" {
   depends_on = [google_bigquery_job.source_mv_job]
   create_duration = "10s"
 }
@@ -3853,7 +3844,7 @@ resource "google_bigquery_dataset_access" "access" {
     table_id   = "%s"
   }
 
-  depends_on = [time_sleep.wait_10_seconds_for_source_mv_job]
+  depends_on = [time_sleep.wait_10_seconds]
 }
 
 resource "google_bigquery_dataset" "replica" {
@@ -3896,33 +3887,11 @@ resource "google_bigquery_job" "drop_source_mv_job" {
   depends_on = [google_bigquery_table.replica_mv]
 }
 
-resource "time_sleep" "wait_10_seconds_for_drop_source_mv_job" {
+resource "time_sleep" "wait_10_seconds_last" {
   depends_on = [google_bigquery_job.drop_source_mv_job]
   create_duration = "10s"
 }
-
-resource "google_bigquery_job" "drop_source_table_job" {
-  provider = google-beta
-
-  project = "bigquerytestdefault"
-  job_id = "%s"
-
-  location = "aws-us-east-1"
-  query {
-    query = "DROP TABLE %s.%s"
-    use_legacy_sql = false
-    create_disposition = ""
-    write_disposition = ""
-  }
-
-  depends_on = [google_bigquery_table.replica_mv]
-}
-
-resource "time_sleep" "wait_10_seconds_for_drop_source_table_job" {
-  depends_on = [google_bigquery_job.drop_source_table_job]
-  create_duration = "10s"
-}
-`, sourceDatasetID, sourceTableJobID, sourceDatasetID, sourceTableID, sourceMVJobID, sourceDatasetID, sourceMVID, sourceDatasetID, sourceTableID, projectID, sourceMVID, replicaDatasetID, replicaMVID, projectID, sourceMVID, replicationIntervalExpr, dropMVJobID, sourceDatasetID, sourceMVID, dropTableJobID, sourceDatasetID, sourceTableID)
+`, sourceDatasetID, sourceTableID, sourceMVJobID, sourceDatasetID, sourceMVID, sourceDatasetID, sourceTableID, projectID, sourceMVID, replicaDatasetID, replicaMVID, projectID, sourceMVID, replicationIntervalExpr, dropMVJobID, sourceDatasetID, sourceMVID)
 }
 
 <% end -%>

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
@@ -3813,7 +3813,9 @@ resource "google_bigquery_table" "source_table" {
   max_staleness = "0-0 0 10:0:0"
  }
 
- resource "google_bigquery_job" "source_mv_job" {
+resource "google_bigquery_job" "source_mv_job" {
+  provider = google-beta
+
   job_id = "%s"
 
   location = "aws-us-east-1"
@@ -3869,6 +3871,8 @@ resource "google_bigquery_table" "replica_mv" {
 }
 
 resource "google_bigquery_job" "drop_source_mv_job" {
+  provider = google-beta
+
   project = "bigquerytestdefault"
   job_id = "%s"
 

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
@@ -1558,6 +1558,7 @@ func TestAccBigQueryTable_TableReplicationInfo_Update(t *testing.T) {
 		},
 	})
 }
+
 <% end -%>
 func testAccCheckBigQueryExtData(t *testing.T, expectedQuoteChar string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -3819,7 +3820,7 @@ resource "google_bigquery_table" "source_mv" {
   materialized_view {
     query = "SELECT * FROM %s.%s"
   }
-	max_staleness = "%s"
+  max_staleness = "%s"
 
   depends_on = ["google_bigquery_table.source_table"]
 }
@@ -3859,6 +3860,7 @@ resource "google_bigquery_table" "replica_mv" {
 }
 `, sourceDatasetID, sourceTableID, connectionID, sourceURI, maxStaleness, sourceMaterializedViewID, sourceDatasetID, sourceTableID, maxStaleness, projectID, destinationDatasetID, replicaMaterializedViewID, projectID, replicationIntervalExpression)
 }
+
 <% end -%>
 
 var TEST_CSV = `lifelock,LifeLock,,web,Tempe,AZ,1-May-07,6850000,USD,b

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
@@ -1459,13 +1459,12 @@ func TestAccBigQueryTable_TableReplicationInfo_WithoutReplicationInterval(t *tes
 
 	sourceDatasetID := fmt.Sprintf("tf_test_source_dataset_%s", acctest.RandString(t, 10))
 	sourceTableID := fmt.Sprintf("tf_test_source_table_%s", acctest.RandString(t, 10))
-	sourceMVJobID := fmt.Sprintf("tf_test_create_source_mv_job_%s", acctest.RandString(t, 10))
 	sourceMVID := fmt.Sprintf("tf_test_source_mv_%s", acctest.RandString(t, 10))
 	replicaDatasetID := fmt.Sprintf("tf_test_replica_dataset_%s", acctest.RandString(t, 10))
 	replicaMVID := fmt.Sprintf("tf_test_replica_mv_%s", acctest.RandString(t, 10))
-	replicationIntervalExpr := ""
+	sourceMVJobID := fmt.Sprintf("tf_test_create_source_mv_job_%s", acctest.RandString(t, 10))
 	dropMVJobID := fmt.Sprintf("tf_test_drop_source_mv_job_%s", acctest.RandString(t, 10))
-
+	replicationIntervalExpr := ""
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
@@ -1475,7 +1474,7 @@ func TestAccBigQueryTable_TableReplicationInfo_WithoutReplicationInterval(t *tes
 		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVJobID, sourceMVID, replicaDatasetID, replicaMVID, replicationIntervalExpr, dropMVJobID),
+				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVID, replicaDatasetID, replicaMVID, sourceMVJobID, dropMVJobID, replicationIntervalExpr),
 			},
 			{
 				ResourceName:            "google_bigquery_table.replica_mv",
@@ -1494,12 +1493,12 @@ func TestAccBigQueryTable_TableReplicationInfo_WithReplicationInterval(t *testin
 
 	sourceDatasetID := fmt.Sprintf("tf_test_source_dataset_%s", acctest.RandString(t, 10))
 	sourceTableID := fmt.Sprintf("tf_test_source_table_%s", acctest.RandString(t, 10))
-	sourceMVJobID := fmt.Sprintf("tf_test_create_source_mv_job_%s", acctest.RandString(t, 10))
 	sourceMVID := fmt.Sprintf("tf_test_source_mv_%s", acctest.RandString(t, 10))
 	replicaDatasetID := fmt.Sprintf("tf_test_replica_dataset_%s", acctest.RandString(t, 10))
 	replicaMVID := fmt.Sprintf("tf_test_replica_mv_%s", acctest.RandString(t, 10))
-	replicationIntervalExpr := "replication_interval_ms = 600000"
+	sourceMVJobID := fmt.Sprintf("tf_test_create_source_mv_job_%s", acctest.RandString(t, 10))
 	dropMVJobID := fmt.Sprintf("tf_test_drop_source_mv_job_%s", acctest.RandString(t, 10))
+	replicationIntervalExpr := "replication_interval_ms = 600000"
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -1510,7 +1509,7 @@ func TestAccBigQueryTable_TableReplicationInfo_WithReplicationInterval(t *testin
 		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVJobID, sourceMVID, replicaDatasetID, replicaMVID, replicationIntervalExpr, dropMVJobID),
+				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVID, replicaDatasetID, replicaMVID, sourceMVJobID, dropMVJobID, replicationIntervalExpr),
 			},
 			{
 				ResourceName:            "google_bigquery_table.replica_mv",
@@ -1529,13 +1528,13 @@ func TestAccBigQueryTable_TableReplicationInfo_Update(t *testing.T) {
 
 	sourceDatasetID := fmt.Sprintf("tf_test_source_dataset_%s", acctest.RandString(t, 10))
 	sourceTableID := fmt.Sprintf("tf_test_source_table_%s", acctest.RandString(t, 10))
-	sourceMVJobID := fmt.Sprintf("tf_test_create_source_mv_job_%s", acctest.RandString(t, 10))
 	sourceMVID := fmt.Sprintf("tf_test_source_mv_%s", acctest.RandString(t, 10))
 	replicaDatasetID := fmt.Sprintf("tf_test_replica_dataset_%s", acctest.RandString(t, 10))
 	replicaMVID := fmt.Sprintf("tf_test_replica_mv_%s", acctest.RandString(t, 10))
+	sourceMVJobID := fmt.Sprintf("tf_test_create_source_mv_job_%s", acctest.RandString(t, 10))
+	dropMVJobID := fmt.Sprintf("tf_test_drop_source_mv_job_%s", acctest.RandString(t, 10))
 	replicationIntervalExprOld := ""
 	replicationIntervalExprNew := "replication_interval_ms = 600000"
-	dropMVJobID := fmt.Sprintf("tf_test_drop_source_mv_job_%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -1546,7 +1545,7 @@ func TestAccBigQueryTable_TableReplicationInfo_Update(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVJobID, sourceMVID, replicaDatasetID, replicaMVID, replicationIntervalExprOld, dropMVJobID),
+				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVID, replicaDatasetID, replicaMVID, sourceMVJobID, dropMVJobID, replicationIntervalExprOld),
 			},
 			{
 				ResourceName:            "google_bigquery_table.replica_mv",
@@ -1555,7 +1554,7 @@ func TestAccBigQueryTable_TableReplicationInfo_Update(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVJobID, sourceMVID, replicaDatasetID, replicaMVID, replicationIntervalExprNew, dropMVJobID),
+				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVID, replicaDatasetID, replicaMVID, sourceMVJobID, dropMVJobID, replicationIntervalExprNew),
 				ExpectError: regexp.MustCompile("Table replication info is not supported in update"),
 			},
 		},
@@ -3786,7 +3785,7 @@ resource "google_bigquery_table" "test" {
 `, datasetID, tableID)
 }
 
-func testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVJobID, sourceMVID, replicaDatasetID, replicaMVID, replicationIntervalExpr, dropMVJobID string) string {
+func testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVID, replicaDatasetID, replicaMVID, sourceMVJobID, dropMVJobID, replicationIntervalExpr string) string {
 	return fmt.Sprintf(`
 resource "google_bigquery_dataset" "source" {
   provider = google-beta
@@ -3811,7 +3810,7 @@ resource "google_bigquery_table" "source_table" {
     ]
   }
   max_staleness = "0-0 0 10:0:0"
- }
+}
 
 resource "google_bigquery_job" "source_mv_job" {
   provider = google-beta

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
@@ -3872,7 +3872,6 @@ resource "google_bigquery_table" "replica_mv" {
 resource "google_bigquery_job" "drop_source_mv_job" {
   provider = google-beta
 
-  project = "bigquerytestdefault"
   job_id = "%s"
 
   location = "aws-us-east-1"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Support replica materialized view in resource_bigquery_table in the beta provider.

The unit tests require external sources. There is precedence e.g. in https://github.com/GoogleCloudPlatform/magic-modules/pull/9440 to use static resources in the `bigquerytestdefault` GCP project, so these new tests will do something similar.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigquery: support replica materialized view in resource_bigquery_table (beta)
```
