### PR TITLE
Add support for 'Engine' and 'Data Store' resources from the Vertex AI Search and Conversation service

### DIFF
--- a/mmv1/products/searchandconversation/app.yaml
+++ b/mmv1/products/searchandconversation/app.yaml
@@ -1,0 +1,131 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'App'
+description: |
+  Vertex AI Search and Conversation app can be used to create a search engine or a chat application by connecting it with a datastore
+references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+    'Create a search data store': 'https://cloud.google.com/generative-ai-app-builder/docs/create-engine-es'
+  # TODO: Update the link to the REST API reference for the resource from v1alpha to v1.
+  api: 'https://cloud.google.com/generative-ai-app-builder/docs/reference/rest/v1alpha/projects.locations.collections.engines'
+
+base_url: 'projects/{{project}}/locations/{{location}}/collections/{{collection_id}}/engines/{{engine_id}}'
+self_link: 'projects/{{project}}/locations/{{location}}/collections/{{collection_id}}/engines/{{engine_id}}'
+create_url: 'projects/{{project}}/locations/{{location}}/collections/{{collection_id}}/engines?engineId={{engine_id}}'
+delete_url: 'projects/{{project}}/locations/{{location}}/collections/{{collection_id}}/engines/{{engine_id}}'
+
+update_verb: :PATCH
+update_mask: true
+
+import_format:
+  [
+    'projects/{{project}}/locations/{{location}}/collections/{{collection_id}}/engines/{{engine_id}}',
+  ]
+
+parameters:
+  - !ruby/object:Api::Type::String
+    name: 'engine_id'
+    description: |
+      The ID to use for App.
+    required: true
+    immutable: true
+    url_param_only: true
+  - !ruby/object:Api::Type::String
+    name: 'collection_id'
+    description: |
+      The collectionId.
+    required: true
+    immutable: true
+    url_param_only: true
+  - !ruby/object:Api::Type::String
+    name: 'location'
+    description: |
+      Location.
+    required: true
+    immutable: true
+    url_param_only: true
+  # - !ruby/object:Api::Type::Boolean
+  #   name: 'create_advanced_site_search'
+  #   description: |
+  #     createAdvancedSiteSearch option, true or false
+  #   required: true
+  #   immutable: true
+  #   url_param_only: true
+properties:
+  - !ruby/object:Api::Type::String
+      name: 'industryVertical'
+      description: |
+        Industry Vertical
+      immutable: true
+  - !ruby/object:Api::Type::String
+      name: 'displayName'
+      description: |
+        displayName
+      required: true
+  - !ruby/object:Api::Type::Array
+      name: 'dataStoreIds'
+      description: |
+        Data Store ID
+      required: true
+      immutable: true
+      item_type: Api::Type::String
+  - !ruby/object:Api::Type::String
+      name: 'solutionType'
+      description: |
+        A solution type
+      immutable: true
+  - !ruby/object:Api::Type::Time
+      name: 'createTime'
+      description: |
+        Timestamp the Engine was created at.
+      output: true
+  - !ruby/object:Api::Type::Time
+      name: 'updateTime'
+      description: |
+        Timestamp the Engine was last updated.
+      output: true
+  - !ruby/object:Api::Type::NestedObject
+      name: 'searchEngineConfig'
+      description: |
+        Configurations for a Search Engine.
+      required: false
+      immutable: false
+      properties:
+        - !ruby/object:Api::Type::String
+          name: 'searchTier'
+          description: |
+            Industry Vertical
+          required: false
+          immutable: false
+        - !ruby/object:Api::Type::Array
+          name: 'searchAddOns'
+          description: |
+            The add-on that this search engine enables.
+          required: false
+          immutable: false
+          item_type: Api::Type::String
+  - !ruby/object:Api::Type::NestedObject
+      name: 'commonConfig'
+      description: |
+        Configurations for a Search Engine.
+      required: false
+      immutable: true
+      properties:
+        - !ruby/object:Api::Type::String
+          name: 'companyName'
+          description: |
+            The name of the company, business or entity that is associated with the engine
+          required: false
+          immutable: true

--- a/mmv1/products/searchandconversation/datastore.yaml
+++ b/mmv1/products/searchandconversation/datastore.yaml
@@ -1,0 +1,83 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'DataStore'
+description: |
+  Vertex AI Search and Conversation data store is a collection of websites and
+  documents used to find answers for end-user's questions.
+references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+    'Create a search data store': 'https://cloud.google.com/generative-ai-app-builder/docs/create-data-store-es'
+  # TODO: Update the link to the REST API reference for the resource from v1alpha to v1.
+  api: 'https://cloud.google.com/generative-ai-app-builder/docs/reference/rest/v1alpha/projects.locations.collections.dataStores'
+
+base_url: 'projects/{{project}}/locations/{{location}}/collections/{{collection_id}}/dataStores/{{data_store_id}}'
+self_link: 'projects/{{project}}/locations/{{location}}/collections/{{collection_id}}/dataStores/{{data_store_id}}'
+create_url: 'projects/{{project}}/locations/{{location}}/collections/{{collection_id}}/dataStores?dataStoreId={{data_store_id}}&createAdvancedSiteSearch={{create_advanced_site_search}}'
+delete_url: 'projects/{{project}}/locations/{{location}}/collections/{{collection_id}}/dataStores/{{data_store_id}}'
+
+update_verb: :PATCH
+update_mask: true
+
+import_format:
+  [
+    'projects/{{project}}/locations/{{location}}/collections/{{collection_id}}/dataStores/{{data_store_id}}',
+  ]
+
+parameters:
+  - !ruby/object:Api::Type::String
+    name: 'data_store_id'
+    description: |
+      The ID to use for DataStore.
+    required: true
+    immutable: true
+    url_param_only: true
+  - !ruby/object:Api::Type::String
+    name: 'collection_id'
+    description: |
+      The collectionId.
+    required: true
+    immutable: true
+    url_param_only: true
+  - !ruby/object:Api::Type::String
+    name: 'location'
+    description: |
+      Location.
+    required: true
+    immutable: true
+    url_param_only: true
+  - !ruby/object:Api::Type::Boolean
+    name: 'create_advanced_site_search'
+    description: |
+      createAdvancedSiteSearch option, true or false
+    required: true
+    immutable: true
+    url_param_only: true
+properties:
+  - !ruby/object:Api::Type::String
+      name: 'industryVertical'
+      description: |
+        Industry Vertical
+      immutable: true
+  - !ruby/object:Api::Type::String
+      name: 'displayName'
+      description: |
+        displayName
+      required: true
+  - !ruby/object:Api::Type::Array
+      name: 'solutionTypes'
+      description: |
+        A list of solution types
+      immutable: true
+      item_type: Api::Type::String

--- a/mmv1/products/searchandconversation/product.yaml
+++ b/mmv1/products/searchandconversation/product.yaml
@@ -1,0 +1,22 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Product
+name: SearchAndConversation
+display_name: SearchAndConversation
+versions:
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: https://discoveryengine.googleapis.com/v1alpha/
+scopes:
+  - https://www.googleapis.com/auth/cloud-platform


### PR DESCRIPTION
This is a PR for Search App TF Provider (DiscoveryEngine)


Closes https://github.com/hashicorp/terraform-provider-google/issues/16787

Adds resource coverage for:
- [Data Store resource](https://cloud.google.com/generative-ai-app-builder/docs/reference/rest/v1alpha/projects.locations.collections.dataStores)
- [Engine resource](https://cloud.google.com/generative-ai-app-builder/docs/reference/rest/v1alpha/projects.locations.collections.engines)

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_search_and_conversation_data_store`
```

```release-note:new-resource
`google_search_and_conversation_app` - TODO: is it engine?
```
