### PR TITLE
delete maxTtl when cache_mode is FORCE_CACHE_ALL - google_compute_backend_bucket

### DIFF
--- a/mmv1/templates/terraform/encoders/compute_backend_bucket.go.erb
+++ b/mmv1/templates/terraform/encoders/compute_backend_bucket.go.erb
@@ -35,6 +35,10 @@ case "USE_ORIGIN_HEADERS":
 	if _, ok := futureCdnPolicy["maxTtl"]; ok {
 		delete(futureCdnPolicy, "maxTtl")
 	}
+case "FORCE_CACHE_ALL":
+	if _, ok := futureCdnPolicy["maxTtl"]; ok {
+		delete(futureCdnPolicy, "maxTtl")
+	}
 }
 
 return obj, nil

--- a/mmv1/third_party/terraform/services/compute/resource_compute_backend_bucket_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_backend_bucket_test.go
@@ -174,6 +174,37 @@ func TestAccComputeBackendBucket_withCompressionMode(t *testing.T) {
 	})
 }
 
+func TestAccComputeBackendBucket_withCdnCacheMode_update(t *testing.T) {
+	t.Parallel()
+
+	backendName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	storageName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeBackendBucketDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeBackendBucket_caheModeCacheAllStatic_basic(backendName, storageName, 7200, 3600),
+			},
+			{
+				ResourceName:      "google_compute_backend_bucket.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeBackendBucket_caheModeForceCacheAll_update(backendName, storageName, 3600),
+			},
+			{
+				ResourceName:      "google_compute_backend_bucket.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccComputeBackendBucket_basic(backendName, storageName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_backend_bucket" "foobar" {
@@ -343,4 +374,43 @@ resource "google_storage_bucket" "bucket" {
   location = "EU"
 }
 `, backendName, age, ttl, code, ttl, storageName)
+}
+
+func testAccComputeBackendBucket_caheModeCacheAllStatic_basic(backendName, storageName string, max_ttl, default_ttl int) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_bucket" "foobar" {
+  name        = "%s"
+  bucket_name = google_storage_bucket.bucket.name
+  enable_cdn  = true
+  cdn_policy {
+	cache_mode                   = "CACHE_ALL_STATIC"
+	max_ttl                      = %d
+	default_ttl                  = %d
+  }
+}
+
+resource "google_storage_bucket" "bucket" {
+  name     = "%s"
+  location = "EU"
+}
+`, backendName, max_ttl, default_ttl, storageName)
+}
+
+func testAccComputeBackendBucket_caheModeForceCacheAll_update(backendName, storageName string, default_ttl int) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_bucket" "foobar" {
+  name        = "%s"
+  bucket_name = google_storage_bucket.bucket.name
+  enable_cdn  = true
+  cdn_policy {
+	cache_mode                   = "FORCE_CACHE_ALL"
+	default_ttl                  = %d
+  }
+}
+
+resource "google_storage_bucket" "bucket" {
+  name     = "%s"
+  location = "EU"
+}
+`, backendName, default_ttl, storageName)
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/16935

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

delete maxTtl from FORCE_CACHE_ALL as maxTtl is only supported with CACHE_ALL_STATIC
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed the bug that `max_ttl` is sent in API calls even it is removed from configuration when changing cache_mode to FORCE_CACHE_ALL in `google_compute_backend_bucket`
```

