### PR TITLE
Add support for "VULNERABILITY_ENTERPRISE" for GKE Cluster Security config Workload Vulnerability

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -4284,10 +4284,19 @@ func TestAccContainerCluster_withSecurityPostureConfig(t *testing.T) {
 			 	Config: testAccContainerCluster_SetWorkloadVulnerabilityToStandard(clusterName, networkName, subnetworkName),
 			},
 			{
+				ResourceName:      "google_container_cluster.with_security_posture_config",
+				ImportState:       true,
+				ImportStateVerify: true,
+			    ImportStateVerifyIgnore: []string{"deletion_protection"},
+		    },
+			{
+				Config: testAccContainerCluster_SetWorkloadVulnerabilityToEnterprise(clusterName, networkName, subnetworkName),
+		    },
+			{
 			 	ResourceName:      "google_container_cluster.with_security_posture_config",
 			 	ImportState:       true,
 			 	ImportStateVerify: true,
-				 ImportStateVerifyIgnore: []string{"deletion_protection"},
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
 				Config: testAccContainerCluster_DisableALL(clusterName, networkName, subnetworkName),
@@ -4450,6 +4459,22 @@ resource "google_container_cluster" "with_security_posture_config" {
   initial_node_count = 1
   security_posture_config {
 	vulnerability_mode = "VULNERABILITY_BASIC"
+  }
+  deletion_protection = false
+  network    = "%s"
+  subnetwork    = "%s"
+}
+`, resource_name, networkName, subnetworkName)
+}
+
+func testAccContainerCluster_SetWorkloadVulnerabilityToEnterprise(resource_name, networkName, subnetworkName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_security_posture_config" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  security_posture_config {
+	vulnerability_mode = "VULNERABILITY_ENTERPRISE"
   }
   deletion_protection = false
   network    = "%s"

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -4288,10 +4288,10 @@ func TestAccContainerCluster_withSecurityPostureConfig(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			    ImportStateVerifyIgnore: []string{"deletion_protection"},
-		    },
+			},
 			{
 				Config: testAccContainerCluster_SetWorkloadVulnerabilityToEnterprise(clusterName, networkName, subnetworkName),
-		    },
+			},
 			{
 			 	ResourceName:      "google_container_cluster.with_security_posture_config",
 			 	ImportState:       true,

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -4287,7 +4287,7 @@ func TestAccContainerCluster_withSecurityPostureConfig(t *testing.T) {
 				ResourceName:      "google_container_cluster.with_security_posture_config",
 				ImportState:       true,
 				ImportStateVerify: true,
-			    ImportStateVerifyIgnore: []string{"deletion_protection"},
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
 				Config: testAccContainerCluster_SetWorkloadVulnerabilityToEnterprise(clusterName, networkName, subnetworkName),


### PR DESCRIPTION
**Add support for "VULNERABILITY_ENTERPRISE" for GKE Cluster Security config Workload Vulnerability**

Support already exists as the field was added by an external committer. This PR just adds an acceptance test for the same. 

Add acceptance test for GKE Cluster->Security_config->Workload Vulnerability->Advanced Vulnerability Insights feature. Feature enum name is VULNERABILITY_ENTERPRISE.

Internal issue: b/302069819

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

```release-note:none
```
