### PR TITLE
Remove wait for instances stable on IGM and RIGM deletion.

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
@@ -4,7 +4,6 @@ package compute
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -984,21 +983,6 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 
 func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
-
-	if d.Get("wait_for_instances").(bool) {
-		err := computeIGMWaitForInstanceStatus(d, meta)
-		if err != nil {
-			notFound, reErr := regexp.MatchString(`not found`, err.Error())
-			if reErr != nil {
-				return reErr
-			}
-			if notFound {
-				// manager was not found, we can exit gracefully
-				return nil
-			}
-			return err
-		}
-	}
 
 	userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
@@ -4,7 +4,6 @@ package compute
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"strings"
 	"time"
 
@@ -933,21 +932,6 @@ func resourceComputeRegionInstanceGroupManagerUpdate(d *schema.ResourceData, met
 
 func resourceComputeRegionInstanceGroupManagerDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
-
-	if d.Get("wait_for_instances").(bool) {
-		err := computeRIGMWaitForInstanceStatus(d, meta)
-		if err != nil {
-			notFound, reErr := regexp.MatchString(`not found`, err.Error())
-			if reErr != nil {
-				return reErr
-			}
-			if notFound {
-				// manager was not found, we can exit gracefully
-				return nil
-			}
-			return err
-		}
-	}
 
 	userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {


### PR DESCRIPTION
These checks were introduced in [a commit](https://github.com/hashicorp/terraform-provider-google/commit/4725a550c3e1d58c5c8976bdb2d7b4c6412488f3) that was meant for create/update.

Fixes b/291958547

**Release Note Template for Downstream PRs (will be copied)**

```release-note:

```
