### PR TITLE
Dataflow - do not crash when given enableStreamingEngine as a parameter

### DIFF
--- a/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job.go.erb
+++ b/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job.go.erb
@@ -364,10 +364,30 @@ func resourceDataflowFlexJobSetupEnv(d *schema.ResourceData, config *transport_t
 	var enableStreamingEngine bool
 	if p, ok := d.GetOk("parameters.enableStreamingEngine"); ok {
 		delete(updatedParameters, "enableStreamingEngine")
-		enableStreamingEngine = p.(bool)
+
+		enabled, ok := p.(bool)
+		if ok {
+			enableStreamingEngine = enabled
+		} else {
+			var err error
+			enableStreamingEngine, err = strconv.ParseBool(p.(string))
+			if err != nil {
+				return dataflow.FlexTemplateRuntimeEnvironment{}, updatedParameters, fmt.Errorf("Parameter enableStreamingEngine must be a valid boolean value, provided %v", p)
+			}
+		}
+
 	} else {
-		if v, ok := d.GetOk("enable_streaming_engine"); ok {
-			enableStreamingEngine = v.(bool)
+			if v, ok := d.GetOk("enable_streaming_engine"); ok {
+			enabled, ok := v.(bool)
+			if ok {
+				enableStreamingEngine = enabled
+			} else {
+				var err error
+				enableStreamingEngine, err = strconv.ParseBool(v.(string))
+				if err != nil {
+					return dataflow.FlexTemplateRuntimeEnvironment{}, updatedParameters, fmt.Errorf("Parameter enable_streaming_engine must be a valid boolean value, provided %v", v)
+				}
+			}
 		}
 	}
 
@@ -764,11 +784,18 @@ func resourceDataflowFlexJobTypeCustomizeDiff(_ context.Context, d *schema.Resou
 
 	if p, ok := d.GetOk("parameters.enableStreamingEngine"); ok {
 		if d.HasChange("enable_streaming_engine") {
-			e := d.Get("enable_streaming_engine")
-			return fmt.Errorf("Error setting enable_streaming_engine, value is supplied twice: enable_streaming_engine=%t, parameters.enableStreamingEngine=%t", e.(bool), p.(bool))
+            e := d.Get("enable_streaming_engine")
+            return fmt.Errorf("Error setting enable_streaming_engine, value is supplied twice: enable_streaming_engine=%v, parameters.enableStreamingEngine=%v", e, p)
 		} else {
-			p := d.Get("parameters.enableStreamingEngine")
-			d.SetNew("enable_streaming_engine", p.(string))
+			enableStreamingEngine, ok := p.(bool)
+			if !ok {
+				var err error
+				enableStreamingEngine, err = strconv.ParseBool(p.(string))
+				if err != nil {
+					return fmt.Errorf("Parameter enableStreamingEngine must be a valid boolean value, provided %v", p)
+				}
+			}
+			d.SetNew("enable_streaming_engine", enableStreamingEngine)
 		}
 	}
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Internal issue b/308551181

There were conflicts related to the now legacy "enableStreamingEngine" parameter, and the top-level `enable_streaming_engine`. 

The provider was crashing when trying to use the inner parameter.

```
Stack trace from the terraform-provider-google-beta_v5.8.0_x5 plugin:

panic: interface conversion: interface {} is string, not bool
```


This change should make things safer. I've tested passing as either string or boolean in both fields and they work fine.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
Dataflow Flex Templates - fix crash when using enableStreamingEngine inside parameters 
```
