### PR TITLE
Pin tensorflow_version on TPU Node Full Test so that the test passes

### DIFF
--- a/mmv1/templates/terraform/examples/tpu_node_full_test.tf.erb
+++ b/mmv1/templates/terraform/examples/tpu_node_full_test.tf.erb
@@ -1,6 +1,3 @@
-data "google_tpu_tensorflow_versions" "available" {
-}
-
 <%#-
   WARNING: cidr_block must not overlap with other existing TPU blocks
   Make sure if you change this value that it does not overlap with the
@@ -13,7 +10,13 @@ resource "google_tpu_node" "<%= ctx[:primary_resource_id] %>" {
 
   accelerator_type = "v3-8"
 
-  tensorflow_version = data.google_tpu_tensorflow_versions.available.versions[0]
+<%#-
+  We previously used the first available version from the
+  google_tpu_tensorflow_versions data source. However, this started to return a
+  random set of versions which caused our tests to occasionally fail, so we pin
+  tensorflow_version to a specific version so that our tests pass reliably.
+-%>
+  tensorflow_version = "2.10.0"
 
   description = "Terraform Google Provider test TPU"
   use_service_networking = true


### PR DESCRIPTION
Pin `tensorflow_version` on TPU Node Full Test so that the test passes. Fixes https://github.com/hashicorp/terraform-provider-google/issues/16703

Because `mmv1/products/tpu/Node.yaml` already uses `tpu_node_full.tf.erb` for documentation and `tpu_node_full_test.tf.erb` for tests, this change shouldn't affect public documentation since we are just updating `tpu_node_full_test.tf.erb`.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
