### PR TITLE
Promote enable_confidential_compute for disks to v1.

### DIFF
--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -433,7 +433,6 @@ properties:
     description: |
       Whether this disk is using confidential compute mode.
       Note: Only supported on hyperdisk skus, disk_encryption_key is required when setting to true
-    min_version: beta
     required: false
     default_from_api: true
   - !ruby/object:Api::Type::Boolean

--- a/mmv1/products/compute/Instance.yaml
+++ b/mmv1/products/compute/Instance.yaml
@@ -203,6 +203,12 @@ properties:
                 the disk, hyperdisk allows for an update of throughput every
                 4 hours. To update your hyperdisk more frequently,
                 you'll need to manually delete and recreate it.
+            - !ruby/object:Api::Type::Boolean
+              name: 'enableConfidentialCompute'
+              description: |
+                Whether this disk is using confidential compute mode.
+                Note: Only supported on hyperdisk skus, disk_encryption_key
+                is required when setting to true.
             - !ruby/object:Api::Type::NestedObject
               name: 'sourceImageEncryptionKey'
               description: |

--- a/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.erb
@@ -560,7 +560,6 @@ func TestAccComputeDisk_encryptionKMS(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccComputeDisk_pdHyperDiskEnableConfidentialCompute(t *testing.T) {
 	t.Skip()
 	t.Parallel()
@@ -596,7 +595,6 @@ func TestAccComputeDisk_pdHyperDiskEnableConfidentialCompute(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func TestAccComputeDisk_deleteDetach(t *testing.T) {
 	t.Parallel()

--- a/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.erb
@@ -561,12 +561,15 @@ func TestAccComputeDisk_encryptionKMS(t *testing.T) {
 }
 
 func TestAccComputeDisk_pdHyperDiskEnableConfidentialCompute(t *testing.T) {
-	t.Skip()
 	t.Parallel()
 
 	context := map[string]interface{}{
 		"random_suffix":        acctest.RandString(t, 10),
-		"kms":                  acctest.BootstrapKMSKey(t).CryptoKey.Name, // global KMS key
+		"kms":                  acctest.BootstrapKMSKeyWithPurposeInLocationAndName(
+			t,
+			"ENCRYPT_DECRYPT",
+			"us-central1",
+			"tf-bootstrap-hyperdisk-key1").CryptoKey.Name, // regional KMS key
 		"disk_size":            64,
 		"confidential_compute": true,
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
@@ -48,9 +48,7 @@ var (
 		"boot_disk.0.initialize_params.0.resource_manager_tags",
 		"boot_disk.0.initialize_params.0.provisioned_iops",
 		"boot_disk.0.initialize_params.0.provisioned_throughput",
-<% unless version == 'ga' -%>
 		"boot_disk.0.initialize_params.0.enable_confidential_compute",
-<% end -%>
 	}
 
 	schedulingKeys = []string{
@@ -267,7 +265,6 @@ func ResourceComputeInstance() *schema.Resource {
 										Description:  `Indicates how much throughput to provision for the disk. This sets the number of throughput mb per second that the disk can handle. Values must be between 1 and 7,124.`,
 									},
 
-<% unless version == 'ga' -%>
 									"enable_confidential_compute": {
 										Type:         schema.TypeBool,
 										Optional:     true,
@@ -275,7 +272,6 @@ func ResourceComputeInstance() *schema.Resource {
 										ForceNew:     true,
 										Description:  `A flag to enable confidential compute mode on boot disk`,
 									},
-<% end -%>
 								},
 							},
 						},
@@ -2832,11 +2828,9 @@ func expandBootDisk(d *schema.ResourceData, config *transport_tpg.Config, projec
 			disk.InitializeParams.ProvisionedThroughput = int64(v.(int))
 		}
 
-		<% unless version == 'ga' -%>
 		if v, ok := d.GetOk("boot_disk.0.initialize_params.0.enable_confidential_compute"); ok {
 			disk.InitializeParams.EnableConfidentialCompute = v.(bool)
 		}
-		<% end -%>
 
 		if v, ok := d.GetOk("boot_disk.0.initialize_params.0.type"); ok {
 			diskTypeName := v.(string)
@@ -2905,9 +2899,7 @@ func flattenBootDisk(d *schema.ResourceData, disk *compute.AttachedDisk, config 
 			"resource_manager_tags": d.Get("boot_disk.0.initialize_params.0.resource_manager_tags"),
 			"provisioned_iops": diskDetails.ProvisionedIops,
 			"provisioned_throughput": diskDetails.ProvisionedThroughput,
-<% unless version == 'ga' -%>
 			"enable_confidential_compute": diskDetails.EnableConfidentialCompute,
-<% end -%>
 		}}
 	}
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -1822,8 +1822,6 @@ func TestAccComputeInstanceConfidentialInstanceConfigMain(t *testing.T) {
 	})
 }
 
-
-<% unless version == 'ga' -%>
 func TestAccComputeInstance_confidentialHyperDiskBootDisk(t *testing.T) {
 	t.Parallel()
 	kms := acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-bootstrap-hyperdisk-key1")
@@ -1862,7 +1860,6 @@ func TestAccComputeInstance_confidentialHyperDiskBootDisk(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func TestAccComputeInstance_hyperdiskBootDisk_provisioned_iops_throughput(t *testing.T) {
 	t.Parallel()
@@ -7060,7 +7057,6 @@ resource "google_compute_instance" "foobar" {
 `, instance, enableConfidentialCompute)
 }
 
-<% unless version == 'ga' -%>
 func testAccComputeInstanceConfidentialHyperDiskBootDisk(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
@@ -7078,7 +7074,7 @@ resource "google_kms_crypto_key_iam_member" "crypto_key" {
 
 resource "google_compute_instance" "foobar" {
   name         = "%{instance_name}"
-  machine_type = "n2-standard-2"
+  machine_type = "h3-standard-88"
   zone         = "%{zone}"
 
   boot_disk {
@@ -7100,7 +7096,6 @@ resource "google_compute_instance" "foobar" {
 }
 `, context)
 }
-<% end -%>
 
 func testAccComputeInstanceHyperDiskBootDiskProvisionedIopsThroughput(context map[string]interface{}) string {
 	return acctest.Nprintf(`

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -265,6 +265,9 @@ is desired, you will need to modify your state file manually using
     recreate the disk, hyperdisk allows for an update of throughput every 4 hours.
     To update your hyperdisk more frequently, you'll need to manually delete and recreate it.
 
+* `enable_confidential_compute` - (Optional) Whether this disk is using confidential compute mode.
+    Note: Only supported on hyperdisk skus, disk_encryption_key is required when setting to true.
+
 <a name="nested_scratch_disk"></a>The `scratch_disk` block supports:
 
 * `interface` - (Required) The disk interface to use for attaching this disk; either SCSI or NVME.


### PR DESCRIPTION
Promote enable_confidential_compute for disks and create-on-create attached disks to v1.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: promoted `google_compute_disk.enable_confidential_compute` to GA
```

```release-note:enhancement
compute: added `enable_confidential_compute` field to `google_compute_instance.boot_disk.initialize_params`
```
