### PR TITLE
Filestore instance - make sourceBackup field configureable.

### DIFF
--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -126,11 +126,11 @@ properties:
           required: true
         - !ruby/object:Api::Type::String
           name: 'sourceBackup'
-          output: true
           description: |
             The resource name of the backup, in the format
             projects/{projectId}/locations/{locationId}/backups/{backupId},
             that this file share has been restored from.
+          immutable: true
         - !ruby/object:Api::Type::Array
           name: 'nfsExportOptions'
           description: |

--- a/mmv1/third_party/terraform/services/filestore/resource_filestore_restore_test.go
+++ b/mmv1/third_party/terraform/services/filestore/resource_filestore_restore_test.go
@@ -1,0 +1,85 @@
+package filestore_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccFilestoreInstance_restore(t *testing.T) {
+	t.Parallel()
+
+	srcInstancetName := fmt.Sprintf("tf-fs-inst-source-%d", acctest.RandInt(t))
+	restoreInstanceName := fmt.Sprintf("tf-fs-inst-restored-%d", acctest.RandInt(t))
+	backupName := fmt.Sprintf("tf-fs-bkup-%d", acctest.RandInt(t))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckFilestoreInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFilestoreInstanceRestore_restore(srcInstancetName, restoreInstanceName, backupName),
+			},
+			{
+				ResourceName:            "google_filestore_instance.instance_source",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location"},
+			},
+		},
+	})
+}
+
+func testAccFilestoreInstanceRestore_restore(srcInstancetName, restoreInstanceName, backupName string) string {
+	return fmt.Sprintf(`
+	resource "google_filestore_instance" "instance_source" {
+		name        = "%s"
+		location    = "us-central1-b"
+		tier        = "BASIC_HDD"
+		description = "An instance created during testing."
+	  
+		file_shares {
+		  capacity_gb = 1024
+		  name        = "volume1"
+		}
+	  
+		networks {
+		  network      = "default"
+		  modes        = ["MODE_IPV4"]
+		  connect_mode = "DIRECT_PEERING"
+		}
+	}
+
+	resource "google_filestore_instance" "instance_restored" {
+		name        = "%s"
+		location    = "us-central1-b"
+		tier        = "BASIC_HDD"
+		description = "An instance created during testing."
+	  
+		file_shares {
+		  capacity_gb = 1024
+		  name        = "volume1"
+		  source_backup = google_filestore_backup.backup.id
+		}
+	  
+		networks {
+		  network      = "default"
+		  modes        = ["MODE_IPV4"]
+		  connect_mode = "DIRECT_PEERING"
+		}
+	}
+	  
+	resource "google_filestore_backup" "backup" {
+		name        = "%s"
+		location    = "us-central1"
+		source_instance   = google_filestore_instance.instance_source.id
+		source_file_share = "volume1"
+	  
+		description = "This is a filestore backup for the test instance"
+	}
+	  
+	`, srcInstancetName, restoreInstanceName, backupName)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Make sourceBackup field configurable to allow instance create from backup.

Fixes hashicorp/terraform-provider-google/issues/16461


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
filestore: make source_backup field configurable
```
