### PR TITLE
Accept the AlloyDB cluster database version as an input

### DIFF
--- a/mmv1/products/alloydb/Cluster.yaml
+++ b/mmv1/products/alloydb/Cluster.yaml
@@ -256,9 +256,9 @@ properties:
       An object containing a list of "key": value pairs. Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
   - !ruby/object:Api::Type::String
     name: 'databaseVersion'
-    output: true
+    default_from_api: true
     description: |
-      The database engine major version. This is an output-only field and it's populated at the Cluster creation time. This field cannot be changed after cluster creation.
+      The database engine major version. This is an optional field and it's populated at the Cluster creation time. This field cannot be changed after cluster creation.
   - !ruby/object:Api::Type::NestedObject
     name: 'initialUser'
     description: |

--- a/mmv1/templates/terraform/examples/alloydb_cluster_full.tf.erb
+++ b/mmv1/templates/terraform/examples/alloydb_cluster_full.tf.erb
@@ -2,6 +2,7 @@ resource "google_alloydb_cluster" "<%= ctx[:primary_resource_id] %>" {
   cluster_id   = "<%= ctx[:vars]['alloydb_cluster_name'] %>"
   location     = "us-central1"
   network      = google_compute_network.default.id
+  database_version = "POSTGRES_15"
 
   initial_user {
     user     = "<%= ctx[:vars]['alloydb_cluster_name'] %>"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
AlloyDB has started accepting DB version as an input: https://cloud.google.com/sdk/gcloud/reference/alloydb/clusters/create#--database-version

This MR adds functionality to accept the Database version as an input from the user through Terraform.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement

AlloyDB: removed output label to `databaseVersion` field

```
