### PR TITLE
throw an error when configured universe differs from assumed default

### DIFF
--- a/mmv1/third_party/terraform/provider/provider.go.erb
+++ b/mmv1/third_party/terraform/provider/provider.go.erb
@@ -286,11 +286,11 @@ func ProviderConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 		}
 	}
 	
-	// Check if the user provided a value from the universe_domain field
-	if v, ok := d.GetOk("universe_domain"); ok {
+	// Check if the user provided a value from the universe_domain field other than the default
+	if v, ok := d.GetOk("universe_domain"); ok && v.(string) != "googleapis.com" {
 		if config.UniverseDomain == "" {
-			config.UniverseDomain = v.(string)
-		} else if  v.(string) != config.UniverseDomain {
+			return nil, diag.FromErr(fmt.Errorf("Universe domain '%s' supplied directly to Terraform with no matching universe domain in credentials. Credentials with no 'universe_domain' set are assumed to be in the default universe.", v))
+		} else if v.(string) != config.UniverseDomain {
 			if _, err := os.Stat(config.Credentials); err == nil {
 				return nil, diag.FromErr(fmt.Errorf("'%s' does not match the universe domain '%s' already set in the credential file '%s'. The 'universe_domain' provider configuration can not be used to override the universe domain that is defined in the active credential.  Set the 'universe_domain' provider configuration when universe domain information is not already available in the credential, e.g. when authenticating with a JWT token.", v, config.UniverseDomain, config.Credentials))
 			} else {

--- a/mmv1/third_party/terraform/provider/universe/universe_domain_compute_test.go
+++ b/mmv1/third_party/terraform/provider/universe/universe_domain_compute_test.go
@@ -2,6 +2,7 @@ package universe_test
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -42,6 +43,21 @@ func TestAccDefaultUniverseDomainDisk(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccUniverseDomain_basic_disk(universeDomain),
+			},
+		},
+	})
+}
+
+func TestAccDefaultUniverseDomain_doesNotMatchExplicit(t *testing.T) {
+	universeDomainFake := "fakedomain.test"
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config:      testAccUniverseDomain_basic_disk(universeDomainFake),
+				ExpectError: regexp.MustCompile("supplied directly to Terraform with no matching universe domain in credentials"),
 			},
 		},
 	})


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
provider: fixed `universe_domain` behavior to correctly throw an error when explicitly configured `domain_universe` values did not match credentials assumed to be in the default universe
```
