### PR TITLE
Ignore output field `reconciling` when importing `google_alloydb_cluster` in acceptance test

### DIFF
--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_secondary_cluster_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_secondary_cluster_test.go
@@ -1148,7 +1148,7 @@ func TestAccAlloydbCluster_secondaryClusterPromoteWithNetworkConfigAndAllocatedI
 				ResourceName:            "google_alloydb_cluster.secondary",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"initial_user", "restore_backup_source", "restore_continuous_backup_source", "cluster_id", "location", "deletion_policy", "labels", "annotations", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"initial_user", "restore_backup_source", "restore_continuous_backup_source", "cluster_id", "location", "deletion_policy", "labels", "annotations", "terraform_labels", "reconciling"},
 			},
 			{
 				Config: testAccAlloydbCluster_secondaryClusterPromoteWithNetworkConfigAndAllocatedIPRange(context),
@@ -1157,7 +1157,7 @@ func TestAccAlloydbCluster_secondaryClusterPromoteWithNetworkConfigAndAllocatedI
 				ResourceName:            "google_alloydb_cluster.secondary",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"initial_user", "restore_backup_source", "restore_continuous_backup_source", "cluster_id", "location", "deletion_policy", "labels", "annotations", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"initial_user", "restore_backup_source", "restore_continuous_backup_source", "cluster_id", "location", "deletion_policy", "labels", "annotations", "terraform_labels", "reconciling"},
 			},
 		},
 	})


### PR DESCRIPTION
This PR updates the ignored fields when testing import of an `google_alloydb_cluster` resource in the `TestAccAlloydbCluster_secondaryClusterPromoteWithNetworkConfigAndAllocatedIPRange` acceptance test

Currently there are test failures due to the resource's reconciling finishing between the initial test step and the import test step:

```
------- Stdout: -------
=== RUN   TestAccAlloydbCluster_secondaryClusterPromoteWithNetworkConfigAndAllocatedIPRange
=== PAUSE TestAccAlloydbCluster_secondaryClusterPromoteWithNetworkConfigAndAllocatedIPRange
=== CONT  TestAccAlloydbCluster_secondaryClusterPromoteWithNetworkConfigAndAllocatedIPRange
    vcr_utils.go:152: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
        (map[string]string) (len=1) {
         (string) (len=11) "reconciling": (string) (len=4) "true"
        }
        (map[string]string) (len=1) {
         (string) (len=11) "reconciling": (string) (len=5) "false"
        }
--- FAIL: TestAccAlloydbCluster_secondaryClusterPromoteWithNetworkConfigAndAllocatedIPRange (1562.58s)
FAIL
```



<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
