### PR TITLE
Fix Spanner update when adding/removing autoscaling config

### DIFF
--- a/mmv1/templates/terraform/encoders/spanner_instance_update.go.erb
+++ b/mmv1/templates/terraform/encoders/spanner_instance_update.go.erb
@@ -18,23 +18,32 @@ if d.HasChange("labels") {
 if d.HasChange("processing_units") {
 	updateMask = append(updateMask, "processingUnits")
 }
-if d.HasChange("autoscaling_config.0.autoscaling_limits.0.max_processing_units") {
-	updateMask = append(updateMask, "autoscalingConfig.autoscalingLimits.maxProcessingUnits")
-}
-if d.HasChange("autoscaling_config.0.autoscaling_limits.0.min_processing_units") {
-	updateMask = append(updateMask, "autoscalingConfig.autoscalingLimits.minProcessingUnits")
-}
-if d.HasChange("autoscaling_config.0.autoscaling_limits.0.max_nodes") {
-	updateMask = append(updateMask, "autoscalingConfig.autoscalingLimits.maxNodes")
-}
-if d.HasChange("autoscaling_config.0.autoscaling_limits.0.min_nodes") {
-	updateMask = append(updateMask, "autoscalingConfig.autoscalingLimits.minNodes")
-}
-if d.HasChange("autoscaling_config.0.autoscaling_targets.0.high_priority_cpu_utilization_percent") {
-	updateMask = append(updateMask, "autoscalingConfig.autoscalingTargets.highPriorityCpuUtilizationPercent")
-}
-if d.HasChange("autoscaling_config.0.autoscaling_targets.0.storage_utilization_percent") {
-	updateMask = append(updateMask, "autoscalingConfig.autoscalingTargets.storageUtilizationPercent")
+if d.HasChange("autoscaling_config") {
+  old, new := d.GetChange("autoscaling_config")
+	oldSlice := old.([]interface{})
+	newSlice := new.([]interface{})
+	if len(oldSlice) == 0 || len(newSlice) == 0 {
+		updateMask = append(updateMask, "autoscalingConfig")
+	} else {
+		if d.HasChange("autoscaling_config.0.autoscaling_limits.0.max_processing_units") {
+			updateMask = append(updateMask, "autoscalingConfig.autoscalingLimits.maxProcessingUnits")
+		}
+		if d.HasChange("autoscaling_config.0.autoscaling_limits.0.min_processing_units") {
+			updateMask = append(updateMask, "autoscalingConfig.autoscalingLimits.minProcessingUnits")
+		}
+		if d.HasChange("autoscaling_config.0.autoscaling_limits.0.max_nodes") {
+			updateMask = append(updateMask, "autoscalingConfig.autoscalingLimits.maxNodes")
+		}
+		if d.HasChange("autoscaling_config.0.autoscaling_limits.0.min_nodes") {
+			updateMask = append(updateMask, "autoscalingConfig.autoscalingLimits.minNodes")
+		}
+		if d.HasChange("autoscaling_config.0.autoscaling_targets.0.high_priority_cpu_utilization_percent") {
+			updateMask = append(updateMask, "autoscalingConfig.autoscalingTargets.highPriorityCpuUtilizationPercent")
+		}
+		if d.HasChange("autoscaling_config.0.autoscaling_targets.0.storage_utilization_percent") {
+			updateMask = append(updateMask, "autoscalingConfig.autoscalingTargets.storageUtilizationPercent")
+		}
+	}
 }
 newObj["fieldMask"] = strings.Join(updateMask, ",")
 return newObj, nil

--- a/mmv1/templates/terraform/encoders/spanner_instance_update.go.erb
+++ b/mmv1/templates/terraform/encoders/spanner_instance_update.go.erb
@@ -19,7 +19,7 @@ if d.HasChange("processing_units") {
 	updateMask = append(updateMask, "processingUnits")
 }
 if d.HasChange("autoscaling_config") {
-  old, new := d.GetChange("autoscaling_config")
+	old, new := d.GetChange("autoscaling_config")
 	oldSlice := old.([]interface{})
 	newSlice := new.([]interface{})
 	if len(oldSlice) == 0 || len(newSlice) == 0 {

--- a/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
+++ b/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
@@ -169,7 +169,7 @@ func TestAccSpannerInstance_basicWithAutoscalingUsingProcessingUnitConfig(t *tes
 func TestAccSpannerInstance_basicWithAutoscalingUsingProcessingUnitConfigUpdate(t *testing.T) {
 	t.Parallel()
 
-	displayName := fmt.Sprintf("tf-test-spanner-%s", acctest.RandString(t, 10))
+	displayName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
@@ -254,7 +254,7 @@ func TestAccSpannerInstance_basicWithAutoscalingUsingNodeConfig(t *testing.T) {
 func TestAccSpannerInstance_basicWithAutoscalingUsingNodeConfigUpdate(t *testing.T) {
 	t.Parallel()
 
-	displayName := fmt.Sprintf("tf-test-spanner-%s", acctest.RandString(t, 10))
+	displayName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),

--- a/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
+++ b/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
@@ -264,6 +264,80 @@ func TestAccSpannerInstance_basicWithAutoscalingUsingNodeConfigUpdate(t *testing
 	})
 }
 
+func TestAccSpannerInstance_basicAddAutoscalingUsingNodeConfigUpdate(t *testing.T) {
+	t.Parallel()
+
+	name := fmt.Sprintf("spanner-test-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSpannerInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSpannerInstance_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
+				),
+			},
+			{
+				ResourceName:            "google_spanner_instance.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccSpannerInstance_basicWithAutoscalerConfigUsingNodesAsConfigs(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
+				),
+			},
+			{
+				ResourceName:            "google_spanner_instance.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func TestAccSpannerInstance_basicAddAutoscalingUsingProcessingUnitConfigUpdate(t *testing.T) {
+	t.Parallel()
+
+	name := fmt.Sprintf("spanner-test-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSpannerInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSpannerInstance_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
+				),
+			},
+			{
+				ResourceName:            "google_spanner_instance.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccSpannerInstance_basicWithAutoscalerConfigUsingProcessingUnitsAsConfigs(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
+				),
+			},
+			{
+				ResourceName:            "google_spanner_instance.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
 func testAccSpannerInstance_basic(name string) string {
 	return fmt.Sprintf(`
 resource "google_spanner_instance" "basic" {

--- a/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
+++ b/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
@@ -169,12 +169,24 @@ func TestAccSpannerInstance_basicWithAutoscalingUsingProcessingUnitConfig(t *tes
 func TestAccSpannerInstance_basicWithAutoscalingUsingProcessingUnitConfigUpdate(t *testing.T) {
 	t.Parallel()
 
-	displayName := fmt.Sprintf("spanner-test-%s-dname", acctest.RandString(t, 10))
+	displayName := fmt.Sprintf("tf-test-spanner-%s", acctest.RandString(t, 10))
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckSpannerInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
+			{
+				Config: testAccSpannerInstance_basic(displayName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
+				),
+			},
+			{
+				ResourceName:            "google_spanner_instance.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
 			{
 				Config: testAccSpannerInstance_basicWithAutoscalerConfigUsingProcessingUnitsAsConfigsUpdate(displayName, 1000, 2000, 65, 95),
 				Check: resource.ComposeTestCheckFunc(
@@ -189,6 +201,18 @@ func TestAccSpannerInstance_basicWithAutoscalingUsingProcessingUnitConfigUpdate(
 			},
 			{
 				Config: testAccSpannerInstance_basicWithAutoscalerConfigUsingProcessingUnitsAsConfigsUpdate(displayName, 2000, 3000, 75, 90),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
+				),
+			},
+			{
+				ResourceName:            "google_spanner_instance.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccSpannerInstance_basic(displayName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
 				),
@@ -230,12 +254,24 @@ func TestAccSpannerInstance_basicWithAutoscalingUsingNodeConfig(t *testing.T) {
 func TestAccSpannerInstance_basicWithAutoscalingUsingNodeConfigUpdate(t *testing.T) {
 	t.Parallel()
 
-	displayName := fmt.Sprintf("spanner-test-%s-dname", acctest.RandString(t, 10))
+	displayName := fmt.Sprintf("tf-test-spanner-%s", acctest.RandString(t, 10))
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckSpannerInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
+			{
+				Config: testAccSpannerInstance_basic(displayName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
+				),
+			},
+			{
+				ResourceName:            "google_spanner_instance.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
 			{
 				Config: testAccSpannerInstance_basicWithAutoscalerConfigUsingNodesAsConfigsUpdate(displayName, 1, 2, 65, 95),
 				Check: resource.ComposeTestCheckFunc(
@@ -260,144 +296,8 @@ func TestAccSpannerInstance_basicWithAutoscalingUsingNodeConfigUpdate(t *testing
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
-		},
-	})
-}
-
-func TestAccSpannerInstance_basicAddAutoscalingUsingNodeConfigUpdate(t *testing.T) {
-	t.Parallel()
-
-	name := fmt.Sprintf("spanner-test-%s", acctest.RandString(t, 10))
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckSpannerInstanceDestroyProducer(t),
-		Steps: []resource.TestStep{
 			{
-				Config: testAccSpannerInstance_basic(name),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
-				),
-			},
-			{
-				ResourceName:            "google_spanner_instance.basic",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
-			},
-			{
-				Config: testAccSpannerInstance_basicWithAutoscalerConfigUsingNodesAsConfigs(name),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
-				),
-			},
-			{
-				ResourceName:            "google_spanner_instance.basic",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
-			},
-		},
-	})
-}
-
-func TestAccSpannerInstance_basicRemoveAutoscalingUsingNodeConfigUpdate(t *testing.T) {
-	t.Parallel()
-
-	name := fmt.Sprintf("spanner-test-%s", acctest.RandString(t, 10))
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckSpannerInstanceDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSpannerInstance_basicWithAutoscalerConfigUsingNodesAsConfigs(name),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
-				),
-			},
-			{
-				ResourceName:            "google_spanner_instance.basic",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
-			},
-			{
-				Config: testAccSpannerInstance_basic(name),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
-				),
-			},
-			{
-				ResourceName:            "google_spanner_instance.basic",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
-			},
-		},
-	})
-}
-
-func TestAccSpannerInstance_basicAddAutoscalingUsingProcessingUnitConfigUpdate(t *testing.T) {
-	t.Parallel()
-
-	name := fmt.Sprintf("spanner-test-%s", acctest.RandString(t, 10))
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckSpannerInstanceDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSpannerInstance_basic(name),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
-				),
-			},
-			{
-				ResourceName:            "google_spanner_instance.basic",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
-			},
-			{
-				Config: testAccSpannerInstance_basicWithAutoscalerConfigUsingProcessingUnitsAsConfigs(name),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
-				),
-			},
-			{
-				ResourceName:            "google_spanner_instance.basic",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
-			},
-		},
-	})
-}
-
-func TestAccSpannerInstance_basicRemoveAutoscalingUsingProcessingUnitConfigUpdate(t *testing.T) {
-	t.Parallel()
-
-	name := fmt.Sprintf("spanner-test-%s", acctest.RandString(t, 10))
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckSpannerInstanceDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSpannerInstance_basicWithAutoscalerConfigUsingProcessingUnitsAsConfigs(name),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
-				),
-			},
-			{
-				ResourceName:            "google_spanner_instance.basic",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
-			},
-			{
-				Config: testAccSpannerInstance_basic(name),
+				Config: testAccSpannerInstance_basic(displayName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
 				),

--- a/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
+++ b/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
@@ -301,6 +301,43 @@ func TestAccSpannerInstance_basicAddAutoscalingUsingNodeConfigUpdate(t *testing.
 	})
 }
 
+func TestAccSpannerInstance_basicRemoveAutoscalingUsingNodeConfigUpdate(t *testing.T) {
+	t.Parallel()
+
+	name := fmt.Sprintf("spanner-test-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSpannerInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSpannerInstance_basicWithAutoscalerConfigUsingNodesAsConfigs(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
+				),
+			},
+			{
+				ResourceName:            "google_spanner_instance.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccSpannerInstance_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
+				),
+			},
+			{
+				ResourceName:            "google_spanner_instance.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
 func TestAccSpannerInstance_basicAddAutoscalingUsingProcessingUnitConfigUpdate(t *testing.T) {
 	t.Parallel()
 
@@ -324,6 +361,43 @@ func TestAccSpannerInstance_basicAddAutoscalingUsingProcessingUnitConfigUpdate(t
 			},
 			{
 				Config: testAccSpannerInstance_basicWithAutoscalerConfigUsingProcessingUnitsAsConfigs(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
+				),
+			},
+			{
+				ResourceName:            "google_spanner_instance.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func TestAccSpannerInstance_basicRemoveAutoscalingUsingProcessingUnitConfigUpdate(t *testing.T) {
+	t.Parallel()
+
+	name := fmt.Sprintf("spanner-test-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSpannerInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSpannerInstance_basicWithAutoscalerConfigUsingProcessingUnitsAsConfigs(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
+				),
+			},
+			{
+				ResourceName:            "google_spanner_instance.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccSpannerInstance_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
 				),


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/16983

When adding/removing `autoscaling_config` in its entirety, set the top-level `autoscalingConfig` config in the update request's `fieldMask`.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
spanner: fixed error when adding `autoscaling_config` to an existing `google_spanner_instance`
```
