### PR TITLE
Add compute_machine_types datasource

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
@@ -71,6 +71,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_compute_instance_serial_port":              compute.DataSourceGoogleComputeInstanceSerialPort(),
 	"google_compute_instance_template":                 compute.DataSourceGoogleComputeInstanceTemplate(),
 	"google_compute_lb_ip_ranges":                      compute.DataSourceGoogleComputeLbIpRanges(),
+	"google_compute_machine_types":                     compute.DataSourceGoogleComputeMachineTypes(),
 	"google_compute_network":                           compute.DataSourceGoogleComputeNetwork(),
 	"google_compute_networks":                          compute.DataSourceGoogleComputeNetworks(),
 	"google_compute_network_endpoint_group":            compute.DataSourceGoogleComputeNetworkEndpointGroup(),

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_machine_types.go.erb
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_machine_types.go.erb
@@ -1,0 +1,252 @@
+<% autogen_exception -%>
+package compute
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+<% if version == "ga" -%>
+	"google.golang.org/api/compute/v1"
+<% else -%>
+	compute "google.golang.org/api/compute/v0.beta"
+<% end -%>
+)
+
+func DataSourceGoogleComputeMachineTypes() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGoogleComputeMachineTypesRead,
+
+		Schema: map[string]*schema.Schema{
+			"filter": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"machine_types": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of machine types`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the machine type.`,
+						},
+						"guest_cpus": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The number of virtual CPUs that are available to the instance.`,
+						},
+						"memory_mb": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The amount of physical memory available to the instance, defined in MB.`,
+						},
+						<% unless version == "ga" -%>
+						"bundled_local_ssds": {
+							Type: schema.TypeSet,
+							Computed: true,
+							Description: `The configuration of bundled local SSD for the machine type.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"default_interface": {
+										Type: schema.TypeString,
+										Computed: true,
+										Description: `The default disk interface if the interface is not specified.`,
+									},
+									"partition_count": {
+										Type: schema.TypeInt,
+										Computed: true,
+										Description: `The number of partitions.`,
+									},
+								},
+							},
+						},
+						<% end -%>
+						"deprecated": {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Description: `The deprecation status associated with this machine type. Only applicable if the machine type is unavailable.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"replacement": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The URL of the suggested replacement for a deprecated machine type.`,
+									},
+									"state": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The deprecation state of this resource. This can be ACTIVE, DEPRECATED, OBSOLETE, or DELETED.`,
+									},
+								},
+							},
+						},
+						"maximum_persistent_disks": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The maximum persistent disks allowed.`,
+						},
+						"maximum_persistent_disks_size_gb": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The maximum total persistent disks size (GB) allowed.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `A textual description of the machine type.`,
+						},
+						"is_shared_cpus": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether this machine type has a shared CPU.`,
+						},
+						"accelerators": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `A list of accelerator configurations assigned to this machine type.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"guest_accelerator_type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The accelerator type resource name, not a full URL, e.g. nvidia-tesla-t4.`,
+									},
+									"guest_accelerator_count": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `Number of accelerator cards exposed to the guest.`,
+									},
+								},
+							},
+						},
+						"self_link": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The server-defined URL for the machine type.`,
+						},
+					},
+				},
+			},
+			"zone": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the zone for this request.`,
+				Optional:    true,
+			},
+
+			"project": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Project ID for this request.`,
+				Optional:    true,
+			},
+		},
+	}
+}
+
+func dataSourceGoogleComputeMachineTypesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	filter := d.Get("filter").(string)
+	zone := d.Get("zone").(string)
+
+	machineTypes := make([]map[string]interface{}, 0)
+	token := ""
+
+	for paginate := true; paginate; {
+		resp, err := config.NewComputeClient(userAgent).MachineTypes.List(project, zone).Context(ctx).Filter(filter).PageToken(token).Do()
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("Error retrieving machine types: %w", err))
+
+		}
+		pageMachineTypes := flattenDatasourceGoogleComputeMachineTypesList(ctx, resp.Items)
+		machineTypes = append(machineTypes, pageMachineTypes...)
+
+		token = resp.NextPageToken
+		paginate = token != ""
+	}
+
+	if err := d.Set("machine_types", machineTypes); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting machine_types: %w", err))
+	}
+
+	if err := d.Set("project", project); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting project: %w", err))
+	}
+	if err := d.Set("zone", zone); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting zone: %w", err))
+	}
+
+	id := fmt.Sprintf("projects/%s/zones/%s/machineTypes/filters/%s", project, zone, filter)
+	d.SetId(id)
+
+	return diag.Diagnostics{}
+}
+
+func flattenDatasourceGoogleComputeMachineTypesList(ctx context.Context, v []*compute.MachineType) []map[string]interface{} {
+	if v == nil {
+		return make([]map[string]interface{}, 0)
+	}
+
+	machineTypes := make([]map[string]interface{}, 0, len(v))
+	for _, mt := range v {
+		accelerators := make([]map[string]interface{}, len(mt.Accelerators))
+		for i, a := range mt.Accelerators {
+			accelerators[i] = map[string]interface{}{
+				"guest_accelerator_type":  a.GuestAcceleratorType,
+				"guest_accelerator_count": a.GuestAcceleratorCount,
+			}
+		}
+		<% unless version == "ga" -%>
+		var localSSDs []map[string]interface{}
+		if bls := mt.BundledLocalSsds; bls != nil {
+			localSSDs = []map[string]interface{}{
+				{
+					"default_interface": bls.DefaultInterface,
+					"partition_count":   bls.PartitionCount,
+				},
+			}
+		}
+		<% end -%>
+		machineType := map[string]interface{}{
+			"name":                             mt.Name,
+			"guest_cpus":                       mt.GuestCpus,
+			"memory_mb":                        mt.MemoryMb,
+			<% unless version == "ga" -%>
+			"bundled_local_ssds":               localSSDs,
+			<% end -%>
+			"maximum_persistent_disks":         mt.MaximumPersistentDisks,
+			"maximum_persistent_disks_size_gb": mt.MaximumPersistentDisksSizeGb,
+			"description":                      mt.Description,
+			"is_shared_cpus":                   mt.IsSharedCpu,
+			"accelerators":                     accelerators,
+			"self_link":                        mt.SelfLink,
+		}
+		if dep := mt.Deprecated; dep != nil {
+			d := map[string]interface{}{
+				"replacement": dep.Replacement,
+				"state":       dep.State,
+			}
+			machineType["deprecated"] = []map[string]interface{}{d}
+		}
+		machineTypes = append(machineTypes, machineType)
+	}
+
+	return machineTypes
+}

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_machine_types_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_machine_types_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+package compute_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccDataSourceGoogleComputeMachineTypes_basic(t *testing.T) {
+	t.Parallel()
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeMachineTypes,
+				Check: resource.ComposeTestCheckFunc(
+					// We can't guarantee machine type availability in a given project and zone, so we'll check set-ness rather than correctness
+					resource.TestMatchResourceAttr("data.google_compute_machine_types.test", "machine_types.0.name", regexp.MustCompile(`^[a-z0-9-]+$`)),
+					resource.TestMatchResourceAttr("data.google_compute_machine_types.test", "machine_types.0.guest_cpus", regexp.MustCompile(`^\d+$`)),
+					resource.TestMatchResourceAttr("data.google_compute_machine_types.test", "machine_types.0.memory_mb", regexp.MustCompile(`^\d+$`)),
+					resource.TestMatchResourceAttr("data.google_compute_machine_types.test", "machine_types.0.maximum_persistent_disks", regexp.MustCompile(`^\d+$`)),
+					resource.TestMatchResourceAttr("data.google_compute_machine_types.test", "machine_types.0.maximum_persistent_disks_size_gb", regexp.MustCompile(`^\d+$`)),
+					resource.TestMatchResourceAttr("data.google_compute_machine_types.test", "machine_types.0.description", regexp.MustCompile(`.+`)),
+					resource.TestMatchResourceAttr("data.google_compute_machine_types.test", "machine_types.0.is_shared_cpus", regexp.MustCompile(`^true|false$`)),
+					resource.TestMatchResourceAttr("data.google_compute_machine_types.test", "machine_types.0.self_link", regexp.MustCompile(`.+`)),
+				),
+			},
+		},
+	})
+}
+
+const testAccComputeMachineTypes = `
+data "google_compute_zones" "available" {}
+
+data "google_compute_machine_types" "test" {
+	filter = "guest_cpus > 0"
+	zone   = data.google_compute_zones.available.names[0]
+}
+`

--- a/mmv1/third_party/terraform/website/docs/d/compute_machine_types.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_machine_types.html.markdown
@@ -1,0 +1,143 @@
+---
+subcategory: "Compute Engine"
+description: |-
+  Provides a list of available Google Compute machine types
+---
+
+# google\_compute\_machine\_types
+
+Provides access to available Google Compute machine types in a zone for a given project.
+See more about [machine type availability](https://cloud.google.com/compute/docs/regions-zones#available) in the upstream docs.
+
+To get more information about machine types, see:
+
+* [API Documentation](https://cloud.google.com/compute/docs/reference/rest/v1/machineTypes/list)
+* [Comparison Guide](https://cloud.google.com/compute/docs/machine-resource)
+
+## Example Usage - Machine Type properties
+
+Configure a Google Kubernetes Engine (GKE) cluster with node auto-provisioning, using memory constraints matching the memory of the provided machine type.
+
+```hcl
+data "google_compute_machine_types" "example" {
+  filter = "name = 'n1-standard-1'"
+  zone   = "us-central1-a"
+}
+
+resource "google_container_cluster" "example" {
+  name = "my-gke-cluster"
+
+  cluster_autoscaling {
+    enabled = true
+    resource_limits {
+      resource_type = "memory"
+      minimum       =  2 * data.google_compute_machine_types.example.machine_types[0].memory_mb
+      maximum       =  4 * data.google_compute_machine_types.example.machine_types[0].memory_mb
+    }
+}
+```
+
+## Example Usage - Property-based availability
+
+Create a VM instance template for each machine type with 16GB of memory and 8 CPUs available in the provided zone.
+
+```hcl
+data "google_compute_machine_types" "example" {
+  filter = "memoryMb = 16384 AND guestCpus = 8"
+  zone   = var.zone
+}
+
+resource "google_compute_instance_template" "example" {
+  for_each     = toset(data.google_compute_machine_types.example.machine_types[*].name)
+  machine_type = each.value
+
+  disk {
+    source_image = "debian-cloud/debian-11"
+    auto_delete  = true
+    boot         = true
+  }
+}
+```
+
+## Example Usage - Machine Family preference
+
+Create an instance template, preferring `c3` machine family if available in the provided zone, otherwise falling back to `c2` and finally `n2`.
+
+```hcl
+data "google_compute_machine_types" "example" {
+  filter = "memoryMb = 16384 AND guestCpus = 4"
+  zone   = var.zone
+}
+
+resource "google_compute_instance_template" "example" {
+  machine_type = coalescelist(
+    [for mt in data.google_compute_machine_types.example.machine_types: mt.name if startswith(mt.name, "c3-")],
+    [for mt in data.google_compute_machine_types.example.machine_types: mt.name if startswith(mt.name, "c2-")],
+    [for mt in data.google_compute_machine_types.example.machine_types: mt.name if startswith(mt.name, "n2-")],
+  )[0]
+
+  disk {
+    source_image = "debian-cloud/debian-11"
+    auto_delete  = true
+    boot         = true
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `filter` (Required) - A filter expression that filters machine types listed in the response.
+
+* `zone` (Required) - Zone from which to list machine types.
+
+* `project` (Optional) - Project from which to list available zones. Defaults to project declared in the provider.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `machine_types` - The list of machine types matching the provided filter. Structure is [documented below](#nested_machine_types).
+
+<a name="nested_machine_types"></a>The `machine_types` block supports:
+
+* `name` - The name of the machine type.
+
+* `description` - A textual description of the machine type.
+
+* `bundled_local_ssds` - ([Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) The configuration of bundled local SSD for the machine type. Structure is [documented below](#nested_bundled_local_ssds).
+
+* `deprecated` - The deprecation status associated with this machine type. Structure is [documented below](#nested_deprecated).
+
+* `guest_cpus` - The number of virtual CPUs that are available to the instance.
+
+* `memory_mb` - The amount of physical memory available to the instance, defined in MB.
+
+* `maximum_persistent_disks` - The maximum persistent disks allowed.
+
+* `maximum_persistent_disks_size_gb` - The maximum total persistent disks size (GB) allowed.
+
+* `is_shared_cpus` - Whether this machine type has a shared CPU.
+
+* `accelerators` - A list of accelerator configurations assigned to this machine type. Structure is [documented below](#nested_accelerators).
+
+* `self_link` - The server-defined URL for the machine type.
+
+<a name="nested_bundled_local_ssds"></a>The `bundled_local_ssds` block supports:
+
+* `default_interface` - ([Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) The default disk interface if the interface is not specified.
+
+* `partition_count` - ([Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) The number of partitions.
+
+<a name="nested_deprecated"></a>The `deprecated` block supports:
+
+* `replacement` - The URL of the suggested replacement for a deprecated machine type.
+
+* `state` - The deprecation state of this resource. This can be `ACTIVE`, `DEPRECATED`, `OBSOLETE`, or `DELETED`.
+
+<a name="nested_accelerators"></a>The `accelerators` block supports:
+
+* `guest_accelerator_type` - The accelerator type resource name, not a full URL, e.g. `nvidia-tesla-t4`.
+
+* `guest_accelerator_count` - Number of accelerator cards exposed to the guest.


### PR DESCRIPTION
This implements a plural version of https://github.com/hashicorp/terraform-provider-google/issues/5606 which should solve the same use-cases while also being more flexible.

Specifically, a plural datasource allows a terraform module to be used across regions without needing to override a machine_type variable based on [machine type availability](https://cloud.google.com/compute/docs/regions-zones#available). The plural datasource can return an empty list rather than fail the terraform operation if a specific machine type isn't available in the given zone.

Regarding the test, similar to other read-only APIs I'm only checking the existence of attributes rather than requesting a specific machine type and checking its values, since different test environments may have different machine type availability.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
`google_compute_machine_types`
```
