### PR TITLE
Make the `destination.cloud_function` field on google_eventarc_trigger output only, update field description in docs

### DIFF
--- a/tpgtools/overrides/eventarc/beta/trigger.yaml
+++ b/tpgtools/overrides/eventarc/beta/trigger.yaml
@@ -15,3 +15,13 @@
   details:
     functions: 
     - tpgresource.DefaultProviderProject
+- type: CUSTOM_SCHEMA_VALUES
+  field: destination.cloud_function
+  details:
+    required: false
+    optional: false
+    computed: true
+- type: CUSTOM_DESCRIPTION
+  field: destination.cloud_function
+  details:
+    description: "The Cloud Function resource name. Only Cloud Functions V2 is supported. Format projects/{project}/locations/{location}/functions/{function} This is a read-only field. [WARNING] Creating Cloud Functions V2 triggers is only supported via the Cloud Functions product. An error will be returned if the user sets this value."

--- a/tpgtools/overrides/eventarc/trigger.yaml
+++ b/tpgtools/overrides/eventarc/trigger.yaml
@@ -21,3 +21,7 @@
     required: false
     optional: false
     computed: true
+- type: CUSTOM_DESCRIPTION
+  field: destination.cloud_function
+  details:
+    description: "The Cloud Function resource name. Only Cloud Functions V2 is supported. Format projects/{project}/locations/{location}/functions/{function} This is a read-only field. [WARNING] Creating Cloud Functions V2 triggers is only supported via the Cloud Functions product. An error will be returned if the user sets this value."

--- a/tpgtools/overrides/eventarc/trigger.yaml
+++ b/tpgtools/overrides/eventarc/trigger.yaml
@@ -15,3 +15,9 @@
   details:
     functions: 
     - tpgresource.DefaultProviderProject
+- type: CUSTOM_SCHEMA_VALUES
+  field: destination.cloud_function
+  details:
+    required: false
+    optional: false
+    computed: true


### PR DESCRIPTION
The [API docs describe this field](https://cloud.google.com/eventarc/docs/reference/rest/v1/projects.locations.triggers#destination) as output only:

>The Cloud Function resource name. Only Cloud Functions V2 is supported. Format: projects/{project}/locations/{location}/functions/{function}This is a read-only field. Creating Cloud Functions V2 triggers is only supported via the Cloud Functions product. An error will be returned if the user sets this value.

In this PR I'm updating the schema for this field so it's Computed and not Optional, and also updating [the provider documentation for this field](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/eventarc_trigger#cloud_function) to match the API docs.


<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
eventarc: made the `destination.cloud_function` field on `google_eventarc_trigger` an output. Previously when users attempted to set this in their configuration it caused an API error.
```
