### PR TITLE
Promote the call_log_level attribute to GA and update tests.

### DIFF
--- a/mmv1/products/workflows/Workflow.yaml
+++ b/mmv1/products/workflows/Workflow.yaml
@@ -96,7 +96,7 @@ properties:
   - !ruby/object:Api::Type::String
     name: 'sourceContents'
     description: |
-      Workflow code to be executed. The size limit is 32KB.
+      Workflow code to be executed. The size limit is 128KB.
   - !ruby/object:Api::Type::String
     name: 'revisionId'
     output: true
@@ -108,6 +108,17 @@ properties:
       The KMS key used to encrypt workflow and execution data.
 
       Format: projects/{project}/locations/{location}/keyRings/{keyRing}/cryptoKeys/{cryptoKey}
+  - !ruby/object:Api::Type::Enum
+    name: 'callLogLevel'
+    description: |
+      Describes the level of platform logging to apply to calls and call responses during
+      executions of this workflow. If both the workflow and the execution specify a logging level,
+      the execution level takes precedence.
+    values:
+      - :CALL_LOG_LEVEL_UNSPECIFIED
+      - :LOG_ALL_CALLS
+      - :LOG_ERRORS_ONLY
+      - :LOG_NONE
   - !ruby/object:Api::Type::KeyValuePairs
     name: 'userEnvVars'
     description: |

--- a/mmv1/templates/terraform/examples/workflow_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/workflow_basic.tf.erb
@@ -8,6 +8,7 @@ resource "google_workflows_workflow" "<%= ctx[:primary_resource_id] %>" {
   region        = "us-central1"
   description   = "Magic"
   service_account = google_service_account.test_account.id
+  call_log_level = "LOG_ERRORS_ONLY"
   labels = {
     env = "test"
   }

--- a/mmv1/third_party/terraform/services/workflows/resource_workflows_workflow_test.go.erb
+++ b/mmv1/third_party/terraform/services/workflows/resource_workflows_workflow_test.go.erb
@@ -37,9 +37,10 @@ func TestAccWorkflowsWorkflow_Update(t *testing.T) {
 func testAccWorkflowsWorkflow_Update(name string) string {
 	return fmt.Sprintf(`
 resource "google_workflows_workflow" "example" {
-  name          = "%s"
-  region        = "us-central1"
-  description   = "Magic"
+  name           = "%s"
+  region         = "us-central1"
+  description    = "Magic"
+  call_log_level = "LOG_ERRORS_ONLY"
   user_env_vars = {
     url = "https://timeapi.io/api/Time/current/zone?timeZone=Europe/Amsterdam"
   }
@@ -77,9 +78,10 @@ EOF
 func testAccWorkflowsWorkflow_Updated(name string) string {
 	return fmt.Sprintf(`
 resource "google_workflows_workflow" "example" {
-  name          = "%s"
-  region        = "us-central1"
-  description   = "Magic"
+  name           = "%s"
+  region         = "us-central1"
+  description    = "Magic"
+  call_log_level = "LOG_ERRORS_ONLY"
   user_env_vars = {
     url = "https://timeapi.io/api/Time/current/zone?timeZone=Europe/Amsterdam"
   }


### PR DESCRIPTION
Promote the call_log_level attribute to GA and update tests.
Fixes https:////github.com/hashicorp/terraform-provider-google/issues/15575.

Also update one comment with the current workflows source code size limit.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
workflows: add support for `call_log_level` to resource `google_workflows_workflow`
```
