### PR TITLE
Fix typo - change `projects` into `folders`

### DIFF
--- a/mmv1/third_party/terraform/website/docs/d/folders.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/folders.html.markdown
@@ -33,7 +33,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `folders` - A list of projects matching the provided filter. Structure is defined below.
+* `folders` - A list of folders matching the provided filter. Structure is defined below.
 
 The `folders` block supports:
 


### PR DESCRIPTION
This PR fixes a type in the documentation that referred to folders as projects. (Guess a copy paste from somewhere)

As it's just a single word typo fix on the docs, no release note added. Thanks.

```release-note:none
```
