### PR TITLE
artifact registry repository - promote cleanup policy to ga

### DIFF
--- a/mmv1/products/artifactregistry/Repository.yaml
+++ b/mmv1/products/artifactregistry/Repository.yaml
@@ -96,7 +96,6 @@ examples:
       description: 'example remote yum repository'
   - !ruby/object:Provider::Terraform::Examples
     name: 'artifact_registry_repository_cleanup'
-    min_version: beta
     primary_resource_id: 'my-repo'
     vars:
       repository_id: 'my-repository'
@@ -253,7 +252,6 @@ properties:
                 Entries with a greater priority value take precedence in the pull order.
   - !ruby/object:Api::Type::Map
     name: 'cleanupPolicies'
-    min_version: beta
     description: |-
       Cleanup policies for this repository. Cleanup policies indicate when
       certain package versions can be automatically deleted.
@@ -263,11 +261,9 @@ properties:
     key_description: |-
       The policy ID. Must be unique within a repository.
     value_type: !ruby/object:Api::Type::NestedObject
-      min_version: beta
       properties:
         - !ruby/object:Api::Type::Enum
           name: action
-          min_version: beta
           description: |-
             Policy action.
           values:
@@ -275,14 +271,12 @@ properties:
             - :KEEP
         - !ruby/object:Api::Type::NestedObject
           name: condition
-          min_version: beta
           description: |-
             Policy condition for matching versions.
           # TODO (jrsb): exactly_one_of: condition, mostRecentVersions
           properties:
             - !ruby/object:Api::Type::Enum
               name: tagState
-              min_version: beta
               description: |-
                 Match versions by tag status.
               values:
@@ -292,37 +286,31 @@ properties:
               default_value: :ANY
             - !ruby/object:Api::Type::Array
               name: tagPrefixes
-              min_version: beta
               description: |-
                 Match versions by tag prefix. Applied on any prefix match.
               item_type: Api::Type::String
             - !ruby/object:Api::Type::Array
               name: versionNamePrefixes
-              min_version: beta
               description: |-
                 Match versions by version name prefix. Applied on any prefix match.
               item_type: Api::Type::String
             - !ruby/object:Api::Type::Array
               name: packageNamePrefixes
-              min_version: beta
               description: |-
                 Match versions by package prefix. Applied on any prefix match.
               item_type: Api::Type::String
             - !ruby/object:Api::Type::String
               name: olderThan
-              min_version: beta
               description: |-
                 Match versions older than a duration.
               diff_suppress_func: 'tpgresource.DurationDiffSuppress'
             - !ruby/object:Api::Type::String
               name: newerThan
-              min_version: beta
               description: |-
                 Match versions newer than a duration.
               diff_suppress_func: 'tpgresource.DurationDiffSuppress'
         - !ruby/object:Api::Type::NestedObject
           name: mostRecentVersions
-          min_version: beta
           description: |-
             Policy condition for retaining a minimum number of versions. May only be
             specified with a Keep action.
@@ -330,13 +318,11 @@ properties:
           properties:
             - !ruby/object:Api::Type::Array
               name: packageNamePrefixes
-              min_version: beta
               description: |-
                 Match versions by package prefix. Applied on any prefix match.
               item_type: Api::Type::String
             - !ruby/object:Api::Type::Integer
               name: keepCount
-              min_version: beta
               description: |-
                 Minimum number of versions to keep.
   - !ruby/object:Api::Type::NestedObject
@@ -542,7 +528,6 @@ properties:
                 immutable: true
   - !ruby/object:Api::Type::Boolean
     name: 'cleanupPolicyDryRun'
-    min_version: beta
     description: |-
       If true, the cleanup pipeline is prevented from deleting versions in this
       repository.

--- a/mmv1/templates/terraform/examples/artifact_registry_repository_cleanup.tf.erb
+++ b/mmv1/templates/terraform/examples/artifact_registry_repository_cleanup.tf.erb
@@ -1,5 +1,4 @@
 resource "google_artifact_registry_repository" "<%= ctx[:primary_resource_id] %>" {
-  provider      = google-beta
   location      = "us-central1"
   repository_id = "<%= ctx[:vars]['repository_id'] %>"
   description   = "<%= ctx[:vars]['description'] %>"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
artifactregistry: promote cleanup policy fields to GA for `google_artifactregistry_repository` resource
```
