### PR TITLE
Update Vmware Engine acceptance tests to provision resources in a new project

### DIFF
--- a/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_peering_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_peering_test.go
@@ -38,62 +38,62 @@ func TestAccDataSourceVmwareengineNetworkPeering_basic(t *testing.T) {
 func testAccVmwareengineNetworkPeering_ds(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_project" "project" {
-	project_id      = "tf-test%{random_suffix}"
-	name            = "tf-test%{random_suffix}"
-	org_id          = "%{org_id}"
-	billing_account = "%{billing_account}"
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
 }
 
 resource "google_project_service" "vmwareengine" {
-	project = google_project.project.project_id
-	service = "vmwareengine.googleapis.com"
+  project = google_project.project.project_id
+  service = "vmwareengine.googleapis.com"
 }
 
 resource "time_sleep" "sleep" {
-	create_duration = "1m"
-	depends_on = [
-		google_project_service.vmwareengine,
-	]
+  create_duration = "1m"
+  depends_on = [
+    google_project_service.vmwareengine,
+  ]
 }
 
 resource "google_vmwareengine_network" "network-peering-nw" {
-	project = google_project.project.project_id
-	name              = "tf-test-sample-nw%{random_suffix}"
-	location          = "global"
-	type              = "STANDARD"
+  project       = google_project.project.project_id
+  name          = "tf-test-sample-nw%{random_suffix}"
+  location      = "global"
+  type          = "STANDARD"
 
-	depends_on = [
-		time_sleep.sleep # Sleep allows permissions in the new project to propagate
-	]
+  depends_on = [
+    time_sleep.sleep # Sleep allows permissions in the new project to propagate
+  ]
 }
 
 resource "google_vmwareengine_network" "network-peering-peer-nw" {
-	project = google_project.project.project_id
-	name              = "tf-test-peer-nw%{random_suffix}"
-	location          = "global"
-	type              = "STANDARD"
+  project = google_project.project.project_id
+  name              = "tf-test-peer-nw%{random_suffix}"
+  location          = "global"
+  type              = "STANDARD"
 
-	depends_on = [
-		time_sleep.sleep # Sleep allows permissions in the new project to propagate
-	]
+  depends_on = [
+    time_sleep.sleep # Sleep allows permissions in the new project to propagate
+  ]
 }
 
 resource "google_vmwareengine_network_peering" "vmw-engine-network-peering" {
-	project = google_project.project.project_id
-	name = "tf-test-sample-network-peering%{random_suffix}"
-	description = "Sample description"
-	vmware_engine_network = google_vmwareengine_network.network-peering-nw.id
-	peer_network = google_vmwareengine_network.network-peering-peer-nw.id
-	peer_network_type = "VMWARE_ENGINE_NETWORK"
+  project = google_project.project.project_id
+  name = "tf-test-sample-network-peering%{random_suffix}"
+  description = "Sample description"
+  vmware_engine_network = google_vmwareengine_network.network-peering-nw.id
+  peer_network = google_vmwareengine_network.network-peering-peer-nw.id
+  peer_network_type = "VMWARE_ENGINE_NETWORK"
 
-	depends_on = [
-		time_sleep.sleep # Sleep allows permissions in the new project to propagate
-	]
+  depends_on = [
+    time_sleep.sleep # Sleep allows permissions in the new project to propagate
+  ]
 }
 
 data "google_vmwareengine_network_peering" "ds" {
-	project = google_project.project.project_id
-	name = google_vmwareengine_network_peering.vmw-engine-network-peering.name
+  project = google_project.project.project_id
+  name = google_vmwareengine_network_peering.vmw-engine-network-peering.name
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_peering_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_peering_test.go
@@ -5,19 +5,25 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestAccDataSourceVmwareengineNetworkPeering_basic(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"random_suffix": acctest.RandString(t, 10),
+		"random_suffix":   acctest.RandString(t, 10),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckVmwareengineNetworkPeeringDestroyProducer(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckVmwareengineNetworkPeeringDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVmwareengineNetworkPeering_ds(context),
@@ -31,31 +37,66 @@ func TestAccDataSourceVmwareengineNetworkPeering_basic(t *testing.T) {
 
 func testAccVmwareengineNetworkPeering_ds(context map[string]interface{}) string {
 	return acctest.Nprintf(`
+resource "google_project" "project" {
+	project_id      = "tf-test%{random_suffix}"
+	name            = "tf-test%{random_suffix}"
+	org_id          = "%{org_id}"
+	billing_account = "%{billing_account}"
+}
+
+resource "google_project_service" "vmwareengine" {
+	project = google_project.project.project_id
+	service = "vmwareengine.googleapis.com"
+}
+
+resource "time_sleep" "sleep" {
+	create_duration = "1m"
+	depends_on = [
+		google_project_service.vmwareengine,
+	]
+}
+
 resource "google_vmwareengine_network" "network-peering-nw" {
+	project = google_project.project.project_id
 	name              = "tf-test-sample-nw%{random_suffix}"
 	location          = "global"
 	type              = "STANDARD"
+
+	depends_on = [
+		google_project_service.vmwareengine,
+		time_sleep.sleep # Sleep allows permissions in the new project to propagate
+	]
 }
 
 resource "google_vmwareengine_network" "network-peering-peer-nw" {
+	project = google_project.project.project_id
 	name              = "tf-test-peer-nw%{random_suffix}"
 	location          = "global"
 	type              = "STANDARD"
+
+	depends_on = [
+		google_project_service.vmwareengine,
+		time_sleep.sleep # Sleep allows permissions in the new project to propagate
+	]
 }
 
 resource "google_vmwareengine_network_peering" "vmw-engine-network-peering" {
+	project = google_project.project.project_id
 	name = "tf-test-sample-network-peering%{random_suffix}"
 	description = "Sample description"
 	vmware_engine_network = google_vmwareengine_network.network-peering-nw.id
 	peer_network = google_vmwareengine_network.network-peering-peer-nw.id
 	peer_network_type = "VMWARE_ENGINE_NETWORK"
+
+	depends_on = [
+		google_project_service.vmwareengine,
+		time_sleep.sleep # Sleep allows permissions in the new project to propagate
+	]
 }
 
 data "google_vmwareengine_network_peering" "ds" {
+	project = google_project.project.project_id
 	name = google_vmwareengine_network_peering.vmw-engine-network-peering.name
-	depends_on = [
-		google_vmwareengine_network_peering.vmw-engine-network-peering,
-	]
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_peering_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_peering_test.go
@@ -63,7 +63,6 @@ resource "google_vmwareengine_network" "network-peering-nw" {
 	type              = "STANDARD"
 
 	depends_on = [
-		google_project_service.vmwareengine,
 		time_sleep.sleep # Sleep allows permissions in the new project to propagate
 	]
 }
@@ -75,7 +74,6 @@ resource "google_vmwareengine_network" "network-peering-peer-nw" {
 	type              = "STANDARD"
 
 	depends_on = [
-		google_project_service.vmwareengine,
 		time_sleep.sleep # Sleep allows permissions in the new project to propagate
 	]
 }
@@ -89,7 +87,6 @@ resource "google_vmwareengine_network_peering" "vmw-engine-network-peering" {
 	peer_network_type = "VMWARE_ENGINE_NETWORK"
 
 	depends_on = [
-		google_project_service.vmwareengine,
 		time_sleep.sleep # Sleep allows permissions in the new project to propagate
 	]
 }

--- a/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_policy_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_policy_test.go
@@ -12,14 +12,19 @@ func TestAccDataSourceVmwareengineNetworkPolicy_basic(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"region":        envvar.GetTestRegionFromEnv(),
-		"random_suffix": acctest.RandString(t, 10),
+		"region":          envvar.GetTestRegionFromEnv(),
+		"random_suffix":   acctest.RandString(t, 10),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckVmwareengineNetworkPolicyDestroyProducer(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckVmwareengineNetworkPolicyDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVmwareengineNetworkPolicy_ds(context),
@@ -33,14 +38,39 @@ func TestAccDataSourceVmwareengineNetworkPolicy_basic(t *testing.T) {
 
 func testAccVmwareengineNetworkPolicy_ds(context map[string]interface{}) string {
 	return acctest.Nprintf(`
+resource "google_project" "project" {
+	project_id      = "tf-test%{random_suffix}"
+	name            = "tf-test%{random_suffix}"
+	org_id          = "%{org_id}"
+	billing_account = "%{billing_account}"
+}
+
+resource "google_project_service" "vmwareengine" {
+	project = google_project.project.project_id
+	service = "vmwareengine.googleapis.com"
+}
+
+resource "time_sleep" "sleep" {
+	create_duration = "1m"
+	depends_on = [
+		google_project_service.vmwareengine,
+	]
+}
+
 resource "google_vmwareengine_network" "network-policy-ds-nw" {
+	project = google_project.project.project_id
 	name = "tf-test-sample-nw%{random_suffix}"
 	location = "global" 
 	type = "STANDARD"
 	description = "VMwareEngine standard network sample"
+
+	depends_on = [
+		time_sleep.sleep # Sleep allows permissions in the new project to propagate
+	]
 }
 
 resource "google_vmwareengine_network_policy" "vmw-engine-network-policy" {
+	project = google_project.project.project_id
 	location = "%{region}"
 	name = "tf-test-sample-network-policy%{random_suffix}"
 	internet_access {
@@ -51,9 +81,14 @@ resource "google_vmwareengine_network_policy" "vmw-engine-network-policy" {
 	}
 	edge_services_cidr = "192.168.30.0/26"
 	vmware_engine_network = google_vmwareengine_network.network-policy-ds-nw.id
+
+	depends_on = [
+		time_sleep.sleep # Sleep allows permissions in the new project to propagate
+	]
 }
 
 data "google_vmwareengine_network_policy" "ds" {
+  project = google_project.project.project_id
   name = google_vmwareengine_network_policy.vmw-engine-network-policy.name
   location = "%{region}"
   depends_on = [

--- a/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_policy_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_policy_test.go
@@ -39,52 +39,52 @@ func TestAccDataSourceVmwareengineNetworkPolicy_basic(t *testing.T) {
 func testAccVmwareengineNetworkPolicy_ds(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_project" "project" {
-	project_id      = "tf-test%{random_suffix}"
-	name            = "tf-test%{random_suffix}"
-	org_id          = "%{org_id}"
-	billing_account = "%{billing_account}"
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
 }
 
 resource "google_project_service" "vmwareengine" {
-	project = google_project.project.project_id
-	service = "vmwareengine.googleapis.com"
+  project = google_project.project.project_id
+  service = "vmwareengine.googleapis.com"
 }
 
 resource "time_sleep" "sleep" {
-	create_duration = "1m"
-	depends_on = [
-		google_project_service.vmwareengine,
-	]
+  create_duration = "1m"
+  depends_on = [
+    google_project_service.vmwareengine,
+  ]
 }
 
 resource "google_vmwareengine_network" "network-policy-ds-nw" {
-	project = google_project.project.project_id
-	name = "tf-test-sample-nw%{random_suffix}"
-	location = "global" 
-	type = "STANDARD"
-	description = "VMwareEngine standard network sample"
+  project = google_project.project.project_id
+  name = "tf-test-sample-nw%{random_suffix}"
+  location = "global" 
+  type = "STANDARD"
+  description = "VMwareEngine standard network sample"
 
-	depends_on = [
-		time_sleep.sleep # Sleep allows permissions in the new project to propagate
-	]
+  depends_on = [
+    time_sleep.sleep # Sleep allows permissions in the new project to propagate
+  ]
 }
 
 resource "google_vmwareengine_network_policy" "vmw-engine-network-policy" {
-	project = google_project.project.project_id
-	location = "%{region}"
-	name = "tf-test-sample-network-policy%{random_suffix}"
-	internet_access {
-		enabled = true
-	}
-	external_ip {
-		enabled = true
-	}
-	edge_services_cidr = "192.168.30.0/26"
-	vmware_engine_network = google_vmwareengine_network.network-policy-ds-nw.id
+  project = google_project.project.project_id
+  location = "%{region}"
+  name = "tf-test-sample-network-policy%{random_suffix}"
+  internet_access {
+    enabled = true
+  }
+  external_ip {
+    enabled = true
+  }
+  edge_services_cidr = "192.168.30.0/26"
+  vmware_engine_network = google_vmwareengine_network.network-policy-ds-nw.id
 
-	depends_on = [
-		time_sleep.sleep # Sleep allows permissions in the new project to propagate
-	]
+  depends_on = [
+    time_sleep.sleep # Sleep allows permissions in the new project to propagate
+  ]
 }
 
 data "google_vmwareengine_network_policy" "ds" {

--- a/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_test.go
@@ -62,6 +62,10 @@ data "google_vmwareengine_network" "ds" {
   name     = google_vmwareengine_network.nw.name
   project  = google_project.project.project_id
   location = "global"
+
+  depends_on = [
+    google_project_service.vmwareengine
+  ]
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_test.go
@@ -50,21 +50,11 @@ resource "google_project_service" "vmwareengine" {
   service = "vmwareengine.googleapis.com"
 }
 
-resource "google_project_iam_member" "vmwareengine_admin" {
-  project = google_project.project.project_id
-  role    = "roles/vmwareengine.vmwareengineAdmin"
-  member  = "serviceAccount:%{terraform_service_account}"
-
-  depends_on = [
-    google_project_service.vmwareengine,
-  ]
-}
-
 resource "time_sleep" "sleep" {
   create_duration = "1m"
 
   depends_on = [
-    google_project_iam_member.vmwareengine_admin,
+    google_project_service.vmwareengine,
   ]
 }
 
@@ -77,8 +67,7 @@ resource "google_vmwareengine_network" "nw" {
 
   depends_on = [
     google_project_service.vmwareengine,
-    google_project_iam_member.vmwareengine_admin,
-	time_sleep.sleep
+    time_sleep.sleep # Sleep allows permissions in the new project to propagate
   ]
 }
 

--- a/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_test.go
@@ -65,7 +65,6 @@ resource "google_vmwareengine_network" "nw" {
   description       = "VMwareEngine standard network sample"
 
   depends_on = [
-    google_project_service.vmwareengine,
     time_sleep.sleep # Sleep allows permissions in the new project to propagate
   ]
 }

--- a/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_test.go
@@ -12,10 +12,9 @@ func TestAccDataSourceVmwareEngineNetwork_basic(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"random_suffix":             acctest.RandString(t, 10),
-		"org_id":                    envvar.GetTestOrgFromEnv(t),
-		"billing_account":           envvar.GetTestBillingAccountFromEnv(t),
-		"terraform_service_account": envvar.GetTestServiceAccountFromEnv(t),
+		"random_suffix":   acctest.RandString(t, 10),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_test.go
@@ -51,6 +51,18 @@ resource "google_project_iam_member" "vmwareengine_admin" {
   project = google_project.project.project_id
   role    = "roles/vmwareengine.vmwareengineAdmin"
   member  = "serviceAccount:%{terraform_service_account}"
+
+  depends_on = [
+    google_project_service.vmwareengine,
+  ]
+}
+
+resource "time_sleep" "sleep" {
+  create_duration = "1m"
+
+  depends_on = [
+    google_project_iam_member.vmwareengine_admin,
+  ]
 }
 
 resource "google_vmwareengine_network" "nw" {
@@ -62,7 +74,8 @@ resource "google_vmwareengine_network" "nw" {
 
   depends_on = [
     google_project_service.vmwareengine,
-    google_project_iam_member.vmwareengine_admin
+    google_project_iam_member.vmwareengine_admin,
+	time_sleep.sleep
   ]
 }
 

--- a/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/data_source_google_vmwareengine_network_test.go
@@ -21,7 +21,10 @@ func TestAccDataSourceVmwareEngineNetwork_basic(t *testing.T) {
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckVmwareengineNetworkDestroyProducer(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckVmwareengineNetworkDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceVmwareEngineNetworkConfig(context),

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_test.go
@@ -118,10 +118,6 @@ resource "google_vmwareengine_private_cloud" "cluster-pc" {
       node_count   = 3
     }
   }
-
-  depends_on = [
-    time_sleep.sleep # Sleep allows permissions in the new project to propagate
-  ]
 }
 
 resource "google_vmwareengine_cluster" "vmw-engine-ext-cluster" {
@@ -132,19 +128,11 @@ resource "google_vmwareengine_cluster" "vmw-engine-ext-cluster" {
     node_count   = %{node_count}
     custom_core_count = 32
   }
-
-  depends_on = [
-    time_sleep.sleep # Sleep allows permissions in the new project to propagate
-  ]
 }
 
 data "google_vmwareengine_cluster" "ds" {
   name = google_vmwareengine_cluster.vmw-engine-ext-cluster.name
   parent = google_vmwareengine_private_cloud.cluster-pc.id
-
-  depends_on = [
-    time_sleep.sleep # Sleep allows permissions in the new project to propagate
-  ]
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_test.go
@@ -20,15 +20,18 @@ func TestAccVmwareengineCluster_vmwareEngineClusterUpdate(t *testing.T) {
 
 	context := map[string]interface{}{
 		"region":          "southamerica-west1", // using region with low node utilization.
+		"random_suffix":   acctest.RandString(t, 10),
 		"org_id":          envvar.GetTestOrgFromEnv(t),
 		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
-		"random_suffix":   acctest.RandString(t, 10),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckVmwareengineClusterDestroyProducer(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckVmwareengineClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testVmwareEngineClusterConfig(context, 3),
@@ -67,15 +70,39 @@ func TestAccVmwareengineCluster_vmwareEngineClusterUpdate(t *testing.T) {
 func testVmwareEngineClusterConfig(context map[string]interface{}, nodeCount int) string {
 	context["node_count"] = nodeCount
 	return acctest.Nprintf(`
+resource "google_project" "project" {
+	project_id      = "tf-test%{random_suffix}"
+	name            = "tf-test%{random_suffix}"
+	org_id          = "%{org_id}"
+	billing_account = "%{billing_account}"
+}
+
+resource "google_project_service" "vmwareengine" {
+	project = google_project.project.project_id
+	service = "vmwareengine.googleapis.com"
+}
+
+resource "time_sleep" "sleep" {
+	create_duration = "1m"
+	depends_on = [
+		google_project_service.vmwareengine,
+	]
+}
 
 resource "google_vmwareengine_network" "cluster-nw" {
+  project = google_project.project.project_id
   name        = "tf-test-cluster-nw%{random_suffix}"
   location    = "global"
   type        = "STANDARD"
   description = "PC network description."
+
+  depends_on = [
+    time_sleep.sleep # Sleep allows permissions in the new project to propagate
+  ]
 }
 
 resource "google_vmwareengine_private_cloud" "cluster-pc" {
+  project = google_project.project.project_id
   location    = "%{region}-a"
   name        = "tf-test-cluster-pc%{random_suffix}"
   description = "Sample test PC."
@@ -91,6 +118,10 @@ resource "google_vmwareengine_private_cloud" "cluster-pc" {
       node_count   = 3
     }
   }
+
+  depends_on = [
+    time_sleep.sleep # Sleep allows permissions in the new project to propagate
+  ]
 }
 
 resource "google_vmwareengine_cluster" "vmw-engine-ext-cluster" {
@@ -99,15 +130,20 @@ resource "google_vmwareengine_cluster" "vmw-engine-ext-cluster" {
   node_type_configs {
     node_type_id = "standard-72"
     node_count   = %{node_count}
-		custom_core_count = 32
+    custom_core_count = 32
   }
+
+  depends_on = [
+    time_sleep.sleep # Sleep allows permissions in the new project to propagate
+  ]
 }
 
-data "google_vmwareengine_cluster" ds {
-  name = "tf-test-ext-cluster%{random_suffix}"
+data "google_vmwareengine_cluster" "ds" {
+  name = google_vmwareengine_cluster.vmw-engine-ext-cluster.name
   parent = google_vmwareengine_private_cloud.cluster-pc.id
+
   depends_on = [
-	google_vmwareengine_cluster.vmw-engine-ext-cluster,
+    time_sleep.sleep # Sleep allows permissions in the new project to propagate
   ]
 }
 `, context)

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_test.go
@@ -71,22 +71,22 @@ func testVmwareEngineClusterConfig(context map[string]interface{}, nodeCount int
 	context["node_count"] = nodeCount
 	return acctest.Nprintf(`
 resource "google_project" "project" {
-	project_id      = "tf-test%{random_suffix}"
-	name            = "tf-test%{random_suffix}"
-	org_id          = "%{org_id}"
-	billing_account = "%{billing_account}"
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
 }
 
 resource "google_project_service" "vmwareengine" {
-	project = google_project.project.project_id
-	service = "vmwareengine.googleapis.com"
+  project = google_project.project.project_id
+  service = "vmwareengine.googleapis.com"
 }
 
 resource "time_sleep" "sleep" {
-	create_duration = "1m"
-	depends_on = [
-		google_project_service.vmwareengine,
-	]
+  create_duration = "1m"
+  depends_on = [
+    google_project_service.vmwareengine,
+  ]
 }
 
 resource "google_vmwareengine_network" "cluster-nw" {

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_access_rule_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_access_rule_test.go
@@ -72,7 +72,7 @@ resource "time_sleep" "sleep" {
 }
 
 resource "google_vmwareengine_network" "external-access-rule-nw" {
-  project     = google_project.project
+  project     = google_project.project.project_id
   name        = "tf-test-sample-external-access-rule-nw-%{random_suffix}"
   location    = "global"
   type        = "STANDARD"

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_access_rule_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_access_rule_test.go
@@ -5,19 +5,25 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestAccVmwareengineExternalAccessRule_vmwareEngineExternalAccessRuleUpdate(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"region":        "southamerica-west1", // using region with low node utilization.
-		"random_suffix": acctest.RandString(t, 10),
+		"region":          "southamerica-west1", // using region with low node utilization.
+		"random_suffix":   acctest.RandString(t, 10),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
 		Steps: []resource.TestStep{
 			{
 				Config: testVmwareEngineExternalAccessRuleCreateConfig(context),
@@ -46,11 +52,34 @@ func TestAccVmwareengineExternalAccessRule_vmwareEngineExternalAccessRuleUpdate(
 
 func testVmwareEngineExternalAccessRuleCreateConfig(context map[string]interface{}) string {
 	return acctest.Nprintf(`
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
+}
+
+resource "google_project_service" "vmwareengine" {
+  project = google_project.project.project_id
+  service = "vmwareengine.googleapis.com"
+}
+
+resource "time_sleep" "sleep" {
+  create_duration = "1m"
+  depends_on = [
+    google_project_service.vmwareengine,
+  ]
+}
 
 resource "google_vmwareengine_network" "external-access-rule-nw" {
+  project     = google_project.project
   name        = "tf-test-sample-external-access-rule-nw-%{random_suffix}"
   location    = "global"
   type        = "STANDARD"
+
+  depends_on = [
+    time_sleep.sleep # Sleep allows permissions in the new project to propagate
+  ]
 }
 
 resource "google_vmwareengine_private_cloud" "external-access-rule-pc" {

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_access_rule_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_access_rule_test.go
@@ -83,6 +83,7 @@ resource "google_vmwareengine_network" "external-access-rule-nw" {
 }
 
 resource "google_vmwareengine_private_cloud" "external-access-rule-pc" {
+  project     = google_project.project.project_id
   location    = "%{region}-a"
   name        = "tf-test-sample-external-access-rule-pc-%{random_suffix}"
   type        = "TIME_LIMITED"
@@ -177,6 +178,7 @@ resource "google_vmwareengine_network" "external-access-rule-nw" {
 }
 
 resource "google_vmwareengine_private_cloud" "external-access-rule-pc" {
+  project     = google_project.project.project_id
   location    = "%{region}-a"
   name        = "tf-test-sample-external-access-rule-pc-%{random_suffix}"
   type        = "TIME_LIMITED"

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_access_rule_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_access_rule_test.go
@@ -171,11 +171,34 @@ data "google_vmwareengine_external_access_rule" "ds" {
 
 func testVmwareEngineExternalAccessRuleUpdateConfig(context map[string]interface{}) string {
 	return acctest.Nprintf(`
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
+}
+
+resource "google_project_service" "vmwareengine" {
+  project = google_project.project.project_id
+  service = "vmwareengine.googleapis.com"
+}
+
+resource "time_sleep" "sleep" {
+  create_duration = "1m"
+  depends_on = [
+    google_project_service.vmwareengine,
+  ]
+}
 
 resource "google_vmwareengine_network" "external-access-rule-nw" {
+  project     = google_project.project.project_id
   name        = "tf-test-sample-external-access-rule-nw-%{random_suffix}"
   location    = "global"
   type        = "STANDARD"
+
+  depends_on = [
+    time_sleep.sleep # Sleep allows permissions in the new project to propagate
+  ]
 }
 
 resource "google_vmwareengine_private_cloud" "external-access-rule-pc" {

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_access_rule_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_access_rule_test.go
@@ -52,38 +52,13 @@ func TestAccVmwareengineExternalAccessRule_vmwareEngineExternalAccessRuleUpdate(
 
 func testVmwareEngineExternalAccessRuleCreateConfig(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_project" "project" {
-  project_id      = "tf-test%{random_suffix}"
-  name            = "tf-test%{random_suffix}"
-  org_id          = "%{org_id}"
-  billing_account = "%{billing_account}"
-}
-
-resource "google_project_service" "vmwareengine" {
-  project = google_project.project.project_id
-  service = "vmwareengine.googleapis.com"
-}
-
-resource "time_sleep" "sleep" {
-  create_duration = "1m"
-  depends_on = [
-    google_project_service.vmwareengine,
-  ]
-}
-
 resource "google_vmwareengine_network" "external-access-rule-nw" {
-  project     = google_project.project.project_id
   name        = "tf-test-sample-external-access-rule-nw-%{random_suffix}"
   location    = "global"
   type        = "STANDARD"
-
-  depends_on = [
-    time_sleep.sleep # Sleep allows permissions in the new project to propagate
-  ]
 }
 
 resource "google_vmwareengine_private_cloud" "external-access-rule-pc" {
-  project     = google_project.project.project_id
   location    = "%{region}-a"
   name        = "tf-test-sample-external-access-rule-pc-%{random_suffix}"
   type        = "TIME_LIMITED"
@@ -102,7 +77,6 @@ resource "google_vmwareengine_private_cloud" "external-access-rule-pc" {
 }
 
 resource "google_vmwareengine_network_policy" "external-access-rule-np" {
-  project     = google_project.project.project_id
   location = "%{region}"
   name = "tf-test-sample-external-access-rule-np-%{random_suffix}"
   edge_services_cidr = "192.168.0.0/26"
@@ -171,38 +145,13 @@ data "google_vmwareengine_external_access_rule" "ds" {
 
 func testVmwareEngineExternalAccessRuleUpdateConfig(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_project" "project" {
-  project_id      = "tf-test%{random_suffix}"
-  name            = "tf-test%{random_suffix}"
-  org_id          = "%{org_id}"
-  billing_account = "%{billing_account}"
-}
-
-resource "google_project_service" "vmwareengine" {
-  project = google_project.project.project_id
-  service = "vmwareengine.googleapis.com"
-}
-
-resource "time_sleep" "sleep" {
-  create_duration = "1m"
-  depends_on = [
-    google_project_service.vmwareengine,
-  ]
-}
-
 resource "google_vmwareengine_network" "external-access-rule-nw" {
-  project     = google_project.project.project_id
   name        = "tf-test-sample-external-access-rule-nw-%{random_suffix}"
   location    = "global"
   type        = "STANDARD"
-
-  depends_on = [
-    time_sleep.sleep # Sleep allows permissions in the new project to propagate
-  ]
 }
 
 resource "google_vmwareengine_private_cloud" "external-access-rule-pc" {
-  project     = google_project.project.project_id
   location    = "%{region}-a"
   name        = "tf-test-sample-external-access-rule-pc-%{random_suffix}"
   type        = "TIME_LIMITED"
@@ -221,7 +170,6 @@ resource "google_vmwareengine_private_cloud" "external-access-rule-pc" {
 }
 
 resource "google_vmwareengine_network_policy" "external-access-rule-np" {
-  project     = google_project.project.project_id
   location = "%{region}"
   name = "tf-test-sample-external-access-rule-np-%{random_suffix}"
   edge_services_cidr = "192.168.0.0/26"

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_access_rule_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_access_rule_test.go
@@ -102,6 +102,7 @@ resource "google_vmwareengine_private_cloud" "external-access-rule-pc" {
 }
 
 resource "google_vmwareengine_network_policy" "external-access-rule-np" {
+  project     = google_project.project.project_id
   location = "%{region}"
   name = "tf-test-sample-external-access-rule-np-%{random_suffix}"
   edge_services_cidr = "192.168.0.0/26"
@@ -197,6 +198,7 @@ resource "google_vmwareengine_private_cloud" "external-access-rule-pc" {
 }
 
 resource "google_vmwareengine_network_policy" "external-access-rule-np" {
+  project     = google_project.project.project_id
   location = "%{region}"
   name = "tf-test-sample-external-access-rule-np-%{random_suffix}"
   edge_services_cidr = "192.168.0.0/26"

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_address_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_address_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -16,13 +17,18 @@ func TestAccVmwareengineExternalAddress_vmwareEngineExternalAddressUpdate(t *tes
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"region":        "southamerica-east1", // using region with low node utilization.
-		"random_suffix": acctest.RandString(t, 10),
+		"region":          "southamerica-east1", // using region with low node utilization.
+		"random_suffix":   acctest.RandString(t, 10),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t)
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
 		CheckDestroy:             testAccCheckVmwareengineExternalAddressDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -54,14 +60,39 @@ func testVmwareEngineExternalAddressConfig(context map[string]interface{}, descr
 	context["internal_ip"] = internalIp
 	context["description"] = description
 	return acctest.Nprintf(`
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
+}
+
+resource "google_project_service" "vmwareengine" {
+  project = google_project.project.project_id
+  service = "vmwareengine.googleapis.com"
+}
+
+resource "time_sleep" "sleep" {
+  create_duration = "1m"
+  depends_on = [
+    google_project_service.vmwareengine,
+  ]
+}
+
 resource "google_vmwareengine_network" "external-address-nw" {
+  project = google_project.project.project_id
   name        = "tf-test-sample-external-address-nw%{random_suffix}"
   location    = "global"
   type        = "STANDARD"
   description = "PC network description."
+
+  depends_on = [
+    time_sleep.sleep # Sleep allows permissions in the new project to propagate
+  ]
 }
 
 resource "google_vmwareengine_private_cloud" "external-address-pc" {
+  project = google_project.project.project_id
   location    = "%{region}-a"
   name        = "tf-test-sample-external-address-pc%{random_suffix}"
   type        = "TIME_LIMITED"
@@ -81,11 +112,12 @@ resource "google_vmwareengine_private_cloud" "external-address-pc" {
 }
 
 resource "google_vmwareengine_network_policy" "external-address-np" {
+  project = google_project.project.project_id
   location = "%{region}"
   name = "tf-test-sample-external-address-np%{random_suffix}"
   edge_services_cidr = "192.168.0.0/26"
   vmware_engine_network = google_vmwareengine_network.external-address-nw.id
-	internet_access {
+  internet_access {
     enabled = true
   }
   external_ip {

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_address_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_address_test.go
@@ -20,7 +20,7 @@ func TestAccVmwareengineExternalAddress_vmwareEngineExternalAddressUpdate(t *tes
 		"region":          "southamerica-east1", // using region with low node utilization.
 		"random_suffix":   acctest.RandString(t, 10),
 		"org_id":          envvar.GetTestOrgFromEnv(t),
-		"billing_account": envvar.GetTestBillingAccountFromEnv(t)
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -29,7 +29,7 @@ func TestAccVmwareengineExternalAddress_vmwareEngineExternalAddressUpdate(t *tes
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"time": {},
 		},
-		CheckDestroy:             testAccCheckVmwareengineExternalAddressDestroyProducer(t),
+		CheckDestroy: testAccCheckVmwareengineExternalAddressDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testVmwareEngineExternalAddressConfig(context, "description1", "192.168.0.66"),

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_peering_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_peering_test.go
@@ -90,6 +90,7 @@ resource "google_vmwareengine_network" "network-peering-peer-nw" {
 }
 
 resource "google_vmwareengine_network_peering" "vmw-engine-network-peering" {
+  project = google_project.project.project_id
   name = "tf-test-sample-network-peering%{random_suffix}"
   description = "%{description}"
   vmware_engine_network = google_vmwareengine_network.network-peering-nw.id

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_peering_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_peering_test.go
@@ -5,19 +5,25 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestAccVmwareengineNetworkPeering_update(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"random_suffix": acctest.RandString(t, 10),
+		"random_suffix":   acctest.RandString(t, 10),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckVmwareengineNetworkPeeringDestroyProducer(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckVmwareengineNetworkPeeringDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVmwareengineNetworkPeering_config(context, "Sample description."),
@@ -44,24 +50,51 @@ func TestAccVmwareengineNetworkPeering_update(t *testing.T) {
 func testAccVmwareengineNetworkPeering_config(context map[string]interface{}, description string) string {
 	context["description"] = description
 	return acctest.Nprintf(`
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
+}
+
+resource "google_project_service" "vmwareengine" {
+  project = google_project.project.project_id
+  service = "vmwareengine.googleapis.com"
+}
+
+resource "time_sleep" "sleep" {
+  create_duration = "1m"
+  depends_on = [
+    google_project_service.vmwareengine,
+  ]
+}
+
 resource "google_vmwareengine_network" "network-peering-nw" {
-	name              = "tf-test-sample-nw%{random_suffix}"
-	location          = "global"
-	type              = "STANDARD"
+  project           = google_project.project
+  name              = "tf-test-sample-nw%{random_suffix}"
+  location          = "global"
+  type              = "STANDARD"
+  depends_on = [
+    time_sleep.sleep, # Sleep allows permissions in the new project to propagate
+  ]
 }
 
 resource "google_vmwareengine_network" "network-peering-peer-nw" {
-	name              = "tf-test-peer-nw%{random_suffix}"
-	location          = "global"
-	type              = "STANDARD"
+  project           = google_project.project
+  name              = "tf-test-peer-nw%{random_suffix}"
+  location          = "global"
+  type              = "STANDARD"
+  depends_on = [
+    time_sleep.sleep, # Sleep allows permissions in the new project to propagate
+  ]
 }
 
 resource "google_vmwareengine_network_peering" "vmw-engine-network-peering" {
-	name = "tf-test-sample-network-peering%{random_suffix}"
-	description = "%{description}"
-	vmware_engine_network = google_vmwareengine_network.network-peering-nw.id
-	peer_network = google_vmwareengine_network.network-peering-peer-nw.id
-	peer_network_type = "VMWARE_ENGINE_NETWORK"
+  name = "tf-test-sample-network-peering%{random_suffix}"
+  description = "%{description}"
+  vmware_engine_network = google_vmwareengine_network.network-peering-nw.id
+  peer_network = google_vmwareengine_network.network-peering-peer-nw.id
+  peer_network_type = "VMWARE_ENGINE_NETWORK"
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_peering_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_peering_test.go
@@ -70,7 +70,7 @@ resource "time_sleep" "sleep" {
 }
 
 resource "google_vmwareengine_network" "network-peering-nw" {
-  project           = google_project.project
+  project           = google_project.project.project_id
   name              = "tf-test-sample-nw%{random_suffix}"
   location          = "global"
   type              = "STANDARD"
@@ -80,7 +80,7 @@ resource "google_vmwareengine_network" "network-peering-nw" {
 }
 
 resource "google_vmwareengine_network" "network-peering-peer-nw" {
-  project           = google_project.project
+  project           = google_project.project.project_id
   name              = "tf-test-peer-nw%{random_suffix}"
   location          = "global"
   type              = "STANDARD"

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_policy_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_policy_test.go
@@ -13,14 +13,19 @@ func TestAccVmwareengineNetworkPolicy_update(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"region":        envvar.GetTestRegionFromEnv(),
-		"random_suffix": acctest.RandString(t, 10),
+		"region":          envvar.GetTestRegionFromEnv(),
+		"random_suffix":   acctest.RandString(t, 10),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckVmwareengineNetworkPolicyDestroyProducer(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckVmwareengineNetworkPolicyDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVmwareengineNetworkPolicy_config(context, "description1", "192.168.0.0/26", false, false),
@@ -51,28 +56,52 @@ func testAccVmwareengineNetworkPolicy_config(context map[string]interface{}, des
 	context["description"] = description
 
 	return acctest.Nprintf(`
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
+}
+
+resource "google_project_service" "vmwareengine" {
+  project = google_project.project.project_id
+  service = "vmwareengine.googleapis.com"
+}
+
+resource "time_sleep" "sleep" {
+  create_duration = "1m"
+  depends_on = [
+    google_project_service.vmwareengine,
+  ]
+}
+
 resource "google_vmwareengine_network" "network-policy-nw" {
-    name              = "tf-test-sample-nw%{random_suffix}"
-    location          = "global" 
-    type              = "STANDARD"
-    description       = "VMwareEngine standard network sample"
+  project           = google_project.project
+  name              = "tf-test-sample-nw%{random_suffix}"
+  location          = "global" 
+  type              = "STANDARD"
+  description       = "VMwareEngine standard network sample"
+
+  depends_on = [
+    time_sleep.sleep # Sleep allows permissions in the new project to propagate
+  ]
 }
 
 resource "google_vmwareengine_network_policy" "vmw-engine-network-policy" {
-    location = "%{region}"
-    name = "tf-test-sample-network-policy%{random_suffix}"
-	description = "%{description}" 
+  location = "%{region}"
+  name = "tf-test-sample-network-policy%{random_suffix}"
+  description = "%{description}" 
 
-    internet_access {
-        enabled = "%{internet_access}"
-    }
+  internet_access {
+    enabled = "%{internet_access}"
+  }
 
-    external_ip {
-        enabled = "%{external_ip}"
-    }
+  external_ip {
+    enabled = "%{external_ip}"
+  }
 
-    edge_services_cidr = "%{edge_services_cidr}"
-    vmware_engine_network = google_vmwareengine_network.network-policy-nw.id
+  edge_services_cidr = "%{edge_services_cidr}"
+  vmware_engine_network = google_vmwareengine_network.network-policy-nw.id
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_policy_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_policy_test.go
@@ -88,6 +88,7 @@ resource "google_vmwareengine_network" "network-policy-nw" {
 }
 
 resource "google_vmwareengine_network_policy" "vmw-engine-network-policy" {
+  project           = google_project.project.project_id
   location = "%{region}"
   name = "tf-test-sample-network-policy%{random_suffix}"
   description = "%{description}" 

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_policy_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_policy_test.go
@@ -76,7 +76,7 @@ resource "time_sleep" "sleep" {
 }
 
 resource "google_vmwareengine_network" "network-policy-nw" {
-  project           = google_project.project
+  project           = google_project.project.project_id
   name              = "tf-test-sample-nw%{random_suffix}"
   location          = "global" 
   type              = "STANDARD"

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_test.go
@@ -26,10 +26,6 @@ func TestAccVmwareengineNetwork_vmwareEngineNetworkUpdate(t *testing.T) {
 			"time": {},
 		},
 		CheckDestroy: testAccCheckVmwareengineNetworkDestroyProducer(t),
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"random": {},
-			"time":   {},
-		},
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(configTemplate, "description1"),

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_test.go
@@ -22,7 +22,10 @@ func TestAccVmwareengineNetwork_vmwareEngineNetworkUpdate(t *testing.T) {
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckVmwareengineNetworkDestroyProducer(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckVmwareengineNetworkDestroyProducer(t),
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"random": {},
 			"time":   {},

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -17,14 +18,19 @@ func TestAccVmwareenginePrivateCloud_vmwareEnginePrivateCloudUpdate(t *testing.T
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"region":        "southamerica-west1",
-		"random_suffix": acctest.RandString(t, 10),
+		"region":          "southamerica-west1",
+		"random_suffix":   acctest.RandString(t, 10),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckVmwareenginePrivateCloudDestroyProducer(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckVmwareenginePrivateCloudDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testPrivateCloudUpdateConfig(context, "description1", 1),
@@ -67,11 +73,34 @@ func testPrivateCloudUpdateConfig(context map[string]interface{}, description st
 	context["description"] = description
 
 	return acctest.Nprintf(`
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
+}
+
+resource "google_project_service" "vmwareengine" {
+  project = google_project.project.project_id
+  service = "vmwareengine.googleapis.com"
+}
+
+resource "time_sleep" "sleep" {
+  create_duration = "1m"
+  depends_on = [
+    google_project_service.vmwareengine,
+  ]
+}
+
 resource "google_vmwareengine_network" "default-nw" {
+  project           = google_project.project
   name              = "tf-test-pc-nw-%{random_suffix}"
   location          = "global"
   type              = "STANDARD"
   description       = "PC network description."
+  depends_on = [
+    time_sleep.sleep # Sleep allows permissions in the new project to propagate
+  ]
 }
 
 resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
@@ -104,6 +104,7 @@ resource "google_vmwareengine_network" "default-nw" {
 }
 
 resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
+  project     = google_project.project.project_id
   location = "%{region}-a"
   name = "tf-test-sample-pc%{random_suffix}"
   description = "%{description}"
@@ -123,6 +124,7 @@ resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
 }
 
 data "google_vmwareengine_private_cloud" "ds" {
+	project     = google_project.project.project_id
 	location = "%{region}-a"
 	name = "tf-test-sample-pc%{random_suffix}"
 	depends_on = [

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
@@ -93,7 +93,7 @@ resource "time_sleep" "sleep" {
 }
 
 resource "google_vmwareengine_network" "default-nw" {
-  project           = google_project.project
+  project           = google_project.project.project_id
   name              = "tf-test-pc-nw-%{random_suffix}"
   location          = "global"
   type              = "STANDARD"

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_subnet_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_subnet_test.go
@@ -73,6 +73,7 @@ resource "time_sleep" "sleep" {
 }
 
 resource "google_vmwareengine_network" "subnet-nw" {
+  project     = google_project.project.project_id
   name        = "tf-test-subnet-nw%{random_suffix}"
   location    = "global"
   type        = "STANDARD"

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_subnet_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_subnet_test.go
@@ -83,6 +83,7 @@ resource "google_vmwareengine_network" "subnet-nw" {
 }
 
 resource "google_vmwareengine_private_cloud" "subnet-pc" {
+  project     = google_project.project.project_id
   location    = "%{region}-a"
   name        = "tf-test-subnet-pc%{random_suffix}"
   type        = "TIME_LIMITED"

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_subnet_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_subnet_test.go
@@ -5,25 +5,19 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestAccVmwareengineSubnet_vmwareEngineUserDefinedSubnetUpdate(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"region":          "southamerica-west1", // using region with low node utilization.
-		"random_suffix":   acctest.RandString(t, 10),
-		"org_id":          envvar.GetTestOrgFromEnv(t),
-		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
+		"region":        "southamerica-west1", // using region with low node utilization.
+		"random_suffix": acctest.RandString(t, 10),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"time": {},
-		},
 		Steps: []resource.TestStep{
 			{
 				Config: testVmwareEngineSubnetConfig(context, "192.168.1.0/26"),
@@ -53,38 +47,14 @@ func TestAccVmwareengineSubnet_vmwareEngineUserDefinedSubnetUpdate(t *testing.T)
 func testVmwareEngineSubnetConfig(context map[string]interface{}, ipCidrRange string) string {
 	context["ip_cidr_range"] = ipCidrRange
 	return acctest.Nprintf(`
-resource "google_project" "project" {
-  project_id      = "tf-test%{random_suffix}"
-  name            = "tf-test%{random_suffix}"
-  org_id          = "%{org_id}"
-  billing_account = "%{billing_account}"
-}
-
-resource "google_project_service" "vmwareengine" {
-  project = google_project.project.project_id
-  service = "vmwareengine.googleapis.com"
-}
-
-resource "time_sleep" "sleep" {
-  create_duration = "1m"
-  depends_on = [
-    google_project_service.vmwareengine,
-  ]
-}
-
 resource "google_vmwareengine_network" "subnet-nw" {
-  project     = google_project.project.project_id
   name        = "tf-test-subnet-nw%{random_suffix}"
   location    = "global"
   type        = "STANDARD"
   description = "PC network description."
-  depends_on = [
-    time_sleep.sleep # Sleep allows permissions in the new project to propagate
-  ]
 }
 
 resource "google_vmwareengine_private_cloud" "subnet-pc" {
-  project     = google_project.project.project_id
   location    = "%{region}-a"
   name        = "tf-test-subnet-pc%{random_suffix}"
   type        = "TIME_LIMITED"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Closes https://github.com/hashicorp/terraform-provider-google/issues/16911

See [this comment for context](https://github.com/hashicorp/terraform-provider-google/issues/16911#issuecomment-1879223432). Tl;dr all VMware acceptance tests currently fail with error messages that don't include actionable information to help make the tests pass. In the past there was one situation where the underlying cause was quotas in the project. Therefore, until the error messages help us optimise in a smarter way, this PR updates VMware acc tests to run tests within temporary new projects.

Note: In this PR I've had some tests that failed after being modified to use separate projects - for these I've reverted the changes. 

Here are the affected tests:
- TestAccDataSourceVmwareengineNetworkPeering_basic
- TestAccDataSourceVmwareengineNetworkPolicy_basic
- TestAccDataSourceVmwareEngineNetwork_basic
- TestAccVmwareengineExternalAccessRule_vmwareEngineExternalAccessRuleUpdate
- TestAccVmwareengineExternalAddress_vmwareEngineExternalAddressUpdate
- TestAccVmwareengineNetworkPeering_update
- TestAccVmwareengineNetworkPolicy_update
- TestAccVmwareengineCluster_vmwareEngineClusterUpdate - skipped in VCR - [here's a build in TeamCity](https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_Google_MmUpstreamTesting_GOOGLE_PACKAGE_VMWAREENGINE/90291?buildTab=overview&expandBuildDeploymentsSection=false&hideTestsFromDependencies=false&expandBuildTestsSection=true&hideProblemsFromDependencies=false&expandBuildChangesSection=true)  - the test still fails due to 'error code 13'
- TestAccVmwareenginePrivateCloud_vmwareEnginePrivateCloudUpdate - skipped in VCR - [here's a build in TeamCity](https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_Google_MmUpstreamTesting_GOOGLE_PACKAGE_VMWAREENGINE/90295?buildTab=overview&hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildChangesSection=true) - the test still fails due to 'error code 13'

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
