### PR TITLE
Firestore: Fix tests

### DIFF
--- a/mmv1/products/firestore/BackupSchedule.yaml
+++ b/mmv1/products/firestore/BackupSchedule.yaml
@@ -40,16 +40,24 @@ docs: !ruby/object:Provider::Terraform::Docs
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'firestore_backup_schedule_daily'
-    primary_resource_id:
-      'daily-backup'
+    primary_resource_id: 'daily-backup'
+    vars:
+      database_id: 'database-id'
+      delete_protection_state: "DELETE_PROTECTION_ENABLED"
     test_env_vars:
-      project_id: :FIRESTORE_PROJECT_NAME
+      project_id: :PROJECT_NAME
+    test_vars_overrides:
+      delete_protection_state: '"DELETE_PROTECTION_DISABLED"'
   - !ruby/object:Provider::Terraform::Examples
     name: 'firestore_backup_schedule_weekly'
-    primary_resource_id:
-      'weekly-backup'
+    primary_resource_id: 'weekly-backup'
+    vars:
+      database_id: 'database-id'
+      delete_protection_state: "DELETE_PROTECTION_ENABLED"
     test_env_vars:
-      project_id: :FIRESTORE_PROJECT_NAME
+      project_id: :PROJECT_NAME
+    test_vars_overrides:
+      delete_protection_state: '"DELETE_PROTECTION_DISABLED"'
 parameters:
   - !ruby/object:Api::Type::String
     name: database
@@ -64,7 +72,7 @@ properties:
     output: true
     description: |
       The unique backup schedule identifier across all locations and databases for the given project. Format:
-      `projects/{{project}}/databases/{{database}}/backupSchedules/{{backupSchedule}}
+      `projects/{{project}}/databases/{{database}}/backupSchedules/{{backupSchedule}}`
     immutable: true
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
   - !ruby/object:Api::Type::String

--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -57,22 +57,18 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'firestore_default_database'
     primary_resource_id: 'database'
-    pull_external: true
-    vars:
-      delete_protection_state: "DELETE_PROTECTION_ENABLED"
     test_env_vars:
       project_id: :PROJECT_NAME
-    test_vars_overrides:
-      delete_protection_state: '"DELETE_PROTECTION_DISABLED"'
     ignore_read_extra:
       - project
       - etag
       - deletion_policy
+    skip_test: true
   - !ruby/object:Provider::Terraform::Examples
     name: 'firestore_database'
     primary_resource_id: 'database'
     vars:
-      name: "example-database-id"
+      database_id: "database-id"
       delete_protection_state: "DELETE_PROTECTION_ENABLED"
     test_env_vars:
       project_id: :PROJECT_NAME
@@ -85,12 +81,8 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'firestore_default_database_in_datastore_mode'
     primary_resource_id: 'datastore_mode_database'
-    vars:
-      delete_protection_state: "DELETE_PROTECTION_ENABLED"
     test_env_vars:
       project_id: :PROJECT_NAME
-    test_vars_overrides:
-      delete_protection_state: '"DELETE_PROTECTION_DISABLED"'
     ignore_read_extra:
       - project
       - etag
@@ -100,7 +92,7 @@ examples:
     name: 'firestore_database_in_datastore_mode'
     primary_resource_id: 'datastore_mode_database'
     vars:
-      name: "example-database-id"
+      database_id: "database-id"
       delete_protection_state: "DELETE_PROTECTION_ENABLED"
     test_env_vars:
       project_id: :PROJECT_NAME

--- a/mmv1/products/firestore/Document.yaml
+++ b/mmv1/products/firestore/Document.yaml
@@ -43,16 +43,20 @@ examples:
     name: 'firestore_document_basic'
     primary_resource_id: 'mydoc'
     test_env_vars:
-      project_id: :FIRESTORE_PROJECT_NAME
+      org_id: :ORG_ID
     vars:
       document_id: 'my-doc-id'
+      project_id: 'project-id'
+    pull_external: true
   - !ruby/object:Provider::Terraform::Examples
     name: 'firestore_document_nested_document'
     primary_resource_id: 'mydoc'
     test_env_vars:
-      project_id: :FIRESTORE_PROJECT_NAME
+      org_id: :ORG_ID
     vars:
       document_id: 'my-doc-id'
+      project_id: 'project-id'
+    pull_external: true
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/firestore_document.go.erb
   decoder: templates/terraform/decoders/firestore_document.go.erb

--- a/mmv1/products/firestore/Field.yaml
+++ b/mmv1/products/firestore/Field.yaml
@@ -60,18 +60,33 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'firestore_field_basic'
     primary_resource_id: 'basic'
+    vars:
+      database_id: 'database-id'
+      delete_protection_state: "DELETE_PROTECTION_ENABLED"
     test_env_vars:
-      project_id: :FIRESTORE_PROJECT_NAME
+      project_id: :PROJECT_NAME
+    test_vars_overrides:
+      delete_protection_state: '"DELETE_PROTECTION_DISABLED"'
   - !ruby/object:Provider::Terraform::Examples
     name: 'firestore_field_timestamp'
     primary_resource_id: 'timestamp'
+    vars:
+      database_id: 'database-id'
+      delete_protection_state: "DELETE_PROTECTION_ENABLED"
     test_env_vars:
-      project_id: :FIRESTORE_PROJECT_NAME
+      project_id: :PROJECT_NAME
+    test_vars_overrides:
+      delete_protection_state: '"DELETE_PROTECTION_DISABLED"'
   - !ruby/object:Provider::Terraform::Examples
     name: 'firestore_field_match_override'
     primary_resource_id: 'match_override'
+    vars:
+      database_id: 'database-id'
+      delete_protection_state: "DELETE_PROTECTION_ENABLED"
     test_env_vars:
-      project_id: :FIRESTORE_PROJECT_NAME
+      project_id: :PROJECT_NAME
+    test_vars_overrides:
+      delete_protection_state: '"DELETE_PROTECTION_DISABLED"'
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/index_self_link_as_name_set_project.go.erb
   encoder: templates/terraform/encoders/firestore_field.go.erb

--- a/mmv1/products/firestore/Index.yaml
+++ b/mmv1/products/firestore/Index.yaml
@@ -59,19 +59,19 @@ examples:
     name: 'firestore_index_basic'
     primary_resource_id:
       'my-index'
-      # This example relies on a well-known collection having been created and
-      # Firestore being enabled on the project. We can't do that automatically
-      # so we need a pre-created project.
+    vars:
+      project_id: "project-id"
     test_env_vars:
-      project_id: :FIRESTORE_PROJECT_NAME
+      org_id: :ORG_ID
+    pull_external: true
   - !ruby/object:Provider::Terraform::Examples
     name: 'firestore_index_datastore_mode'
     primary_resource_id:
-      'my-datastore-mode-index'
+      'my-index'
+    test_env_vars:
       # This example relies on a well-known collection having been created and
       # Firestore being enabled on the project. We can't do that automatically
-      # so we need a pre-created project.
-    test_env_vars:
+      # for Datastore mode so we need a pre-created project.
       project_id: :FIRESTORE_PROJECT_NAME
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/index_self_link_as_name_set_project.go.erb

--- a/mmv1/templates/terraform/examples/firestore_backup_schedule_daily.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_backup_schedule_daily.tf.erb
@@ -1,5 +1,16 @@
+resource "google_firestore_database" "database" {
+  project     = "<%= ctx[:test_env_vars]['project_id'] %>"
+  name        = "<%= ctx[:vars]['database_id'] %>"
+  location_id = "nam5"
+  type        = "FIRESTORE_NATIVE"
+
+  delete_protection_state = "<%= ctx[:vars]['delete_protection_state'] %>"
+  deletion_policy         = "DELETE"
+}
+
 resource "google_firestore_backup_schedule" "<%= ctx[:primary_resource_id] %>" {
-  project = "<%= ctx[:test_env_vars]['project_id'] %>"
+  project  = "<%= ctx[:test_env_vars]['project_id'] %>"
+  database = google_firestore_database.database.name
 
   retention = "604800s" // 7 days (maximum possible value for daily backups)
 

--- a/mmv1/templates/terraform/examples/firestore_backup_schedule_weekly.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_backup_schedule_weekly.tf.erb
@@ -1,6 +1,16 @@
+resource "google_firestore_database" "database" {
+  project     = "<%= ctx[:test_env_vars]['project_id'] %>"
+  name        = "<%= ctx[:vars]['database_id'] %>"
+  location_id = "nam5"
+  type        = "FIRESTORE_NATIVE"
+
+  delete_protection_state = "<%= ctx[:vars]['delete_protection_state'] %>"
+  deletion_policy         = "DELETE"
+}
+
 resource "google_firestore_backup_schedule" "<%= ctx[:primary_resource_id] %>" {
   project  = "<%= ctx[:test_env_vars]['project_id'] %>"
-  database = "(default)"
+  database = google_firestore_database.database.name
 
   retention = "8467200s" // 14 weeks (maximum possible value for weekly backups)
 

--- a/mmv1/templates/terraform/examples/firestore_database.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_database.tf.erb
@@ -1,6 +1,6 @@
 resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
   project                           = "<%= ctx[:test_env_vars]['project_id'] %>"
-  name                              = "<%= ctx[:vars]['name']%>"
+  name                              = "<%= ctx[:vars]['database_id']%>"
   location_id                       = "nam5"
   type                              = "FIRESTORE_NATIVE"
   concurrency_mode                  = "OPTIMISTIC"

--- a/mmv1/templates/terraform/examples/firestore_database_in_datastore_mode.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_database_in_datastore_mode.tf.erb
@@ -1,6 +1,6 @@
 resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
   project                           = "<%= ctx[:test_env_vars]['project_id'] %>"
-  name                              = "<%= ctx[:vars]['name']%>"
+  name                              = "<%= ctx[:vars]['database_id']%>"
   location_id                       = "nam5"
   type                              = "DATASTORE_MODE"
   concurrency_mode                  = "OPTIMISTIC"

--- a/mmv1/templates/terraform/examples/firestore_default_database.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_default_database.tf.erb
@@ -1,8 +1,6 @@
 resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
-  project                 = "<%= ctx[:test_env_vars]['project_id'] %>"
-  name                    = "(default)"
-  location_id             = "nam5"
-  type                    = "FIRESTORE_NATIVE"
-  delete_protection_state = "<%= ctx[:vars]['delete_protection_state'] %>"
-  deletion_policy         = "DELETE"
+  project     = "<%= ctx[:test_env_vars]['project_id'] %>"
+  name        = "(default)"
+  location_id = "nam5"
+  type        = "FIRESTORE_NATIVE"
 }

--- a/mmv1/templates/terraform/examples/firestore_default_database_in_datastore_mode.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_default_database_in_datastore_mode.tf.erb
@@ -1,8 +1,6 @@
 resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
-  project                 = "<%= ctx[:test_env_vars]['project_id'] %>"
-  name                    = "(default)"
-  location_id             = "nam5"
-  type                    = "DATASTORE_MODE"
-  delete_protection_state = "<%= ctx[:vars]['delete_protection_state'] %>"
-  deletion_policy         = "DELETE"
+  project     = "<%= ctx[:test_env_vars]['project_id'] %>"
+  name        = "(default)"
+  location_id = "nam5"
+  type        = "DATASTORE_MODE"
 }

--- a/mmv1/templates/terraform/examples/firestore_document_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_document_basic.tf.erb
@@ -1,5 +1,35 @@
+resource "google_project" "project" {
+  project_id = "<%= ctx[:vars]['project_id'] %>"
+  name       = "<%= ctx[:vars]['project_id'] %>"
+  org_id     = "<%= ctx[:test_env_vars]['org_id'] %>"
+}
+
+resource "time_sleep" "wait_60_seconds" {
+  depends_on = [google_project.project]
+
+  create_duration = "60s"
+}
+
+resource "google_project_service" "firestore" {
+  project = google_project.project.project_id
+  service = "firestore.googleapis.com"
+
+  # Needed for CI tests for permissions to propagate, should not be needed for actual usage
+  depends_on = [time_sleep.wait_60_seconds]
+}
+
+resource "google_firestore_database" "database" {
+  project     = google_project.project.project_id
+  name        = "(default)"
+  location_id = "nam5"
+  type        = "FIRESTORE_NATIVE"
+
+  depends_on = [google_project_service.firestore]
+}
+
 resource "google_firestore_document" "<%= ctx[:primary_resource_id] %>" {
-  project     = "<%= ctx[:test_env_vars]['project_id'] %>"
+  project     = google_project.project.project_id
+  database    = google_firestore_database.database.name
   collection  = "somenewcollection"
   document_id = "<%= ctx[:vars]['document_id'] %>"
   fields      = "{\"something\":{\"mapValue\":{\"fields\":{\"akey\":{\"stringValue\":\"avalue\"}}}}}"

--- a/mmv1/templates/terraform/examples/firestore_document_nested_document.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_document_nested_document.tf.erb
@@ -1,19 +1,51 @@
+resource "google_project" "project" {
+  project_id      = "<%= ctx[:vars]['project_id'] %>"
+  name            = "<%= ctx[:vars]['project_id'] %>"
+  org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
+}
+
+resource "time_sleep" "wait_60_seconds" {
+  depends_on = [google_project.project]
+
+  create_duration = "60s"
+}
+
+resource "google_project_service" "firestore" {
+  project = google_project.project.project_id
+  service = "firestore.googleapis.com"
+
+  # Needed for CI tests for permissions to propagate, should not be needed for actual usage
+  depends_on = [time_sleep.wait_60_seconds]
+}
+
+resource "google_firestore_database" "database" {
+  project     = google_project.project.project_id
+  name        = "(default)"
+  location_id = "nam5"
+  type        = "FIRESTORE_NATIVE"
+
+  depends_on = [google_project_service.firestore]
+}
+
 resource "google_firestore_document" "<%= ctx[:primary_resource_id] %>" {
-  project     = "<%= ctx[:test_env_vars]['project_id'] %>"
+  project     = google_project.project.project_id
+  database    = google_firestore_database.database.name
   collection  = "somenewcollection"
   document_id = "<%= ctx[:vars]['document_id'] %>"
   fields      = "{\"something\":{\"mapValue\":{\"fields\":{\"akey\":{\"stringValue\":\"avalue\"}}}}}"
 }
 
 resource "google_firestore_document" "sub_document" {
-  project     = "<%= ctx[:test_env_vars]['project_id'] %>"
+  project     = google_project.project.project_id
+  database    = google_firestore_database.database.name
   collection  = "${google_firestore_document.<%= ctx[:primary_resource_id] %>.path}/subdocs"
   document_id = "bitcoinkey"
   fields      = "{\"something\":{\"mapValue\":{\"fields\":{\"ayo\":{\"stringValue\":\"val2\"}}}}}"
 }
 
 resource "google_firestore_document" "sub_sub_document" {
-  project     = "<%= ctx[:test_env_vars]['project_id'] %>"
+  project     = google_project.project.project_id
+  database    = google_firestore_database.database.name
   collection  = "${google_firestore_document.sub_document.path}/subsubdocs"
   document_id = "asecret"
   fields      = "{\"something\":{\"mapValue\":{\"fields\":{\"secret\":{\"stringValue\":\"hithere\"}}}}}"

--- a/mmv1/templates/terraform/examples/firestore_field_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_field_basic.tf.erb
@@ -1,8 +1,18 @@
+resource "google_firestore_database" "database" {
+  project     = "<%= ctx[:test_env_vars]['project_id'] %>"
+  name        = "<%= ctx[:vars]['database_id'] %>"
+  location_id = "nam5"
+  type        = "FIRESTORE_NATIVE"
+
+  delete_protection_state = "<%= ctx[:vars]['delete_protection_state'] %>"
+  deletion_policy         = "DELETE"
+}
+
 resource "google_firestore_field" "<%= ctx[:primary_resource_id] %>" {
-  project = "<%= ctx[:test_env_vars]['project_id'] %>"
-  database = "(default)"
+  project    = "<%= ctx[:test_env_vars]['project_id'] %>"
+  database   = google_firestore_database.database.name
   collection = "chatrooms_%{random_suffix}"
-  field = "basic"
+  field      = "basic"
 
   index_config {
     indexes {

--- a/mmv1/templates/terraform/examples/firestore_field_complex_field_name.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_field_complex_field_name.tf.erb
@@ -1,7 +1,7 @@
 resource "google_firestore_field" "<%= ctx[:primary_resource_id] %>" {
-  project = "<%= ctx[:test_env_vars]['project_id'] %>"
+  project    = "<%= ctx[:test_env_vars]['project_id'] %>"
   collection = "chatrooms_%{random_suffix}"
-  field = "`*`"
+  field      = "`*`"
 
   index_config {
     indexes {

--- a/mmv1/templates/terraform/examples/firestore_field_match_override.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_field_match_override.tf.erb
@@ -1,7 +1,18 @@
+resource "google_firestore_database" "database" {
+  project     = "<%= ctx[:test_env_vars]['project_id'] %>"
+  name        = "<%= ctx[:vars]['database_id'] %>"
+  location_id = "nam5"
+  type        = "FIRESTORE_NATIVE"
+
+  delete_protection_state = "<%= ctx[:vars]['delete_protection_state'] %>"
+  deletion_policy         = "DELETE"
+}
+
 resource "google_firestore_field" "<%= ctx[:primary_resource_id] %>" {
-  project = "<%= ctx[:test_env_vars]['project_id'] %>"
+  project    = "<%= ctx[:test_env_vars]['project_id'] %>"
+  database   = google_firestore_database.database.name
   collection = "chatrooms_%{random_suffix}"
-  field = "field_with_same_configuration_as_ancestor"
+  field      = "field_with_same_configuration_as_ancestor"
 
   index_config {
     indexes {

--- a/mmv1/templates/terraform/examples/firestore_field_timestamp.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_field_timestamp.tf.erb
@@ -1,7 +1,18 @@
+resource "google_firestore_database" "database" {
+  project     = "<%= ctx[:test_env_vars]['project_id'] %>"
+  name        = "<%= ctx[:vars]['database_id'] %>"
+  location_id = "nam5"
+  type        = "FIRESTORE_NATIVE"
+
+  delete_protection_state = "<%= ctx[:vars]['delete_protection_state'] %>"
+  deletion_policy         = "DELETE"
+}
+
 resource "google_firestore_field" "<%= ctx[:primary_resource_id] %>" {
-  project = "<%= ctx[:test_env_vars]['project_id'] %>"
-  collection = "chatrooms_%{random_suffix}"
-  field = "timestamp"
+  project    = "<%= ctx[:test_env_vars]['project_id'] %>"
+  database   = google_firestore_database.database.name
+  collection = "chatrooms"
+  field      = "timestamp"
 
   # enables a TTL policy for the document based on the value of entries with this field
   ttl_config {}

--- a/mmv1/templates/terraform/examples/firestore_index_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_index_basic.tf.erb
@@ -1,7 +1,45 @@
-resource "google_firestore_index" "<%= ctx[:primary_resource_id] %>" {
-  project = "<%= ctx[:test_env_vars]['project_id'] %>"
+resource "google_project" "project" {
+  project_id = "<%= ctx[:vars]['project_id'] %>"
+  name       = "<%= ctx[:vars]['project_id'] %>"
+  org_id     = "<%= ctx[:test_env_vars]['org_id'] %>"
+}
 
-  collection = "chatrooms"
+resource "time_sleep" "wait_60_seconds" {
+  depends_on = [google_project.project]
+
+  create_duration = "60s"
+}
+
+resource "google_project_service" "firestore" {
+  project = google_project.project.project_id
+  service = "firestore.googleapis.com"
+
+  # Needed for CI tests for permissions to propagate, should not be needed for actual usage
+  depends_on = [time_sleep.wait_60_seconds]
+}
+
+resource "google_firestore_database" "database" {
+  project     = google_project.project.project_id
+  name        = "(default)"
+  location_id = "nam5"
+  type        = "FIRESTORE_NATIVE"
+
+  depends_on = [google_project_service.firestore]
+}
+
+# Creating a document also creates its collection
+resource "google_firestore_document" "document" {
+  project     = google_project.project.project_id
+  database    = google_firestore_database.database.name
+  collection  = "somenewcollection"
+  document_id = "<%= ctx[:vars]['document_id'] %>"
+  fields      = "{\"something\":{\"mapValue\":{\"fields\":{\"akey\":{\"stringValue\":\"avalue\"}}}}}"
+}
+
+resource "google_firestore_index" "<%= ctx[:primary_resource_id] %>" {
+  project    = google_project.project.project_id
+  database   = google_firestore_database.database.name
+  collection = google_firestore_document.document.collection
 
   fields {
     field_path = "name"

--- a/mmv1/templates/terraform/examples/firestore_index_datastore_mode.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_index_datastore_mode.tf.erb
@@ -1,6 +1,6 @@
 resource "google_firestore_index" "<%= ctx[:primary_resource_id] %>" {
-  project = "<%= ctx[:test_env_vars]['project_id'] %>"
-
+  project    = "<%= ctx[:test_env_vars]['project_id'] %>"
+  database   = "(default)"
   collection = "chatrooms"
 
   query_scope = "COLLECTION_RECURSIVE"
@@ -15,5 +15,4 @@ resource "google_firestore_index" "<%= ctx[:primary_resource_id] %>" {
     field_path = "description"
     order      = "DESCENDING"
   }
-
 }

--- a/mmv1/third_party/terraform/services/firestore/resource_firestore_document_test.go
+++ b/mmv1/third_party/terraform/services/firestore/resource_firestore_document_test.go
@@ -12,15 +12,18 @@ import (
 func TestAccFirestoreDocument_update(t *testing.T) {
 	t.Parallel()
 
-	name := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
-	project := envvar.GetTestFirestoreProjectFromEnv(t)
+	orgId := envvar.GetTestOrgFromEnv(t)
+	randomSuffix := acctest.RandString(t, 10)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFirestoreDocument_update(project, name),
+				Config: testAccFirestoreDocument_update(randomSuffix, orgId, "OPTIMISTIC", "val1"),
 			},
 			{
 				ResourceName:      "google_firestore_document.instance",
@@ -28,7 +31,7 @@ func TestAccFirestoreDocument_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccFirestoreDocument_update2(project, name),
+				Config: testAccFirestoreDocument_update(randomSuffix, orgId, "OPTIMISTIC", "val2"),
 			},
 			{
 				ResourceName:      "google_firestore_document.instance",
@@ -39,26 +42,47 @@ func TestAccFirestoreDocument_update(t *testing.T) {
 	})
 }
 
-func testAccFirestoreDocument_update(project, name string) string {
+func testAccFirestoreDocument_update_basicDeps(randomSuffix, orgId string) string {
 	return fmt.Sprintf(`
-resource "google_firestore_document" "instance" {
-	project     = "%s"
-	database    = "(default)"
-	collection  = "somenewcollection"
-	document_id = "%s"
-	fields      = "{\"something\":{\"mapValue\":{\"fields\":{\"yo\":{\"stringValue\":\"val1\"}}}}}"
-}
-`, project, name)
+resource "google_project" "project" {
+	project_id = "tf-test%s"
+	name       = "tf-test%s"
+	org_id     = "%s"
 }
 
-func testAccFirestoreDocument_update2(project, name string) string {
-	return fmt.Sprintf(`
+resource "time_sleep" "wait_60_seconds" {
+	depends_on = [google_project.project]
+
+	create_duration = "60s"
+}
+
+resource "google_project_service" "firestore" {
+	project = google_project.project.project_id
+	service = "firestore.googleapis.com"
+
+	# Needed for CI tests for permissions to propagate, should not be needed for actual usage
+	depends_on = [time_sleep.wait_60_seconds]
+}
+
+resource "google_firestore_database" "database" {
+	project     = google_project.project.project_id
+	name        = "(default)"
+	location_id = "nam5"
+	type        = "FIRESTORE_NATIVE"
+
+	depends_on = [google_project_service.firestore]
+}
+`, randomSuffix, randomSuffix, orgId)
+}
+
+func testAccFirestoreDocument_update(randomSuffix, orgId, name, val string) string {
+	return testAccFirestoreDocument_update_basicDeps(randomSuffix, orgId) + fmt.Sprintf(`
 resource "google_firestore_document" "instance" {
-	project     = "%s"
-	database    = "(default)"
+	project     = google_project.project.project_id
+	database    = google_firestore_database.database.name
 	collection  = "somenewcollection"
 	document_id = "%s"
-	fields      = "{\"something\":{\"mapValue\":{\"fields\":{\"yo\":{\"stringValue\":\"val2\"}}}}}"
+	fields      = "{\"something\":{\"mapValue\":{\"fields\":{\"yo\":{\"stringValue\":\"%s\"}}}}}"
 }
-`, project, name)
+`, name, val)
 }

--- a/mmv1/third_party/terraform/services/firestore/resource_firestore_field_test.go
+++ b/mmv1/third_party/terraform/services/firestore/resource_firestore_field_test.go
@@ -13,34 +13,37 @@ func TestAccFirestoreField_firestoreFieldUpdateAddIndexExample(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"project_id":    envvar.GetTestFirestoreProjectFromEnv(t),
+		"org_id":        envvar.GetTestOrgFromEnv(t),
 		"random_suffix": acctest.RandString(t, 10),
 		"resource_name": "add_index",
 	}
-	testAccFirestoreField_runUpdateTest(testAccFirestoreField_firestoreFieldUpdateAddIndexExample(context), t, context)
+	testAccFirestoreField_runUpdateTest(testAccFirestoreField_firestoreFieldUpdateAddIndexExample(context), true, t, context)
 }
 
 func TestAccFirestoreField_firestoreFieldUpdateAddTTLExample(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"project_id":    envvar.GetTestFirestoreProjectFromEnv(t),
+		"project_id":    envvar.GetTestProjectFromEnv(),
 		"random_suffix": acctest.RandString(t, 10),
 		"resource_name": "add_ttl",
 	}
-	testAccFirestoreField_runUpdateTest(testAccFirestoreField_firestoreFieldUpdateAddTTLExample(context), t, context)
+	testAccFirestoreField_runUpdateTest(testAccFirestoreField_firestoreFieldUpdateAddTTLExample(context), false, t, context)
 }
 
-func testAccFirestoreField_runUpdateTest(updateConfig string, t *testing.T, context map[string]interface{}) {
+func testAccFirestoreField_runUpdateTest(updateConfig string, useOwnProject bool, t *testing.T, context map[string]interface{}) {
 	resourceName := context["resource_name"].(string)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckFirestoreFieldDestroyProducer(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckFirestoreFieldDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFirestoreField_firestoreFieldUpdateInitialExample(context),
+				Config: testAccFirestoreField_firestoreFieldUpdateInitialExample(context, useOwnProject),
 			},
 			{
 				ResourceName:            fmt.Sprintf("google_firestore_field.%s", resourceName),
@@ -58,7 +61,7 @@ func testAccFirestoreField_runUpdateTest(updateConfig string, t *testing.T, cont
 				ImportStateVerifyIgnore: []string{"database", "collection", "field"},
 			},
 			{
-				Config: testAccFirestoreField_firestoreFieldUpdateInitialExample(context),
+				Config: testAccFirestoreField_firestoreFieldUpdateInitialExample(context, useOwnProject),
 			},
 			{
 				ResourceName:            fmt.Sprintf("google_firestore_field.%s", resourceName),
@@ -70,10 +73,59 @@ func testAccFirestoreField_runUpdateTest(updateConfig string, t *testing.T, cont
 	})
 }
 
-func testAccFirestoreField_firestoreFieldUpdateInitialExample(context map[string]interface{}) string {
-	return acctest.Nprintf(`
+func testAccFirestoreField_update_basicDeps(context map[string]interface{}, useOwnProject bool) string {
+	// TTls require billing, so don't use their own project
+	if useOwnProject {
+		return acctest.Nprintf(`
+resource "google_project" "project" {
+	project_id = "tf-test%{random_suffix}"
+	name       = "tf-test%{random_suffix}"
+	org_id     = "%{org_id}"
+}
+
+resource "time_sleep" "wait_60_seconds" {
+	depends_on = [google_project.project]
+
+	create_duration = "60s"
+}
+
+resource "google_project_service" "firestore" {
+	project = google_project.project.project_id
+	service = "firestore.googleapis.com"
+
+	# Needed for CI tests for permissions to propagate, should not be needed for actual usage
+	depends_on = [time_sleep.wait_60_seconds]
+}
+
+resource "google_firestore_database" "database" {
+	project     = google_project.project.project_id
+	name        = "(default)"
+	location_id = "nam5"
+	type        = "FIRESTORE_NATIVE"
+
+	depends_on = [google_project_service.firestore]
+}
+`, context)
+	} else {
+		return acctest.Nprintf(`
+resource "google_firestore_database" "database" {
+	project     = "%{project_id}"
+	name        = "tf-test%{random_suffix}"
+	location_id = "nam5"
+	type        = "FIRESTORE_NATIVE"
+
+	delete_protection_state = "DELETE_PROTECTION_DISABLED"
+    deletion_policy         = "DELETE"
+}
+`, context)
+	}
+}
+
+func testAccFirestoreField_firestoreFieldUpdateInitialExample(context map[string]interface{}, useOwnProject bool) string {
+	return testAccFirestoreField_update_basicDeps(context, useOwnProject) + acctest.Nprintf(`
 resource "google_firestore_field" "%{resource_name}" {
-	project = "%{project_id}"
+	project = google_firestore_database.database.project
+	database = google_firestore_database.database.name
 	collection = "chatrooms_%{random_suffix}"
 	field = "%{resource_name}"
 
@@ -91,11 +143,13 @@ resource "google_firestore_field" "%{resource_name}" {
 }
 
 func testAccFirestoreField_firestoreFieldUpdateAddTTLExample(context map[string]interface{}) string {
-	return acctest.Nprintf(`
+	// TTLs need billing, so do not use isolated project
+	return testAccFirestoreField_update_basicDeps(context, false) + acctest.Nprintf(`
 resource "google_firestore_field" "%{resource_name}" {
-	project = "%{project_id}"
+	project    = google_firestore_database.database.project
+	database   = google_firestore_database.database.name
 	collection = "chatrooms_%{random_suffix}"
-	field = "%{resource_name}"
+	field      = "%{resource_name}"
 
 	index_config {
 		indexes {
@@ -113,9 +167,10 @@ resource "google_firestore_field" "%{resource_name}" {
 }
 
 func testAccFirestoreField_firestoreFieldUpdateAddIndexExample(context map[string]interface{}) string {
-	return acctest.Nprintf(`
+	return testAccFirestoreField_update_basicDeps(context, true) + acctest.Nprintf(`
 resource "google_firestore_field" "%{resource_name}" {
-	project = "%{project_id}"
+	project = google_firestore_database.database.project
+	database = google_firestore_database.database.name
 	collection = "chatrooms_%{random_suffix}"
 	field = "%{resource_name}"
 


### PR DESCRIPTION
There's a whole bunch of different constraints that have to be met for these tests to pass consistently.

* Backup schedules need to be run in a project with billing enabled, and the database needs a deletion policy to ensure it is properly swept.
* The default-database examples were marked as skip-test. They're valuable as examples but not really as tests - there's nothing Terraform-specific about them worth testing - and the Field tests will fail if default database creation doesn't work in Terraform
* The Document tests need to run against the (default) database due to an existing bug (https://github.com/hashicorp/terraform-provider-google/issues/15550). So they will now create their own project and their own (default) database.
* The basic Field example is also creating its own project and its own database now for test isolation purposes. It might be sufficient to just create a database the same way as for backup schedules; we can evaluate that once the tests have been passing for a while.
* The other two Field examples are following the same pattern as the backup schedule examples.
* The Firestore-native index example is using the inband project creation method, because then we can use the (default) database, which means we can use the Document resource (see the above-mentioned bug), which means that we don't need to use a manually-created project (because creating a Document implicitly creates its collection).
* The Datastore mode Index example can't take that same approach, because it doesn't seem like the Document resource works on datastore-mode databases. So we will need to use the manually-created FIRESTORE_PROJECT_NAME project for that one, and it will need to have a Datastore mode database manually baked into it.

 This exercise has identified a fair number of places for improvement to the Firestore
 Terraform story, but as a stopgap to get the tests passing again, this will have to do.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/16768
Fixes https://github.com/hashicorp/terraform-provider-google/issues/16723

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->


**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
