### PR TITLE
Add `readiness_checks` to `google_workstations_workstation_config`

### DIFF
--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -428,6 +428,20 @@ properties:
         description: |
           The service account to use with the specified KMS key.
         required: true
+  - !ruby/object:Api::Type::Array
+    name: 'readinessChecks'
+    description: |
+      Readiness checks to be performed on a workstation.
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties:
+        - !ruby/object:Api::Type::String
+          name: 'path'
+          description: |
+            Path to which the request should be sent.
+        - !ruby/object:Api::Type::String
+          name: 'port'
+          description: |
+            Port to which the request should be sent.
   - !ruby/object:Api::Type::Boolean
     name: 'degraded'
     description: |

--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -438,10 +438,12 @@ properties:
           name: 'path'
           description: |
             Path to which the request should be sent.
+          required: true
         - !ruby/object:Api::Type::Integer
           name: 'port'
           description: |
             Port to which the request should be sent.
+          required: true
   - !ruby/object:Api::Type::Boolean
     name: 'degraded'
     description: |

--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -438,7 +438,7 @@ properties:
           name: 'path'
           description: |
             Path to which the request should be sent.
-        - !ruby/object:Api::Type::String
+        - !ruby/object:Api::Type::Integer
           name: 'port'
           description: |
             Port to which the request should be sent.

--- a/mmv1/templates/terraform/examples/workstation_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/workstation_basic.tf.erb
@@ -34,6 +34,11 @@ resource "google_workstations_workstation_config" "<%= ctx[:primary_resource_id]
   workstation_cluster_id = google_workstations_workstation_cluster.<%= ctx[:primary_resource_id] %>.workstation_cluster_id
   location   		         = "us-central1"
   
+  readiness_checks {
+    path = "/"
+    port = 80
+  }
+
   host {
     gce_instance {
       machine_type                = "e2-standard-4"

--- a/mmv1/templates/terraform/examples/workstation_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/workstation_basic.tf.erb
@@ -34,11 +34,6 @@ resource "google_workstations_workstation_config" "<%= ctx[:primary_resource_id]
   workstation_cluster_id = google_workstations_workstation_cluster.<%= ctx[:primary_resource_id] %>.workstation_cluster_id
   location   		         = "us-central1"
   
-  readiness_checks {
-    path = "/"
-    port = 80
-  }
-
   host {
     gce_instance {
       machine_type                = "e2-standard-4"

--- a/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
+++ b/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
@@ -372,6 +372,83 @@ func testAccWorkstationsWorkstationConfig_disableTcpConnections(context map[stri
 `, context)
 }
 
+
+func TestAccWorkstationsWorkstationConfig_readinessChecks(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckWorkstationsWorkstationConfigDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkstationsWorkstationConfig_readinessChecks(context),
+			},
+			{
+				ResourceName:            "google_workstations_workstation_cluster.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag"},
+			},
+		},
+	})
+}
+
+func testAccWorkstationsWorkstationConfig_readinessChecks(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+  resource "google_compute_network" "default" {
+    provider                = google-beta
+    name                    = "tf-test-workstation-cluster%{random_suffix}"
+    auto_create_subnetworks = false
+  }
+  
+  resource "google_compute_subnetwork" "default" {
+    provider      = google-beta
+    name          = "tf-test-workstation-cluster%{random_suffix}"
+    ip_cidr_range = "10.0.0.0/24"
+    region        = "us-central1"
+    network       = google_compute_network.default.name
+  }
+  
+  resource "google_workstations_workstation_cluster" "default" {
+    provider                   = google-beta
+    workstation_cluster_id     = "tf-test-workstation-cluster%{random_suffix}"
+    network                    = google_compute_network.default.id
+    subnetwork                 = google_compute_subnetwork.default.id
+    location                   = "us-central1"
+  }
+  
+  resource "google_service_account" "default" {
+    provider = google-beta
+  
+    account_id   = "tf-test-my-account%{random_suffix}"
+    display_name = "Service Account"
+  }
+  
+  resource "google_workstations_workstation_config" "default" {
+    provider               = google-beta
+    workstation_config_id  = "tf-test-workstation-config%{random_suffix}"
+    workstation_cluster_id = google_workstations_workstation_cluster.default.workstation_cluster_id
+    location               = "us-central1"
+
+    readiness_checks {
+      port = 22
+    }
+  
+    host {
+      gce_instance {  
+        service_account             = google_service_account.default.email
+        service_account_scopes      = ["https://www.googleapis.com/auth/cloud-platform"]
+      }
+    }
+  }
+`, context)
+}
+
 func TestAccWorkstationsWorkstationConfig_update(t *testing.T) {
 	t.Parallel()
 

--- a/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
+++ b/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
@@ -436,7 +436,8 @@ func testAccWorkstationsWorkstationConfig_readinessChecks(context map[string]int
     location               = "us-central1"
 
     readiness_checks {
-      port = 22
+      path = "/"
+      port = 80
     }
   
     host {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Adds the `readiness_checks` argument block to the `google_workstations_workstation_config` resource.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
workstations: added `readiness_checks` argument block to `google_workstations_workstation_config` resource (beta)
```

Relates https://github.com/hashicorp/terraform-provider-google/issues/16997