### PR TITLE
Remove Constant, SelfLink types and Api::Object class

### DIFF
--- a/mmv1/api/async.rb
+++ b/mmv1/api/async.rb
@@ -16,7 +16,7 @@ require 'api/timeout'
 
 module Api
   # Base class from which other Async classes can inherit.
-  class Async < Api::Object
+  class Async < Google::YamlValidator
     # Describes an operation
     attr_reader :operation
 
@@ -35,7 +35,7 @@ module Api
     end
 
     # Base async operation type
-    class Operation < Api::Object
+    class Operation < Google::YamlValidator
       # Contains information about an long-running operation, to make
       # requests for the state of an operation.
       attr_reader :timeouts
@@ -48,7 +48,7 @@ module Api
     end
 
     # Base result class
-    class Result < Api::Object
+    class Result < Google::YamlValidator
       # Contains information about the result of an Operation
 
       attr_reader :resource_inside_response
@@ -145,7 +145,7 @@ module Api
 
     # Provides information to parse the result response to check operation
     # status
-    class Status < Api::Object
+    class Status < Google::YamlValidator
       attr_reader :path
       attr_reader :complete
       attr_reader :allowed
@@ -165,7 +165,7 @@ module Api
     end
 
     # Provides information on how to retrieve errors of the executed operations
-    class Error < Api::Object
+    class Error < Google::YamlValidator
       attr_reader :path
       attr_reader :message
 

--- a/mmv1/api/compiler.rb
+++ b/mmv1/api/compiler.rb
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'api/async'
 require 'api/product'
 require 'api/resource'
 require 'api/type'
@@ -20,8 +19,6 @@ require 'google/yaml_validator'
 module Api
   # Process <product>.yaml and produces output module
   class Compiler
-    include Compile::Core
-
     def initialize(catalog)
       @catalog = catalog
     end

--- a/mmv1/api/object.rb
+++ b/mmv1/api/object.rb
@@ -16,74 +16,67 @@ require 'google/logger'
 require 'google/yaml_validator'
 
 module Api
-  # Represents a base object
-  class Object < Google::YamlValidator
-    # Represents an object that has a (mandatory) name
-    class Named < Api::Object
-      # The list of properties (attr_reader) that can be overridden in
-      # <provider>.yaml.
-      module Properties
-        attr_reader :name
+  # Represents an object that has a (mandatory) name
+  class NamedObject < Google::YamlValidator
+    # The list of properties (attr_reader) that can be overridden in
+    # <provider>.yaml.
+    module Properties
+      attr_reader :name
+    end
+
+    def string_array?(arr)
+      types = arr.map(&:class).uniq
+      types.size == 1 && types[0] == String
+    end
+
+    def deep_merge(arr1, arr2)
+      # Scopes is an array of standard strings. In which case return the
+      # version in the overrides. This allows scopes to be removed rather
+      # than allowing for a merge of the two arrays
+      if string_array?(arr1)
+        return arr2.nil? ? arr1 : arr2
       end
 
-      def string_array?(arr)
-        types = arr.map(&:class).uniq
-        types.size == 1 && types[0] == String
+      # Merge any elements that exist in both
+      result = arr1.map do |el1|
+        other = arr2.select { |el2| el1.name == el2.name }.first
+        other.nil? ? el1 : el1.merge(other)
       end
 
-      def deep_merge(arr1, arr2)
-        # Scopes is an array of standard strings. In which case return the
-        # version in the overrides. This allows scopes to be removed rather
-        # than allowing for a merge of the two arrays
-        if string_array?(arr1)
-          return arr2.nil? ? arr1 : arr2
-        end
-
-        # Merge any elements that exist in both
-        result = arr1.map do |el1|
-          other = arr2.select { |el2| el1.name == el2.name }.first
-          other.nil? ? el1 : el1.merge(other)
-        end
-
-        # Add any elements of arr2 that don't exist in arr1
-        result + arr2.reject do |el2|
-          arr1.any? { |el1| el2.name == el1.name }
-        end
-      end
-
-      def merge(other)
-        result = self.class.new
-        instance_variables.each do |v|
-          result.instance_variable_set(v, instance_variable_get(v))
-        end
-
-        other.instance_variables.each do |v|
-          if other.instance_variable_get(v).instance_of?(Array)
-            result.instance_variable_set(v, deep_merge(result.instance_variable_get(v),
-                                                       other.instance_variable_get(v)))
-          else
-            result.instance_variable_set(v, other.instance_variable_get(v))
-          end
-        end
-
-        result
-      end
-
-      include Properties
-
-      # original value of :name before the provider override happens
-      # same as :name if not overridden in provider
-      attr_reader :api_name
-
-      def validate
-        super
-        check :name, type: String, required: true
-        check :api_name, type: String, default: @name
+      # Add any elements of arr2 that don't exist in arr1
+      result + arr2.reject do |el2|
+        arr1.any? { |el1| el2.name == el1.name }
       end
     end
 
-    def out_name
-      @name.underscore
+    def merge(other)
+      result = self.class.new
+      instance_variables.each do |v|
+        result.instance_variable_set(v, instance_variable_get(v))
+      end
+
+      other.instance_variables.each do |v|
+        if other.instance_variable_get(v).instance_of?(Array)
+          result.instance_variable_set(v, deep_merge(result.instance_variable_get(v),
+                                                     other.instance_variable_get(v)))
+        else
+          result.instance_variable_set(v, other.instance_variable_get(v))
+        end
+      end
+
+      result
+    end
+
+    include Properties
+
+    # original value of :name before the provider override happens
+    # same as :name if not overridden in provider
+    attr_reader :api_name
+
+    def validate
+      super
+      check :name, type: String, required: true
+      check :api_name, type: String, default: @name
     end
   end
 end

--- a/mmv1/api/product.rb
+++ b/mmv1/api/product.rb
@@ -19,7 +19,7 @@ require 'json'
 
 module Api
   # Represents a product to be managed
-  class Product < Api::Object::Named
+  class Product < Api::NamedObject
     include Compile::Core
 
     # Inherited:

--- a/mmv1/api/product/version.rb
+++ b/mmv1/api/product/version.rb
@@ -14,12 +14,12 @@
 require 'api/object'
 
 module Api
-  class Product < Api::Object::Named
+  class Product < Api::NamedObject
     # A version of the API for a given product / API group
     # In GCP, different product versions are generally ordered where alpha is
     # a superset of beta, and beta a superset of GA. Each version will have a
     # different version url.
-    class Version < Api::Object::Named
+    class Version < Api::NamedObject
       include Comparable
 
       attr_reader :cai_base_url

--- a/mmv1/api/resource.rb
+++ b/mmv1/api/resource.rb
@@ -19,11 +19,11 @@ require 'google/string_utils'
 
 module Api
   # An object available in the product
-  class Resource < Api::Object::Named
+  class Resource < Api::NamedObject
     # The list of properties (attr_reader) that can be overridden in
     # <provider>.yaml.
     module Properties
-      include Api::Object::Named::Properties
+      include Api::NamedObject::Properties
 
       # [Required] A description of the resource that's surfaced in provider
       # documentation.

--- a/mmv1/api/resource/iam_policy.rb
+++ b/mmv1/api/resource/iam_policy.rb
@@ -16,12 +16,12 @@ require 'google/string_utils'
 
 module Api
   # An object available in the product
-  class Resource < Api::Object::Named
+  class Resource < Api::NamedObject
     # Information about the IAM policy for this resource
     # Several GCP resources have IAM policies that are scoped to
     # and accessed via their parent resource
     # See: https://cloud.google.com/iam/docs/overview
-    class IamPolicy < Api::Object
+    class IamPolicy < Google::YamlValidator
       # boolean of if this binding should be generated
       attr_reader :exclude
 

--- a/mmv1/api/resource/nested_query.rb
+++ b/mmv1/api/resource/nested_query.rb
@@ -16,11 +16,11 @@ require 'google/string_utils'
 
 module Api
   # An object available in the product
-  class Resource < Api::Object::Named
+  class Resource < Api::NamedObject
     # Metadata for resources that are nested within a parent resource, as
     # a list of resources or single object within the parent.
     # e.g. Fine-grained resources
-    class NestedQuery < Api::Object
+    class NestedQuery < Google::YamlValidator
       # A list of keys to traverse in order.
       # i.e. backendBucket --> cdnPolicy.signedUrlKeyNames
       # should be ["cdnPolicy", "signedUrlKeyNames"]

--- a/mmv1/api/resource/reference_links.rb
+++ b/mmv1/api/resource/reference_links.rb
@@ -16,9 +16,9 @@ require 'google/string_utils'
 
 module Api
   # An object available in the product
-  class Resource < Api::Object::Named
+  class Resource < Api::NamedObject
     # Represents a list of documentation links.
-    class ReferenceLinks < Api::Object
+    class ReferenceLinks < Google::YamlValidator
       # Hash containing
       # name: The title of the link
       # value: The URL to navigate on click

--- a/mmv1/api/timeout.rb
+++ b/mmv1/api/timeout.rb
@@ -15,7 +15,7 @@ require 'api/object'
 
 module  Api
   # Provides timeout information for the different operation types
-  class Timeouts < Api::Object
+  class Timeouts < Google::YamlValidator
     # Default timeout for all operation types is 20, the Terraform default (https://www.terraform.io/plugin/sdkv2/resources/retries-and-customizable-timeouts)
     # minutes. This can be overridden for each resource.
     DEFAULT_INSERT_TIMEOUT_MINUTES = 20

--- a/mmv1/api/type.rb
+++ b/mmv1/api/type.rb
@@ -631,17 +631,6 @@ module Api
       end
     end
 
-    # Represents a 'selfLink' property, which returns the URI of the resource.
-    class SelfLink < FetchedExternal
-      EXPORT_KEY = 'selfLink'.freeze
-
-      attr_reader :resource
-
-      def name
-        EXPORT_KEY
-      end
-    end
-
     # Represents a reference to another resource
     class ResourceRef < Type
       # The fields which can be overridden in provider.yaml.

--- a/mmv1/api/type.rb
+++ b/mmv1/api/type.rb
@@ -17,11 +17,11 @@ require 'provider/terraform/validation'
 
 module Api
   # Represents a property type
-  class Type < Api::Object::Named
+  class Type < Api::NamedObject
     # The list of properties (attr_reader) that can be overridden in
     # <provider>.yaml.
     module Fields
-      include Api::Object::Named::Properties
+      include Api::NamedObject::Properties
 
       attr_reader :default_value
       attr_accessor :description
@@ -640,10 +640,6 @@ module Api
       def name
         EXPORT_KEY
       end
-
-      # def out_name
-      #   EXPORT_KEY.underscore
-      # end
     end
 
     # Represents a reference to another resource

--- a/mmv1/api/type.rb
+++ b/mmv1/api/type.rb
@@ -468,16 +468,6 @@ module Api
 
     private
 
-    # A constant value to be provided as field
-    class Constant < Type
-      attr_reader :value
-
-      def validate
-        @description = "This is always #{value}."
-        super
-      end
-    end
-
     # Represents a primitive (non-composite) type.
     class Primitive < Type
     end
@@ -651,9 +641,9 @@ module Api
         EXPORT_KEY
       end
 
-      def out_name
-        EXPORT_KEY.underscore
-      end
+      # def out_name
+      #   EXPORT_KEY.underscore
+      # end
     end
 
     # Represents a reference to another resource

--- a/mmv1/google/yaml_validator.rb
+++ b/mmv1/google/yaml_validator.rb
@@ -118,7 +118,7 @@ module Google
     def check_property_value(property, prop_value, type)
       Google::LOGGER.debug "Checking '#{property}' on #{object_display_name}"
       check_type property, prop_value, type unless type.nil?
-      prop_value.validate if prop_value.is_a?(Api::Object)
+      prop_value.validate if prop_value.is_a?(Google::YamlValidator)
     end
 
     def check_extraneous_properties

--- a/mmv1/openapi_generate/parser.rb
+++ b/mmv1/openapi_generate/parser.rb
@@ -216,7 +216,7 @@ module OpenAPIGenerate
       resource.id_format = self_link
       resource.import_format = [self_link]
 
-      # Name is on the Api::Object::Named parent resource, lets not modify that
+      # Name is on the Api::NamedObject parent resource, lets not modify that
       resource.instance_variable_set(:@name, resource_name)
       # TODO(slevenick): Get resource description published in OpenAPI spec
       resource.description = 'Description'
@@ -267,7 +267,7 @@ module OpenAPIGenerate
       product.versions = [api_version]
       # Standard titling is "Service Name API"
       display_name = root.raw_schema['info']['title'].sub(' API', '')
-      # Name is on the Api::Object::Named parent resource, lets not modify that
+      # Name is on the Api::NamedObject parent resource, lets not modify that
       product.instance_variable_set(:@name, display_name.gsub(' ', ''))
       product.display_name = display_name
       # Scopes should be added soon to OpenAPI, until then use global scope

--- a/mmv1/provider/terraform/custom_code.rb
+++ b/mmv1/provider/terraform/custom_code.rb
@@ -19,7 +19,7 @@ require 'google/golang_utils'
 module Provider
   class Terraform
     # Inserts custom code into terraform resources.
-    class CustomCode < Api::Object
+    class CustomCode < Google::YamlValidator
       # Collection of fields allowed in the CustomCode section for
       # Terraform.
 

--- a/mmv1/provider/terraform/docs.rb
+++ b/mmv1/provider/terraform/docs.rb
@@ -19,7 +19,7 @@ require 'google/golang_utils'
 module Provider
   class Terraform
     # Inserts custom strings into terraform resource docs.
-    class Docs < Api::Object
+    class Docs < Google::YamlValidator
       # All these values should be strings, which will be inserted
       # directly into the terraform resource documentation.  The
       # strings should _not_ be the names of template files

--- a/mmv1/provider/terraform/examples.rb
+++ b/mmv1/provider/terraform/examples.rb
@@ -20,7 +20,7 @@ module Provider
   class Terraform
     # Generates configs to be shown as examples in docs and outputted as tests
     # from a shared template
-    class Examples < Api::Object
+    class Examples < Google::YamlValidator
       include Compile::Core
       include Google::GolangUtils
 

--- a/mmv1/provider/terraform/validation.rb
+++ b/mmv1/provider/terraform/validation.rb
@@ -16,7 +16,7 @@ require 'api/object'
 module Provider
   class Terraform
     # Support for schema ValidateFunc functionality.
-    class Validation < Api::Object
+    class Validation < Google::YamlValidator
       # Ensures the value matches this regex
       attr_reader :regex
       attr_reader :function

--- a/mmv1/provider/terraform/virtual_fields.rb
+++ b/mmv1/provider/terraform/virtual_fields.rb
@@ -32,7 +32,7 @@ module Provider
     # Both are resource level fields and do not make sense, and are also not
     # supported, for nested fields. Nested fields that shouldn't be included
     # in API payloads are better handled with custom expand/encoder logic.
-    class VirtualFields < Api::Object
+    class VirtualFields < Google::YamlValidator
       include Compile::Core
       include Google::GolangUtils
 

--- a/mmv1/spec/object_spec.rb
+++ b/mmv1/spec/object_spec.rb
@@ -23,11 +23,6 @@ describe Api::Object do
     it { is_expected.to raise_error(StandardError, /Missing 'name'/) }
   end
 
-  context 'out_name underscore style' do
-    subject { object('name: "MyCamelCaseObjectName"').out_name }
-    it { is_expected.to eq 'my_camel_case_object_name' }
-  end
-
   private
 
   def object(*data)

--- a/mmv1/spec/object_spec.rb
+++ b/mmv1/spec/object_spec.rb
@@ -13,11 +13,11 @@
 
 require 'spec_helper'
 
-class TestObject < Api::Object::Named
+class TestObject < Api::NamedObject
   attr_reader :some_property
 end
 
-describe Api::Object do
+describe Google::YamlValidator do
   context 'requires name' do
     subject { -> { object('some_property: "bar"').validate } }
     it { is_expected.to raise_error(StandardError, /Missing 'name'/) }

--- a/mmv1/spec/provider_terraform_spec.rb
+++ b/mmv1/spec/provider_terraform_spec.rb
@@ -253,7 +253,7 @@ describe Provider::Terraform do
 
   def named_property(name)
     Google::YamlValidator.parse(
-      format("--- !ruby/object:Api::Object::Named\nname: '%<name>s'",
+      format("--- !ruby/object:Api::NamedObject\nname: '%<name>s'",
              name:)
     )
   end


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

1. Remove `Constant` type and `SelfLink` type, as they are not used now. The `selfLink` property is using `Api::Type::String`
2. Remove method `out_name` from class `Api::Object`, as `out_name` is not used anywhere.
3. After removing method `out_name` from class `Api::Object`, there are not methods or properties in this class. So remove this class. Any classes that inherit `Api::Object` will inherit `Google::YamlValidator` directly. 
4. Rename `Api::Object::Named` to `Api::NamedObject`. The previous relationship is  `Api::Object::Named` < `Api::Object` < `Google::YamlValidator`. After the change, the current relationship is `Api::NamedObject` < `Google::YamlValidator`

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
