### PR TITLE
Remove duplicated function memory parameter

### DIFF
--- a/mmv1/products/firebaseextensions/Instance.yaml
+++ b/mmv1/products/firebaseextensions/Instance.yaml
@@ -119,7 +119,7 @@ properties:
         description: |
           Params whose values are only available at deployment time.
           Unlike other params, these will not be set as environment variables on
-          functions. See a full list of system parameters at 
+          functions. See a full list of system parameters at
           https://firebase.google.com/docs/extensions/publishers/parameters#system_parameters
         default_from_api: true
       - !ruby/object:Api::Type::String
@@ -256,4 +256,3 @@ properties:
               The error message. This is set by the extension developer to give
               more detail on why the extension is unusable and must be re-installed
               or reconfigured.
-

--- a/mmv1/products/firebaseextensions/Instance.yaml
+++ b/mmv1/products/firebaseextensions/Instance.yaml
@@ -119,7 +119,8 @@ properties:
         description: |
           Params whose values are only available at deployment time.
           Unlike other params, these will not be set as environment variables on
-          functions.
+          functions. See a full list of system parameters at 
+          https://firebase.google.com/docs/extensions/publishers/parameters#system_parameters
         default_from_api: true
       - !ruby/object:Api::Type::String
         name: extensionRef

--- a/mmv1/templates/terraform/examples/firebase_extentions_instance_resize_image.tf.erb
+++ b/mmv1/templates/terraform/examples/firebase_extentions_instance_resize_image.tf.erb
@@ -15,7 +15,7 @@ resource "google_firebase_extensions_instance" "resize_image" {
   instance_id = "<%= ctx[:vars]['instance-id'] %>"
   config {
     extension_ref = "firebase/storage-resize-images"
-    extension_version = "0.1.37"
+    extension_version = "0.2.2"
 
     # The following params apply to the firebase/storage-resize-images extension. 
     # Different extensions may have different params
@@ -28,18 +28,17 @@ resource "google_firebase_extensions_instance" "resize_image" {
       DO_BACKFILL          = false
       IMG_SIZES            = "200x200"
       IMG_BUCKET           = google_storage_bucket.images.name
-      LOCATION             = "<%= ctx[:vars]['location'] %>"
     }
 
     system_params = {
+      "firebaseextensions.v1beta.function/location"                   = "<%= ctx[:vars]['location'] %>"
       "firebaseextensions.v1beta.function/maxInstances"               = 3000
-      "firebaseextensions.v1beta.function/memory"                     = 256
       "firebaseextensions.v1beta.function/minInstances"               = 0
       "firebaseextensions.v1beta.function/vpcConnectorEgressSettings" = "VPC_CONNECTOR_EGRESS_SETTINGS_UNSPECIFIED"
     }
 
     allowed_event_types = [
-      "firebase.extensions.storage-resize-images.v1.complete"
+      "firebase.extensions.storage-resize-images.v1.onCompletion"
     ]
 
     eventarc_channel = "projects/<%= ctx[:test_env_vars]['project_id'] %>/locations/<%= ctx[:vars]['location'] %>/channels/firebase"

--- a/mmv1/third_party/terraform/services/firebaseextensions/resource_firebase_extensions_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/firebaseextensions/resource_firebase_extensions_instance_test.go.erb
@@ -66,7 +66,7 @@ resource "google_firebase_extensions_instance" "resize_image" {
   instance_id = "tf-test-storage-resize-images%{random_suffix}"
   config {
     extension_ref = "firebase/storage-resize-images"
-    extension_version = "0.1.37"
+    extension_version = "0.2.2"
 
     # The following params apply to the firebase/storage-resize-images extension. 
     # Different extensions may have different params
@@ -79,18 +79,17 @@ resource "google_firebase_extensions_instance" "resize_image" {
       DO_BACKFILL          = false
       IMG_SIZES            = "200x200"
       IMG_BUCKET           = google_storage_bucket.images.name
-      LOCATION             = "%{location}"
     }
 
     system_params = {
+      "firebaseextensions.v1beta.function/location"                   = "%{location}"
       "firebaseextensions.v1beta.function/maxInstances"               = 3000
-      "firebaseextensions.v1beta.function/memory"                     = 256
       "firebaseextensions.v1beta.function/minInstances"               = 0
       "firebaseextensions.v1beta.function/vpcConnectorEgressSettings" = "VPC_CONNECTOR_EGRESS_SETTINGS_UNSPECIFIED"
     }
 
     allowed_event_types = [
-      "firebase.extensions.storage-resize-images.v1.complete"
+      "firebase.extensions.storage-resize-images.v1.onCompletion"
     ]
 
     eventarc_channel = "projects/%{project_id}/locations/%{location}/channels/firebase"
@@ -118,7 +117,7 @@ resource "google_firebase_extensions_instance" "resize_image" {
   instance_id = "tf-test-storage-resize-images%{random_suffix}"
   config {
     extension_ref = "firebase/storage-resize-images"
-    extension_version = "0.1.37"
+    extension_version = "0.2.2"
 
     # The following params apply to the firebase/storage-resize-images extension. 
     # Different extensions may have different params
@@ -132,13 +131,12 @@ resource "google_firebase_extensions_instance" "resize_image" {
       DO_BACKFILL          = true
       IMG_SIZES            = "400x400"
       IMG_BUCKET           = google_storage_bucket.images.name
-      LOCATION             = "%{location}"
     }
 
     system_params = {
+      "firebaseextensions.v1beta.function/location"                   = "%{location}"
       # Changed params
       "firebaseextensions.v1beta.function/maxInstances"               = 100
-      "firebaseextensions.v1beta.function/memory"                     = 128
       "firebaseextensions.v1beta.function/minInstances"               = 0
       "firebaseextensions.v1beta.function/vpcConnectorEgressSettings" = "VPC_CONNECTOR_EGRESS_SETTINGS_UNSPECIFIED"
     }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/16956

The `FUNCTION_MEMORY` param already specifies the memory.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
