### PR TITLE
Cleaned up conflicts / exactly_one_of / at_least_one_of documentation

### DIFF
--- a/docs/content/develop/field-reference.md
+++ b/docs/content/develop/field-reference.md
@@ -172,7 +172,7 @@ all listed fields. Not supported within
 Example:
 
 ```yaml
-- !ruby/object:Api::Type::Array
+- !ruby/object:Api::Type::String
   name: 'fieldOne'
   conflicts:
     - field_two
@@ -187,7 +187,7 @@ must be set. Must be set separately on all listed fields. Not supported within
 Example:
 
 ```yaml
-- !ruby/object:Api::Type::Array
+- !ruby/object:Api::Type::String
   name: 'fieldOne'
   exactly_one_of:
     - field_one
@@ -204,7 +204,7 @@ set separately on all listed fields. Not supported within
 Example:
 
 ```yaml
-- !ruby/object:Api::Type::Array
+- !ruby/object:Api::Type::String
   name: 'fieldOne'
   at_least_one_of:
     - field_one

--- a/docs/content/develop/field-reference.md
+++ b/docs/content/develop/field-reference.md
@@ -166,27 +166,50 @@ send_empty_value: true
 ### `conflicts`
 Specifies a list of fields (excluding the current field) that cannot be
 specified at the same time as the current field. Must be set separately on
-all listed fields.
+all listed fields. Not supported within
+[lists of nested objects](https://github.com/hashicorp/terraform-plugin-sdk/issues/470#issue-630928923).
 
 Example:
 
 ```yaml
-conflicts:
-  - field_one
-  - nested_object.0.nested_field
+- !ruby/object:Api::Type::Array
+  name: 'fieldOne'
+  conflicts:
+    - field_two
+    - nested_object.0.nested_field
 ```
 
 ### `exactly_one_of`
-Specifies a list of fields (including the current field) that cannot be
-specified at the same time (but at least one of which must be set). Must be
-set separately on all listed fields.
+Specifies a list of fields (including the current field) of which exactly one
+must be set. Must be set separately on all listed fields. Not supported within
+[lists of nested objects](https://github.com/hashicorp/terraform-plugin-sdk/issues/470#issue-630928923).
 
 Example:
 
 ```yaml
-exactly_one_of:
-  - field_one
-  - nested_object.0.nested_field
+- !ruby/object:Api::Type::Array
+  name: 'fieldOne'
+  exactly_one_of:
+    - field_one
+    - field_two
+    - nested_object.0.nested_field
+```
+
+### `at_least_one_of`
+Specifies a list of fields (including the current field) that cannot be
+specified at the same time (but at least one of which must be set). Must be
+set separately on all listed fields. Not supported within
+[lists of nested objects](https://github.com/hashicorp/terraform-plugin-sdk/issues/470#issue-630928923).
+
+Example:
+
+```yaml
+- !ruby/object:Api::Type::Array
+  name: 'fieldOne'
+  at_least_one_of:
+    - field_one
+    - field_two
+    - nested_object.0.nested_field
 ```
 
 ## `Enum` properties


### PR DESCRIPTION
Added documentation for at_least_one_of and clarified in examples that conflicts _excludes_ the current field, but the others _include_ it. Also added a note that these properties are not supported inside lists of nested objects.

Related: yaqs/316453740125093888

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
