### PR TITLE
Revert "Point GKEHub Membership API to v1beta as v1beta1 will be deprecated soon #16950"

### DIFF
--- a/mmv1/products/gkehub/product.yaml
+++ b/mmv1/products/gkehub/product.yaml
@@ -18,7 +18,7 @@ legacy_name: gke_hub
 versions:
   - !ruby/object:Api::Product::Version
     name: beta
-    base_url: https://gkehub.googleapis.com/v1beta/
+    base_url: https://gkehub.googleapis.com/v1beta1/
   - !ruby/object:Api::Product::Version
     name: ga
     base_url: https://gkehub.googleapis.com/v1/


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#9787

```release-note:none
```
