### PR TITLE
Add beta support for confidentialInstanceType

### DIFF
--- a/mmv1/products/compute/Instance.yaml
+++ b/mmv1/products/compute/Instance.yaml
@@ -608,7 +608,21 @@ properties:
     properties:
       - !ruby/object:Api::Type::Boolean
         name: 'enableConfidentialCompute'
-        description: Enables confidential computing
+        description: Enables confidential computing with AMD SEV.
+        at_least_one_of:
+          - confidential_instance_config.0.enable_confidential_compute
+          - confidential_instance_config.0.confidential_instance_type
+      - !ruby/object:Api::Type::Enum
+        name: 'confidentialInstanceType'
+        description: |
+          The confidential computing technology the instance uses.
+          SEV is an AMD feature. One of the following values: SEV, SEV_SNP.
+        values:
+          - :SEV
+          - :SEV_SNP
+        at_least_one_of:
+          - confidential_instance_config.0.enable_confidential_compute
+          - confidential_instance_config.0.confidential_instance_type
   - !ruby/object:Api::Type::Enum
     name: 'status'
     description: |

--- a/mmv1/products/compute/Instance.yaml
+++ b/mmv1/products/compute/Instance.yaml
@@ -617,6 +617,7 @@ properties:
         description: |
           The confidential computing technology the instance uses.
           SEV is an AMD feature. One of the following values: SEV, SEV_SNP.
+          If SEV_SNP, min_cpu_platform = "AMD Milan" is currently required.
         values:
           - :SEV
           - :SEV_SNP

--- a/mmv1/products/compute/Instance.yaml
+++ b/mmv1/products/compute/Instance.yaml
@@ -614,6 +614,7 @@ properties:
           - confidential_instance_config.0.confidential_instance_type
       - !ruby/object:Api::Type::Enum
         name: 'confidentialInstanceType'
+        min_version: beta
         description: |
           The confidential computing technology the instance uses.
           SEV is an AMD feature. One of the following values: SEV, SEV_SNP.

--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.erb
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.erb
@@ -577,16 +577,22 @@ func expandConfidentialInstanceConfig(d tpgresource.TerraformResourceData) *comp
 	prefix := "confidential_instance_config.0"
 	return &compute.ConfidentialInstanceConfig{
 		EnableConfidentialCompute: d.Get(prefix + ".enable_confidential_compute").(bool),
+		<% unless version == "ga" %>
+		ConfidentialInstanceType: d.Get(prefix + ".confidential_instance_type").(string),
+		<% end %>
 	}
 }
 
-func flattenConfidentialInstanceConfig(ConfidentialInstanceConfig *compute.ConfidentialInstanceConfig) []map[string]bool {
+func flattenConfidentialInstanceConfig(ConfidentialInstanceConfig *compute.ConfidentialInstanceConfig) []map[string]interface{} {
 	if ConfidentialInstanceConfig == nil {
 		return nil
 	}
 
-	return []map[string]bool{{
+	return []map[string]interface{}{{
 		"enable_confidential_compute": ConfidentialInstanceConfig.EnableConfidentialCompute,
+		<% unless version == "ga" %>
+		"confidential_instance_type": ConfidentialInstanceConfig.ConfidentialInstanceType,
+		<% end %>
 	}}
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
@@ -1014,7 +1014,8 @@ be from 0 to 999,999,999 inclusive.`,
 							Optional:    true,
 							Description: `
 								Specifies which confidential computing technology to use.
-								This could be one of the following values: SEV, SEV_SNP.`,
+								This could be one of the following values: SEV, SEV_SNP.
+								If SEV_SNP, min_cpu_platform = "AMD Milan" is currently required.`,
 							AtLeastOneOf: []string{"confidential_instance_config.0.enable_confidential_compute", "confidential_instance_config.0.confidential_instance_type"},
 						},
 						<% end %>

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
@@ -1005,7 +1005,7 @@ be from 0 to 999,999,999 inclusive.`,
 						<% else %>
 						"enable_confidential_compute": {
 							Type:        schema.TypeBool,
-							Required:    true,
+							Optional:    true,
 							Description: `Defines whether the instance should have confidential compute enabled. Field will be deprecated in a future release`,
 							AtLeastOneOf: []string{"confidential_instance_config.0. enable_confidential_compute", "confidential_instance_config.0.confidential_instance_type"},
 						},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
@@ -996,11 +996,28 @@ be from 0 to 999,999,999 inclusive.`,
 				Description: `The Confidential VM config being used by the instance.  on_host_maintenance has to be set to TERMINATE or this will fail to create.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						<% if version == "ga" %>
 						"enable_confidential_compute": {
 							Type:        schema.TypeBool,
 							Required:    true,
 							Description: `Defines whether the instance should have confidential compute enabled.`,
 						},
+						<% else %>
+						"enable_confidential_compute": {
+							Type:        schema.TypeBool,
+							Required:    true,
+							Description: `Defines whether the instance should have confidential compute enabled. Field will be deprecated in a future release`,
+							AtLeastOneOf: []string{"confidential_instance_config.0. enable_confidential_compute", "confidential_instance_config.0.confidential_instance_type"},
+						},
+						"confidential_instance_type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `
+								Specifies which confidential computing technology to use.
+								This could be one of the following values: SEV, SEV_SNP.`,
+							AtLeastOneOf: []string{"confidential_instance_config.0.enable_confidential_compute", "confidential_instance_config.0.confidential_instance_type"},
+						},
+						<% end %>
 					},
 				},
 			},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
@@ -1007,7 +1007,7 @@ be from 0 to 999,999,999 inclusive.`,
 							Type:        schema.TypeBool,
 							Optional:    true,
 							Description: `Defines whether the instance should have confidential compute enabled. Field will be deprecated in a future release`,
-							AtLeastOneOf: []string{"confidential_instance_config.0. enable_confidential_compute", "confidential_instance_config.0.confidential_instance_type"},
+							AtLeastOneOf: []string{"confidential_instance_config.0.enable_confidential_compute", "confidential_instance_config.0.confidential_instance_type"},
 						},
 						"confidential_instance_type": {
 							Type:        schema.TypeString,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
@@ -880,7 +880,7 @@ be from 0 to 999,999,999 inclusive.`,
 						<% else %>
 						"enable_confidential_compute": {
 							Type:        schema.TypeBool,
-							Required:    true,
+							Optional:    true,
 							ForceNew:    true,
 							Description: `Defines whether the instance should have confidential compute enabled. Field will be deprecated in a future release.`,
 							AtLeastOneOf: []string{"confidential_instance_config.0.enable_confidential_compute", "confidential_instance_config.0.confidential_instance_type"},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
@@ -870,12 +870,30 @@ be from 0 to 999,999,999 inclusive.`,
 				Description: `The Confidential VM config being used by the instance. on_host_maintenance has to be set to TERMINATE or this will fail to create.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						<% if version == "ga" %>
 						"enable_confidential_compute": {
 							Type:        schema.TypeBool,
 							Required:    true,
 							ForceNew:    true,
 							Description: `Defines whether the instance should have confidential compute enabled.`,
 						},
+						<% else %>
+						"enable_confidential_compute": {
+							Type:        schema.TypeBool,
+							Required:    true,
+							ForceNew:    true,
+							Description: `Defines whether the instance should have confidential compute enabled. Field will be deprecated in a future release.`,
+							AtLeastOneOf: []string{"confidential_instance_config.0.enable_confidential_compute", "confidential_instance_config.0.confidential_instance_type"},
+						},
+						"confidential_instance_type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `
+								Specifies which confidential computing technology to use.
+								This could be one of the following values: SEV, SEV_SNP.`,
+							AtLeastOneOf: []string{"confidential_instance_config.0.enable_confidential_compute", "confidential_instance_config.0.confidential_instance_type"},
+						},
+						<% end %>
 					},
 				},
 			},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
@@ -888,6 +888,7 @@ be from 0 to 999,999,999 inclusive.`,
 						"confidential_instance_type": {
 							Type:        schema.TypeString,
 							Optional:    true,
+							ForceNew:    true,
 							Description: `
 								Specifies which confidential computing technology to use.
 								This could be one of the following values: SEV, SEV_SNP.`,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
@@ -891,7 +891,8 @@ be from 0 to 999,999,999 inclusive.`,
 							ForceNew:    true,
 							Description: `
 								Specifies which confidential computing technology to use.
-								This could be one of the following values: SEV, SEV_SNP.`,
+								This could be one of the following values: SEV, SEV_SNP.
+								If SEV_SNP, min_cpu_platform = "AMD Milan" is currently required.`,
 							AtLeastOneOf: []string{"confidential_instance_config.0.enable_confidential_compute", "confidential_instance_config.0.confidential_instance_type"},
 						},
 						<% end %>

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.erb
@@ -779,10 +779,10 @@ func TestAccComputeInstanceTemplate_ConfidentialInstanceConfigMain(t *testing.T)
 		CheckDestroy:             testAccCheckComputeInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeInstanceTemplateConfidentialInstanceConfig(acctest.RandString(t, 10), true),
+				Config: testAccComputeInstanceTemplateConfidentialInstanceConfig(acctest.RandString(t, 10), true, "SEV"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(t, "google_compute_instance_template.foobar", &instanceTemplate),
-					testAccCheckComputeInstanceTemplateHasConfidentialInstanceConfig(&instanceTemplate, true),
+					testAccCheckComputeInstanceTemplateHasConfidentialInstanceConfig(&instanceTemplate, true, "SEV"),
 				),
 			},
 		},
@@ -1775,12 +1775,17 @@ func testAccCheckComputeInstanceTemplateHasShieldedVmConfig(instanceTemplate *co
 	}
 }
 
-func testAccCheckComputeInstanceTemplateHasConfidentialInstanceConfig(instanceTemplate *compute.InstanceTemplate, EnableConfidentialCompute bool) resource.TestCheckFunc {
+func testAccCheckComputeInstanceTemplateHasConfidentialInstanceConfig(instanceTemplate *compute.InstanceTemplate, EnableConfidentialCompute bool, ConfidentialInstanceType string) resource.TestCheckFunc {
 
 	return func(s *terraform.State) error {
 		if instanceTemplate.Properties.ConfidentialInstanceConfig.EnableConfidentialCompute != EnableConfidentialCompute {
 			return fmt.Errorf("Wrong ConfidentialInstanceConfig EnableConfidentialCompute: expected %t, got, %t", EnableConfidentialCompute, instanceTemplate.Properties.ConfidentialInstanceConfig.EnableConfidentialCompute)
 		}
+		<% unless version == "ga" %>
+		if instanceTemplate.Properties.ConfidentialInstanceConfig.ConfidentialInstanceType != ConfidentialInstanceType {
+			return fmt.Errorf("Wrong ConfidentialInstanceConfig ConfidentialInstanceType: expected %s, got, %s", ConfidentialInstanceType, instanceTemplate.Properties.ConfidentialInstanceConfig.ConfidentialInstanceType)
+		}
+		<% end %>
 
 		return nil
 	}
@@ -3078,7 +3083,7 @@ resource "google_compute_instance_template" "foobar" {
 `, suffix, enableSecureBoot, enableVtpm, enableIntegrityMonitoring)
 }
 
-func testAccComputeInstanceTemplateConfidentialInstanceConfig(suffix string, enableConfidentialCompute bool) string {
+func testAccComputeInstanceTemplateConfidentialInstanceConfig(suffix string, enableConfidentialCompute bool, confidentialInstanceType string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
   family  = "ubuntu-2004-lts"
@@ -3101,6 +3106,9 @@ resource "google_compute_instance_template" "foobar" {
 
   confidential_instance_config {
     enable_confidential_compute       = %t
+    <% unless version == "ga" %>
+    confidential_instance_type        = %q
+    <% end %>
   }
 
   scheduling {
@@ -3108,7 +3116,11 @@ resource "google_compute_instance_template" "foobar" {
   }
 
 }
+<% if version == "ga" %>
 `, suffix, enableConfidentialCompute)
+<% else %>
+`, suffix, enableConfidentialCompute, confidentialInstanceType)
+<% end %>
 }
 
 func testAccComputeInstanceTemplateAdvancedMachineFeatures(suffix string) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.erb
@@ -772,6 +772,9 @@ func TestAccComputeInstanceTemplate_ConfidentialInstanceConfigMain(t *testing.T)
 	t.Parallel()
 
 	var instanceTemplate compute.InstanceTemplate
+	<% unless version == "ga" %>
+	var instanceTemplate2 compute.InstanceTemplate
+	<% end %>
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -779,12 +782,27 @@ func TestAccComputeInstanceTemplate_ConfidentialInstanceConfigMain(t *testing.T)
 		CheckDestroy:             testAccCheckComputeInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeInstanceTemplateConfidentialInstanceConfig(acctest.RandString(t, 10), true, "SEV"),
+				Config: testAccComputeInstanceTemplateConfidentialInstanceConfigEnable(acctest.RandString(t, 10), "SEV"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(t, "google_compute_instance_template.foobar", &instanceTemplate),
 					testAccCheckComputeInstanceTemplateHasConfidentialInstanceConfig(&instanceTemplate, true, "SEV"),
+					<% unless version == "ga" %>
+					testAccCheckComputeInstanceTemplateExists(t, "google_compute_instance_template.foobar2", &instanceTemplate2),
+					testAccCheckComputeInstanceTemplateHasConfidentialInstanceConfig(&instanceTemplate2, true, ""),
+					<% end %>
 				),
 			},
+			<% unless version == "ga" %>
+			{
+				Config: testAccComputeInstanceTemplateConfidentialInstanceConfigNoEnable(acctest.RandString(t, 10), "AMD Milan", "SEV_SNP"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceTemplateExists(t, "google_compute_instance_template.foobar3", &instanceTemplate),
+					testAccCheckComputeInstanceTemplateHasConfidentialInstanceConfig(&instanceTemplate, false, "SEV_SNP"),
+					testAccCheckComputeInstanceTemplateExists(t, "google_compute_instance_template.foobar4", &instanceTemplate2),
+					testAccCheckComputeInstanceTemplateHasConfidentialInstanceConfig(&instanceTemplate2, false, "SEV_SNP"),
+				),
+			},
+			<% end %>
 		},
 	})
 }
@@ -3083,7 +3101,7 @@ resource "google_compute_instance_template" "foobar" {
 `, suffix, enableSecureBoot, enableVtpm, enableIntegrityMonitoring)
 }
 
-func testAccComputeInstanceTemplateConfidentialInstanceConfig(suffix string, enableConfidentialCompute bool, confidentialInstanceType string) string {
+func testAccComputeInstanceTemplateConfidentialInstanceConfigEnable(suffix string, confidentialInstanceType string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
   family  = "ubuntu-2004-lts"
@@ -3096,7 +3114,7 @@ resource "google_compute_instance_template" "foobar" {
 
   disk {
     source_image = data.google_compute_image.my_image.self_link
-	auto_delete  = true
+    auto_delete  = true
     boot         = true
   }
 
@@ -3105,23 +3123,111 @@ resource "google_compute_instance_template" "foobar" {
   }
 
   confidential_instance_config {
-    enable_confidential_compute       = %t
+    enable_confidential_compute       = true
     <% unless version == "ga" %>
     confidential_instance_type        = %q
     <% end %>
   }
 
   scheduling {
-	  on_host_maintenance = "TERMINATE"
+    on_host_maintenance = "TERMINATE"
   }
 
 }
+<% unless version == "ga" %>
+resource "google_compute_instance_template" "foobar2" {
+  name         = "tf-test-instance2-template-%s"
+  machine_type = "n2d-standard-2"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  confidential_instance_config {
+    enable_confidential_compute       = true
+  }
+
+  scheduling {
+    on_host_maintenance = "TERMINATE"
+  }
+
+}
+<% end %>
 <% if version == "ga" %>
-`, suffix, enableConfidentialCompute)
+`, suffix)
 <% else %>
-`, suffix, enableConfidentialCompute, confidentialInstanceType)
+`, suffix, confidentialInstanceType, suffix)
 <% end %>
 }
+
+<% unless version == "ga" %>
+func testAccComputeInstanceTemplateConfidentialInstanceConfigNoEnable(suffix string, minCpuPlatform, confidentialInstanceType string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image2" {
+  family  = "ubuntu-2004-lts"
+  project = "ubuntu-os-cloud"
+}
+
+resource "google_compute_instance_template" "foobar3" {
+  name         = "tf-test-instance3-template-%s"
+  machine_type = "n2d-standard-2"
+
+  disk {
+    source_image = data.google_compute_image.my_image2.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  min_cpu_platform = %q
+
+  confidential_instance_config {
+    enable_confidential_compute       = false
+    confidential_instance_type        = %q
+  }
+
+  scheduling {
+    on_host_maintenance = "TERMINATE"
+  }
+
+}
+resource "google_compute_instance_template" "foobar4" {
+  name         = "tf-test-instance4-template-%s"
+  machine_type = "n2d-standard-2"
+
+  disk {
+    source_image = data.google_compute_image.my_image2.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  min_cpu_platform = %q
+
+  confidential_instance_config {
+    confidential_instance_type        = %q
+  }
+
+  scheduling {
+    on_host_maintenance = "TERMINATE"
+  }
+
+}
+`, suffix, minCpuPlatform, confidentialInstanceType, suffix, minCpuPlatform, confidentialInstanceType)
+}
+<% end %>
 
 func testAccComputeInstanceTemplateAdvancedMachineFeatures(suffix string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -1812,10 +1812,10 @@ func TestAccComputeInstanceConfidentialInstanceConfigMain(t *testing.T) {
 		CheckDestroy: testAccCheckComputeInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeInstanceConfidentialInstanceConfig(instanceName, true),
+				Config: testAccComputeInstanceConfidentialInstanceConfig(instanceName, true, "SEV"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
-					testAccCheckComputeInstanceHasConfidentialInstanceConfig(&instance, true),
+					testAccCheckComputeInstanceHasConfidentialInstanceConfig(&instance, true, "SEV"),
 				),
 			},
 		},
@@ -3850,12 +3850,17 @@ func testAccCheckComputeInstanceHasShieldedVmConfig(instance *compute.Instance, 
 	}
 }
 
-func testAccCheckComputeInstanceHasConfidentialInstanceConfig(instance *compute.Instance, EnableConfidentialCompute bool) resource.TestCheckFunc {
+func testAccCheckComputeInstanceHasConfidentialInstanceConfig(instance *compute.Instance, EnableConfidentialCompute bool, ConfidentialInstanceType string) resource.TestCheckFunc {
 
 	return func(s *terraform.State) error {
 		if instance.ConfidentialInstanceConfig.EnableConfidentialCompute != EnableConfidentialCompute {
 			return fmt.Errorf("Wrong ConfidentialInstanceConfig EnableConfidentialCompute: expected %t, got, %t", EnableConfidentialCompute, instance.ConfidentialInstanceConfig.EnableConfidentialCompute)
 		}
+		<% unless version == "ga" %>
+		if instance.ConfidentialInstanceConfig.ConfidentialInstanceType != ConfidentialInstanceType {
+			return fmt.Errorf("Wrong ConfidentialInstanceConfig ConfidentialInstanceType: expected %s, got, %s", ConfidentialInstanceType, instance.ConfidentialInstanceConfig.ConfidentialInstanceType)
+		}
+		<% end %>
 
 		return nil
 	}
@@ -7023,7 +7028,7 @@ resource "google_compute_instance" "foobar" {
 `, instance, enableSecureBoot, enableVtpm, enableIntegrityMonitoring)
 }
 
-func testAccComputeInstanceConfidentialInstanceConfig(instance string, enableConfidentialCompute bool) string {
+func testAccComputeInstanceConfidentialInstanceConfig(instance string, enableConfidentialCompute bool, confidentialInstanceType string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
   family    = "ubuntu-2004-lts"
@@ -7047,6 +7052,9 @@ resource "google_compute_instance" "foobar" {
 
   confidential_instance_config {
     enable_confidential_compute       = %t
+    <% unless version == "ga" %>
+    confidential_instance_type        = %q
+    <% end %>
   }
 
   scheduling {
@@ -7054,7 +7062,11 @@ resource "google_compute_instance" "foobar" {
   }
 
 }
+<% if version == "ga" %>
 `, instance, enableConfidentialCompute)
+<% else %>
+`, instance, enableConfidentialCompute, confidentialInstanceType)
+<% end %>
 }
 
 func testAccComputeInstanceConfidentialHyperDiskBootDisk(context map[string]interface{}) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -1804,6 +1804,9 @@ func TestAccComputeInstanceConfidentialInstanceConfigMain(t *testing.T) {
 	t.Parallel()
 
 	var instance compute.Instance
+	<% unless version == "ga" %>
+	var instance2 compute.Instance
+	<% end %>
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -1812,12 +1815,27 @@ func TestAccComputeInstanceConfidentialInstanceConfigMain(t *testing.T) {
 		CheckDestroy: testAccCheckComputeInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeInstanceConfidentialInstanceConfig(instanceName, true, "SEV"),
+				Config: testAccComputeInstanceConfidentialInstanceConfigEnable(instanceName, "SEV"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceHasConfidentialInstanceConfig(&instance, true, "SEV"),
+					<% unless version == "ga" %>
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar2", &instance2),
+					testAccCheckComputeInstanceHasConfidentialInstanceConfig(&instance2, true, ""),
+					<% end %>
 				),
 			},
+			<% unless version == "ga" %>
+			{
+				Config: testAccComputeInstanceConfidentialInstanceConfigNoEnable(instanceName, "AMD Milan", "SEV_SNP"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar3", &instance),
+					testAccCheckComputeInstanceHasConfidentialInstanceConfig(&instance, false, "SEV_SNP"),
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar4", &instance2),
+					testAccCheckComputeInstanceHasConfidentialInstanceConfig(&instance2, false, "SEV_SNP"),
+				),
+			},
+			<% end %>
 		},
 	})
 }
@@ -7028,7 +7046,7 @@ resource "google_compute_instance" "foobar" {
 `, instance, enableSecureBoot, enableVtpm, enableIntegrityMonitoring)
 }
 
-func testAccComputeInstanceConfidentialInstanceConfig(instance string, enableConfidentialCompute bool, confidentialInstanceType string) string {
+func testAccComputeInstanceConfidentialInstanceConfigEnable(instance string, confidentialInstanceType string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
   family    = "ubuntu-2004-lts"
@@ -7051,7 +7069,7 @@ resource "google_compute_instance" "foobar" {
   }
 
   confidential_instance_config {
-    enable_confidential_compute       = %t
+    enable_confidential_compute       = true
     <% unless version == "ga" %>
     confidential_instance_type        = %q
     <% end %>
@@ -7062,12 +7080,103 @@ resource "google_compute_instance" "foobar" {
   }
 
 }
+<% unless version == "ga" %>
+resource "google_compute_instance" "foobar2" {
+  name         = "%s2"
+  machine_type = "n2d-standard-2"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  confidential_instance_config {
+    enable_confidential_compute       = true
+  }
+
+  scheduling {
+    on_host_maintenance = "TERMINATE"
+  }
+
+}
+<% end %>
 <% if version == "ga" %>
-`, instance, enableConfidentialCompute)
+`, instance)
 <% else %>
-`, instance, enableConfidentialCompute, confidentialInstanceType)
+`, instance, confidentialInstanceType, instance)
 <% end %>
 }
+
+<% unless version == "ga" %>
+func testAccComputeInstanceConfidentialInstanceConfigNoEnable(instance string, minCpuPlatform, confidentialInstanceType string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image2" {
+  family    = "ubuntu-2004-lts"
+  project   = "ubuntu-os-cloud"
+}
+
+resource "google_compute_instance" "foobar3" {
+  name         = "%s3"
+  machine_type = "n2d-standard-2"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image2.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  min_cpu_platform = %q
+
+  confidential_instance_config {
+    enable_confidential_compute       = false
+    confidential_instance_type        = %q
+  }
+
+  scheduling {
+	  on_host_maintenance = "TERMINATE"
+  }
+
+}
+resource "google_compute_instance" "foobar4" {
+  name         = "%s4"
+  machine_type = "n2d-standard-2"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image2.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  min_cpu_platform = %q
+
+  confidential_instance_config {
+    confidential_instance_type        = %q
+  }
+
+  scheduling {
+    on_host_maintenance = "TERMINATE"
+  }
+
+}
+`, instance, minCpuPlatform, confidentialInstanceType, instance, minCpuPlatform, confidentialInstanceType)
+}
+<% end %>
 
 func testAccComputeInstanceConfidentialHyperDiskBootDisk(context map[string]interface{}) string {
 	return acctest.Nprintf(`

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.erb
@@ -833,7 +833,7 @@ be from 0 to 999,999,999 inclusive.`,
 						<% else %>
 						"enable_confidential_compute": {
 							Type:        schema.TypeBool,
-							Required:    true,
+							Optional:    true,
 							ForceNew:    true,
 							Description: `Defines whether the instance should have confidential compute enabled. Field will be deprecated in a future release.`,
 							AtLeastOneOf: []string{"confidential_instance_config.0.enable_confidential_compute", "confidential_instance_config.0.confidential_instance_type"},
@@ -841,6 +841,7 @@ be from 0 to 999,999,999 inclusive.`,
 						"confidential_instance_type": {
 							Type:        schema.TypeString,
 							Optional:    true,
+							ForceNew:    true,
 							Description: `
 								Specifies which confidential computing technology to use.
 								This could be one of the following values: SEV, SEV_SNP.`,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.erb
@@ -844,7 +844,8 @@ be from 0 to 999,999,999 inclusive.`,
 							ForceNew:    true,
 							Description: `
 								Specifies which confidential computing technology to use.
-								This could be one of the following values: SEV, SEV_SNP.`,
+								This could be one of the following values: SEV, SEV_SNP.
+								If SEV_SNP, min_cpu_platform = "AMD Milan" is currently required.`,
 							AtLeastOneOf: []string{"confidential_instance_config.0.enable_confidential_compute", "confidential_instance_config.0.confidential_instance_type"},
 						},
 						<% end %>

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.erb
@@ -823,12 +823,30 @@ be from 0 to 999,999,999 inclusive.`,
 				Description: `The Confidential VM config being used by the instance. on_host_maintenance has to be set to TERMINATE or this will fail to create.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						<% if version == "ga" %>
 						"enable_confidential_compute": {
 							Type:        schema.TypeBool,
 							Required:    true,
 							ForceNew:    true,
 							Description: `Defines whether the instance should have confidential compute enabled.`,
 						},
+						<% else %>
+						"enable_confidential_compute": {
+							Type:        schema.TypeBool,
+							Required:    true,
+							ForceNew:    true,
+							Description: `Defines whether the instance should have confidential compute enabled. Field will be deprecated in a future release.`,
+							AtLeastOneOf: []string{"confidential_instance_config.0.enable_confidential_compute", "confidential_instance_config.0.confidential_instance_type"},
+						},
+						"confidential_instance_type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `
+								Specifies which confidential computing technology to use.
+								This could be one of the following values: SEV, SEV_SNP.`,
+							AtLeastOneOf: []string{"confidential_instance_config.0.enable_confidential_compute", "confidential_instance_config.0.confidential_instance_type"},
+						},
+						<% end %>
 					},
 				},
 			},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.erb
@@ -686,6 +686,9 @@ func TestAccComputeRegionInstanceTemplate_ConfidentialInstanceConfigMain(t *test
 	t.Parallel()
 
 	var instanceTemplate compute.InstanceTemplate
+	<% unless version == "ga" %>
+	var instanceTemplate2 compute.InstanceTemplate
+	<% end %>
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.AccTestPreCheck(t) },
@@ -693,12 +696,27 @@ func TestAccComputeRegionInstanceTemplate_ConfidentialInstanceConfigMain(t *test
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeRegionInstanceTemplateConfidentialInstanceConfig(acctest.RandString(t, 10), true, "SEV"),
+				Config: testAccComputeRegionInstanceTemplateConfidentialInstanceConfigEnable(acctest.RandString(t, 10), "SEV"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeRegionInstanceTemplateExists(t, "google_compute_region_instance_template.foobar", &instanceTemplate),
 					testAccCheckComputeRegionInstanceTemplateHasConfidentialInstanceConfig(&instanceTemplate, true, "SEV"),
+					<% unless version == "ga" %>
+					testAccCheckComputeRegionInstanceTemplateExists(t, "google_compute_region_instance_template.foobar2", &instanceTemplate2),
+					testAccCheckComputeRegionInstanceTemplateHasConfidentialInstanceConfig(&instanceTemplate2, true, ""),
+					<% end %>
 				),
 			},
+			<% unless version == "ga" %>
+			{
+				Config: testAccComputeRegionInstanceTemplateConfidentialInstanceConfigNoEnable(acctest.RandString(t, 10), "AMD Milan", "SEV_SNP"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(t, "google_compute_region_instance_template.foobar3", &instanceTemplate),
+					testAccCheckComputeRegionInstanceTemplateHasConfidentialInstanceConfig(&instanceTemplate, false, "SEV_SNP"),
+					testAccCheckComputeRegionInstanceTemplateExists(t, "google_compute_region_instance_template.foobar4", &instanceTemplate2),
+					testAccCheckComputeRegionInstanceTemplateHasConfidentialInstanceConfig(&instanceTemplate2, false, "SEV_SNP"),
+				),
+			},
+			<% end %>
 		},
 	})
 }
@@ -2734,7 +2752,7 @@ resource "google_compute_region_instance_template" "foobar" {
 `, suffix, enableSecureBoot, enableVtpm, enableIntegrityMonitoring)
 }
 
-func testAccComputeRegionInstanceTemplateConfidentialInstanceConfig(suffix string, enableConfidentialCompute bool, confidentialInstanceType string) string {
+func testAccComputeRegionInstanceTemplateConfidentialInstanceConfigEnable(suffix string, confidentialInstanceType string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
   family  = "ubuntu-2004-lts"
@@ -2757,7 +2775,7 @@ resource "google_compute_region_instance_template" "foobar" {
   }
 
   confidential_instance_config {
-    enable_confidential_compute       = %t
+    enable_confidential_compute       = true
     <% unless version == "ga" %>
     confidential_instance_type        = %q
     <% end %>
@@ -2768,12 +2786,103 @@ resource "google_compute_region_instance_template" "foobar" {
   }
 
 }
+<% unless version == "ga" %>
+resource "google_compute_region_instance_template" "foobar2" {
+  name         = "tf-test-instance2-template-%s"
+  machine_type = "n2d-standard-2"
+  region      = "us-central1"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+	auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  confidential_instance_config {
+    enable_confidential_compute       = true
+  }
+
+  scheduling {
+	  on_host_maintenance = "TERMINATE"
+  }
+
+}
+<% end %>
 <% if version == "ga" %>
-`, suffix, enableConfidentialCompute)
+`, suffix)
 <% else %>
-`, suffix, enableConfidentialCompute, confidentialInstanceType)
+`, suffix, confidentialInstanceType, suffix)
 <% end %>
 }
+
+<% unless version == "ga" %>
+func testAccComputeRegionInstanceTemplateConfidentialInstanceConfigNoEnable(suffix string, minCpuPlatform, confidentialInstanceType string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image2" {
+  family  = "ubuntu-2004-lts"
+  project = "ubuntu-os-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar3" {
+  name         = "tf-test-instance3-template-%s"
+  machine_type = "n2d-standard-2"
+  region      = "us-central1"
+
+  disk {
+    source_image = data.google_compute_image.my_image2.self_link
+	auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  min_cpu_platform = %q
+
+  confidential_instance_config {
+    enable_confidential_compute       = false
+    confidential_instance_type        = %q
+  }
+
+  scheduling {
+	  on_host_maintenance = "TERMINATE"
+  }
+
+}
+resource "google_compute_region_instance_template" "foobar4" {
+  name         = "tf-test-instance4-template-%s"
+  machine_type = "n2d-standard-2"
+  region      = "us-central1"
+
+  disk {
+    source_image = data.google_compute_image.my_image2.self_link
+	auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  min_cpu_platform = %q
+
+  confidential_instance_config {
+    confidential_instance_type        = %q
+  }
+
+  scheduling {
+	  on_host_maintenance = "TERMINATE"
+  }
+
+}
+`, suffix, minCpuPlatform, confidentialInstanceType, suffix, minCpuPlatform, confidentialInstanceType)
+}
+<% end %>
 
 func testAccComputeRegionInstanceTemplateAdvancedMachineFeatures(suffix string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.erb
@@ -693,10 +693,10 @@ func TestAccComputeRegionInstanceTemplate_ConfidentialInstanceConfigMain(t *test
 		CheckDestroy: testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeRegionInstanceTemplateConfidentialInstanceConfig(acctest.RandString(t, 10), true),
+				Config: testAccComputeRegionInstanceTemplateConfidentialInstanceConfig(acctest.RandString(t, 10), true, "SEV"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeRegionInstanceTemplateExists(t, "google_compute_region_instance_template.foobar", &instanceTemplate),
-					testAccCheckComputeRegionInstanceTemplateHasConfidentialInstanceConfig(&instanceTemplate, true),
+					testAccCheckComputeRegionInstanceTemplateHasConfidentialInstanceConfig(&instanceTemplate, true, "SEV"),
 				),
 			},
 		},
@@ -1601,12 +1601,17 @@ func testAccCheckComputeRegionInstanceTemplateHasShieldedVmConfig(instanceTempla
 	}
 }
 
-func testAccCheckComputeRegionInstanceTemplateHasConfidentialInstanceConfig(instanceTemplate *compute.InstanceTemplate, EnableConfidentialCompute bool) resource.TestCheckFunc {
+func testAccCheckComputeRegionInstanceTemplateHasConfidentialInstanceConfig(instanceTemplate *compute.InstanceTemplate, EnableConfidentialCompute bool, ConfidentialInstanceType string) resource.TestCheckFunc {
 
 	return func(s *terraform.State) error {
 		if instanceTemplate.Properties.ConfidentialInstanceConfig.EnableConfidentialCompute != EnableConfidentialCompute {
 			return fmt.Errorf("Wrong ConfidentialInstanceConfig EnableConfidentialCompute: expected %t, got, %t", EnableConfidentialCompute, instanceTemplate.Properties.ConfidentialInstanceConfig.EnableConfidentialCompute)
 		}
+		<% unless version == "ga" %>
+		if instanceTemplate.Properties.ConfidentialInstanceConfig.ConfidentialInstanceType != ConfidentialInstanceType {
+			return fmt.Errorf("Wrong ConfidentialInstanceConfig ConfidentialInstanceType: expected %s, got, %s", ConfidentialInstanceType, instanceTemplate.Properties.ConfidentialInstanceConfig.ConfidentialInstanceType)
+		}
+		<% end %>
 
 		return nil
 	}
@@ -2729,7 +2734,7 @@ resource "google_compute_region_instance_template" "foobar" {
 `, suffix, enableSecureBoot, enableVtpm, enableIntegrityMonitoring)
 }
 
-func testAccComputeRegionInstanceTemplateConfidentialInstanceConfig(suffix string, enableConfidentialCompute bool) string {
+func testAccComputeRegionInstanceTemplateConfidentialInstanceConfig(suffix string, enableConfidentialCompute bool, confidentialInstanceType string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
   family  = "ubuntu-2004-lts"
@@ -2753,6 +2758,9 @@ resource "google_compute_region_instance_template" "foobar" {
 
   confidential_instance_config {
     enable_confidential_compute       = %t
+    <% unless version == "ga" %>
+    confidential_instance_type        = %q
+    <% end %>
   }
 
   scheduling {
@@ -2760,7 +2768,11 @@ resource "google_compute_region_instance_template" "foobar" {
   }
 
 }
+<% if version == "ga" %>
 `, suffix, enableConfidentialCompute)
+<% else %>
+`, suffix, enableConfidentialCompute, confidentialInstanceType)
+<% end %>
 }
 
 func testAccComputeRegionInstanceTemplateAdvancedMachineFeatures(suffix string) string {

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -485,7 +485,9 @@ specified, then this instance will have no external IPv6 Internet access. Struct
 
 <a name="nested_confidential_instance_config"></a>The `confidential_instance_config` block supports:
 
-* `enable_confidential_compute` (Optional) Defines whether the instance should have confidential compute enabled. [`on_host_maintenance`](#on_host_maintenance) has to be set to TERMINATE or this will fail to create the VM.
+* `enable_confidential_compute` (Optional) Defines whether the instance should have confidential compute enabled with AMD SEV. [`on_host_maintenance`](#on_host_maintenance) has to be set to TERMINATE or this will fail to create the VM.
+
+* `confidential_instance_type` (Optional) [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Defines the confidential computing technology the instance uses. SEV is an AMD feature. One of the following values: `SEV`, `SEV_SNP`. [`on_host_maintenance`](#on_host_maintenance) has to be set to TERMINATE or this will fail to create the VM. If `SEV_SNP`, currently [`min_cpu_platform`](#min_cpu_platform) has to be set to `"AMD Milan"` or this will fail to create the VM.
 
 <a name="nested_advanced_machine_features"></a>The `advanced_machine_features` block supports:
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -650,7 +650,9 @@ The `specific_reservation` block supports:
 
 <a name="nested_confidential_instance_config"></a>The `confidential_instance_config` block supports:
 
-* `enable_confidential_compute` (Optional) Defines whether the instance should have confidential compute enabled. [`on_host_maintenance`](#on_host_maintenance) has to be set to TERMINATE or this will fail to create the VM.
+* `enable_confidential_compute` (Optional) Defines whether the instance should have confidential compute enabled with AMD SEV. [`on_host_maintenance`](#on_host_maintenance) has to be set to TERMINATE or this will fail to create the VM.
+
+* `confidential_instance_type` (Optional) [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Defines the confidential computing technology the instance uses. SEV is an AMD feature. One of the following values: `SEV`, `SEV_SNP`. [`on_host_maintenance`](#on_host_maintenance) has to be set to TERMINATE or this will fail to create the VM. If `SEV_SNP`, currently [`min_cpu_platform`](#min_cpu_platform) has to be set to `"AMD Milan"` or this will fail to create the VM.
 
 <a name="nested_network_performance_config"></a>The `network_performance_config` block supports:
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
@@ -658,7 +658,9 @@ The `specific_reservation` block supports:
 
 <a name="nested_confidential_instance_config"></a>The `confidential_instance_config` block supports:
 
-* `enable_confidential_compute` (Optional) Defines whether the instance should have confidential compute enabled. [`on_host_maintenance`](#on_host_maintenance) has to be set to TERMINATE or this will fail to create the VM.
+* `enable_confidential_compute` (Optional) Defines whether the instance should have confidential compute enabled on AMD SEV. [`on_host_maintenance`](#on_host_maintenance) has to be set to TERMINATE or this will fail to create the VM.
+
+* `confidential_instance_type` (Optional) [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Defines the confidential computing technology the instance uses. SEV is an AMD feature. One of the following values: `SEV`, `SEV_SNP`. [`on_host_maintenance`](#on_host_maintenance) has to be set to TERMINATE or this will fail to create the VM. If `SEV_SNP`, currently [`min_cpu_platform`](#min_cpu_platform) has to be set to `"AMD Milan"` or this will fail to create the VM.
 
 <a name="nested_network_performance_config"></a>The `network_performance_config` block supports:
 


### PR DESCRIPTION
Confidential VMs with SEV-SNP are in public preview, so beta API access requires support for the confidentialInstanceType field of the ConfidentialInstanceConfig.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/14768
Fixes b/312697065
Fixes b/318868778

```release-note:enhancement
compute: added `confidential_instance_config.confidential_instance_type` field to `google_compute_instance`,  `google_compute_instance_template`, and `google_compute_region_instance_template` resources (beta)
```
