### PR TITLE
fix: permadiff issue when `docker_repository` field is not specified

### DIFF
--- a/mmv1/products/cloudfunctions2/Function.yaml
+++ b/mmv1/products/cloudfunctions2/Function.yaml
@@ -422,6 +422,7 @@ properties:
         name: 'dockerRepository'
         description: |
           User managed repository created in Artifact Registry optionally with a customer managed encryption key.
+        default_from_api: true
   - !ruby/object:Api::Type::NestedObject
     name: 'serviceConfig'
     description: 'Describes the Service being deployed.'


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
When docker repository is not specified, by default docker repository `projects/PROJECT_ID/locations/REGION/repositories/gcf-artifacts` is used. Refer https://cloud.google.com/functions/docs/reference/rest/v2beta/projects.locations.functions#dockerregistry

In such a case, terraform plan always generates a difference for `docker_repository` field.
```bash
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.foo.google_cloudfunctions2_function.function will be updated in-place
  ~ resource "google_cloudfunctions2_function" "function" {
        id               = "projects/my-project-e044dd03/locations/europe-west1/functions/foo"
        name             = "foo"
        # (10 unchanged attributes hidden)

      ~ build_config {
          - docker_repository     = "projects/my-project-e044dd03/locations/europe-west1/repositories/gcf-artifacts" -> null
            # (4 unchanged attributes hidden)

            # (1 unchanged block hidden)
        }

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
This fix prevents unnecessary infrastructure change by setting the default repository id received from API.

Relates to https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/pull/1987

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
Fixed an issue when `docker_repository` is not specified in build_config section of the `google_cloudfunctions2_function`, the provider should not generate a diff during plan for the default value used by the API.
```
