### PR TITLE
Remove sending empty oauth2ClientId and oauth2ClientSecret string for null IAP message in google_compute_region_backend_service

### DIFF
--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -57,6 +57,13 @@ examples:
       backend_service_name: 'backend-service'
       http_health_check_name: 'health-check'
   - !ruby/object:Provider::Terraform::Examples
+    name: 'backend_service_external_iap'
+    primary_resource_id: 'default'
+    vars:
+      backend_service_name: 'tf-test-backend-service-external'
+    ignore_read_extra:
+      - 'iap.0.oauth2_client_secret'
+  - !ruby/object:Provider::Terraform::Examples
     name: 'backend_service_cache_simple'
     primary_resource_id: 'default'
     vars:

--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -53,6 +53,13 @@ examples:
       region_backend_service_name: 'region-service'
       health_check_name: 'rbs-health-check'
   - !ruby/object:Provider::Terraform::Examples
+    name: 'region_backend_service_external_iap'
+    primary_resource_id: 'default'
+    vars:
+      region_backend_service_name: 'tf-test-region-service-external'
+    ignore_read_extra:
+      - 'iap.0.oauth2_client_secret'
+  - !ruby/object:Provider::Terraform::Examples
     name: 'region_backend_service_cache'
     primary_resource_id: 'default'
     vars:

--- a/mmv1/templates/terraform/encoders/backend_service.go.erb
+++ b/mmv1/templates/terraform/encoders/backend_service.go.erb
@@ -23,8 +23,6 @@ iapVal := obj["iap"]
 if iapVal == nil {
 	data := map[string]interface{}{}
 	data["enabled"] = false
-	data["oauth2ClientId"] = ""
-	data["oauth2ClientSecret"] = ""
 	obj["iap"] = data
 } else {
 	iap := iapVal.(map[string]interface{})

--- a/mmv1/templates/terraform/encoders/region_backend_service.go.erb
+++ b/mmv1/templates/terraform/encoders/region_backend_service.go.erb
@@ -23,8 +23,6 @@ iapVal := obj["iap"]
 if iapVal == nil {
 	data := map[string]interface{}{}
 	data["enabled"] = false
-	data["oauth2ClientId"] = ""
-	data["oauth2ClientSecret"] = ""
 	obj["iap"] = data
 } else {
 	iap := iapVal.(map[string]interface{})

--- a/mmv1/templates/terraform/examples/backend_service_external_iap.tf.erb
+++ b/mmv1/templates/terraform/examples/backend_service_external_iap.tf.erb
@@ -1,0 +1,9 @@
+resource "google_compute_backend_service" "<%= ctx[:primary_resource_id] %>" {
+  name                  = "<%= ctx[:vars]['backend_service_name'] %>"
+  protocol              = "HTTP"
+  load_balancing_scheme = "EXTERNAL"
+  iap {
+    oauth2_client_id     = "abc"
+    oauth2_client_secret = "xyz"
+  }
+}

--- a/mmv1/templates/terraform/examples/region_backend_service_external_iap.tf.erb
+++ b/mmv1/templates/terraform/examples/region_backend_service_external_iap.tf.erb
@@ -1,0 +1,10 @@
+resource "google_compute_region_backend_service" "<%= ctx[:primary_resource_id] %>" {
+  name                  = "<%= ctx[:vars]['region_backend_service_name'] %>"
+  region                = "us-central1"
+  protocol              = "HTTP"
+  load_balancing_scheme = "EXTERNAL"
+  iap {
+    oauth2_client_id     = "abc"
+    oauth2_client_secret = "xyz"
+  }
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes internal issue b/319412975

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: remove sending empty oauth2ClientId and oauth2ClientSecret string for null IAP message in google_compute_region_backend_service as it triggers resource validation

```
