### PR TITLE
Add network_attachment on gce instance data source

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.erb
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.erb
@@ -359,6 +359,9 @@ func flattenNetworkInterfaces(d *schema.ResourceData, config *transport_tpg.Conf
 			"ipv6_access_config": flattenIpv6AccessConfigs(iface.Ipv6AccessConfigs),
 			"ipv6_address":        iface.Ipv6Address,
 			"queue_count":         iface.QueueCount,
+			<% unless version == 'ga' -%>
+			"network_attachment": iface.NetworkAttachment,
+			<% end -%>
 		}
 		// Instance template interfaces never have names, so they're absent
 		// in the instance template network_interface schema. We want to use the

--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.erb
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.erb
@@ -358,10 +358,7 @@ func flattenNetworkInterfaces(d *schema.ResourceData, config *transport_tpg.Conf
 			"stack_type":          iface.StackType,
 			"ipv6_access_config": flattenIpv6AccessConfigs(iface.Ipv6AccessConfigs),
 			"ipv6_address":        iface.Ipv6Address,
-			"queue_count":         iface.QueueCount,
-			<% unless version == 'ga' -%>
-			"network_attachment": iface.NetworkAttachment,
-			<% end -%>
+			"queue_count":         iface.QueueCount,			
 		}
 		// Instance template interfaces never have names, so they're absent
 		// in the instance template network_interface schema. We want to use the

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance_test.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package compute_test
 
 import (
@@ -106,8 +107,7 @@ resource "google_compute_instance" "foo" {
   }
 
   network_interface {
-    network = "default"
-
+    network = "default"	
     access_config {
       // Ephemeral IP
     }
@@ -137,3 +137,98 @@ data "google_compute_instance" "baz" {
 }
 `, instanceName)
 }
+<% unless version == 'ga' -%>
+func TestAccDataSourceComputeInstance_networkAttachmentUsageExample(t *testing.T) {
+	t.Parallel()
+
+	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceComputeInstance_networkAttachmentUsageConfig(instanceName),
+				Check:  resource.TestCheckResourceAttrSet("data.google_compute_instance.bar", "network_interface.1.network_attachment"),
+			},
+		},
+	})
+}
+
+func testAccDataSourceComputeInstance_networkAttachmentUsageConfig(instanceName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_instance" "foo" {
+	provider = google-beta
+  name           = "%s"
+  machine_type   = "n1-standard-1"   // can't be e2 because of local-ssd
+  zone           = "us-central1-a"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-8-jessie-v20160803"
+    }
+  }
+
+  scratch_disk {
+	interface = "SCSI"
+  }
+
+  network_interface {
+    network = "default"
+	
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+  network_interface { 
+	network_attachment = google_compute_network_attachment.net_attar_default.self_link   
+  }
+
+ 
+
+  labels = {
+    my_key       = "my_value"
+    my_other_key = "my_other_value"
+  }
+
+  enable_display = true
+}
+
+data "google_compute_instance" "bar" {
+	provider = google-beta
+  name = google_compute_instance.foo.name
+  zone = "us-central1-a"
+}
+
+data "google_compute_instance" "baz" {
+	provider = google-beta
+  self_link = google_compute_instance.foo.self_link
+}
+resource "google_compute_network" "net_att_default" {   
+	provider = google-beta
+    name = "basic-network-att"
+    auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnet_att_default" {    
+	provider = google-beta
+    name   = "basic-subnetwork-att" 
+	region = "us-central1"  
+    network       = google_compute_network.net_att_default.id
+    ip_cidr_range = "10.0.0.0/16"
+}
+
+resource "google_compute_network_attachment" "net_attar_default" {   
+	provider = google-beta 
+    name   = "basic-attachment"
+    region = "us-central1"
+    subnetworks = [google_compute_subnetwork.subnet_att_default.id]
+    connection_preference = "ACCEPT_AUTOMATIC"
+}
+`, instanceName)
+}
+<% end -%>

--- a/mmv1/third_party/terraform/website/docs/d/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance.html.markdown
@@ -159,6 +159,8 @@ The following arguments are supported:
 
 * `alias_ip_range` - An array of alias IP ranges for this network interface. Structure [documented below](#nested_alias_ip_range).
 
+* `network_attachment` - [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) The URL of the network attachment to this interface.	
+
 <a name="nested_access_config"></a>The `access_config` block supports:
 
 * `nat_ip` - The IP address that is be 1:1 mapped to the instance's


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/17032
This PR adds the 'network_attachament' on the 'network_interface' block to the GCE instance data source on google-beta-provider
 
If this PR is for Terraform, I acknowledge that I have:

- Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- Ensured that the resource and his fields wich I added that can be set by a user appear in at least one example (for generated resources) or third_party test (for handwritten resources or update tests).
- [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [make test and make lint](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
 docs: added `network_attachment` to `google_compute_instance` data source (beta)
```
