### PR TITLE
google_netapp_volume: Add deletion_policy

### DIFF
--- a/mmv1/products/netapp/volume.yaml
+++ b/mmv1/products/netapp/volume.yaml
@@ -427,6 +427,5 @@ virtual_fields:
       - :DEFAULT
       - :FORCE
     default_value: :DEFAULT
-    ignore_read: true
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   pre_delete: templates/terraform/pre_delete/netapp_volume_force_delete.go.erb

--- a/mmv1/products/netapp/volume.yaml
+++ b/mmv1/products/netapp/volume.yaml
@@ -414,3 +414,16 @@ properties:
 #       description: |-
 #         Full name of the snapshot resource. Format: `projects/{{project}}/locations/{{location}}/volumes/{{volume}}/snapshots/{{snapshot}}`.
 #       required: true
+virtual_fields:
+  - !ruby/object:Api::Type::Enum
+    name: 'deletion_policy'
+    description: |
+      Policy to determine if the volume should be deleted forcefully.
+      Volumes may have nested snapshot resources. Deleting such a volume will fail.
+      Setting this parameter to FORCE will delete volumes including nested snapshots.
+    values:
+      - :DEFAULT
+      - :FORCE
+    default_value: :DEFAULT
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  pre_delete: templates/terraform/pre_delete/netapp_volume_force_delete.go.erb

--- a/mmv1/products/netapp/volume.yaml
+++ b/mmv1/products/netapp/volume.yaml
@@ -203,7 +203,7 @@ properties:
     name: 'description'
     description: |
       An optional description of this resource.
-  # We want to get rid of this. Please don't expose.
+  # Use of snapReserve is depricated. We don't expose it intentially.
   # - !ruby/object:Api::Type::Integer
   #   name: 'snapReserve'
   #   description: |
@@ -425,5 +425,6 @@ virtual_fields:
       - :DEFAULT
       - :FORCE
     default_value: :DEFAULT
+    ignore_read_extra: true
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   pre_delete: templates/terraform/pre_delete/netapp_volume_force_delete.go.erb

--- a/mmv1/products/netapp/volume.yaml
+++ b/mmv1/products/netapp/volume.yaml
@@ -59,6 +59,8 @@ examples:
       volume_name: 'test-volume'
       pool_name: 'test-pool'
       network_name: 'test-network'
+    ignore_read_extra:
+      - "deletion_policy"
     test_vars_overrides:
       network_name: 'acctest.BootstrapSharedServiceNetworkingConnection(t, "gcnv-network-config-1", acctest.ServiceNetworkWithParentService("netapp.servicenetworking.goog"))'
 properties:
@@ -425,6 +427,6 @@ virtual_fields:
       - :DEFAULT
       - :FORCE
     default_value: :DEFAULT
-    ignore_read_extra: true
+    ignore_read: true
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   pre_delete: templates/terraform/pre_delete/netapp_volume_force_delete.go.erb

--- a/mmv1/templates/terraform/examples/volume_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/volume_basic.tf.erb
@@ -13,6 +13,7 @@ resource "google_netapp_volume" "<%= ctx[:primary_resource_id] %>" {
   share_name = "<%= ctx[:vars]['volume_name'] %>"
   storage_pool = google_netapp_storage_pool.default.name
   protocols = ["NFSV3"]
+  deletion_policy = "DEFAULT"
 }
 
 data "google_compute_network" "default" {

--- a/mmv1/templates/terraform/pre_delete/netapp_volume_force_delete.go.erb
+++ b/mmv1/templates/terraform/pre_delete/netapp_volume_force_delete.go.erb
@@ -1,0 +1,4 @@
+// Delete volume even when nested snapshots do exist
+if deletionPolicy := d.Get("deletion_policy"); deletionPolicy == "FORCE" {
+    url = url + "?force=true"
+}

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_test.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_test.go
@@ -319,7 +319,8 @@ resource "google_netapp_volume" "test_volume" {
 		}
 	}
 	restricted_actions = ["DELETE"]
-	}
+	deletion_policy = "FORCE"
+}
 
 data "google_compute_network" "default" {
 	name = "%{network_name}"

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_test.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_test.go
@@ -45,7 +45,7 @@ func TestAccNetappVolume_volumeBasicExample_update(t *testing.T) {
 				ResourceName:            "google_netapp_volume.test_volume",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "name", "labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"location", "name", "labels", "terraform_labels", "deletion_policy"},
 			}, {
 				Config: testAccNetappVolume_volumeBasicExample_full(context),
 			},
@@ -53,7 +53,7 @@ func TestAccNetappVolume_volumeBasicExample_update(t *testing.T) {
 				ResourceName:            "google_netapp_volume.test_volume",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "name", "labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"location", "name", "labels", "terraform_labels", "deletion_policy"},
 			},
 			{
 				Config: testAccNetappVolume_volumeBasicExample_update(context),
@@ -62,7 +62,7 @@ func TestAccNetappVolume_volumeBasicExample_update(t *testing.T) {
 				ResourceName:            "google_netapp_volume.test_volume",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "name", "labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"location", "name", "labels", "terraform_labels", "deletion_policy"},
 			},
 			{
 				Config: testAccNetappVolume_volumeBasicExample_updatesnapshot(context),
@@ -71,7 +71,7 @@ func TestAccNetappVolume_volumeBasicExample_update(t *testing.T) {
 				ResourceName:            "google_netapp_volume.test_volume",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "name", "labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"location", "name", "labels", "terraform_labels", "deletion_policy"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_test.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_test.go
@@ -318,9 +318,21 @@ resource "google_netapp_volume" "test_volume" {
 			nfsv4                 = false
 		}
 	}
+	# Delete protection only gets active after an NFS client mounts.
+	# Setting it here is save, volume can still be deleted.
 	restricted_actions = ["DELETE"]
 	deletion_policy = "FORCE"
 }
+
+# Add the following snapshot block to the test as soon as snapshot resoruce
+# is added to the provider. It will make the test cleanup require
+# deletion_policy = "FORCE" on the volume for successful delete.
+# resource "google_netapp_volumesnapshot" "test-snapshot" {
+#	depends_on = [google_netapp_volume.test_volume]
+#	location = google_netapp_volume.test_volume.location
+#	volume_name = google_netapp_volume.test_volume.name
+#	name = "test-snapshot%{random_suffix}"
+#  }
 
 data "google_compute_network" "default" {
 	name = "%{network_name}"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This PR fixes https://github.com/hashicorp/terraform-provider-google/issues/17076

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
Volume deletions fail if a volume contains nested resources (= snapshot). Such volumes require a force delete.
Adds a new parameter called `deletion_policy`. The user can set it to
- `DEFAULT`: The default behavior is to still fail volume delete if nested resources exist.
- `FORCE`: Force volume deletion, meaning nested resources will be deleted as well.
```
