### PR TITLE
Add support for disableTcpConnections field to google_workstations_workstation_config

### DIFF
--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -196,6 +196,11 @@ properties:
     description: |
       Whether to enable Linux `auditd` logging on the workstation. When enabled, a service account must also be specified that has `logging.buckets.write` permission on the project. Operating system audit logging is distinct from Cloud Audit Logs.
     ignore_read: true
+  - !ruby/object:Api::Type::Boolean
+    name: 'disableTcpConnections'
+    description: |
+      Disables support for plain TCP connections in the workstation. By default the service supports TCP connections via a websocket relay. Setting this option to true disables that relay, which prevents the usage
+      of services that require plain tcp connections, such as ssh. When enabled, all communication must occur over https or wss.
   - !ruby/object:Api::Type::NestedObject
     name: 'host'
     description: |

--- a/mmv1/templates/terraform/examples/workstation_config_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/workstation_config_basic.tf.erb
@@ -42,6 +42,8 @@ resource "google_workstations_workstation_config" "<%= ctx[:primary_resource_id]
     label-one = "value-one"
   }
 
+  disable_tcp_connections = false
+
   labels = {
     "label" = "key"
   }


### PR DESCRIPTION
Add support for disableTcpConnections field to google_workstations_workstation_config



**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
workstations: Add support for `disable_tcp_connections` in `google_workstations_workstation_config` (beta)
```
