### PR TITLE
Remove default value from PC type

### DIFF
--- a/mmv1/products/vmwareengine/PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/PrivateCloud.yaml
@@ -49,6 +49,7 @@ custom_code: !ruby/object:Provider::Terraform::CustomCode
   decoder: "templates/terraform/decoders/private_cloud.go.erb"
   post_update: "templates/terraform/post_update/private_cloud.go.erb"
   update_encoder: "templates/terraform/update_encoder/private_cloud.go.erb"
+  constants: templates/terraform/constants/vmwareengine_private_cloud_type.go.erb
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: "vmware_engine_private_cloud_basic"
@@ -292,7 +293,7 @@ properties:
       Initial type of the private cloud.
     immutable: true
     ignore_read: true
+    diff_suppress_func: vmwareenginePrivateCloudStandardTypeDiffSuppressFunc
     values:
       - :STANDARD
       - :TIME_LIMITED
-    default_value: :STANDARD

--- a/mmv1/templates/terraform/constants/vmwareengine_private_cloud_type.go.erb
+++ b/mmv1/templates/terraform/constants/vmwareengine_private_cloud_type.go.erb
@@ -1,0 +1,6 @@
+func vmwareenginePrivateCloudStandardTypeDiffSuppressFunc(_, old, new string, _ *schema.ResourceData) bool {
+	if ((old == "STANDARD" && new == "") or (old == "" && new == STANDARD)) {
+		return true
+	}
+	return false
+}

--- a/mmv1/templates/terraform/constants/vmwareengine_private_cloud_type.go.erb
+++ b/mmv1/templates/terraform/constants/vmwareengine_private_cloud_type.go.erb
@@ -1,5 +1,5 @@
 func vmwareenginePrivateCloudStandardTypeDiffSuppressFunc(_, old, new string, _ *schema.ResourceData) bool {
-	if ((old == "STANDARD" && new == "") or (old == "" && new == STANDARD)) {
+	if (old == "STANDARD" && new == "") || (old == "" && new == "STANDARD") {
 		return true
 	}
 	return false


### PR DESCRIPTION
Adding a default value to PC forces recreation of existing PC when upgrading version to 5.10.0. This fix would allow users to continue with their old PC configuration without specifying a PC type. 

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
vmwareengine: prevent recreation of existing PCs on upgrading version from <5.10.0
```
