### PR TITLE
Add `STANDARD_WITH_GRAPHQL` option to `json_parsing` field in `google_compute_security_policy` resource

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.erb
@@ -439,7 +439,7 @@ func ResourceComputeSecurityPolicy() *schema.Resource {
 							Type: schema.TypeString,
 							Optional: true,
 							Computed: true,
-							ValidateFunc: validation.StringInSlice([]string{"DISABLED", "STANDARD"}, false),
+							ValidateFunc: validation.StringInSlice([]string{"DISABLED", "STANDARD", "STANDARD_WITH_GRAPHQL"}, false),
 							Description: `JSON body parsing. Supported values include: "DISABLED", "STANDARD".`,
 						},
 						"json_custom_config": {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
@@ -1172,7 +1172,7 @@ func testAccComputeSecurityPolicy_withAdvancedOptionsConfig_update3(spName strin
 	return fmt.Sprintf(`
 resource "google_compute_security_policy" "policy" {
   name        = "%s"
-  description = "updated description changing all advancedOptionsConfig values"
+  description = "updated description changing json_parsing to STANDARD_WITH_GRAPHQL"
 
   advanced_options_config {
     json_parsing = "STANDARD_WITH_GRAPHQL"

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
@@ -207,6 +207,15 @@ func TestAccComputeSecurityPolicy_withAdvancedOptionsConfig(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			// Swap to json_parsing = STANDARD_WITH_GRAPHQL
+			{
+				Config: testAccComputeSecurityPolicy_withAdvancedOptionsConfig_update3(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			<% end -%>
 			{
 				Config: testAccComputeSecurityPolicy_basic(spName),
@@ -1145,6 +1154,28 @@ resource "google_compute_security_policy" "policy" {
 
   advanced_options_config {
     json_parsing = "DISABLED"
+    json_custom_config {
+      content_types = [
+        "application/json",
+        "application/vnd.hyper+json"
+      ]
+    }
+    log_level    = "NORMAL"
+    user_ip_request_headers = [
+    ]
+  }
+}
+`, spName)
+}
+
+func testAccComputeSecurityPolicy_withAdvancedOptionsConfig_update3(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+  name        = "%s"
+  description = "updated description changing all advancedOptionsConfig values"
+
+  advanced_options_config {
+    json_parsing = "STANDARD_WITH_GRAPHQL"
     json_custom_config {
       content_types = [
         "application/json",


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Closes https://github.com/hashicorp/terraform-provider-google/issues/17039

This PR updates the enum field `advanced_options_config.json_parsing` on the `google_compute_security_policy` resource to allow users to use the value `"STANDARD_WITH_GRAPHQL"` 


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: updated the `google_compute_security_policy` resource's `json_parsing` field to accept the value STANDARD_WITH_GRAPHQL
```
