### PR TITLE
Promote `user_ip_request_headers` field on `google_compute_security_policy` resource to GA

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.erb
@@ -5,9 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log"
-<% unless version == 'ga' -%>
 	"strings"
-<% end -%>
 
 	"time"
 
@@ -466,14 +464,12 @@ func ResourceComputeSecurityPolicy() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{"NORMAL", "VERBOSE"}, false),
 							Description: `Logging level. Supported values include: "NORMAL", "VERBOSE".`,
 						},
-						<% unless version == 'ga' -%>
 						"user_ip_request_headers": {
 							Type:        schema.TypeSet,
 							Optional:    true,
 							Description: `An optional list of case-insensitive request header names to use for resolving the callers client IP address.`,
 							Elem:        &schema.Schema{Type: schema.TypeString},
 						},
-						<% end -%>
 					},
 				},
 			},
@@ -742,9 +738,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 		Fingerprint: d.Get("fingerprint").(string),
 	}
 
-	<% unless version == 'ga' -%>
 	updateMask := []string{}
-	<% end -%>
 
 	if d.HasChange("type") {
 		securityPolicy.Type = d.Get("type").(string)
@@ -759,13 +753,11 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 	if d.HasChange("advanced_options_config") {
 		securityPolicy.AdvancedOptionsConfig = expandSecurityPolicyAdvancedOptionsConfig(d.Get("advanced_options_config").([]interface{}))
 		securityPolicy.ForceSendFields = append(securityPolicy.ForceSendFields, "AdvancedOptionsConfig", "advancedOptionsConfig.jsonParsing", "advancedOptionsConfig.jsonCustomConfig", "advancedOptionsConfig.logLevel")
-		<% unless version == 'ga' -%>
 		securityPolicy.ForceSendFields = append(securityPolicy.ForceSendFields, "advanceOptionConfig.userIpRequestHeaders")
 		if len(securityPolicy.AdvancedOptionsConfig.UserIpRequestHeaders) == 0 {
 			// to clean this list we must send the updateMask of this field on the request.
 			updateMask = append(updateMask, "advanced_options_config.user_ip_request_headers")
 		}
-		<% end -%>
 	}
 
 	if d.HasChange("adaptive_protection_config") {
@@ -784,11 +776,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 	if len(securityPolicy.ForceSendFields) > 0 {
 		client := config.NewComputeClient(userAgent)
 
-		<% if version == 'ga' -%>
-		op, err := client.SecurityPolicies.Patch(project, sp, securityPolicy).Do()
-		<% else -%>
 		op, err := client.SecurityPolicies.Patch(project, sp, securityPolicy).UpdateMask(strings.Join(updateMask, ",")).Do()
-		<% end -%>
 
 		if err != nil {
 			return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)
@@ -1230,9 +1218,7 @@ func expandSecurityPolicyAdvancedOptionsConfig(configured []interface{}) *comput
 		JsonParsing:      data["json_parsing"].(string),
 		JsonCustomConfig: expandSecurityPolicyAdvancedOptionsConfigJsonCustomConfig(data["json_custom_config"].([]interface{})),
 		LogLevel:         data["log_level"].(string),
-		<% unless version == 'ga' -%>
 		UserIpRequestHeaders: tpgresource.ConvertStringArr(data["user_ip_request_headers"].(*schema.Set).List()),
-		<% end %>
 	}
 }
 
@@ -1245,9 +1231,7 @@ func flattenSecurityPolicyAdvancedOptionsConfig(conf *compute.SecurityPolicyAdva
 		"json_parsing":       conf.JsonParsing,
 		"json_custom_config": flattenSecurityPolicyAdvancedOptionsConfigJsonCustomConfig(conf.JsonCustomConfig),
 		"log_level":          conf.LogLevel,
-		<% unless version == 'ga' -%>
 		"user_ip_request_headers": schema.NewSet(schema.HashString, tpgresource.ConvertStringArrToInterface(conf.UserIpRequestHeaders)),
-		<% end -%>
 	}
 
 	return []map[string]interface{}{data}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
@@ -189,7 +189,6 @@ func TestAccComputeSecurityPolicy_withAdvancedOptionsConfig(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			<% unless version == 'ga' -%>
 			{
 				Config: testAccComputeSecurityPolicy_withAdvancedOptionsConfig_update(spName),
 			},
@@ -207,7 +206,6 @@ func TestAccComputeSecurityPolicy_withAdvancedOptionsConfig(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			<% end -%>
 			{
 				Config: testAccComputeSecurityPolicy_basic(spName),
 			},
@@ -1099,19 +1097,15 @@ resource "google_compute_security_policy" "policy" {
       ]
     }
     log_level    = "VERBOSE"
-    <% unless version == 'ga' -%>
     user_ip_request_headers = [
       "True-Client-IP", 
       "x-custom-ip"
     ]
-    <% end -%>
-
   }
 }
 `, spName)
 }
 
-<% unless version == 'ga' -%>
 func testAccComputeSecurityPolicy_withAdvancedOptionsConfig_update(spName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_security_policy" "policy" {
@@ -1158,7 +1152,6 @@ resource "google_compute_security_policy" "policy" {
 }
 `, spName)
 }
-<% end -%>
 
 func testAccComputeSecurityPolicy_withAdaptiveProtection(spName string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
@@ -215,8 +215,6 @@ func TestAccComputeSecurityPolicy_withAdvancedOptionsConfig(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			<% end -%>
-
 			{
 				Config: testAccComputeSecurityPolicy_basic(spName),
 			},

--- a/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
@@ -204,7 +204,7 @@ The following arguments are supported:
   * `NORMAL` - Normal log level.
   * `VERBOSE` - Verbose log level.
 
-* `user_ip_request_headers` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) An optional list of case-insensitive request header names to use for resolving the callers client IP address.
+* `user_ip_request_headers` - (Optional) An optional list of case-insensitive request header names to use for resolving the callers client IP address.
 
 <a name="nested_json_custom_config"></a>The `json_custom_config` block supports:
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR promotes the `user_ip_request_headers` field on `google_compute_security_policy` resource to GA.
The API docs show [userIpRequestHeaders as present in the GA version of the API](https://cloud.google.com/compute/docs/reference/rest/v1/securityPolicies#SecurityPolicy.FIELDS.inlinedField_89:~:text=advancedOptionsConfig.userIpRequestHeaders%5B%5D).


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: promoted `user_ip_request_headers` field on `google_compute_security_policy` resource to GA
```
