### PR TITLE
Add creation_timestamp to google_compute_(region_)instance_group_manager

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
@@ -763,7 +763,7 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 	if err := d.Set("zone", tpgresource.GetResourceNameFromSelfLink(manager.Zone)); err != nil {
 		return fmt.Errorf("Error setting zone: %s", err)
 	}
-	if err := d.Set("creation_timestamp", flattenCreationTimestamp(manager.CreationTimestamp, d, config)); err != nil {
+	if err := d.Set("creation_timestamp", manager.CreationTimestamp); err != nil {
 		return fmt.Errorf("Error reading creation_timestamp: %s", err)
 	}
 	if err := d.Set("description", manager.Description); err != nil {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
@@ -109,6 +109,12 @@ func ResourceComputeInstanceGroupManager() *schema.Resource {
 				Description: `The zone that instances in this group should be created in.`,
 			},
 
+			"creation_timestamp": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Creation timestamp in RFC3339 text format.`,
+			},
+
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -757,6 +763,9 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 	if err := d.Set("zone", tpgresource.GetResourceNameFromSelfLink(manager.Zone)); err != nil {
 		return fmt.Errorf("Error setting zone: %s", err)
 	}
+	if err := d.Set("creation_timestamp", flattenCreationTimestamp(manager.CreationTimestamp, d, config)); err != nil {
+		return fmt.Errorf("Error reading IGM: %s", err)
+	}
 	if err := d.Set("description", manager.Description); err != nil {
 		return fmt.Errorf("Error setting description: %s", err)
 	}
@@ -1260,6 +1269,10 @@ func expandUpdatePolicy(configured []interface{}) *compute.InstanceGroupManagerU
 		}
 	}
 	return updatePolicy
+}
+
+func flattenCreationTimestamp(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
 }
 
 func flattenAutoHealingPolicies(autoHealingPolicies []*compute.InstanceGroupManagerAutoHealingPolicy) []map[string]interface{} {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
@@ -1271,10 +1271,6 @@ func expandUpdatePolicy(configured []interface{}) *compute.InstanceGroupManagerU
 	return updatePolicy
 }
 
-func flattenCreationTimestamp(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
-	return v
-}
-
 func flattenAutoHealingPolicies(autoHealingPolicies []*compute.InstanceGroupManagerAutoHealingPolicy) []map[string]interface{} {
 	autoHealingPoliciesSchema := make([]map[string]interface{}, 0, len(autoHealingPolicies))
 	for _, autoHealingPolicy := range autoHealingPolicies {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
@@ -764,7 +764,7 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 		return fmt.Errorf("Error setting zone: %s", err)
 	}
 	if err := d.Set("creation_timestamp", flattenCreationTimestamp(manager.CreationTimestamp, d, config)); err != nil {
-		return fmt.Errorf("Error reading IGM: %s", err)
+		return fmt.Errorf("Error reading creation_timestamp: %s", err)
 	}
 	if err := d.Set("description", manager.Description); err != nil {
 		return fmt.Errorf("Error setting description: %s", err)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
@@ -714,7 +714,7 @@ func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta 
 	if err := d.Set("region", tpgresource.GetResourceNameFromSelfLink(manager.Region)); err != nil {
 		return fmt.Errorf("Error setting region: %s", err)
 	}
-	if err := d.Set("creation_timestamp", flattenCreationTimestamp(manager.CreationTimestamp, d, config)); err != nil {
+	if err := d.Set("creation_timestamp", manager.CreationTimestamp); err != nil {
 		return fmt.Errorf("Error reading creation_timestamp: %s", err)
 	}
 	if err := d.Set("description", manager.Description); err != nil {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
@@ -715,7 +715,7 @@ func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta 
 		return fmt.Errorf("Error setting region: %s", err)
 	}
 	if err := d.Set("creation_timestamp", flattenCreationTimestamp(manager.CreationTimestamp, d, config)); err != nil {
-		return fmt.Errorf("Error reading IGM: %s", err)
+		return fmt.Errorf("Error reading creation_timestamp: %s", err)
 	}
 	if err := d.Set("description", manager.Description); err != nil {
 		return fmt.Errorf("Error setting description: %s", err)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
@@ -110,6 +110,12 @@ func ResourceComputeRegionInstanceGroupManager() *schema.Resource {
 				Description: `The region where the managed instance group resides.`,
 			},
 
+			"creation_timestamp": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Creation timestamp in RFC3339 text format.`,
+			},
+
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -707,6 +713,9 @@ func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta 
 	}
 	if err := d.Set("region", tpgresource.GetResourceNameFromSelfLink(manager.Region)); err != nil {
 		return fmt.Errorf("Error setting region: %s", err)
+	}
+	if err := d.Set("creation_timestamp", flattenCreationTimestamp(manager.CreationTimestamp, d, config)); err != nil {
+		return fmt.Errorf("Error reading IGM: %s", err)
 	}
 	if err := d.Set("description", manager.Description); err != nil {
 		return fmt.Errorf("Error setting description: %s", err)


### PR DESCRIPTION
Add read-only creation_timestamp to google_compute_instance_group_manager and google_compute_region_instance_group_manager.
Solves (R)IGM part of https://github.com/hashicorp/terraform-provider-google/issues/15663

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `creation_timestamp` to `google_compute_instance_group_manager` and `google_compute_region_instance_group_manager`.
```
