### PR TITLE
Added document explaining best practices for resolving permadiffs

### DIFF
--- a/docs/content/develop/field-reference.md
+++ b/docs/content/develop/field-reference.md
@@ -81,7 +81,7 @@ state. See
 for more information.
 
 Sensitive fields are often not returned by the API (because they are sensitive).
-In this case, the field will also need to use [`ignore_read` or a `custom_flatten` function]({{< ref "/develop/field-reference#ignore_read" >}}).
+In this case, the field will also need to use [`ignore_read` or a `custom_flatten` function]({{< ref "/develop/permadiff#ignore_read" >}}).
 
 Example:
 

--- a/docs/content/develop/field-reference.md
+++ b/docs/content/develop/field-reference.md
@@ -212,6 +212,20 @@ Example:
     - nested_object.0.nested_field
 ```
 
+### `diff_suppress_func`
+Specifies the name of a [diff suppress function](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#diffsuppressfunc)
+to use for this field. In many cases, a [custom flattener](https://googlecloudplatform.github.io/magic-modules/develop/custom-code/#custom_flatten)
+is preferred because it will allow the user to see a clearer diff when the field actually is being changed. See
+[Fix a permadiff]({{< ref "/develop/permadiff.md" >}}) for more information and best practices.
+
+Example:
+
+```yaml
+- !ruby/object:Api::Type::String
+  name: 'fieldOne'
+  diff_suppress_func: 'tpgresource.CaseDiffSuppress'
+```
+
 ## `Enum` properties
 
 ### `values`

--- a/docs/content/develop/permadiff.md
+++ b/docs/content/develop/permadiff.md
@@ -1,0 +1,261 @@
+---
+title: "Fix a permadiff"
+weight: 60
+---
+
+# Fix a permadiff
+
+Permadiffs are an extremely common class of errors that users experience. They manifest as diffs at plan time on fields that a user has not modified in their configuration. They can also show up as test failures with the error message: "After applying this test step, the plan was not empty."
+
+In a general sense, permadiffs are caused by the API returning a different value for the field than what the user sent, which causes Terraform to try to re-send the same request, which gets the same response, which continues to result in the user seeing a diff. In general, APIs that return exactly what the user sent are more friendly for Terraform or other declarative tooling. However, many GCP APIs normalize inputs, have server-side defaults that are returned to the user, do not return all the fields set on a resource, or return data in a different format in some other way.
+
+This page outlines best practices for working around various types of permadiffs in the `google` and `google-beta` providers.
+
+## API returns default value for unset field
+
+For new fields, if possible, set a client-side default that matches the API default. This will prevent the diff and will allow users to accurately see what the end state will be if the field is not set in their configuration. A client-side default should only be used if the API sets the same default value in all cases and the default value will be stable over time. Changing a client-side default is a [breaking change]({{< ref "/develop/breaking-changes/breaking-changes" >}}).
+
+{{< tabs "default_value" >}}
+{{< tab "MMv1" >}}
+```yaml
+default_value: DEFAULT_VALUE
+```
+
+In the providers, this will be converted to:
+
+```go
+"field": {
+    // ...
+    Default: "DEFAULT_VALUE",
+}
+```
+
+See [SDKv2 Schema Behaviors - Default ↗](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#default) for more information.
+{{< /tab >}}
+{{< tab "Handwritten" >}}
+```go
+"field": {
+    // ...
+    Default: "DEFAULT_VALUE",
+}
+```
+
+See [SDKv2 Schema Behaviors - Default ↗](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#default) for more information.
+{{< /tab >}}
+{{< /tabs >}}
+
+For existing fields (or new fields that are not eligible for a client-side default), mark the field as having an API-side default. If the field is not set (or is set to an "empty" value such as zero, false, or an empty string) the provider will treat the most recent value returned by the API as the value for the field, and will send that value for the field on subsequent requests. The field will show as `(known after apply)` in plans and it will not be possible for the user to explicitly set the field to an "empty" value.
+
+{{< tabs "default_from_api" >}}
+{{< tab "MMv1" >}}
+```yaml
+default_from_api: true
+```
+
+In the providers, this will be converted to:
+
+```go
+"field": {
+    // ...
+    Optional: true,
+    Computed: true,
+}
+```
+
+See [SDKv2 Schema Behaviors - Optional ↗](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#optional) and [SDKv2 Schema Behaviors - Computed ↗](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#computed) for more information.
+{{< /tab >}}
+{{< tab "Handwritten" >}}
+```go
+"field": {
+    // ...
+    Optional: true,
+    Computed: true,
+}
+```
+
+See [SDKv2 Schema Behaviors - Optional ↗](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#optional) and [SDKv2 Schema Behaviors - Computed ↗](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#computed) for more information.
+{{< /tab >}}
+{{< /tabs >}}
+
+## API returns an empty value if default value is sent
+
+Use a flattener to store the default value in state if the response has an empty value.
+
+{{< tabs "default_if_empty" >}}
+{{< tab "MMv1" >}}
+Use the standard `default_if_empty` flattener.
+
+```yaml
+custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.erb'
+```
+{{< /tab >}}
+{{< tab "Handwritten" >}}
+```go
+func flattenResourceNameFieldName(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+    if v == nil || tpgresource.IsEmptyValue(reflect.ValueOf(v)) {
+        return "DEFAULT_VALUE"
+    }
+    // Any other necessary logic goes here.
+    return v
+}
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+## API normalizes a value
+
+In cases where the API normalizes and returns a value in a simple, predictable way (such as capitalizing the value) add a diff suppress function for the field to suppress the diff.
+
+The `tpgresource` package in each provider supplies diff suppress functions for the following common cases:
+
+- `tpgresource.CaseDiffSuppress`: Suppress diffs from capitalization differences between the user's configuration and the API.
+- `tpgresource.DurationDiffSuppress`: Suppress diffs from duration format differences such as "60.0s" vs "60s". This is necessary for [`Duration`](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration) API fields.
+- `tpgresource.ProjectNumberDiffSuppress`: Suppress diffs caused by the provider sending a project ID and the API returning a project number.
+
+
+{{< tabs "diff_suppress_simple" >}}
+
+{{< tab "MMv1" >}}
+```yaml
+# Use a built-in function
+diff_suppress_func: tpgresource.CaseDiffSuppress
+
+# Reference a resource-specific function
+diff_suppress_func: resourceNameFieldNameDiffSuppress
+```
+
+Define resource-specific functions in a [`custom_code.constants`](https://googlecloudplatform.github.io/magic-modules/develop/custom-code/#add-reusable-variables-and-functions) file.
+
+```go
+func resourceNameFieldNameDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
+    // Separate function for easier unit testing
+    return resourceNameFieldNameDiffSuppressLogic(old, new)
+}
+
+func resourceNameFieldNameDiffSuppressLogic(old, new) bool {
+    // Diff suppression logic. Returns true if the diff should be suppressed - that is, if the
+    // old and new values should be considered "the same".
+}
+```
+
+See [SDKv2 Schema Behaviors - DiffSuppressFunc ↗](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#diffsuppressfunc) for more information.
+{{< /tab >}}
+{{< tab "Handwritten" >}}
+Define resource-specific functions in your service package, for example at the top of the related resource file.
+
+```go
+func resourceNameFieldNameDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
+    // Separate function for easier unit testing
+    return resourceNameFieldNameDiffSuppressLogic(old, new)
+}
+
+func resourceNameFieldNameDiffSuppressLogic(old, new) bool {
+    // Diff suppression logic. Returns true if the diff should be suppressed - that is, if the
+    // old and new values should be considered "the same".
+}
+```
+
+Reference diff suppress functions from the field definition.
+
+```go
+"field": {
+    // ...
+    DiffSuppressFunc: resourceNameFieldNameDiffSuppress,
+}
+```
+
+See [SDKv2 Schema Behaviors - DiffSuppressFunc ↗](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#diffsuppressfunc) for more information.
+{{< /tab >}}
+{{< /tabs >}}
+
+## API does not return a field that was sent
+
+In the flattener for the field, return the value of the field in the user's configuration.
+
+{{< tabs "ignore_read" >}}
+{{< tab "MMv1" >}}
+On top-level fields, this can be done with:
+
+```yaml
+ignore_read: true
+```
+
+For nested fields, `ignore_read` is [not currently supported](https://github.com/hashicorp/terraform-provider-google/issues/12410), so this must be implemented with a [custom flattener]({{< ref "/develop/custom-code#custom_flatten" >}}). You will also need to add the field to `ignore_read_extra` on any examples that are used to generate tests; this will cause tests to ignore the field when checking that the values in the API match the user's configuration.
+
+```go
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+    // We want to ignore read on this field, but cannot because it is nested
+    return d.Get("path.0.to.0.nested.0.field")
+}
+```
+
+```yaml
+examples:
+ - !ruby/object:Provider::Terraform::Examples
+   # example configuration
+   ignore_read_extra:
+     - "path.0.to.0.nested.0.field"
+```
+{{< /tab >}}
+{{< tab "Handwritten" >}}
+Use `d.Get` to set the flattened value to be the same as the user-configured value (instead of a value from the API).
+
+```go
+func flattenParentField(d *schema.ResourceData, disk *compute.AttachedDisk, config *transport_tpg.Config) []map[string]interface{} {
+    result := map[string]interface{}{
+        "nested_field": d.Get("path.0.to.0.parent_field.0.nested_field")
+    }
+    return []map[string]interface{}{result}
+}
+```
+
+In tests, add the field to `ImportStateVerifyIgnore` on any relevant import steps.
+
+```
+{
+    ResourceName:            "google_product_resource.default",
+    ImportState:             true,
+    ImportStateVerify:       true,
+    ImportStateVerifyIgnore: []string{""path.0.to.0.parent_field.0.nested_field"},
+},
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+## API returns a list in a different order than was sent
+
+For an Array of nested objects, convert it to a Set – this is a [breaking change]({{< ref "/develop/breaking-changes/breaking-changes" >}}) and can only happen in a major release.
+
+For an Array of simple values (such as strings or ints), rewrite the value in the flattener to match the order in the user's configuration. This will also simplify diffs if new values are added or removed.
+
+{{< tabs "diff_suppress_list" >}}
+
+{{< tab "MMv1" >}}
+Add a [custom flattener]({{< ref "/develop/custom-code#custom_flatten" >}}) for the field.
+
+```go
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+    configValue := d.Get("path.0.to.0.parent_field.0.nested_field").([]string)
+
+    ret := []string{}
+    // Add values from v to ret to match order in configValue and put any new strings at the end
+
+    return ret
+}
+```
+{{< /tab >}}
+{{< tab "Handwritten" >}}
+Define resource-specific functions in your service package, for example at the top of the related resource file.
+
+```go
+func flattenResourceNameFieldName(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+    configValue := d.Get("path.0.to.0.parent_field.0.nested_field").([]string)
+
+    ret := []string{}
+    // Add values from v to ret to match order in configValue and put any new strings at the end
+
+    return ret
+}
+```
+{{< /tab >}}
+{{< /tabs >}}

--- a/docs/content/develop/permadiff.md
+++ b/docs/content/develop/permadiff.md
@@ -11,7 +11,7 @@ In a general sense, permadiffs are caused by the API returning a different value
 
 This page outlines best practices for working around various types of permadiffs in the `google` and `google-beta` providers.
 
-## API returns default value for unset field
+## API returns default value for unset field {#default}
 
 For new fields, if possible, set a client-side default that matches the API default. This will prevent the diff and will allow users to accurately see what the end state will be if the field is not set in their configuration. A client-side default should only be used if the API sets the same default value in all cases and the default value will be stable over time. Changing a client-side default is a [breaking change]({{< ref "/develop/breaking-changes/breaking-changes" >}}).
 
@@ -77,9 +77,9 @@ See [SDKv2 Schema Behaviors - Optional ↗](https://developer.hashicorp.com/terr
 {{< /tab >}}
 {{< /tabs >}}
 
-## API returns an empty value if default value is sent
+## API returns an empty value if default value is sent {#default_if_empty}
 
-Use a flattener to store the default value in state if the response has an empty value.
+Use a flattener to store the default value in state if the response has an empty (or unset) value.
 
 {{< tabs "default_if_empty" >}}
 {{< tab "MMv1" >}}
@@ -102,7 +102,7 @@ func flattenResourceNameFieldName(v interface{}, d *schema.ResourceData, config 
 {{< /tab >}}
 {{< /tabs >}}
 
-## API normalizes a value
+## API normalizes a value {#normalized-value}
 
 In cases where the API normalizes and returns a value in a simple, predictable way (such as capitalizing the value) add a diff suppress function for the field to suppress the diff.
 
@@ -168,7 +168,9 @@ See [SDKv2 Schema Behaviors - DiffSuppressFunc ↗](https://developer.hashicorp.
 {{< /tab >}}
 {{< /tabs >}}
 
-## API does not return a field that was sent
+## API field that is never included in the response {#ignore_read}
+
+This is common for fields that store credentials or similar information. Such fields should also be marked as [`sensitive`]({{< ref "/develop/field-reference#sensitive" >}}).
 
 In the flattener for the field, return the value of the field in the user's configuration.
 
@@ -222,7 +224,7 @@ In tests, add the field to `ImportStateVerifyIgnore` on any relevant import step
 {{< /tab >}}
 {{< /tabs >}}
 
-## API returns a list in a different order than was sent
+## API returns a list in a different order than was sent {#list-order}
 
 For an Array of nested objects, convert it to a Set – this is a [breaking change]({{< ref "/develop/breaking-changes/breaking-changes" >}}) and can only happen in a major release.
 


### PR DESCRIPTION
Added document explaining our best practices for resolving various classes of permadiffs. This may not capture all cases currently but at least covers some common cases and gives a standard place for this information to live.

![localhost_1313_magic-modules_develop_permadiff_](https://github.com/GoogleCloudPlatform/magic-modules/assets/299979/1b8c1f3d-8f26-4ce5-bba7-0bb9e271b945)

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
