### PR TITLE
add stack_type attribute

### DIFF
--- a/mmv1/products/compute/InterconnectAttachment.yaml
+++ b/mmv1/products/compute/InterconnectAttachment.yaml
@@ -300,3 +300,15 @@ properties:
       - :IPSEC
     default_value: :NONE
     custom_flatten: templates/terraform/custom_flatten/default_if_empty.erb
+  - !ruby/object:Api::Type::Enum
+    name: 'stackType'
+    description: |
+      The stack type for this interconnect attachment to identify whether the IPv6
+      feature is enabled or not. If not specified, IPV4_ONLY will be used.
+
+      This field can be both set at interconnect attachments creation and update
+      interconnect attachment operations.
+    values:
+      - :IPV4_IPV6
+      - :IPV4_ONLY
+    default_from_api: true


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add `stack_type` attribute for `google_compute_interconnect_attachment` resource.

Note: Explicit test for this attribute cannot be added in examples because this attribute cannot be added for attachments of type `PARTNER`, attachments of type `DEDICATED` require `interconnect` to be specified, and there is no Terraform resource for creating an interconnect. Attachments of type `PARTNER_PROVIDER` cannot be created without being an approved partner. 

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/17129

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `stack_type` attribute for `google_compute_interconnect_attachment` resource.
```
