### PR TITLE
netapp_storage_pool: Improve example code

### DIFF
--- a/mmv1/products/netapp/storagePool.yaml
+++ b/mmv1/products/netapp/storagePool.yaml
@@ -22,7 +22,9 @@ description: |
  * LDAP use for NFS volumes, if applicable
  * Customer-managed encryption key (CMEK) policy
 
- The capacity of the pool can be split up and assigned to volumes within the pool. Storage pools are a billable component of NetApp Volumes. Billing is based on the location, service level, and capacity allocated to a pool independent of consumption at the volume level.
+ The capacity of the pool can be split up and assigned to volumes within the pool. Storage pools are a billable
+ component of NetApp Volumes. Billing is based on the location, service level, and capacity allocated to a pool
+ independent of consumption at the volume level.
 references: !ruby/object:Api::Resource::ReferenceLinks
   guides:
     'QUICKSTART_TITLE': 'https://cloud.google.com/netapp/volumes/docs/get-started/quickstarts/create-storage-pool'
@@ -64,7 +66,6 @@ examples:
       network_name: 'test-network'
       global_name: 'test-address'
 properties:
-  # Fields go here
   - !ruby/object:Api::Type::Enum
     name: 'serviceLevel'
     description: |

--- a/mmv1/templates/terraform/examples/Storage_pool_create.tf.erb
+++ b/mmv1/templates/terraform/examples/Storage_pool_create.tf.erb
@@ -1,9 +1,10 @@
-
+# Create a network or use datasource to reference existing network
 resource "google_compute_network" "peering_network" {
   name = "<%= ctx[:vars]['network_name'] %>"
 }
 
-# Create an IP address
+# Reserve a CIDR for NetApp Volumes to use
+# When using shared-VPCs, this resource needs to be created in host project
 resource "google_compute_global_address" "private_ip_alloc" {
   name          = "<%= ctx[:vars]['global_name'] %>"
   purpose       = "VPC_PEERING"
@@ -12,15 +13,29 @@ resource "google_compute_global_address" "private_ip_alloc" {
   network       = google_compute_network.peering_network.id
 }
 
-# Create a private connection
+# Create a Private Service Access connection
+# When using shared-VPCs, this resource needs to be created in host project
 resource "google_service_networking_connection" "default" {
   network                 = google_compute_network.peering_network.id
   service                 = "netapp.servicenetworking.goog"
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
 
+# Modify the PSA Connection to allow import/export of custom routes
+# When using shared-VPCs, this resource needs to be created in host project
+resource "google_compute_network_peering_routes_config" "route_updates" {
+  peering = google_service_networking_connection.default.peering
+  network = google_compute_network.peering_network.name
+
+  import_custom_routes = true
+  export_custom_routes = true
+}
+
+# Create a storage pool
+# Create this resource in the project which is expected to own the volumes
 resource "google_netapp_storage_pool" "<%= ctx[:primary_resource_id] %>" {
   name = "<%= ctx[:vars]['pool_name'] %>"
+  # project = <your_project>
   location = "us-central1"
   service_level = "PREMIUM"
   capacity_gib = "2048"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Users tend to copy the example code for resources and start their customisation from there. The example code was missing a google_compute_network_peering_routes_config resource which makes sure the routing is updated.
While this doesn't have any impact on the NetApp Volumes service itself, it may cause connectivity issues for clients.

It also adds a few comments to the example code to make them aware of some VPC peering basics they need to consider (and to often don't).

While adding these comments seems a bit off-topic, I strongly believe they are relevant to decrease the demand for support tickets.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
