### PR TITLE
add network_url attribute in consumer_accept_list block of google_compute_service_attachment resource

### DIFF
--- a/mmv1/products/compute/ServiceAttachment.yaml
+++ b/mmv1/products/compute/ServiceAttachment.yaml
@@ -69,6 +69,20 @@ examples:
       consumer_address_name: 'psc-ilb-consumer-address'
       consumer_forwarding_rule_name: 'psc-ilb-consumer-forwarding-rule'
   - !ruby/object:Provider::Terraform::Examples
+    name: 'service_attachment_explicit_networks'
+    primary_resource_id: 'psc_ilb_service_attachment'
+    vars:
+      service_attachment_name: 'my-psc-ilb'
+      network_name: 'psc-ilb-network'
+      nat_subnetwork_name: 'psc-ilb-nat'
+      producer_subnetwork_name: 'psc-ilb-producer-subnetwork'
+      producer_health_check_name: 'producer-service-health-check'
+      producer_service_name: 'producer-service'
+      producer_forwarding_rule_name: 'producer-forwarding-rule'
+      consumer_network_name: 'psc-ilb-consumer-network'
+      consumer_address_name: 'psc-ilb-consumer-address'
+      consumer_forwarding_rule_name: 'psc-ilb-consumer-forwarding-rule'
+  - !ruby/object:Provider::Terraform::Examples
     name: 'service_attachment_reconcile_connections'
     primary_resource_id: 'psc_ilb_service_attachment'
     vars:
@@ -198,9 +212,16 @@ properties:
       properties:
         - !ruby/object:Api::Type::String
           name: 'projectIdOrNum'
-          required: true
+          # TODO (laurensknoll): add exactly_one_of when it can be applied to lists (https://github.com/hashicorp/terraform-plugin-sdk/issues/470)
           description: |
             A project that is allowed to connect to this service attachment.
+            Only one of project_id_or_num and network_url may be set.
+        - !ruby/object:Api::Type::String
+          name: 'networkUrl'
+          # TODO (laurensknoll): add exactly_one_of when it can be applied to lists (https://github.com/hashicorp/terraform-plugin-sdk/issues/470)
+          description: |
+            The network that is allowed to connect to this service attachment.
+            Only one of project_id_or_num and network_url may be set.
         - !ruby/object:Api::Type::Integer
           name: 'connectionLimit'
           required: true

--- a/mmv1/products/compute/ServiceAttachment.yaml
+++ b/mmv1/products/compute/ServiceAttachment.yaml
@@ -96,6 +96,7 @@ examples:
       consumer_address_name: 'psc-ilb-consumer-address'
       consumer_forwarding_rule_name: 'psc-ilb-consumer-forwarding-rule'
 custom_code: !ruby/object:Provider::Terraform::CustomCode
+  constants: templates/terraform/constants/compute_service_attachment.go.erb
   update_encoder: 'templates/terraform/update_encoder/compute_service_attachment.go.erb'
 parameters:
   - !ruby/object:Api::Type::ResourceRef
@@ -208,6 +209,7 @@ properties:
       attachment.
     send_empty_value: true
     is_set: true
+    set_hash_func: computeServiceAttachmentConsumerAcceptListsHash
     item_type: !ruby/object:Api::Type::NestedObject
       properties:
         - !ruby/object:Api::Type::String
@@ -222,6 +224,7 @@ properties:
           description: |
             The network that is allowed to connect to this service attachment.
             Only one of project_id_or_num and network_url may be set.
+          diff_suppress_func: 'tpgresource.CompareSelfLinkRelativePaths'
         - !ruby/object:Api::Type::Integer
           name: 'connectionLimit'
           required: true

--- a/mmv1/templates/terraform/constants/compute_service_attachment.go.erb
+++ b/mmv1/templates/terraform/constants/compute_service_attachment.go.erb
@@ -1,0 +1,50 @@
+<%# The license inside this block applies to this file.
+  # Copyright 2020 Google Inc.
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+-%>
+
+// Hash based on key, which is either project_id_or_num or network_url.
+func computeServiceAttachmentConsumerAcceptListsHash(v interface{}) int {
+	if v == nil {
+		return 0
+	}
+
+  var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	log.Printf("[DEBUG] hashing %v", m)
+
+	if v, ok := m["project_id_or_num"]; ok {
+		if v == nil {
+			v = ""
+		}
+
+		buf.WriteString(fmt.Sprintf("%v-", v))
+	}
+
+	if v, ok := m["network_url"]; ok {
+		if v == nil {
+      v = ""
+    } else {
+      if networkUrl, err := tpgresource.GetRelativePath(v.(string)); err != nil {
+        log.Printf("[WARN] Error on retrieving relative path of network url: %s", err)
+      } else {
+        v = networkUrl
+      }
+    }
+
+		buf.WriteString(fmt.Sprintf("%v-", v))
+	}
+
+	log.Printf("[DEBUG] computed hash value of %v from %v", tpgresource.Hashcode(buf.String()), buf.String())
+	return tpgresource.Hashcode(buf.String())
+}

--- a/mmv1/templates/terraform/examples/service_attachment_explicit_networks.tf.erb
+++ b/mmv1/templates/terraform/examples/service_attachment_explicit_networks.tf.erb
@@ -1,0 +1,97 @@
+resource "google_compute_service_attachment" "<%= ctx[:primary_resource_id] %>" {
+  name        = "<%= ctx[:vars]['service_attachment_name'] %>"
+  region      = "us-west2"
+  description = "A service attachment configured with Terraform"
+
+  enable_proxy_protocol    = false
+  
+  connection_preference    = "ACCEPT_MANUAL"
+  nat_subnets              = [google_compute_subnetwork.psc_ilb_nat.id]
+  target_service           = google_compute_forwarding_rule.psc_ilb_target_service.id
+
+  consumer_accept_lists {
+    network_url       = google_compute_network.psc_ilb_consumer_network.self_link
+    connection_limit  = 1
+  }
+}
+
+resource "google_compute_network" "psc_ilb_consumer_network" {
+  name                    = "<%= ctx[:vars]['consumer_network_name'] %>"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "psc_ilb_consumer_subnetwork" {
+  name          = "<%= ctx[:vars]['consumer_network_name'] %>"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-west2"
+  network       = google_compute_network.psc_ilb_consumer_network.id
+}
+
+resource "google_compute_address" "psc_ilb_consumer_address" {
+  name   = "<%= ctx[:vars]['consumer_address_name'] %>"
+  region = "us-west2"
+
+  subnetwork   = google_compute_subnetwork.psc_ilb_consumer_subnetwork.id
+  address_type = "INTERNAL"
+}
+
+resource "google_compute_forwarding_rule" "psc_ilb_consumer" {
+  name   = "<%= ctx[:vars]['consumer_forwarding_rule_name'] %>"
+  region = "us-west2"
+
+  target                = google_compute_service_attachment.psc_ilb_service_attachment.id
+  load_balancing_scheme = "" # need to override EXTERNAL default when target is a service attachment
+  network               = google_compute_network.psc_ilb_consumer_network.id
+  subnetwork            = google_compute_subnetwork.psc_ilb_consumer_subnetwork.id
+  ip_address            = google_compute_address.psc_ilb_consumer_address.id
+}
+
+resource "google_compute_forwarding_rule" "psc_ilb_target_service" {
+  name   = "<%= ctx[:vars]['producer_forwarding_rule_name'] %>"
+  region = "us-west2"
+
+  load_balancing_scheme = "INTERNAL"
+  backend_service       = google_compute_region_backend_service.producer_service_backend.id
+  all_ports             = true
+  network               = google_compute_network.psc_ilb_network.name
+  subnetwork            = google_compute_subnetwork.psc_ilb_producer_subnetwork.name
+}
+
+resource "google_compute_region_backend_service" "producer_service_backend" {
+  name   = "<%= ctx[:vars]['producer_service_name'] %>"
+  region = "us-west2"
+
+  health_checks = [google_compute_health_check.producer_service_health_check.id]
+}
+
+resource "google_compute_health_check" "producer_service_health_check" {
+  name = "<%= ctx[:vars]['producer_health_check_name'] %>"
+
+  check_interval_sec = 1
+  timeout_sec        = 1
+  tcp_health_check {
+    port = "80"
+  }
+}
+
+resource "google_compute_network" "psc_ilb_network" {
+  name = "<%= ctx[:vars]['network_name'] %>"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "psc_ilb_producer_subnetwork" {
+  name   = "<%= ctx[:vars]['producer_subnetwork_name'] %>"
+  region = "us-west2"
+
+  network       = google_compute_network.psc_ilb_network.id
+  ip_cidr_range = "10.0.0.0/16"
+}
+
+resource "google_compute_subnetwork" "psc_ilb_nat" {
+  name   = "<%= ctx[:vars]['nat_subnetwork_name'] %>"
+  region = "us-west2"
+
+  network       = google_compute_network.psc_ilb_network.id
+  purpose       =  "PRIVATE_SERVICE_CONNECT"
+  ip_cidr_range = "10.1.0.0/16"
+}


### PR DESCRIPTION
This change adds the `network_url` attribute to the `consumer_accept_list`-block of the `google_compute_service_attachment` resource.

Note that because ExactlyOneOf is not available for lists, the `projectIdOrNum` attribute is made optional. Issue: https://github.com/hashicorp/terraform-plugin-sdk/issues/470

Fixes:
- https://github.com/hashicorp/terraform-provider-google/issues/15203
- https://github.com/hashicorp/terraform-provider-google/issues/17116

An `service_attachment_explicit_networks` example is added to demonstrate the functionality and acts as an acceptance test.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added the `network_url` attribute to the `consumer_accept_list`-block of the `google_compute_service_attachment` resource.
```
