### PR TITLE
Update `TestAccVmwareengineNetworkPolicy_update ` to ignore `update_time` when testing import

### DIFF
--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_policy_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_policy_test.go
@@ -29,7 +29,7 @@ func TestAccVmwareengineNetworkPolicy_update(t *testing.T) {
 				ResourceName:            "google_vmwareengine_network_policy.vmw-engine-network-policy",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "name"},
+				ImportStateVerifyIgnore: []string{"location", "name", "update_time"},
 			},
 			{
 				Config: testAccVmwareengineNetworkPolicy_config(context, "description2", "192.168.1.0/26", true, true),
@@ -38,7 +38,7 @@ func TestAccVmwareengineNetworkPolicy_update(t *testing.T) {
 				ResourceName:            "google_vmwareengine_network_policy.vmw-engine-network-policy",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "name"},
+				ImportStateVerifyIgnore: []string{"location", "name", "update_time"},
 			},
 		},
 	})


### PR DESCRIPTION
This addresses sporadic (~10%) test failures of `TestAccVmwareengineNetworkPolicy_update` in the **Beta** nightly tests ([link to the test's history for Beta](https://hashicorp.teamcity.com/test/3284620027463961021?currentProjectId=TerraformProviders_GoogleBeta_NightlyTests&expandTestHistoryChartSection=true)):

```
------- Stdout: -------
=== RUN   TestAccVmwareengineNetworkPolicy_update
=== PAUSE TestAccVmwareengineNetworkPolicy_update
=== CONT  TestAccVmwareengineNetworkPolicy_update
    vcr_utils.go:152: ImportStateVerify attributes not equivalent. Difference is shown below. Top is actual, bottom is expected.
        (map[string]string) (len=1) {
         (string) (len=11) "update_time": (string) (len=30) "2024-01-30T06:50:02.973243976Z"
        }
        (map[string]string) (len=1) {
         (string) (len=11) "update_time": (string) (len=30) "2024-01-30T06:49:48.289359855Z"
        }
--- FAIL: TestAccVmwareengineNetworkPolicy_update (130.55s)
FAIL
```

It looks like the resource is updated internal to GCP and this causes drift.


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
