### PR TITLE
Promote support for replica mv in resource_bigquery_table to GA

### DIFF
--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
@@ -1,4 +1,3 @@
-<% autogen_exception -%>
 package bigquery
 
 import (
@@ -1251,7 +1250,6 @@ func ResourceBigQueryTable() *schema.Resource {
 					},
 				},
 			},
-			<% unless version == 'ga' -%>
 			// TableReplicationInfo: [Optional] Replication info of a table created using `AS REPLICA` DDL like: `CREATE MATERIALIZED VIEW mv1 AS REPLICA OF src_mv`.
 			"table_replication_info": {
 				Type:        schema.TypeList,
@@ -1289,7 +1287,6 @@ func ResourceBigQueryTable() *schema.Resource {
 					},
 				},
 			},
-			<% end -%>
 		},
 		UseJSONNumber: true,
 	}
@@ -1426,7 +1423,6 @@ func resourceBigQueryTableCreate(d *schema.ResourceData, meta interface{}) error
 
 	datasetID := d.Get("dataset_id").(string)
 
-	<% unless version == 'ga' -%>
 	if v, ok := d.GetOk("table_replication_info"); ok {
 		if table.Schema != nil || table.View != nil || table.MaterializedView != nil {
 			return errors.New("Schema, view, or materialized view cannot be specified when table replication info is present")
@@ -1467,7 +1463,6 @@ func resourceBigQueryTableCreate(d *schema.ResourceData, meta interface{}) error
 		return resourceBigQueryTableRead(d, meta)
 	}
 
-	<% end -%>
 	if table.View != nil && table.Schema != nil {
 
 		log.Printf("[INFO] Removing schema from table definition because BigQuery does not support setting schema on view creation")
@@ -1679,7 +1674,6 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	<% unless version == 'ga' -%>
 	// TODO: Update when the Get API fields for TableReplicationInfo are available in the client library.
 	url, err := tpgresource.ReplaceVars(d, config, "{{BigQueryBasePath}}projects/{{project}}/datasets/{{dataset_id}}/tables/{{table_id}}")
 	if err != nil {
@@ -1706,7 +1700,6 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-  <% end -%>
 	return nil
 }
 
@@ -2497,7 +2490,6 @@ func flattenTableConstraints(edc *bigquery.TableConstraints) []map[string]interf
 	return []map[string]interface{}{result}
 }
 
-<% unless version == 'ga' -%>
 func expandTableReplicationInfo(cfg interface{}) map[string]interface{} {
 	raw := cfg.([]interface{})[0].(map[string]interface{})
 
@@ -2548,7 +2540,6 @@ func flattenTableReplicationInfo(tableReplicationInfo map[string]interface{}) []
 	return []map[string]interface{}{result}
 }
 
-<% end -%>
 func resourceBigQueryTableImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
@@ -1,4 +1,3 @@
-<% autogen_exception -%>
 package bigquery_test
 
 import (
@@ -1432,7 +1431,6 @@ func TestAccBigQueryTable_invalidSchemas(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccBigQueryTable_TableReplicationInfo_ConflictsWithView(t *testing.T) {
 	t.Parallel()
 
@@ -1441,7 +1439,7 @@ func TestAccBigQueryTable_TableReplicationInfo_ConflictsWithView(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -1467,11 +1465,11 @@ func TestAccBigQueryTable_TableReplicationInfo_WithoutReplicationInterval(t *tes
 	replicationIntervalExpr := ""
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
-		ExternalProviders:        map[string]resource.ExternalProvider{
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
 			"time": {},
 		},
-		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
+		CheckDestroy: testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVID, replicaDatasetID, replicaMVID, sourceMVJobID, dropMVJobID, replicationIntervalExpr),
@@ -1502,11 +1500,11 @@ func TestAccBigQueryTable_TableReplicationInfo_WithReplicationInterval(t *testin
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
-		ExternalProviders:        map[string]resource.ExternalProvider{
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
 			"time": {},
 		},
-		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
+		CheckDestroy: testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVID, replicaDatasetID, replicaMVID, sourceMVJobID, dropMVJobID, replicationIntervalExpr),
@@ -1521,7 +1519,6 @@ func TestAccBigQueryTable_TableReplicationInfo_WithReplicationInterval(t *testin
 	})
 }
 
-<% end -%>
 func testAccCheckBigQueryExtData(t *testing.T, expectedQuoteChar string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		for _, rs := range s.RootModule().Resources {
@@ -3100,7 +3097,7 @@ resource "google_bigquery_table" "test" {
 }
 
 func testAccBigQueryTableFromBigtable(context map[string]interface{}) string {
-  return acctest.Nprintf(`
+	return acctest.Nprintf(`
 resource "google_bigtable_instance" "instance" {
   name = "tf-test-bigtable-inst-%{random_suffix}"
   cluster {
@@ -3717,18 +3714,13 @@ resource "google_bigquery_table" "test" {
 `, datasetID, tableID, schema)
 }
 
-<% unless version == 'ga' -%>
 func testAccBigQueryTableWithReplicationInfoAndView(datasetID, tableID string) string {
 	return fmt.Sprintf(`
 resource "google_bigquery_dataset" "test" {
-  provider = google-beta
-
   dataset_id = "%s"
 }
 
 resource "google_bigquery_table" "test" {
-  provider = google-beta
-
   deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
@@ -3748,15 +3740,11 @@ resource "google_bigquery_table" "test" {
 func testAccBigQueryTableWithReplicationInfo(projectID, sourceDatasetID, sourceTableID, sourceMVID, replicaDatasetID, replicaMVID, sourceMVJobID, dropMVJobID, replicationIntervalExpr string) string {
 	return fmt.Sprintf(`
 resource "google_bigquery_dataset" "source" {
-  provider = google-beta
-
   dataset_id = "%s"
   location = "aws-us-east-1"
 }
 
 resource "google_bigquery_table" "source_table" {
-  provider = google-beta
-
   deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.source.dataset_id
@@ -3773,8 +3761,6 @@ resource "google_bigquery_table" "source_table" {
 }
 
 resource "google_bigquery_job" "source_mv_job" {
-  provider = google-beta
-
   job_id = "%s"
 
   location = "aws-us-east-1"
@@ -3794,8 +3780,6 @@ resource "time_sleep" "wait_10_seconds" {
 }
 
 resource "google_bigquery_dataset_access" "access" {
-  provider = google-beta
-
   dataset_id    = google_bigquery_dataset.source.dataset_id
   view {
     project_id = "%s"
@@ -3807,15 +3791,11 @@ resource "google_bigquery_dataset_access" "access" {
 }
 
 resource "google_bigquery_dataset" "replica" {
-  provider = google-beta
-
   dataset_id = "%s"
   location = "us"
 }
 
 resource "google_bigquery_table" "replica_mv" {
-  provider = google-beta
-
   deletion_protection = false
   dataset_id = google_bigquery_dataset.replica.dataset_id
   table_id   = "%s"
@@ -3830,8 +3810,6 @@ resource "google_bigquery_table" "replica_mv" {
 }
 
 resource "google_bigquery_job" "drop_source_mv_job" {
-  provider = google-beta
-
   job_id = "%s"
 
   location = "aws-us-east-1"
@@ -3852,7 +3830,6 @@ resource "time_sleep" "wait_10_seconds_last" {
 `, sourceDatasetID, sourceTableID, sourceMVJobID, sourceDatasetID, sourceMVID, sourceDatasetID, sourceTableID, projectID, sourceMVID, replicaDatasetID, replicaMVID, projectID, sourceMVID, replicationIntervalExpr, dropMVJobID, sourceDatasetID, sourceMVID)
 }
 
-<% end -%>
 
 var TEST_CSV = `lifelock,LifeLock,,web,Tempe,AZ,1-May-07,6850000,USD,b
 lifelock,LifeLock,,web,Tempe,AZ,1-Oct-06,6000000,USD,a

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
@@ -3830,7 +3830,6 @@ resource "time_sleep" "wait_10_seconds_last" {
 `, sourceDatasetID, sourceTableID, sourceMVJobID, sourceDatasetID, sourceMVID, sourceDatasetID, sourceTableID, projectID, sourceMVID, replicaDatasetID, replicaMVID, projectID, sourceMVID, replicationIntervalExpr, dropMVJobID, sourceDatasetID, sourceMVID)
 }
 
-
 var TEST_CSV = `lifelock,LifeLock,,web,Tempe,AZ,1-May-07,6850000,USD,b
 lifelock,LifeLock,,web,Tempe,AZ,1-Oct-06,6000000,USD,a
 lifelock,LifeLock,,web,Tempe,AZ,1-Jan-08,25000000,USD,c


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Promote support for replica mv in resource_bigquery_table to GA. This is a follow-up to https://github.com/GoogleCloudPlatform/magic-modules/pull/9773.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigquery: promoted support for replica mv in `resource_bigquery_table` to GA
```
