### PR TITLE
Add information to Breaking Change docs about how default can cause permadeletes

### DIFF
--- a/docs/content/develop/breaking-changes/breaking-changes.md
+++ b/docs/content/develop/breaking-changes/breaking-changes.md
@@ -77,6 +77,9 @@ For more information, see
     if the change will destroy and recreate the resource due to changing an immutable value.
     Default changes in the provider are comparable in impact to default changes in an API,
     and modifying examples and modules may achieve the intended effect with a smaller blast radius.
+  * Adding a default value to an optional, immutable field can cause Terraform to propose destroying and
+    recreating a resource. This is true even when the default is added at the same time the new
+    field is first introduced.
 * <a name="field-changing-data-format"></a> Modifying how field data is stored in state
   * For example, changing the case of a value returned by the API in a flattener or decorder
 * Removing diff suppression from a field.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

I recently reviewed a fix for a permadelete that occurred by adding a field that was ForceNew with a Default value: https://github.com/GoogleCloudPlatform/magic-modules/pull/9870

After seeing this page I figured it could be explicitly called out as an issue to watch out for; adding a new field with a default from the beginning may not feel like a breaking change, but it only is if it's immutable.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
