### PR TITLE
Add validations for Composer 2/3 only fields

### DIFF
--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"context"
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -167,6 +168,7 @@ func ResourceComposerEnvironment() *schema.Resource {
 			tpgresource.DefaultProviderProject,
 			tpgresource.DefaultProviderRegion,
 			tpgresource.SetLabelsDiff,
+      customdiff.ValidateChange("config.0.software_config.0.image_version", imageVersionChangeValidationFunc),
 		),
 
 		Schema: map[string]*schema.Schema{
@@ -1915,7 +1917,8 @@ func expandComposerEnvironmentConfig(v interface{}, d *schema.ResourceData, conf
 		composer.PrivateEnvironmentConfig.EnablePrivateEnvironment in API.
 		Check image version to avoid overriding EnablePrivateEnvironment in case of other versions.
 	*/
-	if isComposer3(d, config) {
+	imageVersion := d.Get("config.0.software_config.0.image_version").(string)
+	if isComposer3(imageVersion) {
 		transformed.PrivateEnvironmentConfig = &composer.PrivateEnvironmentConfig{}
 		if enablePrivateEnvironmentRaw, ok := original["enable_private_environment"]; ok {
 			transformed.PrivateEnvironmentConfig.EnablePrivateEnvironment = enablePrivateEnvironmentRaw.(bool)
@@ -2812,7 +2815,13 @@ func versionsEqual(old, new string) (bool, error) {
 	return o.Equal(n), nil
 }
 
-func isComposer3(d *schema.ResourceData, config *transport_tpg.Config)	bool {
-	image_version := d.Get("config.0.software_config.0.image_version").(string)
-	return strings.Contains(image_version, "composer-3")
+func isComposer3(imageVersion string)	bool {
+	return strings.Contains(imageVersion, "composer-3")
+}
+
+func imageVersionChangeValidationFunc(ctx context.Context, old, new, meta any) error {
+	if old.(string) != "" && isComposer3(new.(string)) {
+		return fmt.Errorf("upgrade to composer 3 is not yet supported")
+	}
+	return nil
 }

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -1917,8 +1917,7 @@ func expandComposerEnvironmentConfig(v interface{}, d *schema.ResourceData, conf
 		composer.PrivateEnvironmentConfig.EnablePrivateEnvironment in API.
 		Check image version to avoid overriding EnablePrivateEnvironment in case of other versions.
 	*/
-	imageVersion := d.Get("config.0.software_config.0.image_version").(string)
-	if isComposer3(imageVersion) {
+	if isComposer3(d) {
 		transformed.PrivateEnvironmentConfig = &composer.PrivateEnvironmentConfig{}
 		if enablePrivateEnvironmentRaw, ok := original["enable_private_environment"]; ok {
 			transformed.PrivateEnvironmentConfig.EnablePrivateEnvironment = enablePrivateEnvironmentRaw.(bool)
@@ -2815,12 +2814,23 @@ func versionsEqual(old, new string) (bool, error) {
 	return o.Equal(n), nil
 }
 
-func isComposer3(imageVersion string)	bool {
+func isComposer3(v interface{})	bool {
+	var imageVersion string
+	switch v.(type) {
+	case *schema.ResourceData:
+		imageVersion = v.(*schema.ResourceData).Get("config.0.software_config.0.image_version").(string)
+	case *schema.ResourceDiff:
+		imageVersion = v.(*schema.ResourceDiff).Get("config.0.software_config.0.image_version").(string)
+	case string:
+		imageVersion = v.(string)
+	default:
+		log.Printf("[ERROR] error in plugin: unexpected argument type in isComposer3")
+	}
 	return strings.Contains(imageVersion, "composer-3")
 }
 
 func imageVersionChangeValidationFunc(ctx context.Context, old, new, meta any) error {
-	if old.(string) != "" && isComposer3(new.(string)) {
+	if old.(string) != "" && !isComposer3(old.(string)) && isComposer3(new.(string)) {
 		return fmt.Errorf("upgrade to composer 3 is not yet supported")
 	}
 	return nil

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -1553,11 +1553,12 @@ func flattenComposerEnvironmentConfig(envCfg *composer.EnvironmentConfig) interf
 	transformed["airflow_uri"] = envCfg.AirflowUri
 	transformed["node_config"] = flattenComposerEnvironmentConfigNodeConfig(envCfg.NodeConfig)
 	transformed["software_config"] = flattenComposerEnvironmentConfigSoftwareConfig(envCfg.SoftwareConfig)
-	if !isComposer3(envCfg){
+	imageVersion := envCfg.SoftwareConfig.ImageVersion
+	if !isComposer3(imageVersion){
 		transformed["private_environment_config"] = flattenComposerEnvironmentConfigPrivateEnvironmentConfig(envCfg.PrivateEnvironmentConfig)
 	}
 <% unless version == "ga" -%>
-	if isComposer3(envCfg) && envCfg.PrivateEnvironmentConfig != nil {
+	if isComposer3(imageVersion) && envCfg.PrivateEnvironmentConfig != nil {
 		transformed["enable_private_environment"] = envCfg.PrivateEnvironmentConfig.EnablePrivateEnvironment
 		transformed["enable_private_builds_only"] = envCfg.PrivateEnvironmentConfig.EnablePrivateBuildsOnly
 	}
@@ -1926,7 +1927,8 @@ func expandComposerEnvironmentConfig(v interface{}, d *schema.ResourceData, conf
 		composer.PrivateEnvironmentConfig.EnablePrivateEnvironment in API.
 		Check image version to avoid overriding EnablePrivateEnvironment in case of other versions.
 	*/
-	if isComposer3(d) {
+	imageVersion := d.Get("config.0.software_config.0.image_version").(string)
+	if isComposer3(imageVersion) {
 		transformed.PrivateEnvironmentConfig = &composer.PrivateEnvironmentConfig{}
 		if enablePrivateEnvironmentRaw, ok := original["enable_private_environment"]; ok {
 			transformed.PrivateEnvironmentConfig.EnablePrivateEnvironment = enablePrivateEnvironmentRaw.(bool)
@@ -2823,21 +2825,8 @@ func versionsEqual(old, new string) (bool, error) {
 	return o.Equal(n), nil
 }
 
-func isComposer3(v interface{})	bool {
-	var imageVersion string
-	switch v.(type) {
-	case *schema.ResourceData:
-		imageVersion = v.(*schema.ResourceData).Get("config.0.software_config.0.image_version").(string)
-	case *schema.ResourceDiff:
-		imageVersion = v.(*schema.ResourceDiff).Get("config.0.software_config.0.image_version").(string)
-	case *composer.EnvironmentConfig:
-		imageVersion = v.(*composer.EnvironmentConfig).SoftwareConfig.ImageVersion
-	case string:
-		imageVersion = v.(string)
-	default:
-		log.Printf("[ERROR] error in plugin: unexpected argument type in isComposer3")
-	}
-	return strings.Contains(imageVersion, "composer-3")
+func isComposer3(v string)	bool {
+	return strings.Contains(v, "composer-3")
 }
 
 func imageVersionChangeValidationFunc(ctx context.Context, old, new, meta any) error {
@@ -2849,7 +2838,8 @@ func imageVersionChangeValidationFunc(ctx context.Context, old, new, meta any) e
 
 func validateComposer3FieldUsage(d *schema.ResourceDiff, key string, requireComposer3 bool) error {
 	_, ok := d.GetOk(key)
-	if ok && ( isComposer3(d) != requireComposer3 ) {
+	imageVersion := d.Get("config.0.software_config.0.image_version").(string)
+	if ok && ( isComposer3(imageVersion) != requireComposer3 ) {
 		if requireComposer3 {
 			return fmt.Errorf("error in configuration, %s should only be used in Composer 3", key)
 		} else {

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -169,6 +169,7 @@ func ResourceComposerEnvironment() *schema.Resource {
 			tpgresource.DefaultProviderRegion,
 			tpgresource.SetLabelsDiff,
       customdiff.ValidateChange("config.0.software_config.0.image_version", imageVersionChangeValidationFunc),
+			versionValidationCustomizeDiffFunc,
 		),
 
 		Schema: map[string]*schema.Schema{
@@ -2832,6 +2833,40 @@ func isComposer3(v interface{})	bool {
 func imageVersionChangeValidationFunc(ctx context.Context, old, new, meta any) error {
 	if old.(string) != "" && !isComposer3(old.(string)) && isComposer3(new.(string)) {
 		return fmt.Errorf("upgrade to composer 3 is not yet supported")
+	}
+	return nil
+}
+
+func validateComposer3FieldUsage(d *schema.ResourceDiff, key string, requireComposer3 bool) error {
+	_, ok := d.GetOk(key)
+	if ok && ( isComposer3(d) != requireComposer3 ) {
+		if requireComposer3 {
+			return fmt.Errorf("error in configuration, %s should only be used in Composer 3", key)
+		} else {
+			return fmt.Errorf("error in configuration, %s should not be used in Composer 3", key)
+		}
+	}
+	return nil
+}
+
+func versionValidationCustomizeDiffFunc(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	composer3FieldUsagePolicy := map[string]bool{
+		"config.0.node_config.0.max_pods_per_node": false, // not allowed in composer 3
+		"config.0.node_config.0.enable_ip_masq_agent": false,
+		"config.0.node_config.0.config.0.node_config.0.ip_allocation_policy": false,
+		"config.0.private_environment_config": false,
+		"config.0.master_authorized_networks_config": false,
+		"config.0.node_config.0.composer_network_attachment": true, // allowed only in composer 3
+		"config.0.node_config.0.composer_internal_ipv4_cidr_block": true,
+		"config.0.software_config.0.web_server_plugins_mode": true,
+		"config.0.enable_private_environment": true,
+		"config.0.enable_private_builds_only": true,
+		"config.0.workloads_config.0.dag_processor": true,
+	}
+	for key, allowed := range composer3FieldUsagePolicy {
+		if err := validateComposer3FieldUsage(d, key, allowed); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -1557,7 +1557,7 @@ func flattenComposerEnvironmentConfig(envCfg *composer.EnvironmentConfig) interf
 		transformed["private_environment_config"] = flattenComposerEnvironmentConfigPrivateEnvironmentConfig(envCfg.PrivateEnvironmentConfig)
 	}
 <% unless version == "ga" -%>
-	if isComposer3(envCfg){
+	if isComposer3(envCfg) && envCfg.PrivateEnvironmentConfig != nil {
 		transformed["enable_private_environment"] = envCfg.PrivateEnvironmentConfig.EnablePrivateEnvironment
 		transformed["enable_private_builds_only"] = envCfg.PrivateEnvironmentConfig.EnablePrivateBuildsOnly
 	}

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -977,7 +977,6 @@ func ResourceComposerEnvironment() *schema.Resource {
 						},
 						"gke_cluster": {
 							Type:        schema.TypeString,
-							Computed:    true,
 							Optional:    true,
 							Description: `The Kubernetes Engine cluster used to run this environment.`,
 						},

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -1551,10 +1551,14 @@ func flattenComposerEnvironmentConfig(envCfg *composer.EnvironmentConfig) interf
 	transformed["airflow_uri"] = envCfg.AirflowUri
 	transformed["node_config"] = flattenComposerEnvironmentConfigNodeConfig(envCfg.NodeConfig)
 	transformed["software_config"] = flattenComposerEnvironmentConfigSoftwareConfig(envCfg.SoftwareConfig)
-	transformed["private_environment_config"] = flattenComposerEnvironmentConfigPrivateEnvironmentConfig(envCfg.PrivateEnvironmentConfig)
+	if !isComposer3(envCfg){
+		transformed["private_environment_config"] = flattenComposerEnvironmentConfigPrivateEnvironmentConfig(envCfg.PrivateEnvironmentConfig)
+	}
 <% unless version == "ga" -%>
-	transformed["enable_private_environment"] = envCfg.PrivateEnvironmentConfig.EnablePrivateEnvironment
-	transformed["enable_private_builds_only"] = envCfg.PrivateEnvironmentConfig.EnablePrivateBuildsOnly
+	if isComposer3(envCfg){
+		transformed["enable_private_environment"] = envCfg.PrivateEnvironmentConfig.EnablePrivateEnvironment
+		transformed["enable_private_builds_only"] = envCfg.PrivateEnvironmentConfig.EnablePrivateBuildsOnly
+	}
 <% end -%>
 	transformed["web_server_network_access_control"] = flattenComposerEnvironmentConfigWebServerNetworkAccessControl(envCfg.WebServerNetworkAccessControl)
 	transformed["database_config"] = flattenComposerEnvironmentConfigDatabaseConfig(envCfg.DatabaseConfig)
@@ -1739,7 +1743,9 @@ func flattenComposerEnvironmentConfigWorkloadsConfig(workloadsConfig *composer.W
 	transformed["web_server"] = []interface{}{transformedWebServer}
 	transformed["worker"] = []interface{}{transformedWorker}
 <% unless version == "ga" -%>
-	transformed["dag_processor"] = []interface{}{transformedDagProcessor}
+	if transformedDagProcessor != nil {
+		transformed["dag_processor"] = []interface{}{transformedDagProcessor}
+	}
 <% end -%>
 
 
@@ -2822,6 +2828,8 @@ func isComposer3(v interface{})	bool {
 		imageVersion = v.(*schema.ResourceData).Get("config.0.software_config.0.image_version").(string)
 	case *schema.ResourceDiff:
 		imageVersion = v.(*schema.ResourceDiff).Get("config.0.software_config.0.image_version").(string)
+	case *composer.EnvironmentConfig:
+		imageVersion = v.(*composer.EnvironmentConfig).SoftwareConfig.ImageVersion
 	case string:
 		imageVersion = v.(string)
 	default:

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -976,6 +976,7 @@ func ResourceComposerEnvironment() *schema.Resource {
 						"gke_cluster": {
 							Type:        schema.TypeString,
 							Computed:    true,
+							Optional:    true,
 							Description: `The Kubernetes Engine cluster used to run this environment.`,
 						},
 					},

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -977,7 +977,7 @@ func ResourceComposerEnvironment() *schema.Resource {
 						},
 						"gke_cluster": {
 							Type:        schema.TypeString,
-							Optional:    true,
+							Computed:    true,
 							Description: `The Kubernetes Engine cluster used to run this environment.`,
 						},
 					},

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -2825,8 +2825,8 @@ func versionsEqual(old, new string) (bool, error) {
 	return o.Equal(n), nil
 }
 
-func isComposer3(v string)	bool {
-	return strings.Contains(v, "composer-3")
+func isComposer3(imageVersion string)	bool {
+	return strings.Contains(imageVersion, "composer-3")
 }
 
 func imageVersionChangeValidationFunc(ctx context.Context, old, new, meta any) error {

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -168,8 +168,10 @@ func ResourceComposerEnvironment() *schema.Resource {
 			tpgresource.DefaultProviderProject,
 			tpgresource.DefaultProviderRegion,
 			tpgresource.SetLabelsDiff,
-      customdiff.ValidateChange("config.0.software_config.0.image_version", imageVersionChangeValidationFunc),
+<% unless version == "ga" -%>
+		  customdiff.ValidateChange("config.0.software_config.0.image_version", imageVersionChangeValidationFunc),
 			versionValidationCustomizeDiffFunc,
+<% end -%>
 		),
 
 		Schema: map[string]*schema.Schema{

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go.erb
@@ -1219,6 +1219,44 @@ func TestAccComposerEnvironmentComposer3_upgrade_expectError(t *testing.T) {
 	})
 }
 
+func TestAccComposerEnvironmentComposer2_usesUnsupportedField_expectError(t *testing.T) {
+	t.Parallel()
+
+	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, acctest.RandInt(t))
+	errorRegExp, _ := regexp.Compile(".*error in configuration, .* should only be used in Composer 3.*")
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:		          func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccComposerEnvironmentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccComposerEnvironmentComposer2_usesUnsupportedField(envName),
+				ExpectError:        errorRegExp,
+			},
+		},
+	})
+}
+
+func TestAccComposerEnvironmentComposer3_usesUnsupportedField_expectError(t *testing.T) {
+	t.Parallel()
+
+	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, acctest.RandInt(t))
+	errorRegExp, _ := regexp.Compile(".*error in configuration, .* should not be used in Composer 3.*")
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:		          func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccComposerEnvironmentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccComposerEnvironmentComposer3_usesUnsupportedField(envName),
+				ExpectError:        errorRegExp,
+			},
+		},
+	})
+}
+
 // Checks Composer 3 specific updatable fields.
 func TestAccComposerEnvironmentComposer3_updateToEmpty(t *testing.T) {
 	t.Parallel()
@@ -2912,6 +2950,38 @@ resource "google_compute_subnetwork" "test" {
   network       = google_compute_network.test.self_link
 }
 `, name, network, subnetwork)
+}
+
+func testAccComposerEnvironmentComposer2_usesUnsupportedField(name string) string {
+return fmt.Sprintf(`
+resource "google_composer_environment" "test" {
+  name   = "%s"
+  region = "us-central1"
+  config {
+    software_config {
+      image_version = "composer-2-airflow-2"
+			web_server_plugins_mode = "ENABLED"
+    }
+  }
+}
+`, name)
+}
+
+func testAccComposerEnvironmentComposer3_usesUnsupportedField(name string) string {
+return fmt.Sprintf(`
+resource "google_composer_environment" "test" {
+  name   = "%s"
+  region = "us-central1"
+  config {
+	  node_config {
+	    enable_ip_masq_agent = true
+	  }
+    software_config {
+      image_version = "composer-3-airflow-2"
+    }
+  }
+}
+`, name)
 }
 
 func testAccComposerEnvironmentComposer3_basic(name, network, subnetwork string) string {

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go.erb
@@ -1186,6 +1186,39 @@ func TestAccComposerEnvironmentComposer3_update(t *testing.T) {
 	})
 }
 
+func TestAccComposerEnvironmentComposer3_upgrade_expectError(t *testing.T) {
+	t.Parallel()
+
+	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, acctest.RandInt(t))
+	network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, acctest.RandInt(t))
+	subnetwork := network + "-1"
+	errorRegExp, _ := regexp.Compile(".*upgrade to composer 3 is not yet supported.*")
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:		          func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccComposerEnvironmentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccComposerEnvironmentComposer2_empty(envName, network, subnetwork),
+			},
+			{
+				Config:             testAccComposerEnvironmentComposer3_empty(envName, network, subnetwork),
+				ExpectError:        errorRegExp,
+			},
+			// This is a terrible clean-up step in order to get destroy to succeed,
+			// due to dangling firewall rules left by the Composer Environment blocking network deletion.
+			// TODO: Remove this check if firewall rules bug gets fixed by Composer.
+			{
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+				Config:             testAccComposerEnvironmentComposer2_empty(envName, network, subnetwork),
+				Check:              testAccCheckClearComposerEnvironmentFirewalls(t, network),
+			},
+		},
+	})
+}
+
 // Checks Composer 3 specific updatable fields.
 func TestAccComposerEnvironmentComposer3_updateToEmpty(t *testing.T) {
 	t.Parallel()
@@ -2825,6 +2858,34 @@ resource "google_project_iam_member" "composer-worker" {
 }
 
 <% unless version == "ga" -%>
+func testAccComposerEnvironmentComposer2_empty(name, network, subnetwork string) string {
+	return fmt.Sprintf(`
+resource "google_composer_environment" "test" {
+  name   = "%s"
+  region = "us-central1"
+  config {
+    software_config {
+      image_version = "composer-2-airflow-2"
+    }
+  }
+}
+
+// use a separate network to avoid conflicts with other tests running in parallel
+// that use the default network/subnet
+resource "google_compute_network" "test" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "test" {
+  name          = "%s"
+  ip_cidr_range = "10.2.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.test.self_link
+}
+`, name, network, subnetwork)
+}
+
 func testAccComposerEnvironmentComposer3_empty(name, network, subnetwork string) string {
 	return fmt.Sprintf(`
 resource "google_composer_environment" "test" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
composer: 
- added validations for Composer 2/3 only fields
- blocked Composer2 -> Composer3 upgrade
- updated attributes of fields not used in Composer 3
```
```
Fixes: b/304402327, b/304432953, b/304432956, b/304432959
```
