### PR TITLE
Add support for  disable_ssh field  in workstations_config

### DIFF
--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -213,6 +213,7 @@ properties:
       - 'host.gceInstance.shieldedInstanceConfig.enableIntegrityMonitoring'
       - 'host.gceInstance.confidentialInstanceConfig.enableConfidentialCompute'
       - 'host.gceInstance.accelerators'
+      - 'host.gceInstance.disableSsh'
     properties:
       - !ruby/object:Api::Type::NestedObject
         name: 'gceInstance'
@@ -257,6 +258,10 @@ properties:
             name: 'disablePublicIpAddresses'
             description: |
               Whether instances have no public IP address.
+          - !ruby/object:Api::Type::Boolean
+            name: 'disableSsh'
+            description: |
+              Whether to disable SSH access to the VM.
           - !ruby/object:Api::Type::Boolean
             name: 'enableNestedVirtualization'
             description: |

--- a/mmv1/templates/terraform/examples/workstation_config_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/workstation_config_basic.tf.erb
@@ -51,6 +51,7 @@ resource "google_workstations_workstation_config" "<%= ctx[:primary_resource_id]
       machine_type                = "e2-standard-4"
       boot_disk_size_gb           = 35
       disable_public_ip_addresses = true
+      disable_ssh                 = false
     }
   }
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
 Adds support for the disable_ssh fields in workstations_config create and update flow.

 I acknowledge that I have:

 - [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
 - [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
 
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [make test and make lint](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
 
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
 
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.


<!-- AUTOCHANGELOG for Downstream PRs.
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
workstations: add support for `disable_ssh` in `google_workstations_workstation_config` (beta)
```
