### PR TITLE
Make acctest use bootstrapped KMS key, instead of making new key that resembles a shared key

### DIFF
--- a/mmv1/products/workbench/Instance.yaml
+++ b/mmv1/products/workbench/Instance.yaml
@@ -76,8 +76,9 @@ examples:
     vars:
       instance_name: 'workbench-instance'
       network_name: 'wbi-test-default'
-      keyring_name: 'tftest-shared-keyring-1'
-      key_name: 'tftest-shared-key-1'
+      key_name: 'my-crypto-key'
+    test_vars_overrides:
+      key_name: 'acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
     test_env_vars:
       service_account: :SERVICE_ACCT
     ignore_read_extra:

--- a/mmv1/templates/terraform/examples/workbench_instance_full.tf.erb
+++ b/mmv1/templates/terraform/examples/workbench_instance_full.tf.erb
@@ -10,16 +10,6 @@ resource "google_compute_subnetwork" "my_subnetwork" {
   ip_cidr_range = "10.0.1.0/24"
 }
 
-resource "google_kms_key_ring" "keyring" {
-  name = "<%= ctx[:vars]['keyring_name'] %>"
-  location = "global"
-}
-
-resource "google_kms_crypto_key" "crypto-key" {
-  name     = "<%= ctx[:vars]['key_name'] %>"
-  key_ring = google_kms_key_ring.keyring.id
-}
-
 resource "google_workbench_instance" "<%= ctx[:primary_resource_id] %>" {
   name = "<%= ctx[:vars]['instance_name'] %>"
   location = "us-central1-a"
@@ -41,14 +31,14 @@ resource "google_workbench_instance" "<%= ctx[:primary_resource_id] %>" {
       disk_size_gb  = 310
       disk_type = "PD_SSD"
       disk_encryption = "GMEK"
-      kms_key = google_kms_crypto_key.crypto-key.id
+      kms_key = "<%= ctx[:vars]['key_name'] %>"
     }
 
     data_disks {
       disk_size_gb  = 330
       disk_type = "PD_SSD"
       disk_encryption = "GMEK"
-      kms_key = google_kms_crypto_key.crypto-key.id
+      kms_key = "<%= ctx[:vars]['key_name'] %>"
     }
 
     network_interfaces {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This acceptance test used to create new crypto keys and key rings that had names very similar to the shared KMS resources used in the test projects. The input `tftest-shared-key-1` would be changed in the test to include the `tf-test-` prefix and a random string suffix though, so no errors were encountered about a resource with that name already existing.

I've updated this test to actually use the bootstrapped resource and to avoid creating undeletable KMS resources in the test project.


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
