### PR TITLE
Add IAM resources for Cloud Deploy Target

### DIFF
--- a/mmv1/products/clouddeploy/Target.yaml
+++ b/mmv1/products/clouddeploy/Target.yaml
@@ -1,0 +1,40 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'Target'
+description: |
+  A Target defines a location to which a Skaffold configuration can be deployed.
+base_url: 'projects/{{project}}/locations/{{location}}/targets'
+self_link: 'projects/{{project}}/locations/{{location}}/targets/{{name}}'
+exclude_resource: true
+id_format: 'projects/{{project}}/locations/{{location}}/targets/{{name}}'
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/targets/{{name}}'
+iam_policy: !ruby/object:Api::Resource::IamPolicy
+  parent_resource_attribute: 'name'
+  method_name_separator: ':'
+  base_url: 'projects/{{project}}/locations/{{location}}/targets/{{name}}'
+  import_format: ['projects/{{project}}/locations/{{location}}/targets/{{name}}', '{{name}}']
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'clouddeploy_target_basic'
+    primary_resource_id: 'default'
+    primary_resource_name: 'fmt.Sprintf("tf-test-cd-target%s", context["random_suffix"])'
+    vars:
+      target: 'cd-target'
+properties:
+  - !ruby/object:Api::Type::String
+    name: "name"
+    description: "Dummy property."
+    required: true

--- a/mmv1/products/clouddeploy/Target.yaml
+++ b/mmv1/products/clouddeploy/Target.yaml
@@ -14,7 +14,7 @@
 --- !ruby/object:Api::Resource
 name: 'Target'
 description: |
-  A Target defines a location to which a Skaffold configuration can be deployed.
+  The Cloud Deploy `Target` resource.
 base_url: 'projects/{{project}}/locations/{{location}}/targets'
 self_link: 'projects/{{project}}/locations/{{location}}/targets/{{name}}'
 exclude_resource: true
@@ -25,7 +25,6 @@ iam_policy: !ruby/object:Api::Resource::IamPolicy
   parent_resource_attribute: 'name'
   method_name_separator: ':'
   base_url: 'projects/{{project}}/locations/{{location}}/targets/{{name}}'
-  import_format: ['projects/{{project}}/locations/{{location}}/targets/{{name}}', '{{name}}']
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'clouddeploy_target_basic'

--- a/mmv1/products/clouddeploy/Target.yaml
+++ b/mmv1/products/clouddeploy/Target.yaml
@@ -25,6 +25,7 @@ iam_policy: !ruby/object:Api::Resource::IamPolicy
   parent_resource_attribute: 'name'
   method_name_separator: ':'
   base_url: 'projects/{{project}}/locations/{{location}}/targets/{{name}}'
+  import_format: ['projects/{{project}}/locations/{{location}}/targets/{{name}}', '{{name}}']
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'clouddeploy_target_basic'

--- a/mmv1/templates/terraform/examples/clouddeploy_target_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/clouddeploy_target_basic.tf.erb
@@ -1,0 +1,4 @@
+resource "google_clouddeploy_target" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['target'] %>"
+  location = "us-central1"
+ }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Part of https://github.com/hashicorp/terraform-provider-google/issues/13042

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_clouddeploy_target_iam_*`
```
