### PR TITLE
Enable CRONs in TeamCity

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_triggers.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_triggers.kt
@@ -20,8 +20,7 @@ fun Triggers.runNightly(config: NightlyTriggerConfiguration) {
     val filter = "+:refs/heads/main"
 
     schedule{
-        // enabled = config.nightlyTestsEnabled
-        enabled = false // Temporary measure while developing new config
+        enabled = config.nightlyTestsEnabled
         branchFilter = filter
         triggerBuild = always() // Run build even if no new commits/pending changes
         withPendingChangesOnly = false

--- a/mmv1/third_party/terraform/.teamcity/components/constants.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/constants.kt
@@ -5,7 +5,7 @@ const val ProviderNameGa = "google"
 const val ProviderNameBeta = "google-beta"
 
 // specifies the default hour (UTC) at which tests should be triggered, if enabled
-const val DefaultStartHour = 17
+const val DefaultStartHour = 4
 
 // specifies the default level of parallelism per-service-package
 const val DefaultParallelism = 6


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to --
>

Follows https://github.com/GoogleCloudPlatform/magic-modules/pull/9837

Now that the migration of data from old to new projects is complete I'm unpausing the CRONs + making the trigger time go back to 4am UTC

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
