### PR TITLE
Fix TeamCity project sweeper to run project sweeper only

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_per_package.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_per_package.kt
@@ -6,7 +6,6 @@ import DefaultBuildTimeoutDuration
 import DefaultParallelism
 import generated.ServiceParallelism
 import jetbrains.buildServer.configs.kotlin.BuildType
-import jetbrains.buildServer.configs.kotlin.SharedResource
 import jetbrains.buildServer.configs.kotlin.sharedResources
 import jetbrains.buildServer.configs.kotlin.vcs.GitVcsRoot
 import replaceCharsId

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_parameters.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_parameters.kt
@@ -199,6 +199,13 @@ fun ParametrizedWithType.terraformSkipProjectSweeper() {
     text("env.SKIP_PROJECT_SWEEPER", "1")
 }
 
+// BuildType.disableProjectSweep disabled sweeping project resources after a build configuration has been initialised
+fun BuildType.disableProjectSweep(){
+    params {
+        terraformSkipProjectSweeper()
+    }
+}
+
 // ParametrizedWithType.terraformEnableProjectSweeper unsets an environment variable used to skip the sweeper for project resources
 fun ParametrizedWithType.terraformEnableProjectSweeper() {
     text("env.SKIP_PROJECT_SWEEPER", "")
@@ -211,7 +218,7 @@ fun BuildType.enableProjectSweep(){
     }
 }
 
-// ParametrizedWithType.terraformEnableProjectSweeper unsets an environment variable used to skip the sweeper for project resources
+// ParametrizedWithType.vcrEnvironmentVariables unsets an environment variable used to skip the sweeper for project resources
 fun ParametrizedWithType.vcrEnvironmentVariables(config: AccTestConfiguration, providerName: String) {
     text("env.VCR_MODE", "RECORDING")
     text("env.VCR_PATH", "%system.teamcity.build.checkoutDir%/fixtures")

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_parameters.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_parameters.kt
@@ -218,7 +218,8 @@ fun BuildType.enableProjectSweep(){
     }
 }
 
-// ParametrizedWithType.vcrEnvironmentVariables unsets an environment variable used to skip the sweeper for project resources
+// ParametrizedWithType.vcrEnvironmentVariables sets environment variables that influence how VCR tests run
+// These values can be changed in custom builds, e.g. setting VCR_MODE=REPLAYING
 fun ParametrizedWithType.vcrEnvironmentVariables(config: AccTestConfiguration, providerName: String) {
     text("env.VCR_MODE", "RECORDING")
     text("env.VCR_PATH", "%system.teamcity.build.checkoutDir%/fixtures")

--- a/mmv1/third_party/terraform/.teamcity/components/projects/google_beta_subproject.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/google_beta_subproject.kt
@@ -3,9 +3,14 @@
 package projects
 
 import ProviderNameBeta
-import builds.*
+import builds.AllContextParameters
+import builds.getBetaAcceptanceTestConfig
+import builds.getVcrAcceptanceTestConfig
+import builds.readOnlySettings
 import jetbrains.buildServer.configs.kotlin.Project
-import projects.reused.*
+import projects.reused.mmUpstream
+import projects.reused.nightlyTests
+import projects.reused.vcrRecording
 import replaceCharsId
 import vcs_roots.HashiCorpVCSRootBeta
 import vcs_roots.ModularMagicianVCSRootBeta

--- a/mmv1/third_party/terraform/.teamcity/components/projects/google_ga_subproject.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/google_ga_subproject.kt
@@ -3,12 +3,13 @@
 package projects
 
 import ProviderNameGa
-import builds.*
+import builds.AllContextParameters
+import builds.getGaAcceptanceTestConfig
+import builds.getVcrAcceptanceTestConfig
+import builds.readOnlySettings
 import jetbrains.buildServer.configs.kotlin.Project
-import jetbrains.buildServer.configs.kotlin.RelativeId
 import projects.reused.mmUpstream
 import projects.reused.nightlyTests
-import projects.reused.vcrRecording
 import replaceCharsId
 import vcs_roots.HashiCorpVCSRootGa
 import vcs_roots.ModularMagicianVCSRootGa

--- a/mmv1/third_party/terraform/.teamcity/components/projects/project_sweeper_project.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/project_sweeper_project.kt
@@ -26,8 +26,7 @@ fun projectSweeperSubProject(allConfig: AllContextParameters): Project {
 
     // Create build config for sweeping project resources
     // Uses the HashiCorpVCSRootGa VCS Root so that the latest sweepers in hashicorp/terraform-provider-google are used
-    val serviceSweeperConfig = BuildConfigurationForSweeper("N/A", ProjectSweeperName, SweepersList, projectId, HashiCorpVCSRootGa, sharedResources, gaConfig)
-    serviceSweeperConfig.enableProjectSweep()
+    val serviceSweeperConfig = BuildConfigurationForProjectSweeper("N/A", ProjectSweeperName, SweepersList, projectId, HashiCorpVCSRootGa, sharedResources, gaConfig)
     val trigger  = NightlyTriggerConfiguration()
     serviceSweeperConfig.addTrigger(trigger)
 

--- a/mmv1/third_party/terraform/.teamcity/components/projects/reused/mm_upstream.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/reused/mm_upstream.kt
@@ -31,7 +31,7 @@ fun mmUpstream(parentProject: String, providerName: String, vcsRoot: GitVcsRoot,
     val packageBuildConfigs = BuildConfigurationsForPackages(allPackages, providerName, projectId, vcsRoot, sharedResources, config)
 
     // Create build config for sweeping the nightly test project - everything except projects
-    val serviceSweeperConfig = BuildConfigurationForSweeper(providerName, ServiceSweeperName, SweepersList, projectId, vcsRoot, sharedResources, config)
+    val serviceSweeperConfig = BuildConfigurationForServiceSweeper(providerName, ServiceSweeperName, SweepersList, projectId, vcsRoot, sharedResources, config)
     val trigger  = NightlyTriggerConfiguration()
     serviceSweeperConfig.addTrigger(trigger) // Only the sweeper is on a schedule in this project
 

--- a/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
@@ -41,7 +41,7 @@ fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot
     }
 
     // Create build config for sweeping the nightly test project
-    val serviceSweeperConfig = BuildConfigurationForSweeper(providerName, ServiceSweeperName, SweepersList, projectId, vcsRoot, sharedResources, config)
+    val serviceSweeperConfig = BuildConfigurationForServiceSweeper(providerName, ServiceSweeperName, SweepersList, projectId, vcsRoot, sharedResources, config)
     serviceSweeperConfig.addTrigger(trigger)
 
     return Project {

--- a/mmv1/third_party/terraform/.teamcity/components/projects/root_project.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/root_project.kt
@@ -8,8 +8,8 @@ import SharedResourceNameVcr
 import builds.AllContextParameters
 import builds.readOnlySettings
 import generated.GetPackageNameList
-import generated.ServicesListGa
 import generated.ServicesListBeta
+import generated.ServicesListGa
 import jetbrains.buildServer.configs.kotlin.Project
 import jetbrains.buildServer.configs.kotlin.sharedResource
 

--- a/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
@@ -1,0 +1,86 @@
+// This file is controlled by MMv1, any changes made here will be overwritten
+
+package tests
+
+import ServiceSweeperName
+import jetbrains.buildServer.configs.kotlin.BuildType
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import jetbrains.buildServer.configs.kotlin.Project
+import org.junit.Assert
+import projects.googleCloudRootProject
+
+class SweeperTests {
+    @Test
+    fun projectSweeperProjectDoesNotSkipProjectSweep() {
+        val project = googleCloudRootProject(testContextParameters())
+
+        // Find Project sweeper project
+        val projectSweeperProject: Project? =  project.subProjects.find { p->  p.name == projectSweeperProjectName}
+        if (projectSweeperProject == null) {
+            Assert.fail("Could not find the Project Sweeper project")
+        }
+
+        // For the project sweeper to be skipped, SKIP_PROJECT_SWEEPER needs a value
+        // See https://github.com/GoogleCloudPlatform/magic-modules/blob/501429790939717ca6dce76dbf4b1b82aef4e9d9/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_sweeper.go#L18-L26
+
+        projectSweeperProject!!.buildTypes.forEach{bt ->
+            val value = bt.params.findRawParam("env.SKIP_PROJECT_SWEEPER")!!.value
+            assertTrue("env.SKIP_PROJECT_SWEEPER is set to an empty value, so project sweepers are NOT skipped. Value = `${value}` ", value == "")
+        }
+    }
+
+    @Test
+    fun gaNightlyProjectServiceSweeperSkipsProjectSweep() {
+        val project = googleCloudRootProject(testContextParameters())
+
+        // Find GA nightly test project
+        val gaProject: Project? =  project.subProjects.find { p->  p.name == gaProjectName}
+        if (gaProject == null) {
+            Assert.fail("Could not find the Google (GA) project")
+        }
+        val gaNightlyTestProject: Project? = gaProject!!.subProjects.find { p->  p.name == nightlyTestsProjectName}
+        if (gaNightlyTestProject == null) {
+            Assert.fail("Could not find the Google (GA) Nightly Test project")
+        }
+
+        // Find sweeper inside
+        val sweeper: BuildType? = gaNightlyTestProject!!.buildTypes.find { p-> p.name == ServiceSweeperName}
+        if (sweeper == null) {
+            Assert.fail("Could not find the sweeper build in the Google (GA) Nightly Test project")
+        }
+
+        // For the project sweeper to be skipped, SKIP_PROJECT_SWEEPER needs a value
+        // See https://github.com/GoogleCloudPlatform/magic-modules/blob/501429790939717ca6dce76dbf4b1b82aef4e9d9/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_sweeper.go#L18-L26
+
+        val value = sweeper!!.params.findRawParam("env.SKIP_PROJECT_SWEEPER")!!.value
+        assertTrue("env.SKIP_PROJECT_SWEEPER is set to a non-empty string, so project sweepers are skipped. Value = `${value}` ", value != "")
+    }
+
+    @Test
+    fun betaNightlyProjectServiceSweeperSkipsProjectSweep() {
+        val project = googleCloudRootProject(testContextParameters())
+
+        // Find Beta nightly test project
+        val betaProject: Project? =  project.subProjects.find { p->  p.name == betaProjectName}
+        if (betaProject == null) {
+            Assert.fail("Could not find the Google (GA) project")
+        }
+        val betaNightlyTestProject: Project? = betaProject!!.subProjects.find { p->  p.name == nightlyTestsProjectName}
+        if (betaNightlyTestProject == null) {
+            Assert.fail("Could not find the Google (GA) Nightly Test project")
+        }
+
+        // Find sweeper inside
+        val sweeper: BuildType? = betaNightlyTestProject!!.buildTypes.find { p-> p.name == ServiceSweeperName}
+        if (sweeper == null) {
+            Assert.fail("Could not find the sweeper build in the Google (GA) Nightly Test project")
+        }
+
+        // For the project sweeper to be skipped, SKIP_PROJECT_SWEEPER needs a value
+        // See https://github.com/GoogleCloudPlatform/magic-modules/blob/501429790939717ca6dce76dbf4b1b82aef4e9d9/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_sweeper.go#L18-L26
+
+        val value = sweeper!!.params.findRawParam("env.SKIP_PROJECT_SWEEPER")!!.value
+        assertTrue("env.SKIP_PROJECT_SWEEPER is set to a non-empty string, so project sweepers are skipped. Value = `${value}` ", value != "")
+    }
+}

--- a/mmv1/third_party/terraform/.teamcity/tests/test_utils.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/test_utils.kt
@@ -7,6 +7,7 @@ import builds.AllContextParameters
 const val gaProjectName = "Google"
 const val betaProjectName = "Google Beta"
 const val nightlyTestsProjectName = "Nightly Tests"
+const val projectSweeperProjectName = "Project Sweeper"
 
 fun testContextParameters(): AllContextParameters {
     return AllContextParameters(


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Currently the project sweeper runs all sweepers including the project sweeper.
This PR aims to refactor code so that code is reused to make service sweepers (runs all sweepers bar project sweeper) and project sweepers (run only project sweepers).

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
