### PR TITLE
Add sample for trigger using http_destination

### DIFF
--- a/mmv1/third_party/terraform/go.mod.erb
+++ b/mmv1/third_party/terraform/go.mod.erb
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	cloud.google.com/go/bigtable v1.19.0
-	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.61.0
+	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.62.0
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dnaeon/go-vcr v1.0.1

--- a/mmv1/third_party/terraform/go.sum
+++ b/mmv1/third_party/terraform/go.sum
@@ -15,8 +15,8 @@ cloud.google.com/go/iam v1.1.5/go.mod h1:rB6P/Ic3mykPbFio+vo7403drjlgvoWfYpJhMXE
 cloud.google.com/go/longrunning v0.5.4 h1:w8xEcbZodnA2BbW6sVirkkoC+1gP8wS57EUUgGS0GVg=
 cloud.google.com/go/longrunning v0.5.4/go.mod h1:zqNVncI0BOP8ST6XQD1+VcvuShMmq7+xFSzOL++V0dI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GoogleCloudPlatform/declarative-resource-client-library v1.61.0 h1:IAr9UlYbxURIYABRMagXXo8pDlkFNFFXWz5J2+srrnc=
-github.com/GoogleCloudPlatform/declarative-resource-client-library v1.61.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.62.0 h1:s4Y6r6RrYLBnqosGXLwR0h1Gqr0VT3wgd6rqvHsD9OE=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.62.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=

--- a/mmv1/third_party/terraform/services/eventarc/resource_eventarc_trigger_test.go.erb
+++ b/mmv1/third_party/terraform/services/eventarc/resource_eventarc_trigger_test.go.erb
@@ -70,8 +70,7 @@ func TestAccEventarcTrigger_HttpDest(t *testing.T) {
 		"project_name":    envvar.GetTestProjectFromEnv(),
 		"service_account": envvar.GetTestServiceAccountFromEnv(t),
                 "network_attachment": fullFormNetworkAttachmentName,
-
-		
+                "random_suffix": acctest.RandString(t, 10),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/services/eventarc/resource_eventarc_trigger_test.go.erb
+++ b/mmv1/third_party/terraform/services/eventarc/resource_eventarc_trigger_test.go.erb
@@ -53,6 +53,44 @@ func TestAccEventarcTrigger_channel(t *testing.T) {
 	})
 }
 
+func TestAccEventarcTrigger_HttpDest(t *testing.T) {
+	t.Parallel()
+
+	region := envvar.GetTestRegionFromEnv()
+	
+        testNetworkName := acctest.BootstrapSharedTestNetwork(t, "attachment-network")
+	subnetName := acctest.BootstrapSubnet(t, "tf-test-subnet", testNetworkName)
+	networkAttachmentName := acctest.BootstrapNetworkAttachment(t, "tf-test-attachment", subnetName)
+
+	// Need to have the full network attachment name in the format project/{project_id}/regions/{region_id}/networkAttachments/{networkAttachmentName}
+	fullFormNetworkAttachmentName := fmt.Sprintf("projects/%s/regions/%s/networkAttachments/%s", envvar.GetTestProjectFromEnv(), envvar.GetTestRegionFromEnv(), networkAttachmentName)
+
+	context := map[string]interface{}{
+		"region":          region,
+		"project_name":    envvar.GetTestProjectFromEnv(),
+		"service_account": envvar.GetTestServiceAccountFromEnv(t),
+                "network_attachment": fullFormNetworkAttachmentName,
+
+		
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckEventarcChannelTriggerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEventarcTrigger_createTriggerWithHttpDest(context),
+			},
+			{
+				ResourceName:      "google_eventarc_trigger.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccEventarcTrigger_createTriggerWithChannelName(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_project" "test_project" {
@@ -130,6 +168,34 @@ resource "google_eventarc_trigger" "primary" {
     channel = "projects/${data.google_project.test_project.project_id}/locations/%{region}/channels/${google_eventarc_channel.test_channel.name}"
 
     depends_on = [google_cloud_run_service.default,google_eventarc_channel.test_channel]
+}
+`, context)
+}
+
+func testAccEventarcTrigger_createTriggerWithHttpDest(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "test_project" {
+	project_id  = "%{project_name}"
+}
+
+resource "google_eventarc_trigger" "primary" {
+	name = "tf-test-trigger%{random_suffix}"
+	location = "%{region}"
+	matching_criteria {
+		attribute = "type"
+		value = "datadog.v1.alert"
+	}
+	destination {
+		http_endpoint {
+			uri = "http://10.10.10.8:80/route"
+		}
+                network_config {
+                        network_attachment = "%{network_attachment}"
+                }
+
+	}
+	service_account = "%{service_account}"
+
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/eventarc/resource_eventarc_trigger_test.go.erb
+++ b/mmv1/third_party/terraform/services/eventarc/resource_eventarc_trigger_test.go.erb
@@ -183,7 +183,7 @@ resource "google_eventarc_trigger" "primary" {
 	location = "%{region}"
 	matching_criteria {
 		attribute = "type"
-		value = "datadog.v1.alert"
+		value = "google.cloud.pubsub.topic.v1.messagePublished"
 	}
 	destination {
 		http_endpoint {

--- a/tpgtools/go.mod
+++ b/tpgtools/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	bitbucket.org/creachadair/stringset v0.0.11
-	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.61.0
+	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.62.0
 	github.com/golang/glog v1.1.2
 	github.com/hashicorp/hcl v1.0.0
 	github.com/kylelemons/godebug v1.1.0

--- a/tpgtools/go.sum
+++ b/tpgtools/go.sum
@@ -10,7 +10,7 @@ github.com/GoogleCloudPlatform/declarative-resource-client-library v1.60.0 h1:RF
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.60.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.61.0 h1:IAr9UlYbxURIYABRMagXXo8pDlkFNFFXWz5J2+srrnc=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.61.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
-github.com/GoogleCloudPlatform/declarative-resource-client-library v1.62.0 h1: s4Y6r6RrYLBnqosGXLwR0h1Gqr0VT3wgd6rqvHsD9O=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.62.0 h1:s4Y6r6RrYLBnqosGXLwR0h1Gqr0VT3wgd6rqvHsD9O=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.62.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=

--- a/tpgtools/go.sum
+++ b/tpgtools/go.sum
@@ -10,7 +10,7 @@ github.com/GoogleCloudPlatform/declarative-resource-client-library v1.60.0 h1:RF
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.60.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.61.0 h1:IAr9UlYbxURIYABRMagXXo8pDlkFNFFXWz5J2+srrnc=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.61.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
-github.com/GoogleCloudPlatform/declarative-resource-client-library v1.62.0 h1:s4Y6r6RrYLBnqosGXLwR0h1Gqr0VT3wgd6rqvHsD9O=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.62.0 h1:s4Y6r6RrYLBnqosGXLwR0h1Gqr0VT3wgd6rqvHsD9OE=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.62.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=

--- a/tpgtools/go.sum
+++ b/tpgtools/go.sum
@@ -10,6 +10,8 @@ github.com/GoogleCloudPlatform/declarative-resource-client-library v1.60.0 h1:RF
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.60.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.61.0 h1:IAr9UlYbxURIYABRMagXXo8pDlkFNFFXWz5J2+srrnc=
 github.com/GoogleCloudPlatform/declarative-resource-client-library v1.61.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.62.0 h1: s4Y6r6RrYLBnqosGXLwR0h1Gqr0VT3wgd6rqvHsD9O=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.62.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
Add sample for trigger using http_destination

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [make test and make lint](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
 - [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x]  Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.


**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
eventarc: added support for `http_endpoint.uri` and `network_config.network_attachment` to `google_eventarc_trigger`
clouddeploy: added support for `canary_revision_tags`, `prior_revision_tags`, `stable_revision_tags`, and `stable_cutback_duration` to `google_clouddeploy_delivery_pipeline`
```
