### PR TITLE
Fix test failures TestAccGKEHubFeatureMembership_gkehubFeaturePolicyController

### DIFF
--- a/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.erb
@@ -1256,6 +1256,7 @@ resource "google_project" "project" {
 resource "google_project_service" "anthos" {
   project = google_project.project.project_id
   service = "anthos.googleapis.com"
+  disable_on_destroy = false
 }
 
 resource "google_project_service" "mesh" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fix test failures where Policy Controller FeatureMembership resource cannot be deleted if Anthos API is disabled.

Fix issue: https://github.com/hashicorp/terraform-provider-google/issues/10224

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
