### PR TITLE
Allow vcenter_network to be set

### DIFF
--- a/mmv1/products/gkeonprem/VmwareCluster.yaml
+++ b/mmv1/products/gkeonprem/VmwareCluster.yaml
@@ -253,6 +253,7 @@ properties:
           vcenter_network specifies vCenter network name. Inherited from the
           admin cluster.
         immutable: true
+        default_from_api: true
       - !ruby/object:Api::Type::NestedObject
         name: 'hostConfig'
         description:

--- a/mmv1/products/gkeonprem/VmwareCluster.yaml
+++ b/mmv1/products/gkeonprem/VmwareCluster.yaml
@@ -252,7 +252,7 @@ properties:
         description:
           vcenter_network specifies vCenter network name. Inherited from the
           admin cluster.
-        output: true
+        immutable: true
       - !ruby/object:Api::Type::NestedObject
         name: 'hostConfig'
         description:

--- a/mmv1/templates/terraform/examples/gkeonprem_vmware_cluster_f5lb.tf.erb
+++ b/mmv1/templates/terraform/examples/gkeonprem_vmware_cluster_f5lb.tf.erb
@@ -21,6 +21,7 @@ resource "google_gkeonprem_vmware_cluster" "<%= ctx[:primary_resource_id] %>" {
         gateway="test-gateway"
       }
     }
+    vcenter_network = "test-vcenter-network"
   }
   control_plane_node {
      cpus = 4


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
https://github.com/hashicorp/terraform-provider-google/issues/16821

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
pkeonprem: allowed `vcenter_network` to be set in `google_gkeonprem_vmware_cluster`, while the field does not support in-place update
```
