### PR TITLE
TeamCity: Trigger sweepers later in the day than acceptance test builds

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/projects/project_sweeper_project.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/project_sweeper_project.kt
@@ -27,7 +27,7 @@ fun projectSweeperSubProject(allConfig: AllContextParameters): Project {
     // Create build config for sweeping project resources
     // Uses the HashiCorpVCSRootGa VCS Root so that the latest sweepers in hashicorp/terraform-provider-google are used
     val serviceSweeperConfig = BuildConfigurationForProjectSweeper("N/A", ProjectSweeperName, SweepersList, projectId, HashiCorpVCSRootGa, sharedResources, gaConfig)
-    val trigger  = NightlyTriggerConfiguration()
+    val trigger  = NightlyTriggerConfiguration(startHour=12)
     serviceSweeperConfig.addTrigger(trigger)
 
     return Project{

--- a/mmv1/third_party/terraform/.teamcity/components/projects/reused/mm_upstream.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/reused/mm_upstream.kt
@@ -32,7 +32,7 @@ fun mmUpstream(parentProject: String, providerName: String, vcsRoot: GitVcsRoot,
 
     // Create build config for sweeping the nightly test project - everything except projects
     val serviceSweeperConfig = BuildConfigurationForServiceSweeper(providerName, ServiceSweeperName, SweepersList, projectId, vcsRoot, sharedResources, config)
-    val trigger  = NightlyTriggerConfiguration()
+    val trigger  = NightlyTriggerConfiguration(startHour=12)
     serviceSweeperConfig.addTrigger(trigger) // Only the sweeper is on a schedule in this project
 
     return Project {

--- a/mmv1/third_party/terraform/.teamcity/components/projects/reused/mm_upstream.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/reused/mm_upstream.kt
@@ -30,7 +30,7 @@ fun mmUpstream(parentProject: String, providerName: String, vcsRoot: GitVcsRoot,
     val allPackages = getAllPackageInProviderVersion(providerName)
     val packageBuildConfigs = BuildConfigurationsForPackages(allPackages, providerName, projectId, vcsRoot, sharedResources, config)
 
-    // Create build config for sweeping the nightly test project - everything except projects
+    // Create build config for sweeping the VCR test project - everything except projects
     val serviceSweeperConfig = BuildConfigurationForServiceSweeper(providerName, ServiceSweeperName, SweepersList, projectId, vcsRoot, sharedResources, config)
     val trigger  = NightlyTriggerConfiguration(startHour=12)
     serviceSweeperConfig.addTrigger(trigger) // Only the sweeper is on a schedule in this project

--- a/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
@@ -30,19 +30,18 @@ fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot
         else -> throw Exception("Provider name not supplied when generating a nightly test subproject")
     }
 
-    // CRON trigger that's reused for all build configurations
-    val trigger  = NightlyTriggerConfiguration()
-
     // Create build configs to run acceptance tests for each package defined in packages.kt and services.kt files
     val allPackages = getAllPackageInProviderVersion(providerName)
     val packageBuildConfigs = BuildConfigurationsForPackages(allPackages, providerName, projectId, vcsRoot, sharedResources, config)
+    val accTestTrigger  = NightlyTriggerConfiguration()
     packageBuildConfigs.forEach { buildConfiguration ->
-        buildConfiguration.addTrigger(trigger)
+        buildConfiguration.addTrigger(accTestTrigger)
     }
 
     // Create build config for sweeping the nightly test project
     val serviceSweeperConfig = BuildConfigurationForServiceSweeper(providerName, ServiceSweeperName, SweepersList, projectId, vcsRoot, sharedResources, config)
-    serviceSweeperConfig.addTrigger(trigger)
+    val sweeperTrigger  = NightlyTriggerConfiguration(startHour=12)  // Override hour
+    serviceSweeperConfig.addTrigger(sweeperTrigger)
 
     return Project {
         id(projectId)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Closes https://github.com/hashicorp/terraform-provider-google/issues/17217

See issue for details!
This PR makes all sweeper builds run at 12pm UTC, versus the default of 4am UTC

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
