### PR TITLE
Address dependency issues in TestAccFirestoreField_* tests

### DIFF
--- a/mmv1/templates/terraform/custom_check_destroy/firestore_field.go.erb
+++ b/mmv1/templates/terraform/custom_check_destroy/firestore_field.go.erb
@@ -16,7 +16,16 @@ res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 	UserAgent: config.UserAgent,
 })
 if err != nil {
-  return err
+	e := err.(*googleapi.Error)
+	if e.Code == 403 && strings.Contains(e.Message, "Cloud Firestore API has not been used in project") {
+		// The acceptance test has provisioned the resources under test in a new project, and the destory check is seeing the
+		// effects of the project not existing. This means the service isn't enabled, and that the resource is definitely destroyed.
+		// We do not return the error in this case - destroy was successful
+		return nil
+	}
+
+	// Return err in all other cases
+	return err
 }
 
 if v := res["indexConfig"]; v != nil {

--- a/mmv1/templates/terraform/custom_delete/firestore_field_delete.go.erb
+++ b/mmv1/templates/terraform/custom_delete/firestore_field_delete.go.erb
@@ -52,7 +52,8 @@ if err != nil {
 	return err
 }
 
+log.Printf("[DEBUG] Finished deleting Field %q", d.Id())
+
 d.SetId("") // Remove the resource from state
 
-log.Printf("[DEBUG] Finished deleting Field %q", d.Id())
 return nil

--- a/mmv1/templates/terraform/custom_delete/firestore_field_delete.go.erb
+++ b/mmv1/templates/terraform/custom_delete/firestore_field_delete.go.erb
@@ -52,5 +52,7 @@ if err != nil {
 	return err
 }
 
+d.SetId("") // Remove the resource from state
+
 log.Printf("[DEBUG] Finished deleting Field %q", d.Id())
 return nil

--- a/mmv1/templates/terraform/custom_delete/firestore_field_delete.go.erb
+++ b/mmv1/templates/terraform/custom_delete/firestore_field_delete.go.erb
@@ -53,7 +53,4 @@ if err != nil {
 }
 
 log.Printf("[DEBUG] Finished deleting Field %q", d.Id())
-
-d.SetId("") // Remove the resource from state
-
 return nil

--- a/mmv1/third_party/terraform/services/firestore/resource_firestore_field_test.go
+++ b/mmv1/third_party/terraform/services/firestore/resource_firestore_field_test.go
@@ -83,11 +83,10 @@ resource "google_project" "project" {
 	org_id     = "%{org_id}"
 }
 
-resource "time_sleep" "wait_60_sec" {
+resource "time_sleep" "wait_60_seconds" {
 	depends_on = [google_project.project]
 
 	create_duration = "60s"
-	destroy_duration = "60s"
 }
 
 resource "google_project_service" "firestore" {
@@ -95,7 +94,7 @@ resource "google_project_service" "firestore" {
 	service = "firestore.googleapis.com"
 
 	# Needed for CI tests for permissions to propagate, should not be needed for actual usage
-	depends_on = [time_sleep.wait_60_sec]
+	depends_on = [time_sleep.wait_60_seconds]
 }
 
 resource "google_firestore_database" "database" {

--- a/mmv1/third_party/terraform/services/firestore/resource_firestore_field_test.go
+++ b/mmv1/third_party/terraform/services/firestore/resource_firestore_field_test.go
@@ -83,18 +83,10 @@ resource "google_project" "project" {
 	org_id     = "%{org_id}"
 }
 
-# 60s wait between creating the project and enabling the service
-resource "time_sleep" "wait_360_sec_after_project" {
+resource "time_sleep" "wait_60_sec" {
 	depends_on = [google_project.project]
 
-	create_duration = "360s"
-}
-
-# 60s wait between enabling the service and trying to use it
-resource "time_sleep" "wait_360_sec_after_service" {
-	depends_on = [google_project_service.firestore]
-
-	create_duration = "360s"
+	create_duration = "60s"
 }
 
 resource "google_project_service" "firestore" {
@@ -102,7 +94,7 @@ resource "google_project_service" "firestore" {
 	service = "firestore.googleapis.com"
 
 	# Needed for CI tests for permissions to propagate, should not be needed for actual usage
-	depends_on = [time_sleep.wait_360_sec_after_project]
+	depends_on = [time_sleep.wait_60_sec]
 }
 
 resource "google_firestore_database" "database" {
@@ -111,7 +103,7 @@ resource "google_firestore_database" "database" {
 	location_id = "nam5"
 	type        = "FIRESTORE_NATIVE"
 
-	depends_on = [time_sleep.wait_360_sec_after_service]
+	depends_on = [google_project_service.firestore] # control delete order
 }
 `, context)
 	} else {
@@ -123,7 +115,7 @@ resource "google_firestore_database" "database" {
 	type        = "FIRESTORE_NATIVE"
 
 	delete_protection_state = "DELETE_PROTECTION_DISABLED"
-    deletion_policy         = "DELETE"
+	deletion_policy         = "DELETE"
 }
 `, context)
 	}

--- a/mmv1/third_party/terraform/services/firestore/resource_firestore_field_test.go
+++ b/mmv1/third_party/terraform/services/firestore/resource_firestore_field_test.go
@@ -84,17 +84,17 @@ resource "google_project" "project" {
 }
 
 # 60s wait between creating the project and enabling the service
-resource "time_sleep" "wait_60_sec_after_project" {
+resource "time_sleep" "wait_360_sec_after_project" {
 	depends_on = [google_project.project]
 
-	create_duration = "60s"
+	create_duration = "360s"
 }
 
 # 60s wait between enabling the service and trying to use it
-resource "time_sleep" "wait_60_sec_after_service" {
+resource "time_sleep" "wait_360_sec_after_service" {
 	depends_on = [google_project_service.firestore]
 
-	create_duration = "60s"
+	create_duration = "360s"
 }
 
 resource "google_project_service" "firestore" {
@@ -102,7 +102,7 @@ resource "google_project_service" "firestore" {
 	service = "firestore.googleapis.com"
 
 	# Needed for CI tests for permissions to propagate, should not be needed for actual usage
-	depends_on = [time_sleep.wait_60_sec_after_project]
+	depends_on = [time_sleep.wait_360_sec_after_project]
 }
 
 resource "google_firestore_database" "database" {
@@ -111,7 +111,7 @@ resource "google_firestore_database" "database" {
 	location_id = "nam5"
 	type        = "FIRESTORE_NATIVE"
 
-	depends_on = [time_sleep.wait_60_sec_after_service]
+	depends_on = [time_sleep.wait_360_sec_after_service]
 }
 `, context)
 	} else {

--- a/mmv1/third_party/terraform/services/firestore/resource_firestore_field_test.go
+++ b/mmv1/third_party/terraform/services/firestore/resource_firestore_field_test.go
@@ -87,6 +87,7 @@ resource "time_sleep" "wait_60_sec" {
 	depends_on = [google_project.project]
 
 	create_duration = "60s"
+	destroy_duration = "60s"
 }
 
 resource "google_project_service" "firestore" {

--- a/mmv1/third_party/terraform/services/firestore/resource_firestore_field_test.go
+++ b/mmv1/third_party/terraform/services/firestore/resource_firestore_field_test.go
@@ -83,8 +83,16 @@ resource "google_project" "project" {
 	org_id     = "%{org_id}"
 }
 
-resource "time_sleep" "wait_60_seconds" {
+# 60s wait between creating the project and enabling the service
+resource "time_sleep" "wait_60_sec_after_project" {
 	depends_on = [google_project.project]
+
+	create_duration = "60s"
+}
+
+# 60s wait between enabling the service and trying to use it
+resource "time_sleep" "wait_60_sec_after_service" {
+	depends_on = [google_project_service.firestore]
 
 	create_duration = "60s"
 }
@@ -94,7 +102,7 @@ resource "google_project_service" "firestore" {
 	service = "firestore.googleapis.com"
 
 	# Needed for CI tests for permissions to propagate, should not be needed for actual usage
-	depends_on = [time_sleep.wait_60_seconds]
+	depends_on = [time_sleep.wait_60_sec_after_project]
 }
 
 resource "google_firestore_database" "database" {
@@ -103,7 +111,7 @@ resource "google_firestore_database" "database" {
 	location_id = "nam5"
 	type        = "FIRESTORE_NATIVE"
 
-	depends_on = [google_project_service.firestore]
+	depends_on = [time_sleep.wait_60_sec_after_service]
 }
 `, context)
 	} else {

--- a/mmv1/third_party/terraform/services/firestore/resource_firestore_field_test.go
+++ b/mmv1/third_party/terraform/services/firestore/resource_firestore_field_test.go
@@ -103,7 +103,11 @@ resource "google_firestore_database" "database" {
 	location_id = "nam5"
 	type        = "FIRESTORE_NATIVE"
 
-	depends_on = [google_project_service.firestore] # control delete order
+	# used to control delete order
+	depends_on = [
+		google_project_service.firestore,
+		google_project.project
+	]
 }
 `, context)
 	} else {


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/17392

Adding an additional delay in TestAccFirestoreField_* tests to address an 100% error occurring since late Jan:

![Screenshot 2024-02-09 at 16 43 41](https://github.com/GoogleCloudPlatform/magic-modules/assets/15078782/d01b14fa-552c-4f20-a21f-c0163b26955a)

```
------- Stdout: -------
=== RUN   TestAccFirestoreField_firestoreFieldUpdateAddIndexExample
=== PAUSE TestAccFirestoreField_firestoreFieldUpdateAddIndexExample
=== CONT  TestAccFirestoreField_firestoreFieldUpdateAddIndexExample
    testing_new.go:84: Error running post-test destroy, there may be dangling resources: googleapi: Error 403: Cloud Firestore API has not been used in project tf-test3abifux6ev before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/firestore.googleapis.com/overview?project=tf-test3abifux6ev then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.
        Details:
        [
          {
            "@type": "type.googleapis.com/google.rpc.Help",
            "links": [
              {
                "description": "Google developers console API activation",
                "url": "https://console.developers.google.com/apis/api/firestore.googleapis.com/overview?project=tf-test3abifux6ev
              }
            ]
          },
          {
            "@type": "type.googleapis.com/google.rpc.ErrorInfo",
            "domain": "googleapis.com",
            "metadata": {
              "consumer": "projects/tf-test3abifux6ev",
              "service": "firestore.googleapis.com"
            },
            "reason": "SERVICE_DISABLED"
          }
        ]
--- FAIL: TestAccFirestoreField_firestoreFieldUpdateAddIndexExample (1163.75s)
FAIL
```


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
