### PR TITLE
Allow GCE apis to handle validations for boot disk permformance

### DIFF
--- a/mmv1/products/compute/Instance.yaml
+++ b/mmv1/products/compute/Instance.yaml
@@ -186,23 +186,21 @@ properties:
               description: |
                 Indicates how many IOPS to provision for the disk. This
                 sets the number of I/O operations per second that the
-                disk can handle. Values must be between 10,000 and 120,000.
-                Note: Updating currently is only supported for hyperdisk skus
-                via disk update api/gcloud without the need to delete and recreate
-                the disk, hyperdisk allows for an update of IOPS every
-                4 hours. To update your hyperdisk more frequently,
+                disk can handle. Note: Updating currently is only supported for
+                hyperdisk skus via disk update api/gcloud without the need to
+                delete and recreate the disk, hyperdisk allows for an update of
+                IOPS every 4 hours. To update your hyperdisk more frequently,
                 you'll need to manually delete and recreate it.
             - !ruby/object:Api::Type::Integer
               name: 'provisionedThroughput'
               description: |
                 Indicates how much throughput to provision for the disk.
                 This sets the number of throughput mb per second that
-                the disk can handle. Values must be between 1 and 7,124.
-                Note: Updating currently is only supported for hyperdisk skus
-                via disk update api/gcloud without the need to delete and recreate
-                the disk, hyperdisk allows for an update of throughput every
-                4 hours. To update your hyperdisk more frequently,
-                you'll need to manually delete and recreate it.
+                the disk can handle. Note: Updating currently is only supported
+                for hyperdisk skus via disk update api/gcloud without the need
+                to delete and recreate the disk, hyperdisk allows for an update
+                of throughput every 4 hours. To update your hyperdisk more
+                frequently, you'll need to manually delete and recreate it.
             - !ruby/object:Api::Type::Boolean
               name: 'enableConfidentialCompute'
               description: |

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
@@ -251,8 +251,7 @@ func ResourceComputeInstance() *schema.Resource {
 										AtLeastOneOf: initializeParamsKeys,
 										Computed:     true,
 										ForceNew:     true,
-										ValidateFunc: validation.IntBetween(10000, 120000),
-										Description:  `Indicates how many IOPS to provision for the disk. This sets the number of I/O operations per second that the disk can handle. Values must be between 10,000 and 120,000.`,
+										Description:  `Indicates how many IOPS to provision for the disk. This sets the number of I/O operations per second that the disk can handle.`,
 									},
 
 									"provisioned_throughput": {
@@ -261,8 +260,7 @@ func ResourceComputeInstance() *schema.Resource {
 										AtLeastOneOf: initializeParamsKeys,
 										Computed:     true,
 										ForceNew:     true,
-										ValidateFunc: validation.IntBetween(1, 7124),
-										Description:  `Indicates how much throughput to provision for the disk. This sets the number of throughput mb per second that the disk can handle. Values must be between 1 and 7,124.`,
+										Description:  `Indicates how much throughput to provision for the disk. This sets the number of throughput mb per second that the disk can handle.`,
 									},
 
 									"enable_confidential_compute": {

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -251,8 +251,7 @@ is desired, you will need to modify your state file manually using
 
 * `provisioned_iops` - (Optional) Indicates how many IOPS to provision for the disk.
     This sets the number of I/O operations per second that the disk can handle.
-    Values must be between 10,000 and 120,000. For more details,see the 
-    [Extreme persistent disk documentation](https://cloud.google.com/compute/docs/disks/extreme-persistent-disk).
+    For more details,see the [Hyperdisk documentation](https://cloud.google.com/compute/docs/disks/hyperdisks).
     Note: Updating currently is only supported for hyperdisk skus via disk update
     api/gcloud without the need to delete and recreate the disk, hyperdisk allows
     for an update of IOPS every 4 hours. To update your hyperdisk more frequently,
@@ -260,10 +259,11 @@ is desired, you will need to modify your state file manually using
 
 * `provisioned_throughput` - (Optional) Indicates how much throughput to provision for the disk.
     This sets the number of throughput mb per second that the disk can handle.
-    Values must be between 1 and 7,124. Note: Updating currently is only supported
-    for hyperdisk skus via disk update api/gcloud without the need to delete and
-    recreate the disk, hyperdisk allows for an update of throughput every 4 hours.
-    To update your hyperdisk more frequently, you'll need to manually delete and recreate it.
+    For more details,see the [Hyperdisk documentation](https://cloud.google.com/compute/docs/disks/hyperdisks).
+    Note: Updating currently is only supported for hyperdisk skus via disk update
+    api/gcloud without the need to delete and recreate the disk, hyperdisk allows
+    for an update of throughput every 4 hours. To update your hyperdisk more
+    frequently, you'll need to manually delete and recreate it.
 
 * `enable_confidential_compute` - (Optional) Whether this disk is using confidential compute mode.
     Note: Only supported on hyperdisk skus, disk_encryption_key is required when setting to true.


### PR DESCRIPTION
Allow GCE apis to handle validations for provisionedIops and provisionedThrouoghput for attached boot disk for compute_instance. The performance metrics are updated with introduction of new disk type and feature. 

```release-note:enhancement
allowed GCE apis to handle validations for boor disk provisionedIops and provisionedThroughput performance metrics.
```
