### PR TITLE
fix forceNew on resource_manager_tags

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
@@ -628,7 +628,7 @@ Google Cloud KMS.`,
 			"resource_manager_tags": {
 				Type:        schema.TypeMap,
 				Optional:    true,
-				ForceNew:    false,
+				ForceNew:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Set:         schema.HashString,
 				Description: `A map of resource manager tags.

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.erb
@@ -590,7 +590,7 @@ Google Cloud KMS.`,
 			"resource_manager_tags": {
 				Type:        schema.TypeMap,
 				Optional:    true,
-				ForceNew:    false,
+				ForceNew:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Set:         schema.HashString,
 				Description: `A map of resource manager tags.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/17239

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed doing nothing when `resource_manager_tags` is changed on `google_compute_instance_template` and `google_compute_region_instance_template`
```
