### PR TITLE
Additional fixes for stateful ips in (region)_instance_group_manager

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
@@ -904,17 +904,10 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 	}
 	<% end -%>
 
-	<% unless version == "ga" -%>
 	if d.HasChange("stateful_internal_ip") || d.HasChange("stateful_external_ip") || d.HasChange("stateful_disk") {
 		updatedManager.StatefulPolicy = expandStatefulPolicy(d)
 		change = true
 	}
-	<% else -%>
-	if d.HasChange("stateful_disk") {
-		updatedManager.StatefulPolicy = expandStatefulPolicy(d)
-		change = true
-	}
-	<% end -%>
 
 	if d.HasChange("list_managed_instances_results") {
 		updatedManager.ListManagedInstancesResults = d.Get("list_managed_instances_results").(string)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
@@ -847,17 +847,10 @@ func resourceComputeRegionInstanceGroupManagerUpdate(d *schema.ResourceData, met
 		change = true
 	}
 
-	<% unless version == "ga" -%>
 	if d.HasChange("stateful_internal_ip") || d.HasChange("stateful_external_ip") || d.HasChange("stateful_disk") {
 		updatedManager.StatefulPolicy = expandStatefulPolicy(d)
 		change = true
 	}
-	<% else -%>
-	if d.HasChange("stateful_disk") {
-		updatedManager.StatefulPolicy = expandStatefulPolicy(d)
-		change = true
-	}
-	<% end -%>
 
 	<% unless version == "ga" -%>
 	if d.HasChange("all_instances_config") {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.erb
@@ -323,8 +323,6 @@ func TestAccRegionInstanceGroupManager_distributionPolicy(t *testing.T) {
 }
 
 func TestAccRegionInstanceGroupManager_stateful(t *testing.T) {
-	// TODO: Flaky test due to ordering of IPs https://github.com/hashicorp/terraform-provider-google/issues/13430
-	t.Skip()
 	t.Parallel()
 
 	template := fmt.Sprintf("tf-test-rigm-%s", acctest.RandString(t, 10))


### PR DESCRIPTION
This fixes an issue omitted during GA promotion: https://github.com/GoogleCloudPlatform/magic-modules/pull/9115, where changes only in stateful_(internal|external)_ip will not trigger a Patch call in the GA provider.
fixes #10908

Also, reenables a test that should no longer flake due to https://github.com/GoogleCloudPlatform/magic-modules/pull/9577
#13430

If this PR is for Terraform, I acknowledge that I have:

Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
[Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran make test and make lint to ensure it passes unit and linter tests.
Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
[Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
Fix issue that changes only in stateful_(internal|external)_ip will not trigger a Patch call in the GA provider for compute_(region_)instance_group_manager
```
