### PR TITLE
add featureregistry field support for featureview

### DIFF
--- a/mmv1/products/vertexai/FeatureOnlineStoreFeatureview.yaml
+++ b/mmv1/products/vertexai/FeatureOnlineStoreFeatureview.yaml
@@ -56,6 +56,11 @@ examples:
     vars:
       name: 'example_feature_view'
   - !ruby/object:Provider::Terraform::Examples
+    name: 'vertex_ai_featureonlinestore_featureview_feature_registry'
+    primary_resource_id: 'featureview_featureregistry'
+    vars:
+      name: 'example_feature_view_feature_registry'
+  - !ruby/object:Provider::Terraform::Examples
     name: 'vertex_ai_featureonlinestore_featureview_with_vector_search'
     primary_resource_id: 'featureview_vector_search'
     vars:
@@ -112,6 +117,9 @@ properties:
     name: 'bigQuerySource'
     description: |
       Configures how data is supposed to be extracted from a BigQuery source to be loaded onto the FeatureOnlineStore.
+    exactly_one_of:
+      - big_query_source
+      - feature_registry_source
     properties:
       - !ruby/object:Api::Type::String
         name: 'uri'
@@ -125,9 +133,39 @@ properties:
           Columns to construct entityId / row keys. Start by supporting 1 only.
         item_type: Api::Type::String
   - !ruby/object:Api::Type::NestedObject
+    name: 'featureRegistrySource'
+    conflicts:
+      - vector_search_config
+    exactly_one_of:
+      - big_query_source
+      - feature_registry_source
+    description: |
+      Configures the features from a Feature Registry source that need to be loaded onto the FeatureOnlineStore.
+    properties:
+      - !ruby/object:Api::Type::Array
+        name: 'featureGroups'
+        required: true
+        description: |
+          List of features that need to be synced to Online Store.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::String
+              name: 'featureGroupId'
+              required: true
+              description: |
+                Identifier of the feature group.
+            - !ruby/object:Api::Type::Array
+              name: featureIds
+              required: true
+              description: |
+                Identifiers of features under the feature group.
+              item_type: Api::Type::String
+  - !ruby/object:Api::Type::NestedObject
     name: 'vectorSearchConfig'
     description: |
       Configuration for vector search. It contains the required configurations to create an index from source data, so that approximate nearest neighbor (a.k.a ANN) algorithms search can be performed during online serving.
+    conflicts:
+      - feature_registry_source
     immutable: true
     min_version: beta
     properties:

--- a/mmv1/templates/terraform/examples/vertex_ai_featureonlinestore_featureview_feature_registry.tf.erb
+++ b/mmv1/templates/terraform/examples/vertex_ai_featureonlinestore_featureview_feature_registry.tf.erb
@@ -1,0 +1,93 @@
+resource "google_vertex_ai_feature_online_store" "featureonlinestore" {
+  name     = "<%= ctx[:vars]['name'] %>"
+  labels = {
+    foo = "bar"
+  }
+  region = "us-central1"
+  bigtable {
+    auto_scaling {
+      min_node_count         = 1
+      max_node_count         = 2
+      cpu_utilization_target = 80
+    }
+  }
+}
+
+resource "google_bigquery_dataset" "sample_dataset" {
+  dataset_id                  = "<%= ctx[:vars]['name'] %>"
+  friendly_name               = "test"
+  description                 = "This is a test description"
+  location                    = "US"
+}
+
+resource "google_bigquery_table" "sample_table" {
+  deletion_protection = false
+  dataset_id = google_bigquery_dataset.sample_dataset.dataset_id
+  table_id   = "<%= ctx[:vars]['name'] %>"
+
+  schema = <<EOF
+[
+    {
+        "name": "feature_id",
+        "type": "STRING",
+        "mode": "NULLABLE"
+    },
+    {
+        "name": "<%= ctx[:vars]['name'] %>",
+        "type": "STRING",
+        "mode": "NULLABLE"
+    },
+    {
+        "name": "feature_timestamp",
+        "type": "TIMESTAMP",
+        "mode": "NULLABLE"
+    }
+]
+EOF
+}
+
+resource "google_vertex_ai_feature_group" "sample_feature_group" {
+  name = "<%= ctx[:vars]['name'] %>"
+  description = "A sample feature group"
+  region = "us-central1"
+  labels = {
+      label-one = "value-one"
+  }
+  big_query {
+    big_query_source {
+        # The source table must have a column named 'feature_timestamp' of type TIMESTAMP.
+        input_uri = "bq://${google_bigquery_table.sample_table.project}.${google_bigquery_table.sample_table.dataset_id}.${google_bigquery_table.sample_table.table_id}"
+    }
+    entity_id_columns = ["feature_id"]
+  }
+}
+
+
+
+resource "google_vertex_ai_feature_group_feature" "sample_feature" {
+  name = "<%= ctx[:vars]['name'] %>"
+  region = "us-central1"
+  feature_group = google_vertex_ai_feature_group.sample_feature_group.name
+  description = "A sample feature"
+  labels = {
+      label-one = "value-one"
+  }
+}
+
+
+resource "google_vertex_ai_feature_online_store_featureview" "<%= ctx[:primary_resource_id] %>" {
+  name                 = "<%= ctx[:vars]['name'] %>"
+  region               = "us-central1"
+  feature_online_store = google_vertex_ai_feature_online_store.featureonlinestore.name
+  sync_config {
+    cron = "0 0 * * *"
+  }
+  feature_registry_source {
+    
+    feature_groups { 
+        feature_group_id = google_vertex_ai_feature_group.sample_feature_group.name
+        feature_ids      = [google_vertex_ai_feature_group_feature.sample_feature.name]
+       }
+  }
+}
+

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_feature_online_store_featureview_test.go
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_feature_online_store_featureview_test.go
@@ -198,3 +198,291 @@ func testAccVertexAIFeatureOnlineStoreFeatureview_vertexAiFeatureonlinestoreFeat
   }
 `, context)
 }
+
+func TestAccVertexAIFeatureOnlineStoreFeatureview_vertexAiFeatureonlinestoreFeatureview_featureRegistry_updated(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckVertexAIFeatureOnlineStoreFeatureviewDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVertexAIFeatureOnlineStoreFeatureview_vertexAiFeatureonlinestoreFeatureview_featureRegistry_basic(context),
+			},
+			{
+				ResourceName:            "google_vertex_ai_feature_online_store_featureview.featureregistry_featureview",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "etag", "feature_online_store", "labels", "terraform_labels"},
+			},
+			{
+				Config: testAccVertexAIFeatureOnlineStoreFeatureview_vertexAiFeatureonlinestoreFeatureview_featureRegistry_update(context),
+			},
+			{
+				ResourceName:            "google_vertex_ai_feature_online_store_featureview.featureregistry_featureview",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "feature_online_store", "labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccVertexAIFeatureOnlineStoreFeatureview_vertexAiFeatureonlinestoreFeatureview_featureRegistry_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+  resource "google_vertex_ai_feature_online_store" "featureregistry_featureonlinestore" {
+    name = "tf_test_featureonlinestore%{random_suffix}"
+    labels = {
+      foo = "bar"
+    }
+    region = "us-central1"
+    bigtable {
+      auto_scaling {
+        min_node_count         = 1
+        max_node_count         = 2
+        cpu_utilization_target = 80
+      }
+    }
+  }
+  
+  resource "google_bigquery_dataset" "featureregistry-tf-test-dataset" {
+  
+    dataset_id    = "tf_test_dataset1_featureview%{random_suffix}"
+    friendly_name = "test"
+    description   = "This is a test description"
+    location      = "US"
+  }
+  
+  resource "google_bigquery_table" "sample_table" {
+    deletion_protection = false
+  
+    dataset_id = google_bigquery_dataset.featureregistry-tf-test-dataset.dataset_id
+    table_id   = "tf_test_bq_table%{random_suffix}"
+    schema     = <<EOF
+      [
+        {
+          "name": "feature_id",
+          "type": "STRING",
+          "mode": "NULLABLE"
+      },
+      {
+        "name": "feature_id_updated",
+        "type": "STRING",
+        "mode": "NULLABLE"
+    },
+      {
+        "name": "entity_id",
+        "mode": "NULLABLE",
+        "type": "STRING",
+        "description": "Test default entity_id"
+      },
+        {
+        "name": "test_entity_column",
+        "mode": "NULLABLE",
+        "type": "STRING",
+        "description": "test secondary entity column"
+      },
+      {
+        "name": "feature_timestamp",
+        "mode": "NULLABLE",
+        "type": "TIMESTAMP",
+        "description": "Default timestamp value"
+      }
+    ]
+    EOF
+  }
+
+  resource "google_vertex_ai_feature_group" "sample_feature_group" {
+    name = "tf_test_feature_group%{random_suffix}"
+    description = "A sample feature group"
+    region = "us-central1"
+    labels = {
+        label-one = "value-one"
+    }
+    big_query {
+      big_query_source {
+          # The source table must have a column named 'feature_timestamp' of type TIMESTAMP.
+          input_uri = "bq://${google_bigquery_table.sample_table.project}.${google_bigquery_table.sample_table.dataset_id}.${google_bigquery_table.sample_table.table_id}"
+      }
+      entity_id_columns = ["feature_id"]
+    }
+  }
+  
+  
+  
+  resource "google_vertex_ai_feature_group_feature" "sample_feature" {
+    name = "feature_id"
+    region = "us-central1"
+    feature_group = google_vertex_ai_feature_group.sample_feature_group.name
+    description = "A sample feature"
+    labels = {
+        label-one = "value-one"
+    }
+  }  
+  resource "google_vertex_ai_feature_group_feature" "updated_feature" {
+    name = "feature_id_updated"
+    region = "us-central1"
+    feature_group = google_vertex_ai_feature_group.sample_feature_group.name
+    version_column_name = "feature_id_updated"
+    description = "Updated feature"
+    labels = {
+        label-one = "value-one"
+    }
+  }
+  
+  resource "google_vertex_ai_feature_online_store_featureview" "featureregistry_featureview" {
+    name   = "tf_test_fv%{random_suffix}"
+    region = "us-central1"
+    labels = {
+      foo = "bar"
+    }
+    feature_online_store = google_vertex_ai_feature_online_store.featureregistry_featureonlinestore.name
+    sync_config {
+      cron = "0 0 * * *"
+    }
+    feature_registry_source {
+    
+      feature_groups { 
+          feature_group_id = google_vertex_ai_feature_group.sample_feature_group.name
+          feature_ids      = [google_vertex_ai_feature_group_feature.sample_feature.name]
+         }
+    }
+  }
+  
+  data "google_project" "project" {
+    provider = google
+  }  
+`, context)
+}
+
+func testAccVertexAIFeatureOnlineStoreFeatureview_vertexAiFeatureonlinestoreFeatureview_featureRegistry_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+  resource "google_vertex_ai_feature_online_store" "featureregistry_featureonlinestore" {
+    name = "tf_test_featureonlinestore%{random_suffix}"
+    labels = {
+      foo = "bar"
+    }
+    region = "us-central1"
+    bigtable {
+      auto_scaling {
+        min_node_count         = 1
+        max_node_count         = 2
+        cpu_utilization_target = 80
+      }
+    }
+  }
+  
+  resource "google_bigquery_dataset" "featureregistry-tf-test-dataset" {
+  
+    dataset_id    = "tf_test_dataset1_featureview%{random_suffix}"
+    friendly_name = "test"
+    description   = "This is a test description"
+    location      = "US"
+  }
+  
+  resource "google_bigquery_table" "sample_table" {
+    deletion_protection = false
+  
+    dataset_id = google_bigquery_dataset.featureregistry-tf-test-dataset.dataset_id
+    table_id   = "tf_test_bq_table%{random_suffix}"
+    schema     = <<EOF
+      [
+        {
+          "name": "feature_id",
+          "type": "STRING",
+          "mode": "NULLABLE"
+      },
+      {
+        "name": "feature_id_updated",
+        "type": "STRING",
+        "mode": "NULLABLE"
+    },
+      {
+        "name": "entity_id",
+        "mode": "NULLABLE",
+        "type": "STRING",
+        "description": "Test default entity_id"
+      },
+        {
+        "name": "test_entity_column",
+        "mode": "NULLABLE",
+        "type": "STRING",
+        "description": "test secondary entity column"
+      },
+      {
+        "name": "feature_timestamp",
+        "mode": "NULLABLE",
+        "type": "TIMESTAMP",
+        "description": "Default timestamp value"
+      }
+    ]
+    EOF
+  }
+
+  resource "google_vertex_ai_feature_group" "sample_feature_group" {
+    name = "tf_test_feature_group%{random_suffix}"
+    description = "A sample feature group"
+    region = "us-central1"
+    labels = {
+        label-one = "value-one"
+    }
+    big_query {
+      big_query_source {
+          # The source table must have a column named 'feature_timestamp' of type TIMESTAMP.
+          input_uri = "bq://${google_bigquery_table.sample_table.project}.${google_bigquery_table.sample_table.dataset_id}.${google_bigquery_table.sample_table.table_id}"
+      }
+      entity_id_columns = ["feature_id"]
+    }
+  }
+  
+  
+  
+  resource "google_vertex_ai_feature_group_feature" "sample_feature" {
+    name = "feature_id"
+    region = "us-central1"
+    feature_group = google_vertex_ai_feature_group.sample_feature_group.name
+    description = "A sample feature"
+    labels = {
+        label-one = "value-one"
+    }
+  }  
+  resource "google_vertex_ai_feature_group_feature" "updated_feature" {
+    name = "feature_id_updated"
+    region = "us-central1"
+    feature_group = google_vertex_ai_feature_group.sample_feature_group.name
+    version_column_name = "feature_id_updated"
+    description = "Updated feature"
+    labels = {
+        label-one = "value-one"
+    }
+  }
+  
+  resource "google_vertex_ai_feature_online_store_featureview" "featureregistry_featureview" {
+    name   = "tf_test_fv%{random_suffix}"
+    region = "us-central1"
+    labels = {
+      foo = "bar"
+    }
+    feature_online_store = google_vertex_ai_feature_online_store.featureregistry_featureonlinestore.name
+    sync_config {
+      cron = "0 0 * * *"
+    }
+    feature_registry_source {
+    
+      feature_groups { 
+          feature_group_id = google_vertex_ai_feature_group.sample_feature_group.name
+          feature_ids      = [google_vertex_ai_feature_group_feature.updated_feature.name]
+         }
+    }
+  }
+  
+  data "google_project" "project" {
+    provider = google
+  }
+`, context)
+}


### PR DESCRIPTION
This PR adds support for field "featureRegistrySource" for [FeatureView resource](https://cloud.google.com/vertex-ai/docs/reference/rest/v1beta1/projects.locations.featureOnlineStores.featureViews#resource:-featureview)

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

```release-note:enhancement
vertexai: added `feature_registry_source` field to `google_vertex_ai_feature_online_store_featureview` resource
```
