### PR TITLE
Add location field in DNS authorization resource.

### DIFF
--- a/mmv1/products/certificatemanager/DnsAuthorization.yaml
+++ b/mmv1/products/certificatemanager/DnsAuthorization.yaml
@@ -13,9 +13,9 @@
 
 --- !ruby/object:Api::Resource
 name: 'DnsAuthorization'
-base_url: 'projects/{{project}}/locations/global/dnsAuthorizations'
-create_url: 'projects/{{project}}/locations/global/dnsAuthorizations?dnsAuthorizationId={{name}}'
-self_link: 'projects/{{project}}/locations/global/dnsAuthorizations/{{name}}'
+base_url: 'projects/{{project}}/locations/{{location}}/dnsAuthorizations'
+create_url: 'projects/{{project}}/locations/{{location}}/dnsAuthorizations?dnsAuthorizationId={{name}}'
+self_link: 'projects/{{project}}/locations/{{location}}/dnsAuthorizations/{{name}}'
 update_verb: :PATCH
 update_mask: true
 description: |
@@ -39,7 +39,9 @@ async: !ruby/object:Api::OpAsync
 docs: !ruby/object:Provider::Terraform::Docs
 autogen_async: true
 import_format:
-  ['projects/{{project}}/locations/global/dnsAuthorizations/{{name}}']
+  ['projects/{{project}}/locations/{{location}}/dnsAuthorizations/{{name}}']
+schema_version: 1
+state_upgraders: true
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'certificate_manager_dns_authorization_basic'
@@ -58,6 +60,13 @@ parameters:
       Name of the resource; provided by the client when the resource is created.
       The name must be 1-64 characters long, and match the regular expression [a-zA-Z][a-zA-Z0-9_-]* which means the first character must be a letter,
       and all following characters must be a dash, underscore, letter or digit.
+  - !ruby/object:Api::Type::String
+    name: 'location'
+    description: |
+      The Certificate Manager location. If not specified, "global" is used.
+    default_value: global
+    immutable: true
+    url_param_only: true
 properties:
   - !ruby/object:Api::Type::String
     name: 'description'

--- a/mmv1/templates/terraform/examples/certificate_manager_dns_authorization_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/certificate_manager_dns_authorization_basic.tf.erb
@@ -1,6 +1,7 @@
 resource "google_certificate_manager_dns_authorization" "<%= ctx[:primary_resource_id] %>" {
   name        = "<%= ctx[:vars]['dns_auth_name'] %>"
-  description = "The default dnss"
+  location    = "global"
+  description = "The default dns"
   domain      = "<%= ctx[:vars]['subdomain'] %>.hashicorptest.com"
 }
 

--- a/mmv1/templates/terraform/state_migrations/certificate_manager_dns_authorization.go.erb
+++ b/mmv1/templates/terraform/state_migrations/certificate_manager_dns_authorization.go.erb
@@ -1,0 +1,91 @@
+func ResourceCertificateManagerDnsAuthorizationUpgradeV0(_ context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	log.Printf("[DEBUG] Attributes before migration: %#v", rawState)
+	// Version 0 didn't support location. Default it to global.
+	rawState["location"] = "global"
+	log.Printf("[DEBUG] Attributes after migration: %#v", rawState)
+	return rawState, nil
+}
+
+func resourceCertificateManagerDnsAuthorizationResourceV0() *schema.Resource {
+    return &schema.Resource{
+        Schema: map[string]*schema.Schema{
+			"domain": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				Description: `A domain which is being authorized. A DnsAuthorization resource covers a
+single domain and its wildcard, e.g. authorization for "example.com" can
+be used to issue certificates for "example.com" and "*.example.com".`,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				Description: `Name of the resource; provided by the client when the resource is created.
+The name must be 1-64 characters long, and match the regular expression [a-zA-Z][a-zA-Z0-9_-]* which means the first character must be a letter,
+and all following characters must be a dash, underscore, letter or digit.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `A human-readable description of the resource.`,
+			},
+			"labels": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Description: `Set of label tags associated with the DNS Authorization resource.
+
+**Note**: This field is non-authoritative, and will only manage the labels present in your configuration.
+Please refer to the field 'effective_labels' for all of the labels present on the resource.`,
+				Elem: &schema.Schema{Type: schema.TypeString},
+			},
+			"dns_resource_record": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Description: `The structure describing the DNS Resource Record that needs to be added
+to DNS configuration for the authorization to be usable by
+certificate.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"data": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Data of the DNS Resource Record.`,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+							Description: `Fully qualified name of the DNS Resource Record.
+E.g. '_acme-challenge.example.com'.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Type of the DNS Resource Record.`,
+						},
+					},
+				},
+			},
+			"effective_labels": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: `All of labels (key/value pairs) present on the resource in GCP, including the labels configured through Terraform, other clients and services.`,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"terraform_labels": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Description: `The combination of labels configured directly on the resource
+ and default labels configured on the provider.`,
+				Elem: &schema.Schema{Type: schema.TypeString},
+			},
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+		},    
+    }
+
+}

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_dns_authorization_upgrade_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_dns_authorization_upgrade_test.go
@@ -1,0 +1,77 @@
+package certificatemanager_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+// Tests schema version migration by creating a dns authorization with an old version of the provider (5.15.0)
+// and then updating it with the current version the provider.
+func TestAccCertificateManagerDnsAuthorization_migration(t *testing.T) {
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+	name := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+
+	oldVersion := map[string]resource.ExternalProvider{
+		"google": {
+			VersionConstraint: "5.15.0", // a version that doesn't support location yet.
+			Source:            "registry.terraform.io/hashicorp/google",
+		},
+	}
+	newVersion := map[string]func() (*schema.Provider, error){
+		"mynewprovider": func() (*schema.Provider, error) { return acctest.TestAccProviders["google"], nil },
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		CheckDestroy: testAccCheckCertificateManagerDnsAuthorizationDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config:            dnsAuthorizationResourceConfig(name),
+				ExternalProviders: oldVersion,
+			},
+			{
+				ResourceName:            "google_certificate_manager_dns_authorization.default",
+				ImportState:             true,
+				ImportStateVerifyIgnore: []string{"location"},
+				ExternalProviders:       oldVersion,
+			},
+			{
+				Config:            dnsAuthorizationResourceConfigUpdated(name),
+				ProviderFactories: newVersion,
+			},
+			{
+				ResourceName:            "google_certificate_manager_dns_authorization.default",
+				ImportState:             true,
+				ImportStateVerifyIgnore: []string{"location"},
+				ProviderFactories:       newVersion,
+			},
+		},
+	})
+}
+
+func dnsAuthorizationResourceConfig(name string) string {
+	return fmt.Sprintf(`
+	resource "google_certificate_manager_dns_authorization" "default" {
+		name        = "%s"
+		description = "The default dns"
+		domain      = "domain.hashicorptest.com"
+	  }
+	`, name)
+}
+
+func dnsAuthorizationResourceConfigUpdated(name string) string {
+	return fmt.Sprintf(`
+	provider "mynewprovider" {}
+	
+	resource "google_certificate_manager_dns_authorization" "default" {
+		name        = "%s"
+		description = "The migrated default dns"
+		domain      = "domain.hashicorptest.com"
+	  }
+	`, name)
+}

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_dns_authorization_upgrade_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_dns_authorization_upgrade_test.go
@@ -69,6 +69,7 @@ func dnsAuthorizationResourceConfigUpdated(name string) string {
 	provider "mynewprovider" {}
 	
 	resource "google_certificate_manager_dns_authorization" "default" {
+		provider = mynewprovider
 		name        = "%s"
 		description = "The migrated default dns"
 		domain      = "domain.hashicorptest.com"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add a new field `location` in `DnsAuthorization` resource in certificate managers.  The field will default to global in case it's unset. 

This is pretty much similar to what happened in https://github.com/GoogleCloudPlatform/magic-modules/pull/7825, I used this PR as a reference to make a state_migration to avoid breaking changes. 

The resource does not yet support non global instances, but once it does, we will add a new example with a different location. 
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
certificatemanager: added `location` field to `google_certificate_manager_dns_authorization` resource

```
