### PR TITLE
AppAttest and PlayIntegrity for App Check

### DIFF
--- a/mmv1/products/firebaseappcheck/AppAttestConfig.yaml
+++ b/mmv1/products/firebaseappcheck/AppAttestConfig.yaml
@@ -1,0 +1,89 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+!ruby/object:Api::Resource
+name: "AppAttestConfig"
+base_url: projects/{{project}}/apps/{{app_id}}/appAttestConfig
+self_link: projects/{{project}}/apps/{{app_id}}/appAttestConfig
+create_url: projects/{{project}}/apps/{{app_id}}/appAttestConfig?updateMask=token_ttl
+create_verb: :PATCH
+update_verb: :PATCH
+update_mask: true
+skip_delete: true
+description: |
+  An app's App Attest configuration object. Note that the Team ID registered with your
+  app is used as part of the validation process. Make sure your `google_firebase_apple_app` has a team_id present.
+references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+    "Official Documentation": "https://firebase.google.com/docs/app-check"
+  api: "https://firebase.google.com/docs/reference/appcheck/rest/v1/projects.apps.appAttestConfig"
+import_format:
+  [
+    "projects/{{project}}/apps/{{app_id}}/appAttestConfig",
+    "{{project}}/{{app_id}}",
+    "{{app_id}}",
+  ]
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: "firebase_app_check_app_attest_config_minimal"
+    # Need the time_sleep resource
+    pull_external: true
+    primary_resource_id: "default"
+    vars:
+      team_id: "9987654321"
+      bundle_id: "bundle.id.appattest"
+    test_vars_overrides:
+      # Don't add random suffix
+      team_id: '"9987654321"'
+    test_env_vars:
+      project_id: :PROJECT_NAME
+  - !ruby/object:Provider::Terraform::Examples
+    name: "firebase_app_check_app_attest_config_full"
+    # Need the time_sleep resource
+    pull_external: true
+    primary_resource_id: "default"
+    vars:
+      team_id: "9987654321"
+      bundle_id: "bundle.id.appattest"
+      token_ttl: "7200s"
+    test_vars_overrides:
+      # Don't add random suffix
+      team_id: '"9987654321"'
+      token_ttl: '"7200s"'
+    test_env_vars:
+      project_id: :PROJECT_NAME
+parameters:
+  - !ruby/object:Api::Type::String
+    name: app_id
+    description: |
+      The ID of an
+      [Apple App](https://firebase.google.com/docs/reference/firebase-management/rest/v1beta1/projects.iosApps#IosApp.FIELDS.app_id).
+    required: true
+    immutable: true
+    url_param_only: true
+properties:
+  - !ruby/object:Api::Type::String
+    name: name
+    description: |
+      The relative resource name of the App Attest configuration object
+    output: true
+    pattern: projects/{{project}}/apps/{{app_id}}/appAttestConfig
+  - !ruby/object:Api::Type::String
+    name: tokenTtl
+    description: |
+      Specifies the duration for which App Check tokens exchanged from App Attest artifacts will be valid.
+      If unset, a default value of 1 hour is assumed. Must be between 30 minutes and 7 days, inclusive.
+
+      A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.5s".
+    default_from_api: true

--- a/mmv1/products/firebaseappcheck/PlayIntegrityConfig.yaml
+++ b/mmv1/products/firebaseappcheck/PlayIntegrityConfig.yaml
@@ -1,0 +1,83 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+!ruby/object:Api::Resource
+name: "PlayIntegrityConfig"
+base_url: projects/{{project}}/apps/{{app_id}}/playIntegrityConfig
+self_link: projects/{{project}}/apps/{{app_id}}/playIntegrityConfig
+create_url: projects/{{project}}/apps/{{app_id}}/playIntegrityConfig?updateMask=token_ttl
+create_verb: :PATCH
+update_verb: :PATCH
+update_mask: true
+skip_delete: true
+description: |
+  An app's Play Integrity configuration object. Note that your registered SHA-256 certificate fingerprints are used to validate tokens issued by the Play Integrity API.
+  Make sure your `google_firebase_android_app` has at least one `sha256_hashes` present.
+references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+    "Official Documentation": "https://firebase.google.com/docs/app-check"
+  api: "https://firebase.google.com/docs/reference/appcheck/rest/v1/projects.apps.playIntegrityConfig"
+import_format:
+  [
+    "projects/{{project}}/apps/{{app_id}}/playIntegrityConfig",
+    "{{project}}/{{app_id}}",
+    "{{app_id}}",
+  ]
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: "firebase_app_check_play_integrity_config_minimal"
+    # Need the time_sleep resource
+    pull_external: true
+    primary_resource_id: "default"
+    vars:
+      package_name: "package.name.playintegrity"
+    test_env_vars:
+      project_id: :PROJECT_NAME
+  - !ruby/object:Provider::Terraform::Examples
+    name: "firebase_app_check_play_integrity_config_full"
+    # Need the time_sleep resource
+    pull_external: true
+    primary_resource_id: "default"
+    vars:
+      package_name: "package.name.playintegrity"
+      token_ttl: "7200s"
+    test_vars_overrides:
+      # Don't add random suffix
+      token_ttl: '"7200s"'
+    test_env_vars:
+      project_id: :PROJECT_NAME
+parameters:
+  - !ruby/object:Api::Type::String
+    name: app_id
+    description: |
+      The ID of an
+      [Android App](https://firebase.google.com/docs/reference/firebase-management/rest/v1beta1/projects.androidApps#AndroidApp.FIELDS.app_id).
+    required: true
+    immutable: true
+    url_param_only: true
+properties:
+  - !ruby/object:Api::Type::String
+    name: name
+    description: |
+      The relative resource name of the Play Integrity configuration object
+    output: true
+    pattern: projects/{{project}}/apps/{{app_id}}/playIntegrityConfig
+  - !ruby/object:Api::Type::String
+    name: tokenTtl
+    description: |
+      Specifies the duration for which App Check tokens exchanged from Play Integrity artifacts will be valid.
+      If unset, a default value of 1 hour is assumed. Must be between 30 minutes and 7 days, inclusive.
+
+      A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.5s".
+    default_from_api: true

--- a/mmv1/templates/terraform/examples/firebase_app_check_app_attest_config_full.tf.erb
+++ b/mmv1/templates/terraform/examples/firebase_app_check_app_attest_config_full.tf.erb
@@ -1,0 +1,21 @@
+resource "google_firebase_apple_app" "default" {
+  project = "<%= ctx[:test_env_vars]['project_id'] %>"
+  display_name = "Apple app"
+  bundle_id = "<%= ctx[:vars]['bundle_id'] %>"
+  team_id = "<%= ctx[:vars]['team_id'] %>"
+}
+
+# It takes a while for App Check to recognize the new app
+# If your app already exists, you don't have to wait 30 seconds.
+resource "time_sleep" "wait_30s" {
+  depends_on = [google_firebase_apple_app.default]
+  create_duration = "30s"
+}
+
+resource "google_firebase_app_check_app_attest_config" "default" {
+  project = "<%= ctx[:test_env_vars]['project_id'] %>"
+  app_id = google_firebase_apple_app.default.app_id
+  token_ttl = "<%= ctx[:vars]['token_ttl'] %>"
+
+  depends_on = [time_sleep.wait_30s]
+}

--- a/mmv1/templates/terraform/examples/firebase_app_check_app_attest_config_minimal.tf.erb
+++ b/mmv1/templates/terraform/examples/firebase_app_check_app_attest_config_minimal.tf.erb
@@ -1,0 +1,20 @@
+resource "google_firebase_apple_app" "default" {
+  project = "<%= ctx[:test_env_vars]['project_id'] %>"
+  display_name = "Apple app"
+  bundle_id = "<%= ctx[:vars]['bundle_id'] %>"
+  team_id = "<%= ctx[:vars]['team_id'] %>"
+}
+
+# It takes a while for App Check to recognize the new app
+# If your app already exists, you don't have to wait 30 seconds.
+resource "time_sleep" "wait_30s" {
+  depends_on = [google_firebase_apple_app.default]
+  create_duration = "30s"
+}
+
+resource "google_firebase_app_check_app_attest_config" "default" {
+  project = "<%= ctx[:test_env_vars]['project_id'] %>"
+  app_id = google_firebase_apple_app.default.app_id
+
+  depends_on = [time_sleep.wait_30s]
+}

--- a/mmv1/templates/terraform/examples/firebase_app_check_play_integrity_config_full.tf.erb
+++ b/mmv1/templates/terraform/examples/firebase_app_check_play_integrity_config_full.tf.erb
@@ -1,0 +1,22 @@
+resource "google_firebase_android_app" "default" {
+  project       = "<%= ctx[:test_env_vars]['project_id'] %>"
+  display_name  = "Play Integrity app"
+  package_name  = "<%= ctx[:vars]['package_name'] %>"
+  sha1_hashes   = ["2145bdf698b8715039bd0e83f2069bed435ac21c"]
+  sha256_hashes = ["2145bdf698b8715039bd0e83f2069bed435ac21ca1b2c3d4e5f6123456789abc"]
+}
+
+# It takes a while for App Check to recognize the new app
+# If your app already exists, you don't have to wait 30 seconds.
+resource "time_sleep" "wait_30s" {
+  depends_on      = [google_firebase_android_app.default]
+  create_duration = "30s"
+}
+
+resource "google_firebase_app_check_play_integrity_config" "default" {
+  project = "<%= ctx[:test_env_vars]['project_id'] %>"
+  app_id = google_firebase_android_app.default.app_id
+  token_ttl = "<%= ctx[:vars]['token_ttl'] %>"
+
+  depends_on = [time_sleep.wait_30s]
+}

--- a/mmv1/templates/terraform/examples/firebase_app_check_play_integrity_config_minimal.tf.erb
+++ b/mmv1/templates/terraform/examples/firebase_app_check_play_integrity_config_minimal.tf.erb
@@ -1,0 +1,21 @@
+resource "google_firebase_android_app" "default" {
+  project       = "<%= ctx[:test_env_vars]['project_id'] %>"
+  display_name  = "Play Integrity app"
+  package_name  = "<%= ctx[:vars]['package_name'] %>"
+  sha1_hashes   = ["2145bdf698b8715039bd0e83f2069bed435ac21c"]
+  sha256_hashes = ["2145bdf698b8715039bd0e83f2069bed435ac21ca1b2c3d4e5f6123456789abc"]
+}
+
+# It takes a while for App Check to recognize the new app
+# If your app already exists, you don't have to wait 30 seconds.
+resource "time_sleep" "wait_30s" {
+  depends_on      = [google_firebase_android_app.default]
+  create_duration = "30s"
+}
+
+resource "google_firebase_app_check_play_integrity_config" "default" {
+  project = "<%= ctx[:test_env_vars]['project_id'] %>"
+  app_id  = google_firebase_android_app.default.app_id
+
+  depends_on = [time_sleep.wait_30s]
+}

--- a/mmv1/third_party/terraform/services/firebaseappcheck/resource_firebase_app_check_app_attest_config_test.go
+++ b/mmv1/third_party/terraform/services/firebaseappcheck/resource_firebase_app_check_app_attest_config_test.go
@@ -1,0 +1,59 @@
+package firebaseappcheck_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccFirebaseAppCheckAppAttestConfig_firebaseAppCheckAppAttestConfigUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project_id":    envvar.GetTestProjectFromEnv(),
+		"team_id":       "9987654321",
+		"random_suffix": acctest.RandString(t, 10),
+		"token_ttl":     "7200s",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {},
+			"time":   {},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFirebaseAppCheckAppAttestConfig_firebaseAppCheckAppAttestConfigMinimalExample(context),
+			},
+			{
+				ResourceName:            "google_firebase_app_check_app_attest_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"app_id"},
+			},
+			{
+				Config: testAccFirebaseAppCheckAppAttestConfig_firebaseAppCheckAppAttestConfigFullExample(context),
+			},
+			{
+				ResourceName:            "google_firebase_app_check_app_attest_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"app_id"},
+			},
+			{
+				Config: testAccFirebaseAppCheckAppAttestConfig_firebaseAppCheckAppAttestConfigMinimalExample(context),
+			},
+			{
+				ResourceName:            "google_firebase_app_check_app_attest_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"app_id"},
+			},
+		},
+	})
+}

--- a/mmv1/third_party/terraform/services/firebaseappcheck/resource_firebase_app_check_play_integrity_config_test.go
+++ b/mmv1/third_party/terraform/services/firebaseappcheck/resource_firebase_app_check_play_integrity_config_test.go
@@ -1,0 +1,58 @@
+package firebaseappcheck_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccFirebaseAppCheckPlayIntegrityConfig_firebaseAppCheckPlayIntegrityConfigUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project_id":    envvar.GetTestProjectFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+		"token_ttl":     "7200s",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {},
+			"time":   {},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFirebaseAppCheckPlayIntegrityConfig_firebaseAppCheckPlayIntegrityConfigMinimalExample(context),
+			},
+			{
+				ResourceName:            "google_firebase_app_check_play_integrity_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"app_id"},
+			},
+			{
+				Config: testAccFirebaseAppCheckPlayIntegrityConfig_firebaseAppCheckPlayIntegrityConfigFullExample(context),
+			},
+			{
+				ResourceName:            "google_firebase_app_check_play_integrity_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"app_id"},
+			},
+			{
+				Config: testAccFirebaseAppCheckPlayIntegrityConfig_firebaseAppCheckPlayIntegrityConfigMinimalExample(context),
+			},
+			{
+				ResourceName:            "google_firebase_app_check_play_integrity_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"app_id"},
+			},
+		},
+	})
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add support for Apple's [App Attest](https://firebase.google.com/docs/reference/appcheck/rest/v1/projects.apps.appAttestConfig) provider and Android's [Play Integrity](https://firebase.google.com/docs/reference/appcheck/rest/v1/projects.apps.playIntegrityConfig) provider for App Check. 

Part of https://github.com/hashicorp/terraform-provider-google/issues/17095

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_firebase_app_check_app_attest_config`
`google_firebase_app_check_play_integrity_config`
```
