### PR TITLE
Adding support for reject_duplicate_message flag while creating hl7v2store

### DIFF
--- a/mmv1/products/healthcare/Hl7V2Store.yaml
+++ b/mmv1/products/healthcare/Hl7V2Store.yaml
@@ -73,6 +73,12 @@ properties:
       ** Changing this property may recreate the Hl7v2 store (removing all data) **
     required: true
     immutable: true
+  - !ruby/object:Api::Type::Boolean
+    name: rejectDuplicateMessage
+    required: false
+    default_value: false
+    description: |
+      Determines whether duplicate messages are allowed.
   - !ruby/object:Api::Type::NestedObject
     name: parserConfig
     required: false

--- a/mmv1/templates/terraform/examples/healthcare_hl7_v2_store_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/healthcare_hl7_v2_store_basic.tf.erb
@@ -1,6 +1,7 @@
 resource "google_healthcare_hl7_v2_store" "store" {
   name    = "<%= ctx[:vars]['hl7_v2_store_name'] %>"
   dataset = google_healthcare_dataset.dataset.id
+  reject_duplicate_message = true
 
   notification_configs {
     pubsub_topic = google_pubsub_topic.topic.id

--- a/mmv1/third_party/terraform/services/healthcare/resource_healthcare_hl7_v2_store_test.go.erb
+++ b/mmv1/third_party/terraform/services/healthcare/resource_healthcare_hl7_v2_store_test.go.erb
@@ -162,8 +162,7 @@ func testGoogleHealthcareHl7V2Store_basic(hl7_v2StoreName, datasetName string) s
 resource "google_healthcare_hl7_v2_store" "default" {
   name     = "%s"
   dataset  = google_healthcare_dataset.dataset.id
-  reject_duplicate_message= true
-
+  reject_duplicate_message = true
 }
 
 resource "google_healthcare_dataset" "dataset" {

--- a/mmv1/third_party/terraform/services/healthcare/resource_healthcare_hl7_v2_store_test.go.erb
+++ b/mmv1/third_party/terraform/services/healthcare/resource_healthcare_hl7_v2_store_test.go.erb
@@ -162,12 +162,13 @@ func testGoogleHealthcareHl7V2Store_basic(hl7_v2StoreName, datasetName string) s
 resource "google_healthcare_hl7_v2_store" "default" {
   name     = "%s"
   dataset  = google_healthcare_dataset.dataset.id
+  reject_duplicate_message= true
+
 }
 
 resource "google_healthcare_dataset" "dataset" {
   name     = "%s"
   location = "us-central1"
-  reject_duplicate_message= true
 }
 `, hl7_v2StoreName, datasetName)
 }

--- a/mmv1/third_party/terraform/services/healthcare/resource_healthcare_hl7_v2_store_test.go.erb
+++ b/mmv1/third_party/terraform/services/healthcare/resource_healthcare_hl7_v2_store_test.go.erb
@@ -167,6 +167,7 @@ resource "google_healthcare_hl7_v2_store" "default" {
 resource "google_healthcare_dataset" "dataset" {
   name     = "%s"
   location = "us-central1"
+  reject_duplicate_message= true
 }
 `, hl7_v2StoreName, datasetName)
 }


### PR DESCRIPTION
Adding support for flag "reject_duplicate_message" while creating hl7v2 store.

```release-note:enhancement
healthcare: added `reject_duplicate_message` field to `google_healthcare_hl7_v2_store ` resource
```

fixes: https://github.com/hashicorp/terraform-provider-google/issues/17212