### PR TITLE
Fix documentation notes for google_compute_instance_group, google_compute_instance_group_membership and google_compute_region_network_endpoint resources

### DIFF
--- a/mmv1/products/compute/InstanceGroup.yaml
+++ b/mmv1/products/compute/InstanceGroup.yaml
@@ -59,7 +59,7 @@ parameters:
       and will not be deleted.
       Only the full identifier of the instance will be returned.
 
-      **NOTE** If a user will be recreating instances under the same name
+      !> **WARNING** If a user will be recreating instances under the same name
       (eg. via `terraform taint`), please consider adding instances to an instance
       group via the `instance_group_membership` resource, along side the
       `update_triggered_by` lifecycle method with an instance's ID.

--- a/mmv1/products/compute/InstanceGroupMembership.yaml
+++ b/mmv1/products/compute/InstanceGroupMembership.yaml
@@ -18,11 +18,11 @@ base_url: 'projects/{{project}}/zones/{{zone}}/instanceGroups/{{instance_group}}
 description: |
   Represents the Instance membership to the Instance Group.
 
-  **NOTE** You can use this resource instead of the `instances` field in the
+  -> **NOTE** You can use this resource instead of the `instances` field in the
   `google_compute_instance_group`, however it's not recommended to use it alongside this field.
   It might cause inconsistencies, as they can end up competing over control.
 
-  **NOTE** This resource has been added to avoid a situation, where after
+  -> **NOTE** This resource has been added to avoid a situation, where after
   Instance is recreated, it's removed from Instance Group and it's needed to
   perform `apply` twice. To avoid situations like this, please use this resource
   with the lifecycle `update_triggered_by` method, with the passed Instance's ID.

--- a/mmv1/products/compute/RegionNetworkEndpoint.yaml
+++ b/mmv1/products/compute/RegionNetworkEndpoint.yaml
@@ -19,7 +19,7 @@ description: |
   A Region network endpoint represents a IP address/FQDN and port combination that is
   part of a specific network endpoint group (NEG).
 
-  **NOTE**: Network endpoints cannot be created outside of a network endpoint group.
+  ~> **NOTE**: Network endpoints cannot be created outside of a network endpoint group.
 immutable: true
 create_verb: :POST
 create_url: projects/{{project}}/regions/{{region}}/networkEndpointGroups/{{region_network_endpoint_group}}/attachNetworkEndpoints


### PR DESCRIPTION
Fix documentation notes for google_compute_instance_group, google_compute_instance_group_membership and google_compute_region_network_endpoint resources

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
