### PR TITLE
Fix updating NIC stack type for google compute instance

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
@@ -444,7 +444,7 @@ func ResourceComputeInstance() *schema.Resource {
 
 						"ipv6_access_config": {
 							Type:        schema.TypeList,
-							Optional:    true,
+                                                        Optional:    true,
 							Description: `An array of IPv6 access configurations for this interface. Currently, only one IPv6 access config, DIRECT_IPV6, is supported. If there is no ipv6AccessConfig specified, then this instance will have no external IPv6 Internet access.`,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -2054,6 +2054,23 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 
 			networkInterfacePatchObj := &compute.NetworkInterface{
 				AliasIpRanges: networkInterface.AliasIpRanges,
+				Fingerprint:   instNetworkInterface.Fingerprint,
+			}
+			updateCall := config.NewComputeClient(userAgent).Instances.UpdateNetworkInterface(project, zone, instance.Name, networkName, networkInterfacePatchObj).Do
+			op, err := updateCall()
+			if err != nil {
+				return errwrap.Wrapf("Error updating network interface: {{err}}", err)
+			}
+			opErr := ComputeOperationWaitTime(config, op, project, "network interface to update", userAgent, d.Timeout(schema.TimeoutUpdate))
+			if opErr != nil {
+				return opErr
+			}
+		}
+
+		if !updateDuringStop && d.HasChange(prefix+".stack_type") {
+
+			networkInterfacePatchObj := &compute.NetworkInterface{
+				StackType: d.Get(prefix+".stack_type").(string),
 				Fingerprint:   instNetworkInterface.Fingerprint,
 			}
 			updateCall := config.NewComputeClient(userAgent).Instances.UpdateNetworkInterface(project, zone, instance.Name, networkName, networkInterfacePatchObj).Do

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -3279,6 +3279,33 @@ func TestAccComputeInstance_NetworkAttachmentUpdate(t *testing.T) {
 }
 <% end %>
 
+func TestAccComputeInstance_NicStackTypeUpdate(t *testing.T) {
+	t.Parallel()
+	suffix := acctest.RandString(t, 10)
+	envRegion := envvar.GetTestRegionFromEnv()
+	instanceName := fmt.Sprintf("tf-test-compute-instance-%s", suffix)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_nicStackTypeUpdate(suffix, envRegion, "IPV4_ONLY", instanceName),
+			},
+			computeInstanceImportStep("us-central1-a", instanceName, []string{"allow_stopping_for_update"}),
+			{
+				Config: testAccComputeInstance_nicStackTypeUpdate(suffix, envRegion, "IPV4_IPV6", instanceName),
+			},
+			computeInstanceImportStep("us-central1-a", instanceName, []string{"allow_stopping_for_update"}),
+			{
+				Config: testAccComputeInstance_nicStackTypeUpdate(suffix, envRegion, "IPV4_ONLY", instanceName),
+			},
+			computeInstanceImportStep("us-central1-a", instanceName, []string{"allow_stopping_for_update"}),
+		},
+	})
+}
+
 func testAccCheckComputeInstanceDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
@@ -8964,3 +8991,50 @@ resource "google_compute_instance" "foobar" {
 }
 <% end %>
 
+func testAccComputeInstance_nicStackTypeUpdate(suffix, region, stack_type, instance string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_network" "net" {
+  name                    = "tf-test-network-%s"
+  enable_ula_internal_ipv6 = true
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnet-ipv6" {
+  region                     = "%s"
+  name                       = "tf-test-subnet-ip6-%s"
+  ip_cidr_range              = "10.0.0.0/22"
+  purpose                    = "PRIVATE"
+  stack_type                 = "IPV4_IPV6"
+  ipv6_access_type           = "INTERNAL"
+  network                    = google_compute_network.net.id
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+  zone         = "%s-a"
+  tags         = ["foo", "bar"]
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = google_compute_network.net.self_link
+    subnetwork = google_compute_subnetwork.subnet-ipv6.self_link
+    stack_type = "%s"
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+}
+`, suffix, region, suffix, instance, region, stack_type)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Support updating StackType of NetworkInterface of `google_compute_instance` resource. Previously it was ignored which made it impossible to update.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/17210

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: support updating `network_interface.stack_type` field on `google_compute_instance` resource.
```
