### PR TITLE
fixes: permadiff issue if event trigger region is not specified

### DIFF
--- a/mmv1/products/cloudfunctions2/Function.yaml
+++ b/mmv1/products/cloudfunctions2/Function.yaml
@@ -594,6 +594,7 @@ properties:
           events originating in this region. It can be the same
           region as the function, a different region or multi-region, or the global
           region. If not provided, defaults to the same region as the function.
+        default_from_api: true
       - !ruby/object:Api::Type::String
         name: 'eventType'
         description: 'Required. The type of event to observe.'

--- a/mmv1/templates/terraform/examples/cloudfunctions2_basic_gcs.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudfunctions2_basic_gcs.tf.erb
@@ -91,7 +91,6 @@ resource "google_cloudfunctions2_function" "<%= ctx[:primary_resource_id] %>" {
   }
 
   event_trigger {
-    trigger_region = "us-central1" # The trigger must be in the same location as the bucket
     event_type = "google.cloud.storage.object.v1.finalized"
     retry_policy = "RETRY_POLICY_RETRY"
     service_account_email = google_service_account.account.email


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
As per https://cloud.google.com/functions/docs/reference/rest/v2/projects.locations.functions#eventtrigger, the trigger_region if not provided, defaults to the same region as the function.

fixes https://github.com/hashicorp/terraform-provider-google/issues/17161

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
cloudfunctions2: fixed an issue where not specifying `event_config.trigger_region` in `google_cloudfunctions2_function` resulted in a permanent diff. The field now pulls a default value from the API when unset.
```
