### PR TITLE
Separated review requests into a github action

### DIFF
--- a/.ci/magician/cmd/membership_checker.go
+++ b/.ci/magician/cmd/membership_checker.go
@@ -97,41 +97,6 @@ func execMembershipChecker(prNumber, commitSha, branchName, headRepoUrl, headBra
 	authorUserType := gh.GetUserType(author)
 	trusted := authorUserType == github.CoreContributorUserType || authorUserType == github.GooglerUserType
 
-	if authorUserType != github.CoreContributorUserType {
-		fmt.Println("Not core contributor - assigning reviewer")
-
-		requestedReviewers, err := gh.GetPullRequestRequestedReviewers(prNumber)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-
-		previousReviewers, err := gh.GetPullRequestPreviousReviewers(prNumber)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-
-		reviewersToRequest, newPrimaryReviewer := github.ChooseCoreReviewers(requestedReviewers, previousReviewers)
-
-		for _, reviewer := range reviewersToRequest {
-			err = gh.RequestPullRequestReviewer(prNumber, reviewer)
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
-			}
-		}
-
-		if newPrimaryReviewer != "" {
-			comment := github.FormatReviewerComment(newPrimaryReviewer, authorUserType, trusted)
-			err = gh.PostComment(prNumber, comment)
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
-			}
-		}
-	}
-
 	// auto_run(contributor-membership-checker) will be run on every commit or /gcbrun:
 	// only triggers builds for trusted users
 	if trusted {

--- a/.ci/magician/cmd/request_reviewer.go
+++ b/.ci/magician/cmd/request_reviewer.go
@@ -1,0 +1,102 @@
+/*
+* Copyright 2024 Google LLC. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+package cmd
+
+import (
+	"fmt"
+	"magician/github"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// requestReviewerCmd represents the requestReviewer command
+var requestReviewerCmd = &cobra.Command{
+	Use:   "request-reviewer",
+	Short: "Assigns and re-requests reviewers",
+	Long: `This command automatically requests (or re-requests) core contributor reviews for a PR based on whether the user is a core contributor.
+
+	The command expects the following pull request details as arguments:
+	1. PR Number
+	2. Commit SHA
+	3. Branch Name
+	4. Head Repo URL
+	5. Head Branch
+	6. Base Branch
+
+	It then performs the following operations:
+	1. Determines the author of the pull request
+	2. If the author is not a core contributor:
+			a. Identifies the initially requested reviewer and those who previously reviewed this PR.
+			b. Determines and requests reviewers based on the above.
+			c. As appropriate, posts a welcome comment on the PR.
+	`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		prNumber := args[0]
+		fmt.Println("PR Number: ", prNumber)
+		gh := github.NewClient()
+		execRequestReviewer(prNumber, gh)
+	},
+}
+
+func execRequestReviewer(prNumber string, gh GithubClient) {
+	pullRequest, err := gh.GetPullRequest(prNumber)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	author := pullRequest.User.Login
+	if !github.IsCoreContributor(author) {
+		fmt.Println("Not core contributor - assigning reviewer")
+
+		requestedReviewers, err := gh.GetPullRequestRequestedReviewers(prNumber)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		previousReviewers, err := gh.GetPullRequestPreviousReviewers(prNumber)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		reviewersToRequest, newPrimaryReviewer := github.ChooseCoreReviewers(requestedReviewers, previousReviewers)
+
+		for _, reviewer := range reviewersToRequest {
+			err = gh.RequestPullRequestReviewer(prNumber, reviewer)
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+		}
+
+		if newPrimaryReviewer != "" {
+			comment := github.FormatReviewerComment(newPrimaryReviewer)
+			err = gh.PostComment(prNumber, comment)
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+		}
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(requestReviewerCmd)
+}

--- a/.ci/magician/cmd/request_reviewer_test.go
+++ b/.ci/magician/cmd/request_reviewer_test.go
@@ -1,0 +1,103 @@
+/*
+* Copyright 2024 Google LLC. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package cmd
+
+import (
+	"github.com/stretchr/testify/assert"
+	"magician/github"
+	"testing"
+)
+
+func TestExecRequestReviewer(t *testing.T) {
+	availableReviewers := github.AvailableReviewers()
+	cases := map[string]struct {
+		pullRequest             github.PullRequest
+		requestedReviewers      []string
+		previousReviewers       []string
+		teamMembers             map[string][]string
+		expectSpecificReviewers []string
+		expectReviewersFromList []string
+	}{
+		"core contributor author doesn't get a new reviewer, re-request, or comment with no previous reviewers": {
+			pullRequest: github.PullRequest{
+				User: github.User{Login: availableReviewers[0]},
+			},
+			expectSpecificReviewers: []string{},
+		},
+		"core contributor author doesn't get a new reviewer, re-request, or comment with previous reviewers": {
+			pullRequest: github.PullRequest{
+				User: github.User{Login: availableReviewers[0]},
+			},
+			previousReviewers:       []string{availableReviewers[1]},
+			expectSpecificReviewers: []string{},
+		},
+		"non-core-contributor author gets a new reviewer with no previous reviewers": {
+			pullRequest: github.PullRequest{
+				User: github.User{Login: "author"},
+			},
+			expectReviewersFromList: availableReviewers,
+		},
+		"non-core-contributor author doesn't get a new reviewer (but does get re-request) with previous reviewers": {
+			pullRequest: github.PullRequest{
+				User: github.User{Login: "author"},
+			},
+			previousReviewers:       []string{availableReviewers[1], "author2", availableReviewers[2]},
+			expectSpecificReviewers: []string{availableReviewers[1], availableReviewers[2]},
+		},
+		"non-core-contributor author doesn't get a new reviewer or a re-request with already-requested reviewers": {
+			pullRequest: github.PullRequest{
+				User: github.User{Login: "author"},
+			},
+			requestedReviewers:      []string{availableReviewers[1], "author2", availableReviewers[2]},
+			expectSpecificReviewers: []string{},
+		},
+	}
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			requestedReviewers := []github.User{}
+			for _, login := range tc.requestedReviewers {
+				requestedReviewers = append(requestedReviewers, github.User{Login: login})
+			}
+			previousReviewers := []github.User{}
+			for _, login := range tc.previousReviewers {
+				previousReviewers = append(previousReviewers, github.User{Login: login})
+			}
+			gh := &mockGithub{
+				pullRequest:        tc.pullRequest,
+				requestedReviewers: requestedReviewers,
+				previousReviewers:  previousReviewers,
+				calledMethods:      make(map[string][][]any),
+			}
+
+			execRequestReviewer("1", gh)
+
+			actualReviewers := []string{}
+			for _, args := range gh.calledMethods["RequestPullRequestReviewer"] {
+				actualReviewers = append(actualReviewers, args[1].(string))
+			}
+
+			if tc.expectSpecificReviewers != nil {
+				assert.ElementsMatch(t, tc.expectSpecificReviewers, actualReviewers)
+			}
+			if tc.expectReviewersFromList != nil {
+				for _, reviewer := range actualReviewers {
+					assert.Contains(t, tc.expectReviewersFromList, reviewer)
+				}
+			}
+		})
+	}
+}

--- a/.ci/magician/github/REVIEWER_ASSIGNMENT_COMMENT.md
+++ b/.ci/magician/github/REVIEWER_ASSIGNMENT_COMMENT.md
@@ -1,4 +1,4 @@
-Hello! I am a robot. It looks like you are a: {{if eq .authorUserType "Community Contributor"}}Community Contributor{{else}}~Community Contributor~{{end}} {{if eq .authorUserType "Googler"}}Googler{{else}}~Googler~{{end}} {{if eq .authorUserType "Core Contributor"}}Core Contributor{{else}}~Core Contributor~{{end}}. {{if .trusted}}Tests will run automatically.{{else}}Tests will require approval to run.{{end}}
+Hello! I am a robot. Tests will require approval from a repository maintainer to run.
 
 @{{.reviewer}}, a repository maintainer, has been assigned to review your changes. If you have not received review feedback within 2 business days, please leave a comment on this PR asking them to take a look.
 

--- a/.ci/magician/github/membership.go
+++ b/.ci/magician/github/membership.go
@@ -43,8 +43,7 @@ var (
 	}
 
 	// This is for new team members who are onboarding
-	trustedContributors = []string{
-	}
+	trustedContributors = []string{}
 
 	// This is for reviewers who are "on vacation": will not receive new review assignments but will still receive re-requests for assigned PRs.
 	onVacationReviewers = []string{
@@ -74,8 +73,8 @@ func (ut UserType) String() string {
 }
 
 func (gh *Client) GetUserType(user string) UserType {
-	if isTeamMember(user, gh.token) {
-		fmt.Println("User is a team member")
+	if IsCoreContributor(user) {
+		fmt.Println("User is a core contributor")
 		return CoreContributorUserType
 	}
 
@@ -93,11 +92,11 @@ func (gh *Client) GetUserType(user string) UserType {
 }
 
 // Check if a user is team member to not request a random reviewer
-func isTeamMember(author, githubToken string) bool {
-	return slices.Contains(reviewerRotation, author) || slices.Contains(trustedContributors, author)
+func IsCoreContributor(user string) bool {
+	return slices.Contains(reviewerRotation, user) || slices.Contains(trustedContributors, user)
 }
 
-func IsTeamReviewer(reviewer string) bool {
+func IsCoreReviewer(reviewer string) bool {
 	return slices.Contains(reviewerRotation, reviewer)
 }
 
@@ -112,8 +111,12 @@ func isOrgMember(author, org, githubToken string) bool {
 }
 
 func GetRandomReviewer() string {
-	availableReviewers := utils.Removes(reviewerRotation, onVacationReviewers)
+	availableReviewers := AvailableReviewers()
 	rand.Seed(time.Now().UnixNano())
 	reviewer := availableReviewers[rand.Intn(len(availableReviewers))]
 	return reviewer
+}
+
+func AvailableReviewers() []string {
+	return utils.Removes(reviewerRotation, onVacationReviewers)
 }

--- a/.ci/magician/github/reviewer_assignment.go
+++ b/.ci/magician/github/reviewer_assignment.go
@@ -34,14 +34,14 @@ func ChooseCoreReviewers(requestedReviewers, previousReviewers []User) (reviewer
 	newPrimaryReviewer = ""
 
 	for _, reviewer := range requestedReviewers {
-		if IsTeamReviewer(reviewer.Login) {
+		if IsCoreReviewer(reviewer.Login) {
 			hasPrimaryReviewer = true
 			break
 		}
 	}
 
 	for _, reviewer := range previousReviewers {
-		if IsTeamReviewer(reviewer.Login) {
+		if IsCoreReviewer(reviewer.Login) {
 			hasPrimaryReviewer = true
 			reviewersToRequest = append(reviewersToRequest, reviewer.Login)
 		}
@@ -55,16 +55,14 @@ func ChooseCoreReviewers(requestedReviewers, previousReviewers []User) (reviewer
 	return reviewersToRequest, newPrimaryReviewer
 }
 
-func FormatReviewerComment(newPrimaryReviewer string, authorUserType UserType, trusted bool) string {
+func FormatReviewerComment(newPrimaryReviewer string) string {
 	tmpl, err := template.New("REVIEWER_ASSIGNMENT_COMMENT.md").Parse(reviewerAssignmentComment)
 	if err != nil {
 		panic(fmt.Sprintf("Unable to parse REVIEWER_ASSIGNMENT_COMMENT.md: %s", err))
 	}
 	sb := new(strings.Builder)
 	tmpl.Execute(sb, map[string]any{
-		"reviewer":       newPrimaryReviewer,
-		"authorUserType": authorUserType.String(),
-		"trusted":        trusted,
+		"reviewer": newPrimaryReviewer,
 	})
 	return sb.String()
 }

--- a/.ci/magician/github/reviewer_assignment_test.go
+++ b/.ci/magician/github/reviewer_assignment_test.go
@@ -127,27 +127,12 @@ func TestFormatReviewerComment(t *testing.T) {
 		tc := tc
 		t.Run(tn, func(t *testing.T) {
 			t.Parallel()
-			comment := FormatReviewerComment(tc.Reviewer, tc.AuthorUserType, tc.Trusted)
+			comment := FormatReviewerComment(tc.Reviewer)
 			t.Log(comment)
 			if !strings.Contains(comment, fmt.Sprintf("@%s", tc.Reviewer)) {
 				t.Errorf("wanted comment to contain @%s; does not.", tc.Reviewer)
 			}
-			if !strings.Contains(comment, tc.AuthorUserType.String()) {
-				t.Errorf("wanted comment to contain user type (%s); does not.", tc.AuthorUserType.String())
-			}
-			if strings.Contains(comment, fmt.Sprintf("~%s~", tc.AuthorUserType.String())) {
-				t.Errorf("wanted user type (%s) in comment to not be crossed out, but it is", tc.AuthorUserType.String())
-			}
-			for _, ut := range []UserType{CommunityUserType, GooglerUserType, CoreContributorUserType} {
-				if ut != tc.AuthorUserType && !strings.Contains(comment, fmt.Sprintf("~%s~", ut.String())) {
-					t.Errorf("wanted other user type (%s) in comment to be crossed out, but it is not", ut)
-				}
-			}
-
-			if tc.Trusted && !strings.Contains(comment, "Tests will run automatically") {
-				t.Errorf("wanted comment to say tests will run automatically; does not")
-			}
-			if !tc.Trusted && !strings.Contains(comment, "Tests will require approval") {
+			if !strings.Contains(comment, "Tests will require approval") {
 				t.Errorf("wanted comment to say tests will require approval; does not")
 			}
 		})

--- a/.github/workflows/request-reviewer.yml
+++ b/.github/workflows/request-reviewer.yml
@@ -1,0 +1,38 @@
+name: request-reviewer
+
+permissions: read-all
+
+on:
+  pull_request_target:
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
+    branches:
+      - 'main'
+      - 'FEATURE-BRANCH-*'
+
+jobs:
+  request-review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '^1.20'
+      - name: Build magician
+        run: |
+          cd .ci/magician
+          go build .
+      - name: Request reviewer
+        permissions:
+          pull-requests: write
+        run: .ci/magician request-reviewer ${{ github.event.pull_request.number }}
+

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @GoogleCloudPlatform/terraform-team


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This PR migrates the review request logic from the membership-checker CloudBuild job to a GitHub Action which runs on pull_request_target. It will run using code from the main branch (so it has been previously approved) and it will have very restricted permissions. This is a slight move away from "everything must be run using the code from the pull request" but it's necessary to move this logic into a GitHub action, which decouples it from test runs. We also do not expect to be changing this logic as frequently.

I also added logic so that reviews are only requested on PRs that are not in draft mode.

I've cleared out the CODEOWNERS file. I'll keep an eye on PRs that run after merge to ensure this is working as expected.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
