### PR TITLE
Corrected request-reviewer permissions to be at the job level

### DIFF
--- a/.github/workflows/request-reviewer.yml
+++ b/.github/workflows/request-reviewer.yml
@@ -18,6 +18,8 @@ jobs:
   request-review:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -32,7 +34,5 @@ jobs:
           cd .ci/magician
           go build .
       - name: Request reviewer
-        permissions:
-          pull-requests: write
         run: .ci/magician request-reviewer ${{ github.event.pull_request.number }}
 


### PR DESCRIPTION
Step-level permissions are not actually a thing. https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idpermissions

Example failure: https://github.com/GoogleCloudPlatform/magic-modules/actions/runs/7923579443
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
