### PR TITLE
make poilcy sets and policies required field.

### DIFF
--- a/mmv1/products/securityposture/posture.yaml
+++ b/mmv1/products/securityposture/posture.yaml
@@ -120,6 +120,7 @@ properties:
     output: true
   - !ruby/object:Api::Type::Array
     name: 'policySets'
+    required: true
     description: |
       List of policy sets for the posture.
     item_type: !ruby/object:Api::Type::NestedObject
@@ -141,6 +142,7 @@ properties:
           name: 'policies'
           description: |
             List of security policy
+          required: true
           item_type: !ruby/object:Api::Type::NestedObject
             name: 'Policy'
             description: |


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
securityposture: marked `policy_sets` and `policy_sets.policies` required in `google_securityposture_posture`. API validation already enforced this, so no resources could be provisioned without these
```
