### PR TITLE
Adds description for default value of `cpuidle` field

### DIFF
--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -430,7 +430,7 @@ properties:
                 - !ruby/object:Api::Type::Boolean
                   name: 'cpuIdle'
                   description: |-
-                    Determines whether CPU is only allocated during requests. True by default if the parent `resources` field is not set. However, if 
+                    Determines whether CPU is only allocated during requests. True by default if the parent `resources` field is not set. However, if
                     `resources` is set, this field must be explicitly set to true to preserve the default behavior.
                 - !ruby/object:Api::Type::Boolean
                   name: 'startupCpuBoost'

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -430,7 +430,8 @@ properties:
                 - !ruby/object:Api::Type::Boolean
                   name: 'cpuIdle'
                   description: |-
-                    Determines whether CPU should be throttled or not outside of requests.
+                    Determines whether CPU is only allocated during requests. True by default if the parent `resources` field is not set. However, if 
+                    `resources` is set, this field must be explicitly set to true to preserve the default behavior.
                 - !ruby/object:Api::Type::Boolean
                   name: 'startupCpuBoost'
                   description: |-


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

For https://github.com/hashicorp/terraform-provider-google/issues/17246 

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
