### PR TITLE
Add ceritificateManagerCertificates field to ComputeRegionTargetHttpsProxy resource

### DIFF
--- a/mmv1/products/compute/RegionTargetHttpsProxy.yaml
+++ b/mmv1/products/compute/RegionTargetHttpsProxy.yaml
@@ -41,6 +41,9 @@ async: !ruby/object:Api::OpAsync
   error: !ruby/object:Api::OpAsync::Error
     path: 'error/errors'
     message: 'message'
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  encoder: templates/terraform/encoders/compute_region_target_https_proxy.go.erb
+  decoder: templates/terraform/decoders/compute_region_target_https_proxy.go.erb
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'region_target_https_proxy_basic'
@@ -51,6 +54,14 @@ examples:
       region_url_map_name: 'url-map'
       region_backend_service_name: 'backend-service'
       region_health_check_name: 'http-health-check'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'region_target_https_proxy_certificate_manager_certificate'
+    primary_resource_id: 'default'
+    vars:
+      region_target_https_proxy_name: 'target-http-proxy'
+      certificate_manager_certificate_name: 'my-certificate'
+      region_url_map_name: 'url-map'
+      region_backend_service_name: 'backend-service'
 parameters:
   - !ruby/object:Api::Type::ResourceRef
     name: 'region'
@@ -110,12 +121,25 @@ properties:
   #   update_url:
   #     'projects/{{project}}/regions/{{region}}/targetHttpsProxies/{{name}}/setQuicOverride'
   - !ruby/object:Api::Type::Array
+    name: 'certificateManagerCertificates'
+    description: |
+      URLs to certificate manager certificate resources that are used to authenticate connections between users and the load balancer.
+      Currently, you may specify up to 15 certificates. Certificate manager certificates do not apply when the load balancing scheme is set to INTERNAL_SELF_MANAGED.
+      sslCertificates and certificateManagerCertificates fields can not be defined together.
+      Accepted format is `//certificatemanager.googleapis.com/projects/{project}/locations/{location}/certificates/{resourceName}` or just the self_link `projects/{project}/locations/{location}/certificates/{resourceName}`
+    update_verb: :POST
+    update_url: 'projects/{{project}}/regions/{{region}}/targetHttpsProxies/{{name}}/setSslCertificates'
+    item_type: Api::Type::String
+    custom_expand: 'templates/terraform/custom_expand/certificate_manager_certificate_construct_full_url.go.erb'
+    diff_suppress_func: 'tpgresource.CompareResourceNames'
+    conflicts:
+      - ssl_certificates
+  - !ruby/object:Api::Type::Array
     name: 'sslCertificates'
     description: |
-      A list of RegionSslCertificate resources that are used to authenticate
-      connections between users and the load balancer. Currently, exactly
-      one SSL certificate must be specified.
-    required: true
+      URLs to SslCertificate resources that are used to authenticate connections between users and the load balancer.
+      At least one SSL certificate must be specified. Currently, you may specify up to 15 SSL certificates.
+      sslCertificates do not apply when the load balancing scheme is set to INTERNAL_SELF_MANAGED.
     update_verb: :POST
     update_url: 'projects/{{project}}/regions/{{region}}/targetHttpsProxies/{{name}}/setSslCertificates'
     item_type: !ruby/object:Api::Type::ResourceRef
@@ -124,6 +148,8 @@ properties:
       imports: 'selfLink'
       description: 'The SSL certificates used by this TargetHttpsProxy'
     custom_expand: 'templates/terraform/custom_expand/array_resourceref_with_validation.go.erb'
+    conflicts:
+      - certificate_manager_certificates
   - !ruby/object:Api::Type::ResourceRef
     name: 'sslPolicy'
     resource: 'RegionSslPolicy'

--- a/mmv1/templates/terraform/decoders/compute_region_target_https_proxy.go.erb
+++ b/mmv1/templates/terraform/decoders/compute_region_target_https_proxy.go.erb
@@ -1,0 +1,15 @@
+// Since both sslCertificates and certificateManagerCertificates maps to the same API field (sslCertificates), we need to check the types
+// of certificates that exist in the array and decide whether to change the field to certificateManagerCertificate or not. 
+// The decoder logic depends on the fact that the API does not allow mixed type of certificates and it returns
+// certificate manager certificates in the format of //certificatemanager.googleapis.com/projects/*/locations/*/certificates/* 
+if sslCertificates, ok := res["sslCertificates"].([]interface{}); ok && len(sslCertificates) > 0 {
+	regPat, _ := regexp.Compile("//certificatemanager.googleapis.com/projects/(.*)/locations/(.*)/certificates/(.*)")
+
+	if regPat.MatchString(sslCertificates[0].(string)) {
+		// It is enough to check only the type of one of the provided certificates beacuse all the certificates should be the same type.
+		log.Printf("[DEBUG] The field sslCertificates contains certificateManagerCertificates, the field name will be converted to certificateManagerCertificates")
+		res["certificateManagerCertificates"] = res["sslCertificates"]
+		delete(res, "sslCertificates")
+	}
+}
+return res, nil

--- a/mmv1/templates/terraform/encoders/compute_region_target_https_proxy.go.erb
+++ b/mmv1/templates/terraform/encoders/compute_region_target_https_proxy.go.erb
@@ -1,0 +1,10 @@
+
+if _, ok := obj["certificateManagerCertificates"]; ok {
+	// The field certificateManagerCertificates should not be included in the API request, and it should be renamed to `sslCertificates`
+	// The API does not allow using both certificate manager certificates and sslCertificates. If that changes
+	// in the future, the encoder logic should change accordingly because this will mean that both fields are no longer mutual exclusive.
+	log.Printf("[DEBUG] converting the field CertificateManagerCertificates to sslCertificates before sending the request")
+	obj["sslCertificates"] = obj["certificateManagerCertificates"]
+	delete(obj, "certificateManagerCertificates")
+}
+return obj, nil

--- a/mmv1/templates/terraform/examples/region_target_https_proxy_certificate_manager_certificate.tf.erb
+++ b/mmv1/templates/terraform/examples/region_target_https_proxy_certificate_manager_certificate.tf.erb
@@ -1,0 +1,28 @@
+resource "google_compute_region_target_https_proxy" "<%= ctx[:primary_resource_id] %>" {
+  name                             = "<%= ctx[:vars]['region_target_https_proxy_name'] %>"
+  url_map                          = google_compute_region_url_map.default.id
+  certificate_manager_certificates =  ["//certificatemanager.googleapis.com/${google_certificate_manager_certificate.default.id}"] # [google_certificate_manager_certificate.default.id] is also acceptable
+}
+
+resource "google_certificate_manager_certificate" "default" {
+  name              = "<%= ctx[:vars]['certificate_manager_certificate_name'] %>"
+  location          = "us-central1"
+  self_managed {
+    pem_certificate = file("test-fixtures/cert.pem")
+    pem_private_key = file("test-fixtures/private-key.pem")                                                                                                                
+  }
+}
+
+resource "google_compute_region_url_map" "default" {
+  name            = "<%= ctx[:vars]['region_url_map_name'] %>"
+  default_service = google_compute_region_backend_service.default.id
+  region          = "us-central1"
+}
+
+resource "google_compute_region_backend_service" "default" {
+  name                  = "<%= ctx[:vars]['region_backend_service_name'] %>"
+  region                = "us-central1"
+  protocol              = "HTTPS"
+  timeout_sec           = 30
+  load_balancing_scheme = "INTERNAL_MANAGED"
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add a new field certificateManagerCertificates field to ComputeRegionTargetHttpsProxy resource. 

This is exactly the same to what was done for ComputeTargetHttpsProxy https://github.com/GoogleCloudPlatform/magic-modules/pull/9144

**Context** :
The resource ComputeRegionTargetHttpsProxy has a field called sslCertificates, this field used to reference only ssl certificates. Recently, certificates of type CertificateManagerCertificates has been allowed. However, either all the items of the sslCertificates array will be sslCertificates or certificate manager certificates.

Furthermore, the field in TF couldn't accept certificate manager certificates because of a custom_expand function that only validates compute certificates (sslcertificates). It was agreed to handle this situation by defining a new field that shall be used when the customer wants to reference certificate manager certificates instead of sslCertificates. 

[More discussion about this here](https://github.com/GoogleCloudPlatform/magic-modules/pull/8941#issuecomment-1743191092)


What has been done in this PR: 
1. Added a new field `CertificateManagerCerticates` in the resource
2. Removed`required=true` from sslCertificates field
3. stated that SslCertificates and CertificateManagerCertificates are conflicting fields 
4. Used the encoder to rename CertificateManagerCertificates to sslCertificates before sending it to the API
5. Decoder is used to rename back `sslCertificates` to `CertificateManagerCertificates` in TF in case the user used certificate manager certs instead of sslCerts (note that we can't have both sslCertificates and CertificateManagerCertificates defined together) 
6. The API expects the format of the certificate to be `//certificatemanager.googleapis.com/projects/{{project}}/..`. For a better and more convenient UX, an expander is defined so that the customer can use the `id` of the resource (i.e. `projects/{{project}}/...`) and the expander will take care of the conversion 
7. If the customer used the id, the API still responds back with `//certificatemanager.googleapis.com/projects/{{project}}/..`, that's why a diff_suppress_func is used.
8. Added an example that demonstrates using CertificateManagerCertificates in ComputeRegionTargetHttpsProxy

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/16998
b/320650971

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `certificate_manager_certificates` field to `google_compute_region_target_https_proxy` resource
```
