### PR TITLE
doc: Fix the description for attribute skip_initial_version_creation of the resource google_kms_crypto_key

### DIFF
--- a/mmv1/products/kms/CryptoKey.yaml
+++ b/mmv1/products/kms/CryptoKey.yaml
@@ -69,7 +69,8 @@ parameters:
     name: 'skipInitialVersionCreation'
     description: |
       If set to true, the request will create a CryptoKey without any CryptoKeyVersions.
-      You must use the `google_kms_key_ring_import_job` resource to import the CryptoKeyVersion.
+      You must use the `google_kms_crypto_key_version` resource to create a new CryptoKeyVersion
+      or `google_kms_key_ring_import_job` resource to import the CryptoKeyVersion.
     immutable: true
     url_param_only: true
 properties:


### PR DESCRIPTION
It is actually possible to create a new CryptoKeyVersion using `google_kms_crypto_key_version` resource, and not only `google_kms_key_ring_import_job`. I suggest to update the documentation, so it does not confuse users.

That change was also requested by @melinath earlier on another PR's review: https://github.com/GoogleCloudPlatform/magic-modules/pull/6553#pullrequestreview-1111083661

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
Fixed the description for attribute `skip_initial_version_creation` of the resource `google_kms_crypto_key`
```
