### PR TITLE
Add check for Environment proto field before accessing in Dataflow provider

### DIFF
--- a/mmv1/third_party/terraform/services/dataflow/resource_dataflow_job.go.erb
+++ b/mmv1/third_party/terraform/services/dataflow/resource_dataflow_job.go.erb
@@ -371,6 +371,9 @@ func resourceDataflowJobRead(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("effective_labels", job.Labels); err != nil {
 		return fmt.Errorf("Error setting effective_labels: %s", err)
 	}
+	if job.Environment == nil {
+		return fmt.Errorf("Error accessing Environment proto: proto is nil")
+	}
 	if err := d.Set("kms_key_name", job.Environment.ServiceKmsKeyName); err != nil {
 		return fmt.Errorf("Error setting kms_key_name: %s", err)
 	}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds an extra check to the Dataflow provider when accessing job proto fields; an edge case existed where the `Environment` proto field is nil, causing a nil-pointer exception when accessing sub-fields rather than an error that can be returned up the call stack. Checking for existence and bubbling an error up should eliminate that issue.

Validated the code change is propagated to the generated repos following https://googlecloudplatform.github.io/magic-modules/get-started/generate-providers/, also passed linting + unit tests + dataflow acceptance tests

Fixes https://github.com/hashicorp/terraform-provider-google/issues/17046

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
dataflow: fixes potential nil-pointer error if a job's Environment field is nil when reading job information
```
