### PR TITLE
Updating Documentation for  build_worker_pool field in cloudfunctions

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
@@ -149,6 +149,8 @@ Please refer to the field 'effective_labels' for all of the labels present on th
 
 * `build_environment_variables` - (Optional) A set of key/value environment variable pairs available during build time.
 
+* `build_worker_pool` - (Optional) Name of the Cloud Build Custom Worker Pool that should be used to build the function.
+
 * `vpc_connector` - (Optional) The VPC Network Connector that this cloud function can connect to. It should be set up as fully-qualified URI. The format of this field is `projects/*/locations/*/connectors/*`.
 
 * `vpc_connector_egress_settings` - (Optional) The egress settings for the connector, controlling what traffic is diverted through it. Allowed values are `ALL_TRAFFIC` and `PRIVATE_RANGES_ONLY`. Defaults to `PRIVATE_RANGES_ONLY`. If unset, this field preserves the previously set value.


### PR DESCRIPTION
This field was added in [https://github.com/hashicorp/terraform-provider-google/pull/12591](url) , updating documentation to reflect this 

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
