### PR TITLE
Add sweepers for gkebackupPlan and restorePlan

### DIFF
--- a/mmv1/products/gkebackup/BackupPlan.yaml
+++ b/mmv1/products/gkebackup/BackupPlan.yaml
@@ -105,7 +105,6 @@ examples:
       deletion_protection: 'false'
     test_env_vars:
       project: :PROJECT_NAME
-skip_sweeper: true
 parameters:
   - !ruby/object:Api::Type::String
     name: 'location'

--- a/mmv1/products/gkebackup/RestorePlan.yaml
+++ b/mmv1/products/gkebackup/RestorePlan.yaml
@@ -134,7 +134,6 @@ examples:
       subnetwork_name: 'acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       deletion_protection: 'false'
-skip_sweeper: true
 parameters:
   - !ruby/object:Api::Type::String
     name: 'location'


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Tested both locally and they work fine.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
