### PR TITLE
Add type field to DNS authorization reosurce

### DIFF
--- a/mmv1/products/certificatemanager/Certificate.yaml
+++ b/mmv1/products/certificatemanager/Certificate.yaml
@@ -88,6 +88,13 @@ examples:
       dns_auth_name2: 'dns-auth2'
       dns_auth_subdomain2: 'subdomain2'
       cert_name: 'dns-cert'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'certificate_manager_google_managed_regional_certificate_dns_auth'
+    primary_resource_id: 'default'
+    vars:
+      dns_auth_name: 'dns-auth'
+      dns_auth_subdomain: 'subdomain'
+      cert_name: 'dns-cert'
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   constants: templates/terraform/constants/cert_manager.erb
 parameters:

--- a/mmv1/products/certificatemanager/DnsAuthorization.yaml
+++ b/mmv1/products/certificatemanager/DnsAuthorization.yaml
@@ -105,7 +105,7 @@ properties:
     immutable: true
     values:
       - :FIXED_RECORD
-      - :PER_RPOJECT_REOCRD
+      - :PER_PROJECT_RECORD
     default_from_api: true
   - !ruby/object:Api::Type::NestedObject
     name: 'dnsResourceRecord'

--- a/mmv1/products/certificatemanager/DnsAuthorization.yaml
+++ b/mmv1/products/certificatemanager/DnsAuthorization.yaml
@@ -104,8 +104,8 @@ properties:
       projects.
     immutable: true
     values:
-    - :FIXED_RECORD
-    - :PER_RPOJECT_REOCRD
+      - :FIXED_RECORD
+      - :PER_RPOJECT_REOCRD
     default_from_api: true
   - !ruby/object:Api::Type::NestedObject
     name: 'dnsResourceRecord'

--- a/mmv1/products/certificatemanager/DnsAuthorization.yaml
+++ b/mmv1/products/certificatemanager/DnsAuthorization.yaml
@@ -84,6 +84,22 @@ properties:
       A domain which is being authorized. A DnsAuthorization resource covers a
       single domain and its wildcard, e.g. authorization for "example.com" can
       be used to issue certificates for "example.com" and "*.example.com".
+  - !ruby/object:Api::Type::Enum
+    name: type
+    description: |
+      type of DNS authorization. If unset during the resource creation, FIXED_RECORD will
+      be used for global resources, and PER_PROJECT_RECORD will be used for other locations.
+
+      FIXED_RECORD DNS authorization uses DNS-01 validation method
+
+      PER_PROJECT_RECORD DNS authorization allows for independent management
+      of Google-managed certificates with DNS authorization across multiple
+      projects.
+    immutable: true
+    values:
+    - :FIXED_RECORD
+    - :PER_RPOJECT_REOCRD
+    default_from_api: true
   - !ruby/object:Api::Type::NestedObject
     name: 'dnsResourceRecord'
     output: true

--- a/mmv1/products/certificatemanager/DnsAuthorization.yaml
+++ b/mmv1/products/certificatemanager/DnsAuthorization.yaml
@@ -50,6 +50,13 @@ examples:
       dns_auth_name: 'dns-auth'
       zone_name: 'my-zone'
       subdomain: 'subdomain'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'certificate_manager_dns_authorization_regional'
+    primary_resource_id: 'default'
+    vars:
+      dns_auth_name: 'dns-auth'
+      zone_name: 'my-zone'
+      subdomain: 'subdomain'
 parameters:
   - !ruby/object:Api::Type::String
     name: 'name'

--- a/mmv1/templates/terraform/examples/certificate_manager_dns_authorization_regional.tf.erb
+++ b/mmv1/templates/terraform/examples/certificate_manager_dns_authorization_regional.tf.erb
@@ -2,5 +2,6 @@ resource "google_certificate_manager_dns_authorization" "<%= ctx[:primary_resour
   name        = "<%= ctx[:vars]['dns_auth_name'] %>"
   location    = "us-central1"
   description = "reginal dns"
+  type        = "PER_PROJECT_RECORD"
   domain      = "<%= ctx[:vars]['subdomain'] %>.hashicorptest.com"
 }

--- a/mmv1/templates/terraform/examples/certificate_manager_dns_authorization_regional.tf.erb
+++ b/mmv1/templates/terraform/examples/certificate_manager_dns_authorization_regional.tf.erb
@@ -1,0 +1,6 @@
+resource "google_certificate_manager_dns_authorization" "<%= ctx[:primary_resource_id] %>" {
+  name        = "<%= ctx[:vars]['dns_auth_name'] %>"
+  location    = "us-central1"
+  description = "reginal dns"
+  domain      = "<%= ctx[:vars]['subdomain'] %>.hashicorptest.com"
+}

--- a/mmv1/templates/terraform/examples/certificate_manager_google_managed_regional_certificate_dns_auth.tf.erb
+++ b/mmv1/templates/terraform/examples/certificate_manager_google_managed_regional_certificate_dns_auth.tf.erb
@@ -13,7 +13,7 @@ resource "google_certificate_manager_certificate" "<%= ctx[:primary_resource_id]
 }
 resource "google_certificate_manager_dns_authorization" "instance" {
   name        = "<%= ctx[:vars]['dns_auth_name'] %>"
-  location = "us-central1"
+  location    = "us-central1"
   description = "The default dnss"
   domain      = "<%= ctx[:vars]['dns_auth_subdomain'] %>.hashicorptest.com"
 }

--- a/mmv1/templates/terraform/examples/certificate_manager_google_managed_regional_certificate_dns_auth.tf.erb
+++ b/mmv1/templates/terraform/examples/certificate_manager_google_managed_regional_certificate_dns_auth.tf.erb
@@ -1,0 +1,19 @@
+resource "google_certificate_manager_certificate" "<%= ctx[:primary_resource_id] %>" {
+  name        = "<%= ctx[:vars]['cert_name'] %>"
+  description = "regional managed certs"
+  location = "us-central1"
+  managed {
+    domains = [
+      google_certificate_manager_dns_authorization.instance.domain,
+      ]
+    dns_authorizations = [
+      google_certificate_manager_dns_authorization.instance.id,
+      ]
+  }
+}
+resource "google_certificate_manager_dns_authorization" "instance" {
+  name        = "<%= ctx[:vars]['dns_auth_name'] %>"
+  location = "us-central1"
+  description = "The default dnss"
+  domain      = "<%= ctx[:vars]['dns_auth_subdomain'] %>.hashicorptest.com"
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This PR: 
- Added `type`, a new optional field, to Certificate Manager DNS authorization resource. 
- Added an example for creating regional DNS authorization resource (as it's now supported + in public review) 
- Added an example for creating regional certificate manager certificate with regional DNS auth. 

Tests that I ran: 
```
make testacc TEST=./google/services/certificatemanager TESTARGS='-run=TestAccCertificateManagerDnsAuthorization_certificateManagerDnsAuthorizationRegionalExample'

make testacc TEST=./google/services/certificatemanager TESTARGS='-run=TestAccCertificateManagerCertificate_certificateManagerGoogleManagedRegionalCertificateDnsAuthExample'
```

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
certificatemanager: added `type` field to `google_certificate_manager_dns_authorization` resource

```
