### PR TITLE
Allow sending empty app_engine and serverless google_compute_region_network_endpoint_group

### DIFF
--- a/mmv1/products/compute/RegionNetworkEndpointGroup.yaml
+++ b/mmv1/products/compute/RegionNetworkEndpointGroup.yaml
@@ -69,6 +69,11 @@ examples:
     vars:
       neg_name: 'appengine-neg'
   - !ruby/object:Provider::Terraform::Examples
+    name: 'region_network_endpoint_group_appengine_empty'
+    primary_resource_id: 'appengine_neg'
+    vars:
+      neg_name: 'appengine-neg'
+  - !ruby/object:Provider::Terraform::Examples
     name: 'region_network_endpoint_group_psc'
     primary_resource_id: 'psc_neg'
     vars:
@@ -209,6 +214,7 @@ properties:
       - cloud_function
       - serverless_deployment
     allow_empty_object: true
+    send_empty_value: true
     description: |
       This field is only used for SERVERLESS NEGs.
 
@@ -278,6 +284,7 @@ properties:
       - cloud_function
       - app_engine
     allow_empty_object: true
+    send_empty_value: true
     description: |
       This field is only used for SERVERLESS NEGs.
 

--- a/mmv1/templates/terraform/examples/region_network_endpoint_group_appengine_empty.tf.erb
+++ b/mmv1/templates/terraform/examples/region_network_endpoint_group_appengine_empty.tf.erb
@@ -1,0 +1,8 @@
+// App Engine Example
+resource "google_compute_region_network_endpoint_group" "<%= ctx[:primary_resource_id] %>" {
+  name                  = "<%= ctx[:vars]['neg_name'] %>"
+  network_endpoint_type = "SERVERLESS"
+  region                = "us-central1"
+  app_engine {
+  }
+}


### PR DESCRIPTION

Add sending empty values for SERVERLESS compute_region_network_endpoint_group NEG

fixes [#15593](https://github.com/hashicorp/terraform-provider-google/issues/15593)

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: allowed sending empty values for `SERVERLESS` in `google_compute_region_network_endpoint_group` resource
```
