### PR TITLE
Added missing quote marks to TEST_PREFIX

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
@@ -118,7 +118,7 @@ fun BuildSteps.runAcceptanceTests() {
                   exit 0
                 fi
                 
-                export TEST_COUNT=${'$'}(./test-binary -test.list=%TEST_PREFIX% | wc -l)
+                export TEST_COUNT=${'$'}(./test-binary -test.list="%TEST_PREFIX%" | wc -l)
                 echo "Found ${'$'}{TEST_COUNT} tests that match the given test prefix %TEST_PREFIX%"
                 if test ${'$'}TEST_COUNT -le "0"; then
                   echo "Skipping test execution; no tests to run"


### PR DESCRIPTION
Without this, `|` gets interpreted as a pipe and the test count always becomes 0 if there are multiple prefixes supplied

Example build: https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_GoogleCloud_GOOGLE_MMUPSTREAMTESTS_GOOGLE_PACKAGE_CONTAINER/105366?buildTab=log&focusLine=0&logView=flowAware&linesState=1217

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
