### PR TITLE
Add support for string --> object map for DCL resources

### DIFF
--- a/mmv1/third_party/terraform/go.mod.erb
+++ b/mmv1/third_party/terraform/go.mod.erb
@@ -5,7 +5,7 @@ go 1.20
 
 require (
 	cloud.google.com/go/bigtable v1.19.0
-	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.62.0
+	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.63.0
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dnaeon/go-vcr v1.0.1

--- a/mmv1/third_party/terraform/go.sum
+++ b/mmv1/third_party/terraform/go.sum
@@ -413,3 +413,5 @@ gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 rsc.io/binaryregexp v0.2.0 h1:HfqmD5MEmC0zvwBuF187nq9mdnXjXsSivRiXN7SmRkE=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.63.0 h1:eSOBYPZVnU2fZul9sAJFGLVCgv6stNVKkmsogKF7UeY=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.63.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=

--- a/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.erb
@@ -1008,6 +1008,17 @@ func TestAccGKEHubFeatureMembership_gkehubFeaturePolicyController(t *testing.T) 
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+      {
+        Config: testAccGKEHubFeatureMembership_policycontrollerUpdateMaps(context),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckGkeHubFeatureMembershipPresent(t, fmt.Sprintf("tf-test-gkehub%s", context["random_suffix"]), "global", "policycontroller", fmt.Sprintf("tf-test1%s", context["random_suffix"])),
+        ),
+      },
+      {
+        ResourceName:      "google_gke_hub_feature_membership.feature_member",
+        ImportState:       true,
+        ImportStateVerify: true,
+      },
 		},
 	})
 }
@@ -1064,9 +1075,92 @@ resource "google_gke_hub_feature_membership" "feature_member" {
           "PROMETHEUS"
         ]
       }
+      deployment_configs {
+        key_name = "admission"
+        replica_count = 3
+        pod_affinity = "ANTI_AFFINITY"
+        container_resources {
+          limits {
+            memory = "1Gi"
+            cpu = "1.5"
+          }
+          requests {
+            memory = "500Mi"
+            cpu = "150m"
+          }
+        }
+        pod_tolerations {
+          key = "key1"
+          operator = "Equal"
+          value = "value1"
+          effect = "NoSchedule"
+        }
+      }
+      deployment_configs {
+        key_name = "mutation"
+        replica_count = 3
+        pod_affinity = "ANTI_AFFINITY"
+      }
       policy_content {
         template_library {
-          installation = "NOT_INSTALLED"
+          installation = "ALL"
+        }
+        bundles {
+          key_name = "pci-dss-v3.2.1"
+          exempted_namespaces = ["sample-namespace"]
+        }
+        bundles {
+          key_name = "nist-sp-800-190"
+        }
+      }
+    }
+    version = "1.17.0"
+  }
+}
+`, context)
+}
+
+func testAccGKEHubFeatureMembership_policycontrollerUpdateMaps(context map[string]interface{}) string {
+  return gkeHubFeatureProjectSetup(context) + gkeHubClusterMembershipSetup(context) + acctest.Nprintf(`
+resource "google_gke_hub_feature" "feature" {
+  project = google_project.project.project_id
+  name = "policycontroller"
+  location = "global"
+  depends_on = [google_project_service.container, google_project_service.gkehub, google_project_service.poco]
+}
+
+resource "google_gke_hub_feature_membership" "feature_member" {
+  project = google_project.project.project_id
+  location = "global"
+  feature = google_gke_hub_feature.feature.name
+  membership = google_gke_hub_membership.membership.membership_id
+  policycontroller {
+    policy_controller_hub_config {
+      install_spec = "INSTALL_SPEC_SUSPENDED"
+      constraint_violation_limit = 50
+      referential_rules_enabled = true
+      log_denies_enabled = true
+      mutation_enabled = true
+      monitoring {
+        backends = [
+          "PROMETHEUS"
+        ]
+      }
+      deployment_configs {
+        key_name = "admission"
+        pod_affinity = "NO_AFFINITY"
+      }
+      deployment_configs {
+        key_name = "audit"
+        container_resources {
+          limits {
+            memory = "1Gi"
+            cpu = "1.5"
+          }
+          requests {
+            memory = "500Mi"
+            cpu = "150m"
+          }
         }
       }
     }

--- a/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.erb
@@ -1076,7 +1076,7 @@ resource "google_gke_hub_feature_membership" "feature_member" {
         ]
       }
       deployment_configs {
-        key_name = "admission"
+        component_name = "admission"
         replica_count = 3
         pod_affinity = "ANTI_AFFINITY"
         container_resources {
@@ -1097,7 +1097,7 @@ resource "google_gke_hub_feature_membership" "feature_member" {
         }
       }
       deployment_configs {
-        key_name = "mutation"
+        component_name = "mutation"
         replica_count = 3
         pod_affinity = "ANTI_AFFINITY"
       }
@@ -1106,11 +1106,11 @@ resource "google_gke_hub_feature_membership" "feature_member" {
           installation = "ALL"
         }
         bundles {
-          key_name = "pci-dss-v3.2.1"
+          bundle_name = "pci-dss-v3.2.1"
           exempted_namespaces = ["sample-namespace"]
         }
         bundles {
-          key_name = "nist-sp-800-190"
+          bundle_name = "nist-sp-800-190"
         }
       }
     }
@@ -1147,11 +1147,11 @@ resource "google_gke_hub_feature_membership" "feature_member" {
         ]
       }
       deployment_configs {
-        key_name = "admission"
+        component_name = "admission"
         pod_affinity = "NO_AFFINITY"
       }
       deployment_configs {
-        key_name = "audit"
+        component_name = "audit"
         container_resources {
           limits {
             memory = "1Gi"

--- a/mmv1/third_party/terraform/website/docs/r/gke_hub_feature_membership.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/gke_hub_feature_membership.html.markdown
@@ -522,7 +522,7 @@ The following arguments are supported:
     
 * `component_name` -
   (Required)
-  The name for the key in the map for which this object is mapped to in the API
+  The name of the component. One of `admission` `audit` or `mutation`
     
 * `container_resources` -
   (Optional)
@@ -603,7 +603,7 @@ The `bundles` block supports:
     
 * `bundle_name` -
   (Required)
-  The name for the key in the map for which this object is mapped to in the API
+  The name of the bundle.
     
 * `exempted_namespaces` -
   (Optional)

--- a/mmv1/third_party/terraform/website/docs/r/gke_hub_feature_membership.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/gke_hub_feature_membership.html.markdown
@@ -504,6 +504,10 @@ The following arguments are supported:
   (Optional)
   The maximum number of audit violations to be stored in a constraint. If not set, the  default of 20 will be used.
 
+  * `deployment_configs` -
+  (Optional)
+  Map of deployment configs to deployments ("admission", "audit", "mutation").
+
 * `policy_content` -
   (Optional)
   Specifies the desired policy content on the cluster. Structure is [documented below](#nested_policy_content).
@@ -514,11 +518,96 @@ The following arguments are supported:
   (Optional)
   Specifies the list of backends Policy Controller will export to. Must be one of `CLOUD_MONITORING` or `PROMETHEUS`. Defaults to [`CLOUD_MONITORING`, `PROMETHEUS`]. Specifying an empty value `[]` disables metrics export.
 
+<a name="nested_deployment_configs"></a>The `deployment_configs` block supports:
+    
+* `component_name` -
+  (Required)
+  The name for the key in the map for which this object is mapped to in the API
+    
+* `container_resources` -
+  (Optional)
+  Container resource requirements.
+    
+* `pod_affinity` -
+  (Optional)
+  Pod affinity configuration. Possible values: AFFINITY_UNSPECIFIED, NO_AFFINITY, ANTI_AFFINITY
+    
+* `pod_tolerations` -
+  (Optional)
+  Pod tolerations of node taints.
+    
+* `replica_count` -
+  (Optional)
+  Pod replica count.
+    
+<a name="nested_container_resources"></a>The `container_resources` block supports:
+    
+* `limits` -
+  (Optional)
+  Limits describes the maximum amount of compute resources allowed for use by the running container.
+    
+* `requests` -
+  (Optional)
+  Requests describes the amount of compute resources reserved for the container by the kube-scheduler.
+    
+<a name="nested_limits"></a>The `limits` block supports:
+    
+* `cpu` -
+  (Optional)
+  CPU requirement expressed in Kubernetes resource units.
+    
+* `memory` -
+  (Optional)
+  Memory requirement expressed in Kubernetes resource units.
+    
+<a name="nested_requests"></a>The `requests` block supports:
+    
+* `cpu` -
+  (Optional)
+  CPU requirement expressed in Kubernetes resource units.
+    
+* `memory` -
+  (Optional)
+  Memory requirement expressed in Kubernetes resource units.
+    
+<a name="nested_pod_tolerations"></a>The `pod_tolerations` block supports:
+    
+* `effect` -
+  (Optional)
+  Matches a taint effect.
+    
+* `key` -
+  (Optional)
+  Matches a taint key (not necessarily unique).
+    
+* `operator` -
+  (Optional)
+  Matches a taint operator.
+    
+* `value` -
+  (Optional)
+  Matches a taint value.
+
 <a name="nested_policy_content"></a>The `policy_content` block supports:
+
+* `bundles` -
+  (Optional)
+  map of bundle name to BundleInstallSpec. The bundle name maps to the `bundleName` key in the `policycontroller.gke.io/constraintData` annotation on a constraint.
 
 * `template_library`
   (Optional)
   Configures the installation of the Template Library. Structure is [documented below](#nested_template_library).
+
+<a name="nested_bundles"></a>The `template_library` block supports:
+The `bundles` block supports:
+    
+* `bundle_name` -
+  (Required)
+  The name for the key in the map for which this object is mapped to in the API
+    
+* `exempted_namespaces` -
+  (Optional)
+  The set of namespaces to be exempted from the bundle.
 
 <a name="nested_template_library"></a>The `template_library` block supports:
 

--- a/tpgtools/go.mod
+++ b/tpgtools/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	bitbucket.org/creachadair/stringset v0.0.11
-	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.62.0
+	github.com/GoogleCloudPlatform/declarative-resource-client-library v1.63.0
 	github.com/golang/glog v1.1.2
 	github.com/hashicorp/hcl v1.0.0
 	github.com/kylelemons/godebug v1.1.0

--- a/tpgtools/go.sum
+++ b/tpgtools/go.sum
@@ -6,12 +6,8 @@ cloud.google.com/go/compute v1.23.0/go.mod h1:4tCnrn48xsqlwSAiLf1HXMQk8CONslYbdi
 cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
 cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GoogleCloudPlatform/declarative-resource-client-library v1.60.0 h1:RFZs9I3tXewC7cJf8RKbUMpQZO6jWZ9SHSnNd+auxsQ=
-github.com/GoogleCloudPlatform/declarative-resource-client-library v1.60.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
-github.com/GoogleCloudPlatform/declarative-resource-client-library v1.61.0 h1:IAr9UlYbxURIYABRMagXXo8pDlkFNFFXWz5J2+srrnc=
-github.com/GoogleCloudPlatform/declarative-resource-client-library v1.61.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
-github.com/GoogleCloudPlatform/declarative-resource-client-library v1.62.0 h1:s4Y6r6RrYLBnqosGXLwR0h1Gqr0VT3wgd6rqvHsD9OE=
-github.com/GoogleCloudPlatform/declarative-resource-client-library v1.62.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.63.0 h1:eSOBYPZVnU2fZul9sAJFGLVCgv6stNVKkmsogKF7UeY=
+github.com/GoogleCloudPlatform/declarative-resource-client-library v1.63.0/go.mod h1:pL2Qt5HT+x6xrTd806oMiM3awW6kNIXB/iiuClz6m6k=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/tpgtools/override.go
+++ b/tpgtools/override.go
@@ -79,6 +79,7 @@ const (
 	CustomListSize                    = "CUSTOM_LIST_SIZE_CONSTRAINT"
 	CustomDefault                     = "CUSTOM_DEFAULT"
 	CustomSchemaValues                = "CUSTOM_SCHEMA_VALUES"
+	ComplexMapKey                     = "COMPLEX_MAP_KEY_NAME"
 )
 
 // Overrides represents the type a resource's override file can be marshalled

--- a/tpgtools/override_details.go
+++ b/tpgtools/override_details.go
@@ -230,3 +230,8 @@ type StateUpgradeDetails struct {
 	// The current schema version
 	SchemaVersion int
 }
+
+type ComplexMapKeyDetails struct {
+	// The name of the key as exposed by Terraform
+	KeyName string
+}

--- a/tpgtools/overrides/gkehub/beta/feature_membership.yaml
+++ b/tpgtools/overrides/gkehub/beta/feature_membership.yaml
@@ -36,4 +36,4 @@
 - type: COMPLEX_MAP_KEY_NAME
   field: policycontroller.policy_controller_hub_config.deployment_configs
   details:
-    keyname: deployment_type
+    keyname: component_name

--- a/tpgtools/overrides/gkehub/beta/feature_membership.yaml
+++ b/tpgtools/overrides/gkehub/beta/feature_membership.yaml
@@ -29,3 +29,11 @@
   details:
     functions: 
     - tpgresource.DefaultProviderProject
+- type: COMPLEX_MAP_KEY_NAME
+  field: policycontroller.policy_controller_hub_config.policy_content.bundles
+  details:
+    keyname: bundle_name
+- type: COMPLEX_MAP_KEY_NAME
+  field: policycontroller.policy_controller_hub_config.deployment_configs
+  details:
+    keyname: deployment_type

--- a/tpgtools/overrides/gkehub/feature_membership.yaml
+++ b/tpgtools/overrides/gkehub/feature_membership.yaml
@@ -25,3 +25,11 @@
   details:
     message: >-
       Deprecated in favor of the `management` field
+- type: COMPLEX_MAP_KEY_NAME
+  field: policycontroller.policy_controller_hub_config.policy_content.bundles
+  details:
+    keyname: bundle_name
+- type: COMPLEX_MAP_KEY_NAME
+  field: policycontroller.policy_controller_hub_config.deployment_configs
+  details:
+    keyname: component_name

--- a/tpgtools/property.go
+++ b/tpgtools/property.go
@@ -697,7 +697,7 @@ func createPropertiesFromSchema(schema *openapi.Schema, typeFetcher *TypeFetcher
 				Required: true,
 				Description: "The name for the key in the map for which this object is mapped to in the API",
 			}
-			props = append(props, keyProp)
+			props = append([]Property{keyProp}, props...)
 
 			p.Properties = props
 			e := fmt.Sprintf("%s%sSchema()", resource.PathType(), p.PackagePath())

--- a/tpgtools/property.go
+++ b/tpgtools/property.go
@@ -210,8 +210,9 @@ func (t Type) IsSet() bool {
 }
 
 // Complex map is for maps of string --> object that are supported in DCL but
-// not in Terraform. We handle this by adding a `name` field in the Terraform 
-// schema for the key in the map
+// not in Terraform. We handle this by adding a field in the Terraform schema 
+// for the key in the map. This must be added via a COMPLEX_MAP_KEY_NAME
+// override
 func (t Type) IsComplexMap() bool {
 	if t.typ.AdditionalProperties != nil {
 		return t.typ.AdditionalProperties.Type != "string"

--- a/tpgtools/templates/resource.go.tmpl
+++ b/tpgtools/templates/resource.go.tmpl
@@ -690,7 +690,7 @@ func expand{{$.PathType}}{{$v.PackagePath}}Map(o interface{}) map[string]{{$.Pac
 	for _, item := range objs {
 		i := expand{{$.PathType}}{{$v.PackagePath}}(item)
 		if item != nil {
-			items[item.(map[string]interface{})["key_name"].(string)] = *i
+			items[item.(map[string]interface{})["{{$v.ComplexMapKeyName}}"].(string)] = *i
 		}
 	}
 
@@ -721,7 +721,7 @@ func expand{{$.PathType}}{{$v.PackagePath}}(o interface{}) *{{$.Package}}.{{$v.O
 	{{- end }}
 	return &{{$.Package}}.{{$v.ObjectType}}{
 	{{- range $p := $v.Properties }}
-		{{- if and ($p.Settable) ($p.ExpandGetter) (or (not $v.IsComplexMap) (ne $p.Name "key_name")) }}
+		{{- if and ($p.Settable) ($p.ExpandGetter) (or (not $v.IsComplexMap) (ne $p.Name $v.ComplexMapKeyName)) }}
 		{{$p.PackageName}}: {{$p.ExpandGetter}},
 		{{- end -}}
 	{{ end }}
@@ -768,13 +768,13 @@ func flatten{{$.PathType}}{{$v.PackagePath}}(obj *{{$.Package}}.{{$v.ObjectType}
 	}
 	transformed := map[string]interface{}{
 {{- range $p := $v.Properties }}
-	{{- if or (not $v.IsComplexMap) (ne $p.Name "key_name") }}
+	{{- if or (not $v.IsComplexMap) (ne $p.Name $v.ComplexMapKeyName) }}
 		"{{$p.Name}}": {{$p.FlattenGetter}},
 	{{- end -}}
 {{ end }}
 	}
 {{ if $v.IsComplexMap }}
-	transformed["key_name"] = name
+	transformed["{{$v.ComplexMapKeyName}}"] = name
 {{ end }}
 {{ if $v.IsObject }}
 	return []interface{}{transformed}

--- a/tpgtools/templates/resource.go.tmpl
+++ b/tpgtools/templates/resource.go.tmpl
@@ -665,6 +665,39 @@ func expand{{$.PathType}}{{$v.PackagePath}}Array(o interface{}) []{{$.Package}}.
 }
 		{{- end }}
 
+		{{ if $v.IsComplexMap -}}
+func expand{{$.PathType}}{{$v.PackagePath}}Map(o interface{}) map[string]{{$.Package}}.{{$v.ObjectType}} {
+	if o == nil {
+	{{- if $v.Computed }}
+		return nil
+	{{- else }}
+		return make(map[string]{{$.Package}}.{{$v.ObjectType}})
+	{{- end }}
+	}
+
+	o = o.(*schema.Set).List()
+
+	objs := o.([]interface{})
+	if len(objs) == 0 || objs[0] == nil {
+	{{- if $v.Computed }}
+		return nil
+	{{- else }}
+		return make(map[string]{{$.Package}}.{{$v.ObjectType}})
+	{{- end }}
+	}
+
+	items := make(map[string]{{$.Package}}.{{$v.ObjectType}})
+	for _, item := range objs {
+		i := expand{{$.PathType}}{{$v.PackagePath}}(item)
+		if item != nil {
+			items[item.(map[string]interface{})["key_name"].(string)] = *i
+		}
+	}
+
+	return items
+}
+		{{- end }}
+
 func expand{{$.PathType}}{{$v.PackagePath}}(o interface{}) *{{$.Package}}.{{$v.ObjectType}} {
 	if o == nil {
 	{{- if $v.Computed }}
@@ -688,7 +721,7 @@ func expand{{$.PathType}}{{$v.PackagePath}}(o interface{}) *{{$.Package}}.{{$v.O
 	{{- end }}
 	return &{{$.Package}}.{{$v.ObjectType}}{
 	{{- range $p := $v.Properties }}
-		{{- if and ($p.Settable) ($p.ExpandGetter) }}
+		{{- if and ($p.Settable) ($p.ExpandGetter) (or (not $v.IsComplexMap) (ne $p.Name "key_name")) }}
 		{{$p.PackageName}}: {{$p.ExpandGetter}},
 		{{- end -}}
 	{{ end }}
@@ -713,17 +746,36 @@ func flatten{{$.PathType}}{{$v.PackagePath}}Array(objs []{{$.Package}}.{{$v.Obje
 }
 	{{- end }}
 
-func flatten{{$.PathType}}{{$v.PackagePath}}(obj *{{$.Package}}.{{$v.ObjectType}}) interface{} {
-	if obj == nil || obj.Empty(){
+	{{ if $v.IsComplexMap -}}
+func flatten{{$.PathType}}{{$v.PackagePath}}Map(objs map[string]{{$.Package}}.{{$v.ObjectType}}) []interface{} {
+	if objs == nil {
+		return nil
+	}
+
+	items := []interface{}{}
+	for name, item := range objs {
+		i := flatten{{$.PathType}}{{$v.PackagePath}}(&item, name)
+		items = append(items, i)
+	}
+
+	return items
+}
+	{{- end }}
+
+func flatten{{$.PathType}}{{$v.PackagePath}}(obj *{{$.Package}}.{{$v.ObjectType}}{{- if $v.IsComplexMap -}}, name string{{- end -}}) interface{} {
+	if obj == nil {{- if not $v.IsComplexMap -}}|| obj.Empty(){{- end -}}{
 		return nil
 	}
 	transformed := map[string]interface{}{
 {{- range $p := $v.Properties }}
-	{{- if ($p.FlattenGetter) }}
+	{{- if or (not $v.IsComplexMap) (ne $p.Name "key_name") }}
 		"{{$p.Name}}": {{$p.FlattenGetter}},
-	{{- end -}}
+	{{- end}}
 {{ end }}
 	}
+{{ if $v.IsComplexMap }}
+	transformed["key_name"] = name
+{{ end }}
 {{ if $v.IsObject }}
 	return []interface{}{transformed}
 {{ else }}

--- a/tpgtools/templates/resource.go.tmpl
+++ b/tpgtools/templates/resource.go.tmpl
@@ -770,7 +770,7 @@ func flatten{{$.PathType}}{{$v.PackagePath}}(obj *{{$.Package}}.{{$v.ObjectType}
 {{- range $p := $v.Properties }}
 	{{- if or (not $v.IsComplexMap) (ne $p.Name "key_name") }}
 		"{{$p.Name}}": {{$p.FlattenGetter}},
-	{{- end}}
+	{{- end -}}
 {{ end }}
 	}
 {{ if $v.IsComplexMap }}

--- a/tpgtools/type.go
+++ b/tpgtools/type.go
@@ -67,14 +67,13 @@ func (t Type) String() string {
 		}
 		return "unknown number type"
 	case "object":
-		// assume if this is set, it's a string -> string map for now.
-		// https://swagger.io/docs/specification/data-models/dictionaries/
-		// describes the behaviour of AdditionalProperties for type: object
 		if t.typ.AdditionalProperties != nil {
 			if v := t.typ.AdditionalProperties.Type; v == "string" {
 				return SchemaTypeMap
 			} else {
-				return fmt.Sprintf("unknown AdditionalProperties: %q", v)
+				// Complex maps are handled as sets with an extra value for the
+				// name of the object
+				return SchemaTypeSet
 			}
 		}
 		return SchemaTypeList


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/16777

Tests for gkehub pass in CI

This adds an override for these maps that specifies the key name and must be present for these fields to work.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
gkehub: added support for `policycontroller.policy_controller_hub_config.policy_content.bundles` and 
`policycontroller.policy_controller_hub_config.deployment_configs` fields to `google_gke_hub_feature_membership`
```
