### PR TITLE
feat: Add CMEK support for Firestore database in Beta provider

### DIFF
--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -79,6 +79,23 @@ examples:
       - etag
       - deletion_policy
   - !ruby/object:Provider::Terraform::Examples
+    name: 'firestore_cmek_database'
+    min_version: beta
+    primary_resource_id: 'database'
+    vars:
+      database_id: "cmek-database-id"
+      delete_protection_state: "DELETE_PROTECTION_ENABLED"
+      kms_key_ring_name: "kms-key-ring"
+      kms_key_name: "kms-key"
+    test_env_vars:
+      project_id: :PROJECT_NAME
+    test_vars_overrides:
+      delete_protection_state: '"DELETE_PROTECTION_DISABLED"'
+    ignore_read_extra:
+      - project
+      - etag
+      - deletion_policy
+  - !ruby/object:Provider::Terraform::Examples
     name: 'firestore_default_database_in_datastore_mode'
     primary_resource_id: 'datastore_mode_database'
     test_env_vars:
@@ -94,6 +111,23 @@ examples:
     vars:
       database_id: "database-id"
       delete_protection_state: "DELETE_PROTECTION_ENABLED"
+    test_env_vars:
+      project_id: :PROJECT_NAME
+    test_vars_overrides:
+      delete_protection_state: '"DELETE_PROTECTION_DISABLED"'
+    ignore_read_extra:
+      - project
+      - etag
+      - deletion_policy
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'firestore_cmek_database_in_datastore_mode'
+    min_version: beta
+    primary_resource_id: 'database'
+    vars:
+      database_id: "cmek-database-id"
+      delete_protection_state: "DELETE_PROTECTION_ENABLED"
+      kms_key_ring_name: "kms-key-ring"
+      kms_key_name: "kms-key"
     test_env_vars:
       project_id: :PROJECT_NAME
     test_vars_overrides:
@@ -234,3 +268,39 @@ properties:
       This value is continuously updated, and becomes stale the moment it is queried. If you are using this value to recover data, make sure to account for the time from the moment when the value is queried to the moment when you initiate the recovery.
       A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
     output: true
+  - !ruby/object:Api::Type::NestedObject
+    name: cmekConfig
+    min_version: beta
+    description: |
+       The CMEK (Customer Managed Encryption Key) configuration for a Firestore
+       database. If not present, the database is secured by the default Google
+       encryption key.
+    properties:
+      - !ruby/object:Api::Type::String
+        name: kmsKeyName
+        description: |
+          Only keys in the same location as this database are allowed to be used
+          for encryption. This feature is allowlist only in initial launch.
+
+          For Firestore's nam5 multi-region, this corresponds to Cloud KMS
+          multi-region us. For Firestore's eur3 multi-region, this corresponds to
+          Cloud KMS multi-region europe. See https://cloud.google.com/kms/docs/locations.
+
+          This value should be the KMS key resource ID in the format of
+          `projects/{project_id}/locations/{kms_location}/keyRings/{key_ring}/cryptoKeys/{crypto_key}`.
+          How to retrive this resource ID is listed at
+          https://cloud.google.com/kms/docs/getting-resource-ids#getting_the_id_for_a_key_and_version.
+        required: true
+        immutable: true
+      - !ruby/object:Api::Type::Array
+        name: activeKeyVersion
+        output: true
+        description: |
+           Currently in-use KMS key versions (https://cloud.google.com/kms/docs/resource-hierarchy#key_versions).
+           During key rotation (https://cloud.google.com/kms/docs/key-rotation), there can be
+           multiple in-use key versions.
+
+           The expected format is
+           `projects/{project_id}/locations/{kms_location}/keyRings/{key_ring}/cryptoKeys/{crypto_key}/cryptoKeyVersions/{key_version}`.
+        item_type: Api::Type::String
+  

--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -286,7 +286,7 @@ properties:
           be a Customer-managed Encryption Key (CMEK) database encrypted with
           this key. This feature is allowlist only in initial launch.
 
-          Only the key in the same location as this database is allowed to be used
+          Only keys in the same location as this database are allowed to be used
           for encryption. For Firestore's nam5 multi-region, this corresponds to Cloud KMS
           multi-region us. For Firestore's eur3 multi-region, this corresponds to
           Cloud KMS multi-region europe. See https://cloud.google.com/kms/docs/locations.

--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -271,6 +271,7 @@ properties:
   - !ruby/object:Api::Type::NestedObject
     name: cmekConfig
     min_version: beta
+    immutable: true
     description: |
        The CMEK (Customer Managed Encryption Key) configuration for a Firestore
        database. If not present, the database is secured by the default Google
@@ -278,6 +279,8 @@ properties:
     properties:
       - !ruby/object:Api::Type::String
         name: kmsKeyName
+        required: true
+        immutable: true
         description: |
           The resource ID of a Cloud KMS key. If set, the database created will
           be a Customer-managed Encryption Key (CMEK) database encrypted with
@@ -292,8 +295,6 @@ properties:
           `projects/{project_id}/locations/{kms_location}/keyRings/{key_ring}/cryptoKeys/{crypto_key}`.
           How to retrive this resource ID is listed at
           https://cloud.google.com/kms/docs/getting-resource-ids#getting_the_id_for_a_key_and_version.
-        required: true
-        immutable: true
       - !ruby/object:Api::Type::Array
         name: activeKeyVersion
         output: true

--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -282,7 +282,7 @@ properties:
           The resource ID of a Cloud KMS key. If set, the database created will
           be a Customer-managed Encryption Key (CMEK) database encrypted with
           this key. This feature is allowlist only in initial launch.
-          
+
           Only keys in the same location as this database are allowed to be used
           for encryption. For Firestore's nam5 multi-region, this corresponds to Cloud KMS
           multi-region us. For Firestore's eur3 multi-region, this corresponds to

--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -279,10 +279,12 @@ properties:
       - !ruby/object:Api::Type::String
         name: kmsKeyName
         description: |
+          The resource ID of a Cloud KMS key. If set, the database created will
+          be a Customer-managed Encryption Key (CMEK) database encrypted with
+          this key. This feature is allowlist only in initial launch.
+          
           Only keys in the same location as this database are allowed to be used
-          for encryption. This feature is allowlist only in initial launch.
-
-          For Firestore's nam5 multi-region, this corresponds to Cloud KMS
+          for encryption. For Firestore's nam5 multi-region, this corresponds to Cloud KMS
           multi-region us. For Firestore's eur3 multi-region, this corresponds to
           Cloud KMS multi-region europe. See https://cloud.google.com/kms/docs/locations.
 

--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -286,7 +286,7 @@ properties:
           be a Customer-managed Encryption Key (CMEK) database encrypted with
           this key. This feature is allowlist only in initial launch.
 
-          Only keys in the same location as this database are allowed to be used
+          Only the key in the same location as this database is allowed to be used
           for encryption. For Firestore's nam5 multi-region, this corresponds to Cloud KMS
           multi-region us. For Firestore's eur3 multi-region, this corresponds to
           Cloud KMS multi-region europe. See https://cloud.google.com/kms/docs/locations.

--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -303,4 +303,3 @@ properties:
            The expected format is
            `projects/{project_id}/locations/{kms_location}/keyRings/{key_ring}/cryptoKeys/{crypto_key}/cryptoKeyVersions/{key_version}`.
         item_type: Api::Type::String
-  

--- a/mmv1/templates/terraform/examples/firestore_cmek_database.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_cmek_database.tf.erb
@@ -1,0 +1,50 @@
+data "google_project" "project" {
+  provider = google-beta
+}
+
+resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+
+  project                           = "<%= ctx[:test_env_vars]['project_id'] %>"
+  name                              = "<%= ctx[:vars]['database_id']%>"
+  location_id                       = "nam5"
+  type                              = "FIRESTORE_NATIVE"
+  concurrency_mode                  = "OPTIMISTIC"
+  app_engine_integration_mode       = "DISABLED"
+  point_in_time_recovery_enablement = "POINT_IN_TIME_RECOVERY_ENABLED"
+  delete_protection_state           = "<%= ctx[:vars]['delete_protection_state'] %>"
+  deletion_policy                   = "DELETE"
+  cmek_config {
+    kms_key_name                    = google_kms_crypto_key.crypto_key.id
+  }
+
+  depends_on = [
+    google_kms_crypto_key_iam_binding.firestore_cmek_keyuser
+  ]
+}
+
+resource "google_kms_crypto_key" "crypto_key" {
+  provider = google-beta
+
+  name     = "<%= ctx[:vars]['kms_key_name'] %>"
+  key_ring = google_kms_key_ring.key_ring.id
+  purpose  = "ENCRYPT_DECRYPT"
+}
+
+resource "google_kms_key_ring" "key_ring" {
+  provider = google-beta
+
+  name     = "<%= ctx[:vars]['kms_key_ring_name'] %>"
+  location = "us"
+}
+
+resource "google_kms_crypto_key_iam_binding" "firestore_cmek_keyuser" {
+  provider = google-beta
+
+  crypto_key_id = google_kms_crypto_key.crypto_key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+  members = [
+    "serviceAccount:service-${data.google_project.project.number}@gcp-sa-firestore.iam.gserviceaccount.com",
+  ]
+}

--- a/mmv1/templates/terraform/examples/firestore_cmek_database_in_datastore_mode.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_cmek_database_in_datastore_mode.tf.erb
@@ -1,0 +1,50 @@
+data "google_project" "project" {
+  provider = google-beta
+}
+
+resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+
+  project                           = "<%= ctx[:test_env_vars]['project_id'] %>"
+  name                              = "<%= ctx[:vars]['database_id']%>"
+  location_id                       = "nam5"
+  type                              = "DATASTORE_MODE"
+  concurrency_mode                  = "OPTIMISTIC"
+  app_engine_integration_mode       = "DISABLED"
+  point_in_time_recovery_enablement = "POINT_IN_TIME_RECOVERY_ENABLED"
+  delete_protection_state           = "<%= ctx[:vars]['delete_protection_state'] %>"
+  deletion_policy                   = "DELETE"
+  cmek_config {
+    kms_key_name                    = google_kms_crypto_key.crypto_key.id
+  }
+
+  depends_on = [
+    google_kms_crypto_key_iam_binding.firestore_cmek_keyuser
+  ]
+}
+
+resource "google_kms_crypto_key" "crypto_key" {
+  provider = google-beta
+
+  name     = "<%= ctx[:vars]['kms_key_name'] %>"
+  key_ring = google_kms_key_ring.key_ring.id
+  purpose  = "ENCRYPT_DECRYPT"
+}
+
+resource "google_kms_key_ring" "key_ring" {
+  provider = google-beta
+
+  name     = "<%= ctx[:vars]['kms_key_ring_name'] %>"
+  location = "us"
+}
+
+resource "google_kms_crypto_key_iam_binding" "firestore_cmek_keyuser" {
+  provider = google-beta
+
+  crypto_key_id = google_kms_crypto_key.crypto_key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+  members = [
+    "serviceAccount:service-${data.google_project.project.number}@gcp-sa-firestore.iam.gserviceaccount.com",
+  ]
+}


### PR DESCRIPTION
Adds the new field `cmek_config` to google_firestore_database to support creating a Firestore CMEK database.
 - The change is added to `Beta` version only because it's only a Preview feature


**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
firestore: added `cmek_config` field to `google_firestore_database` resource (beta)
```
