### PR TITLE
Graduate support of GKE Queued Provisioning to GA

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
@@ -207,7 +207,6 @@ var schemaNodePool = map[string]*schema.Schema{
 		},
 	},
 
-<% unless version == 'ga' -%>
 	"queued_provisioning": {
 		Type:        schema.TypeList,
 		Optional:    true,
@@ -225,7 +224,6 @@ var schemaNodePool = map[string]*schema.Schema{
 			},
 		},
 	},
-<% end -%>
 
 	"max_pods_per_node": &schema.Schema{
 		Type:        schema.TypeInt,
@@ -988,7 +986,6 @@ func expandNodePool(d *schema.ResourceData, prefix string) (*container.NodePool,
 		}
 	}
 
-<% unless version == 'ga' -%>
 	if v, ok := d.GetOk(prefix + "queued_provisioning"); ok {
 		if v.([]interface{}) != nil && v.([]interface{})[0] != nil {
 			queued_provisioning := v.([]interface{})[0].(map[string]interface{})
@@ -997,7 +994,6 @@ func expandNodePool(d *schema.ResourceData, prefix string) (*container.NodePool,
 			}
 		}
 	}
-<% end -%>
 
 	if v, ok := d.GetOk(prefix + "max_pods_per_node"); ok {
 		np.MaxPodsConstraint = &container.MaxPodsConstraint{
@@ -1192,7 +1188,6 @@ func flattenNodePool(d *schema.ResourceData, config *transport_tpg.Config, np *c
 		}
 	}
 
-<% unless version == 'ga' -%>
 	if np.QueuedProvisioning != nil {
 		nodePool["queued_provisioning"] = []map[string]interface{}{
 			{
@@ -1200,7 +1195,6 @@ func flattenNodePool(d *schema.ResourceData, config *transport_tpg.Config, np *c
 			},
 		}
 	}
-<% end -%>
 
 	if np.MaxPodsConstraint != nil {
 		nodePool["max_pods_per_node"] = np.MaxPodsConstraint.MaxPodsPerNode

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -1950,7 +1950,6 @@ resource "google_container_node_pool" "np" {
 `, cluster, networkName, subnetworkName, policyName, np)
 }
 
-<% unless version == 'ga' -%>
 func TestAccContainerNodePool_enableQueuedProvisioning(t *testing.T) {
 	t.Parallel()
 
@@ -2022,7 +2021,6 @@ resource "google_container_node_pool" "np" {
 }
 `, cluster, networkName, subnetworkName, np, enabled)
 }
-<% end -%>
 
 func TestAccContainerNodePool_threadsPerCore(t *testing.T) {
 	t.Parallel()

--- a/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
@@ -172,7 +172,7 @@ cluster.
 * `placement_policy` - (Optional) Specifies a custom placement policy for the
   nodes.
 
-* `queued_provisioning` - (Optional, Beta) Specifies node pool-level settings of queued provisioning.
+* `queued_provisioning` - (Optional) Specifies node pool-level settings of queued provisioning.
     Structure is [documented below](#nested_queued_provisioning).
 
 <a name="nested_autoscaling"></a>The `autoscaling` block supports (either total or per zone limits are required):


### PR DESCRIPTION
Graduate support of GKE Queued Provisioning to GA

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: promoted `google_container_node_pool.queued_provisioning` to GA (ga)
```
