### PR TITLE
Make kmsServiceAccountId editable for Logging Settings

### DIFF
--- a/mmv1/products/logging/FolderSettings.yaml
+++ b/mmv1/products/logging/FolderSettings.yaml
@@ -23,8 +23,8 @@ base_url: 'folders/{{folder}}/settings'
 self_link: 'folders/{{folder}}/settings'
 import_format: ['folders/{{folder}}/settings']
 # Hardcode the updateMask since d.HasChanged does not work on create.
-create_url: 'folders/{{folder}}/settings?updateMask=disableDefaultSink,storageLocation,kmsKeyName'
-update_url: 'folders/{{folder}}/settings?updateMask=disableDefaultSink,storageLocation,kmsKeyName'
+create_url: 'folders/{{folder}}/settings?updateMask=disableDefaultSink,storageLocation,kmsKeyName,kmsServiceAccountId'
+update_url: 'folders/{{folder}}/settings?updateMask=disableDefaultSink,storageLocation,kmsKeyName,kmsServiceAccountId'
 # This is a singleton resource that already is created, so create
 # is really an update, and therefore should be PATCHed.
 create_verb: :PATCH

--- a/mmv1/products/logging/FolderSettings.yaml
+++ b/mmv1/products/logging/FolderSettings.yaml
@@ -64,7 +64,7 @@ properties:
       The resource name for the configured Cloud KMS key.
   - !ruby/object:Api::Type::String
     name: kmsServiceAccountId
-    output: true
+    default_from_api: true
     description: |
       The service account that will be used by the Log Router to access your Cloud KMS key.
   - !ruby/object:Api::Type::String

--- a/mmv1/products/logging/FolderSettings.yaml
+++ b/mmv1/products/logging/FolderSettings.yaml
@@ -66,7 +66,7 @@ properties:
     name: kmsServiceAccountId
     default_from_api: true
     description: |
-      The service account that will be used by the Log Router to access your Cloud KMS key.
+      The service account that will be used by the Log Router to access your Cloud KMS key. This can be modified only once to migrate from the legacy CMEK service account to the logging service account as described in [Migrate CMEK SA](https://cloud.google.com/logging/docs/routing/troubleshoot-cmek-orgs#migrate-cmek-sa).
   - !ruby/object:Api::Type::String
     name: storageLocation
     default_from_api: true

--- a/mmv1/products/logging/OrganizationSettings.yaml
+++ b/mmv1/products/logging/OrganizationSettings.yaml
@@ -64,7 +64,7 @@ properties:
     name: kmsServiceAccountId
     default_from_api: true
     description: |
-      The service account that will be used by the Log Router to access your Cloud KMS key.
+      The service account that will be used by the Log Router to access your Cloud KMS key. This can be modified only once to migrate from the legacy CMEK service account to the logging service account as described in [Migrate CMEK SA](https://cloud.google.com/logging/docs/routing/troubleshoot-cmek-orgs#migrate-cmek-sa).
   - !ruby/object:Api::Type::String
     name: storageLocation
     default_from_api: true

--- a/mmv1/products/logging/OrganizationSettings.yaml
+++ b/mmv1/products/logging/OrganizationSettings.yaml
@@ -23,8 +23,8 @@ base_url: 'organizations/{{organization}}/settings'
 self_link: 'organizations/{{organization}}/settings'
 import_format: ['organizations/{{organization}}/settings']
 # Hardcode the updateMask since d.HasChanged does not work on create.
-create_url: 'organizations/{{organization}}/settings?updateMask=disableDefaultSink,storageLocation,kmsKeyName'
-update_url: 'organizations/{{organization}}/settings?updateMask=disableDefaultSink,storageLocation,kmsKeyName'
+create_url: 'organizations/{{organization}}/settings?updateMask=disableDefaultSink,storageLocation,kmsKeyName,kmsServiceAccountId'
+update_url: 'organizations/{{organization}}/settings?updateMask=disableDefaultSink,storageLocation,kmsKeyName,kmsServiceAccountId'
 # This is a singleton resource that already is created, so create
 # is really an update, and therefore should be PATCHed.
 create_verb: :PATCH

--- a/mmv1/products/logging/OrganizationSettings.yaml
+++ b/mmv1/products/logging/OrganizationSettings.yaml
@@ -62,7 +62,7 @@ properties:
       The resource name for the configured Cloud KMS key.
   - !ruby/object:Api::Type::String
     name: kmsServiceAccountId
-    output: true
+    default_from_api: true
     description: |
       The service account that will be used by the Log Router to access your Cloud KMS key.
   - !ruby/object:Api::Type::String

--- a/mmv1/templates/terraform/examples/logging_folder_settings_all.tf.erb
+++ b/mmv1/templates/terraform/examples/logging_folder_settings_all.tf.erb
@@ -3,7 +3,7 @@ resource "google_logging_folder_settings" "<%= ctx[:primary_resource_id] %>" {
   folder                 = google_folder.my_folder.folder_id
   kms_key_name           = "<%= ctx[:vars]['key_name'] %>"
   storage_location       = "us-central1"
-  kms_service_account_id = google_logging_folder_settings.settings.logging_service_account_id
+  kms_service_account_id = data.google_logging_folder_settings.settings.logging_service_account_id
   depends_on             = [ google_kms_crypto_key_iam_member.iam ]
 }
 

--- a/mmv1/templates/terraform/examples/logging_folder_settings_all.tf.erb
+++ b/mmv1/templates/terraform/examples/logging_folder_settings_all.tf.erb
@@ -1,9 +1,10 @@
 resource "google_logging_folder_settings" "<%= ctx[:primary_resource_id] %>" {
-  disable_default_sink = true
-  folder               = google_folder.my_folder.folder_id
-  kms_key_name         = "<%= ctx[:vars]['key_name'] %>"
-  storage_location     = "us-central1"
-  depends_on           = [ google_kms_crypto_key_iam_member.iam ]
+  disable_default_sink   = true
+  folder                 = google_folder.my_folder.folder_id
+  kms_key_name           = "<%= ctx[:vars]['key_name'] %>"
+  storage_location       = "us-central1"
+  kms_service_account_id = google_logging_folder_settings.settings.logging_service_account_id
+  depends_on             = [ google_kms_crypto_key_iam_member.iam ]
 }
 
 resource "google_folder" "my_folder" {

--- a/mmv1/templates/terraform/examples/logging_organization_settings_all.tf.erb
+++ b/mmv1/templates/terraform/examples/logging_organization_settings_all.tf.erb
@@ -3,7 +3,7 @@ resource "google_logging_organization_settings" "<%= ctx[:primary_resource_id] %
   kms_key_name           = "<%= ctx[:vars]['key_name'] %>"
   organization           = "<%= ctx[:test_env_vars]['org_id'] %>"
   storage_location       = "us-central1"
-  kms_service_account_id = google_logging_organization_settings.settings.logging_service_account_id
+  kms_service_account_id = data.google_logging_organization_settings.settings.logging_service_account_id
   depends_on             = [ google_kms_crypto_key_iam_member.iam ]
 }
 

--- a/mmv1/templates/terraform/examples/logging_organization_settings_all.tf.erb
+++ b/mmv1/templates/terraform/examples/logging_organization_settings_all.tf.erb
@@ -1,9 +1,10 @@
 resource "google_logging_organization_settings" "<%= ctx[:primary_resource_id] %>" {
-  disable_default_sink = true
-  kms_key_name         = "<%= ctx[:vars]['key_name'] %>"
-  organization         = "<%= ctx[:test_env_vars]['org_id'] %>"
-  storage_location     = "us-central1"
-  depends_on           = [ google_kms_crypto_key_iam_member.iam ]
+  disable_default_sink.  = true
+  kms_key_name           = "<%= ctx[:vars]['key_name'] %>"
+  organization           = "<%= ctx[:test_env_vars]['org_id'] %>"
+  storage_location       = "us-central1"
+  kms_service_account_id = google_logging_organization_settings.settings.logging_service_account_id
+  depends_on             = [ google_kms_crypto_key_iam_member.iam ]
 }
 
 data "google_logging_organization_settings" "settings" {

--- a/mmv1/third_party/terraform/services/logging/resource_logging_folder_settings_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_folder_settings_test.go
@@ -48,11 +48,12 @@ func TestAccLoggingFolderSettings_update(t *testing.T) {
 func testAccLoggingFolderSettings_full(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_logging_folder_settings" "example" {
-  disable_default_sink = true
-  folder               = google_folder.my_folder.folder_id
-  kms_key_name         = "%{original_key}"
-  storage_location     = "us-central1"
-  depends_on           = [ google_kms_crypto_key_iam_member.iam ]
+  disable_default_sink.  = true
+  folder                 = google_folder.my_folder.folder_id
+  kms_key_name           = "%{original_key}"
+  storage_location       = "us-central1"
+  kms_service_account_id = data.google_logging_folder_settings.settings.logging_service_account_id
+  depends_on             = [ google_kms_crypto_key_iam_member.iam ]
 }
 
 resource "google_folder" "my_folder" {

--- a/mmv1/third_party/terraform/services/logging/resource_logging_organization_settings_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_organization_settings_test.go
@@ -50,7 +50,7 @@ resource "google_logging_organization_settings" "example" {
   kms_key_name           = "%{original_key}"
   organization           = "%{org_id}"
   storage_location       = "us-central1"
-  kms_service_account_id = google_logging_organization_settings.settings.logging_service_account_id
+  kms_service_account_id = data.google_logging_organization_settings.settings.logging_service_account_id
   depends_on             = [ google_kms_crypto_key_iam_member.iam ]
 }
 

--- a/mmv1/third_party/terraform/services/logging/resource_logging_organization_settings_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_organization_settings_test.go
@@ -46,11 +46,12 @@ func TestAccLoggingOrganizationSettings_update(t *testing.T) {
 func testAccLoggingOrganizationSettings_full(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_logging_organization_settings" "example" {
-  disable_default_sink = false
-  kms_key_name         = "%{original_key}"
-  organization         = "%{org_id}"
-  storage_location     = "us-central1"
-  depends_on           = [ google_kms_crypto_key_iam_member.iam ]
+  disable_default_sink   = false
+  kms_key_name           = "%{original_key}"
+  organization           = "%{org_id}"
+  storage_location       = "us-central1"
+  kms_service_account_id = google_logging_organization_settings.settings.logging_service_account_id
+  depends_on             = [ google_kms_crypto_key_iam_member.iam ]
 }
 
 data "google_logging_organization_settings" "settings" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Google Cloud Logging now supports setting the `kmsServiceAccountId` setting at the Project, Folder, and Organization level. This PR updates the `google_logging_folder_settings` and  `google_logging_organization_settings` resource to allow setting this field. A future PR will be opened to create a new `google_logging_project_settings` resource, there is only a datasource right now as until recently there were no modifiable fields  on `google_logging_project_settings`

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
`google_logging_folder_settings` and  `google_logging_organization_settings` resources to allow setting `kms_service_account_id`
```
