### PR TITLE
Add google_logging_project_settings resource.

### DIFF
--- a/mmv1/products/logging/ProjectSettings.yaml
+++ b/mmv1/products/logging/ProjectSettings.yaml
@@ -61,7 +61,7 @@ properties:
     name: kmsServiceAccountId
     default_from_api: true
     description: |
-      The service account that will be used by the Log Router to access your Cloud KMS key.
+      The service account that will be used by the Log Router to access your Cloud KMS key. This can be modified only once to migrate from the legacy CMEK service account to the logging service account as described in [Migrate CMEK SA](https://cloud.google.com/logging/docs/routing/troubleshoot-cmek-orgs#migrate-cmek-sa).
   - !ruby/object:Api::Type::String
     name: storageLocation
     output: true

--- a/mmv1/products/logging/ProjectSettings.yaml
+++ b/mmv1/products/logging/ProjectSettings.yaml
@@ -1,0 +1,79 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'ProjectSettings'
+description: |
+  Default resource settings control whether CMEK is required for new log buckets. These settings also determine the storage location for the _Default and _Required log buckets, and whether the _Default sink is enabled or disabled.
+references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+    'Configure default settings for organizations and folders': 'https://cloud.google.com/logging/docs/default-settings'
+  api: 'https://cloud.google.com/logging/docs/reference/v2/rest/v2/TopLevel/getSettings'
+base_url: 'projects/{{project}}/settings'
+self_link: 'projects/{{project}}/settings'
+import_format: ['projects/{{project}}/settings']
+# Hardcode the updateMask since d.HasChanged does not work on create.
+create_url: 'projects/{{project}}/settings?updateMask=kmsServiceAccountId'
+update_url: 'projects/{{project}}/settings?updateMask=kmsServiceAccountId'
+# This is a singleton resource that already is created, so create
+# is really an update, and therefore should be PATCHed.
+create_verb: :PATCH
+update_verb: :PATCH
+# update_mask: true
+# This is a singleton resource that cannot be deleted, so skip delete.
+skip_delete: true
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: "logging_project_settings_all"
+    primary_resource_id: "example"
+    test_env_vars:
+      project_name: :PROJECT_NAME
+parameters:
+  - !ruby/object:Api::Type::String
+    name: 'project'
+    required: true
+    immutable: true
+    url_param_only: true
+    description: |
+      The project for which to retrieve settings.
+properties:
+  - !ruby/object:Api::Type::String
+    name: name
+    output: true
+    description: |
+      The resource name of the settings.
+  - !ruby/object:Api::Type::String
+    name: kmsKeyName
+    output: true
+    description: |
+      The resource name for the configured Cloud KMS key.
+  - !ruby/object:Api::Type::String
+    name: kmsServiceAccountId
+    default_from_api: true
+    description: |
+      The service account that will be used by the Log Router to access your Cloud KMS key.
+  - !ruby/object:Api::Type::String
+    name: storageLocation
+    output: true
+    description: |
+      The storage location that Cloud Logging will use to create new resources when a location is needed but not explicitly provided.
+  - !ruby/object:Api::Type::Boolean
+    name: disableDefaultSink
+    output: true
+    description: |
+      If set to true, the _Default sink in newly created projects and folders will created in a disabled state. This can be used to automatically disable log storage if there is already an aggregated sink configured in the hierarchy. The _Default sink can be re-enabled manually if needed.
+  - !ruby/object:Api::Type::String
+    name: loggingServiceAccountId
+    output: true
+    description: |
+      The service account for the given container. Sinks use this service account as their writerIdentity if no custom service account is provided.

--- a/mmv1/templates/terraform/examples/logging_project_settings_all.tf.erb
+++ b/mmv1/templates/terraform/examples/logging_project_settings_all.tf.erb
@@ -1,0 +1,8 @@
+resource "google_logging_project_settings" "<%= ctx[:primary_resource_id] %>" {
+  project                = "<%= ctx[:test_env_vars]['project_name'] %>"
+  kms_service_account_id = data.google_logging_project_settings.settings.kms_service_account_id
+}
+
+data "google_logging_project_settings" "settings" {
+  project = "<%= ctx[:test_env_vars]['project_name'] %>"
+}

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_settings_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_settings_test.go
@@ -1,0 +1,64 @@
+package logging_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccLoggingProjectSettings_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id": envvar.GetTestOrgFromEnv(t),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingProjectSettings_onlyRequired(context),
+			},
+			{
+				ResourceName:            "google_logging_project_settings.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"project"},
+			},
+			{
+				Config: testAccLoggingProjectSettings_full(context),
+			},
+			{
+				ResourceName:            "google_logging_project_settings.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"project"},
+			},
+		},
+	})
+}
+
+func testAccLoggingProjectSettings_full(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_logging_project_settings" "example" {
+  project                = "%{project_name}"
+  kms_service_account_id = data.google_logging_project_settings.settings.logging_service_account_id
+}
+
+data "google_logging_project_settings" "settings" {
+  project = "%{project_name}"
+}
+`, context)
+}
+
+func testAccLoggingProjectSettings_onlyRequired(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_logging_project_settings" "example" {
+  project = "%{project_name}"
+}
+`, context)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds a google_logging_project_settings resource now that it has an editable field. 

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
Adds google_logging_project_settings resource.
```
