### PR TITLE
Add `region_from_id` and `zone_from_id` provider-defined functions

### DIFF
--- a/mmv1/third_party/terraform/functions/location_from_id_test.go
+++ b/mmv1/third_party/terraform/functions/location_from_id_test.go
@@ -12,6 +12,8 @@ import (
 
 func TestAccProviderFunction_location_from_id(t *testing.T) {
 	t.Parallel()
+	// Skipping due to requiring TF 1.8.0 in VCR systems : https://github.com/hashicorp/terraform-provider-google/issues/17451
+	acctest.SkipIfVcr(t)
 
 	location := envvar.GetTestRegionFromEnv()
 	locationRegex := regexp.MustCompile(fmt.Sprintf("^%s$", location))

--- a/mmv1/third_party/terraform/functions/project_from_id_test.go
+++ b/mmv1/third_party/terraform/functions/project_from_id_test.go
@@ -12,6 +12,8 @@ import (
 
 func TestAccProviderFunction_project_from_id(t *testing.T) {
 	t.Parallel()
+	// Skipping due to requiring TF 1.8.0 in VCR systems : https://github.com/hashicorp/terraform-provider-google/issues/17451
+	acctest.SkipIfVcr(t)
 
 	projectId := envvar.GetTestProjectFromEnv()
 	projectIdRegex := regexp.MustCompile(fmt.Sprintf("^%s$", projectId))

--- a/mmv1/third_party/terraform/functions/region_from_id.go
+++ b/mmv1/third_party/terraform/functions/region_from_id.go
@@ -1,0 +1,59 @@
+package functions
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-framework/function"
+)
+
+var _ function.Function = RegionFromIdFunction{}
+
+func NewRegionFromIdFunction() function.Function {
+	return &RegionFromIdFunction{}
+}
+
+type RegionFromIdFunction struct{}
+
+func (f RegionFromIdFunction) Metadata(ctx context.Context, req function.MetadataRequest, resp *function.MetadataResponse) {
+	resp.Name = "region_from_id"
+}
+
+func (f RegionFromIdFunction) Definition(ctx context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
+	resp.Definition = function.Definition{
+		Summary:     "Returns the region name within a provided resource id, self link, or OP style resource name.",
+		Description: "Takes a single string argument, which should be a resource id, self link, or OP style resource name. This function will either return the region name from the input string or raise an error due to no region being present in the string. The function uses the presence of \"regions/{{region}}/\" in the input string to identify the region name, e.g. when the function is passed the id \"projects/my-project/regions/us-central1/subnetworks/my-subnetwork\" as an argument it will return \"us-central1\".",
+		Parameters: []function.Parameter{
+			function.StringParameter{
+				Name:        "id",
+				Description: "A string of a resource's id, a resource's self link, or an OP style resource name. For example, \"projects/my-project/regions/us-central1/subnetworks/my-subnetwork\" and \"https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1/subnetworks/my-subnetwork\" are valid values containing regions",
+			},
+		},
+		Return: function.StringReturn{},
+	}
+}
+
+func (f RegionFromIdFunction) Run(ctx context.Context, req function.RunRequest, resp *function.RunResponse) {
+	// Load arguments from function call
+	var arg0 string
+	resp.Diagnostics.Append(req.Arguments.GetArgument(ctx, 0, &arg0)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Prepare how we'll identify region name from input string
+	regex := regexp.MustCompile("regions/(?P<RegionName>[^/]+)/") // Should match the pattern below
+	template := "$RegionName"                                     // Should match the submatch identifier in the regex
+	pattern := "regions/{region}/"                                // Human-readable pseudo-regex pattern used in errors and warnings
+
+	// Validate input
+	ValidateElementFromIdArguments(arg0, regex, pattern, resp)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get and return element from input string
+	region := GetElementFromId(arg0, regex, template)
+	resp.Diagnostics.Append(resp.Result.Set(ctx, region)...)
+}

--- a/mmv1/third_party/terraform/functions/region_from_id_internal_test.go
+++ b/mmv1/third_party/terraform/functions/region_from_id_internal_test.go
@@ -1,0 +1,113 @@
+package functions
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+func TestFunctionRun_region_from_id(t *testing.T) {
+	t.Parallel()
+
+	regionName := "us-central1"
+
+	// Happy path inputs
+	validId := fmt.Sprintf("projects/my-project/regions/%s/subnetworks/my-subnetwork", regionName)
+	validSelfLink := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/my-project/regions/%s/subnetworks/my-subnetwork", regionName)
+	validOpStyleResourceName := fmt.Sprintf("//compute.googleapis.com/projects/my-project/regions/%s/addresses/my-address", regionName)
+
+	// Unhappy path inputs
+	repetitiveInput := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/my-project/regions/%s/regions/not-this-one/subnetworks/my-subnetwork", regionName)
+	invalidInput := "projects/my-project/zones/us-central1-c/instances/my-instance"
+
+	testCases := map[string]struct {
+		request  function.RunRequest
+		expected function.RunResponse
+	}{
+		"it returns the expected output value when given a valid resource id input": {
+			request: function.RunRequest{
+				Arguments: function.NewArgumentsData([]attr.Value{types.StringValue(validId)}),
+			},
+			expected: function.RunResponse{
+				Result: function.NewResultData(types.StringValue(regionName)),
+			},
+		},
+		"it returns the expected output value when given a valid resource self_link input": {
+			request: function.RunRequest{
+				Arguments: function.NewArgumentsData([]attr.Value{types.StringValue(validSelfLink)}),
+			},
+			expected: function.RunResponse{
+				Result: function.NewResultData(types.StringValue(regionName)),
+			},
+		},
+		"it returns the expected output value when given a valid OP style resource name input": {
+			request: function.RunRequest{
+				Arguments: function.NewArgumentsData([]attr.Value{types.StringValue(validOpStyleResourceName)}),
+			},
+			expected: function.RunResponse{
+				Result: function.NewResultData(types.StringValue(regionName)),
+			},
+		},
+		"it returns a warning and the first submatch when given repetitive input": {
+			request: function.RunRequest{
+				Arguments: function.NewArgumentsData([]attr.Value{types.StringValue(repetitiveInput)}),
+			},
+			expected: function.RunResponse{
+				Result: function.NewResultData(types.StringValue(regionName)),
+				Diagnostics: diag.Diagnostics{
+					diag.NewArgumentWarningDiagnostic(
+						0,
+						ambiguousMatchesWarningSummary,
+						fmt.Sprintf("The input string \"%s\" contains more than one match for the pattern \"regions/{region}/\". Terraform will use the first found match.", repetitiveInput),
+					),
+				},
+			},
+		},
+		"it returns an error when given input with no submatches": {
+			request: function.RunRequest{
+				Arguments: function.NewArgumentsData([]attr.Value{types.StringValue(invalidInput)}),
+			},
+			expected: function.RunResponse{
+				Result: function.NewResultData(types.StringNull()),
+				Diagnostics: diag.Diagnostics{
+					diag.NewArgumentErrorDiagnostic(
+						0,
+						noMatchesErrorSummary,
+						fmt.Sprintf("The input string \"%s\" doesn't contain the expected pattern \"regions/{region}/\".", invalidInput),
+					),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		tn, tc := name, testCase
+
+		t.Run(tn, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			got := function.RunResponse{
+				Result: function.NewResultData(basetypes.StringValue{}),
+			}
+
+			// Act
+			NewRegionFromIdFunction().Run(context.Background(), tc.request, &got)
+
+			// Assert
+			if diff := cmp.Diff(got.Result, tc.expected.Result); diff != "" {
+				t.Errorf("unexpected diff between expected and received result: %s", diff)
+			}
+			if diff := cmp.Diff(got.Diagnostics, tc.expected.Diagnostics); diff != "" {
+				t.Errorf("unexpected diff between expected and received diagnostics: %s", diff)
+			}
+		})
+	}
+}

--- a/mmv1/third_party/terraform/functions/region_from_id_test.go
+++ b/mmv1/third_party/terraform/functions/region_from_id_test.go
@@ -12,6 +12,8 @@ import (
 
 func TestAccProviderFunction_region_from_id(t *testing.T) {
 	t.Parallel()
+	// Skipping due to requiring TF 1.8.0 in VCR systems : https://github.com/hashicorp/terraform-provider-google/issues/17451
+	acctest.SkipIfVcr(t)
 
 	region := envvar.GetTestRegionFromEnv()
 	regionRegex := regexp.MustCompile(fmt.Sprintf("^%s$", region))

--- a/mmv1/third_party/terraform/functions/region_from_id_test.go
+++ b/mmv1/third_party/terraform/functions/region_from_id_test.go
@@ -29,7 +29,7 @@ func TestAccProviderFunction_region_from_id(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Can get the region from a resource's id in one step
-				// Uses google_compute_subnetwork resource's id attribute with format projects/{{project}}/regions/{{region}}/subnetworks/{{name}}
+				// Uses google_compute_node_template resource's id attribute with format projects/{{project}}/regions/{{region}}/nodeTemplates/{{name}}
 				Config: testProviderFunction_get_region_from_resource_id(context),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchOutput(context["output_name"].(string), regionRegex),
@@ -37,7 +37,7 @@ func TestAccProviderFunction_region_from_id(t *testing.T) {
 			},
 			{
 				// Can get the region from a resource's self_link in one step
-				// Uses google_compute_subnetwork resource's self_link attribute
+				// Uses google_compute_node_template resource's self_link attribute
 				Config: testProviderFunction_get_region_from_resource_self_link(context),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchOutput(context["output_name"].(string), regionRegex),
@@ -58,18 +58,12 @@ terraform {
   }
 }
 
-data "google_compute_network" "default" {
-  name = "default"
-}
-
-resource "google_compute_subnetwork" "default" {
-  name          = "%{resource_name}"
-  ip_cidr_range = "10.2.0.0/16"
-  network        = data.google_compute_network.default.id
+resource "google_compute_node_template" "default" {
+  name      = "%{resource_name}"
 }
 
 output "%{output_name}" {
-  value = provider::google::%{function_name}(google_compute_subnetwork.default.id)
+  value = provider::google::%{function_name}(google_compute_node_template.default.id)
 }
 `, context)
 }
@@ -85,18 +79,12 @@ terraform {
   }
 }
 
-data "google_compute_network" "default" {
-  name = "default"
-}
-
-resource "google_compute_subnetwork" "default" {
-  name          = "%{resource_name}"
-  ip_cidr_range = "10.2.0.0/16"
-  network        = data.google_compute_network.default.id
+resource "google_compute_node_template" "default" {
+  name      = "%{resource_name}"
 }
 
 output "%{output_name}" {
-  value = provider::google::%{function_name}(google_compute_subnetwork.default.self_link)
+  value = provider::google::%{function_name}(google_compute_node_template.default.self_link)
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/functions/region_from_id_test.go
+++ b/mmv1/third_party/terraform/functions/region_from_id_test.go
@@ -49,11 +49,11 @@ func testProviderFunction_get_region_from_resource_id(context map[string]interfa
 	return acctest.Nprintf(`
 # terraform block required for provider function to be found
 terraform {
-	required_providers {
-		google = {
-			source = "hashicorp/google"
-		}
-	}
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
 }
 
 data "google_compute_network" "default" {
@@ -76,11 +76,11 @@ func testProviderFunction_get_region_from_resource_self_link(context map[string]
 	return acctest.Nprintf(`
 # terraform block required for provider function to be found
 terraform {
-	required_providers {
-		google = {
-			source = "hashicorp/google"
-		}
-	}
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
 }
 
 data "google_compute_network" "default" {
@@ -94,7 +94,7 @@ resource "google_compute_subnetwork" "default" {
 }
 
 output "%{output_name}" {
-	value = provider::google::%{function_name}(google_compute_subnetwork.default.self_link)
+  value = provider::google::%{function_name}(google_compute_subnetwork.default.self_link)
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/functions/region_from_id_test.go
+++ b/mmv1/third_party/terraform/functions/region_from_id_test.go
@@ -1,0 +1,100 @@
+package functions_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccProviderFunction_region_from_id(t *testing.T) {
+	t.Parallel()
+
+	region := envvar.GetTestRegionFromEnv()
+	regionRegex := regexp.MustCompile(fmt.Sprintf("^%s$", region))
+
+	context := map[string]interface{}{
+		"function_name": "region_from_id",
+		"output_name":   "region",
+		"resource_name": fmt.Sprintf("tf-test-region-id-func-%s", acctest.RandString(t, 10)),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				// Can get the region from a resource's id in one step
+				// Uses google_compute_subnetwork resource's id attribute with format projects/{{project}}/regions/{{region}}/subnetworks/{{name}}
+				Config: testProviderFunction_get_region_from_resource_id(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchOutput(context["output_name"].(string), regionRegex),
+				),
+			},
+			{
+				// Can get the region from a resource's self_link in one step
+				// Uses google_compute_subnetwork resource's self_link attribute
+				Config: testProviderFunction_get_region_from_resource_self_link(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchOutput(context["output_name"].(string), regionRegex),
+				),
+			},
+		},
+	})
+}
+
+func testProviderFunction_get_region_from_resource_id(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+# terraform block required for provider function to be found
+terraform {
+	required_providers {
+		google = {
+			source = "hashicorp/google"
+		}
+	}
+}
+
+data "google_compute_network" "default" {
+  name = "default"
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "%{resource_name}"
+  ip_cidr_range = "10.2.0.0/16"
+  network        = data.google_compute_network.default.id
+}
+
+output "%{output_name}" {
+  value = provider::google::%{function_name}(google_compute_subnetwork.default.id)
+}
+`, context)
+}
+
+func testProviderFunction_get_region_from_resource_self_link(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+# terraform block required for provider function to be found
+terraform {
+	required_providers {
+		google = {
+			source = "hashicorp/google"
+		}
+	}
+}
+
+data "google_compute_network" "default" {
+  name = "default"
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "%{resource_name}"
+  ip_cidr_range = "10.2.0.0/16"
+  network        = data.google_compute_network.default.id
+}
+
+output "%{output_name}" {
+	value = provider::google::%{function_name}(google_compute_subnetwork.default.self_link)
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/functions/zone_from_id.go
+++ b/mmv1/third_party/terraform/functions/zone_from_id.go
@@ -1,0 +1,59 @@
+package functions
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-framework/function"
+)
+
+var _ function.Function = ZoneFromIdFunction{}
+
+func NewZoneFromIdFunction() function.Function {
+	return &ZoneFromIdFunction{}
+}
+
+type ZoneFromIdFunction struct{}
+
+func (f ZoneFromIdFunction) Metadata(ctx context.Context, req function.MetadataRequest, resp *function.MetadataResponse) {
+	resp.Name = "zone_from_id"
+}
+
+func (f ZoneFromIdFunction) Definition(ctx context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
+	resp.Definition = function.Definition{
+		Summary:     "Returns the zone name within the resource id or self link provided as an argument.",
+		Description: "Takes a single string argument, which should be an id or self link of a resource. This function will either return the zone name from the input string or raise an error due to no zone being present in the string. The function uses the presence of \"zones/{{zone}}/\" in the input string to identify the zone name, e.g. when the function is passed the id \"projects/my-project/zones/us-central1-c/instances/my-instance\" as an argument it will return \"us-central1-c\".",
+		Parameters: []function.Parameter{
+			function.StringParameter{
+				Name:        "id",
+				Description: "An id of a resouce, or a self link. For example, both \"projects/my-project/zones/us-central1-c/instances/my-instance\" and \"https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-c/instances/my-instance\" are valid inputs",
+			},
+		},
+		Return: function.StringReturn{},
+	}
+}
+
+func (f ZoneFromIdFunction) Run(ctx context.Context, req function.RunRequest, resp *function.RunResponse) {
+	// Load arguments from function call
+	var arg0 string
+	resp.Diagnostics.Append(req.Arguments.GetArgument(ctx, 0, &arg0)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Prepare how we'll identify zone name from input string
+	regex := regexp.MustCompile("zones/(?P<ZoneName>[^/]+)/") // Should match the pattern below
+	template := "$ZoneName"                                   // Should match the submatch identifier in the regex
+	pattern := "zones/{zone}/"                                // Human-readable pseudo-regex pattern used in errors and warnings
+
+	// Validate input
+	ValidateElementFromIdArguments(arg0, regex, pattern, resp)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get and return element from input string
+	zone := GetElementFromId(arg0, regex, template)
+	resp.Diagnostics.Append(resp.Result.Set(ctx, zone)...)
+}

--- a/mmv1/third_party/terraform/functions/zone_from_id_internal_test.go
+++ b/mmv1/third_party/terraform/functions/zone_from_id_internal_test.go
@@ -1,0 +1,114 @@
+package functions
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestFunctionRun_zone_from_id(t *testing.T) {
+	t.Parallel()
+
+	zone := envvar.GetTestZoneFromEnv()
+
+	// Happy path inputs
+	validId := fmt.Sprintf("projects/my-project/zones/%s/networkEndpointGroups/my-neg", zone)
+	validSelfLink := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/my-project/zones/%s/networkEndpointGroups/my-neg", zone)
+	validOpStyleResourceName := fmt.Sprintf("//compute.googleapis.com/projects/my-project/zones/%s/instances/my-instance", zone)
+
+	// Unhappy path inputs
+	repetitiveInput := fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/my-project/zones/%s/zones/not-this-one/networkEndpointGroups/my-neg", zone)
+	invalidInput := "projects/my-project/regions/us-central1/subnetworks/my-subnetwork"
+
+	testCases := map[string]struct {
+		request  function.RunRequest
+		expected function.RunResponse
+	}{
+		"it returns the expected output value when given a valid resource id input": {
+			request: function.RunRequest{
+				Arguments: function.NewArgumentsData([]attr.Value{types.StringValue(validId)}),
+			},
+			expected: function.RunResponse{
+				Result: function.NewResultData(types.StringValue(zone)),
+			},
+		},
+		"it returns the expected output value when given a valid resource self_link input": {
+			request: function.RunRequest{
+				Arguments: function.NewArgumentsData([]attr.Value{types.StringValue(validSelfLink)}),
+			},
+			expected: function.RunResponse{
+				Result: function.NewResultData(types.StringValue(zone)),
+			},
+		},
+		"it returns the expected output value when given a valid OP style resource name input": {
+			request: function.RunRequest{
+				Arguments: function.NewArgumentsData([]attr.Value{types.StringValue(validOpStyleResourceName)}),
+			},
+			expected: function.RunResponse{
+				Result: function.NewResultData(types.StringValue(zone)),
+			},
+		},
+		"it returns a warning and the first submatch when given repetitive input": {
+			request: function.RunRequest{
+				Arguments: function.NewArgumentsData([]attr.Value{types.StringValue(repetitiveInput)}),
+			},
+			expected: function.RunResponse{
+				Result: function.NewResultData(types.StringValue(zone)),
+				Diagnostics: diag.Diagnostics{
+					diag.NewArgumentWarningDiagnostic(
+						0,
+						ambiguousMatchesWarningSummary,
+						fmt.Sprintf("The input string \"%s\" contains more than one match for the pattern \"regions/{region}/\". Terraform will use the first found match.", repetitiveInput),
+					),
+				},
+			},
+		},
+		"it returns an error when given input with no submatches": {
+			request: function.RunRequest{
+				Arguments: function.NewArgumentsData([]attr.Value{types.StringValue(invalidInput)}),
+			},
+			expected: function.RunResponse{
+				Result: function.NewResultData(types.StringNull()),
+				Diagnostics: diag.Diagnostics{
+					diag.NewArgumentErrorDiagnostic(
+						0,
+						noMatchesErrorSummary,
+						fmt.Sprintf("The input string \"%s\" doesn't contain the expected pattern \"regions/{region}/\".", invalidInput),
+					),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		tn, tc := name, testCase
+
+		t.Run(tn, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			got := function.RunResponse{
+				Result: function.NewResultData(basetypes.StringValue{}),
+			}
+
+			// Act
+			NewZoneFromIdFunction().Run(context.Background(), tc.request, &got)
+
+			// Assert
+			if diff := cmp.Diff(got.Result, tc.expected.Result); diff != "" {
+				t.Errorf("unexpected diff between expected and received result: %s", diff)
+			}
+			if diff := cmp.Diff(got.Diagnostics, tc.expected.Diagnostics); diff != "" {
+				t.Errorf("unexpected diff between expected and received diagnostics: %s", diff)
+			}
+		})
+	}
+}

--- a/mmv1/third_party/terraform/functions/zone_from_id_internal_test.go
+++ b/mmv1/third_party/terraform/functions/zone_from_id_internal_test.go
@@ -11,13 +11,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/function"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestFunctionRun_zone_from_id(t *testing.T) {
 	t.Parallel()
 
-	zone := envvar.GetTestZoneFromEnv()
+	zone := "us-central1-a"
 
 	// Happy path inputs
 	validId := fmt.Sprintf("projects/my-project/zones/%s/networkEndpointGroups/my-neg", zone)

--- a/mmv1/third_party/terraform/functions/zone_from_id_internal_test.go
+++ b/mmv1/third_party/terraform/functions/zone_from_id_internal_test.go
@@ -81,7 +81,7 @@ func TestFunctionRun_zone_from_id(t *testing.T) {
 					diag.NewArgumentErrorDiagnostic(
 						0,
 						noMatchesErrorSummary,
-						fmt.Sprintf("The input string \"%s\" doesn't contain the expected pattern \"regions/{region}/\".", invalidInput),
+						fmt.Sprintf("The input string \"%s\" doesn't contain the expected pattern \"zones/{zone}/\".", invalidInput),
 					),
 				},
 			},

--- a/mmv1/third_party/terraform/functions/zone_from_id_internal_test.go
+++ b/mmv1/third_party/terraform/functions/zone_from_id_internal_test.go
@@ -66,7 +66,7 @@ func TestFunctionRun_zone_from_id(t *testing.T) {
 					diag.NewArgumentWarningDiagnostic(
 						0,
 						ambiguousMatchesWarningSummary,
-						fmt.Sprintf("The input string \"%s\" contains more than one match for the pattern \"regions/{region}/\". Terraform will use the first found match.", repetitiveInput),
+						fmt.Sprintf("The input string \"%s\" contains more than one match for the pattern \"zones/{zone}/\". Terraform will use the first found match.", repetitiveInput),
 					),
 				},
 			},

--- a/mmv1/third_party/terraform/functions/zone_from_id_test.go
+++ b/mmv1/third_party/terraform/functions/zone_from_id_test.go
@@ -29,7 +29,7 @@ func TestAccProviderFunction_zone_from_id(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Can get the zone from a resource's id in one step
-				// Uses google_compute_disk resource's id attribute with format projects/{{project}}/zones/{{zone}}/networkEndpointGroups/{{name}}
+				// Uses google_compute_disk resource's id attribute with format projects/{{project}}/zones/{{zone}}/disks/{{name}}
 				Config: testProviderFunction_get_zone_from_resource_id(context),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchOutput(context["output_name"].(string), zoneRegex),

--- a/mmv1/third_party/terraform/functions/zone_from_id_test.go
+++ b/mmv1/third_party/terraform/functions/zone_from_id_test.go
@@ -12,6 +12,8 @@ import (
 
 func TestAccProviderFunction_zone_from_id(t *testing.T) {
 	t.Parallel()
+	// Skipping due to requiring TF 1.8.0 in VCR systems : https://github.com/hashicorp/terraform-provider-google/issues/17451
+	acctest.SkipIfVcr(t)
 
 	zone := envvar.GetTestZoneFromEnv()
 	zoneRegex := regexp.MustCompile(fmt.Sprintf("^%s$", zone))

--- a/mmv1/third_party/terraform/functions/zone_from_id_test.go
+++ b/mmv1/third_party/terraform/functions/zone_from_id_test.go
@@ -49,11 +49,11 @@ func testProviderFunction_get_zone_from_resource_id(context map[string]interface
 	return acctest.Nprintf(`
 # terraform block required for provider function to be found
 terraform {
-	required_providers {
-		google = {
-			source = "hashicorp/google"
-		}
-	}
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
 }
 
 data "google_compute_network" "default" {
@@ -74,7 +74,7 @@ resource "google_compute_network_endpoint_group" "default" {
 }
 
 output "%{output_name}" {
-	value = provider::google::%{function_name}(google_compute_network_endpoint_group.default.id)
+  value = provider::google::%{function_name}(google_compute_network_endpoint_group.default.id)
 }
 `, context)
 }
@@ -83,11 +83,11 @@ func testProviderFunction_get_zone_from_resource_self_link(context map[string]in
 	return acctest.Nprintf(`
 # terraform block required for provider function to be found
 terraform {
-	required_providers {
-		google = {
-			source = "hashicorp/google"
-		}
-	}
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
 }
 
 data "google_compute_network" "default" {
@@ -108,7 +108,7 @@ resource "google_compute_network_endpoint_group" "default" {
 }
 
 output "%{output_name}" {
-	value = provider::google::%{function_name}(google_compute_network_endpoint_group.default.self_link)
+  value = provider::google::%{function_name}(google_compute_network_endpoint_group.default.self_link)
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/functions/zone_from_id_test.go
+++ b/mmv1/third_party/terraform/functions/zone_from_id_test.go
@@ -29,7 +29,7 @@ func TestAccProviderFunction_zone_from_id(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Can get the zone from a resource's id in one step
-				// Uses google_compute_network_endpoint_group resource's id attribute with format projects/{{project}}/zones/{{zone}}/networkEndpointGroups/{{name}}
+				// Uses google_compute_disk resource's id attribute with format projects/{{project}}/zones/{{zone}}/networkEndpointGroups/{{name}}
 				Config: testProviderFunction_get_zone_from_resource_id(context),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchOutput(context["output_name"].(string), zoneRegex),
@@ -37,7 +37,7 @@ func TestAccProviderFunction_zone_from_id(t *testing.T) {
 			},
 			{
 				// Can get the zone from a resource's self_link in one step
-				// Uses google_compute_network_endpoint_group resource's self_link attribute
+				// Uses google_compute_disk resource's self_link attribute
 				Config: testProviderFunction_get_zone_from_resource_self_link(context),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchOutput(context["output_name"].(string), zoneRegex),
@@ -58,25 +58,12 @@ terraform {
   }
 }
 
-data "google_compute_network" "default" {
-  name = "default"
-}
-
-resource "google_compute_subnetwork" "default" {
-  name          = "%{resource_name}"
-  ip_cidr_range = "10.2.0.0/16"
-  network        = data.google_compute_network.default.id
-}
-
-resource "google_compute_network_endpoint_group" "default" {
-  name         = "%{resource_name}"
-  network      = data.google_compute_network.default.id
-  subnetwork   = google_compute_subnetwork.default.id
-  default_port = "90"
+resource "google_compute_disk" "default" {
+  name  = "%{resource_name}"
 }
 
 output "%{output_name}" {
-  value = provider::google::%{function_name}(google_compute_network_endpoint_group.default.id)
+  value = provider::google::%{function_name}(google_compute_disk.default.id)
 }
 `, context)
 }
@@ -92,25 +79,12 @@ terraform {
   }
 }
 
-data "google_compute_network" "default" {
-  name = "default"
-}
-
-resource "google_compute_subnetwork" "default" {
-  name          = "%{resource_name}"
-  ip_cidr_range = "10.2.0.0/16"
-  network        = data.google_compute_network.default.id
-}
-
-resource "google_compute_network_endpoint_group" "default" {
-  name         = "%{resource_name}"
-  network      = data.google_compute_network.default.id
-  subnetwork   = google_compute_subnetwork.default.id
-  default_port = "90"
+resource "google_compute_disk" "default" {
+  name  = "%{resource_name}"
 }
 
 output "%{output_name}" {
-  value = provider::google::%{function_name}(google_compute_network_endpoint_group.default.self_link)
+  value = provider::google::%{function_name}(google_compute_disk.default.self_link)
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/functions/zone_from_id_test.go
+++ b/mmv1/third_party/terraform/functions/zone_from_id_test.go
@@ -1,0 +1,114 @@
+package functions_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccProviderFunction_zone_from_id(t *testing.T) {
+	t.Parallel()
+
+	zone := envvar.GetTestZoneFromEnv()
+	zoneRegex := regexp.MustCompile(fmt.Sprintf("^%s$", zone))
+
+	context := map[string]interface{}{
+		"function_name": "zone_from_id",
+		"output_name":   "zone",
+		"resource_name": fmt.Sprintf("tf-test-zone-id-func-%s", acctest.RandString(t, 10)),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				// Can get the zone from a resource's id in one step
+				// Uses google_compute_network_endpoint_group resource's id attribute with format projects/{{project}}/zones/{{zone}}/networkEndpointGroups/{{name}}
+				Config: testProviderFunction_get_zone_from_resource_id(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchOutput(context["output_name"].(string), zoneRegex),
+				),
+			},
+			{
+				// Can get the zone from a resource's self_link in one step
+				// Uses google_compute_network_endpoint_group resource's self_link attribute
+				Config: testProviderFunction_get_zone_from_resource_self_link(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchOutput(context["output_name"].(string), zoneRegex),
+				),
+			},
+		},
+	})
+}
+
+func testProviderFunction_get_zone_from_resource_id(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+# terraform block required for provider function to be found
+terraform {
+	required_providers {
+		google = {
+			source = "hashicorp/google"
+		}
+	}
+}
+
+data "google_compute_network" "default" {
+  name = "default"
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "%{resource_name}"
+  ip_cidr_range = "10.2.0.0/16"
+  network        = data.google_compute_network.default.id
+}
+
+resource "google_compute_network_endpoint_group" "default" {
+  name         = "%{resource_name}"
+  network      = data.google_compute_network.default.id
+  subnetwork   = google_compute_subnetwork.default.id
+  default_port = "90"
+}
+
+output "%{output_name}" {
+	value = provider::google::%{function_name}(google_compute_network_endpoint_group.default.id)
+}
+`, context)
+}
+
+func testProviderFunction_get_zone_from_resource_self_link(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+# terraform block required for provider function to be found
+terraform {
+	required_providers {
+		google = {
+			source = "hashicorp/google"
+		}
+	}
+}
+
+data "google_compute_network" "default" {
+  name = "default"
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "%{resource_name}"
+  ip_cidr_range = "10.2.0.0/16"
+  network        = data.google_compute_network.default.id
+}
+
+resource "google_compute_network_endpoint_group" "default" {
+  name         = "%{resource_name}"
+  network      = data.google_compute_network.default.id
+  subnetwork   = google_compute_subnetwork.default.id
+  default_port = "90"
+}
+
+output "%{output_name}" {
+	value = provider::google::%{function_name}(google_compute_network_endpoint_group.default.self_link)
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/fwprovider/framework_provider.go.erb
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider.go.erb
@@ -305,5 +305,6 @@ func (p *FrameworkProvider) Functions(_ context.Context) []func() function.Funct
 	return []func() function.Function{
 		functions.NewProjectFromIdFunction,
 		functions.NewLocationFromIdFunction,
+		functions.NewRegionFromIdFunction,
 	}
 }

--- a/mmv1/third_party/terraform/fwprovider/framework_provider.go.erb
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider.go.erb
@@ -306,5 +306,6 @@ func (p *FrameworkProvider) Functions(_ context.Context) []func() function.Funct
 		functions.NewProjectFromIdFunction,
 		functions.NewLocationFromIdFunction,
 		functions.NewRegionFromIdFunction,
+		functions.NewZoneFromIdFunction,
 	}
 }

--- a/mmv1/third_party/terraform/website/docs/functions/region_from_id.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/functions/region_from_id.html.markdown
@@ -1,0 +1,61 @@
+---
+page_title: region_from_id Function - terraform-provider-google
+description: |-
+  Returns the region within a provided resource id, self link, or OP style resource name.
+---
+
+# Function: region_from_id
+
+Returns the region within a provided resource's id, resource URI, self link, or full resource name.
+
+For more information about using provider-defined functions with Terraform [see the official documentation](https://developer.hashicorp.com/terraform/plugin/framework/functions/concepts).
+
+## Example Usage
+
+### Use with the `google` provider
+
+```terraform
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+# Value is "us-central1"
+output "function_output" {
+  value = provider::google::region_from_id("https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1/subnetworks/my-subnetwork")
+}
+```
+
+### Use with the `google-beta` provider
+
+```terraform
+terraform {
+  required_providers {
+    google-beta = {
+      source = "hashicorp/google-beta"
+    }
+  }
+}
+
+# Value is "us-central1"
+output "function_output" {
+  value = provider::google-beta::region_from_id("https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1/subnetworks/my-subnetwork")
+}
+```
+
+## Signature
+
+```text
+region_from_id(id string) string
+```
+
+## Arguments
+
+1. `id` (String) A string of a resource's id, resource URI, self link, or full resource name. For example, these are all valid values:
+
+* `"projects/my-project/regions/us-central1/subnetworks/my-subnetwork"`
+* `"https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1/subnetworks/my-subnetwork"`
+* `"//compute.googleapis.com/projects/my-project/regions/us-central1/subnetworks/my-subnetwork"`

--- a/mmv1/third_party/terraform/website/docs/functions/region_from_id.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/functions/region_from_id.html.markdown
@@ -23,9 +23,19 @@ terraform {
   }
 }
 
+resource "google_compute_node_template" "default" {
+  name = "my-node-template"
+  region = "us-central1"
+}
+
 # Value is "us-central1"
-output "function_output" {
-  value = provider::google::region_from_id("https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1/subnetworks/my-subnetwork")
+output "region_from_id" {
+  value = provider::google::region_from_id(google_compute_node_template.default.id)
+}
+
+# Value is "us-central1"
+output "region_from_self_link" {
+  value = provider::google::region_from_id(google_compute_node_template.default.self_link)
 }
 ```
 
@@ -40,9 +50,20 @@ terraform {
   }
 }
 
+resource "google_compute_node_template" "default" {
+  # provider argument omitted - provisioning by google or google-beta doesn't impact this example
+  name = "my-node-template"
+  region = "us-central1"
+}
+
 # Value is "us-central1"
-output "function_output" {
-  value = provider::google-beta::region_from_id("https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1/subnetworks/my-subnetwork")
+output "region_from_id" {
+  value = provider::google-beta::region_from_id(google_compute_node_template.default.id)
+}
+
+# Value is "us-central1"
+output "region_from_self_link" {
+  value = provider::google-beta::region_from_id(google_compute_node_template.default.self_link)
 }
 ```
 

--- a/mmv1/third_party/terraform/website/docs/functions/zone_from_id.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/functions/zone_from_id.html.markdown
@@ -1,0 +1,61 @@
+---
+page_title: zone_from_id Function - terraform-provider-google
+description: |-
+  Returns the project within a provided resource id, self link, or OP style resource name.
+---
+
+# Function: zone_from_id
+
+Returns the zone within a provided resource's id, resource URI, self link, or full resource name.
+
+For more information about using provider-defined functions with Terraform [see the official documentation](https://developer.hashicorp.com/terraform/plugin/framework/functions/concepts).
+
+## Example Usage
+
+### Use with the `google` provider
+
+```terraform
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+# Value is "us-central1-c"
+output "function_output" {
+  value = provider::google::zone_from_id("https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-c/instances/my-instance")
+}
+```
+
+### Use with the `google-beta` provider
+
+```terraform
+terraform {
+  required_providers {
+    google-beta = {
+      source = "hashicorp/google-beta"
+    }
+  }
+}
+
+# Value is "us-central1-c"
+output "function_output" {
+  value = provider::google-beta::zone_from_id("https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-c/instances/my-instance")
+}
+```
+
+## Signature
+
+```text
+zone_from_id(id string) string
+```
+
+## Arguments
+
+1. `id` (String) A string of a resource's id, resource URI, self link, or full resource name. For example, these are all valid values:
+
+* `"projects/my-project/zones/us-central1-c/instances/my-instance"`
+* `"https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-c/instances/my-instance"`
+* `"//gkehub.googleapis.com/projects/my-project/locations/us-central1/memberships/my-membership"`

--- a/mmv1/third_party/terraform/website/docs/functions/zone_from_id.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/functions/zone_from_id.html.markdown
@@ -23,9 +23,19 @@ terraform {
   }
 }
 
+resource "google_compute_disk" "default" {
+  name  = "my-disk"
+  zone  = "us-central1-c"
+}
+
 # Value is "us-central1-c"
-output "function_output" {
-  value = provider::google::zone_from_id("https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-c/instances/my-instance")
+output "zone_from_id" {
+  value = provider::google::zone_from_id(google_compute_disk.default.id)
+}
+
+# Value is "us-central1-c"
+output "zone_from_self_link" {
+  value = provider::google::zone_from_id(google_compute_disk.default.self_link)
 }
 ```
 
@@ -40,9 +50,19 @@ terraform {
   }
 }
 
+resource "google_compute_disk" "default" {
+  name  = "my-disk"
+  zone  = "us-central1-c"
+}
+
 # Value is "us-central1-c"
-output "function_output" {
-  value = provider::google-beta::zone_from_id("https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-c/instances/my-instance")
+output "zone_from_id" {
+  value = provider::google-beta::zone_from_id(google_compute_disk.default.id)
+}
+
+# Value is "us-central1-c"
+output "zone_from_self_link" {
+  value = provider::google-beta::zone_from_id(google_compute_disk.default.self_link)
 }
 ```
 

--- a/mmv1/third_party/terraform/website/docs/functions/zone_from_id.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/functions/zone_from_id.html.markdown
@@ -51,6 +51,7 @@ terraform {
 }
 
 resource "google_compute_disk" "default" {
+  # provider argument omitted - provisioning by google or google-beta doesn't impact this example
   name  = "my-disk"
   zone  = "us-central1-c"
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR adds support for 2 new provider-defined functions:
- region_from_id
- zone_from_id

There are unit and acceptance tests for both of these, and documentation

## Note about testing

Currently, testing this PR requires downloading an [alpha release of TF 1.8.0](https://github.com/hashicorp/terraform/releases/tag/v1.8.0-alpha20240216) and running the acceptance test locally. The unit tests should work fine because they don't use a TF binary like acc tests do, and the dependencies on this branch include provider function support.


------

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
provider: added provider-defined function `region_from_id` for retrieving the region from a resource's self link or id
```

```release-note:enhancement
provider: added provider-defined function `zone_from_id` for retrieving the zone from a resource's self link or id
```