### PR TITLE
Create resource definition for IAP Tunnel DestGroup

### DIFF
--- a/mmv1/products/iap/TunnelDestGroup.yaml
+++ b/mmv1/products/iap/TunnelDestGroup.yaml
@@ -40,7 +40,6 @@ iam_policy: !ruby/object:Api::Resource::IamPolicy
     'projects/{{project}}/iap_tunnel/locations/{{region}}/destGroups/{{dest_group}}',
     '{{project}}/iap_tunnel/locations/{{region}}/destGroups/{{dest_group}}',
   ]
-
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'iap_destgroup'

--- a/mmv1/products/iap/TunnelDestGroup.yaml
+++ b/mmv1/products/iap/TunnelDestGroup.yaml
@@ -28,7 +28,6 @@ import_format: [
   '{{project}}/iap_tunnel/locations/{{region}}/destGroups/{{group_name}}',
   '{{region}}/destGroups/{{group_name}}',
 ]
-
 iam_policy: !ruby/object:Api::Resource::IamPolicy
   skip_import_test: true
   parent_resource_attribute: 'dest_group'

--- a/mmv1/products/iap/TunnelDestGroup.yaml
+++ b/mmv1/products/iap/TunnelDestGroup.yaml
@@ -1,0 +1,80 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'TunnelDestGroup'
+description: |
+  Tunnel destination groups represent resources that have the same tunnel access restrictions.
+references: !ruby/object:Api::Resource::ReferenceLinks
+  api: 'https://cloud.google.com/iap/docs/reference/rest/v1/projects.iap_tunnel.locations.destGroups'
+  guides:
+    'Set up IAP TCP forwarding with an IP address or hostname in a Google Cloud or non-Google Cloud environment': 'https://cloud.google.com/iap/docs/tcp-by-host'
+base_url: 'projects/{{project}}/iap_tunnel/locations/{{region}}/destGroups'
+create_url: 'projects/{{project}}/iap_tunnel/locations/{{region}}/destGroups?tunnelDestGroupId={{group_name}}'
+update_verb: :PATCH
+self_link: 'projects/{{project}}/iap_tunnel/locations/{{region}}/destGroups/{{group_name}}'
+import_format: [
+  'projects/{{project}}/iap_tunnel/locations/{{region}}/destGroups/{{group_name}}',
+  '{{project}}/iap_tunnel/locations/{{region}}/destGroups/{{group_name}}',
+  '{{region}}/destGroups/{{group_name}}',
+]
+
+iam_policy: !ruby/object:Api::Resource::IamPolicy
+  skip_import_test: true
+  parent_resource_attribute: 'dest_group'
+  method_name_separator: ':'
+  fetch_iam_policy_verb: :POST
+  allowed_iam_role: 'roles/iap.tunnelResourceAccessor'
+  iam_conditions_request_type: :REQUEST_BODY
+  base_url: 'projects/{{project}}/iap_tunnel/locations/{{region}}/destGroups/{{dest_group}}'
+  import_format: [
+    'projects/{{project}}/iap_tunnel/locations/{{region}}/destGroups/{{dest_group}}',
+    '{{project}}/iap_tunnel/locations/{{region}}/destGroups/{{dest_group}}',
+  ]
+
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'iap_destgroup'
+    pull_external: true
+    primary_resource_id: 'dest_group'
+    primary_resource_name: 'fmt.Sprintf("tf-test%s", context["random_suffix"])'
+parameters:
+  - !ruby/object:Api::Type::String
+    name: 'region'
+    description: |
+      The region of the tunnel group. Must be the same as the network resources in the group.
+    immutable: true
+    url_param_only: true
+    default_from_api: true
+  - !ruby/object:Api::Type::String
+    name: 'group_name'
+    description: Unique tunnel destination group name.
+    required: true
+    immutable: true
+    url_param_only: true
+properties:
+  - !ruby/object:Api::Type::String
+    name: 'name'
+    description: Full resource name.
+    immutable: true
+    output: true
+  - !ruby/object:Api::Type::Array
+    name: 'cidrs'
+    description: |
+      List of CIDRs that this group applies to.
+    item_type: Api::Type::String
+  - !ruby/object:Api::Type::Array
+    name: 'fqdns'
+    description: |
+      List of FQDNs that this group applies to.
+    item_type: Api::Type::String

--- a/mmv1/templates/terraform/examples/iap_destgroup.tf.erb
+++ b/mmv1/templates/terraform/examples/iap_destgroup.tf.erb
@@ -1,0 +1,9 @@
+resource "google_iap_tunnel_dest_group" "dest_group" {
+  region = "us-central1"
+  group_name = "testgroup%{random_suffix}"
+  cidrs = [
+    "10.1.0.0/16",
+    "192.168.10.0/24",
+  ]
+}
+

--- a/mmv1/third_party/terraform/services/iap/resource_iap_tunnel_dest_group_test.go
+++ b/mmv1/third_party/terraform/services/iap/resource_iap_tunnel_dest_group_test.go
@@ -1,0 +1,94 @@
+package iap_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccIapTunnelDestGroup_updates(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {},
+			"time":   {},
+		},
+		CheckDestroy: testAccCheckIapTunnelDestGroupDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIapTunnelDestGroup_full(context),
+			},
+			{
+				ResourceName:            "google_iap_tunnel_dest_group.dest_group",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"region", "group_name"},
+			},
+			{
+				Config: testAccIapTunnelDestGroup_updated(context),
+			},
+			{
+				ResourceName:            "google_iap_tunnel_dest_group.dest_group",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"region", "group_name"},
+			},
+			{
+				Config: testAccIapTunnelDestGroup_updated_fqdns(context),
+			},
+			{
+				ResourceName:            "google_iap_tunnel_dest_group.dest_group",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"region", "group_name"},
+			},
+		},
+	})
+}
+
+func testAccIapTunnelDestGroup_full(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_iap_tunnel_dest_group" "dest_group" {
+  region = "us-central1"
+  group_name = "testgroup%{random_suffix}"
+  cidrs = [
+    "10.1.0.0/16",
+    "192.168.10.0/24",
+  ]
+}
+`, context)
+}
+
+func testAccIapTunnelDestGroup_updated(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_iap_tunnel_dest_group" "dest_group" {
+  region = "us-central1"
+  group_name = "testgroup%{random_suffix}"
+  cidrs = [
+    "10.1.0.0/16",
+  ]
+}
+`, context)
+}
+
+func testAccIapTunnelDestGroup_updated_fqdns(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_iap_tunnel_dest_group" "dest_group" {
+  region = "us-central1"
+  group_name = "testgroup%{random_suffix}"
+  cidrs = [
+    "10.1.0.0/16",
+  ]
+  fqdns = ["proxied.lan"]
+}
+`, context)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add a new resource definition for IAP tunnel destination groups and related IAM policies.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/17417

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_iap_tunnel_dest_group`
```
