### PR TITLE
Add `region_from_zone` provider function

### DIFF
--- a/mmv1/third_party/terraform/functions/region_from_zone.go
+++ b/mmv1/third_party/terraform/functions/region_from_zone.go
@@ -1,5 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
 package functions
 
 import (

--- a/mmv1/third_party/terraform/functions/region_from_zone.go
+++ b/mmv1/third_party/terraform/functions/region_from_zone.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
 package functions
 
 import (
@@ -41,11 +43,23 @@ func (f RegionFromZoneFunction) Run(ctx context.Context, req function.RunRequest
 		return
 	}
 
-	// Validate input - can't be an empty string, every zone will have 2nd to last element in string be a `-`
-	if len(arg0) != 0 && arg0[len(arg0)-2] == '-' {
-		resp.Diagnostics.Append(resp.Result.Set(ctx, arg0[:len(arg0)-2])...)
-	} else {
+	if arg0 == "" {
+		resp.Diagnostics.AddArgumentError(
+			0,
+			noMatchesErrorSummary,
+			"The input string is empty.",
+		)
 		return
 	}
 
+	if arg0[len(arg0)-2] != '-' {
+		resp.Diagnostics.AddArgumentError(
+			0,
+			noMatchesErrorSummary,
+			"The input string is invalid.",
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.Result.Set(ctx, arg0[:len(arg0)-2])...)
 }

--- a/mmv1/third_party/terraform/functions/region_from_zone.go
+++ b/mmv1/third_party/terraform/functions/region_from_zone.go
@@ -4,6 +4,7 @@ package functions
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/function"
 )
@@ -56,7 +57,7 @@ func (f RegionFromZoneFunction) Run(ctx context.Context, req function.RunRequest
 		resp.Diagnostics.AddArgumentError(
 			0,
 			noMatchesErrorSummary,
-			"The input string is invalid.",
+			fmt.Sprintf("The input string \"%s\" is not a valid zone name.", arg0),
 		)
 		return
 	}

--- a/mmv1/third_party/terraform/functions/region_from_zone.go
+++ b/mmv1/third_party/terraform/functions/region_from_zone.go
@@ -48,7 +48,7 @@ func (f RegionFromZoneFunction) Run(ctx context.Context, req function.RunRequest
 		resp.Diagnostics.AddArgumentError(
 			0,
 			noMatchesErrorSummary,
-			"The input string is empty.",
+			"The input string cannot be empty.",
 		)
 		return
 	}

--- a/mmv1/third_party/terraform/functions/region_from_zone.go
+++ b/mmv1/third_party/terraform/functions/region_from_zone.go
@@ -1,0 +1,51 @@
+package functions
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/function"
+)
+
+var _ function.Function = RegionFromZoneFunction{}
+
+func NewRegionFromZoneFunction() function.Function {
+	return &RegionFromZoneFunction{}
+}
+
+type RegionFromZoneFunction struct{}
+
+func (f RegionFromZoneFunction) Metadata(ctx context.Context, req function.MetadataRequest, resp *function.MetadataResponse) {
+	resp.Name = "region_from_zone"
+}
+
+func (f RegionFromZoneFunction) Definition(ctx context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
+	resp.Definition = function.Definition{
+		Summary:     "Returns the region within a provided resource's zone",
+		Description: "Takes a single string argument, which should be a resource's zone.",
+		Parameters: []function.Parameter{
+			function.StringParameter{
+				Name:        "zone",
+				Description: "A string of a resource's zone.",
+			},
+		},
+		Return: function.StringReturn{},
+	}
+}
+
+func (f RegionFromZoneFunction) Run(ctx context.Context, req function.RunRequest, resp *function.RunResponse) {
+	// Load arguments from function call
+	var arg0 string
+	resp.Diagnostics.Append(req.Arguments.GetArgument(ctx, 0, &arg0)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Validate input - can't be an empty string, every zone will have 2nd to last element in string be a `-`
+	if len(arg0) != 0 && arg0[len(arg0)-2] == '-' {
+		resp.Diagnostics.Append(resp.Result.Set(ctx, arg0[:len(arg0)-2])...)
+	} else {
+		return
+	}
+
+}

--- a/mmv1/third_party/terraform/functions/region_from_zone_internal_test.go
+++ b/mmv1/third_party/terraform/functions/region_from_zone_internal_test.go
@@ -1,8 +1,9 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
 package functions
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -30,9 +31,9 @@ func TestFunctionRun_region_from_zone(t *testing.T) {
 				Result: function.NewResultData(types.StringValue(region)),
 			},
 		},
-		"it returns an error when given input that is empty": {
+		"it returns an error when given input is empty": {
 			request: function.RunRequest{
-				Arguments: function.NewArgumentsData([]attr.Value{types.StringNull()}),
+				Arguments: function.NewArgumentsData([]attr.Value{types.StringValue("")}),
 			},
 			expected: function.RunResponse{
 				Result: function.NewResultData(types.StringNull()),
@@ -40,12 +41,12 @@ func TestFunctionRun_region_from_zone(t *testing.T) {
 					diag.NewArgumentErrorDiagnostic(
 						0,
 						noMatchesErrorSummary,
-						fmt.Sprintf("The input string is empty."),
+						"The input string is empty.",
 					),
 				},
 			},
 		},
-		"it returns an error when given input that is not a zone": {
+		"it returns an error when given input is not a zone": {
 			request: function.RunRequest{
 				Arguments: function.NewArgumentsData([]attr.Value{types.StringValue("foobar")}),
 			},
@@ -55,7 +56,7 @@ func TestFunctionRun_region_from_zone(t *testing.T) {
 					diag.NewArgumentErrorDiagnostic(
 						0,
 						noMatchesErrorSummary,
-						fmt.Sprintf("The input string foobar is not a valid zone."),
+						"The input string is invalid.",
 					),
 				},
 			},

--- a/mmv1/third_party/terraform/functions/region_from_zone_internal_test.go
+++ b/mmv1/third_party/terraform/functions/region_from_zone_internal_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
 package functions
 
 import (
@@ -56,7 +54,7 @@ func TestFunctionRun_region_from_zone(t *testing.T) {
 					diag.NewArgumentErrorDiagnostic(
 						0,
 						noMatchesErrorSummary,
-						"The input string is invalid.",
+						"The input string \"foobar\" is not a valid zone name.",
 					),
 				},
 			},

--- a/mmv1/third_party/terraform/functions/region_from_zone_internal_test.go
+++ b/mmv1/third_party/terraform/functions/region_from_zone_internal_test.go
@@ -39,7 +39,7 @@ func TestFunctionRun_region_from_zone(t *testing.T) {
 					diag.NewArgumentErrorDiagnostic(
 						0,
 						noMatchesErrorSummary,
-						"The input string is empty.",
+						"The input string cannot be empty.",
 					),
 				},
 			},

--- a/mmv1/third_party/terraform/functions/region_from_zone_internal_test.go
+++ b/mmv1/third_party/terraform/functions/region_from_zone_internal_test.go
@@ -1,0 +1,88 @@
+package functions
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+func TestFunctionRun_region_from_zone(t *testing.T) {
+	t.Parallel()
+
+	region := "us-central1"
+
+	testCases := map[string]struct {
+		request  function.RunRequest
+		expected function.RunResponse
+	}{
+		"it returns the expected output value when given a valid zone input": {
+			request: function.RunRequest{
+				Arguments: function.NewArgumentsData([]attr.Value{types.StringValue("us-central1-b")}),
+			},
+			expected: function.RunResponse{
+				Result: function.NewResultData(types.StringValue(region)),
+			},
+		},
+		"it returns an error when given input that is empty": {
+			request: function.RunRequest{
+				Arguments: function.NewArgumentsData([]attr.Value{types.StringNull()}),
+			},
+			expected: function.RunResponse{
+				Result: function.NewResultData(types.StringNull()),
+				Diagnostics: diag.Diagnostics{
+					diag.NewArgumentErrorDiagnostic(
+						0,
+						noMatchesErrorSummary,
+						fmt.Sprintf("The input string is empty."),
+					),
+				},
+			},
+		},
+		"it returns an error when given input that is not a zone": {
+			request: function.RunRequest{
+				Arguments: function.NewArgumentsData([]attr.Value{types.StringValue("foobar")}),
+			},
+			expected: function.RunResponse{
+				Result: function.NewResultData(types.StringNull()),
+				Diagnostics: diag.Diagnostics{
+					diag.NewArgumentErrorDiagnostic(
+						0,
+						noMatchesErrorSummary,
+						fmt.Sprintf("The input string foobar is not a valid zone."),
+					),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		tn, tc := name, testCase
+
+		t.Run(tn, func(t *testing.T) {
+			t.Parallel()
+
+			// Arrange
+			got := function.RunResponse{
+				Result: function.NewResultData(basetypes.StringValue{}),
+			}
+
+			// Act
+			NewRegionFromZoneFunction().Run(context.Background(), tc.request, &got)
+
+			// Assert
+			if diff := cmp.Diff(got.Result, tc.expected.Result); diff != "" {
+				t.Errorf("unexpected diff between expected and received result: %s", diff)
+			}
+			if diff := cmp.Diff(got.Diagnostics, tc.expected.Diagnostics); diff != "" {
+				t.Errorf("unexpected diff between expected and received diagnostics: %s", diff)
+			}
+		})
+	}
+}

--- a/mmv1/third_party/terraform/functions/region_from_zone_test.go
+++ b/mmv1/third_party/terraform/functions/region_from_zone_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
 package functions_test
 
 import (
@@ -13,6 +15,9 @@ import (
 func TestAccProviderFunction_region_from_zone(t *testing.T) {
 	t.Parallel()
 
+	projectZone := envvar.GetTestZoneFromEnv()
+	projectZoneRegex := regexp.MustCompile(fmt.Sprintf("^%s$", projectZone[:len(projectZone)-2]))
+
 	context := map[string]interface{}{
 		"function_name": "region_from_zone",
 		"output_name":   "zone",
@@ -25,7 +30,7 @@ func TestAccProviderFunction_region_from_zone(t *testing.T) {
 			{
 				Config: testProviderFunction_get_region_from_zone(context),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchOutput(context["output_name"].(string), "us-central1"),
+					resource.TestMatchOutput(context["output_name"].(string), projectZoneRegex),
 				),
 			},
 		},
@@ -60,7 +65,7 @@ resource "google_filestore_instance" "instance" {
   }
 
 output "%{output_name}" {
-	value = provider::google::%{function_name}(google_filestore_instance.default.location)
+	value = provider::google::%{function_name}(google_filestore_instance.instance.location)
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/functions/region_from_zone_test.go
+++ b/mmv1/third_party/terraform/functions/region_from_zone_test.go
@@ -15,7 +15,10 @@ func TestAccProviderFunction_region_from_zone(t *testing.T) {
 	// Skipping due to requiring TF 1.8.0 in VCR systems : https://github.com/hashicorp/terraform-provider-google/issues/17451
 	acctest.SkipIfVcr(t)
 	projectZone := envvar.GetTestZoneFromEnv()
-	projectZoneRegex := regexp.MustCompile(fmt.Sprintf("^%s$", projectZone[:len(projectZone)-2]))
+	if projectZone != "" {
+		projectZone = projectZone[:len(projectZone)-2]
+	}
+	projectZoneRegex := regexp.MustCompile(fmt.Sprintf("^%s$", projectZone))
 
 	context := map[string]interface{}{
 		"function_name":     "region_from_zone",

--- a/mmv1/third_party/terraform/functions/region_from_zone_test.go
+++ b/mmv1/third_party/terraform/functions/region_from_zone_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
 package functions_test
 
 import (

--- a/mmv1/third_party/terraform/functions/region_from_zone_test.go
+++ b/mmv1/third_party/terraform/functions/region_from_zone_test.go
@@ -14,11 +14,9 @@ func TestAccProviderFunction_region_from_zone(t *testing.T) {
 	t.Parallel()
 	// Skipping due to requiring TF 1.8.0 in VCR systems : https://github.com/hashicorp/terraform-provider-google/issues/17451
 	acctest.SkipIfVcr(t)
-	projectZone := envvar.GetTestZoneFromEnv()
-	if projectZone != "" {
-		projectZone = projectZone[:len(projectZone)-2]
-	}
-	projectZoneRegex := regexp.MustCompile(fmt.Sprintf("^%s$", projectZone))
+	projectZone := "us-central1-a"
+	projectRegion := "us-central1"
+	projectRegionRegex := regexp.MustCompile(fmt.Sprintf("^%s$", projectRegion))
 
 	context := map[string]interface{}{
 		"function_name":     "region_from_zone",

--- a/mmv1/third_party/terraform/functions/region_from_zone_test.go
+++ b/mmv1/third_party/terraform/functions/region_from_zone_test.go
@@ -42,31 +42,24 @@ func testProviderFunction_get_region_from_zone(context map[string]interface{}) s
 terraform {
 	required_providers {
 		google = {
-			source = "hashicorp/google"
+		  source = "hashicorp/google"
 		}
 	}
 }
 
-resource "google_cloud_run_service" "default" {
-	name     = "%{resource_name}"
-	location = "%{resource_location}"
-  
-	template {
-	  spec {
-		containers {
-		  image = "us-docker.pkg.dev/cloudrun/container/hello"
-		}
-	  }
+resource "google_compute_disk" "default" {
+	name  = "%{resource_name}"
+	type  = "pd-ssd"
+	zone  = "%{resource_location}"
+	image = "debian-11-bullseye-v20220719"
+	labels = {
+	  environment = "dev"
 	}
-  
-	traffic {
-	  percent         = 100
-	  latest_revision = true
-	}
+	physical_block_size_bytes = 4096
   }
 
 output "%{output_name}" {
-	value = provider::google::%{function_name}(google_cloud_run_service.default.location)
+  value = provider::google::%{function_name}(google_compute_disk.default.zone)
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/functions/region_from_zone_test.go
+++ b/mmv1/third_party/terraform/functions/region_from_zone_test.go
@@ -12,7 +12,8 @@ import (
 
 func TestAccProviderFunction_region_from_zone(t *testing.T) {
 	t.Parallel()
-
+	// Skipping due to requiring TF 1.8.0 in VCR systems : https://github.com/hashicorp/terraform-provider-google/issues/17451
+	acctest.SkipIfVcr(t)
 	projectZone := envvar.GetTestZoneFromEnv()
 	projectZoneRegex := regexp.MustCompile(fmt.Sprintf("^%s$", projectZone[:len(projectZone)-2]))
 

--- a/mmv1/third_party/terraform/functions/region_from_zone_test.go
+++ b/mmv1/third_party/terraform/functions/region_from_zone_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestAccProviderFunction_region_from_zone(t *testing.T) {
@@ -31,7 +30,7 @@ func TestAccProviderFunction_region_from_zone(t *testing.T) {
 			{
 				Config: testProviderFunction_get_region_from_zone(context),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchOutput(context["output_name"].(string), projectZoneRegex),
+					resource.TestMatchOutput(context["output_name"].(string), projectRegionRegex),
 				),
 			},
 		},

--- a/mmv1/third_party/terraform/functions/region_from_zone_test.go
+++ b/mmv1/third_party/terraform/functions/region_from_zone_test.go
@@ -1,0 +1,66 @@
+package functions_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccProviderFunction_region_from_zone(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"function_name": "region_from_zone",
+		"output_name":   "zone",
+		"resource_name": fmt.Sprintf("tf-test-region-from-zone-func-%s", acctest.RandString(t, 10)),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testProviderFunction_get_region_from_zone(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchOutput(context["output_name"].(string), "us-central1"),
+				),
+			},
+		},
+	})
+}
+
+func testProviderFunction_get_region_from_zone(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+# terraform block required for provider function to be found
+terraform {
+	required_providers {
+		google = {
+			source = "hashicorp/google"
+		}
+	}
+}
+
+resource "google_filestore_instance" "instance" {
+	name = "%{resource_name}"
+	location = "us-central1-b"
+	tier     = "BASIC_HDD"
+  
+	file_shares {
+	  capacity_gb = 1024
+	  name        = "share1"
+	}
+  
+	networks {
+	  network = "default"
+	  modes   = ["MODE_IPV4"]
+	}
+  }
+
+output "%{output_name}" {
+	value = provider::google::%{function_name}(google_filestore_instance.default.location)
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/fwprovider/framework_provider.go.erb
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider.go.erb
@@ -305,5 +305,6 @@ func (p *FrameworkProvider) Functions(_ context.Context) []func() function.Funct
 	return []func() function.Function{
 		functions.NewProjectFromIdFunction,
         functions.NewRegionFromZoneFunction,
+		functions.NewLocationFromIdFunction,
 	}
 }

--- a/mmv1/third_party/terraform/fwprovider/framework_provider.go.erb
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider.go.erb
@@ -304,5 +304,6 @@ func (p *FrameworkProvider) Resources(_ context.Context) []func() resource.Resou
 func (p *FrameworkProvider) Functions(_ context.Context) []func() function.Function {
 	return []func() function.Function{
 		functions.NewProjectFromIdFunction,
+        functions.NewRegionFromZoneFunction,
 	}
 }

--- a/mmv1/third_party/terraform/website/docs/functions/region_from_zone.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/functions/region_from_zone.html.markdown
@@ -6,7 +6,7 @@ description: |-
 
 # Function: region_from_zone
 
-Returns the region within a provided resource's zone.
+Returns a region name derived from a provided zone.
 
 For more information about using provider-defined functions with Terraform [see the official documentation](https://developer.hashicorp.com/terraform/plugin/framework/functions/concepts).
 

--- a/mmv1/third_party/terraform/website/docs/functions/region_from_zone.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/functions/region_from_zone.html.markdown
@@ -1,0 +1,57 @@
+---
+page_title: region_from_zone Function - terraform-provider-google
+description: |-
+  Returns the region within a provided zone.
+---
+
+# Function: region_from_zone
+
+Returns the region within a provided resource's zone.
+
+For more information about using provider-defined functions with Terraform [see the official documentation](https://developer.hashicorp.com/terraform/plugin/framework/functions/concepts).
+
+## Example Usage
+
+### Use with the `google` provider
+
+```terraform
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+}
+
+# Value is "us-central1"
+output "function_output" {
+  value = provider::google::region_from_zone("us-central1-b")
+}
+```
+
+### Use with the `google-beta` provider
+
+```terraform
+terraform {
+  required_providers {
+    google-beta = {
+      source = "hashicorp/google-beta"
+    }
+  }
+}
+
+# Value is "us-central1"
+output "function_output" {
+  value = provider::google-beta::region_from_zone("us-central1-b")
+}
+```
+
+## Signature
+
+```text
+region_from_zone(zone string) string
+```
+
+## Arguments
+
+1. `zone` (String) A string of a resource's zone


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


Implement a provider function that lets users get the region from a zone, e.g. get “us-central1” from “us-central1-a”.

We need to decide how the function responds to ‘bad' input and document this in automated tests.

Examples of bad input:

- empty string

- string of an inappropriate string like “foobar”

- string of a region, when a zone is expected

Acceptance Criteria
- [X] Provider function is implemented
- [x] Unit tests cover the function’s logic
- [x] Appropriate levels of acceptance tests added
- [x] Copy for documentation created
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
provider: added provider-defined function `region_from_zone` for retrieving the region from a resource's location/zone
```
