### PR TITLE
TeamCity: Add project for testing the provider functions feature branch

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_per_package.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_per_package.kt
@@ -33,7 +33,7 @@ fun BuildConfigurationsForPackages(packages: Map<String, Map<String, String>>, p
     return list
 }
 
-// BuildConfigurationForSinglePackage accepts a details of a single package in a provider and returns a build configurations for it
+// BuildConfigurationForSinglePackage accepts details of a single package in a provider and returns a build configuration for it
 // Intended to be used in short-lived projects where we're testing specific packages, e.g. feature branch testing
 fun BuildConfigurationForSinglePackage(packageName: String, packagePath: String, packageDisplayName: String, providerName: String, parentProjectName: String, vcsRoot: GitVcsRoot, sharedResources: List<String>, environmentVariables: AccTestConfiguration): BuildType{
     val pkg = PackageDetails(packageName, packageDisplayName, providerName, parentProjectName)

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_per_package.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_per_package.kt
@@ -15,6 +15,8 @@ import jetbrains.buildServer.configs.kotlin.sharedResources
 import jetbrains.buildServer.configs.kotlin.vcs.GitVcsRoot
 import replaceCharsId
 
+// BuildConfigurationsForPackages accepts a map containing details of multiple packages in a provider and returns a list of build configurations for them all.
+// Intended to be used in projects where we're testing all packages, e.g. the nightly test projects
 fun BuildConfigurationsForPackages(packages: Map<String, Map<String, String>>, providerName: String, parentProjectName: String, vcsRoot: GitVcsRoot, sharedResources: List<String>, environmentVariables: AccTestConfiguration): List<BuildType> {
     val list = ArrayList<BuildType>()
 
@@ -29,6 +31,13 @@ fun BuildConfigurationsForPackages(packages: Map<String, Map<String, String>>, p
     }
 
     return list
+}
+
+// BuildConfigurationForSinglePackage accepts a details of a single package in a provider and returns a build configurations for it
+// Intended to be used in short-lived projects where we're testing specific packages, e.g. feature branch testing
+fun BuildConfigurationForSinglePackage(packageName: String, packagePath: String, packageDisplayName: String, providerName: String, parentProjectName: String, vcsRoot: GitVcsRoot, sharedResources: List<String>, environmentVariables: AccTestConfiguration): BuildType{
+    val pkg = PackageDetails(packageName, packageDisplayName, providerName, parentProjectName)
+    return pkg.buildConfiguration(packagePath, vcsRoot, sharedResources, environmentVariables)
 }
 
 class PackageDetails(private val packageName: String, private val displayName: String, private val providerName: String, private val parentProjectName: String) {

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_parameters.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_parameters.kt
@@ -252,10 +252,18 @@ fun ParametrizedWithType.readOnlySettings() {
 }
 
 // ParametrizedWithType.terraformCoreBinaryTesting sets environment variables that control what Terraform version is downloaded
-// and ensures the testing framework uses that downloaded version
-fun ParametrizedWithType.terraformCoreBinaryTesting() {
-    text("env.TERRAFORM_CORE_VERSION", DefaultTerraformCoreVersion, "The version of Terraform Core which should be used for testing")
+// and ensures the testing framework uses that downloaded version. The default Terraform core version is used if no argument is supplied.
+fun ParametrizedWithType.terraformCoreBinaryTesting(tfVersion: String = DefaultTerraformCoreVersion) {
+    text("env.TERRAFORM_CORE_VERSION", tfVersion, "The version of Terraform Core which should be used for testing")
     hiddenVariable("env.TF_ACC_TERRAFORM_PATH", "%system.teamcity.build.checkoutDir%/tools/terraform", "The path where the Terraform Binary is located. Used by the testing framework.")
+}
+
+// BuildType.overrideTerraformCoreVersion is used to override the value of TERRAFORM_CORE_VERSION in special cases where we're testing new features
+// that rely on a specific version of Terraform we might not want to be used for all our tests in TeamCity.
+fun BuildType.overrideTerraformCoreVersion(tfVersion: String){
+    params {
+        terraformCoreBinaryTesting(tfVersion)
+    }
 }
 
 fun ParametrizedWithType.terraformShouldPanicForSchemaErrors() {

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
@@ -64,8 +64,9 @@ fun BuildSteps.downloadTerraformBinary() {
     // https://releases.hashicorp.com/terraform/0.12.28/terraform_0.12.28_linux_amd64.zip
     val terraformUrl = "https://releases.hashicorp.com/terraform/%env.TERRAFORM_CORE_VERSION%/terraform_%env.TERRAFORM_CORE_VERSION%_linux_amd64.zip"
     step(ScriptBuildStep {
-        name = "Download Terraform version %s".format(DefaultTerraformCoreVersion)
+        name = "Download Terraform (version set by environment variable TERRAFORM_CORE_VERSION)"
         scriptContent = """
+        echo "Downloading Terraform version %env.TERRAFORM_CORE_VERSION%"
         #!/bin/bash
         mkdir -p tools
         wget -O tf.zip %s

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
@@ -64,15 +64,15 @@ fun BuildSteps.downloadTerraformBinary() {
     // https://releases.hashicorp.com/terraform/0.12.28/terraform_0.12.28_linux_amd64.zip
     val terraformUrl = "https://releases.hashicorp.com/terraform/%env.TERRAFORM_CORE_VERSION%/terraform_%env.TERRAFORM_CORE_VERSION%_linux_amd64.zip"
     step(ScriptBuildStep {
-        name = "Download Terraform (version set by environment variable TERRAFORM_CORE_VERSION)"
+        name = "Download Terraform"
         scriptContent = """
         #!/bin/bash
-        echo \"Downloading Terraform version %env.TERRAFORM_CORE_VERSION%\"
+        echo "Downloading Terraform version %env.TERRAFORM_CORE_VERSION%"
         mkdir -p tools
-        wget -O tf.zip %s
+        wget -O tf.zip $terraformUrl
         unzip tf.zip
         mv terraform tools/
-        """.format(terraformUrl).trimIndent()
+        """.trimIndent()
     })
 }
 

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
@@ -66,8 +66,8 @@ fun BuildSteps.downloadTerraformBinary() {
     step(ScriptBuildStep {
         name = "Download Terraform (version set by environment variable TERRAFORM_CORE_VERSION)"
         scriptContent = """
-        echo "Downloading Terraform version %env.TERRAFORM_CORE_VERSION%"
         #!/bin/bash
+        echo \"Downloading Terraform version %env.TERRAFORM_CORE_VERSION%\"
         mkdir -p tools
         wget -O tf.zip %s
         unzip tf.zip

--- a/mmv1/third_party/terraform/.teamcity/components/inputs/packages.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/inputs/packages.kt
@@ -13,6 +13,11 @@ var PackagesListGa = mapOf(
         "displayName" to "Environment Variables",
         "path" to "./google/envvar"
     ),
+    "functions" to mapOf(
+        "name" to "functions",
+        "displayName" to "Provider-Defined Functions",
+        "path" to "./google/functions"
+    ),
     "fwmodels" to mapOf(
         "name" to "fwmodels",
         "displayName" to "Framework Models",
@@ -63,6 +68,11 @@ var PackagesListBeta = mapOf(
         "name" to "envvar",
         "displayName" to "Environment Variables",
         "path" to "./google-beta/envvar"
+    ),
+    "functions" to mapOf(
+        "name" to "functions",
+        "displayName" to "Provider-Defined Functions",
+        "path" to "./google-beta/functions"
     ),
     "fwmodels" to mapOf(
         "name" to "fwmodels",

--- a/mmv1/third_party/terraform/.teamcity/components/projects/feature_branches/FEATURE-BRANCH-provider-functions.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/feature_branches/FEATURE-BRANCH-provider-functions.kt
@@ -42,6 +42,7 @@ fun featureBranchProviderFunctionSubProject(allConfig: AllContextParameters): Pr
 
     val packageName = "functions" // This project will contain only builds to test this single package
     val sharedResourcesEmpty: List<String> = listOf() // No locking when testing functions
+    val vcrConfig = getVcrAcceptanceTestConfig(allConfig) // Reused below for both MM testing build configs
 
     var parentId: String // To be overwritten when each build config is generated below.
 
@@ -52,6 +53,9 @@ fun featureBranchProviderFunctionSubProject(allConfig: AllContextParameters): Pr
     // Enable testing using hashicorp/terraform-provider-google
     parentId = "${projectId}_HC_GA"
     val buildConfigHashiCorpGa = BuildConfigurationForSinglePackage(packageName, functionPackageGa.getValue("path"), "Provider-Defined Functions (GA provider, HashiCorp downstream)", ProviderNameGa, parentId, HashicorpVCSRootGa_featureBranchProviderFunctions, sharedResourcesEmpty, gaConfig)
+    // Enable testing using modular-magician/terraform-provider-google
+    parentId = "${projectId}_MM_GA"
+    val buildConfigModularMagicianGa = BuildConfigurationForSinglePackage(packageName, functionPackageGa.getValue("path"), "Provider-Defined Functions (GA provider, MM upstream)", ProviderNameGa, parentId, ModularMagicianVCSRootGa, sharedResourcesEmpty, vcrConfig)
 
     // Beta
     val betaConfig = getBetaAcceptanceTestConfig(allConfig)
@@ -59,8 +63,11 @@ fun featureBranchProviderFunctionSubProject(allConfig: AllContextParameters): Pr
     // Enable testing using hashicorp/terraform-provider-google-beta
     parentId = "${projectId}_HC_BETA"
     val buildConfigHashiCorpBeta = BuildConfigurationForSinglePackage(packageName, functionPackageBeta.getValue("path"), "Provider-Defined Functions (Beta provider, HashiCorp downstream)", ProviderNameBeta, parentId, HashicorpVCSRootBeta_featureBranchProviderFunctions, sharedResourcesEmpty, betaConfig)
+    // Enable testing using modular-magician/terraform-provider-google-beta
+    parentId = "${projectId}_MM_BETA"
+    val buildConfigModularMagicianBeta = BuildConfigurationForSinglePackage(packageName, functionPackageBeta.getValue("path"), "Provider-Defined Functions (Beta provider, MM upstream)", ProviderNameBeta, parentId, ModularMagicianVCSRootBeta, sharedResourcesEmpty, vcrConfig)
 
-    val allBuildConfigs = listOf(buildConfigHashiCorpGa, buildConfigHashiCorpBeta)
+    val allBuildConfigs = listOf(buildConfigHashiCorpGa, buildConfigModularMagicianGa, buildConfigHashiCorpBeta, buildConfigModularMagicianBeta)
 
     // Make these builds use a 1.8.0-ish version of TF core
     allBuildConfigs.forEach{ b ->

--- a/mmv1/third_party/terraform/.teamcity/components/projects/feature_branches/FEATURE-BRANCH-provider-functions.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/feature_branches/FEATURE-BRANCH-provider-functions.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// This file is controlled by MMv1, any changes made here will be overwritten
+
+package projects.feature_branches
+
+import ProviderNameBeta
+import ProviderNameGa
+import builds.*
+import generated.PackagesListBeta
+import generated.PackagesListGa
+import jetbrains.buildServer.configs.kotlin.Project
+import jetbrains.buildServer.configs.kotlin.vcs.GitVcsRoot
+import replaceCharsId
+import vcs_roots.ModularMagicianVCSRootBeta
+import vcs_roots.ModularMagicianVCSRootGa
+
+const val featureBranchProviderFunctionsName = "FEATURE-BRANCH-provider-functions"
+const val providerFunctionsTfCoreVersion = "1.8.0-alpha20240228"
+
+// VCS Roots specifically for pulling code from the feature branches in the downstream and upstream repos
+object HashicorpVCSRootGa_featureBranchProviderFunctions: GitVcsRoot({
+    name = "VCS root for the hashicorp/terraform-provider-${ProviderNameGa} repo @ refs/heads/${featureBranchProviderFunctionsName}"
+    url = "https://github.com/hashicorp/terraform-provider-${ProviderNameGa}"
+    branch = "refs/heads/${featureBranchProviderFunctionsName}"
+    branchSpec = "" // empty as we'll access no other branches
+})
+
+object HashicorpVCSRootBeta_featureBranchProviderFunctions: GitVcsRoot({
+    name = "VCS root for the hashicorp/terraform-provider-${ProviderNameBeta} repo @ refs/heads/${featureBranchProviderFunctionsName}"
+    url = "https://github.com/hashicorp/terraform-provider-${ProviderNameBeta}"
+    branch = "refs/heads/${featureBranchProviderFunctionsName}"
+    branchSpec = "" // empty as we'll access no other branches
+})
+
+fun featureBranchProviderFunctionSubProject(allConfig: AllContextParameters): Project {
+
+    val projectId = replaceCharsId(featureBranchProviderFunctionsName)
+
+    val packageName = "functions" // This project will contain only builds to test this single package
+    val sharedResourcesEmpty: List<String> = listOf() // No locking when testing functions
+
+    var parentId: String // To be overwritten when each build config is generated below.
+
+    // GA
+    val gaConfig = getGaAcceptanceTestConfig(allConfig)
+    // How to make only build configuration to the relevant package(s)
+    val functionPackageGa = PackagesListGa.getValue(packageName)
+    // Enable testing using hashicorp/terraform-provider-google
+    parentId = "${projectId}_HC_GA"
+    val buildConfigHashiCorpGa = BuildConfigurationForSinglePackage(packageName, functionPackageGa.getValue("path"), "Provider-Defined Functions (GA provider, HashiCorp downstream)", ProviderNameGa, parentId, HashicorpVCSRootGa_featureBranchProviderFunctions, sharedResourcesEmpty, gaConfig)
+
+    // Beta
+    val betaConfig = getBetaAcceptanceTestConfig(allConfig)
+    val functionPackageBeta = PackagesListBeta.getValue("functions")
+    // Enable testing using hashicorp/terraform-provider-google-beta
+    parentId = "${projectId}_HC_BETA"
+    val buildConfigHashiCorpBeta = BuildConfigurationForSinglePackage(packageName, functionPackageBeta.getValue("path"), "Provider-Defined Functions (Beta provider, HashiCorp downstream)", ProviderNameBeta, parentId, HashicorpVCSRootBeta_featureBranchProviderFunctions, sharedResourcesEmpty, betaConfig)
+
+    val allBuildConfigs = listOf(buildConfigHashiCorpGa, buildConfigHashiCorpBeta)
+
+    // Make these builds use a 1.8.0-ish version of TF core
+    allBuildConfigs.forEach{ b ->
+        b.overrideTerraformCoreVersion(providerFunctionsTfCoreVersion)
+    }
+
+    return Project{
+        id(projectId)
+        name = featureBranchProviderFunctionsName
+        description = "Subproject for testing feature branch $featureBranchProviderFunctionsName"
+
+        // Register feature branch-specific VCS roots in the project
+        vcsRoot(HashicorpVCSRootGa_featureBranchProviderFunctions)
+        vcsRoot(HashicorpVCSRootBeta_featureBranchProviderFunctions)
+
+        // Register all build configs in the project
+        allBuildConfigs.forEach{ b ->
+            buildType(b)
+        }
+
+        params {
+            readOnlySettings()
+        }
+    }
+}

--- a/mmv1/third_party/terraform/.teamcity/components/projects/feature_branches/FEATURE-BRANCH-provider-functions.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/feature_branches/FEATURE-BRANCH-provider-functions.kt
@@ -43,6 +43,7 @@ fun featureBranchProviderFunctionSubProject(allConfig: AllContextParameters): Pr
     val packageName = "functions" // This project will contain only builds to test this single package
     val sharedResourcesEmpty: List<String> = listOf() // No locking when testing functions
     val vcrConfig = getVcrAcceptanceTestConfig(allConfig) // Reused below for both MM testing build configs
+    val trigger  = NightlyTriggerConfiguration() // Resued below for running tests against the downstream repos every night.
 
     var parentId: String // To be overwritten when each build config is generated below.
 
@@ -50,9 +51,12 @@ fun featureBranchProviderFunctionSubProject(allConfig: AllContextParameters): Pr
     val gaConfig = getGaAcceptanceTestConfig(allConfig)
     // How to make only build configuration to the relevant package(s)
     val functionPackageGa = PackagesListGa.getValue(packageName)
+
     // Enable testing using hashicorp/terraform-provider-google
     parentId = "${projectId}_HC_GA"
     val buildConfigHashiCorpGa = BuildConfigurationForSinglePackage(packageName, functionPackageGa.getValue("path"), "Provider-Defined Functions (GA provider, HashiCorp downstream)", ProviderNameGa, parentId, HashicorpVCSRootGa_featureBranchProviderFunctions, sharedResourcesEmpty, gaConfig)
+    buildConfigHashiCorpGa.addTrigger(trigger)
+
     // Enable testing using modular-magician/terraform-provider-google
     parentId = "${projectId}_MM_GA"
     val buildConfigModularMagicianGa = BuildConfigurationForSinglePackage(packageName, functionPackageGa.getValue("path"), "Provider-Defined Functions (GA provider, MM upstream)", ProviderNameGa, parentId, ModularMagicianVCSRootGa, sharedResourcesEmpty, vcrConfig)
@@ -60,9 +64,12 @@ fun featureBranchProviderFunctionSubProject(allConfig: AllContextParameters): Pr
     // Beta
     val betaConfig = getBetaAcceptanceTestConfig(allConfig)
     val functionPackageBeta = PackagesListBeta.getValue("functions")
+
     // Enable testing using hashicorp/terraform-provider-google-beta
     parentId = "${projectId}_HC_BETA"
     val buildConfigHashiCorpBeta = BuildConfigurationForSinglePackage(packageName, functionPackageBeta.getValue("path"), "Provider-Defined Functions (Beta provider, HashiCorp downstream)", ProviderNameBeta, parentId, HashicorpVCSRootBeta_featureBranchProviderFunctions, sharedResourcesEmpty, betaConfig)
+    buildConfigHashiCorpBeta.addTrigger(trigger)
+
     // Enable testing using modular-magician/terraform-provider-google-beta
     parentId = "${projectId}_MM_BETA"
     val buildConfigModularMagicianBeta = BuildConfigurationForSinglePackage(packageName, functionPackageBeta.getValue("path"), "Provider-Defined Functions (Beta provider, MM upstream)", ProviderNameBeta, parentId, ModularMagicianVCSRootBeta, sharedResourcesEmpty, vcrConfig)

--- a/mmv1/third_party/terraform/.teamcity/components/projects/root_project.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/root_project.kt
@@ -18,6 +18,7 @@ import generated.ServicesListBeta
 import generated.ServicesListGa
 import jetbrains.buildServer.configs.kotlin.Project
 import jetbrains.buildServer.configs.kotlin.sharedResource
+import projects.feature_branches.featureBranchProviderFunctionSubProject
 
 // googleCloudRootProject returns a root project that contains a subprojects for the GA and Beta version of the
 // Google provider. There are also resources to help manage the test projects used for acceptance tests.
@@ -57,9 +58,13 @@ fun googleCloudRootProject(allConfig: AllContextParameters): Project {
             }
         }
 
+        // Projects required for nightly testing, testing MM upstreams, and sweepers
         subProject(googleSubProjectGa(allConfig))
         subProject(googleSubProjectBeta(allConfig))
         subProject(projectSweeperSubProject(allConfig))
+
+        // Feature branch-testing projects - these will be added and removed as needed
+        subProject(featureBranchProviderFunctionSubProject(allConfig))
 
         params {
             readOnlySettings()


### PR DESCRIPTION
Partially addresses https://github.com/hashicorp/terraform-provider-google/issues/17451

This PR adds a new project in TeamCity to enable testing of provider-defined functions:

- Tests the FEATURE-BRANCH-provider-functions branch in the downstreams on a schedule
- Allows testing provider-defined functions from PRs in the MM upstream forks
- Runs those tests with an alpha release of TF 1.8.0 while leaving our nightly tests etc unaffected (using the default version of Terraform - 1.2.5)



<img width="1361" alt="Screenshot 2024-02-29 at 12 06 20" src="https://github.com/GoogleCloudPlatform/magic-modules/assets/15078782/ebeb143b-8de2-4b01-854a-7492964d3438">

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
