### PR TITLE
fix forceNew on master_ipv4_cidr_block and private_endpoint_subnetwork

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -3079,46 +3079,6 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		log.Printf("[INFO] GKE cluster %s's enable private endpoint has been updated to %v", d.Id(), enabled)
 	}
-	
-	if d.HasChange("private_cluster_config.0.private_endpoint_subnetwork") {
-		subnetwork := d.Get("private_cluster_config.0.private_endpoint_subnetwork").(string)
-		req := &container.UpdateClusterRequest{
-			Update: &container.ClusterUpdate{
-				DesiredPrivateClusterConfig: &container.PrivateClusterConfig{
-					PrivateEndpointSubnetwork: subnetwork,
-					ForceSendFields:          []string{"PrivateEndpointSubnetwork"},
-				},
-			},
-		}
-
-		updateF := updateFunc(req, "updating private endpoint subnetwork")
-		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
-			return err
-		}
-
-		log.Printf("[INFO] GKE cluster %s's private endpoint subnetwork has been updated to %v", d.Id(), subnetwork)
-	}
-
-	if d.HasChange("private_cluster_config.0.master_ipv4_cidr_block") {
-		cidr := d.Get("private_cluster_config.0.master_ipv4_cidr_block").(string)
-		req := &container.UpdateClusterRequest{
-			Update: &container.ClusterUpdate{
-				DesiredPrivateClusterConfig: &container.PrivateClusterConfig{
-					MasterIpv4CidrBlock: cidr,
-					ForceSendFields:     []string{"MasterIpv4CidrBlock"},
-				},
-			},
-		}
-
-		updateF := updateFunc(req, "updating master IPv4 CIDR block")
-		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
-			return err
-		}
-
-		log.Printf("[INFO] GKE cluster %s's master IPv4 CIDR block has been updated to %v", d.Id(), cidr)
-	}
 
 	if d.HasChange("private_cluster_config") && d.HasChange("private_cluster_config.0.master_global_access_config") {
 		config := d.Get("private_cluster_config.0.master_global_access_config")

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -1664,7 +1664,6 @@ func ResourceContainerCluster() *schema.Resource {
 							Type:         schema.TypeString,
 							Computed:     true,
 							Optional:     true,
-							ForceNew:     true,
 							AtLeastOneOf: privateClusterConfigKeys,
 							ValidateFunc: verify.OrEmpty(validation.IsCIDRNetwork(28, 28)),
 							Description:  `The IP range in CIDR notation to use for the hosted master network. This range will be used for assigning private IP addresses to the cluster master(s) and the ILB VIP. This range must not overlap with any other ranges in use within the cluster's network, and it must be a /28 subnet. See Private Cluster Limitations for more details. This field only applies to private clusters, when enable_private_nodes is true.`,
@@ -1682,7 +1681,6 @@ func ResourceContainerCluster() *schema.Resource {
 						"private_endpoint_subnetwork": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ForceNew:     true,
 							AtLeastOneOf: privateClusterConfigKeys,
 							DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName,
 							Description: `Subnetwork in cluster's network where master's endpoint will be provisioned.`,
@@ -3080,6 +3078,46 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 
 		log.Printf("[INFO] GKE cluster %s's enable private endpoint has been updated to %v", d.Id(), enabled)
+	}
+	
+	if d.HasChange("private_cluster_config.0.private_endpoint_subnetwork") {
+		subnetwork := d.Get("private_cluster_config.0.private_endpoint_subnetwork").(string)
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				DesiredPrivateClusterConfig: &container.PrivateClusterConfig{
+					PrivateEndpointSubnetwork: subnetwork,
+					ForceSendFields:          []string{"PrivateEndpointSubnetwork"},
+				},
+			},
+		}
+
+		updateF := updateFunc(req, "updating private endpoint subnetwork")
+		// Call update serially.
+		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] GKE cluster %s's private endpoint subnetwork has been updated to %v", d.Id(), subnetwork)
+	}
+
+	if d.HasChange("private_cluster_config.0.master_ipv4_cidr_block") {
+		cidr := d.Get("private_cluster_config.0.master_ipv4_cidr_block").(string)
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				DesiredPrivateClusterConfig: &container.PrivateClusterConfig{
+					MasterIpv4CidrBlock: cidr,
+					ForceSendFields:     []string{"MasterIpv4CidrBlock"},
+				},
+			},
+		}
+
+		updateF := updateFunc(req, "updating master IPv4 CIDR block")
+		// Call update serially.
+		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] GKE cluster %s's master IPv4 CIDR block has been updated to %v", d.Id(), cidr)
 	}
 
 	if d.HasChange("private_cluster_config") && d.HasChange("private_cluster_config.0.master_global_access_config") {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -1242,39 +1242,6 @@ func TestAccContainerCluster_withPrivateClusterConfigMissingCidrBlock(t *testing
 	})
 }
 
-func TestAccContainerCluster_withPrivateClusterConfigCidrBlockUpdate(t *testing.T) {
-	t.Parallel()
-
-	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
-	containerNetName := fmt.Sprintf("tf-test-container-net-%s", acctest.RandString(t, 10))
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccContainerCluster_PscBasic(containerNetName, clusterName),
-			},
-			{
-				ResourceName:            "google_container_cluster.with_private_endpoint_subnetwork",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
-			},
-			{
-				Config: testAccContainerCluster_withPrivateClusterConfigCidrBlockUpdate(containerNetName, clusterName),
-			},
-			{
-				ResourceName:            "google_container_cluster.with_private_endpoint_subnetwork",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
-			},
-		},
-	})
-}
-
 func TestAccContainerCluster_withPrivateClusterConfigMissingCidrBlock_withAutopilot(t *testing.T) {
 	t.Parallel()
 
@@ -7798,77 +7765,6 @@ resource "google_container_cluster" "with_resource_usage_export_config" {
   subnetwork    = "%s"
 }
 `, datasetId, clusterName, networkName, subnetworkName)
-}
-
-func testAccContainerCluster_PscBasic(containerNetName, clusterName string) string {
-  return fmt.Sprintf(`
-resource "google_compute_network" "container_network" {
-  name                    = "%s"
-  auto_create_subnetworks = false
-}
-
-resource "google_compute_subnetwork" "container_subnetwork" {
-  name                     = google_compute_network.container_network.name
-  network                  = google_compute_network.container_network.name
-  ip_cidr_range            = "10.0.36.0/24"
-  region                   = "us-central1"
-}
-
-resource "google_container_cluster" "psc" {
-  name               = "%s"
-  location           = "us-central1-c"
-  initial_node_count = 1
-
-  network    = google_compute_network.container_network.name
-  subnetwork = google_compute_subnetwork.container_subnetwork.name
-
-  master_authorized_networks_config {
-    gcp_public_cidrs_access_enabled = false 
-  }
-
-  private_cluster_config {
-    enable_private_nodes = true
-  }
-  min_master_version = "1.29.1-gke.1575000"
-  
-}
-`, containerNetName, clusterName)
-}
-
-func testAccContainerCluster_withPrivateClusterConfigCidrBlockUpdate(containerNetName, clusterName string) string {
-	return fmt.Sprintf(`
-resource "google_compute_network" "container_network" {
-  name                    = "%s"
-  auto_create_subnetworks = false
-}
-
-resource "google_compute_subnetwork" "container_subnetwork" {
-  name                     = google_compute_network.container_network.name
-  network                  = google_compute_network.container_network.name
-  ip_cidr_range            = "10.0.36.0/24"
-  region                   = "us-central1"
-}
-
-resource "google_container_cluster" "psc" {
-  name               = "%s"
-  location           = "us-central1-c"
-  initial_node_count = 1
-
-  network    = google_compute_network.container_network.name
-  subnetwork = google_compute_subnetwork.container_subnetwork.name
-
-  master_authorized_networks_config {
-    gcp_public_cidrs_access_enabled = false 
-  }
-
-  private_cluster_config {
-    enable_private_nodes = true
-	master_ipv4_cidr_block = "172.15.0.0/28"
-  }
-  min_master_version = "1.29.1-gke.1575000"
-  
-}
-`, containerNetName, clusterName)
 }
 
 func testAccContainerCluster_withPrivateClusterConfigMissingCidrBlock(containerNetName, clusterName, location string, autopilotEnabled bool) string {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -1242,6 +1242,39 @@ func TestAccContainerCluster_withPrivateClusterConfigMissingCidrBlock(t *testing
 	})
 }
 
+func TestAccContainerCluster_withPrivateClusterConfigCidrBlockUpdate(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	containerNetName := fmt.Sprintf("tf-test-container-net-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_PscBasic(containerNetName, clusterName),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_private_endpoint_subnetwork",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_withPrivateClusterConfigCidrBlockUpdate(containerNetName, clusterName),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_private_endpoint_subnetwork",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
+			},
+		},
+	})
+}
+
 func TestAccContainerCluster_withPrivateClusterConfigMissingCidrBlock_withAutopilot(t *testing.T) {
 	t.Parallel()
 
@@ -7765,6 +7798,77 @@ resource "google_container_cluster" "with_resource_usage_export_config" {
   subnetwork    = "%s"
 }
 `, datasetId, clusterName, networkName, subnetworkName)
+}
+
+func testAccContainerCluster_PscBasic(containerNetName, clusterName string) string {
+  return fmt.Sprintf(`
+resource "google_compute_network" "container_network" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "container_subnetwork" {
+  name                     = google_compute_network.container_network.name
+  network                  = google_compute_network.container_network.name
+  ip_cidr_range            = "10.0.36.0/24"
+  region                   = "us-central1"
+}
+
+resource "google_container_cluster" "psc" {
+  name               = "%s"
+  location           = "us-central1-c"
+  initial_node_count = 1
+
+  network    = google_compute_network.container_network.name
+  subnetwork = google_compute_subnetwork.container_subnetwork.name
+
+  master_authorized_networks_config {
+    gcp_public_cidrs_access_enabled = false 
+  }
+
+  private_cluster_config {
+    enable_private_nodes = true
+  }
+  min_master_version = "1.29.1-gke.1575000"
+  
+}
+`, containerNetName, clusterName)
+}
+
+func testAccContainerCluster_withPrivateClusterConfigCidrBlockUpdate(containerNetName, clusterName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "container_network" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "container_subnetwork" {
+  name                     = google_compute_network.container_network.name
+  network                  = google_compute_network.container_network.name
+  ip_cidr_range            = "10.0.36.0/24"
+  region                   = "us-central1"
+}
+
+resource "google_container_cluster" "psc" {
+  name               = "%s"
+  location           = "us-central1-c"
+  initial_node_count = 1
+
+  network    = google_compute_network.container_network.name
+  subnetwork = google_compute_subnetwork.container_subnetwork.name
+
+  master_authorized_networks_config {
+    gcp_public_cidrs_access_enabled = false 
+  }
+
+  private_cluster_config {
+    enable_private_nodes = true
+	master_ipv4_cidr_block = "172.15.0.0/28"
+  }
+  min_master_version = "1.29.1-gke.1575000"
+  
+}
+`, containerNetName, clusterName)
 }
 
 func testAccContainerCluster_withPrivateClusterConfigMissingCidrBlock(containerNetName, clusterName, location string, autopilotEnabled bool) string {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Remove forceNew on these two fields as
- cx no longer need to provide `master_ipv4_cidr_block` for creating PSC clusters
- `private_endpoint_subnetwork` field is no more used


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:bug

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: changed `master_ipv4_cidr_block`/`private_endpoint_subnetwork` to `ForceNew: false` on `Cluster`
```
