### PR TITLE
Revert "Promote metric settings in compute region autoscaler to GA"

### DIFF
--- a/mmv1/products/compute/RegionAutoscaler.yaml
+++ b/mmv1/products/compute/RegionAutoscaler.yaml
@@ -140,6 +140,7 @@ properties:
           Defines operating mode for this policy.
       - !ruby/object:Api::Type::NestedObject
         name: 'scaleDownControl'
+        min_version: beta
         description: |
           Defines scale down controls to reduce the risk of response latency
           and outages due to abrupt scale-in events
@@ -264,6 +265,7 @@ properties:
               required: true
             - !ruby/object:Api::Type::Double
               name: 'singleInstanceAssignment'
+              min_version: beta
               description: |
                 If scaling is based on a per-group metric value that represents the
                 total amount of work to be done or resource usage, set this value to
@@ -339,6 +341,7 @@ properties:
                 (if you are using gce_instance resource type). If multiple
                 TimeSeries are returned upon the query execution, the autoscaler
                 will sum their respective values to obtain its scaling value.
+              min_version: beta
       - !ruby/object:Api::Type::NestedObject
         name: 'loadBalancingUtilization'
         description: |

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_autoscaler_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_autoscaler_test.go.erb
@@ -217,12 +217,14 @@ resource "google_compute_region_autoscaler" "foobar" {
       target = 0.5
       predictive_method = "OPTIMIZE_AVAILABILITY"
     }
+<% unless version == 'ga' -%>
     scale_down_control {
       max_scaled_down_replicas {
         percent = 80
       }
       time_window_sec = 300
     }
+<% end -%>
   }
 }
 `, autoscalerName)
@@ -267,12 +269,14 @@ resource "google_compute_region_autoscaler" "foobar" {
     cpu_utilization {
       target = 0.5
     }
+<% unless version == 'ga' -%>
     scale_down_control {
       max_scaled_down_replicas {
         percent = 80
       }
       time_window_sec = 300
     }
+<% end -%>
     scaling_schedules {
       name = "every-weekday-morning"
       description = "Increase to 2 every weekday at 7AM for 6 hours."


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#10045

```release-note:enhancement
compute: promoted `metric.single_instance_assignment` and `metric.filter` for `google_compute_region_autoscaler` to GA (revert)
```