### PR TITLE
Remove provider-related caches to address cache issues

### DIFF
--- a/.github/workflows/test-tpg.yml
+++ b/.github/workflows/test-tpg.yml
@@ -41,16 +41,6 @@ jobs:
         repository: ${{ github.event.inputs.owner }}/${{ github.event.inputs.repo }}
         ref: ${{ github.event.inputs.branch }}
         fetch-depth: 2
-    - name: Cache Go modules and build cache
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        key: ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{hashFiles('go.sum','google-*/transport/**','google-*/tpgresource/**','google-*/acctest/**','google-*/envvar/**','google-*/sweeper/**','google-*/verify/**') }}
-        restore-keys: |
-          ${{ runner.os }}-test-${{ github.event.inputs.repo }}-${{ hashFiles('go.sum') }}
-          ${{ runner.os }}-test-${{ github.event.inputs.repo }}-
     - name: Check for Code Changes
       id: pull_request
       run: |

--- a/.github/workflows/unit-test-tpg.yml
+++ b/.github/workflows/unit-test-tpg.yml
@@ -30,17 +30,6 @@ jobs:
         with:
           go-version: '^1.20'
 
-      - name: Cache Go modules and build cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-test-${{ inputs.repo }}-${{hashFiles('go.sum','google-*/transport/**','google-*/tpgresource/**','google-*/acctest/**','google-*/envvar/**','google-*/sweeper/**','google-*/verify/**') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ inputs.repo }}-${{ hashFiles('go.sum') }}
-            ${{ runner.os }}-test-${{ inputs.repo }}-
-
       - name: Build Provider
         run: |
           go build


### PR DESCRIPTION
We keep exceeding the 10GB cache limit for the repo, resulting in workflows stalling for 30min on caching steps and then timing out.

Recent examples:
- https://github.com/GoogleCloudPlatform/magic-modules/actions/runs/8110750120/job/22168743566
- https://github.com/GoogleCloudPlatform/magic-modules/actions/runs/8111707791
- https://github.com/GoogleCloudPlatform/magic-modules/actions/runs/8114921062/job/22181809313

This PR removes caching for the providers, which are the larger items stored in the cache. I've left in caching for things like bundler gems, Maven dependencies, and the cache for tgc.



<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
