### PR TITLE
TeamCity: enable ad hoc triggers of teamcity-diff-check GHA

### DIFF
--- a/.github/workflows/teamcity-services-diff-check-weekly.yml
+++ b/.github/workflows/teamcity-services-diff-check-weekly.yml
@@ -2,8 +2,12 @@ name: TeamCity Services Weekly Diff Check
 permissions: read-all
 
 on:
+  # Enable ad hoc checks
+  workflow_dispatch:
+  
+  # Scheduled checks to catch edge cases
   schedule:
-    # Runs every tuesday morning
+    # Every Tuesday morning
     - cron:  '0 4 * * 2'
 
 jobs:

--- a/.github/workflows/teamcity-services-diff-check.yml
+++ b/.github/workflows/teamcity-services-diff-check.yml
@@ -2,7 +2,6 @@ name: TeamCity Services Diff Check
 permissions: read-all
 
 on:
-  workflow_dispatch:
   pull_request:
     paths:
       - '.github/workflows/teamcity-services-diff-check.yml'


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Manually triggering the GHA for testing PRs is mostly going to result in the GHA terminating early because no new service is being added.

By moving the manual trigger to the weekly version of the GHA we can run ad hoc tests to see if a new service has been added or not

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
