### PR TITLE
feat(alloydb): (beta) instance: add support for inbound public ip and authorized networks

### DIFF
--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -55,6 +55,7 @@ autogen_async: true
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/alloydb_instance.go.erb
   pre_create: templates/terraform/pre_create/alloydb_instance.go.erb
+  post_create: templates/terraform/post_create/alloydb_instance.go.erb
   pre_delete: templates/terraform/pre_delete/alloydb_instance.go.erb
 examples:
   - !ruby/object:Provider::Terraform::Examples
@@ -68,6 +69,17 @@ examples:
       - 'reconciling'
       - 'update_time'
     skip_test: true
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'alloydb_instance_public_ip'
+    primary_resource_id: 'public_ip_instance'
+    min_version: beta
+    vars:
+      alloydb_cluster_name: 'alloydb-cluster'
+      alloydb_instance_name: 'alloydb-instance'
+      network_name: 'alloydb-network'
+    ignore_read_extra:
+      - 'reconciling'
+      - 'update_time'
   - !ruby/object:Provider::Terraform::Examples
     name: 'alloydb_secondary_instance_basic'
     primary_resource_id: 'secondary'
@@ -278,3 +290,29 @@ properties:
             values:
               - :ENCRYPTED_ONLY
               - :ALLOW_UNENCRYPTED_AND_ENCRYPTED
+  - !ruby/object:Api::Type::NestedObject
+    name: 'networkConfig'
+    default_from_api: true
+    min_version: beta
+    description: |
+      Metadata related to network configuration.
+    properties:
+      - !ruby/object:Api::Type::Boolean
+        name: enablePublicIp
+        description: |
+          Enables inbound public IP address.
+      - !ruby/object:Api::Type::Array
+        name: authorizedExternalNetworks
+        description: |
+          list of external networks authorized to access the instance.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::String
+              name: cidrRange
+              description: |
+                The IP range in CIDR notation that is allowed to access the instance.
+  - !ruby/object:Api::Type::String
+    name: publicIpAddress
+    output: true
+    description: |
+      The public IP address for the Instance, if `network_config.enable_public_ip` is set to true.

--- a/mmv1/templates/terraform/examples/alloydb_instance_public_ip.tf.erb
+++ b/mmv1/templates/terraform/examples/alloydb_instance_public_ip.tf.erb
@@ -1,0 +1,57 @@
+resource "google_alloydb_instance" "<%= ctx[:primary_resource_id] %>" {
+  provider      = google-beta
+  
+  cluster       = google_alloydb_cluster.<%= ctx[:primary_resource_id] %>.name
+  instance_id   = "<%= ctx[:vars]['alloydb_instance_name'] %>"
+  instance_type = "PRIMARY"
+
+  machine_config {
+    cpu_count = 2
+  }
+  
+  network_config {
+    enable_public_ip = true
+    authorized_external_networks {
+      cidr_range = "10.0.0.0/24"
+    }
+  }
+
+  depends_on = [google_service_networking_connection.vpc_connection]
+}
+
+resource "google_alloydb_cluster" "<%= ctx[:primary_resource_id] %>" {
+  provider   = google-beta
+
+  cluster_id = "<%= ctx[:vars]['alloydb_cluster_name'] %>"
+  location   = "us-central1"
+  network    = google_compute_network.default.id
+
+  initial_user {
+    password = "<%= ctx[:vars]['alloydb_cluster_name'] %>"
+  }
+}
+
+data "google_project" "project" {
+  provider   = google-beta
+}
+
+resource "google_compute_network" "default" {
+  provider = google-beta
+  name     = "<%= ctx[:vars]['network_name'] %>"
+}
+
+resource "google_compute_global_address" "private_ip_alloc" {
+  provider      = google-beta
+  name          =  "<%= ctx[:vars]['alloydb_cluster_name'] %>"
+  address_type  = "INTERNAL"
+  purpose       = "VPC_PEERING"
+  prefix_length = 16
+  network       = google_compute_network.default.id
+}
+
+resource "google_service_networking_connection" "vpc_connection" {
+  provider                = google-beta
+  network                 = google_compute_network.default.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
+}

--- a/mmv1/templates/terraform/post_create/alloydb_instance.go.erb
+++ b/mmv1/templates/terraform/post_create/alloydb_instance.go.erb
@@ -1,0 +1,43 @@
+<% unless version == 'ga' -%>
+networkConfigProp, err = expandAlloydbInstanceNetworkConfig(d.Get("network_config"), d, config)
+if err != nil {
+	return err
+} else if v, ok := d.GetOkExists("network_config"); !tpgresource.IsEmptyValue(reflect.ValueOf(networkConfigProp)) && (ok || !reflect.DeepEqual(v, networkConfigProp)) {
+	// an instance cannot be created with public IP addresses, so we need to PATCH the instance 
+        // after its created
+	url, err := tpgresource.ReplaceVars(d, config, "{{AlloydbBasePath}}{{cluster}}/instances/{{instance_id}}")
+	if err != nil {
+		return err 
+	}
+	log.Printf("[DEBUG] Updating network configuration for alloyDB instance %q", d.Id())
+	obj = make(map[string]interface{})
+	obj["networkConfig"] = networkConfigProp
+
+	url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": "networkConfig"})
+	if err != nil {
+		return err
+	}
+
+	patchRes, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config: config,
+		Method: "PATCH",
+		Project: billingProject,
+		RawURL: url,
+		UserAgent: userAgent,
+		Body: obj,
+		Timeout: d.Timeout(schema.TimeoutUpdate),
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error updating network configuration for alloydb instance %q: %s", d.Id(), err)
+	}
+
+	err = AlloydbOperationWaitTime(
+		config, patchRes, project, "Creating Instance", userAgent,
+		d.Timeout(schema.TimeoutUpdate))
+
+	if err != nil {
+		return fmt.Errorf("Error updating network configuration for alloydb instance %q: %s", d.Id(), err)
+	}
+}
+<% end -%>

--- a/mmv1/templates/terraform/pre_create/alloydb_instance.go.erb
+++ b/mmv1/templates/terraform/pre_create/alloydb_instance.go.erb
@@ -3,3 +3,18 @@
 if instanceType := d.Get("instance_type"); instanceType == "SECONDARY" {
   url = strings.Replace(url, "instances?instanceId", "instances:createsecondary?instanceId", 1)
 }
+
+<% unless version == 'ga' -%>
+if val, ok := obj["networkConfig"]; ok {
+  networkConfig := val.(map[string]interface{})
+  if val, ok = networkConfig["enablePublicIp"]; ok {
+    // public IPs can only be enabled after creation
+    // we will temporarily remove it from the creation request, and update
+    // the value in post_create
+    delete(networkConfig, "enablePublicIp")
+  }
+  if val, ok = networkConfig["authorizedExternalNetworks"]; ok {
+    delete(networkConfig, "authorizedExternalNetworks")
+  }
+}
+<% end -%>


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/17091

```tf
resource "google_alloydb_instance" {
  # ...
  network_config {
    enable_public_ip = true
    authorized_external_networks {
      cidr_range = "x.y.z.a/32"
    }
  }
}
```

Adds support for Inbound public IP and external network addresses pre GA.
https://cloud.google.com/alloydb/docs/connect-public-ip

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
alloydb: added `network_config.enable_public_ip`, `network_config.authorized_external_networks` and `public_ip_address` fields to `google_alloydb_instance` resource (beta)
```
