### PR TITLE
subnetwork and service_account_email params described (17211)

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/dataflow_flex_template_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataflow_flex_template_job.html.markdown
@@ -118,6 +118,10 @@ provided, the provider project is used.
 
 * `region` - (Optional) The region in which the created job should run.
 
+* `service_account_email` - (Optional) Service account to run the workers as.
+
+* `subnetwork` - (Optional) Compute Engine subnetwork for launching instances to run your pipeline.
+
 ## Attributes Reference
 In addition to the arguments listed above, the following computed attributes are exported:
 

--- a/mmv1/third_party/terraform/website/docs/r/dataflow_flex_template_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataflow_flex_template_job.html.markdown
@@ -118,7 +118,7 @@ provided, the provider project is used.
 
 * `region` - (Optional) The region in which the created job should run.
 
-* `service_account_email` - (Optional) Service account to run the workers as.
+* `service_account_email` - (Optional) Service account email to run the workers as.
 
 * `subnetwork` - (Optional) Compute Engine subnetwork for launching instances to run your pipeline.
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Updated doc for dataflow flex job - added subnetwork and service_account_email params.
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/17211

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
Updated doc for dataflow flex job - added subnetwork and service_account_email params.
```
