### PR TITLE
Bump GHA actions to navigate deprecations of NodeJS 12 and 16

### DIFF
--- a/.github/workflows/build-downstream.yml
+++ b/.github/workflows/build-downstream.yml
@@ -21,7 +21,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build-downstream.yml
+++ b/.github/workflows/build-downstream.yml
@@ -108,7 +108,7 @@ jobs:
           (current_dir=$(pwd) && cd $OUTPUT_PATH && zip -r "$current_dir/output.zip" .)
 
       - name: Upload built artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: artifact-${{ inputs.repo  }}
           path: output.zip

--- a/.github/workflows/build-downstream.yml
+++ b/.github/workflows/build-downstream.yml
@@ -45,7 +45,7 @@ jobs:
         working-directory: mmv1
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: '^1.20'
 

--- a/.github/workflows/build-downstream.yml
+++ b/.github/workflows/build-downstream.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+        uses: ruby/setup-ruby@036ef458ddccddb148a2b9fb67e95a22fdbf728b # v1.160.0
         with:
           ruby-version: '3.1'
 

--- a/.github/workflows/build-downstream.yml
+++ b/.github/workflows/build-downstream.yml
@@ -31,7 +31,7 @@ jobs:
           ruby-version: '3.1'
 
       - name: Cache Bundler gems
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: mmv1/vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('mmv1/**/Gemfile.lock') }}
@@ -51,7 +51,7 @@ jobs:
 
       # Cache Go modules
       - name: Cache Go modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: repo
       - name: Check Changelog

--- a/.github/workflows/magic-modules.yml
+++ b/.github/workflows/magic-modules.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: repo
           fetch-depth: 0
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: repo
           fetch-depth: 2

--- a/.github/workflows/magic-modules.yml
+++ b/.github/workflows/magic-modules.yml
@@ -49,7 +49,7 @@ jobs:
           git fetch origin ${{ github.base_ref }} # Fetch the base branch
           git merge --no-ff origin/${{ github.base_ref }} # Merge with the base branch
       - name: Set up Ruby
-        uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+        uses: ruby/setup-ruby@036ef458ddccddb148a2b9fb67e95a22fdbf728b # v1.160.0
         with:
           ruby-version: '3.1'
       - name: Install dependencies

--- a/.github/workflows/membership-checker.yml
+++ b/.github/workflows/membership-checker.yml
@@ -11,7 +11,7 @@ jobs:
   build-and-unit-tests:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Go
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/repository-documentation.yml
+++ b/.github/workflows/repository-documentation.yml
@@ -12,7 +12,7 @@ jobs:
   deploy:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true  # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod

--- a/.github/workflows/teamcity-services-diff-check-weekly.yml
+++ b/.github/workflows/teamcity-services-diff-check-weekly.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Go
         uses: actions/setup-go@v3

--- a/.github/workflows/teamcity-services-diff-check-weekly.yml
+++ b/.github/workflows/teamcity-services-diff-check-weekly.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: '^1.20'
 

--- a/.github/workflows/teamcity-services-diff-check.yml
+++ b/.github/workflows/teamcity-services-diff-check.yml
@@ -15,7 +15,7 @@ jobs:
       services: ${{steps.services.outputs.services}}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: "Check for New Services"
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Go
         uses: actions/setup-go@v3

--- a/.github/workflows/teamcity-services-diff-check.yml
+++ b/.github/workflows/teamcity-services-diff-check.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: '^1.20'
 

--- a/.github/workflows/test-tgc.yml
+++ b/.github/workflows/test-tgc.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 30
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ${{ github.event.inputs.owner }}/${{ github.event.inputs.repo }}
         ref: ${{ github.event.inputs.branch }}

--- a/.github/workflows/test-tgc.yml
+++ b/.github/workflows/test-tgc.yml
@@ -79,7 +79,7 @@ jobs:
         }'
     - name: Set up Go
       if: ${{ !failure() && steps.pull_request.outputs.has_changes == 'true' }}
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: '^1.20'
     - name: Build Terraform Google Conversion

--- a/.github/workflows/test-tpg.yml
+++ b/.github/workflows/test-tpg.yml
@@ -36,7 +36,7 @@ jobs:
     timeout-minutes: 30
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ${{ github.event.inputs.owner }}/${{ github.event.inputs.repo }}
         ref: ${{ github.event.inputs.branch }}

--- a/.github/workflows/test-tpg.yml
+++ b/.github/workflows/test-tpg.yml
@@ -70,7 +70,7 @@ jobs:
         }'
     - name: Set up Go
       if: ${{ !failure() && steps.pull_request.outputs.has_changes == 'true' }}
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: '^1.20'
     - name: Build Provider

--- a/.github/workflows/unit-test-tgc.yml
+++ b/.github/workflows/unit-test-tgc.yml
@@ -28,7 +28,7 @@ jobs:
           rm artifacts-tpgb/output.zip
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: '^1.20'
 

--- a/.github/workflows/unit-test-tpg.yml
+++ b/.github/workflows/unit-test-tpg.yml
@@ -26,7 +26,7 @@ jobs:
           rm artifacts/output.zip
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: '^1.20'
 

--- a/.github/workflows/unit-tests-diff-processor.yml
+++ b/.github/workflows/unit-tests-diff-processor.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v4


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Closes https://github.com/hashicorp/terraform-provider-google/issues/17467

This PR:

- **Updates all uses of actions/cache to v3** - this was the highest version used within this repo prior to this PR
- **Updates all uses of actions/checkout to v4**  - this was the highest version used within this repo prior to this PR
- **Updates all uses of actions/upload-artifact to v3.1.0**  - this was the highest version used within this repo prior to this PR
- **Updates all uses of actions/setup-go to v4.0.0**  - this was the highest version used within this repo prior to this PR

This PR doesn't touch `actions/download-artifact` because it's unclear if it's been upgraded to use Node20 and the latest major version has some large breaking changes: https://github.com/actions/download-artifact/releases/tag/v4.0.0 That should be addressed in a standalone PR.

---

Addresses this warnings:

See https://github.com/GoogleCloudPlatform/magic-modules/actions/runs/8146336553

![Screenshot 2024-03-04 at 21 01 20](https://github.com/GoogleCloudPlatform/magic-modules/assets/15078782/42154070-da71-408b-ba5b-835036ed7986)



<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
