### PR TITLE
fix permadiff by reading empty docker_config field

### DIFF
--- a/mmv1/products/artifactregistry/Repository.yaml
+++ b/mmv1/products/artifactregistry/Repository.yaml
@@ -181,6 +181,7 @@ properties:
     name: 'dockerConfig'
     description: |-
       Docker repository config contains repository level configuration for the repositories of docker type.
+    allow_empty_object: true
     properties:
       - !ruby/object:Api::Type::Boolean
         name: 'immutableTags'


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/14846.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
artifactregistry: fixed docker_config permadiff
```