### PR TITLE
Change `advertised_ip_ranges` fields in `google_compute_router_peer` and `google_compute_router` resources to Sets

### DIFF
--- a/mmv1/products/compute/Router.yaml
+++ b/mmv1/products/compute/Router.yaml
@@ -150,7 +150,7 @@ properties:
           This enum field has the one valid value: ALL_SUBNETS
         item_type: Api::Type::String  # TODO(#324): enum?
         send_empty_value: true
-      - !ruby/object:Api::Type::Array
+      - !ruby/object:Api::Type::Set
         name: advertisedIpRanges
         description: |
           User-specified list of individual IP ranges to advertise in

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
@@ -113,7 +113,7 @@ Leave this field blank to advertise no custom groups.`,
 				},
 			},
 			"advertised_ip_ranges": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Description: `User-specified list of individual IP ranges to advertise in
 custom mode. This field can only be populated if advertiseMode
@@ -1095,8 +1095,9 @@ func expandNestedComputeRouterBgpPeerAdvertisedGroups(v interface{}, d tpgresour
 }
 
 func expandNestedComputeRouterBgpPeerAdvertisedIpRanges(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	v = v.(*Schema.Set).List()
 	l := v.([]interface{})
-	req := make([]interface{}, 0, len(l))
+	req := make(map[string]interface{}, 0, len(l))
 	for _, raw := range l {
 		if raw == nil {
 			continue


### PR DESCRIPTION
# Description
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Linked to https://github.com/hashicorp/terraform-provider-google/issues/9353

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: changed the `advertised_ip_ranges` fields in both `google_compute_router_peer` and `google_compute_router` resources to be sets. This will reduce diffs due to re-ordering.
```

# ToDo

Need to test it to be sure their is no impacts with https://registry.terraform.io/providers/public-cloud-wl/google/5.17.4 from https://github.com/public-cloud-wl/terraform-provider-google/commit/1a4d7e6ecb001cf279c502512133edda167f6f4a