### PR TITLE
Clarify usage of min/max throughput and instances

### DIFF
--- a/mmv1/products/vpcaccess/Connector.yaml
+++ b/mmv1/products/vpcaccess/Connector.yaml
@@ -106,19 +106,23 @@ properties:
   - !ruby/object:Api::Type::Integer
     name: minThroughput
     description: |
-      Minimum throughput of the connector in Mbps. Default and min is 200.
+      Minimum throughput of the connector in Mbps. Default and min is 200. Refers to the expected throughput when using an e2-micro machine type. 
+      Value must be a multiple of 100 from 200 through 900. Must be lower than the value specified by maxThroughput. If both minThroughput and
+      minInstances are provided, minInstances takes precedence over minThroughput. The use of minThroughput is discouraged in favor of minInstances.
     default_value: 200
     validation: !ruby/object:Provider::Terraform::Validation
       function: 'validation.IntBetween(200, 1000)'
   - !ruby/object:Api::Type::Integer
     name: minInstances
     description: |
-      Minimum value of instances in autoscaling group underlying the connector.
+      Minimum value of instances in autoscaling group underlying the connector. Value must be between 2 and 9, inclusive. Must be
+      lower than the value specified by maxInstances.
     default_from_api: true
   - !ruby/object:Api::Type::Integer
     name: maxInstances
     description: |
-      Maximum value of instances in autoscaling group underlying the connector.
+      Maximum value of instances in autoscaling group underlying the connector. Value must be between 3 and 10, inclusive. Must be
+      higher than the value specified by minInstances.
     default_from_api: true
   - !ruby/object:Api::Type::Integer
     name: maxThroughput
@@ -126,7 +130,10 @@ properties:
     # throughput must be lower than the maximum. The console defaults to 1000, so I changed it to that.
     # API returns 300 if it is not sent
     description: |
-      Maximum throughput of the connector in Mbps, must be greater than `min_throughput`. Default is 300.
+      Maximum throughput of the connector in Mbps, must be greater than `min_throughput`. Default is 300. Refers to the expected throughput
+      when using an e2-micro machine type. Value must be a multiple of 100 from 300 through 1000. Must be higher than the value specified by
+      minThroughput. If both maxThroughput and maxInstances are provided, maxInstances takes precedence over maxThroughput. The use of
+      maxThroughput is discouraged in favor of maxInstances.
     default_value: 300
     validation: !ruby/object:Provider::Terraform::Validation
       function: 'validation.IntBetween(200, 1000)'


### PR DESCRIPTION
Adding more descriptive comments for min/max throughput and instances to make behaviour more clear.
This is to address issues: https://github.com/hashicorp/terraform-provider-google/issues/10244 and https://github.com/hashicorp/terraform-provider-google/issues/15278.



<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:Update documentation for vpcaccess min/max instances and throughput

```
