### PR TITLE
Add Private Cloud Sweepers for southamerica-west1

### DIFF
--- a/mmv1/products/vmwareengine/PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/PrivateCloud.yaml
@@ -44,6 +44,7 @@ async: !ruby/object:Api::OpAsync
     message: "message"
 import_format: ["projects/{{project}}/locations/{{location}}/privateClouds/{{name}}"]
 autogen_async: true
+skip_sweeper: true
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   post_delete: "templates/terraform/post_delete/private_cloud.go.erb"
   decoder: "templates/terraform/decoders/private_cloud.go.erb"

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_test.go
@@ -70,39 +70,14 @@ func TestAccVmwareengineCluster_vmwareEngineClusterUpdate(t *testing.T) {
 func testVmwareEngineClusterConfig(context map[string]interface{}, nodeCount int) string {
 	context["node_count"] = nodeCount
 	return acctest.Nprintf(`
-resource "google_project" "project" {
-  project_id      = "tf-test%{random_suffix}"
-  name            = "tf-test%{random_suffix}"
-  org_id          = "%{org_id}"
-  billing_account = "%{billing_account}"
-}
-
-resource "google_project_service" "vmwareengine" {
-  project = google_project.project.project_id
-  service = "vmwareengine.googleapis.com"
-}
-
-resource "time_sleep" "sleep" {
-  create_duration = "1m"
-  depends_on = [
-    google_project_service.vmwareengine,
-  ]
-}
-
 resource "google_vmwareengine_network" "cluster-nw" {
-  project = google_project.project.project_id
   name        = "tf-test-cluster-nw%{random_suffix}"
   location    = "global"
   type        = "STANDARD"
   description = "PC network description."
-
-  depends_on = [
-    time_sleep.sleep # Sleep allows permissions in the new project to propagate
-  ]
 }
 
 resource "google_vmwareengine_private_cloud" "cluster-pc" {
-  project = google_project.project.project_id
   location    = "%{region}-a"
   name        = "tf-test-cluster-pc%{random_suffix}"
   description = "Sample test PC."

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_address_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_address_test.go
@@ -17,7 +17,7 @@ func TestAccVmwareengineExternalAddress_vmwareEngineExternalAddressUpdate(t *tes
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"region":          "southamerica-east1", // using region with low node utilization.
+		"region":          "southamerica-west1", // using region with low node utilization.
 		"random_suffix":   acctest.RandString(t, 10),
 		"org_id":          envvar.GetTestOrgFromEnv(t),
 		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
@@ -60,39 +60,14 @@ func testVmwareEngineExternalAddressConfig(context map[string]interface{}, descr
 	context["internal_ip"] = internalIp
 	context["description"] = description
 	return acctest.Nprintf(`
-resource "google_project" "project" {
-  project_id      = "tf-test%{random_suffix}"
-  name            = "tf-test%{random_suffix}"
-  org_id          = "%{org_id}"
-  billing_account = "%{billing_account}"
-}
-
-resource "google_project_service" "vmwareengine" {
-  project = google_project.project.project_id
-  service = "vmwareengine.googleapis.com"
-}
-
-resource "time_sleep" "sleep" {
-  create_duration = "1m"
-  depends_on = [
-    google_project_service.vmwareengine,
-  ]
-}
-
 resource "google_vmwareengine_network" "external-address-nw" {
-  project = google_project.project.project_id
   name        = "tf-test-sample-external-address-nw%{random_suffix}"
   location    = "global"
   type        = "STANDARD"
   description = "PC network description."
-
-  depends_on = [
-    time_sleep.sleep # Sleep allows permissions in the new project to propagate
-  ]
 }
 
 resource "google_vmwareengine_private_cloud" "external-address-pc" {
-  project = google_project.project.project_id
   location    = "%{region}-a"
   name        = "tf-test-sample-external-address-pc%{random_suffix}"
   type        = "TIME_LIMITED"
@@ -101,7 +76,6 @@ resource "google_vmwareengine_private_cloud" "external-address-pc" {
     management_cidr       = "192.168.1.0/24"
     vmware_engine_network = google_vmwareengine_network.external-address-nw.id
   }
-
   management_cluster {
     cluster_id = "tf-test-sample-external-address-cluster%{random_suffix}"
     node_type_configs {
@@ -112,7 +86,6 @@ resource "google_vmwareengine_private_cloud" "external-address-pc" {
 }
 
 resource "google_vmwareengine_network_policy" "external-address-np" {
-  project = google_project.project.project_id
   location = "%{region}"
   name = "tf-test-sample-external-address-np%{random_suffix}"
   edge_services_cidr = "192.168.0.0/26"

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_sweeper.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_sweeper.go
@@ -1,0 +1,128 @@
+package vmwareengine
+
+import (
+	"context"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/sweeper"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func init() {
+	sweeper.AddTestSweepers("VmwareenginePrivateCloud", testSweepVmwareenginePrivateCloud)
+}
+
+// At the time of writing, the CI only passes us-central1 as the region
+func testSweepVmwareenginePrivateCloud(region string) error {
+	location := "southamerica-west1-a"
+	resourceName := "VmwareenginePrivateCloud"
+	log.Printf("[INFO][SWEEPER_LOG] Starting sweeper for %s", resourceName)
+
+	config, err := sweeper.SharedConfigForRegion(location)
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error getting shared config for region: %s", err)
+		return err
+	}
+
+	err = config.LoadAndValidate(context.Background())
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error loading: %s", err)
+		return err
+	}
+
+	t := &testing.T{}
+	billingId := envvar.GetTestBillingAccountFromEnv(t)
+
+	// Setup variables to replace in list template
+	d := &tpgresource.ResourceDataMock{
+		FieldsInSchema: map[string]interface{}{
+			"project":         config.Project,
+			"region":          location,
+			"location":        location,
+			"zone":            "-",
+			"billing_account": billingId,
+		},
+	}
+
+	listTemplate := strings.Split("https://vmwareengine.googleapis.com/v1/projects/{{project}}/locations/{{location}}/privateClouds", "?")[0]
+	listUrl, err := tpgresource.ReplaceVars(d, config, listTemplate)
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error preparing sweeper list url: %s", err)
+		return nil
+	}
+
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   config.Project,
+		RawURL:    listUrl,
+		UserAgent: config.UserAgent,
+	})
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)
+		return nil
+	}
+
+	resourceList, ok := res["privateClouds"]
+	if !ok {
+		log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
+		return nil
+	}
+
+	rl := resourceList.([]interface{})
+
+	log.Printf("[INFO][SWEEPER_LOG] Found %d items in %s list response.", len(rl), resourceName)
+	// Keep count of items that aren't sweepable for logging.
+	nonPrefixCount := 0
+	for _, ri := range rl {
+		obj := ri.(map[string]interface{})
+		if obj["name"] == nil {
+			log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
+			return nil
+		}
+
+		name := tpgresource.GetResourceNameFromSelfLink(obj["name"].(string))
+		// Skip resources that shouldn't be sweeped
+		if !sweeper.IsSweepableTestResource(name) {
+			nonPrefixCount++
+			continue
+		}
+
+		deleteTemplate := "https://vmwareengine.googleapis.com/v1/projects/{{project}}/locations/{{location}}/privateClouds/{{name}}"
+		deleteUrl, err := tpgresource.ReplaceVars(d, config, deleteTemplate)
+		if err != nil {
+			log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
+			return nil
+		}
+		deleteUrl = deleteUrl + name
+
+		body := make(map[string]interface{})
+		body["delayHours"] = 0
+		body["force"] = true
+
+		// Don't wait on operations as we may have a lot to delete
+		_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "DELETE",
+			Project:   config.Project,
+			RawURL:    deleteUrl,
+			Body:      body,
+			UserAgent: config.UserAgent,
+		})
+		if err != nil {
+			log.Printf("[INFO][SWEEPER_LOG] Error deleting for url %s : %s", deleteUrl, err)
+		} else {
+			log.Printf("[INFO][SWEEPER_LOG] Sent delete request for %s resource: %s", resourceName, name)
+		}
+	}
+
+	if nonPrefixCount > 0 {
+		log.Printf("[INFO][SWEEPER_LOG] %d items were non-sweepable and skipped.", nonPrefixCount)
+	}
+
+	return nil
+}

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
@@ -71,40 +71,15 @@ func TestAccVmwareenginePrivateCloud_vmwareEnginePrivateCloudUpdate(t *testing.T
 func testPrivateCloudUpdateConfig(context map[string]interface{}, description string, nodeCount int) string {
 	context["node_count"] = nodeCount
 	context["description"] = description
-
 	return acctest.Nprintf(`
-resource "google_project" "project" {
-  project_id      = "tf-test%{random_suffix}"
-  name            = "tf-test%{random_suffix}"
-  org_id          = "%{org_id}"
-  billing_account = "%{billing_account}"
-}
-
-resource "google_project_service" "vmwareengine" {
-  project = google_project.project.project_id
-  service = "vmwareengine.googleapis.com"
-}
-
-resource "time_sleep" "sleep" {
-  create_duration = "1m"
-  depends_on = [
-    google_project_service.vmwareengine,
-  ]
-}
-
 resource "google_vmwareengine_network" "default-nw" {
-  project           = google_project.project.project_id
   name              = "tf-test-pc-nw-%{random_suffix}"
   location          = "global"
   type              = "STANDARD"
   description       = "PC network description."
-  depends_on = [
-    time_sleep.sleep # Sleep allows permissions in the new project to propagate
-  ]
 }
 
 resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
-  project     = google_project.project.project_id
   location = "%{region}-a"
   name = "tf-test-sample-pc%{random_suffix}"
   description = "%{description}"
@@ -124,7 +99,6 @@ resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
 }
 
 data "google_vmwareengine_private_cloud" "ds" {
-	project     = google_project.project.project_id
 	location = "%{region}-a"
 	name = "tf-test-sample-pc%{random_suffix}"
 	depends_on = [


### PR DESCRIPTION
Vmwareengine Private Cloud tests run in the location `southamerica-west1-a`. This is because these tests require provisioning multiple nodes and southamerica-west1 region has low utilisation. 

Since sweepers only clean up `us-central1` resources, this PR adds a handwritten sweeper cleaning up the dandling private clouds and is an intended fix for b/326669990

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
