### PR TITLE
Fix two lifecycle rules with different no_age value always generates change issue

### DIFF
--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
@@ -1237,10 +1237,10 @@ func flattenBucketLifecycle(d *schema.ResourceData, lifecycle *storage.BucketLif
 
 	rules := make([]map[string]interface{}, 0, len(lifecycle.Rule))
 
-	for _, rule := range lifecycle.Rule {
+	for index, rule := range lifecycle.Rule {
 		rules = append(rules, map[string]interface{}{
 			"action":    schema.NewSet(resourceGCSBucketLifecycleRuleActionHash, []interface{}{flattenBucketLifecycleRuleAction(rule.Action)}),
-			"condition": schema.NewSet(resourceGCSBucketLifecycleRuleConditionHash, []interface{}{flattenBucketLifecycleRuleCondition(d, rule.Condition)}),
+			"condition": schema.NewSet(resourceGCSBucketLifecycleRuleConditionHash, []interface{}{flattenBucketLifecycleRuleCondition(index, d, rule.Condition)}),
 		})
 	}
 
@@ -1254,7 +1254,7 @@ func flattenBucketLifecycleRuleAction(action *storage.BucketLifecycleRuleAction)
 	}
 }
 
-func flattenBucketLifecycleRuleCondition(d *schema.ResourceData, condition *storage.BucketLifecycleRuleCondition) map[string]interface{} {
+func flattenBucketLifecycleRuleCondition(index int, d *schema.ResourceData, condition *storage.BucketLifecycleRuleCondition) map[string]interface{} {
 	ruleCondition := map[string]interface{}{
 		"created_before":             condition.CreatedBefore,
 		"matches_storage_class":      tpgresource.ConvertStringArrToInterface(condition.MatchesStorageClass),
@@ -1279,7 +1279,7 @@ func flattenBucketLifecycleRuleCondition(d *schema.ResourceData, condition *stor
 		}
 	}
   // setting no_age value from state config since it is terraform only variable and not getting value from backend.
-	if v, ok := d.GetOk("lifecycle_rule.0.condition"); ok{
+	if v, ok := d.GetOk(fmt.Sprintf("lifecycle_rule.%d.condition",index)); ok{
 		state_condition := v.(*schema.Set).List()[0].(map[string]interface{})
 		ruleCondition["no_age"] = state_condition["no_age"].(bool)
 	}

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
@@ -508,7 +508,7 @@ func TestAccStorageBucket_lifecycleRulesNoAge(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.no_age"},
+				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.1.condition.0.no_age"},
 			},
 			{
 				Config: testAccStorageBucket_customAttributes_withLifecycleNoAgeAndAge(bucketName),
@@ -522,7 +522,7 @@ func TestAccStorageBucket_lifecycleRulesNoAge(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.no_age"},
+				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.1.condition.0.no_age"},
 			},
 			{
 				Config: testAccStorageBucket_customAttributes_withLifecycle1(bucketName),
@@ -1477,8 +1477,8 @@ func testAccCheckStorageBucketLifecycleConditionState(expected *bool, b *storage
 
 func testAccCheckStorageBucketLifecycleConditionNoAge(expected *int64, b *storage.Bucket) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		actual := b.Lifecycle.Rule[0].Condition.Age
-		if expected == nil && b.Lifecycle.Rule[0].Condition.Age== nil {
+		actual := b.Lifecycle.Rule[1].Condition.Age
+		if expected == nil && b.Lifecycle.Rule[1].Condition.Age == nil {
 			return nil
 		}
 		if expected == nil {
@@ -1689,6 +1689,15 @@ resource "google_storage_bucket" "bucket" {
   location      = "EU"
   force_destroy = "true"
   lifecycle_rule {
+     action {
+       type = "Delete"
+     }
+     condition {
+        age = 10
+        no_age = false
+     }
+  }
+  lifecycle_rule {
     action {
       type = "Delete"
     }
@@ -1707,6 +1716,15 @@ resource "google_storage_bucket" "bucket" {
   name          = "%s"
   location      = "EU"
   force_destroy = "true"
+  lifecycle_rule {
+     action {
+       type = "Delete"
+     }
+     condition {
+       age = 10
+       no_age = false
+     }
+  }
   lifecycle_rule {
     action {
       type = "Delete"


### PR DESCRIPTION

Fixes [hashicorp/terraform-provider-google/issues/17314](https://github.com/hashicorp/terraform-provider-google/issues/17314)

```release-note:bug
storage: fixed two or more lifecycle rules with different values of `no_age` field always generates change in `google_storage_bucket` resource.
```
