### PR TITLE
Make universe domain test independent from test credentials

### DIFF
--- a/mmv1/third_party/terraform/provider/provider.go.erb
+++ b/mmv1/third_party/terraform/provider/provider.go.erb
@@ -299,12 +299,12 @@ func ProviderConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 	// Check if the user provided a value from the universe_domain field other than the default
 	if v, ok := d.GetOk("universe_domain"); ok && v.(string) != "googleapis.com" {
 		if config.UniverseDomain == "" {
-			return nil, diag.FromErr(fmt.Errorf("Universe domain '%s' supplied directly to Terraform with no matching universe domain in credentials. Credentials with no 'universe_domain' set are assumed to be in the default universe.", v))
+			return nil, diag.FromErr(fmt.Errorf("Universe domain mismatch: '%s' supplied directly to Terraform with no matching universe domain in credentials. Credentials with no 'universe_domain' set are assumed to be in the default universe.", v))
 		} else if v.(string) != config.UniverseDomain {
 			if _, err := os.Stat(config.Credentials); err == nil {
-				return nil, diag.FromErr(fmt.Errorf("'%s' does not match the universe domain '%s' already set in the credential file '%s'. The 'universe_domain' provider configuration can not be used to override the universe domain that is defined in the active credential.  Set the 'universe_domain' provider configuration when universe domain information is not already available in the credential, e.g. when authenticating with a JWT token.", v, config.UniverseDomain, config.Credentials))
+				return nil, diag.FromErr(fmt.Errorf("Universe domain mismatch: '%s' does not match the universe domain '%s' already set in the credential file '%s'. The 'universe_domain' provider configuration can not be used to override the universe domain that is defined in the active credential.  Set the 'universe_domain' provider configuration when universe domain information is not already available in the credential, e.g. when authenticating with a JWT token.", v, config.UniverseDomain, config.Credentials))
 			} else {
-				return nil, diag.FromErr(fmt.Errorf("'%s' does not match the universe domain '%s' supplied directly to Terraform. The 'universe_domain' provider configuration can not be used to override the universe domain that is defined in the active credential.  Set the 'universe_domain' provider configuration when universe domain information is not already available in the credential, e.g. when authenticating with a JWT token.", v, config.UniverseDomain))
+				return nil, diag.FromErr(fmt.Errorf("Universe domain mismatch: '%s' does not match the universe domain '%s' supplied directly to Terraform. The 'universe_domain' provider configuration can not be used to override the universe domain that is defined in the active credential.  Set the 'universe_domain' provider configuration when universe domain information is not already available in the credential, e.g. when authenticating with a JWT token.", v, config.UniverseDomain))
 			}
 		}
 	}

--- a/mmv1/third_party/terraform/provider/universe/universe_domain_compute_test.go
+++ b/mmv1/third_party/terraform/provider/universe/universe_domain_compute_test.go
@@ -57,7 +57,7 @@ func TestAccDefaultUniverseDomain_doesNotMatchExplicit(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config:      testAccUniverseDomain_basic_disk(universeDomainFake),
-				ExpectError: regexp.MustCompile("supplied directly to Terraform with no matching universe domain in credentials"),
+				ExpectError: regexp.MustCompile("Universe domain mismatch"),
 			},
 		},
 	})


### PR DESCRIPTION


<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
https://github.com/GoogleCloudPlatform/magic-modules/pull/10071#issuecomment-1984587963

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
