### PR TITLE
Simplified / clarified approval flow for presubmits

### DIFF
--- a/.ci/gcb-contributor-membership-checker.yml
+++ b/.ci/gcb-contributor-membership-checker.yml
@@ -68,6 +68,7 @@ steps:
       - "membership-checker"
       - $_PR_NUMBER
       - $COMMIT_SHA
+      # The following are unused and should be safe to remove at least 2 weeks after this comment was added.
       - $BRANCH_NAME
       - $_HEAD_REPO_URL
       - $_HEAD_BRANCH

--- a/.ci/gcb-contributor-membership-checker.yml
+++ b/.ci/gcb-contributor-membership-checker.yml
@@ -68,11 +68,6 @@ steps:
       - "membership-checker"
       - $_PR_NUMBER
       - $COMMIT_SHA
-      # The following are unused and should be safe to remove at least 2 weeks after this comment was added.
-      - $BRANCH_NAME
-      - $_HEAD_REPO_URL
-      - $_HEAD_BRANCH
-      - $_BASE_BRANCH
 
 availableSecrets:
   secretManager:

--- a/.ci/magician/cmd/community_checker_test.go
+++ b/.ci/magician/cmd/community_checker_test.go
@@ -37,12 +37,16 @@ func TestExecCommunityChecker_CoreContributorFlow(t *testing.T) {
 
 	execCommunityChecker("pr1", "sha1", "branch1", "url1", "head1", "base1", gh, cb)
 
-	if _, ok := cb.calledMethods["TriggerMMPresubmitRuns"]; ok {
-		t.Fatal("Presubmit runs redundantly triggered for core contributor")
+	method := "TriggerMMPresubmitRuns"
+	expected := [][]any{{"sha1", map[string]string{"BRANCH_NAME": "branch1", "_BASE_BRANCH": "base1", "_HEAD_BRANCH": "head1", "_HEAD_REPO_URL": "url1", "_PR_NUMBER": "pr1"}}}
+	if calls, ok := cb.calledMethods[method]; !ok {
+		t.Fatal("Presubmit runs not triggered for core contributor")
+	} else if !reflect.DeepEqual(calls, expected) {
+		t.Fatalf("Wrong calls for %s, got %v, expected %v", method, calls, expected)
 	}
 
-	method := "RemoveLabel"
-	expected := [][]any{{"pr1", "awaiting-approval"}}
+	method = "RemoveLabel"
+	expected = [][]any{{"pr1", "awaiting-approval"}}
 	if calls, ok := gh.calledMethods[method]; !ok {
 		t.Fatal("awaiting-approval label not removed for PR ")
 	} else if !reflect.DeepEqual(calls, expected) {
@@ -69,12 +73,16 @@ func TestExecCommunityChecker_GooglerFlow(t *testing.T) {
 
 	execCommunityChecker("pr1", "sha1", "branch1", "url1", "head1", "base1", gh, cb)
 
-	if _, ok := cb.calledMethods["TriggerMMPresubmitRuns"]; ok {
-		t.Fatal("Presubmit runs redundantly triggered for googler")
+	method := "TriggerMMPresubmitRuns"
+	expected := [][]any{{"sha1", map[string]string{"BRANCH_NAME": "branch1", "_BASE_BRANCH": "base1", "_HEAD_BRANCH": "head1", "_HEAD_REPO_URL": "url1", "_PR_NUMBER": "pr1"}}}
+	if calls, ok := cb.calledMethods[method]; !ok {
+		t.Fatal("Presubmit runs not triggered for googler")
+	} else if !reflect.DeepEqual(calls, expected) {
+		t.Fatalf("Wrong calls for %s, got %v, expected %v", method, calls, expected)
 	}
 
-	method := "RemoveLabel"
-	expected := [][]any{{"pr1", "awaiting-approval"}}
+	method = "RemoveLabel"
+	expected = [][]any{{"pr1", "awaiting-approval"}}
 	if calls, ok := gh.calledMethods[method]; !ok {
 		t.Fatal("awaiting-approval label not removed for PR ")
 	} else if !reflect.DeepEqual(calls, expected) {

--- a/.ci/magician/cmd/membership_checker.go
+++ b/.ci/magician/cmd/membership_checker.go
@@ -33,22 +33,13 @@ var membershipCheckerCmd = &cobra.Command{
 	The command expects the following pull request details as arguments:
 	1. PR Number
 	2. Commit SHA
-	3. Branch Name
-	4. Head Repo URL
-	5. Head Branch
-	6. Base Branch
 
 	It then performs the following operations:
 	1. Extracts and displays the pull request details.
 	2. Fetches the author of the pull request and determines their contribution type.
-	3. If the author is not a core contributor:
-			a. Identifies the initially requested reviewer and those who previously reviewed this PR.
-			b. Determines and requests reviewers based on the above.
-			c. Posts comments tailored to the contribution type, the trust level of the contributor, and the primary reviewer.
-	4. For trusted authors (Core Contributors and Googlers):
-			a. Triggers generate-diffs using the provided PR details.
-			b. Automatically approves the community-checker run.
-	5. For external or untrusted contributors:
+	3. For trusted authors (Core Contributors and Googlers):
+			a. Automatically approves the community-checker run.
+	4. For external or untrusted contributors:
 			a. Adds the 'awaiting-approval' label.
 			b. Posts a link prompting approval for the build.
 	`,

--- a/.ci/magician/cmd/membership_checker_test.go
+++ b/.ci/magician/cmd/membership_checker_test.go
@@ -35,22 +35,10 @@ func TestExecMembershipChecker_CoreContributorFlow(t *testing.T) {
 		calledMethods: make(map[string][][]any),
 	}
 
-	execMembershipChecker("pr1", "sha1", "branch1", "url1", "head1", "base1", gh, cb)
+	execMembershipChecker("pr1", "sha1", gh, cb)
 
-	if _, ok := gh.calledMethods["RequestPullRequestReviewer"]; ok {
-		t.Fatal("Incorrectly requested review for core contributor")
-	}
-
-	method := "TriggerMMPresubmitRuns"
-	expected := [][]any{{"sha1", map[string]string{"BRANCH_NAME": "branch1", "_BASE_BRANCH": "base1", "_HEAD_BRANCH": "head1", "_HEAD_REPO_URL": "url1", "_PR_NUMBER": "pr1"}}}
-	if calls, ok := cb.calledMethods[method]; !ok {
-		t.Fatal("Presubmit runs not triggered for core author")
-	} else if !reflect.DeepEqual(calls, expected) {
-		t.Fatalf("Wrong calls for %s, got %v, expected %v", method, calls, expected)
-	}
-
-	method = "ApproveCommunityChecker"
-	expected = [][]any{{"pr1", "sha1"}}
+	method := "ApproveCommunityChecker"
+	expected := [][]any{{"pr1", "sha1"}}
 	if calls, ok := cb.calledMethods[method]; !ok {
 		t.Fatal("Community checker not approved for core author")
 	} else if !reflect.DeepEqual(calls, expected) {
@@ -75,18 +63,10 @@ func TestExecMembershipChecker_GooglerFlow(t *testing.T) {
 		calledMethods: make(map[string][][]any),
 	}
 
-	execMembershipChecker("pr1", "sha1", "branch1", "url1", "head1", "base1", gh, cb)
+	execMembershipChecker("pr1", "sha1", gh, cb)
 
-	method := "TriggerMMPresubmitRuns"
-	expected := [][]any{{"sha1", map[string]string{"BRANCH_NAME": "branch1", "_BASE_BRANCH": "base1", "_HEAD_BRANCH": "head1", "_HEAD_REPO_URL": "url1", "_PR_NUMBER": "pr1"}}}
-	if calls, ok := cb.calledMethods[method]; !ok {
-		t.Fatal("Presubmit runs not triggered for googler")
-	} else if !reflect.DeepEqual(calls, expected) {
-		t.Fatalf("Wrong calls for %s, got %v, expected %v", method, calls, expected)
-	}
-
-	method = "ApproveCommunityChecker"
-	expected = [][]any{{"pr1", "sha1"}}
+	method := "ApproveCommunityChecker"
+	expected := [][]any{{"pr1", "sha1"}}
 	if calls, ok := cb.calledMethods[method]; !ok {
 		t.Fatal("Community checker not approved for googler")
 	} else if !reflect.DeepEqual(calls, expected) {
@@ -110,7 +90,7 @@ func TestExecMembershipChecker_AmbiguousUserFlow(t *testing.T) {
 		calledMethods: make(map[string][][]any),
 	}
 
-	execMembershipChecker("pr1", "sha1", "branch1", "url1", "head1", "base1", gh, cb)
+	execMembershipChecker("pr1", "sha1", gh, cb)
 
 	method := "AddLabel"
 	expected := [][]any{{"pr1", "awaiting-approval"}}
@@ -131,10 +111,6 @@ func TestExecMembershipChecker_AmbiguousUserFlow(t *testing.T) {
 	if _, ok := gh.calledMethods["ApproveCommunityChecker"]; ok {
 		t.Fatal("Incorrectly approved community checker for ambiguous user")
 	}
-
-	if _, ok := gh.calledMethods["TriggerMMPresubmitRuns"]; ok {
-		t.Fatal("Incorrectly triggered presubmit runs for ambiguous user")
-	}
 }
 
 func TestExecMembershipChecker_CommentForNewPrimaryReviewer(t *testing.T) {
@@ -153,5 +129,5 @@ func TestExecMembershipChecker_CommentForNewPrimaryReviewer(t *testing.T) {
 		calledMethods: make(map[string][][]any),
 	}
 
-	execMembershipChecker("pr1", "sha1", "branch1", "url1", "head1", "base1", gh, cb)
+	execMembershipChecker("pr1", "sha1", gh, cb)
 }

--- a/mmv1/third_party/terraform/services/compute/metadata.go.erb
+++ b/mmv1/third_party/terraform/services/compute/metadata.go.erb
@@ -15,7 +15,6 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
-// force generation
 // Since the google compute API uses optimistic locking, there is a chance
 // we need to resubmit our updated metadata. To do this, you need to provide
 // an update function that attempts to submit your metadata

--- a/mmv1/third_party/terraform/services/compute/metadata.go.erb
+++ b/mmv1/third_party/terraform/services/compute/metadata.go.erb
@@ -15,6 +15,7 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
+// force generation
 // Since the google compute API uses optimistic locking, there is a chance
 // we need to resubmit our updated metadata. To do this, you need to provide
 // an update function that attempts to submit your metadata


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Previously, the flow looked like:

Trusted contributor:

1. Commit added to PR triggers membership-checker and community-checker
2. membership-checker triggers presubmit-generate-diffs and approves community-checker
3. community-checker is a no-op for trusted contributors

Untrusted contributor:
1. Commit added to PR triggers membership-checker and community-checker
2. [on /gcbrun] membership-checker approves community-checker
3. community-checker triggers presubmit-generate-diffs

This PR simplifies the flow to always be:

1. Commit added to PR triggers membership-checker and community-checker
2. [automatically or on /gcbrun] membership-checker approves community-checker
3. community-checker triggers presubmit-generate-diffs

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
