### PR TITLE
Move pre_delete code closer to the request

### DIFF
--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -1032,7 +1032,6 @@ func resource<%= object.resource_name -%>Delete(d *schema.ResourceData, meta int
 
 <%# If the deletion of the object requires sending a request body, the custom code will set 'obj' -%>
     var obj map[string]interface{}
-<%= lines(compile(pwd + '/' + object.custom_code.pre_delete)) if object.custom_code.pre_delete -%>
 <%      if object.nested_query&.modify_by_patch -%>
 <%# Keep this after mutex - patch request data relies on current resource state %>
     obj, err = resource<%= object.resource_name -%>PatchDeleteEncoder(d, meta, obj)
@@ -1047,18 +1046,19 @@ func resource<%= object.resource_name -%>Delete(d *schema.ResourceData, meta int
 <%        end -%>
 <%      end -%>
 <%      if object.supports_indirect_user_project_override -%>
-
     if parts := regexp.MustCompile(`projects\/([^\/]+)\/`).FindStringSubmatch(url); parts != nil {
         billingProject = parts[1]
     }
-
 <%      end -%>
-    log.Printf("[DEBUG] Deleting <%= object.name -%> %q", d.Id())
 
     // err == nil indicates that the billing_project value was found
     if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
       billingProject = bp
     }
+
+<%= lines(compile(pwd + '/' + object.custom_code.pre_delete)) if object.custom_code.pre_delete -%>
+
+    log.Printf("[DEBUG] Deleting <%= object.name -%> %q", d.Id())
 
     res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
         Config: config,


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

`pre_create` runs right before the request, do the same with `pre_delete`. The update actions are both in different places as well (since update is structured as two bodies, standard and custom update) but I'm not fixing that here. For any future readers, consider that a reasonable precedent though :)

This change effectively just moves the function to after determining the final `billing_project` for all current resources.

Several resources send requests in pre_deletes that should use the billing project but use the resource project- those are correctable now. Filed https://github.com/hashicorp/terraform-provider-google/issues/17528. (Well, they were correctable before but would have had a slight bug like the ones below)

Interesting cases, all more correct than before IMO as we now always use the same billingProject as the final delete:

* google-beta/services/firebasedatabase/resource_firebase_database_instance.go
* google-beta/services/netapp/resource_netapp_volume_replication.go
* google-beta/services/privateca/resource_privateca_certificate_authority.go
* google-beta/services/spanner/resource_spanner_instance.go

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
