### PR TITLE
Clean up delete template

### DIFF
--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -1047,19 +1047,17 @@ func resource<%= object.resource_name -%>Delete(d *schema.ResourceData, meta int
 <%        end -%>
 <%      end -%>
 <%      if object.supports_indirect_user_project_override -%>
-
     if parts := regexp.MustCompile(`projects\/([^\/]+)\/`).FindStringSubmatch(url); parts != nil {
         billingProject = parts[1]
     }
-
 <%      end -%>
-    log.Printf("[DEBUG] Deleting <%= object.name -%> %q", d.Id())
 
     // err == nil indicates that the billing_project value was found
     if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
       billingProject = bp
     }
 
+    log.Printf("[DEBUG] Deleting <%= object.name -%> %q", d.Id())
     res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
         Config: config,
         Method: "<%= object.delete_verb.to_s.upcase -%>",


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

I want to move `pre_delete` to right before the request- similar to `pre_create`- and had some minor cleanups I did at the same time in https://github.com/GoogleCloudPlatform/magic-modules/pull/10143 while checking the diff. Get those done in advance so there's a minimal diff for the real change.

/cc @c2thorn @zli82016 as I'm touching the templates in a few (limited) PRs

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
