### PR TITLE
AccessContextManager - Add dry run service perimeter resource

### DIFF
--- a/mmv1/products/accesscontextmanager/ServicePerimeterDryRunResource.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterDryRunResource.yaml
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Resource
-name: 'ServicePerimeterResource'
+name: 'ServicePerimeterDryRunResource'
 create_url: '{{perimeter_name}}'
 base_url: ''
 self_link: '{{perimeter_name}}'
@@ -26,21 +26,21 @@ nested_query: !ruby/object:Api::Resource::NestedQuery
   modify_by_patch: true
   is_list_of_ids: true
   keys:
-    - status
+    - spec
     - resources
 references: !ruby/object:Api::Resource::ReferenceLinks
   guides:
     'Service Perimeter Quickstart': 'https://cloud.google.com/vpc-service-controls/docs/quickstart'
   api: 'https://cloud.google.com/access-context-manager/docs/reference/rest/v1/accessPolicies.servicePerimeters'
 description: |
-  Allows configuring a single GCP resource that should be inside the `status` block of a service perimeter.
+  Allows configuring a single GCP resource that should be inside of the `spec` block of a dry run service perimeter.
   This resource is intended to be used in cases where it is not possible to compile a full list
   of projects to include in a `google_access_context_manager_service_perimeter` resource,
   to enable them to be added separately.
-  If your perimeter is in dry-run mode use `google_access_context_manager_service_perimeter_dry_run_resource` instead.
+  If your perimeter is NOT in dry-run mode use `google_access_context_manager_service_perimeter_resource` instead.
 
   ~> **Note:** If this resource is used alongside a `google_access_context_manager_service_perimeter` resource,
-  the service perimeter resource must have a `lifecycle` block with `ignore_changes = [status[0].resources]` so
+  the service perimeter resource must have a `lifecycle` block with `ignore_changes = [spec[0].resources]` so
   they don't fight over which resources should be in the policy.
 docs: !ruby/object:Provider::Terraform::Docs
   warning: |
@@ -58,13 +58,16 @@ import_format: ['{{perimeter_name}}/{{resource}}']
 mutex: '{{perimeter_name}}'
 examples:
   - !ruby/object:Provider::Terraform::Examples
-    name: 'access_context_manager_service_perimeter_resource_basic'
+    name: 'access_context_manager_service_perimeter_dry_run_resource_basic'
     skip_test: true
-    primary_resource_id: 'service-perimeter-resource'
+    primary_resource_id: 'service-perimeter-dry-run-resource'
     vars:
       service_perimeter_name: 'restrict_all'
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/access_context_manager_service_perimeter_resource.go.erb
+  pre_update: templates/terraform/pre_create/access_context_manager_service_perimeter_dry_run_resource.go.erb
+  pre_create: templates/terraform/pre_create/access_context_manager_service_perimeter_dry_run_resource.go.erb
+  pre_delete: templates/terraform/pre_create/access_context_manager_service_perimeter_dry_run_resource.go.erb
 parameters:
   - !ruby/object:Api::Type::ResourceRef
     name: 'perimeterName'

--- a/mmv1/templates/terraform/examples/access_context_manager_service_perimeter_dry_run_resource_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/access_context_manager_service_perimeter_dry_run_resource_basic.tf.erb
@@ -1,0 +1,22 @@
+resource "google_access_context_manager_service_perimeter_dry_run_resource" "<%= ctx[:primary_resource_id] %>" {
+  perimeter_name = google_access_context_manager_service_perimeter.<%= ctx[:primary_resource_id] %>.name
+  resource = "projects/987654321"
+}
+
+resource "google_access_context_manager_service_perimeter" "<%= ctx[:primary_resource_id] %>" {
+  parent = "accessPolicies/${google_access_context_manager_access_policy.access-policy.name}"
+  name   = "accessPolicies/${google_access_context_manager_access_policy.access-policy.name}/servicePerimeters/<%= ctx[:vars]['service_perimeter_name'] %>"
+  title  = "<%= ctx[:vars]['service_perimeter_name'] %>"
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+  }
+  use_explicit_dry_run_spec = true
+  lifecycle {
+    ignore_changes = [spec[0].resources]
+  }
+}
+
+resource "google_access_context_manager_access_policy" "access-policy" {
+  parent = "organizations/123456789"
+  title  = "my policy"
+}

--- a/mmv1/templates/terraform/pre_create/access_context_manager_service_perimeter_dry_run_resource.go.erb
+++ b/mmv1/templates/terraform/pre_create/access_context_manager_service_perimeter_dry_run_resource.go.erb
@@ -1,0 +1,1 @@
+obj["use_explicit_dry_run_spec"] = true

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_policy_test.go.erb
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_policy_test.go.erb
@@ -17,21 +17,22 @@ import (
 // can exist, they need to be run serially
 func TestAccAccessContextManager(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
-		"access_policy":                    testAccAccessContextManagerAccessPolicy_basicTest,
-		"access_policy_scoped":             testAccAccessContextManagerAccessPolicy_scopedTest,
-		"service_perimeter":                testAccAccessContextManagerServicePerimeter_basicTest,
-		"service_perimeter_update":         testAccAccessContextManagerServicePerimeter_updateTest,
-		"service_perimeter_resource":       testAccAccessContextManagerServicePerimeterResource_basicTest,
-		"access_level":                     testAccAccessContextManagerAccessLevel_basicTest,
-		"access_level_full":                testAccAccessContextManagerAccessLevel_fullTest,
-		"access_level_custom":              testAccAccessContextManagerAccessLevel_customTest,
-		"access_levels":                    testAccAccessContextManagerAccessLevels_basicTest,
-		"access_level_condition":           testAccAccessContextManagerAccessLevelCondition_basicTest,
-		"service_perimeter_egress_policy":  testAccAccessContextManagerServicePerimeterEgressPolicy_basicTest,
-		"service_perimeter_ingress_policy": testAccAccessContextManagerServicePerimeterIngressPolicy_basicTest,
-		"service_perimeters":               testAccAccessContextManagerServicePerimeters_basicTest,
-		"gcp_user_access_binding":          testAccAccessContextManagerGcpUserAccessBinding_basicTest,
-		"authorized_orgs_desc":             testAccAccessContextManagerAuthorizedOrgsDesc_basicTest,
+		"access_policy":				testAccAccessContextManagerAccessPolicy_basicTest,
+		"access_policy_scoped":				testAccAccessContextManagerAccessPolicy_scopedTest,
+		"service_perimeter":				testAccAccessContextManagerServicePerimeter_basicTest,
+		"service_perimeter_update":			testAccAccessContextManagerServicePerimeter_updateTest,
+		"service_perimeter_resource":			testAccAccessContextManagerServicePerimeterResource_basicTest,
+		"service_perimeter_dry_run_resource":		testAccAccessContextManagerServicePerimeterResource_basicTest,
+		"access_level":					testAccAccessContextManagerAccessLevel_basicTest,
+		"access_level_full":				testAccAccessContextManagerAccessLevel_fullTest,
+		"access_level_custom":				testAccAccessContextManagerAccessLevel_customTest,
+		"access_levels":				testAccAccessContextManagerAccessLevels_basicTest,
+		"access_level_condition":			testAccAccessContextManagerAccessLevelCondition_basicTest,
+		"service_perimeter_egress_policy":		testAccAccessContextManagerServicePerimeterEgressPolicy_basicTest,
+		"service_perimeter_ingress_policy":		testAccAccessContextManagerServicePerimeterIngressPolicy_basicTest,
+		"service_perimeters":				testAccAccessContextManagerServicePerimeters_basicTest,
+		"gcp_user_access_binding":			testAccAccessContextManagerGcpUserAccessBinding_basicTest,
+		"authorized_orgs_desc":				testAccAccessContextManagerAuthorizedOrgsDesc_basicTest,
 	}
 
 	for name, tc := range testCases {

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_dry_run_resource_test.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_dry_run_resource_test.go
@@ -1,0 +1,139 @@
+package accesscontextmanager_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+// Since each test here is acting on the same organization and only one AccessPolicy
+// can exist, they need to be run serially. See AccessPolicy for the test runner.
+
+func testAccAccessContextManagerServicePerimeterDryRunResource_basicTest(t *testing.T) {
+	// Multiple fine-grained resources
+	acctest.SkipIfVcr(t)
+	org := envvar.GetTestOrgFromEnv(t)
+	projects := acctest.BootstrapServicePerimeterProjects(t, 2)
+	policyTitle := "my policy"
+	perimeterTitle := "perimeter"
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccessContextManagerServicePerimeterDryRunResource_basic(org, policyTitle, perimeterTitle, projects[0].ProjectNumber, projects[1].ProjectNumber),
+			},
+			{
+				ResourceName:      "google_access_context_manager_service_perimeter_dry_run_resource.test-access1",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "google_access_context_manager_service_perimeter_dry_run_resource.test-access2",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Use a separate TestStep rather than a CheckDestroy because we need the service perimeter to still exist
+			{
+				Config: testAccAccessContextManagerServicePerimeterDryRunResource_destroy(org, policyTitle, perimeterTitle),
+				Check:  testAccCheckAccessContextManagerServicePerimeterDryRunResourceDestroyProducer(t),
+			},
+		},
+	})
+}
+
+func testAccCheckAccessContextManagerServicePerimeterDryRunResourceDestroyProducer(t *testing.T) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "google_access_context_manager_service_perimeter_dry_run_resource" {
+				continue
+			}
+
+			config := acctest.GoogleProviderConfig(t)
+
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{AccessContextManagerBasePath}}{{perimeter_name}}")
+			if err != nil {
+				return err
+			}
+
+			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				RawURL:    url,
+				UserAgent: config.UserAgent,
+			})
+			if err != nil {
+				return err
+			}
+
+			v, ok := res["spec"]
+			if !ok || v == nil {
+				return nil
+			}
+
+			res = v.(map[string]interface{})
+			v, ok = res["resources"]
+			if !ok || v == nil {
+				return nil
+			}
+
+			resources := v.([]interface{})
+			if len(resources) == 0 {
+				return nil
+			}
+
+			return fmt.Errorf("expected 0 resources in perimeter, found %d: %v", len(resources), resources)
+		}
+
+		return nil
+	}
+}
+
+func testAccAccessContextManagerServicePerimeterDryRunResource_basic(org, policyTitle, perimeterTitleName string, projectNumber1, projectNumber2 int64) string {
+	return fmt.Sprintf(`
+%s
+
+resource "google_access_context_manager_service_perimeter_dry_run_resource" "test-access1" {
+  perimeter_name = google_access_context_manager_service_perimeter.test-access.name
+  resource = "projects/%d"
+}
+
+resource "google_access_context_manager_service_perimeter_dry_run_resource" "test-access2" {
+  perimeter_name = google_access_context_manager_service_perimeter.test-access.name
+  resource = "projects/%d"
+}
+`, testAccAccessContextManagerServicePerimeterDryRunResource_destroy(org, policyTitle, perimeterTitleName), projectNumber1, projectNumber2)
+}
+
+func testAccAccessContextManagerServicePerimeterDryRunResource_destroy(org, policyTitle, perimeterTitleName string) string {
+	return fmt.Sprintf(`
+resource "google_access_context_manager_access_policy" "test-access" {
+  parent = "organizations/%s"
+  title  = "%s"
+}
+
+resource "google_access_context_manager_service_perimeter" "test-access" {
+  parent         = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}"
+  name           = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}/servicePerimeters/%s"
+  title          = "%s"
+  perimeter_type = "PERIMETER_TYPE_REGULAR"
+  status {
+    restricted_services = ["storage.googleapis.com"]
+  }
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+  }
+  use_explicit_dry_run_spec = true
+  lifecycle {
+    ignore_changes = [spec[0].resources]
+  }
+}
+`, org, policyTitle, perimeterTitleName, perimeterTitleName)
+}


### PR DESCRIPTION
Adds a dry run version of the existing google_access_context_manager_service_perimeter_resource.

Addresses:
[10642](https://www.google.com/url?q=https://github.com/hashicorp/terraform-provider-google/issues/10642&sa=D&source=buganizer&usg=AOvVaw0oyIMC1DTEGwV7Yd1bafAs) - b/301066068
 
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.


**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
accesscontextmanager: support managing service perimeter dry run resources outside the perimeter via new resource `google_access_context_manager_service_perimeter_dry_run_resource`
```

```release-note:new-resource
`google_access_context_manager_service_perimeter_dry_run_resource`
```
