### PR TITLE
added missing web documentation about create_timestamp for compute_(r)igm

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
@@ -313,6 +313,8 @@ exported:
 
 * `id` - an identifier for the resource with format `projects/{{project}}/zones/{{zone}}/instanceGroupManagers/{{name}}`
 
+* `creation_timestamp` - Creation timestamp in RFC3339 text format.
+
 * `fingerprint` - The fingerprint of the instance group manager.
 
 * `instance_group` - The full URL of the instance group created by the manager.

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -324,6 +324,8 @@ exported:
 
 * `id` - an identifier for the resource with format `projects/{{project}}/regions/{{region}}/instanceGroupManagers/{{name}}`
 
+* `creation_timestamp` - Creation timestamp in RFC3339 text format.
+
 * `fingerprint` - The fingerprint of the instance group manager.
 
 * `instance_group` - The full URL of the instance group created by the manager.


### PR DESCRIPTION
added missing web documentation about create_timestamp for compute_(region_)instance_group_manager

Solves (R)IGM part of https://github.com/hashicorp/terraform-provider-google/issues/15663

It's adding the missing part of https://github.com/GoogleCloudPlatform/magic-modules/pull/9874

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
doc: added documentation about `creation_timestamp` to `google_compute_instance_group_manager` and `google_compute_region_instance_group_manager`
```
