### PR TITLE
Updating Documentation for exchanging credentials with the kubernetes…

### DIFF
--- a/mmv1/third_party/terraform/website/docs/guides/using_gke_with_terraform.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/using_gke_with_terraform.html.markdown
@@ -59,6 +59,29 @@ provider "kubernetes" {
   )
 }
 ```
+Although the above can result in authentication errors, over time, as the token recorded in the google_client_cofig data resource is short lived (thus it expires) and it's stored in state.  Fortunately, the [kubernetes provider can accept valid credentials from an exec-based plugin](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#exec-plugins) to fetch a new token before each Terraform operation (so long as you have the [gke-cloud-auth-plugin for kubectl installed](https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke)), like so:
+
+```hcl
+# Retrieve an access token as the Terraform runner
+data "google_client_config" "provider" {}
+
+data "google_container_cluster" "my_cluster" {
+  name     = "my-cluster"
+  location = "us-central1"
+}
+
+provider "kubernetes" {
+  host  = "https://${data.google_container_cluster.my_cluster.endpoint}"
+  token = data.google_client_config.provider.access_token
+  cluster_ca_certificate = base64decode(
+    data.google_container_cluster.my_cluster.master_auth[0].cluster_ca_certificate,
+  )
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "gke-gcloud-auth-plugin"
+  }
+}
+```
 
 Alternatively, you can authenticate as another service account on which your
 Terraform user has been granted the `roles/iam.serviceAccountTokenCreator`

--- a/mmv1/third_party/terraform/website/docs/guides/using_gke_with_terraform.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/using_gke_with_terraform.html.markdown
@@ -60,7 +60,7 @@ provider "kubernetes" {
 }
 ```
 Although the above can result in authentication errors, over time, as the token recorded in the google_client_cofig data resource is short lived (thus it expires) and it's stored in state.  Fortunately, the [kubernetes provider can accept valid credentials from an exec-based plugin](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#exec-plugins) to fetch a new token before each Terraform operation (so long as you have the [gke-cloud-auth-plugin for kubectl installed](https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke)), like so:
-
+ 
 ```hcl
 # Retrieve an access token as the Terraform runner
 data "google_client_config" "provider" {}


### PR DESCRIPTION
… provider to include using gke-gcloud-auth-plugin as an exec-plugin

The guide documenting the use of GKE with terraform lacks details on the kubernetes providers' ability to accept the gke-auth-plugin as an exec-plugin for refreshing short lived credentials.  This PR adds details of that method for passing credentials to the kubernetes provider that've been sourced using the google provider.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
