### PR TITLE
Refactor TeamCity Services Diff Check to run as one job

### DIFF
--- a/.github/actions/build-downstream/action.yml
+++ b/.github/actions/build-downstream/action.yml
@@ -1,0 +1,104 @@
+name: build
+description: Generates Provider
+
+
+runs:
+    using: "composite"
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@036ef458ddccddb148a2b9fb67e95a22fdbf728b # v1.160.0
+        with:
+          ruby-version: '3.1'
+
+      - name: Cache Bundler gems
+        uses: actions/cache@v3
+        with:
+          path: mmv1/vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('mmv1/**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
+      - name: Install Ruby dependencies
+        shell: bash
+        run: |
+          bundle config path mmv1/vendor/bundle
+          bundle install
+        working-directory: mmv1
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '^1.20'
+
+      # Cache Go modules
+      - name: Cache Go modules
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - run: go install golang.org/x/tools/cmd/goimports@latest
+        shell: bash
+      - name: Build ${{ inputs.repo  }}
+        shell: bash
+        env:
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          set -x
+          # Set GOPATH to a directory the runner user has access to
+          export GOPATH=~/go
+
+          function clone_repo() {
+            export OUTPUT_PATH=$GOPATH/src/github.com/$UPSTREAM_OWNER/$GH_REPO
+            GITHUB_PATH=https://x-access-token:$GITHUB_TOKEN@github.com/$UPSTREAM_OWNER/$GH_REPO
+            mkdir -p "$(dirname $OUTPUT_PATH)"
+            git clone $GITHUB_PATH $OUTPUT_PATH --branch $BASE_BRANCH
+          }
+
+          GH_REPO="${{ inputs.repo  }}"
+          if [ "$GH_REPO" == "docs-examples" ] && [ "$BASE_BRANCH" == "main" ]; then
+              BASE_BRANCH="master"
+          fi
+
+          GITHUB_PATH=https://x-access-token:$GITHUB_TOKEN@github.com/$UPSTREAM_OWNER/$GH_REPO
+
+          if [[ "$GH_REPO" == terraform-provider-google* ]]; then
+            UPSTREAM_OWNER=hashicorp
+            clone_repo
+          if [ "$GH_REPO" == "terraform-provider-google" ]; then
+              export VERSION=ga
+            else
+              export VERSION=beta
+            fi
+            make clean-provider
+            make provider
+          elif [ "$GH_REPO" == "terraform-google-conversion" ]; then
+            UPSTREAM_OWNER=GoogleCloudPlatform
+            clone_repo
+            make clean-tgc
+            make tgc
+          elif [ "$GH_REPO" == "docs-examples" ]; then
+            UPSTREAM_OWNER=terraform-google-modules
+            clone_repo
+            make tf-oics
+          else
+            echo "case not supported"
+            exit 1
+          fi
+
+          (current_dir=$(pwd) && cd $OUTPUT_PATH && zip -r "$current_dir/output.zip" .)
+
+      - name: Upload built artifacts
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        with:
+          name: artifact-${{ inputs.repo  }}
+          path: output.zip

--- a/.github/actions/build-downstream/action.yml
+++ b/.github/actions/build-downstream/action.yml
@@ -1,5 +1,5 @@
 name: build
-description: Generates Provider
+description: Generates Google/Google-Beta Provider
 inputs:
   repo:
     description: "provider repo"

--- a/.github/actions/build-downstream/action.yml
+++ b/.github/actions/build-downstream/action.yml
@@ -65,7 +65,7 @@ runs:
 
           function clone_repo() {
             export OUTPUT_PATH=$GOPATH/src/github.com/$UPSTREAM_OWNER/$GH_REPO
-            echo $OUTPUT_PATH >> $GITHUB_ENV
+            echo "$OUTPUT_PATH" >> $GITHUB_ENV
             GITHUB_PATH=https://x-access-token:$GITHUB_TOKEN@github.com/$UPSTREAM_OWNER/$GH_REPO
             mkdir -p "$(dirname $OUTPUT_PATH)"
             git clone $GITHUB_PATH $OUTPUT_PATH --branch $BASE_BRANCH

--- a/.github/actions/build-downstream/action.yml
+++ b/.github/actions/build-downstream/action.yml
@@ -102,9 +102,3 @@ runs:
           fi
 
           (current_dir=$(pwd) && cd $OUTPUT_PATH && zip -r "$current_dir/output.zip" .)
-
-      - name: Upload built artifacts
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
-        with:
-          name: artifact-${{ inputs.repo  }}
-          path: output.zip

--- a/.github/actions/build-downstream/action.yml
+++ b/.github/actions/build-downstream/action.yml
@@ -65,6 +65,7 @@ runs:
 
           function clone_repo() {
             export OUTPUT_PATH=$GOPATH/src/github.com/$UPSTREAM_OWNER/$GH_REPO
+            echo $OUTPUT_PATH >> $GITHUB_ENV
             GITHUB_PATH=https://x-access-token:$GITHUB_TOKEN@github.com/$UPSTREAM_OWNER/$GH_REPO
             mkdir -p "$(dirname $OUTPUT_PATH)"
             git clone $GITHUB_PATH $OUTPUT_PATH --branch $BASE_BRANCH

--- a/.github/actions/build-downstream/action.yml
+++ b/.github/actions/build-downstream/action.yml
@@ -1,6 +1,12 @@
 name: build
 description: Generates Provider
-
+inputs:
+  repo:
+    description: "provider repo"
+    required: true
+  token:
+    description: "github token"
+    required: true
 
 runs:
     using: "composite"
@@ -50,7 +56,7 @@ runs:
         shell: bash
         env:
           BASE_BRANCH: ${{ github.event.pull_request.base.ref || github.ref_name }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ inputs.token }}
         run: |
           set -e
           set -x

--- a/.github/actions/build-downstream/action.yml
+++ b/.github/actions/build-downstream/action.yml
@@ -65,7 +65,7 @@ runs:
 
           function clone_repo() {
             export OUTPUT_PATH=$GOPATH/src/github.com/$UPSTREAM_OWNER/$GH_REPO
-            echo "$OUTPUT_PATH" >> $GITHUB_ENV
+            echo "OUTPUT_PATH=$OUTPUT_PATH" >> $GITHUB_ENV
             GITHUB_PATH=https://x-access-token:$GITHUB_TOKEN@github.com/$UPSTREAM_OWNER/$GH_REPO
             mkdir -p "$(dirname $OUTPUT_PATH)"
             git clone $GITHUB_PATH $OUTPUT_PATH --branch $BASE_BRANCH

--- a/.github/actions/build-downstream/action.yml
+++ b/.github/actions/build-downstream/action.yml
@@ -1,5 +1,5 @@
 name: build
-description: Generates Google/Google-Beta Provider
+description: Generates given downstream Magic Modules Repository from `repo` input
 inputs:
   repo:
     description: "provider repo"

--- a/.github/workflows/teamcity-services-diff-check-weekly.yml
+++ b/.github/workflows/teamcity-services-diff-check-weekly.yml
@@ -23,18 +23,18 @@ jobs:
           with:
             repo: 'terraform-provider-google'
             token: '$GITHUB_TOKEN'
-        - run: export GOOGLE_REPO_PATH=${{ env.OUTPUT_PATH}}
+        - run: echo "GOOGLE_REPO_PATH=${{ env.OUTPUT_PATH}}" >> $GITHUB_ENV
         - name: TeamCity Google Beta Provider Generate
           uses: ./.github/actions/build-downstream
           with:
             repo: 'terraform-provider-google-beta'
             token: '$GITHUB_TOKEN'
-        - run: export GOOGLE_BETA_REPO_PATH=${{ env.OUTPUT_PATH}}
+        - run: echo "GOOGLE_BETA_REPO_PATH=${{ env.OUTPUT_PATH}}" >> $GITHUB_ENV
         - name: Check that new services have been added to the TeamCity configuration code
           run: |
               # Create lists of service packages in providers
-              ls ${GOOGLE_REPO_PATH}/google/services > tools/teamcity-diff-check/services_ga.txt
-              ls ${GOOGLE_BETA_REPO_PATH}/google-beta/services > tools/teamcity-diff-check/services_beta.txt
+              ls ${{env.GOOGLE_REPO_PATH}}/google/services > tools/teamcity-diff-check/services_ga.txt
+              ls ${{env.GOOGLE_BETA_REPO_PATH}}/google-beta/services > tools/teamcity-diff-check/services_beta.txt
     
               # Run tool to compare service packages in the providers vs those listed in TeamCity config files
               cd tools/teamcity-diff-check

--- a/.github/workflows/teamcity-services-diff-check-weekly.yml
+++ b/.github/workflows/teamcity-services-diff-check-weekly.yml
@@ -21,43 +21,13 @@ jobs:
           with:
             repo: 'terraform-provider-google'
             token: '$GITHUB_TOKEN'
-    
         - name: TeamCity Google Beta Provider Generate
           uses: ./.github/actions/build-downstream
           with:
             repo: 'terraform-provider-google-beta'
             token: '$GITHUB_TOKEN'
-    
         - name: Checkout Repository
           uses: actions/checkout@v4
-    
-        - name: Setup Go
-          uses: actions/setup-go@v4
-          with:
-            go-version: '^1.20'
-    
-        - name: Download built artifacts - GA provider
-          uses: actions/download-artifact@v2
-          with:
-            name: artifact-terraform-provider-google
-            path: artifacts
-    
-        - name: Unzip the artifacts and delete the zip
-          run: |
-              unzip -o artifacts/output.zip -d ./provider
-              rm artifacts/output.zip
-    
-        - name: Download built artifacts - Beta provider
-          uses: actions/download-artifact@v2
-          with:
-            name: artifact-terraform-provider-google-beta
-            path: artifacts
-    
-        - name: Unzip the artifacts and delete the zip
-          run: |
-              unzip -o artifacts/output.zip -d ./provider
-              rm artifacts/output.zip
-    
         - name: Check that new services have been added to the TeamCity configuration code
           run: |
               # Create lists of service packages in providers

--- a/.github/workflows/teamcity-services-diff-check-weekly.yml
+++ b/.github/workflows/teamcity-services-diff-check-weekly.yml
@@ -23,13 +23,18 @@ jobs:
           with:
             repo: 'terraform-provider-google'
             token: '$GITHUB_TOKEN'
-        - run: echo "GOOGLE_REPO_PATH=${{ env.OUTPUT_PATH}}" >> $GITHUB_ENV
+        # The path where GA/Beta providers are generated is grabbed from the OUTPUT_PATH that's set in build_downstream.yaml
+        # export OUTPUT_PATH=$GOPATH/src/github.com/$UPSTREAM_OWNER/$GH_REPO
+        # OUTPUT_PATH changes after each generate (GA/beta)
+        - name: Set GOOGLE_REPO_PATH to path where GA provider was generated
+          run: echo "GOOGLE_REPO_PATH=${{ env.OUTPUT_PATH}}" >> $GITHUB_ENV
         - name: TeamCity Google Beta Provider Generate
           uses: ./.github/actions/build-downstream
           with:
             repo: 'terraform-provider-google-beta'
             token: '$GITHUB_TOKEN'
-        - run: echo "GOOGLE_BETA_REPO_PATH=${{ env.OUTPUT_PATH}}" >> $GITHUB_ENV
+        - name: Set GOOGLE_BETA_REPO_PATH to path where beta provider was generated
+          run: echo "GOOGLE_BETA_REPO_PATH=${{ env.OUTPUT_PATH}}" >> $GITHUB_ENV
         - name: Check that new services have been added to the TeamCity configuration code
           run: |
               # Create lists of service packages in providers

--- a/.github/workflows/teamcity-services-diff-check-weekly.yml
+++ b/.github/workflows/teamcity-services-diff-check-weekly.yml
@@ -23,16 +23,18 @@ jobs:
           with:
             repo: 'terraform-provider-google'
             token: '$GITHUB_TOKEN'
+        - run: export GOOGLE_REPO_PATH=$OUTPUT_PATH
         - name: TeamCity Google Beta Provider Generate
           uses: ./.github/actions/build-downstream
           with:
             repo: 'terraform-provider-google-beta'
             token: '$GITHUB_TOKEN'
+        - run: export GOOGLE_BETA_REPO_PATH=$OUTPUT_PATH
         - name: Check that new services have been added to the TeamCity configuration code
           run: |
               # Create lists of service packages in providers
-              ls provider/google/services > tools/teamcity-diff-check/services_ga.txt
-              ls provider/google-beta/services > tools/teamcity-diff-check/services_beta.txt
+              ls ${GOOGLE_REPO_PATH}/google/services > tools/teamcity-diff-check/services_ga.txt
+              ls ${GOOGLE_BETA_REPO_PATH}/google-beta/services > tools/teamcity-diff-check/services_beta.txt
     
               # Run tool to compare service packages in the providers vs those listed in TeamCity config files
               cd tools/teamcity-diff-check

--- a/.github/workflows/teamcity-services-diff-check-weekly.yml
+++ b/.github/workflows/teamcity-services-diff-check-weekly.yml
@@ -16,6 +16,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       runs-on: ubuntu-22.04
       steps:
+        - name: Checkout Repository
+          uses: actions/checkout@v4
         - name: TeamCity Google Provider Generate
           uses: ./.github/actions/build-downstream
           with:
@@ -26,8 +28,6 @@ jobs:
           with:
             repo: 'terraform-provider-google-beta'
             token: '$GITHUB_TOKEN'
-        - name: Checkout Repository
-          uses: actions/checkout@v4
         - name: Check that new services have been added to the TeamCity configuration code
           run: |
               # Create lists of service packages in providers

--- a/.github/workflows/teamcity-services-diff-check-weekly.yml
+++ b/.github/workflows/teamcity-services-diff-check-weekly.yml
@@ -23,13 +23,13 @@ jobs:
           with:
             repo: 'terraform-provider-google'
             token: '$GITHUB_TOKEN'
-        - run: export GOOGLE_REPO_PATH=$OUTPUT_PATH
+        - run: export GOOGLE_REPO_PATH=${{ env.OUTPUT_PATH}}
         - name: TeamCity Google Beta Provider Generate
           uses: ./.github/actions/build-downstream
           with:
             repo: 'terraform-provider-google-beta'
             token: '$GITHUB_TOKEN'
-        - run: export GOOGLE_BETA_REPO_PATH=$OUTPUT_PATH
+        - run: export GOOGLE_BETA_REPO_PATH=${{ env.OUTPUT_PATH}}
         - name: Check that new services have been added to the TeamCity configuration code
           run: |
               # Create lists of service packages in providers

--- a/.github/workflows/teamcity-services-diff-check-weekly.yml
+++ b/.github/workflows/teamcity-services-diff-check-weekly.yml
@@ -9,59 +9,61 @@ on:
   schedule:
     # Every Tuesday morning
     - cron:  '0 4 * * 2'
-
 jobs:
-  terraform-provider-google:
-    uses: ./.github/workflows/build-downstream.yml
-    with:
-      repo: 'terraform-provider-google'
-
-  terraform-provider-google-beta:
-    uses: ./.github/workflows/build-downstream.yml
-    with:
-      repo: 'terraform-provider-google-beta'
-
   teamcity-services-diff-check:
-    needs: [terraform-provider-google, terraform-provider-google-beta]
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Setup Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '^1.20'
-
-      - name: Download built artifacts - GA provider
-        uses: actions/download-artifact@v2
-        with:
-          name: artifact-terraform-provider-google
-          path: artifacts
-
-      - name: Unzip the artifacts and delete the zip
-        run: |
-          unzip -o artifacts/output.zip -d ./provider
-          rm artifacts/output.zip
-
-      - name: Download built artifacts - Beta provider
-        uses: actions/download-artifact@v2
-        with:
-          name: artifact-terraform-provider-google-beta
-          path: artifacts
-
-      - name: Unzip the artifacts and delete the zip
-        run: |
-          unzip -o artifacts/output.zip -d ./provider
-          rm artifacts/output.zip
-
-      - name: Check that new services have been added to the TeamCity configuration code
-        run: |
-          # Create lists of service packages in providers
-          ls provider/google/services > tools/teamcity-diff-check/services_ga.txt
-          ls provider/google-beta/services > tools/teamcity-diff-check/services_beta.txt
-
-          # Run tool to compare service packages in the providers vs those listed in TeamCity config files
-          cd tools/teamcity-diff-check
-          go run main.go -service_file=services_ga
-          go run main.go -service_file=services_beta
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      runs-on: ubuntu-22.04
+      steps:
+        - name: TeamCity Google Provider Generate
+          uses: ./.github/actions/build-downstream
+          with:
+            repo: 'terraform-provider-google'
+            token: '$GITHUB_TOKEN'
+    
+        - name: TeamCity Google Beta Provider Generate
+          uses: ./.github/actions/build-downstream
+          with:
+            repo: 'terraform-provider-google-beta'
+            token: '$GITHUB_TOKEN'
+    
+        - name: Checkout Repository
+          uses: actions/checkout@v4
+    
+        - name: Setup Go
+          uses: actions/setup-go@v4
+          with:
+            go-version: '^1.20'
+    
+        - name: Download built artifacts - GA provider
+          uses: actions/download-artifact@v2
+          with:
+            name: artifact-terraform-provider-google
+            path: artifacts
+    
+        - name: Unzip the artifacts and delete the zip
+          run: |
+              unzip -o artifacts/output.zip -d ./provider
+              rm artifacts/output.zip
+    
+        - name: Download built artifacts - Beta provider
+          uses: actions/download-artifact@v2
+          with:
+            name: artifact-terraform-provider-google-beta
+            path: artifacts
+    
+        - name: Unzip the artifacts and delete the zip
+          run: |
+              unzip -o artifacts/output.zip -d ./provider
+              rm artifacts/output.zip
+    
+        - name: Check that new services have been added to the TeamCity configuration code
+          run: |
+              # Create lists of service packages in providers
+              ls provider/google/services > tools/teamcity-diff-check/services_ga.txt
+              ls provider/google-beta/services > tools/teamcity-diff-check/services_beta.txt
+    
+              # Run tool to compare service packages in the providers vs those listed in TeamCity config files
+              cd tools/teamcity-diff-check
+              go run main.go -service_file=services_ga
+              go run main.go -service_file=services_beta

--- a/.github/workflows/teamcity-services-diff-check.yml
+++ b/.github/workflows/teamcity-services-diff-check.yml
@@ -33,14 +33,19 @@ jobs:
         with:
           repo: 'terraform-provider-google'
           token: '$GITHUB_TOKEN'
-      - run: echo "GOOGLE_REPO_PATH=${{ env.OUTPUT_PATH}}" >> $GITHUB_ENV
+        # The path where GA/Beta providers are generated is grabbed from the OUTPUT_PATH that's set in build_downstream.yaml
+        # export OUTPUT_PATH=$GOPATH/src/github.com/$UPSTREAM_OWNER/$GH_REPO
+        # OUTPUT_PATH changes after each generate (GA/beta)
+      - name: Set GOOGLE_REPO_PATH to path where GA provider was generated
+        run: echo "GOOGLE_REPO_PATH=${{ env.OUTPUT_PATH}}" >> $GITHUB_ENV
       - name: TeamCity Google Beta Provider Generate
         if: steps.generate.outcome == 'success'
         uses: ./.github/actions/build-downstream
         with:
           repo: 'terraform-provider-google-beta'
           token: '$GITHUB_TOKEN'
-      - run: echo "GOOGLE_BETA_REPO_PATH=${{ env.OUTPUT_PATH}}" >> $GITHUB_ENV
+      - name: Set GOOGLE_BETA_REPO_PATH to path where beta provider was generated
+        run: echo "GOOGLE_BETA_REPO_PATH=${{ env.OUTPUT_PATH}}" >> $GITHUB_ENV
       - name: Checkout Repository
         if: steps.generate.outcome == 'success'
         uses: actions/checkout@v4

--- a/.github/workflows/teamcity-services-diff-check.yml
+++ b/.github/workflows/teamcity-services-diff-check.yml
@@ -33,50 +33,15 @@ jobs:
         with:
           repo: 'terraform-provider-google'
           token: '$GITHUB_TOKEN'
-
       - name: TeamCity Google Beta Provider Generate
         if: steps.generate.outcome == 'success'
         uses: ./.github/actions/build-downstream
         with:
           repo: 'terraform-provider-google-beta'
           token: '$GITHUB_TOKEN'
-
       - name: Checkout Repository
         if: steps.generate.outcome == 'success'
         uses: actions/checkout@v4
-
-      - name: Setup Go
-        if: steps.generate.outcome == 'success'
-        uses: actions/setup-go@v4
-        with:
-          go-version: '^1.20'
-
-      - name: Download built artifacts - GA provider
-        if: steps.generate.outcome == 'success'
-        uses: actions/download-artifact@v2
-        with:
-          name: artifact-terraform-provider-google
-          path: artifacts
-
-      - name: Unzip the artifacts and delete the zip
-        if: steps.generate.outcome == 'success'
-        run: |
-          unzip -o artifacts/output.zip -d ./provider
-          rm artifacts/output.zip
-
-      - name: Download built artifacts - Beta provider
-        if: steps.generate.outcome == 'success'
-        uses: actions/download-artifact@v2
-        with:
-          name: artifact-terraform-provider-google-beta
-          path: artifacts
-
-      - name: Unzip the artifacts and delete the zip
-        if: steps.generate.outcome == 'success'
-        run: |
-          unzip -o artifacts/output.zip -d ./provider
-          rm artifacts/output.zip
-
       - name: Check that new services have been added to the TeamCity configuration code
         if: steps.generate.outcome == 'success'
         run: |

--- a/.github/workflows/teamcity-services-diff-check.yml
+++ b/.github/workflows/teamcity-services-diff-check.yml
@@ -25,6 +25,9 @@ jobs:
           if [ "$newServices" = "0" ];then
           echo "No new service found." 
           fi
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
       - name: TeamCity Google Provider Generate
         if: ${{steps.services.outputs.services != '0'}}
         uses: ./.github/workflows/build-downstream.yml

--- a/.github/workflows/teamcity-services-diff-check.yml
+++ b/.github/workflows/teamcity-services-diff-check.yml
@@ -25,9 +25,9 @@ jobs:
           echo "services=$newServices" >> "${GITHUB_OUTPUT}"
           if [ "$newServices" = "0" ];then
           echo "No new service found."
-          exit 1
           fi
       - name: TeamCity Google Provider Generate
+        id: generate
         if: ${{steps.services.outputs.services != '0'}}
         uses: ./.github/actions/build-downstream
         with:
@@ -35,42 +35,50 @@ jobs:
           token: '$GITHUB_TOKEN'
 
       - name: TeamCity Google Beta Provider Generate
+        if: steps.generate.outcome == 'success'
         uses: ./.github/actions/build-downstream
         with:
           repo: 'terraform-provider-google-beta'
           token: '$GITHUB_TOKEN'
 
       - name: Checkout Repository
+        if: steps.generate.outcome == 'success'
         uses: actions/checkout@v4
 
       - name: Setup Go
+        if: steps.generate.outcome == 'success'
         uses: actions/setup-go@v4
         with:
           go-version: '^1.20'
 
       - name: Download built artifacts - GA provider
+        if: steps.generate.outcome == 'success'
         uses: actions/download-artifact@v2
         with:
           name: artifact-terraform-provider-google
           path: artifacts
 
       - name: Unzip the artifacts and delete the zip
+        if: steps.generate.outcome == 'success'
         run: |
           unzip -o artifacts/output.zip -d ./provider
           rm artifacts/output.zip
 
       - name: Download built artifacts - Beta provider
+        if: steps.generate.outcome == 'success'
         uses: actions/download-artifact@v2
         with:
           name: artifact-terraform-provider-google-beta
           path: artifacts
 
       - name: Unzip the artifacts and delete the zip
+        if: steps.generate.outcome == 'success'
         run: |
           unzip -o artifacts/output.zip -d ./provider
           rm artifacts/output.zip
 
       - name: Check that new services have been added to the TeamCity configuration code
+        if: steps.generate.outcome == 'success'
         run: |
           # Create lists of service packages in providers
           ls provider/google/services > tools/teamcity-diff-check/services_ga.txt

--- a/.github/workflows/teamcity-services-diff-check.yml
+++ b/.github/workflows/teamcity-services-diff-check.yml
@@ -9,13 +9,8 @@ on:
       - 'mmv1/third_party/terraform/.teamcity/components/inputs/services_beta.kt'
       - 'mmv1/products/**'
 jobs:
-  check-pr:
-    runs-on: ubuntu-22.04
-    outputs:
-      services: ${{steps.services.outputs.services}}
   teamcity-services-diff-check:
     
-    needs: check-pr
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository

--- a/.github/workflows/teamcity-services-diff-check.yml
+++ b/.github/workflows/teamcity-services-diff-check.yml
@@ -25,17 +25,14 @@ jobs:
           if [ "$newServices" = "0" ];then
           echo "No new service found." 
           fi
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
       - name: TeamCity Google Provider Generate
         if: ${{steps.services.outputs.services != '0'}}
-        uses: ./.github/workflows/build-downstream.yml
+        uses: ./.github/actions/build-downstream/action.yml
         with:
           repo: 'terraform-provider-google'
 
       - name: TeamCity Google Beta Provider Generate
-        uses: ./.github/workflows/build-downstream.yml
+        uses: ./.github/actions/build-downstream/action.yml
         with:
           repo: 'terraform-provider-google-beta'
 

--- a/.github/workflows/teamcity-services-diff-check.yml
+++ b/.github/workflows/teamcity-services-diff-check.yml
@@ -33,14 +33,14 @@ jobs:
         with:
           repo: 'terraform-provider-google'
           token: '$GITHUB_TOKEN'
-      - run: export GOOGLE_REPO_PATH=$OUTPUT_PATH
+      - run: echo "GOOGLE_REPO_PATH=${{ env.OUTPUT_PATH}}" >> $GITHUB_ENV
       - name: TeamCity Google Beta Provider Generate
         if: steps.generate.outcome == 'success'
         uses: ./.github/actions/build-downstream
         with:
           repo: 'terraform-provider-google-beta'
           token: '$GITHUB_TOKEN'
-      - run: export GOOGLE_BETA_REPO_PATH=$OUTPUT_PATH
+      - run: echo "GOOGLE_BETA_REPO_PATH=${{ env.OUTPUT_PATH}}" >> $GITHUB_ENV
       - name: Checkout Repository
         if: steps.generate.outcome == 'success'
         uses: actions/checkout@v4
@@ -48,8 +48,8 @@ jobs:
         if: steps.generate.outcome == 'success'
         run: |
           # Create lists of service packages in providers
-          ls ${GOOGLE_REPO_PATH}/google/services > tools/teamcity-diff-check/services_ga.txt
-          ls ${GOOGLE_BETA_REPO_PATH}/google-beta/services > tools/teamcity-diff-check/services_beta.txt
+          ls ${{env.GOOGLE_REPO_PATH}}/google/services > tools/teamcity-diff-check/services_ga.txt
+          ls ${{env.GOOGLE_BETA_REPO_PATH}}/google-beta/services > tools/teamcity-diff-check/services_beta.txt
 
           # Run tool to compare service packages in the providers vs those listed in TeamCity config files
           cd tools/teamcity-diff-check

--- a/.github/workflows/teamcity-services-diff-check.yml
+++ b/.github/workflows/teamcity-services-diff-check.yml
@@ -33,12 +33,14 @@ jobs:
         with:
           repo: 'terraform-provider-google'
           token: '$GITHUB_TOKEN'
+      - run: export GOOGLE_REPO_PATH=$OUTPUT_PATH
       - name: TeamCity Google Beta Provider Generate
         if: steps.generate.outcome == 'success'
         uses: ./.github/actions/build-downstream
         with:
           repo: 'terraform-provider-google-beta'
           token: '$GITHUB_TOKEN'
+      - run: export GOOGLE_BETA_REPO_PATH=$OUTPUT_PATH
       - name: Checkout Repository
         if: steps.generate.outcome == 'success'
         uses: actions/checkout@v4
@@ -46,8 +48,8 @@ jobs:
         if: steps.generate.outcome == 'success'
         run: |
           # Create lists of service packages in providers
-          ls provider/google/services > tools/teamcity-diff-check/services_ga.txt
-          ls provider/google-beta/services > tools/teamcity-diff-check/services_beta.txt
+          ls ${GOOGLE_REPO_PATH}/google/services > tools/teamcity-diff-check/services_ga.txt
+          ls ${GOOGLE_BETA_REPO_PATH}/google-beta/services > tools/teamcity-diff-check/services_beta.txt
 
           # Run tool to compare service packages in the providers vs those listed in TeamCity config files
           cd tools/teamcity-diff-check

--- a/.github/workflows/teamcity-services-diff-check.yml
+++ b/.github/workflows/teamcity-services-diff-check.yml
@@ -13,6 +13,10 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       services: ${{steps.services.outputs.services}}
+  teamcity-services-diff-check:
+    
+    needs: check-pr
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -26,24 +30,17 @@ jobs:
           if [ "$newServices" = "0" ];then
           echo "No new service found." 
           fi
-  terraform-provider-google:
-    if: ${{needs.check-pr.outputs.services != '0'}}
-    needs: check-pr
-    uses: ./.github/workflows/build-downstream.yml
-    with:
-      repo: 'terraform-provider-google'
+      - name: TeamCity Google Provider Generate
+        if: ${{steps.services.outputs.services != '0'}}
+        uses: ./.github/workflows/build-downstream.yml
+        with:
+          repo: 'terraform-provider-google'
 
-  terraform-provider-google-beta:
-    if: ${{needs.check-pr.outputs.services != '0'}} 
-    needs: check-pr
-    uses: ./.github/workflows/build-downstream.yml
-    with:
-      repo: 'terraform-provider-google-beta'
+      - name: TeamCity Google Beta Provider Generate
+        uses: ./.github/workflows/build-downstream.yml
+        with:
+          repo: 'terraform-provider-google-beta'
 
-  teamcity-services-diff-check:
-    needs: [terraform-provider-google, terraform-provider-google-beta]
-    runs-on: ubuntu-22.04
-    steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/teamcity-services-diff-check.yml
+++ b/.github/workflows/teamcity-services-diff-check.yml
@@ -10,7 +10,8 @@ on:
       - 'mmv1/products/**'
 jobs:
   teamcity-services-diff-check:
-    
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
@@ -30,11 +31,13 @@ jobs:
         uses: ./.github/actions/build-downstream
         with:
           repo: 'terraform-provider-google'
+          token: '$GITHUB_TOKEN'
 
       - name: TeamCity Google Beta Provider Generate
         uses: ./.github/actions/build-downstream
         with:
           repo: 'terraform-provider-google-beta'
+          token: '$GITHUB_TOKEN'
 
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/teamcity-services-diff-check.yml
+++ b/.github/workflows/teamcity-services-diff-check.yml
@@ -27,12 +27,12 @@ jobs:
           fi
       - name: TeamCity Google Provider Generate
         if: ${{steps.services.outputs.services != '0'}}
-        uses: ./.github/actions/build-downstream/action.yml
+        uses: ./.github/actions/build-downstream
         with:
           repo: 'terraform-provider-google'
 
       - name: TeamCity Google Beta Provider Generate
-        uses: ./.github/actions/build-downstream/action.yml
+        uses: ./.github/actions/build-downstream
         with:
           repo: 'terraform-provider-google-beta'
 

--- a/.github/workflows/teamcity-services-diff-check.yml
+++ b/.github/workflows/teamcity-services-diff-check.yml
@@ -24,7 +24,8 @@ jobs:
           newServices=$(($(git diff --name-only --diff-filter=A origin/main HEAD | grep -P "mmv1/products/.*/product.yaml" | wc -l)))
           echo "services=$newServices" >> "${GITHUB_OUTPUT}"
           if [ "$newServices" = "0" ];then
-          echo "No new service found." 
+          echo "No new service found."
+          exit 1
           fi
       - name: TeamCity Google Provider Generate
         if: ${{steps.services.outputs.services != '0'}}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

To reduce the amount of checks that appear in a PR. we reduced the amount of jobs to just require one job.

Doing this required to create a `build-downstream` action.yml since workflows are used in jobs and not steps.

We may want to consider using the action over the workflow to prevent having two `build-downstreams` although this could be something we discuss further.

`build-downstream/action` was used for the TeamCity PR Diff Check and TeamCity Weekly Diff Check 

We'd want to refactor all places where `downstream.yml` workflow is used and replace with the action.yml that's been created in this PR. Only other place is in `downstream.yml`, doing this would shorten it to just be one job instead of four. This can be done in a second PR. https://github.com/GoogleCloudPlatform/magic-modules/blob/ab2122202ab62d620cbbbc8928078b0782146994/.github/workflows/downstreams.yml#L16-L31

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:NONE

```
