### PR TITLE
Add DisplayName to Product struct

### DIFF
--- a/mmv1/api/async.go
+++ b/mmv1/api/async.go
@@ -66,7 +66,7 @@ type Result struct {
 
 	// Contains information about the result of an Operation
 
-	ResourceInsideResponse bool
+	ResourceInsideResponse bool `yaml:"resource_inside_response"`
 }
 
 // def validate

--- a/mmv1/api/product.go
+++ b/mmv1/api/product.go
@@ -15,6 +15,7 @@ package api
 
 import (
 	"github.com/GoogleCloudPlatform/magic-modules/mmv1/api/product"
+	"github.com/GoogleCloudPlatform/magic-modules/mmv1/google"
 	"golang.org/x/exp/slices"
 )
 
@@ -38,6 +39,7 @@ type Product struct {
 	// Name string
 
 	// Display Name: The full name of the GCP product; eg "Cloud Bigtable"
+	DisplayName string `yaml:"display_name"`
 
 	Objects []*Resource
 
@@ -108,15 +110,15 @@ func (p *Product) Validate() {
 //     name.downcase
 //   end
 
-//   // The product full name is the "display name" in string form intended for
-//   // users to read in documentation; "Google Compute Engine", "Cloud Bigtable"
-//   def display_name
-//     if @display_name.nil?
-//       name.space_separated
-//     else
-//       @display_name
-//     end
-//   end
+// The product full name is the "display name" in string form intended for
+// users to read in documentation; "Google Compute Engine", "Cloud Bigtable"
+func (p Product) GetDisplayName() string {
+	if p.DisplayName == "" {
+		return google.SpaceSeparated(p.Name)
+	}
+
+	return p.DisplayName
+}
 
 //   // Most general version that exists for the product
 //   // If GA is present, use that, else beta, else alpha

--- a/mmv1/google/string_utils.go
+++ b/mmv1/google/string_utils.go
@@ -1,0 +1,111 @@
+// Copyright 2024 Google Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google
+
+import (
+	"regexp"
+	"strings"
+)
+
+// // Helper class to process and mutate strings.
+// class StringUtils
+//   // Converts string from camel case to underscore
+//   def self.underscore(source)
+//     source.gsub(/::/, '/')
+//           .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+//           .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+//           .tr('-', '_')
+//           .tr('.', '_')
+//           .downcase
+//   end
+
+//   // Converts from PascalCase to Space Separated
+//   def self.space_separated(source)
+//     tmp = source.gsub(/([A-Z]+)([A-Z][a-z])/, '\1 \2')
+//                 .gsub(/([a-z\d])([A-Z])/, '\1 \2')
+//                 .downcase
+//     tmp[0].upcase.concat(tmp[1..])
+//   end
+
+// Converts from PascalCase to Space Separated
+// For example, converts "AccessApproval" to "Access Approval"
+func SpaceSeparated(source string) string {
+	tmp := regexp.MustCompile(`([A-Z]+)([A-Z][a-z])`).ReplaceAllString(source, "${1} ${2}")
+	tmp = regexp.MustCompile(`([a-z\d])([A-Z])`).ReplaceAllString(tmp, "${1} ${2}")
+	tmp = strings.ToLower(tmp)
+	tmp = strings.Title(tmp)
+	return tmp
+}
+
+//   // Converts a string to space-separated capitalized words
+//   def self.title(source)
+//     ss = space_separated(source)
+//     ss.gsub(/\b(?<!\w['’`()])[a-z]/, &:capitalize)
+//   end
+
+//   // rubocop:disable Style/SafeNavigation // support Ruby < 2.3.0
+//   def self.symbolize(key)
+//     key.to_sym unless key.nil?
+//   end
+//   // rubocop:enable Style/SafeNavigation
+
+//   // Returns all the characters up until the period (.) or returns text
+//   // unchanged if there is no period.
+//   def self.first_sentence(text)
+//     period_pos = text.index(/[.?!]/)
+//     return text if period_pos.nil?
+
+//     text[0, period_pos + 1]
+//   end
+
+//   // Returns the plural form of a word
+//   def self.plural(source)
+//     // policies -> policies
+//     // indices -> indices
+//     return source if source.end_with?('ies') || source.end_with?('es')
+
+//     // index -> indices
+//     return "//{source.gsub(/ex$/, '')}ices" if source.end_with?('ex')
+
+//     // mesh -> meshes
+//     return "//{source}es" if source.end_with?('esh')
+
+//     // key -> keys
+//     // gateway -> gateways
+//     return "//{source}s" if source.end_with?('ey') || source.end_with?('ay')
+
+//     // policy -> policies
+//     return "//{source.gsub(/y$/, '')}ies" if source.end_with?('y')
+
+//     "//{source}s"
+//   end
+
+//   // Slimmed down version of ActiveSupport::Inflector code
+//   def self.camelize(term, uppercase_first_letter)
+//     acronyms_camelize_regex = /^(?:(?=a)b(?=\b|[A-Z_])|\w)/
+
+//     string = term.to_s
+//     string = if uppercase_first_letter
+//                string.sub(/^[a-z\d]*/) { |match| match.capitalize! || match }
+//              else
+//                string.sub(acronyms_camelize_regex) { |match| match.downcase! || match }
+//              end
+//     // handle snake case
+//     string.gsub!(/(?:_)([a-z\d]*)/i) do
+//       word = ::Regexp.last_match(1)
+//       word.capitalize! || word
+//     end
+//     string
+//   end
+// end


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add `DisplayName` to Product struct

In the current ruby code, if `display_name` is not provided, it will convert the name to the space separated sentence.
For example, it converts `BlockchainNodeEngine` to `Blockchain node engine`
https://registry.terraform.io/providers/hashicorp/google/latest/docs


After rewriting the function `GetDisplayName` with Go, it works a little bit different. 
For example, it converts `BlockchainNodeEngine` to `Blockchain Node Engine` to match with other display names provided in the yaml files.



<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
