### PR TITLE
Refactor `project_from_id` acc test to use non-networking resources

### DIFF
--- a/mmv1/third_party/terraform/functions/project_from_id_test.go
+++ b/mmv1/third_party/terraform/functions/project_from_id_test.go
@@ -19,7 +19,7 @@ func TestAccProviderFunction_project_from_id(t *testing.T) {
 	context := map[string]interface{}{
 		"function_name": "project_from_id",
 		"output_name":   "project_id",
-		"resource_name": fmt.Sprintf("tf-test-project-id-func-%s", acctest.RandString(t, 10)),
+		"resource_name": fmt.Sprintf("tf_test_project_id_func_%s", acctest.RandString(t, 10)),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -35,7 +35,7 @@ func TestAccProviderFunction_project_from_id(t *testing.T) {
 			},
 			{
 				// Can get the project from a resource's self_link in one step
-				// Uses google_compute_subnetwork resource's self_link attribute
+				// Uses google_bigquery_dataset resource's self_link attribute
 				Config: testProviderFunction_get_project_from_resource_self_link(context),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchOutput(context["output_name"].(string), projectIdRegex),
@@ -49,11 +49,11 @@ func testProviderFunction_get_project_from_resource_id(context map[string]interf
 	return acctest.Nprintf(`
 # terraform block required for provider function to be found
 terraform {
-	required_providers {
-		google = {
-			source = "hashicorp/google"
-		}
-	}
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
 }
 
 resource "google_pubsub_topic" "default" {
@@ -61,7 +61,7 @@ resource "google_pubsub_topic" "default" {
 }
 
 output "%{output_name}" {
-	value = provider::google::%{function_name}(google_pubsub_topic.default.id)
+  value = provider::google::%{function_name}(google_pubsub_topic.default.id)
 }
 `, context)
 }
@@ -70,25 +70,20 @@ func testProviderFunction_get_project_from_resource_self_link(context map[string
 	return acctest.Nprintf(`
 # terraform block required for provider function to be found
 terraform {
-	required_providers {
-		google = {
-			source = "hashicorp/google"
-		}
-	}
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
 }
 
-data "google_compute_network" "default" {
-  name = "default"
-}
-
-resource "google_compute_subnetwork" "default" {
-  name          = "%{resource_name}"
-  ip_cidr_range = "10.2.0.0/16"
-  network        = data.google_compute_network.default.id
+resource "google_bigquery_dataset" "default" {
+  dataset_id  = "%{resource_name}"
+  description = "This dataset is made in an acceptance test"
 }
 
 output "%{output_name}" {
-	value = provider::google::%{function_name}(google_compute_subnetwork.default.self_link)
+  value = provider::google::%{function_name}(google_bigquery_dataset.default.self_link)
 }
 `, context)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Previously when I wrote the first iteration of these acceptance tests for provider-functions I used subnetworks as my go-to Compute resources that would return self_links but CIDR ranges causes trouble in the test projects. This PR replaces use of subnetworks with bigquery datasets as a resource that returns a self_link that contains project information

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
