### PR TITLE
Update `location_from_id` acceptance test to not use GOOGLE_REGION ENV

### DIFF
--- a/mmv1/third_party/terraform/functions/location_from_id_test.go
+++ b/mmv1/third_party/terraform/functions/location_from_id_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestAccProviderFunction_location_from_id(t *testing.T) {
@@ -15,7 +14,7 @@ func TestAccProviderFunction_location_from_id(t *testing.T) {
 	// Skipping due to requiring TF 1.8.0 in VCR systems : https://github.com/hashicorp/terraform-provider-google/issues/17451
 	acctest.SkipIfVcr(t)
 
-	location := envvar.GetTestRegionFromEnv()
+	location := "us-central1"
 	locationRegex := regexp.MustCompile(fmt.Sprintf("^%s$", location))
 
 	context := map[string]interface{}{


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR makes `TestAccProviderFunction_location_from_id` not use `GOOGLE_REGION` to get a region value.

I won't update `TestAccProviderFunction_project_from_id` in a similar way because the acceptance test cannot run without GOOGLE_PROJECT set.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
