### PR TITLE
Run Firestore index tests in fresh databases.

### DIFF
--- a/mmv1/products/firestore/Index.yaml
+++ b/mmv1/products/firestore/Index.yaml
@@ -60,16 +60,18 @@ examples:
     primary_resource_id:
       'my-index'
     vars:
-      project_id: "project-id"
       database_id: "database-id"
+    test_env_vars:
+      project_id: :PROJECT_NAME
     pull_external: true
   - !ruby/object:Provider::Terraform::Examples
     name: 'firestore_index_datastore_mode'
     primary_resource_id:
       'my-index'
     vars:
-      project_id: "project-id"
       database_id: "database-id-dm"
+    test_env_vars:
+      project_id: :PROJECT_NAME
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/index_self_link_as_name_set_project.go.erb
   encoder: templates/terraform/encoders/index.go.erb

--- a/mmv1/products/firestore/Index.yaml
+++ b/mmv1/products/firestore/Index.yaml
@@ -61,18 +61,15 @@ examples:
       'my-index'
     vars:
       project_id: "project-id"
-    test_env_vars:
-      org_id: :ORG_ID
+      database_id: "database-id"
     pull_external: true
   - !ruby/object:Provider::Terraform::Examples
     name: 'firestore_index_datastore_mode'
     primary_resource_id:
       'my-index'
-    test_env_vars:
-      # This example relies on a well-known collection having been created and
-      # Firestore being enabled on the project. We can't do that automatically
-      # for Datastore mode so we need a pre-created project.
-      project_id: :FIRESTORE_PROJECT_NAME
+    vars:
+      project_id: "project-id"
+      database_id: "database-id-dm"
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/index_self_link_as_name_set_project.go.erb
   encoder: templates/terraform/encoders/index.go.erb

--- a/mmv1/templates/terraform/examples/firestore_index_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_index_basic.tf.erb
@@ -1,45 +1,17 @@
-resource "google_project" "project" {
-  project_id = "<%= ctx[:vars]['project_id'] %>"
-  name       = "<%= ctx[:vars]['project_id'] %>"
-  org_id     = "<%= ctx[:test_env_vars]['org_id'] %>"
-}
-
-resource "time_sleep" "wait_60_seconds" {
-  depends_on = [google_project.project]
-
-  create_duration = "60s"
-}
-
-resource "google_project_service" "firestore" {
-  project = google_project.project.project_id
-  service = "firestore.googleapis.com"
-
-  # Needed for CI tests for permissions to propagate, should not be needed for actual usage
-  depends_on = [time_sleep.wait_60_seconds]
-}
-
 resource "google_firestore_database" "database" {
-  project     = google_project.project.project_id
-  name        = "(default)"
+  project     = "<%= ctx[:test_env_vars]['project_id'] %>"
+  name        = "<%= ctx[:vars]['database_id'] %>"
   location_id = "nam5"
   type        = "FIRESTORE_NATIVE"
 
-  depends_on = [google_project_service.firestore]
-}
-
-# Creating a document also creates its collection
-resource "google_firestore_document" "document" {
-  project     = google_project.project.project_id
-  database    = google_firestore_database.database.name
-  collection  = "somenewcollection"
-  document_id = "<%= ctx[:vars]['document_id'] %>"
-  fields      = "{\"something\":{\"mapValue\":{\"fields\":{\"akey\":{\"stringValue\":\"avalue\"}}}}}"
+  delete_protection_state = "<%= ctx[:vars]['delete_protection_state'] %>"
+  deletion_policy         = "DELETE"
 }
 
 resource "google_firestore_index" "<%= ctx[:primary_resource_id] %>" {
-  project    = google_project.project.project_id
+  project     = "<%= ctx[:test_env_vars]['project_id'] %>"
   database   = google_firestore_database.database.name
-  collection = google_firestore_document.document.collection
+  collection = "atestcollection"
 
   fields {
     field_path = "name"
@@ -50,5 +22,4 @@ resource "google_firestore_index" "<%= ctx[:primary_resource_id] %>" {
     field_path = "description"
     order      = "DESCENDING"
   }
-
 }

--- a/mmv1/templates/terraform/examples/firestore_index_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_index_basic.tf.erb
@@ -4,7 +4,7 @@ resource "google_firestore_database" "database" {
   location_id = "nam5"
   type        = "FIRESTORE_NATIVE"
 
-  delete_protection_state = "<%= ctx[:vars]['delete_protection_state'] %>"
+  delete_protection_state = "DELETE_PROTECTION_DISABLED"
   deletion_policy         = "DELETE"
 }
 

--- a/mmv1/templates/terraform/examples/firestore_index_datastore_mode.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_index_datastore_mode.tf.erb
@@ -1,15 +1,15 @@
 resource "google_firestore_database" "database" {
-  project     = "<%= ctx[:test_env_vars]['project_id'] %>"
+  project     = "<%= ctx[:vars]['project_id'] %>"
   name        = "<%= ctx[:vars]['database_id'] %>"
   location_id = "nam5"
   type        = "DATASTORE_MODE"
 
-  delete_protection_state = "<%= ctx[:vars]['delete_protection_state'] %>"
+  delete_protection_state = "DELETE_PROTECTION_DISABLED"
   deletion_policy         = "DELETE"
 }
 
 resource "google_firestore_index" "<%= ctx[:primary_resource_id] %>" {
-  project     = "<%= ctx[:test_env_vars]['project_id'] %>"
+  project     = "<%= ctx[:vars]['project_id'] %>"
   database   = google_firestore_database.database.name
   collection = "atestcollection"
 

--- a/mmv1/templates/terraform/examples/firestore_index_datastore_mode.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_index_datastore_mode.tf.erb
@@ -1,5 +1,5 @@
 resource "google_firestore_database" "database" {
-  project     = "<%= ctx[:vars]['project_id'] %>"
+  project     = "<%= ctx[:test_env_vars]['project_id'] %>"
   name        = "<%= ctx[:vars]['database_id'] %>"
   location_id = "nam5"
   type        = "DATASTORE_MODE"
@@ -9,7 +9,7 @@ resource "google_firestore_database" "database" {
 }
 
 resource "google_firestore_index" "<%= ctx[:primary_resource_id] %>" {
-  project     = "<%= ctx[:vars]['project_id'] %>"
+  project     = "<%= ctx[:test_env_vars]['project_id'] %>"
   database   = google_firestore_database.database.name
   collection = "atestcollection"
 

--- a/mmv1/templates/terraform/examples/firestore_index_datastore_mode.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_index_datastore_mode.tf.erb
@@ -1,7 +1,17 @@
+resource "google_firestore_database" "database" {
+  project     = "<%= ctx[:test_env_vars]['project_id'] %>"
+  name        = "<%= ctx[:vars]['database_id'] %>"
+  location_id = "nam5"
+  type        = "DATASTORE_MODE"
+
+  delete_protection_state = "<%= ctx[:vars]['delete_protection_state'] %>"
+  deletion_policy         = "DELETE"
+}
+
 resource "google_firestore_index" "<%= ctx[:primary_resource_id] %>" {
-  project    = "<%= ctx[:test_env_vars]['project_id'] %>"
-  database   = "(default)"
-  collection = "chatrooms"
+  project     = "<%= ctx[:test_env_vars]['project_id'] %>"
+  database   = google_firestore_database.database.name
+  collection = "atestcollection"
 
   query_scope = "COLLECTION_RECURSIVE"
   api_scope = "DATASTORE_MODE_API"


### PR DESCRIPTION
This removes the index dependency on creating a document, as creating indexes on a non-existent collection is a valid operation in Firestore.

This removes the dependency on a fixed (default) database, which should deflake tests.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/17393.

Verified with a local execution of `make testacc TEST=./google/services/f
irestore TESTARGS='-run=TestAccFirestoreIndex_'`

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
