### PR TITLE
cloudrunv2: Validate number of ports specified restricting to 1.

### DIFF
--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -448,6 +448,7 @@ properties:
                     Determines whether CPU should be boosted on startup of a new container instance above the requested CPU threshold, this can help reduce cold-start latency.
             - !ruby/object:Api::Type::Array
               name: 'ports'
+              maxSize: 1
               description: |-
                 List of ports to expose from the container. Only a single port can be specified. The specified ports must be listening on all interfaces (0.0.0.0) within the container to be accessible.
 

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -448,7 +448,7 @@ properties:
                     Determines whether CPU should be boosted on startup of a new container instance above the requested CPU threshold, this can help reduce cold-start latency.
             - !ruby/object:Api::Type::Array
               name: 'ports'
-              maxSize: 1
+              max_size: 1
               description: |-
                 List of ports to expose from the container. Only a single port can be specified. The specified ports must be listening on all interfaces (0.0.0.0) within the container to be accessible.
 


### PR DESCRIPTION
Accidentally specifying the `containers.ports` twice results in the following error:

```
Error: Error updating Service "projects/myproject/locations/us-central1/services/myservice": googleapi: Error 400: Violation in UpdateServiceRequest.service.template.containers[0].ports: ports should contain 0 or 1 port.
│ Details:
│ [
│   {
│     "@type": "type.googleapis.com/google.rpc.BadRequest",
│     "fieldViolations": [
│       {
│         "description": "ports should contain 0 or 1 port.",
│         "field": "Violation in UpdateServiceRequest.service.template.containers[0].ports"
│       }
│     ]
│   }
│ ]
│ 
│   with google_cloud_run_v2_service.myservice,
│   on myservice.tf line 1, in resource "google_cloud_run_v2_service" "myservice":
│    1: resource "google_cloud_run_v2_service" "myservice" {
│ 
```

It would be convenient if this issue could be caught at validation time.

```release-note:enhancement
cloudrunv2: added the validation to restrict number of ports to 1 to match server-side validation
```
