### PR TITLE
Fix for PrivateNat test failures

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_nat_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_nat_test.go.erb
@@ -1679,6 +1679,9 @@ resource "google_compute_router" "foobar" {
   name     = "%s"
   region   = google_compute_subnetwork.subnet1.region
   network  = google_compute_network.foobar.self_link
+  depends_on = [
+    google_network_connectivity_spoke.primary
+  ]
 }
 `, routerName, routerName, routerName, routerName, routerName, hubName, routerName, routerName)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes the failing test: TestAccComputeRouterNat_withPrivateNatAndEmptyAction https://github.com/hashicorp/terraform-provider-google/issues/17379

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
