### PR TITLE
Add support for boost configs in workstations configs

### DIFF
--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -102,13 +102,6 @@ examples:
       workstation_cluster_name: 'workstation-cluster'
       workstation_config_name: 'workstation-config'
   - !ruby/object:Provider::Terraform::Examples
-    name: 'workstation_config_service_account'
-    min_version: beta
-    primary_resource_id: 'default'
-    vars:
-      workstation_cluster_name: 'workstation-cluster'
-      workstation_config_name: 'workstation-config'
-  - !ruby/object:Provider::Terraform::Examples
     name: 'workstation_config_accelerators'
     min_version: beta
     primary_resource_id: 'default'

--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -102,6 +102,13 @@ examples:
       workstation_cluster_name: 'workstation-cluster'
       workstation_config_name: 'workstation-config'
   - !ruby/object:Provider::Terraform::Examples
+    name: 'workstation_config_service_account'
+    min_version: beta
+    primary_resource_id: 'default'
+    vars:
+      workstation_cluster_name: 'workstation-cluster'
+      workstation_config_name: 'workstation-config'
+  - !ruby/object:Provider::Terraform::Examples
     name: 'workstation_config_accelerators'
     min_version: beta
     primary_resource_id: 'default'
@@ -213,6 +220,7 @@ properties:
       - 'host.gceInstance.shieldedInstanceConfig.enableIntegrityMonitoring'
       - 'host.gceInstance.confidentialInstanceConfig.enableConfidentialCompute'
       - 'host.gceInstance.accelerators'
+      - 'host.gceInstance.boostConfigs'
       - 'host.gceInstance.disableSsh'
     properties:
       - !ruby/object:Api::Type::NestedObject
@@ -319,6 +327,37 @@ properties:
                   description: |
                     Number of accelerator cards exposed to the instance.
                   required: true
+          - !ruby/object:Api::Type::Array
+            name: 'boostConfigs'
+            description: |
+              A list of the boost configurations that workstations created using this workstation configuration are allowed to use.
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: 'id'
+                  description: |
+                    The id to be used for the boost config.
+                  required: true
+                - !ruby/object:Api::Type::String
+                  name: 'machineType'
+                  description: |
+                    The type of machine that boosted VM instances will use. Defaults to `e2-standard-4`.
+                - !ruby/object:Api::Type::Array
+                  name: 'accelerators'
+                  description: |
+                    An accelerator card attached to the boost instance.
+                  item_type: !ruby/object:Api::Type::NestedObject
+                    properties:
+                      - !ruby/object:Api::Type::String
+                        name: 'type'
+                        description: |
+                          Type of accelerator resource to attach to the instance, for example, "nvidia-tesla-p100".
+                        required: true
+                      - !ruby/object:Api::Type::Integer
+                        name: 'count'
+                        description: |
+                          Number of accelerator cards exposed to the instance.
+                        required: true
   - !ruby/object:Api::Type::Array
     name: 'persistentDirectories'
     description: |

--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -116,6 +116,13 @@ examples:
       workstation_cluster_name: 'workstation-cluster'
       workstation_config_name: 'workstation-config'
   - !ruby/object:Provider::Terraform::Examples
+    name: 'workstation_config_boost'
+    min_version: beta
+    primary_resource_id: 'default'
+    vars:
+      workstation_cluster_name: 'workstation-cluster'
+      workstation_config_name: 'workstation-config'
+  - !ruby/object:Provider::Terraform::Examples
     name: 'workstation_config_encryption_key'
     min_version: beta
     primary_resource_id: 'default'

--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -341,7 +341,7 @@ properties:
                 - !ruby/object:Api::Type::String
                   name: 'machineType'
                   description: |
-                    The type of machine that boosted VM instances will use. Defaults to `e2-standard-4`.
+                    The type of machine that boosted VM instances will use—for example, e2-standard-4. For more information about machine types that Cloud Workstations supports, see the list of available machine types https://cloud.google.com/workstations/docs/available-machine-types. Defaults to e2-standard-4.
                 - !ruby/object:Api::Type::Array
                   name: 'accelerators'
                   description: |

--- a/mmv1/templates/terraform/examples/workstation_config_boost.tf.erb
+++ b/mmv1/templates/terraform/examples/workstation_config_boost.tf.erb
@@ -1,0 +1,56 @@
+resource "google_compute_network" "default" {
+  provider                = google-beta
+  name                    = "<%= ctx[:vars]['workstation_cluster_name'] %>"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  provider      = google-beta
+  name          = "<%= ctx[:vars]['workstation_cluster_name'] %>"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.default.name
+}
+
+resource "google_workstations_workstation_cluster" "<%= ctx[:primary_resource_id] %>" {
+  provider               = google-beta
+  workstation_cluster_id = "<%= ctx[:vars]['workstation_cluster_name'] %>"
+  network                = google_compute_network.default.id
+  subnetwork             = google_compute_subnetwork.default.id
+  location               = "us-central1"
+  
+  labels = {
+    "label" = "key"
+  }
+
+  annotations = {
+    label-one = "value-one"
+  }
+}
+
+resource "google_workstations_workstation_config" "<%= ctx[:primary_resource_id] %>" {
+  provider               = google-beta
+  workstation_config_id  = "<%= ctx[:vars]['workstation_config_name'] %>"
+  workstation_cluster_id = google_workstations_workstation_cluster.<%= ctx[:primary_resource_id] %>.workstation_cluster_id
+  location               = "us-central1"
+
+  host {
+    gce_instance {
+      machine_type                = "e2-standard-4"
+      boot_disk_size_gb           = 35
+      disable_public_ip_addresses = true
+      boost_configs {
+        id           = "boost-1"
+        machine_type = "n1-standard-2"
+        accelerators {
+          type  = "nvidia-tesla-t4"
+          count = "1"
+        }
+      }
+      boost_configs {
+        id           = "boost-1"
+        machine_type = "e2-standard-2"
+      }
+    }
+  }
+}

--- a/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
+++ b/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
@@ -963,11 +963,7 @@ resource "google_workstations_workstation_config" "default" {
  
       boost_configs {
         id           = "boost-1"
-        machine_type = "n1-standard-2"
-        accelerators {
-          type  = "nvidia-tesla-t4"
-          count = 1
-        }
+        machine_type = "n2d-standard-2"
       }
     }
   }

--- a/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
+++ b/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
@@ -476,6 +476,80 @@ func testAccWorkstationsWorkstationConfig_serviceAccount(context map[string]inte
 `, context)
 }
 
+func TestAccWorkstationsWorkstationConfig_boost(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckWorkstationsWorkstationConfigDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkstationsWorkstationConfig_boost(context),
+			},
+			{
+				ResourceName:            "google_workstations_workstation_cluster.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"etag"},
+			},
+		},
+	})
+}
+
+func testAccWorkstationsWorkstationConfig_boost(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+  resource "google_compute_network" "default" {
+    provider                = google-beta
+    name                    = "tf-test-workstation-cluster%{random_suffix}"
+    auto_create_subnetworks = false
+  }
+  
+  resource "google_compute_subnetwork" "default" {
+    provider      = google-beta
+    name          = "tf-test-workstation-cluster%{random_suffix}"
+    ip_cidr_range = "10.0.0.0/24"
+    region        = "us-central1"
+    network       = google_compute_network.default.name
+  }
+  
+  resource "google_workstations_workstation_cluster" "default" {
+    provider                   = google-beta
+    workstation_cluster_id     = "tf-test-workstation-cluster%{random_suffix}"
+    network                    = google_compute_network.default.id
+    subnetwork                 = google_compute_subnetwork.default.id
+    location                   = "us-central1"
+  }
+
+  resource "google_workstations_workstation_config" "default" {
+    provider               = google-beta
+    workstation_config_id  = "tf-test-workstation-config%{random_suffix}"
+    workstation_cluster_id = google_workstations_workstation_cluster.default.workstation_cluster_id
+    location               = "us-central1"
+    host {
+      gce_instance {  
+        boost_configs {
+          id           = "boost-1"
+          machine_type = "n1-standard-2"
+          accelerators {
+            type  = "nvidia-tesla-t4"
+            count = "1"
+          }
+        }
+        boost_configs {
+          id           = "boost-1"
+          machine_type = "e2-standard-2"
+        }
+      }
+    }
+  }
+`, context)
+}
+
 func TestAccWorkstationsWorkstationConfig_disableTcpConnections(t *testing.T) {
 	t.Parallel()
 

--- a/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
+++ b/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
@@ -1021,7 +1021,6 @@ resource "google_workstations_workstation_config" "default" {
 
       shielded_instance_config {}
       confidential_instance_config {}
-      boost_configs {}
     }
   }
 }

--- a/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
+++ b/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
@@ -531,13 +531,13 @@ func testAccWorkstationsWorkstationConfig_boost(context map[string]interface{}) 
     workstation_cluster_id = google_workstations_workstation_cluster.default.workstation_cluster_id
     location               = "us-central1"
     host {
-      gce_instance {  
+      gce_instance {
         boost_configs {
           id           = "boost-1"
           machine_type = "n1-standard-2"
           accelerators {
             type  = "nvidia-tesla-t4"
-            count = "1"
+            count = 1
           }
         }
         boost_configs {
@@ -960,6 +960,15 @@ resource "google_workstations_workstation_config" "default" {
       confidential_instance_config {
         enable_confidential_compute = true
       }
+ 
+      boost_configs {
+        id           = "boost-1"
+        machine_type = "n1-standard-2"
+        accelerators {
+          type  = "nvidia-tesla-t4"
+          count = 1
+        }
+      }
     }
   }
 }
@@ -1016,6 +1025,7 @@ resource "google_workstations_workstation_config" "default" {
 
       shielded_instance_config {}
       confidential_instance_config {}
+      boost_configs {}
     }
   }
 }


### PR DESCRIPTION
fixes: b/315040685

This change updates  `google_workstations_workstation_config`  with the `host.gceInstance.boostConfig` field that is supported by the cloud workstations api and can be set when creating and updating workstation configs to provide workstations with a configuration that can be boosted up to.

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [make test and make lint](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.


**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
workstations: added `host.gceInstance.boostConfig` to `google_workstations_workstation_config` (beta)
```
