### PR TITLE
attempt at fixing the (R)IGM.status output message

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
@@ -459,13 +459,18 @@ func ResourceComputeInstanceGroupManager() *schema.Resource {
 							Computed:    true,
 							Description: `Status of all-instances configuration on the group.`,
 							Elem: &schema.Resource{
-      					Schema: map[string]*schema.Schema{
-      						"effective": {
-      							Type:        schema.TypeBool,
-      							Computed:    true,
-      							Description: `A bit indicating whether this configuration has been applied to all managed instances in the group.`,
-      						},
-      					},
+								Schema: map[string]*schema.Schema{
+									"effective": {
+										Type:        schema.TypeBool,
+										Computed:    true,
+										Description: `A bit indicating whether this configuration has been applied to all managed instances in the group.`,
+									},
+									"current_revision": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `Current all-instances configuration revision. This value is in RFC3339 text format.`,
+									},
+								},
       				},
 						},
 						"stateful": {
@@ -1492,6 +1497,7 @@ func flattenStatusAllInstancesConfig(allInstancesConfig *compute.InstanceGroupMa
 	results := []map[string]interface{}{}
 	data := map[string]interface{}{
 		"effective": allInstancesConfig.Effective,
+		"current_revision": allInstancesConfig.CurrentRevision,
 	}
 	results = append(results, data)
 	return results

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
@@ -487,7 +487,7 @@ func ResourceComputeInstanceGroupManager() *schema.Resource {
 									"per_instance_configs": {
 										Type:        schema.TypeList,
 										Computed:    true,
-										Description: `Status of per-instance configs on the instance.`,
+										Description: `Status of per-instance configs on the instances.`,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"all_effective": {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
@@ -514,7 +514,7 @@ func ResourceComputeRegionInstanceGroupManager() *schema.Resource {
 									"per_instance_configs": {
 										Type:        schema.TypeList,
 										Computed:    true,
-										Description: `Status of per-instance configs on the instance.`,
+										Description: `Status of per-instance configs on the instances.`,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"all_effective": {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.erb
@@ -492,6 +492,11 @@ func ResourceComputeRegionInstanceGroupManager() *schema.Resource {
 										Computed:    true,
 										Description: `A bit indicating whether this configuration has been applied to all managed instances in the group.`,
 									},
+									"current_revision": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `Current all-instances configuration revision. This value is in RFC3339 text format.`,
+									},
 								},
 							},
 						},

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
@@ -329,11 +329,19 @@ The `status` block holds:
 
 * `version_target` - A status of consistency of Instances' versions with their target version specified by version field on Instance Group Manager.
 
+* `all_instances_config` - Status of all-instances configuration on the group.
+
+* `stateful` - Stateful status of the given Instance Group Manager.
+
 The `version_target` block holds:
 
 * `version_target` - A bit indicating whether version target has been reached in this managed instance group, i.e. all instances are in their target version. Instances' target version are specified by version field on Instance Group Manager.
 
-* `stateful` - Stateful status of the given Instance Group Manager.
+The `all_instances_config` block holds:
+
+* `effective` -  A bit indicating whether this configuration has been applied to all managed instances in the group.
+
+* `current_revision` - Current all-instances configuration revision. This value is in RFC3339 text format.
 
 The `stateful` block holds:
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
@@ -347,7 +347,7 @@ The `stateful` block holds:
 
 * `has_stateful_config` - A bit indicating whether the managed instance group has stateful configuration, that is, if you have configured any items in a stateful policy or in per-instance configs. The group might report that it has no stateful config even when there is still some preserved state on a managed instance, for example, if you have deleted all PICs but not yet applied those deletions.
 
-* `per_instance_configs` - Status of per-instance configs on the instance.
+* `per_instance_configs` - Status of per-instance configs on the instances.
 
 The `per_instance_configs` block holds:
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -336,13 +336,21 @@ The `status` block holds:
 
 * `is_stable` - A bit indicating whether the managed instance group is in a stable state. A stable state means that: none of the instances in the managed instance group is currently undergoing any type of change (for example, creation, restart, or deletion); no future changes are scheduled for instances in the managed instance group; and the managed instance group itself is not being modified.
 
+* `all_instances_config` - Status of all-instances configuration on the group.
+
+* `stateful` - Stateful status of the given Instance Group Manager.
+
 * `version_target` - A status of consistency of Instances' versions with their target version specified by version field on Instance Group Manager.
 
 The `version_target` block holds:
 
 * `version_target` - A bit indicating whether version target has been reached in this managed instance group, i.e. all instances are in their target version. Instances' target version are specified by version field on Instance Group Manager.
 
-* `stateful` - Stateful status of the given Instance Group Manager.
+The `all_instances_config` block holds:
+
+* `effective` -  A bit indicating whether this configuration has been applied to all managed instances in the group.
+
+* `current_revision` - Current all-instances configuration revision. This value is in RFC3339 text format.
 
 The `stateful` block holds:
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -356,7 +356,7 @@ The `stateful` block holds:
 
 * `has_stateful_config` - A bit indicating whether the managed instance group has stateful configuration, that is, if you have configured any items in a stateful policy or in per-instance configs. The group might report that it has no stateful config even when there is still some preserved state on a managed instance, for example, if you have deleted all PICs but not yet applied those deletions.
 
-* `per_instance_configs` - Status of per-instance configs on the instance.
+* `per_instance_configs` - Status of per-instance configs on the instances.
 
 The `per_instance_configs` block holds:
 


### PR DESCRIPTION
Add google_compute_(region)_instance_group_manager.status.all_instances_config.revision field
Fix status fields in (Regional)InstanceGroupManagers.

fixes https://github.com/hashicorp/terraform-provider-google/issues/17572

Making documentation consistent with the implementation and with the API 
the tfstate file contains (e.g.):
```
"status": [
              {
                "all_instances_config": [
                  {
                    "current_revision": "2024-03-11T15:56:35.837380Z",
                    "effective": true
                  }
                ],
                "is_stable": false,
                "stateful": [
                  {
                    "has_stateful_config": false,
                    "per_instance_configs": [
                      {
                        "all_effective": true
                      }
                    ]
                  }
                ],
                "version_target": [
                  {
                    "is_reached": true
                  }
                ]
              }
            ],
```
this is consistent (apart from the autoscaler field, which is not in scope of this PR) with the public discovery docs:
```
    "InstanceGroupManagerStatus": {
      "id": "InstanceGroupManagerStatus",
      "type": "object",
      "properties": {
        "isStable": {
          "description": "[Output Only] A bit indicating whether the managed instance group is in a stable state. A stable state means that: none of the instances in the managed instance group is currently undergoing any type of change (for example, creation, restart, or deletion); no future changes are scheduled for instances in the managed instance group; and the managed instance group itself is not being modified.",
          "type": "boolean"
        },
        "allInstancesConfig": {
          "description": "[Output only] Status of all-instances configuration on the group.",
          "$ref": "InstanceGroupManagerStatusAllInstancesConfig"
        },
        "versionTarget": {
          "description": "[Output Only] A status of consistency of Instances' versions with their target version specified by version field on Instance Group Manager.",
          "$ref": "InstanceGroupManagerStatusVersionTarget"
        },
        "stateful": {
          "description": "[Output Only] Stateful status of the given Instance Group Manager.",
          "$ref": "InstanceGroupManagerStatusStateful"
        },
        "autoscaler": {
          "description": "[Output Only] The URL of the Autoscaler that targets this instance group manager.",
          "type": "string"
        }
      }
    },
    "InstanceGroupManagerStatusAllInstancesConfig": {
      "id": "InstanceGroupManagerStatusAllInstancesConfig",
      "type": "object",
      "properties": {
        "effective": {
          "description": "[Output Only] A bit indicating whether this configuration has been applied to all managed instances in the group.",
          "type": "boolean"
        },
        "currentRevision": {
          "description": "[Output Only] Current all-instances configuration revision. This value is in RFC3339 text format.",
          "type": "string"
        }
      }
    },
    "InstanceGroupManagerStatusVersionTarget": {
      "id": "InstanceGroupManagerStatusVersionTarget",
      "type": "object",
      "properties": {
        "isReached": {
          "description": "[Output Only] A bit indicating whether version target has been reached in this managed instance group, i.e. all instances are in their target version. Instances' target version are specified by version field on Instance Group Manager.",
          "type": "boolean"
        }
      }
    },
    "InstanceGroupManagerStatusStateful": {
      "id": "InstanceGroupManagerStatusStateful",
      "type": "object",
      "properties": {
        "hasStatefulConfig": {
          "description": "[Output Only] A bit indicating whether the managed instance group has stateful configuration, that is, if you have configured any items in a stateful policy or in per-instance configs. The group might report that it has no stateful configuration even when there is still some preserved state on a managed instance, for example, if you have deleted all PICs but not yet applied those deletions.",
          "type": "boolean"
        },
        "perInstanceConfigs": {
          "description": "[Output Only] Status of per-instance configurations on the instance.",
          "$ref": "InstanceGroupManagerStatusStatefulPerInstanceConfigs"
        }
      }
    },
    "InstanceGroupManagerStatusStatefulPerInstanceConfigs": {
      "id": "InstanceGroupManagerStatusStatefulPerInstanceConfigs",
      "type": "object",
      "properties": {
        "allEffective": {
          "description": "A bit indicating if all of the group's per-instance configurations (listed in the output of a listPerInstanceConfigs API call) have status EFFECTIVE or there are no per-instance-configs.",
          "type": "boolean"
        }
      }
    },

```

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `status.all_instances_config.revision` field to `google_compute_instance_group_manager` and `google_compute_region_instance_group_manager`
```
