### PR TITLE
Improve the error messages when mmv1 compilation fails

### DIFF
--- a/mmv1/compiler.rb
+++ b/mmv1/compiler.rb
@@ -192,6 +192,9 @@ products_for_version = Parallel.map(all_product_files, in_processes: 8) do |prod
       )
       resource.validate
       resources.push(resource)
+    rescue StandardError => e
+      Google::LOGGER.error "Failed to compile #{file_path}: #{e}"
+      raise e
     end
 
     if override_dir
@@ -221,6 +224,9 @@ products_for_version = Parallel.map(all_product_files, in_processes: 8) do |prod
         )
         resource.validate
         resources.push(resource)
+      rescue StandardError => e
+        Google::LOGGER.error "Failed to compile using override #{override_path}: #{e}"
+        raise e
       end
     end
     resources = resources.sort_by(&:name)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fixes https://github.com/hashicorp/terraform-provider-google/issues/16650

When errors are raised during compilation, we don't always get clear signal regarding where the failure happened (due in part to multiple threads being used). This comes up fairly regularly when we see EAP build failures, and it is often difficult to track down where a fix is needed.

For example, during one recent EAP failure, we saw this message:
```
compiler.rb:206:in `block (2 levels) in <top (required)>': undefined local variable or method `file_path' for main:Object (NameError)
	from compiler.rb:203:in `each'
	from compiler.rb:203:in `block in <top (required)>'
	from /Users/ryanoaks/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/parallel-1.22.1/lib/parallel.rb:587:in `call_with_index'
...
```

After this change, we can see which file triggered the failure:
```
E, [2024-03-05T19:37:44.467169 #14233] ERROR -- : Failed to compile using override ../../../../../../../../Users/ryanoaks/projects/magic-modules-private-overrides/products/compute/BackendService.yaml: undefined local variable or method `file_path' for main:Object

        || File.basename(file_path).include?('go_')
                         ^^^^^^^^^
...
compiler.rb:206:in `block (2 levels) in <top (required)>': undefined local variable or method `file_path' for main:Object (NameError)
	from compiler.rb:203:in `each'
	from compiler.rb:203:in `block in <top (required)>'
...
```

Note: my ruby is a bit rusty, so hopefully this is a suitable way to capture the error, print some more info, and then re-raise it.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
