### PR TITLE
google_firebase_android_app should be replaced when package_name changes

### DIFF
--- a/mmv1/products/firebase/AndroidApp.yaml
+++ b/mmv1/products/firebase/AndroidApp.yaml
@@ -122,8 +122,10 @@ properties:
       This identifier should be treated as an opaque token, as the data format is not specified.
   - !ruby/object:Api::Type::String
     name: packageName
+    immutable: true
+    required: true
     description: |
-      Immutable. The canonical package name of the Android app as would appear in the Google Play
+      The canonical package name of the Android app as would appear in the Google Play
       Developer Console.
   - !ruby/object:Api::Type::Array
     name: sha1Hashes


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This is already the behavior in the API. It was forgotten in the initial PR. However, it's not a common operation for an app to change the package_name mid-way, so it probably has little real impact.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
firebase: made the `google_firebase_android_app` resource's `package_name` field required and immutable. This prevents API errors encountered by users who attempted to update or leave that field unset in their configurations.
```
