### PR TITLE
Modify issue labeler to skip linked issues

### DIFF
--- a/tools/issue-labeler/labeler/backfill.go
+++ b/tools/issue-labeler/labeler/backfill.go
@@ -98,6 +98,14 @@ func ComputeIssueUpdates(issues []Issue, regexpLabels []RegexpLabel) []IssueUpda
 			continue
 		}
 
+		// Decision was made to no longer add new service labels to linked tickets, because it is
+		// more difficult to know which teams have received those tickets and which haven't.
+		// Forwarding a ticket to a different service team should involve removing the old service
+		// label and `linked` label.
+		if linked {
+			continue
+		}
+
 		var issueUpdate IssueUpdate
 		for label := range desired {
 			issueUpdate.OldLabels = append(issueUpdate.OldLabels, label)

--- a/tools/issue-labeler/labeler/backfill_test.go
+++ b/tools/issue-labeler/labeler/backfill_test.go
@@ -136,7 +136,7 @@ func TestComputeIssueUpdates(t *testing.T) {
 				},
 			},
 		},
-		"add missing service labels even if already linked": {
+		"don't add missing service labels if already linked": {
 			issues: []Issue{
 				{
 					Number:      1,
@@ -145,14 +145,8 @@ func TestComputeIssueUpdates(t *testing.T) {
 					PullRequest: map[string]any{},
 				},
 			},
-			regexpLabels: defaultRegexpLabels,
-			expectedIssueUpdates: []IssueUpdate{
-				{
-					Number:    1,
-					Labels:    []string{"forward/linked", "service/service1", "service/service2-subteam1"},
-					OldLabels: []string{"service/service2-subteam1", "forward/linked"},
-				},
-			},
+			regexpLabels:         defaultRegexpLabels,
+			expectedIssueUpdates: []IssueUpdate{},
 		},
 	}
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Context is in the comment: adding service labels to a linked issue creates ambiguity that is difficult for us to detect and address, so we decided it was better to skip them.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
