### PR TITLE
metastore - add support for scheduled backups

### DIFF
--- a/mmv1/products/metastore/Service.yaml
+++ b/mmv1/products/metastore/Service.yaml
@@ -264,7 +264,7 @@ properties:
         name: 'backupLocation'
         description: |
           A Cloud Storage URI of a folder, in the format gs://<bucket_name>/<path_inside_bucket>. A sub-folder <backup_folder> containing backup files will be stored below it.
-        required: true  
+        required: true
   - !ruby/object:Api::Type::NestedObject
     name: 'maintenanceWindow'
     description: |

--- a/mmv1/products/metastore/Service.yaml
+++ b/mmv1/products/metastore/Service.yaml
@@ -250,7 +250,7 @@ properties:
         name: 'enabled'
         description: |
           Defines whether the scheduled backup is enabled. The default value is false.
-        default_value: false
+        default_from_api: true
       - !ruby/object:Api::Type::String
         name: 'cronSchedule'
         description: |

--- a/mmv1/products/metastore/Service.yaml
+++ b/mmv1/products/metastore/Service.yaml
@@ -138,6 +138,11 @@ examples:
     primary_resource_id: 'dpms2_scaling_factor_lt1'
     vars:
       metastore_service_name: 'ms-dpms2sflt1'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'dataproc_metastore_service_scheduled_backup'
+    primary_resource_id: 'backup'
+    vars:
+      metastore_service_name: 'backup'
 parameters:
   - !ruby/object:Api::Type::String
     name: 'serviceId'
@@ -236,6 +241,30 @@ properties:
         description: |
           Scaling factor, in increments of 0.1 for values less than 1.0, and increments of 1.0 for values greater than 1.0.
         required: false
+  - !ruby/object:Api::Type::NestedObject
+    name: 'scheduledBackup'
+    description: |
+      The configuration of scheduled backup for the metastore service.
+    properties:
+      - !ruby/object:Api::Type::Boolean
+        name: 'enabled'
+        description: |
+          Defines whether the scheduled backup is enabled. The default value is false.
+        default_value: false
+      - !ruby/object:Api::Type::String
+        name: 'cronSchedule'
+        description: |
+          The scheduled interval in Cron format, see https://en.wikipedia.org/wiki/Cron The default is empty: scheduled backup is not enabled. Must be specified to enable scheduled backups.
+      - !ruby/object:Api::Type::String
+        name: 'timeZone'
+        description: |
+          Specifies the time zone to be used when interpreting cronSchedule. Must be a time zone name from the time zone database (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), e.g. America/Los_Angeles or Africa/Abidjan. If left unspecified, the default is UTC.
+        default_value: 'UTC'
+      - !ruby/object:Api::Type::String
+        name: 'backupLocation'
+        description: |
+          A Cloud Storage URI of a folder, in the format gs://<bucket_name>/<path_inside_bucket>. A sub-folder <backup_folder> containing backup files will be stored below it.
+        required: true  
   - !ruby/object:Api::Type::NestedObject
     name: 'maintenanceWindow'
     description: |

--- a/mmv1/products/metastore/Service.yaml
+++ b/mmv1/products/metastore/Service.yaml
@@ -259,7 +259,7 @@ properties:
         name: 'timeZone'
         description: |
           Specifies the time zone to be used when interpreting cronSchedule. Must be a time zone name from the time zone database (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), e.g. America/Los_Angeles or Africa/Abidjan. If left unspecified, the default is UTC.
-        default_value: 'UTC'
+        default_from_api: true
       - !ruby/object:Api::Type::String
         name: 'backupLocation'
         description: |

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_scheduled_backup.tf.erb
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_scheduled_backup.tf.erb
@@ -16,6 +16,7 @@ resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" 
   scheduled_backup {
     enabled         = true
     cron_schedule   = "0 0 * * *"
+    time_zone       = "UTC"
     backup_location = "gs://${google_storage_bucket.bucket.name}"
   }
 

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_scheduled_backup.tf.erb
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_scheduled_backup.tf.erb
@@ -1,0 +1,30 @@
+resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" {
+  service_id = "<%= ctx[:vars]['metastore_service_name'] %>"
+  location   = "us-central1"
+  port       = 9080
+  tier       = "DEVELOPER"
+
+  maintenance_window {
+    hour_of_day = 2
+    day_of_week = "SUNDAY"
+  }
+
+  hive_metastore_config {
+    version = "2.3.6"
+  }
+
+  scheduled_backup {
+    enabled         = true
+    cron_schedule   = "0 0 * * *"
+    backup_location = "gs://${google_storage_bucket.bucket.name}"
+  }
+
+  labels = {
+    env = "test"
+  }
+}
+
+resource "google_storage_bucket" "bucket" {
+  name     = "<%= ctx[:vars]['metastore_service_name'] %>"
+  location = "us-central1"
+}

--- a/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_service_test.go.erb
@@ -136,7 +136,7 @@ resource "google_dataproc_metastore_service" "default" {
 func testAccDataprocMetastoreService_dataprocMetastoreServiceScheduledBackupExampleUpdate(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_dataproc_metastore_service" "backup" {
-  service_id = "backup%{random_suffix}"
+  service_id = "tf-test-backup%{random_suffix}"
   location   = "us-central1"
   port       = 9080
   tier       = "DEVELOPER"

--- a/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_service_test.go.erb
@@ -53,6 +53,34 @@ resource "google_dataproc_metastore_service" "my_metastore" {
 `, name, tier)
 }
 
+func TestAccDataprocMetastoreService_dataprocMetastoreServiceScheduledBackupExample(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataprocMetastoreServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataprocMetastoreService_dataprocMetastoreServiceScheduledBackupExample(context),
+			},
+			{
+				ResourceName:            "google_dataproc_metastore_service.backup",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"service_id", "location", "labels", "terraform_labels"},
+			},
+			{
+				Config: testAccDataprocMetastoreService_dataprocMetastoreServiceScheduledBackupExampleUpdate(context),
+			},
+		},
+	})
+}
+
 func TestAccDataprocMetastoreService_PrivateServiceConnect(t *testing.T) {
 	t.Skip("Skipping due to https://github.com/hashicorp/terraform-provider-google/issues/13710")
 	t.Parallel()
@@ -103,4 +131,38 @@ resource "google_dataproc_metastore_service" "default" {
   }
 }
 `, context)
+}
+
+func testAccDataprocMetastoreService_dataprocMetastoreServiceScheduledBackupExampleUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_dataproc_metastore_service" "backup" {
+  service_id = "backup%{random_suffix}"
+  location   = "us-central1"
+  port       = 9080
+  tier       = "DEVELOPER"
+
+  maintenance_window {
+    hour_of_day = 2
+    day_of_week = "SUNDAY"
+  }
+
+  hive_metastore_config {
+    version = "2.3.6"
+  }
+
+  scheduled_backup {
+    enabled         = true
+    cron_schedule   = "0 0 * * 0"
+    time_zone       = "UTC"
+    backup_location = "gs://${google_storage_bucket.bucket.name}"
+  }
+
+  labels = {
+    env = "test"
+  }
+}
+
+resource "google_storage_bucket" "bucket" {
+  name     = "backup%{random_suffix}"
+  location = "us-central1"
 }

--- a/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_service_test.go.erb
@@ -53,7 +53,7 @@ resource "google_dataproc_metastore_service" "my_metastore" {
 `, name, tier)
 }
 
-func TestAccDataprocMetastoreService_dataprocMetastoreServiceScheduledBackupExample(t *testing.T) {
+func TestAccDataprocMetastoreService_dataprocMetastoreServiceScheduledBackupExampleUpdate(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
@@ -156,7 +156,7 @@ resource "google_dataproc_metastore_service" "backup" {
     time_zone       = "UTC"
     backup_location = "gs://${google_storage_bucket.bucket.name}"
   }
-  
+
   labels = {
     env = "test"
   }

--- a/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_service_test.go.erb
@@ -163,7 +163,7 @@ resource "google_dataproc_metastore_service" "backup" {
 }
 
 resource "google_storage_bucket" "bucket" {
-  name     = "backup%{random_suffix}"
+  name     = "tf-test-backup%{random_suffix}"
   location = "us-central1"
 }
 `, context)

--- a/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_service_test.go.erb
@@ -156,7 +156,7 @@ resource "google_dataproc_metastore_service" "backup" {
     time_zone       = "UTC"
     backup_location = "gs://${google_storage_bucket.bucket.name}"
   }
-
+  
   labels = {
     env = "test"
   }
@@ -165,4 +165,6 @@ resource "google_dataproc_metastore_service" "backup" {
 resource "google_storage_bucket" "bucket" {
   name     = "backup%{random_suffix}"
   location = "us-central1"
+}
+`, context)
 }

--- a/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_service_test.go.erb
@@ -153,7 +153,7 @@ resource "google_dataproc_metastore_service" "backup" {
   scheduled_backup {
     enabled         = true
     cron_schedule   = "0 0 * * 0"
-    time_zone       = "UTC"
+    time_zone       = "America/Los_Angeles"
     backup_location = "gs://${google_storage_bucket.bucket.name}"
   }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

```
--- PASS: TestAccDataprocMetastoreService_dataprocMetastoreServiceScheduledBackupExample (1731.95s)
```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
metastore: added `scheduled_backup` field to `google_dataproc_metastore_service` resource
```
