### PR TITLE
add nfs support to cloudrun v2 jobs in beta

### DIFF
--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -400,6 +400,7 @@ properties:
                   #   - template.0.template.0.volumes.0.cloudSqlInstance
                   #   - template.0.template.0.volumes.0.emptyDir
                   #   - template.0.volumes.0.gcs
+                  #   - template.0.volumes.0.nfs
                   properties:
                     - !ruby/object:Api::Type::String
                       name: 'secret'
@@ -439,6 +440,7 @@ properties:
                   #   - template.0.template.0.volumes.0.cloudSqlInstance
                   #   - template.0.template.0.volumes.0.emptyDir
                   #   - template.0.volumes.0.gcs
+                  #   - template.0.volumes.0.nfs
                   properties:
                     - !ruby/object:Api::Type::Array
                       name: 'instances'
@@ -455,6 +457,7 @@ properties:
                   #   - template.0.template.0.volumes.0.cloudSqlInstance
                   #   - template.0.template.0.volumes.0.emptyDir
                   #   - template.0.volumes.0.gcs
+                  #   - template.0.volumes.0.nfs
                   properties:
                     - !ruby/object:Api::Type::Enum
                       name: 'medium'
@@ -477,6 +480,7 @@ properties:
                   #   - template.0.volumes.0.cloudSqlInstance
                   #   - template.0.volumes.0.emptyDir
                   #   - template.0.volumes.0.gcs
+                  #   - template.0.volumes.0.nfs
                   properties:
                     - !ruby/object:Api::Type::String
                       name: 'bucket'
@@ -492,6 +496,12 @@ properties:
                   description: |-
                     NFS share mounted as a volume. This feature requires the launch stage to be set to ALPHA or BETA.
                   min_version: beta
+                  # exactly_one_of:
+                  #   - template.0.volumes.0.secret
+                  #   - template.0.volumes.0.cloudSqlInstance
+                  #   - template.0.volumes.0.emptyDir
+                  #   - template.0.volumes.0.gcs
+                  #   - template.0.volumes.0.nfs
                   properties:
                     - !ruby/object:Api::Type::String
                       name: 'server'

--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -487,6 +487,25 @@ properties:
                       name: 'readOnly'
                       description: |-
                         If true, mount this volume as read-only in all mounts. If false, mount this volume as read-write.
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'nfs'
+                  description: |-
+                    NFS share mounted as a volume. This feature requires the launch stage to be set to ALPHA or BETA.
+                  min_version: beta
+                  properties:
+                    - !ruby/object:Api::Type::String
+                      name: 'server'
+                      required: true
+                      description: |-
+                        Hostname or IP address of the NFS server.
+                    - !ruby/object:Api::Type::String
+                      name: 'path'
+                      description: |-
+                        Path that is exported by the NFS server.
+                    - !ruby/object:Api::Type::Boolean
+                      name: 'readOnly'
+                      description: |-
+                        If true, mount this volume as read-only in all mounts.
           - !ruby/object:Api::Type::String
             name: 'timeout'
             description: |-

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_job_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_job_test.go.erb
@@ -386,4 +386,68 @@ func testAccCloudRunV2Job_cloudrunv2JobWithGcsVolume(context map[string]interfac
   }
 `, context)
 }
+
+func TestAccCloudRunV2Job_cloudrunv2JobWithNfsUpdate(t *testing.T) {
+	t.Parallel()
+
+	jobName := fmt.Sprintf("tf-test-cloudrun-service%s", acctest.RandString(t, 10))
+	context := map[string]interface{}{
+		"job_name": jobName,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckCloudRunV2JobDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudRunV2Job_cloudrunv2JobWithNoVolume(context),
+			},
+			{
+				ResourceName:            "google_cloud_run_v2_job.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "launch_stage"},
+			},
+			{
+				Config: testAccCloudRunV2Job_cloudrunv2JobWithNfsVolume(context),
+			},
+			{
+				ResourceName:            "google_cloud_run_v2_job.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "launch_stage"},
+			},
+		},
+	})
+}
+
+func testAccCloudRunV2Job_cloudrunv2JobWithNfsVolume(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+  resource "google_cloud_run_v2_job" "default" {
+    name     = "%{job_name}"
+    location = "us-central1"
+    launch_stage = "BETA"
+    template {
+      template {
+        containers {
+          image = "us-docker.pkg.dev/cloudrun/container/job"
+          volume_mounts {
+            name = "nfs"
+            mount_path = "/mnt/nfs"
+          }
+        }
+        volumes {
+          name = "nfs"
+          nfs {
+            server = "10.0.10.10"
+            path = "/"
+            read_only = true
+          }
+        }
+      }
+    }
+  }
+`, context)
+}
 <% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fixes https://github.com/hashicorp/terraform-provider-google/issues/17336

Support new feature NFS in cloudrunv2 jobs in beta.

This finishes Beta support for https://github.com/hashicorp/terraform-provider-google/issues/17336

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudrunv2: added `template.volumes.nfs` field to `google_cloud_run_v2_job` resource (beta)
```
