### PR TITLE
google_monitoring_alert_policy periods doc update & dataproc doc update

### DIFF
--- a/mmv1/products/monitoring/AlertPolicy.yaml
+++ b/mmv1/products/monitoring/AlertPolicy.yaml
@@ -926,6 +926,7 @@ properties:
             name: period
             description: |
               Not more than one notification per period.
+              A duration in seconds with up to nine fractional digits, terminated by 's'. Example "60.5s".
       - !ruby/object:Api::Type::String
         name: autoClose
         description: |

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
@@ -2127,7 +2127,7 @@ resource "google_dataproc_cluster" "with_endpoint_config" {
     }
 
 		endpoint_config {
-			enable_http_port_access = "true"
+			enable_http_port_access = true
 		}
 	}
 }

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -926,7 +926,7 @@ cluster_config {
 ```hcl
 cluster_config {
   endpoint_config {
-    enable_http_port_access = "true"
+    enable_http_port_access = true
   }
 }
 ```


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Minor PR for 2 doc updates.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/17566
`enable_http_port_access` example in https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dataproc_cluster is specified as a string but it is a boolean.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
