### PR TITLE
remove `pattern` field from `.yaml` files

### DIFF
--- a/mmv1/products/backupdr/ManagementServer.yaml
+++ b/mmv1/products/backupdr/ManagementServer.yaml
@@ -87,7 +87,7 @@ properties:
           description: |
             Network with format `projects/{{project_id}}/global/networks/{{network_id}}`
           required: true
-          pattern: projects/{{project}}/global/networks/{{network}}
+          
         - !ruby/object:Api::Type::Enum
           name: 'peeringMode'
           description: |

--- a/mmv1/products/backupdr/ManagementServer.yaml
+++ b/mmv1/products/backupdr/ManagementServer.yaml
@@ -87,7 +87,6 @@ properties:
           description: |
             Network with format `projects/{{project_id}}/global/networks/{{network_id}}`
           required: true
-          
         - !ruby/object:Api::Type::Enum
           name: 'peeringMode'
           description: |

--- a/mmv1/products/certificatemanager/CertificateMap.yaml
+++ b/mmv1/products/certificatemanager/CertificateMap.yaml
@@ -53,7 +53,6 @@ parameters:
     required: true
     immutable: true
     url_param_only: true
-    
     description: |
       A user-defined name of the Certificate Map. Certificate Map names must be unique
       globally and match the pattern `projects/*/locations/*/certificateMaps/*`.

--- a/mmv1/products/certificatemanager/CertificateMap.yaml
+++ b/mmv1/products/certificatemanager/CertificateMap.yaml
@@ -53,7 +53,7 @@ parameters:
     required: true
     immutable: true
     url_param_only: true
-    pattern: projects/{{project}}/locations/global/certificateMaps/{{name}}
+    
     description: |
       A user-defined name of the Certificate Map. Certificate Map names must be unique
       globally and match the pattern `projects/*/locations/*/certificateMaps/*`.

--- a/mmv1/products/cloudfunctions/CloudFunction.yaml
+++ b/mmv1/products/cloudfunctions/CloudFunction.yaml
@@ -77,7 +77,7 @@ properties:
     description: |
       A user-defined name of the function. Function names must
       be unique globally and match pattern `projects/*/locations/*/functions/*`.
-    pattern: projects/{{project}}/locations/{{location}}/functions/{{name}}
+    
   - !ruby/object:Api::Type::String
     name: 'description'
     description: 'User-provided description of a function.'

--- a/mmv1/products/cloudfunctions/CloudFunction.yaml
+++ b/mmv1/products/cloudfunctions/CloudFunction.yaml
@@ -77,7 +77,6 @@ properties:
     description: |
       A user-defined name of the function. Function names must
       be unique globally and match pattern `projects/*/locations/*/functions/*`.
-    
   - !ruby/object:Api::Type::String
     name: 'description'
     description: 'User-provided description of a function.'

--- a/mmv1/products/cloudfunctions2/Function.yaml
+++ b/mmv1/products/cloudfunctions2/Function.yaml
@@ -278,7 +278,7 @@ properties:
     description: |
       A user-defined name of the function. Function names must
       be unique globally and match pattern `projects/*/locations/*/functions/*`.
-    pattern: projects/{{project}}/locations/{{location}}/functions/{{name}}
+    
     custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
     custom_expand: 'templates/terraform/custom_expand/shortname_to_url.go.erb'
   - !ruby/object:Api::Type::String

--- a/mmv1/products/cloudfunctions2/Function.yaml
+++ b/mmv1/products/cloudfunctions2/Function.yaml
@@ -278,7 +278,6 @@ properties:
     description: |
       A user-defined name of the function. Function names must
       be unique globally and match pattern `projects/*/locations/*/functions/*`.
-    
     custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
     custom_expand: 'templates/terraform/custom_expand/shortname_to_url.go.erb'
   - !ruby/object:Api::Type::String

--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -128,7 +128,6 @@ properties:
     url_param_only: true
     description: |
       Name of the Job.
-    
     diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
     custom_expand: templates/terraform/custom_expand/resource_from_self_link.go.erb
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb

--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -128,7 +128,7 @@ properties:
     url_param_only: true
     description: |
       Name of the Job.
-    pattern: projects/{{project}}/locations/{{location}}/jobs/{{name}}
+    
     diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
     custom_expand: templates/terraform/custom_expand/resource_from_self_link.go.erb
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -139,7 +139,7 @@ properties:
     url_param_only: true
     description: |
       Name of the Service.
-    pattern: projects/{{project}}/locations/{{location}}/services/{{name}}
+    
     diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
     custom_expand: templates/terraform/custom_expand/resource_from_self_link.go.erb
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -139,7 +139,6 @@ properties:
     url_param_only: true
     description: |
       Name of the Service.
-    
     diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
     custom_expand: templates/terraform/custom_expand/resource_from_self_link.go.erb
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb

--- a/mmv1/products/cloudtasks/Queue.yaml
+++ b/mmv1/products/cloudtasks/Queue.yaml
@@ -57,7 +57,7 @@ properties:
     name: 'name'
     immutable: true
     description: The queue name.
-    pattern: projects/{{project}}/locations/{{location}}/queues/{{name}}
+    
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
     custom_expand: templates/terraform/custom_expand/qualify_queue_name.go.erb
   - !ruby/object:Api::Type::NestedObject

--- a/mmv1/products/cloudtasks/Queue.yaml
+++ b/mmv1/products/cloudtasks/Queue.yaml
@@ -57,7 +57,6 @@ properties:
     name: 'name'
     immutable: true
     description: The queue name.
-    
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
     custom_expand: templates/terraform/custom_expand/qualify_queue_name.go.erb
   - !ruby/object:Api::Type::NestedObject

--- a/mmv1/products/datapipeline/Pipeline.yaml
+++ b/mmv1/products/datapipeline/Pipeline.yaml
@@ -51,7 +51,7 @@ properties:
       "PIPELINE_ID is the ID of the pipeline. Must be unique for the selected project and location."
     required: true
     immutable: true
-    pattern: projects/{{project}}/locations/{{region}}/functions/{{name}}
+    
     custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
     custom_expand: 'templates/terraform/custom_expand/shortname_to_url.go.erb'
   - !ruby/object:Api::Type::String

--- a/mmv1/products/datapipeline/Pipeline.yaml
+++ b/mmv1/products/datapipeline/Pipeline.yaml
@@ -51,7 +51,6 @@ properties:
       "PIPELINE_ID is the ID of the pipeline. Must be unique for the selected project and location."
     required: true
     immutable: true
-    
     custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
     custom_expand: 'templates/terraform/custom_expand/shortname_to_url.go.erb'
   - !ruby/object:Api::Type::String

--- a/mmv1/products/filestore/Backup.yaml
+++ b/mmv1/products/filestore/Backup.yaml
@@ -57,7 +57,7 @@ properties:
     required: true
     immutable: true
     url_param_only: true
-    pattern: projects/{{project}}/locations/{{location}}/backups/{{backupId}}
+    
   - !ruby/object:Api::Type::String
     name: 'description'
     description: |

--- a/mmv1/products/filestore/Backup.yaml
+++ b/mmv1/products/filestore/Backup.yaml
@@ -57,7 +57,6 @@ properties:
     required: true
     immutable: true
     url_param_only: true
-    
   - !ruby/object:Api::Type::String
     name: 'description'
     description: |

--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -82,7 +82,7 @@ properties:
       The resource name of the instance.
     required: true
     url_param_only: true
-    pattern: projects/{{project}}/locations/{{location}}/instances/{{name}}
+    
     custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
   - !ruby/object:Api::Type::String
     name: 'description'

--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -82,7 +82,6 @@ properties:
       The resource name of the instance.
     required: true
     url_param_only: true
-    
     custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
   - !ruby/object:Api::Type::String
     name: 'description'

--- a/mmv1/products/filestore/Snapshot.yaml
+++ b/mmv1/products/filestore/Snapshot.yaml
@@ -70,7 +70,6 @@ properties:
     required: true
     immutable: true
     url_param_only: true
-    
   - !ruby/object:Api::Type::String
     name: 'description'
     description: |

--- a/mmv1/products/filestore/Snapshot.yaml
+++ b/mmv1/products/filestore/Snapshot.yaml
@@ -70,7 +70,7 @@ properties:
     required: true
     immutable: true
     url_param_only: true
-    pattern: projects/{{project}}/locations/{{location}}/instances/{{instance}}/snapshots/{{name}}
+    
   - !ruby/object:Api::Type::String
     name: 'description'
     description: |

--- a/mmv1/products/firebaseappcheck/AppAttestConfig.yaml
+++ b/mmv1/products/firebaseappcheck/AppAttestConfig.yaml
@@ -78,7 +78,7 @@ properties:
     description: |
       The relative resource name of the App Attest configuration object
     output: true
-    pattern: projects/{{project}}/apps/{{app_id}}/appAttestConfig
+    
   - !ruby/object:Api::Type::String
     name: tokenTtl
     description: |

--- a/mmv1/products/firebaseappcheck/AppAttestConfig.yaml
+++ b/mmv1/products/firebaseappcheck/AppAttestConfig.yaml
@@ -78,7 +78,6 @@ properties:
     description: |
       The relative resource name of the App Attest configuration object
     output: true
-    
   - !ruby/object:Api::Type::String
     name: tokenTtl
     description: |

--- a/mmv1/products/firebaseappcheck/PlayIntegrityConfig.yaml
+++ b/mmv1/products/firebaseappcheck/PlayIntegrityConfig.yaml
@@ -72,7 +72,6 @@ properties:
     description: |
       The relative resource name of the Play Integrity configuration object
     output: true
-    
   - !ruby/object:Api::Type::String
     name: tokenTtl
     description: |

--- a/mmv1/products/firebaseappcheck/PlayIntegrityConfig.yaml
+++ b/mmv1/products/firebaseappcheck/PlayIntegrityConfig.yaml
@@ -72,7 +72,7 @@ properties:
     description: |
       The relative resource name of the Play Integrity configuration object
     output: true
-    pattern: projects/{{project}}/apps/{{app_id}}/playIntegrityConfig
+    
   - !ruby/object:Api::Type::String
     name: tokenTtl
     description: |

--- a/mmv1/products/firebaseappcheck/ServiceConfig.yaml
+++ b/mmv1/products/firebaseappcheck/ServiceConfig.yaml
@@ -81,7 +81,7 @@ properties:
     description: |
       The fully-qualified resource name of the service enforcement configuration.
     output: true
-    pattern: projects/{{project}}/services/{{service_id}}
+    
   - !ruby/object:Api::Type::Enum
     name: enforcementMode
     description: |

--- a/mmv1/products/firebaseappcheck/ServiceConfig.yaml
+++ b/mmv1/products/firebaseappcheck/ServiceConfig.yaml
@@ -81,7 +81,6 @@ properties:
     description: |
       The fully-qualified resource name of the service enforcement configuration.
     output: true
-    
   - !ruby/object:Api::Type::Enum
     name: enforcementMode
     description: |

--- a/mmv1/products/firebaseextensions/Instance.yaml
+++ b/mmv1/products/firebaseextensions/Instance.yaml
@@ -78,7 +78,6 @@ properties:
     description: |
       The fully-qualified resource name of the Extension Instance.
     output: true
-    
   - !ruby/object:Api::Type::Time
     name: createTime
     description: The time at which the Extension Instance was created.
@@ -104,7 +103,6 @@ properties:
         name: name
         description: The unique identifier for this configuration.
         output: true
-        
       - !ruby/object:Api::Type::Time
         name: createTime
         description: The time at which the Extension Instance Config was created.
@@ -143,7 +141,6 @@ properties:
         name: eventarcChannel
         description: |
           Fully qualified Eventarc resource name that consumers should use for event triggers.
-        
         default_from_api: true
       - !ruby/object:Api::Type::String
         name: populatedPostinstallContent
@@ -211,7 +208,6 @@ properties:
     description: |
       The name of the last operation that acted on this Extension
       Instance
-    
   - !ruby/object:Api::Type::String
     name: lastOperationType
     output: true

--- a/mmv1/products/firebaseextensions/Instance.yaml
+++ b/mmv1/products/firebaseextensions/Instance.yaml
@@ -78,7 +78,7 @@ properties:
     description: |
       The fully-qualified resource name of the Extension Instance.
     output: true
-    pattern: projects/{{project}}/instances/{{instance_id}}
+    
   - !ruby/object:Api::Type::Time
     name: createTime
     description: The time at which the Extension Instance was created.
@@ -104,7 +104,7 @@ properties:
         name: name
         description: The unique identifier for this configuration.
         output: true
-        pattern: projects/{{project}}/instances/{{instance_id}}/configs/{{config_id}}
+        
       - !ruby/object:Api::Type::Time
         name: createTime
         description: The time at which the Extension Instance Config was created.
@@ -143,7 +143,7 @@ properties:
         name: eventarcChannel
         description: |
           Fully qualified Eventarc resource name that consumers should use for event triggers.
-        pattern: projects/{{project}}/locations/{{location}}/channels/{{channel_id}}
+        
         default_from_api: true
       - !ruby/object:Api::Type::String
         name: populatedPostinstallContent
@@ -211,7 +211,7 @@ properties:
     description: |
       The name of the last operation that acted on this Extension
       Instance
-    pattern: projects/{{project}}/operations/{{operation_id}}
+    
   - !ruby/object:Api::Type::String
     name: lastOperationType
     output: true

--- a/mmv1/products/firebasehosting/Channel.yaml
+++ b/mmv1/products/firebasehosting/Channel.yaml
@@ -65,7 +65,6 @@ parameters:
 properties:
   - !ruby/object:Api::Type::String
     name: name
-    
     description: |
       The fully-qualified resource name for the channel, in the format:
       sites/SITE_ID/channels/CHANNEL_ID

--- a/mmv1/products/firebasehosting/Channel.yaml
+++ b/mmv1/products/firebasehosting/Channel.yaml
@@ -65,7 +65,7 @@ parameters:
 properties:
   - !ruby/object:Api::Type::String
     name: name
-    pattern: sites/{{site_id}}/channels/{{channel_id}}
+    
     description: |
       The fully-qualified resource name for the channel, in the format:
       sites/SITE_ID/channels/CHANNEL_ID

--- a/mmv1/products/firebasehosting/CustomDomain.yaml
+++ b/mmv1/products/firebasehosting/CustomDomain.yaml
@@ -126,7 +126,7 @@ virtual_fields:
 properties:
   - !ruby/object:Api::Type::String
     name: name
-    pattern: projects/{{project}}/sites/{{site_id}}/customDomains/{{custom_domain}}
+    
     description: |
       The fully-qualified name of the `CustomDomain`.
     output: true

--- a/mmv1/products/firebasehosting/CustomDomain.yaml
+++ b/mmv1/products/firebasehosting/CustomDomain.yaml
@@ -126,7 +126,6 @@ virtual_fields:
 properties:
   - !ruby/object:Api::Type::String
     name: name
-    
     description: |
       The fully-qualified name of the `CustomDomain`.
     output: true

--- a/mmv1/products/firebasestorage/Bucket.yaml
+++ b/mmv1/products/firebasestorage/Bucket.yaml
@@ -48,7 +48,6 @@ parameters:
 properties:
   - !ruby/object:Api::Type::String
     name: name
-    
     description:
       Resource name of the bucket in the format
       projects/PROJECT_IDENTIFIER/buckets/BUCKET_ID

--- a/mmv1/products/firebasestorage/Bucket.yaml
+++ b/mmv1/products/firebasestorage/Bucket.yaml
@@ -48,7 +48,7 @@ parameters:
 properties:
   - !ruby/object:Api::Type::String
     name: name
-    pattern: projects/{{project}}/buckets/{{bucket_id}}
+    
     description:
       Resource name of the bucket in the format
       projects/PROJECT_IDENTIFIER/buckets/BUCKET_ID

--- a/mmv1/products/memcache/Instance.yaml
+++ b/mmv1/products/memcache/Instance.yaml
@@ -64,7 +64,7 @@ properties:
     required: true
     immutable: true
     url_param_only: true
-    pattern: projects/{{project}}/locations/{{region}}/instances/{{name}}
+    
     custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
   - !ruby/object:Api::Type::String
     name: 'displayName'

--- a/mmv1/products/memcache/Instance.yaml
+++ b/mmv1/products/memcache/Instance.yaml
@@ -64,7 +64,6 @@ properties:
     required: true
     immutable: true
     url_param_only: true
-    
     custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
   - !ruby/object:Api::Type::String
     name: 'displayName'

--- a/mmv1/products/notebooks/Environment.yaml
+++ b/mmv1/products/notebooks/Environment.yaml
@@ -38,7 +38,7 @@ properties:
     required: true
     immutable: true
     url_param_only: true
-    pattern: projects/{{project}}/locations/{{location}}/environments/{{name}}
+    
   - !ruby/object:Api::Type::ResourceRef
     name: 'location'
     description: 'A reference to the zone where the machine resides.'

--- a/mmv1/products/notebooks/Environment.yaml
+++ b/mmv1/products/notebooks/Environment.yaml
@@ -38,7 +38,6 @@ properties:
     required: true
     immutable: true
     url_param_only: true
-    
   - !ruby/object:Api::Type::ResourceRef
     name: 'location'
     description: 'A reference to the zone where the machine resides.'

--- a/mmv1/products/notebooks/Instance.yaml
+++ b/mmv1/products/notebooks/Instance.yaml
@@ -131,7 +131,7 @@ properties:
     required: true
     immutable: true
     url_param_only: true
-    pattern: projects/{{project}}/locations/{{location}}/instances/{{name}}
+    
     custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
   - !ruby/object:Api::Type::String
     name: 'machineType'
@@ -143,7 +143,7 @@ properties:
     # TODO: Implement allow_stopping_for_update here and for acceleratorConfig
     # update_verb: :PATCH
     # update_url: 'projects/{{project}}/locations/{{location}}/instances/{{name}}:setMachineType'
-    pattern: projects/{{project}}/zones/{{location}}/machineTypes/{{name}}
+    
     diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
   - !ruby/object:Api::Type::String

--- a/mmv1/products/notebooks/Instance.yaml
+++ b/mmv1/products/notebooks/Instance.yaml
@@ -131,7 +131,6 @@ properties:
     required: true
     immutable: true
     url_param_only: true
-    
     custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
   - !ruby/object:Api::Type::String
     name: 'machineType'
@@ -143,7 +142,6 @@ properties:
     # TODO: Implement allow_stopping_for_update here and for acceleratorConfig
     # update_verb: :PATCH
     # update_url: 'projects/{{project}}/locations/{{location}}/instances/{{name}}:setMachineType'
-    
     diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
   - !ruby/object:Api::Type::String

--- a/mmv1/products/notebooks/Runtime.yaml
+++ b/mmv1/products/notebooks/Runtime.yaml
@@ -111,7 +111,7 @@ properties:
     required: true
     immutable: true
     url_param_only: true
-    pattern: projects/{{project}}/locations/{{location}}/runtimes/{{name}}
+    
   - !ruby/object:Api::Type::NestedObject
     name: 'virtualMachine'
     exactly_one_of:

--- a/mmv1/products/notebooks/Runtime.yaml
+++ b/mmv1/products/notebooks/Runtime.yaml
@@ -111,7 +111,6 @@ properties:
     required: true
     immutable: true
     url_param_only: true
-    
   - !ruby/object:Api::Type::NestedObject
     name: 'virtualMachine'
     exactly_one_of:

--- a/mmv1/products/pubsub/Subscription.yaml
+++ b/mmv1/products/pubsub/Subscription.yaml
@@ -92,7 +92,7 @@ properties:
     description: 'Name of the subscription.'
     required: true
     immutable: true
-    pattern: 'projects/{{project}}/subscriptions/{{name}}'
+    
     custom_expand: templates/terraform/custom_expand/shortname_to_url.go.erb
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
   - !ruby/object:Api::Type::ResourceRef
@@ -105,7 +105,7 @@ properties:
       the topic is in the same project as the subscription.
     required: true
     immutable: true
-    pattern: 'projects/{{project}}/topics/{{topic}}'
+    
     diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
     custom_expand: templates/terraform/custom_expand/computed_subscription_topic.erb
   - !ruby/object:Api::Type::KeyValueLabels

--- a/mmv1/products/pubsub/Subscription.yaml
+++ b/mmv1/products/pubsub/Subscription.yaml
@@ -92,7 +92,6 @@ properties:
     description: 'Name of the subscription.'
     required: true
     immutable: true
-    
     custom_expand: templates/terraform/custom_expand/shortname_to_url.go.erb
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
   - !ruby/object:Api::Type::ResourceRef
@@ -105,7 +104,6 @@ properties:
       the topic is in the same project as the subscription.
     required: true
     immutable: true
-    
     diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
     custom_expand: templates/terraform/custom_expand/computed_subscription_topic.erb
   - !ruby/object:Api::Type::KeyValueLabels

--- a/mmv1/products/pubsub/Topic.yaml
+++ b/mmv1/products/pubsub/Topic.yaml
@@ -86,7 +86,6 @@ properties:
     required: true
     description: 'Name of the topic.'
     immutable: true
-    
     diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
     custom_expand: templates/terraform/custom_expand/resource_from_self_link.go.erb
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb

--- a/mmv1/products/pubsub/Topic.yaml
+++ b/mmv1/products/pubsub/Topic.yaml
@@ -86,7 +86,7 @@ properties:
     required: true
     description: 'Name of the topic.'
     immutable: true
-    pattern: 'projects/{{project}}/topics/{{name}}'
+    
     diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
     custom_expand: templates/terraform/custom_expand/resource_from_self_link.go.erb
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb

--- a/mmv1/products/pubsub/go_Subscription.yaml
+++ b/mmv1/products/pubsub/go_Subscription.yaml
@@ -97,7 +97,7 @@ properties:
   - name: 'name'
     type: String
     description: "Name of the subscription."
-    pattern: 'projects/{{project}}/subscriptions/{{name}}'
+    
     required: true
     immutable: true
     custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
@@ -107,7 +107,7 @@ properties:
     description: "A reference to a Topic resource, of the form projects/{project}/topics/{{name}}
 (as in the id property of a google_pubsub_topic), or just a topic name if
 the topic is in the same project as the subscription."
-    pattern: 'projects/{{project}}/topics/{{topic}}'
+    
     required: true
     immutable: true
     diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'

--- a/mmv1/products/pubsub/go_Subscription.yaml
+++ b/mmv1/products/pubsub/go_Subscription.yaml
@@ -97,7 +97,6 @@ properties:
   - name: 'name'
     type: String
     description: "Name of the subscription."
-    
     required: true
     immutable: true
     custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
@@ -107,7 +106,6 @@ properties:
     description: "A reference to a Topic resource, of the form projects/{project}/topics/{{name}}
 (as in the id property of a google_pubsub_topic), or just a topic name if
 the topic is in the same project as the subscription."
-    
     required: true
     immutable: true
     diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'

--- a/mmv1/products/pubsub/go_Topic.yaml
+++ b/mmv1/products/pubsub/go_Topic.yaml
@@ -79,7 +79,7 @@ properties:
   - name: 'name'
     type: String
     description: "Name of the topic."
-    pattern: 'projects/{{project}}/topics/{{name}}'
+    
     required: true
     immutable: true
     diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'

--- a/mmv1/products/pubsub/go_Topic.yaml
+++ b/mmv1/products/pubsub/go_Topic.yaml
@@ -79,7 +79,6 @@ properties:
   - name: 'name'
     type: String
     description: "Name of the topic."
-    
     required: true
     immutable: true
     diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'

--- a/mmv1/products/pubsublite/Subscription.yaml
+++ b/mmv1/products/pubsublite/Subscription.yaml
@@ -62,7 +62,7 @@ properties:
       A reference to a Topic resource.
     required: true
     immutable: true
-    pattern: 'projects/{{project}}/locations/{{zone}}/topics/{{name}}'
+    
     diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
     custom_expand: templates/terraform/custom_expand/computed_lite_subscription_topic.erb
   - !ruby/object:Api::Type::NestedObject

--- a/mmv1/products/pubsublite/Subscription.yaml
+++ b/mmv1/products/pubsublite/Subscription.yaml
@@ -62,7 +62,6 @@ properties:
       A reference to a Topic resource.
     required: true
     immutable: true
-    
     diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
     custom_expand: templates/terraform/custom_expand/computed_lite_subscription_topic.erb
   - !ruby/object:Api::Type::NestedObject

--- a/mmv1/products/pubsublite/Topic.yaml
+++ b/mmv1/products/pubsublite/Topic.yaml
@@ -112,6 +112,6 @@ properties:
         imports: 'name'
         description: |
           The Reservation to use for this topic's throughput capacity.
-        pattern: 'projects/{{project}}/locations/{{region}}/reservations/{{name}}'
+        
         diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
         custom_expand: templates/terraform/custom_expand/pubsublite_topic_reservation_config_throughput_reservation.go.erb

--- a/mmv1/products/pubsublite/Topic.yaml
+++ b/mmv1/products/pubsublite/Topic.yaml
@@ -112,6 +112,5 @@ properties:
         imports: 'name'
         description: |
           The Reservation to use for this topic's throughput capacity.
-        
         diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
         custom_expand: templates/terraform/custom_expand/pubsublite_topic_reservation_config_throughput_reservation.go.erb

--- a/mmv1/products/runtimeconfig/Config.yaml
+++ b/mmv1/products/runtimeconfig/Config.yaml
@@ -42,7 +42,7 @@ parameters:
       The name of the runtime config.
     required: true
     immutable: true
-    pattern: projects/{{project}}/configs/{{name}}
+    
 properties:
   - !ruby/object:Api::Type::String
     name: 'description'

--- a/mmv1/products/runtimeconfig/Config.yaml
+++ b/mmv1/products/runtimeconfig/Config.yaml
@@ -42,7 +42,6 @@ parameters:
       The name of the runtime config.
     required: true
     immutable: true
-    
 properties:
   - !ruby/object:Api::Type::String
     name: 'description'

--- a/mmv1/products/sourcerepo/Repository.yaml
+++ b/mmv1/products/sourcerepo/Repository.yaml
@@ -58,7 +58,6 @@ properties:
     description: |
       Resource name of the repository, of the form `{{repo}}`.
       The repo name may contain slashes. eg, `name/with/slash`
-    
     custom_expand: templates/terraform/custom_expand/shortname_to_url.go.erb
     custom_flatten: templates/terraform/custom_flatten/repository_short_name_from_name.go.erb
   - !ruby/object:Api::Type::String

--- a/mmv1/products/sourcerepo/Repository.yaml
+++ b/mmv1/products/sourcerepo/Repository.yaml
@@ -58,7 +58,7 @@ properties:
     description: |
       Resource name of the repository, of the form `{{repo}}`.
       The repo name may contain slashes. eg, `name/with/slash`
-    pattern: 'projects/{{project}}/repos/{{name}}'
+    
     custom_expand: templates/terraform/custom_expand/shortname_to_url.go.erb
     custom_flatten: templates/terraform/custom_flatten/repository_short_name_from_name.go.erb
   - !ruby/object:Api::Type::String

--- a/mmv1/products/vertexai/FeatureOnlineStore.yaml
+++ b/mmv1/products/vertexai/FeatureOnlineStore.yaml
@@ -88,7 +88,7 @@ properties:
     immutable: true
     required: true
     url_param_only: true
-    pattern: projects/{{project}}/locations/{{region}}/featureOnlineStores/{{name}}
+    
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
   - !ruby/object:Api::Type::String
     name: createTime

--- a/mmv1/products/vertexai/FeatureOnlineStore.yaml
+++ b/mmv1/products/vertexai/FeatureOnlineStore.yaml
@@ -88,7 +88,6 @@ properties:
     immutable: true
     required: true
     url_param_only: true
-    
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
   - !ruby/object:Api::Type::String
     name: createTime

--- a/mmv1/products/vertexai/Featurestore.yaml
+++ b/mmv1/products/vertexai/Featurestore.yaml
@@ -128,7 +128,7 @@ properties:
       valid characters are [a-z0-9_]. The first character cannot be a number.
     immutable: true
     url_param_only: true
-    pattern: projects/{{project}}/locations/{{region}}/featurestores/{{name}}
+    
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
   - !ruby/object:Api::Type::String
     name: 'etag'

--- a/mmv1/products/vertexai/Featurestore.yaml
+++ b/mmv1/products/vertexai/Featurestore.yaml
@@ -128,7 +128,6 @@ properties:
       valid characters are [a-z0-9_]. The first character cannot be a number.
     immutable: true
     url_param_only: true
-    
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
   - !ruby/object:Api::Type::String
     name: 'etag'

--- a/mmv1/products/vertexai/FeaturestoreEntitytype.yaml
+++ b/mmv1/products/vertexai/FeaturestoreEntitytype.yaml
@@ -112,7 +112,7 @@ properties:
       valid characters are [a-z0-9_]. The first character cannot be a number.
     immutable: true
     url_param_only: true
-    pattern: '{featurestore}}/entityTypes/{{name}}'
+    
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
   - !ruby/object:Api::Type::String
     name: 'description'

--- a/mmv1/products/vertexai/FeaturestoreEntitytype.yaml
+++ b/mmv1/products/vertexai/FeaturestoreEntitytype.yaml
@@ -112,7 +112,6 @@ properties:
       valid characters are [a-z0-9_]. The first character cannot be a number.
     immutable: true
     url_param_only: true
-    
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
   - !ruby/object:Api::Type::String
     name: 'description'

--- a/mmv1/products/vertexai/FeaturestoreEntitytypeFeature.yaml
+++ b/mmv1/products/vertexai/FeaturestoreEntitytypeFeature.yaml
@@ -88,7 +88,6 @@ properties:
       entity type.
     immutable: true
     url_param_only: true
-    
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
   - !ruby/object:Api::Type::String
     name: 'etag'

--- a/mmv1/products/vertexai/FeaturestoreEntitytypeFeature.yaml
+++ b/mmv1/products/vertexai/FeaturestoreEntitytypeFeature.yaml
@@ -88,7 +88,7 @@ properties:
       entity type.
     immutable: true
     url_param_only: true
-    pattern: '{{entitytype}}/features/{{name}}'
+    
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
   - !ruby/object:Api::Type::String
     name: 'etag'

--- a/mmv1/products/vertexai/MetadataStore.yaml
+++ b/mmv1/products/vertexai/MetadataStore.yaml
@@ -67,7 +67,6 @@ properties:
       valid characters are [a-z0-9_]. The first character cannot be a number.
     immutable: true
     url_param_only: true
-    
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
   - !ruby/object:Api::Type::String
     name: 'description'

--- a/mmv1/products/vertexai/MetadataStore.yaml
+++ b/mmv1/products/vertexai/MetadataStore.yaml
@@ -67,7 +67,7 @@ properties:
       valid characters are [a-z0-9_]. The first character cannot be a number.
     immutable: true
     url_param_only: true
-    pattern: projects/{{project}}/locations/{{region}}/metadataStores/{{name}}
+    
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
   - !ruby/object:Api::Type::String
     name: 'description'

--- a/mmv1/products/workbench/Instance.yaml
+++ b/mmv1/products/workbench/Instance.yaml
@@ -120,7 +120,6 @@ properties:
     required: true
     immutable: true
     url_param_only: true
-    
     custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
   - !ruby/object:Api::Type::NestedObject
     name: gceSetup
@@ -132,7 +131,6 @@ properties:
         default_from_api: true
         description: |
           Optional. The machine type of the VM instance. https://cloud.google.com/compute/docs/machine-resource
-        
         diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
         custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
       - !ruby/object:Api::Type::Array

--- a/mmv1/products/workbench/Instance.yaml
+++ b/mmv1/products/workbench/Instance.yaml
@@ -120,7 +120,7 @@ properties:
     required: true
     immutable: true
     url_param_only: true
-    pattern: v2/projects/{{project}}/locations/{{location}}/instances/{{name}}
+    
     custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
   - !ruby/object:Api::Type::NestedObject
     name: gceSetup
@@ -132,7 +132,7 @@ properties:
         default_from_api: true
         description: |
           Optional. The machine type of the VM instance. https://cloud.google.com/compute/docs/machine-resource
-        pattern: projects/{{project}}/zones/{{location}}/machineTypes/{{name}}
+        
         diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
         custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
       - !ruby/object:Api::Type::Array


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


Removes the `pattern` field from all `.yaml` fields since they aren't used in .erb or .rb files.

This was done by doing a regex search with `pattern:.*[^>|\.|\?]$` on all `.yaml` files in the repo

Fixes [#17269
](https://github.com/hashicorp/terraform-provider-google/issues/17269)
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
