### PR TITLE
TeamCity: Make service sweepers run before project sweepers, assert that in a test

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/reused/nightly_tests.kt
@@ -51,7 +51,7 @@ fun nightlyTests(parentProject:String, providerName: String, vcsRoot: GitVcsRoot
         else -> throw Exception("Provider name not supplied when generating a nightly test subproject")
     }
     val serviceSweeperConfig = BuildConfigurationForServiceSweeper(providerName, ServiceSweeperName, sweepersList, projectId, vcsRoot, sharedResources, config)
-    val sweeperTrigger  = NightlyTriggerConfiguration(startHour=12)  // Override hour
+    val sweeperTrigger  = NightlyTriggerConfiguration(startHour=11)  // Override hour
     serviceSweeperConfig.addTrigger(sweeperTrigger)
 
     return Project {

--- a/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
@@ -7,12 +7,14 @@
 
 package tests
 
+import ProjectSweeperName
 import ServiceSweeperName
 import jetbrains.buildServer.configs.kotlin.BuildType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import jetbrains.buildServer.configs.kotlin.Project
+import jetbrains.buildServer.configs.kotlin.triggers.ScheduleTrigger
 import org.junit.Assert
 import projects.googleCloudRootProject
 
@@ -101,5 +103,51 @@ class SweeperTests {
         // Check PACKAGE_PATH is in google-beta
         val value = sweeper!!.params.findRawParam("PACKAGE_PATH")!!.value
         assertEquals("./google-beta/sweeper", value)
+    }
+
+    @Test
+    fun projectSweepersRunAfterServiceSweepers() {
+        val project = googleCloudRootProject(testContextParameters())
+
+        // Find GA nightly test project's service sweeper
+        val gaNightlyTestProject = getSubProject(project, gaProjectName, nightlyTestsProjectName)
+        val sweeperGa: BuildType? = gaNightlyTestProject!!.buildTypes.find { p-> p.name == ServiceSweeperName}
+        if (sweeperGa == null) {
+            Assert.fail("Could not find the sweeper build in the Google (GA) Nightly Test project")
+        }
+
+        // Find Beta nightly test project's service sweeper
+        val betaNightlyTestProject = getSubProject(project, betaProjectName, nightlyTestsProjectName)
+        val sweeperBeta: BuildType? = betaNightlyTestProject!!.buildTypes.find { p-> p.name == ServiceSweeperName}
+        if (sweeperBeta == null) {
+            Assert.fail("Could not find the sweeper build in the Google (Beta) Nightly Test project")
+        }
+
+        // Find Project sweeper project's build
+        val projectSweeperProject: Project? =  project.subProjects.find { p->  p.name == projectSweeperProjectName}
+        if (projectSweeperProject == null) {
+            Assert.fail("Could not find the Project Sweeper project")
+        }
+        val projectSweeper: BuildType? = projectSweeperProject!!.buildTypes.find { p-> p.name == ProjectSweeperName}
+        if (projectSweeper == null) {
+            Assert.fail("Could not find the sweeper build in the Google (Beta) Nightly Test project")
+        }
+
+
+        // Check only one schedule trigger is on the builds in question
+        assertTrue(sweeperGa!!.triggers.items.size == 1)
+        assertTrue(sweeperBeta!!.triggers.items.size == 1)
+        assertTrue(projectSweeper!!.triggers.items.size == 1)
+
+        // Assert that the hour value that sweeper builds are triggered at is less than the hour value that project sweeper builds are triggered at
+        // i.e. sweeper builds are triggered first
+        val stGa = sweeperGa!!.triggers.items[0] as ScheduleTrigger
+        val cronGa = stGa.schedulingPolicy as ScheduleTrigger.SchedulingPolicy.Cron
+        val stBeta = sweeperBeta!!.triggers.items[0] as ScheduleTrigger
+        val cronBeta = stBeta.schedulingPolicy as ScheduleTrigger.SchedulingPolicy.Cron
+        val stProject = projectSweeper!!.triggers.items[0] as ScheduleTrigger
+        val cronProject = stProject.schedulingPolicy as ScheduleTrigger.SchedulingPolicy.Cron
+        assertTrue("Service sweeper for the GA Nightly Test project is triggered at an earlier hour than the project sweeper", cronGa.hours.toString() < cronProject.hours.toString()) // Values are strings like "11", "12"
+        assertTrue("Service sweeper for the Beta Nightly Test project is triggered at an earlier hour than the project sweeper", cronBeta.hours.toString() < cronProject.hours.toString() )
     }
 }

--- a/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
@@ -125,17 +125,17 @@ class SweeperTests {
         val projectSweeper: BuildType = getBuildFromProject(projectSweeperProject!!, ProjectSweeperName)
         
         // Check only one schedule trigger is on the builds in question
-        assertTrue(sweeperGa!!.triggers.items.size == 1)
-        assertTrue(sweeperBeta!!.triggers.items.size == 1)
-        assertTrue(projectSweeper!!.triggers.items.size == 1)
+        assertTrue(sweeperGa.triggers.items.size == 1)
+        assertTrue(sweeperBeta.triggers.items.size == 1)
+        assertTrue(projectSweeper.triggers.items.size == 1)
 
         // Assert that the hour value that sweeper builds are triggered at is less than the hour value that project sweeper builds are triggered at
         // i.e. sweeper builds are triggered first
-        val stGa = sweeperGa!!.triggers.items[0] as ScheduleTrigger
+        val stGa = sweeperGa.triggers.items[0] as ScheduleTrigger
         val cronGa = stGa.schedulingPolicy as ScheduleTrigger.SchedulingPolicy.Cron
-        val stBeta = sweeperBeta!!.triggers.items[0] as ScheduleTrigger
+        val stBeta = sweeperBeta.triggers.items[0] as ScheduleTrigger
         val cronBeta = stBeta.schedulingPolicy as ScheduleTrigger.SchedulingPolicy.Cron
-        val stProject = projectSweeper!!.triggers.items[0] as ScheduleTrigger
+        val stProject = projectSweeper.triggers.items[0] as ScheduleTrigger
         val cronProject = stProject.schedulingPolicy as ScheduleTrigger.SchedulingPolicy.Cron
         assertTrue("Service sweeper for the GA Nightly Test project is triggered at an earlier hour than the project sweeper", cronGa.hours.toString() < cronProject.hours.toString()) // Values are strings like "11", "12"
         assertTrue("Service sweeper for the Beta Nightly Test project is triggered at an earlier hour than the project sweeper", cronBeta.hours.toString() < cronProject.hours.toString() )

--- a/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
@@ -110,30 +110,20 @@ class SweeperTests {
         val project = googleCloudRootProject(testContextParameters())
 
         // Find GA nightly test project's service sweeper
-        val gaNightlyTestProject = getSubProject(project, gaProjectName, nightlyTestsProjectName)
-        val sweeperGa: BuildType? = gaNightlyTestProject!!.buildTypes.find { p-> p.name == ServiceSweeperName}
-        if (sweeperGa == null) {
-            Assert.fail("Could not find the sweeper build in the Google (GA) Nightly Test project")
-        }
+        val gaNightlyTests: Project = getSubProject(project, gaProjectName, nightlyTestsProjectName)
+        val sweeperGa: BuildType = getBuildFromProject(gaNightlyTests, ServiceSweeperName)
 
         // Find Beta nightly test project's service sweeper
-        val betaNightlyTestProject = getSubProject(project, betaProjectName, nightlyTestsProjectName)
-        val sweeperBeta: BuildType? = betaNightlyTestProject!!.buildTypes.find { p-> p.name == ServiceSweeperName}
-        if (sweeperBeta == null) {
-            Assert.fail("Could not find the sweeper build in the Google (Beta) Nightly Test project")
-        }
+        val betaNightlyTests : Project = getSubProject(project, betaProjectName, nightlyTestsProjectName)
+        val sweeperBeta: BuildType = getBuildFromProject(betaNightlyTests, ServiceSweeperName)
 
         // Find Project sweeper project's build
-        val projectSweeperProject: Project? =  project.subProjects.find { p->  p.name == projectSweeperProjectName}
+        val projectSweeperProject : Project? =  project.subProjects.find { p->  p.name == projectSweeperProjectName}
         if (projectSweeperProject == null) {
             Assert.fail("Could not find the Project Sweeper project")
         }
-        val projectSweeper: BuildType? = projectSweeperProject!!.buildTypes.find { p-> p.name == ProjectSweeperName}
-        if (projectSweeper == null) {
-            Assert.fail("Could not find the sweeper build in the Google (Beta) Nightly Test project")
-        }
-
-
+        val projectSweeper: BuildType = getBuildFromProject(projectSweeperProject!!, ProjectSweeperName)
+        
         // Check only one schedule trigger is on the builds in question
         assertTrue(sweeperGa!!.triggers.items.size == 1)
         assertTrue(sweeperBeta!!.triggers.items.size == 1)

--- a/mmv1/third_party/terraform/.teamcity/tests/test_utils.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/test_utils.kt
@@ -8,6 +8,8 @@
 package tests
 
 import builds.AllContextParameters
+import jetbrains.buildServer.BuildProject
+import jetbrains.buildServer.configs.kotlin.BuildType
 import jetbrains.buildServer.configs.kotlin.Project
 import org.junit.Assert
 
@@ -56,15 +58,24 @@ fun testContextParameters(): AllContextParameters {
 
 fun getSubProject(rootProject: Project, parentProjectName: String, subProjectName: String): Project {
     // Find parent project within root
-    var parentProject: Project? =  rootProject.subProjects.find { p->  p.name == parentProjectName}
+    val parentProject: Project? =  rootProject.subProjects.find { p->  p.name == parentProjectName}
     if (parentProject == null) {
         Assert.fail("Could not find the $parentProjectName project")
     }
     // Find subproject within parent identified above
-    var subProject: Project?  = parentProject!!.subProjects.find { p->  p.name == subProjectName}
+    val subProject: Project?  = parentProject!!.subProjects.find { p->  p.name == subProjectName}
     if (subProject == null) {
         Assert.fail("Could not find the $subProjectName project")
     }
 
     return subProject!!
+}
+
+fun getBuildFromProject(parentProject: Project, buildName: String): BuildType {
+    val buildType: BuildType?  = parentProject!!.buildTypes.find { p->  p.name == buildName}
+    if (buildType == null) {
+        Assert.fail("Could not find the '$buildName' build in project ${parentProject.name}")
+    }
+
+    return buildType!!
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Closes https://github.com/hashicorp/terraform-provider-google/issues/17556

This PR makes sure project sweepers enter the build queue after service sweepers do, effectively ensuring that service sweepers run first and the project sweeper build will wait for them to complete before leaving the queue itself.

The desired consequence of this is that all resources that put liens on projects will be removed, so the project sweeper will experience fewer blocks on deleting projects due to liens.


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
