### PR TITLE
Update min_cpu_platform to Intel Skylake for TestAccDataprocCluster_spotWithAuxiliaryNodeGroups

### DIFF
--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
@@ -550,7 +550,7 @@ func TestAccDataprocCluster_spotWithAuxiliaryNodeGroups(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.roles.0", "DRIVER"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.node_group_config.0.num_instances", "2"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.node_group_config.0.machine_type", "n1-standard-2"),
-					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.node_group_config.0.min_cpu_platform", "AMD Rome"),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.node_group_config.0.min_cpu_platform", "Intel Skylake"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.node_group_config.0.disk_config.0.boot_disk_size_gb", "35"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.node_group_config.0.disk_config.0.boot_disk_type", "pd-standard"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.node_group_config.0.disk_config.0.num_local_ssds", "1"),
@@ -1961,7 +1961,7 @@ resource "google_dataproc_cluster" "with_auxiliary_node_groups" {
         node_group_config{
           num_instances=2
           machine_type="n1-standard-2"
-          min_cpu_platform = "AMD Rome"
+          min_cpu_platform = "Intel Skylake"
           disk_config {
             boot_disk_size_gb = 35
             boot_disk_type = "pd-standard"


### PR DESCRIPTION
Updated min_cpu_platform to Intel Skylake for TestAccDataprocCluster_spotWithAuxiliaryNodeGroups. n1-standard-2 is not compatible with cpu platform "AMD Rome"

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/17534

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
dataproc: Updated min_cpu_platform to Intel Skylake for TestAccDataprocCluster_spotWithAuxiliaryNodeGroups. n1-standard-2 is not compatible with cpu platform "AMD Rome".
```
