### PR TITLE
Add nfs support to cloudrun v1 services.

### DIFF
--- a/mmv1/products/cloudrun/Service.yaml
+++ b/mmv1/products/cloudrun/Service.yaml
@@ -875,6 +875,28 @@ properties:
                             Driver-specific attributes. The following options are supported for available drivers:
                               * gcsfuse.run.googleapis.com
                                 * bucketName: The name of the Cloud Storage Bucket that backs this volume. The Cloud Run Service identity must have access to this bucket.
+                    - !ruby/object:Api::Type::NestedObject
+                      name: nfs
+                      description: |-
+                        A filesystem backed by a Network File System share. This filesystem requires the
+                        run.googleapis.com/execution-environment annotation to be set to "gen2" and
+                        run.googleapis.com/launch-stage set to "BETA" or "ALPHA".
+                      min_version: beta
+                      properties:
+                        - !ruby/object:Api::Type::String
+                          name: server
+                          required: true
+                          description: |-
+                            IP address or hostname of the NFS server
+                        - !ruby/object:Api::Type::String
+                          name: path
+                          required: true
+                          description: |-
+                            Path exported by the NFS server
+                        - !ruby/object:Api::Type::Boolean
+                          name: readOnly
+                          description: |-
+                            If true, mount the NFS volume as read only in all mounts. Defaults to false.
               - !ruby/object:Api::Type::Enum
                 name: servingState
                 deprecation_message: >-

--- a/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.erb
@@ -1273,6 +1273,28 @@ func TestAccCloudRunService_csiVolume(t *testing.T) {
                         },
       })
     }
+func TestAccCloudRunService_nfsVolume(t *testing.T) {
+	t.Parallel()
+
+	project := envvar.GetTestProjectFromEnv()
+	suffix := acctest.RandString(t, 6)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudRunService_cloudRunServiceWithFilestoreVolume(suffix, project),
+			},
+			{
+				ResourceName:            "google_cloud_run_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "metadata.0.annotations", "metadata.0.labels", "metadata.0.terraform_labels", "status.0.conditions"},
+			},
+    },
+  })
+}
 
 
 func testAccCloudRunService_cloudRunServiceWithEmptyDirVolume(name, project string) string {
@@ -1364,6 +1386,87 @@ resource "google_cloud_run_service" "default" {
   }
 }
 `, name, project)
+}
+
+func testAccCloudRunService_cloudRunServiceWithFilestoreVolume(suffix, project string) string {
+	return acctest.Nprintf(`
+resource "google_compute_subnetwork" "test_subnet" {
+  provider = google-beta
+  name          = "tf-test-cloudrun-subnet-%{suffix}"
+  ip_cidr_range = "10.2.0.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.test_network.id
+}
+resource "google_compute_network" "test_network" {
+  provider = google-beta
+  name = "tf-test-cloudrun-network-%{suffix}"
+  auto_create_subnetworks = false
+}
+resource "google_filestore_instance" "nfs_share" {
+ provider = google-beta  
+  name     = "tf-test-cloudrun-fstore-%{suffix}"
+  zone = "us-central1-b"
+  tier     = "BASIC_HDD"
+
+  file_shares {
+    capacity_gb = 1024
+    name        = "share1"
+  }
+
+  networks {
+    network = "${google_compute_network.test_network.name}"
+    modes   = ["MODE_IPV4"]
+  }
+}  
+resource "google_cloud_run_service" "default" {
+  provider = google-beta
+  name     = "tf-test-cloudrun-svc-%{suffix}"
+  location = "us-central1"
+
+  metadata {
+    namespace = "%{project}"
+    annotations = {
+      generated-by = "magic-modules"
+      "run.googleapis.com/launch-stage" = "BETA"
+    }
+  }
+
+  template {
+    metadata {
+      annotations = {
+        "run.googleapis.com/execution-environment" = "gen2"
+        "run.googleapis.com/network-interfaces" = "[{\"network\": \"${google_compute_network.test_network.id}\", \"subnetwork\": \"${google_compute_subnetwork.test_subnet.name}\"}]"
+        "run.googleapis.com/vpc-access-egress" = "private-ranges-only"
+      }
+    }
+    spec {
+      containers {
+        image = "gcr.io/cloudrun/hello"
+        volume_mounts {
+          name = "vol1"
+          mount_path = "/mnt/vol1"
+        }
+      }
+      volumes {
+        name = "vol1"
+        nfs {
+          server = google_filestore_instance.nfs_share.networks[0].ip_addresses[0]
+          path = "/${google_filestore_instance.nfs_share.file_shares[0].name}"
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      metadata.0.annotations,
+    ]
+  }
+}
+`, map[string]interface{}{
+  "suffix": suffix,
+  "project": project,
+})
 }
 
 <% end -%>

--- a/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.erb
@@ -1273,28 +1273,6 @@ func TestAccCloudRunService_csiVolume(t *testing.T) {
                         },
       })
     }
-func TestAccCloudRunService_nfsVolume(t *testing.T) {
-	t.Parallel()
-
-	project := envvar.GetTestProjectFromEnv()
-	suffix := acctest.RandString(t, 6)
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCloudRunService_cloudRunServiceWithFilestoreVolume(suffix, project),
-			},
-			{
-				ResourceName:            "google_cloud_run_service.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "metadata.0.annotations", "metadata.0.labels", "metadata.0.terraform_labels", "status.0.conditions"},
-			},
-    },
-  })
-}
 
 
 func testAccCloudRunService_cloudRunServiceWithEmptyDirVolume(name, project string) string {
@@ -1386,87 +1364,6 @@ resource "google_cloud_run_service" "default" {
   }
 }
 `, name, project)
-}
-
-func testAccCloudRunService_cloudRunServiceWithFilestoreVolume(suffix, project string) string {
-	return acctest.Nprintf(`
-resource "google_compute_subnetwork" "test_subnet" {
-  provider = google-beta
-  name          = "tf-test-cloudrun-subnet-%{suffix}"
-  ip_cidr_range = "10.2.0.0/24"
-  region        = "us-central1"
-  network       = google_compute_network.test_network.id
-}
-resource "google_compute_network" "test_network" {
-  provider = google-beta
-  name = "tf-test-cloudrun-network-%{suffix}"
-  auto_create_subnetworks = false
-}
-resource "google_filestore_instance" "nfs_share" {
- provider = google-beta  
-  name     = "tf-test-cloudrun-fstore-%{suffix}"
-  zone = "us-central1-b"
-  tier     = "BASIC_HDD"
-
-  file_shares {
-    capacity_gb = 1024
-    name        = "share1"
-  }
-
-  networks {
-    network = "${google_compute_network.test_network.name}"
-    modes   = ["MODE_IPV4"]
-  }
-}  
-resource "google_cloud_run_service" "default" {
-  provider = google-beta
-  name     = "tf-test-cloudrun-svc-%{suffix}"
-  location = "us-central1"
-
-  metadata {
-    namespace = "%{project}"
-    annotations = {
-      generated-by = "magic-modules"
-      "run.googleapis.com/launch-stage" = "BETA"
-    }
-  }
-
-  template {
-    metadata {
-      annotations = {
-        "run.googleapis.com/execution-environment" = "gen2"
-        "run.googleapis.com/network-interfaces" = "[{\"network\": \"${google_compute_network.test_network.id}\", \"subnetwork\": \"${google_compute_subnetwork.test_subnet.name}\"}]"
-        "run.googleapis.com/vpc-access-egress" = "private-ranges-only"
-      }
-    }
-    spec {
-      containers {
-        image = "gcr.io/cloudrun/hello"
-        volume_mounts {
-          name = "vol1"
-          mount_path = "/mnt/vol1"
-        }
-      }
-      volumes {
-        name = "vol1"
-        nfs {
-          server = google_filestore_instance.nfs_share.networks[0].ip_addresses[0]
-          path = "/${google_filestore_instance.nfs_share.file_shares[0].name}"
-        }
-      }
-    }
-  }
-
-  lifecycle {
-    ignore_changes = [
-      metadata.0.annotations,
-    ]
-  }
-}
-`, map[string]interface{}{
-  "suffix": suffix,
-  "project": project,
-})
 }
 
 <% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Support for NFS in v2 services was added in https://github.com/GoogleCloudPlatform/magic-modules/pull/9728, this adds it to v1.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudrun: support nfs volumes (beta)

```
