### PR TITLE
Change ItemType to object

### DIFF
--- a/mmv1/api/type.go
+++ b/mmv1/api/type.go
@@ -135,7 +135,7 @@ type Type struct {
 
 	EnumValues []string `yaml:"enum_values"`
 
-	ItemType string `yaml:"item_type"`
+	ItemType *Type `yaml:"item_type"`
 
 	Resource string
 

--- a/mmv1/products/datafusion/go_instance.yaml
+++ b/mmv1/products/datafusion/go_instance.yaml
@@ -279,20 +279,21 @@ able to access the public internet."
 
 If accelerators are enabled it is possible a permadiff will be created with the Options field.
 Users will need to either manually update their state file to include these diffed options, or include the field in a [lifecycle ignore changes block](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes)."
-    item_type: NestedObject
-    properties:
-      - name: 'acceleratorType'
-        type: Enum
-        description: "The type of an accelator for a CDF instance."
-        required: true
-        enum_values:
-          - 'CDC'
-          - 'HEALTHCARE'
-          - 'CCAI_INSIGHTS'
-      - name: 'state'
-        type: Enum
-        description: "The type of an accelator for a CDF instance."
-        required: true
-        enum_values:
-          - 'ENABLED'
-          - 'DISABLED'
+    item_type:
+      properties:
+        - name: 'acceleratorType'
+          type: Enum
+          description: "The type of an accelator for a CDF instance."
+          required: true
+          enum_values:
+            - 'CDC'
+            - 'HEALTHCARE'
+            - 'CCAI_INSIGHTS'
+        - name: 'state'
+          type: Enum
+          description: "The type of an accelator for a CDF instance."
+          required: true
+          enum_values:
+            - 'ENABLED'
+            - 'DISABLED'
+      type: NestedObject

--- a/mmv1/products/pubsub/go_Topic.yaml
+++ b/mmv1/products/pubsub/go_Topic.yaml
@@ -116,7 +116,8 @@ constraints are in effect."
     allowed regions. An empty list means that no regions are allowed,
     and is not a valid configuration."
         required: true
-        item_type: Api::Type::String
+        item_type:
+          type: String
   - name: 'schemaSettings'
     type: NestedObject
     description: "Settings for validating messages published against a schema."


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Change `ItemType` of an array property to an object to cover the case that `ItemType` is a `ResourceRef` 
https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/products/compute/Image.yaml#L190

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
