### PR TITLE
Fixed issues with diff-processor caused by GA-only compilation errors

### DIFF
--- a/.ci/magician/cmd/generate_comment.go
+++ b/.ci/magician/cmd/generate_comment.go
@@ -237,29 +237,30 @@ func execGenerateComment(prNumber int, ghTokenMagicModules, buildId, buildStep, 
 		if err != nil {
 			fmt.Println("building diff processor: ", err)
 			errors[repo.Title] = append(errors[repo.Title], "The diff processor failed to build. This is usually due to the downstream provider failing to compile.")
-		} else {
-			breakingChanges, err := computeBreakingChanges(diffProcessorPath, rnr)
-			if err != nil {
-				fmt.Println("computing breaking changes: ", err)
-				errors[repo.Title] = append(errors[repo.Title], "The diff processor crashed while computing breaking changes. This is usually due to the downstream provider failing to compile.")
-			}
-			for _, breakingChange := range breakingChanges {
-				uniqueBreakingChanges[breakingChange] = struct{}{}
-			}
+			continue
+		}
 
-			// If fetching the PR failed, Labels will be empty
-			labels := make([]string, len(pullRequest.Labels))
-			for i, label := range pullRequest.Labels {
-				labels[i] = label.Name
-			}
-			serviceLabels, err := changedSchemaLabels(prNumber, labels, diffProcessorPath, gh, rnr)
-			if err != nil {
-				fmt.Println("computing changed schema labels: ", err)
-				errors[repo.Title] = append(errors[repo.Title], "The diff processor crashed while computing changed schema labels.")
-			}
-			for _, serviceLabel := range serviceLabels {
-				uniqueServiceLabels[serviceLabel] = struct{}{}
-			}
+		breakingChanges, err := computeBreakingChanges(diffProcessorPath, rnr)
+		if err != nil {
+			fmt.Println("computing breaking changes: ", err)
+			errors[repo.Title] = append(errors[repo.Title], "The diff processor crashed while computing breaking changes. This is usually due to the downstream provider failing to compile.")
+		}
+		for _, breakingChange := range breakingChanges {
+			uniqueBreakingChanges[breakingChange] = struct{}{}
+		}
+
+		// If fetching the PR failed, Labels will be empty
+		labels := make([]string, len(pullRequest.Labels))
+		for i, label := range pullRequest.Labels {
+			labels[i] = label.Name
+		}
+		serviceLabels, err := changedSchemaLabels(prNumber, labels, diffProcessorPath, gh, rnr)
+		if err != nil {
+			fmt.Println("computing changed schema labels: ", err)
+			errors[repo.Title] = append(errors[repo.Title], "The diff processor crashed while computing changed schema labels.")
+		}
+		for _, serviceLabel := range serviceLabels {
+			uniqueServiceLabels[serviceLabel] = struct{}{}
 		}
 
 		err = cleanDiffProcessor(diffProcessorPath, rnr)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_interface.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_interface.go.erb
@@ -13,7 +13,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-google/google/verify"
 	"google.golang.org/api/googleapi"
 
 <% if version == "ga" -%>
@@ -81,15 +80,6 @@ func ResourceComputeRouterInterface() *schema.Resource {
 				AtLeastOneOf:   []string{"ip_range", "interconnect_attachment", "subnetwork", "vpn_tunnel"},
 				Description:    `The IP address and range of the interface. The IP range must be in the RFC3927 link-local IP space. Changing this forces a new interface to be created.`,
 			},
-			<% unless version == 'ga' -%>
-			"ip_version": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:       true,
-				ValidateFunc: verify.ValidateEnum([]string{"IPV4", "IPV6"}),
-				Description:  `IP version of this interface.`,
-			},
-			<% end -%>
 			"private_ip_address": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -188,12 +178,6 @@ func resourceComputeRouterInterfaceCreate(d *schema.ResourceData, meta interface
 		iface.IpRange = ipRangeVal.(string)
 	}
 
-	<% unless version == 'ga' -%>
-	if ipVersionVal, ok := d.GetOk("ip_version"); ok {
-		iface.IpVersion = ipVersionVal.(string)
-	}
-	<% end -%>
-
 	if privateIpVal, ok := d.GetOk("private_ip_address"); ok {
 		iface.PrivateIpAddress = privateIpVal.(string)
 	}
@@ -285,11 +269,6 @@ func resourceComputeRouterInterfaceRead(d *schema.ResourceData, meta interface{}
 			if err := d.Set("ip_range", iface.IpRange); err != nil {
 				return fmt.Errorf("Error setting ip_range: %s", err)
 			}
-			<% unless version == 'ga' -%>
-			if err := d.Set("ip_version", iface.IpVersion); err != nil {
-				return fmt.Errorf("Error setting ip_version: %s", err)
-			}
-			<% end -%>
 			if err := d.Set("private_ip_address", iface.PrivateIpAddress); err != nil {
 				return fmt.Errorf("Error setting private_ip_address: %s", err)
 			}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_interface.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_interface.go.erb
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/verify"
 	"google.golang.org/api/googleapi"
 
 <% if version == "ga" -%>
@@ -80,6 +81,15 @@ func ResourceComputeRouterInterface() *schema.Resource {
 				AtLeastOneOf:   []string{"ip_range", "interconnect_attachment", "subnetwork", "vpn_tunnel"},
 				Description:    `The IP address and range of the interface. The IP range must be in the RFC3927 link-local IP space. Changing this forces a new interface to be created.`,
 			},
+			<% unless version == 'ga' -%>
+			"ip_version": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:       true,
+				ValidateFunc: verify.ValidateEnum([]string{"IPV4", "IPV6"}),
+				Description:  `IP version of this interface.`,
+			},
+			<% end -%>
 			"private_ip_address": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -178,6 +188,12 @@ func resourceComputeRouterInterfaceCreate(d *schema.ResourceData, meta interface
 		iface.IpRange = ipRangeVal.(string)
 	}
 
+	<% unless version == 'ga' -%>
+	if ipVersionVal, ok := d.GetOk("ip_version"); ok {
+		iface.IpVersion = ipVersionVal.(string)
+	}
+	<% end -%>
+
 	if privateIpVal, ok := d.GetOk("private_ip_address"); ok {
 		iface.PrivateIpAddress = privateIpVal.(string)
 	}
@@ -269,6 +285,11 @@ func resourceComputeRouterInterfaceRead(d *schema.ResourceData, meta interface{}
 			if err := d.Set("ip_range", iface.IpRange); err != nil {
 				return fmt.Errorf("Error setting ip_range: %s", err)
 			}
+			<% unless version == 'ga' -%>
+			if err := d.Set("ip_version", iface.IpVersion); err != nil {
+				return fmt.Errorf("Error setting ip_version: %s", err)
+			}
+			<% end -%>
 			if err := d.Set("private_ip_address", iface.PrivateIpAddress); err != nil {
 				return fmt.Errorf("Error setting private_ip_address: %s", err)
 			}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
The diff processor needs to be cleaned up between runs or else it won't build properly. We lost this in the move from bash to go in cases where something goes wrong with the `google` repository. TBH I'm a little surprised at the symptoms, but cleaning up between builds (by always cleaning up immediately before trying to buid) resolves the issue.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
