### PR TITLE
Convert field ExternalIpv6PrefixLength in Cai2Hcl converter for ComputeInstance

### DIFF
--- a/mmv1/third_party/cai2hcl/services/compute/compute_instance.go
+++ b/mmv1/third_party/cai2hcl/services/compute/compute_instance.go
@@ -333,6 +333,7 @@ func flattenIpv6AccessConfigs(ipv6AccessConfigs []*compute.AccessConfig) []map[s
 		}
 		flattened[i]["public_ptr_domain_name"] = ac.PublicPtrDomainName
 		flattened[i]["external_ipv6"] = ac.ExternalIpv6
+		flattened[i]["external_ipv6_prefix_length"] = ac.ExternalIpv6PrefixLength
 	}
 	return flattened
 }

--- a/mmv1/third_party/cai2hcl/services/compute/testdata/full_compute_instance.json
+++ b/mmv1/third_party/cai2hcl/services/compute/testdata/full_compute_instance.json
@@ -115,6 +115,15 @@
           },
           {
             "subnetwork": "projects/test-subnetwork_project/regions/us-central1/subnetworks/test-subnetwork"
+          },
+          {
+            "ipv6AccessConfigs": [
+              {
+                "externalIpv6": "2001:0000:130F:0000:0000:09C0:876A:130B",
+                "externalIpv6PrefixLength": 96,
+                "networkTier": "PREMIUM"
+              }
+            ]
           }
         ],
         "scheduling": {

--- a/mmv1/third_party/cai2hcl/services/compute/testdata/full_compute_instance.json
+++ b/mmv1/third_party/cai2hcl/services/compute/testdata/full_compute_instance.json
@@ -119,7 +119,7 @@
           {
             "ipv6AccessConfigs": [
               {
-                "externalIpv6": "2001:0000:130F:0000:0000:09C0:876A:130B",
+                "externalIpv6": "0000:00000:00000:00000:00000:00000:00000:1",
                 "externalIpv6PrefixLength": 96,
                 "networkTier": "PREMIUM"
               }

--- a/mmv1/third_party/cai2hcl/services/compute/testdata/full_compute_instance.tf
+++ b/mmv1/third_party/cai2hcl/services/compute/testdata/full_compute_instance.tf
@@ -83,6 +83,16 @@ resource "google_compute_instance" "test1" {
     subnetwork  = "projects/test-subnetwork_project/regions/us-central1/subnetworks/test-subnetwork"
   }
 
+  network_interface {
+    ipv6_access_config {
+      external_ipv6               = "2001:0000:130F:0000:0000:09C0:876A:130B"
+      external_ipv6_prefix_length = "96"
+      network_tier                = "PREMIUM"
+    }
+
+    queue_count = 0
+  }
+
   scheduling {
     automatic_restart   = true
     on_host_maintenance = "test-on_host_maintenance"

--- a/mmv1/third_party/cai2hcl/services/compute/testdata/full_compute_instance.tf
+++ b/mmv1/third_party/cai2hcl/services/compute/testdata/full_compute_instance.tf
@@ -85,7 +85,7 @@ resource "google_compute_instance" "test1" {
 
   network_interface {
     ipv6_access_config {
-      external_ipv6               = "2001:0000:130F:0000:0000:09C0:876A:130B"
+      external_ipv6               = "0000:00000:00000:00000:00000:00000:00000:1"
       external_ipv6_prefix_length = "96"
       network_tier                = "PREMIUM"
     }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Convert field `NetworkInterfaces.0.Ipv6AccessConfigs.0.ExternalIpv6PrefixLength` to `network_interface.0.ipv6_access_config.0.external_ipv6_prefix_length` in Cai2Hcl converter for `ComputeInstance`
https://registry.terraform.io/providers/hashicorp/google/4.32.0/docs/resources/compute_instance#network_interface.0.ipv6_access_config.0.external_ipv6_prefix_length



<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
