### PR TITLE
Add update_encoder to target proxy compute resources

### DIFF
--- a/mmv1/products/compute/RegionTargetHttpsProxy.yaml
+++ b/mmv1/products/compute/RegionTargetHttpsProxy.yaml
@@ -43,6 +43,10 @@ async: !ruby/object:Api::OpAsync
     message: 'message'
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   encoder: templates/terraform/encoders/compute_region_target_https_proxy.go.erb
+  # update_encoder is usually the same as encoder by default. This resource is an uncommon case where the whole resource
+  # is marked to be immutable, but we have a field specific update that overrides it (e.g certifiacteManagerCertificates). 
+  # This causes the encoder logic to not be applied during update.
+  update_encoder: templates/terraform/encoders/compute_region_target_https_proxy.go.erb 
   decoder: templates/terraform/decoders/compute_region_target_https_proxy.go.erb
 examples:
   - !ruby/object:Provider::Terraform::Examples

--- a/mmv1/products/compute/RegionTargetHttpsProxy.yaml
+++ b/mmv1/products/compute/RegionTargetHttpsProxy.yaml
@@ -44,9 +44,9 @@ async: !ruby/object:Api::OpAsync
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   encoder: templates/terraform/encoders/compute_region_target_https_proxy.go.erb
   # update_encoder is usually the same as encoder by default. This resource is an uncommon case where the whole resource
-  # is marked to be immutable, but we have a field specific update that overrides it (e.g certifiacteManagerCertificates). 
+  # is marked to be immutable, but we have a field specific update that overrides it (e.g certifiacteManagerCertificates).
   # This causes the encoder logic to not be applied during update.
-  update_encoder: templates/terraform/encoders/compute_region_target_https_proxy.go.erb 
+  update_encoder: templates/terraform/encoders/compute_region_target_https_proxy.go.erb
   decoder: templates/terraform/decoders/compute_region_target_https_proxy.go.erb
 examples:
   - !ruby/object:Provider::Terraform::Examples

--- a/mmv1/products/compute/TargetHttpsProxy.yaml
+++ b/mmv1/products/compute/TargetHttpsProxy.yaml
@@ -45,6 +45,10 @@ async: !ruby/object:Api::OpAsync
     message: 'message'
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   encoder: templates/terraform/encoders/compute_target_https_proxy.go.erb
+  # update_encoder is usually the same as encoder by default. This resource is an uncommon case where the whole resource
+  # is marked to be immutable, but we have a field specific update that overrides it (e.g certifiacteManagerCertificates). 
+  # This causes the encoder logic to not be applied during update.
+  update_encoder: templates/terraform/encoders/compute_target_https_proxy.go.erb
   decoder: templates/terraform/decoders/compute_target_https_proxy.go.erb
 examples:
   - !ruby/object:Provider::Terraform::Examples

--- a/mmv1/products/compute/TargetHttpsProxy.yaml
+++ b/mmv1/products/compute/TargetHttpsProxy.yaml
@@ -46,7 +46,7 @@ async: !ruby/object:Api::OpAsync
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   encoder: templates/terraform/encoders/compute_target_https_proxy.go.erb
   # update_encoder is usually the same as encoder by default. This resource is an uncommon case where the whole resource
-  # is marked to be immutable, but we have a field specific update that overrides it (e.g certifiacteManagerCertificates). 
+  # is marked to be immutable, but we have a field specific update that overrides it (e.g certifiacteManagerCertificates).
   # This causes the encoder logic to not be applied during update.
   update_encoder: templates/terraform/encoders/compute_target_https_proxy.go.erb
   decoder: templates/terraform/decoders/compute_target_https_proxy.go.erb


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add update_encoder to `ComputeTargetHttpsProxy` and `ComputeRegionTargetHttpsProxy` resources.

In case a customer changes the field certificate_manager_certificate, the encoder logic does not get applied. I fixed this by using `update_encoder` which is the same as the encoder.

The reason that encoder is not applied during the update might relate to the fact that those resources are immutable, though there is a field-specific-update that overrides this (see the YAQ question below)

Fixes: hashicorp/terraform-provider-google/issues/17641 

yaqs/2098594962982567936
b/329516022

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: Added explicit update_encoder to `ComputeTargetHttpsProxy` and `ComputeRegionTargetHttpsProxy` resources.
```
