### PR TITLE
Initial resource documentation templating

### DIFF
--- a/mmv1/api/product.go
+++ b/mmv1/api/product.go
@@ -211,6 +211,13 @@ func (p *Product) SetPropertiesBasedOnVersion(version *product.Version) {
 	p.BaseUrl = version.BaseUrl
 }
 
+func (p *Product) TerraformName() string {
+	if p.LegacyName != "" {
+		return google.Underscore(p.LegacyName)
+	}
+	return google.Underscore(p.Name)
+}
+
 // ====================
 // Debugging Methods
 // ====================

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -764,3 +764,10 @@ func (r Resource) HasZone() bool {
 func (r Resource) Lineage() string {
 	return r.Name
 }
+
+func (r Resource) TerraformName() string {
+	if r.LegacyName != "" {
+		return r.LegacyName
+	}
+	return fmt.Sprintf("google_%s_%s", r.ProductMetadata.TerraformName(), google.Underscore(r.Name))
+}

--- a/mmv1/provider/terraform.go
+++ b/mmv1/provider/terraform.go
@@ -127,18 +127,20 @@ func (t *Terraform) GenerateResource(object api.Resource, templateData TemplateD
 	if generateCode {
 		productName := t.Product.ApiName
 		targetFolder := path.Join(outputFolder, t.FolderName(), "services", productName)
-
 		if err := os.MkdirAll(targetFolder, os.ModePerm); err != nil {
 			log.Println(fmt.Errorf("error creating parent directory %v: %v", targetFolder, err))
 		}
-
 		targetFilePath := path.Join(targetFolder, fmt.Sprintf("resource_%s.go", t.FullResourceName(object)))
-
 		templateData.GenerateResourceFile(targetFilePath, object)
 	}
 
 	if generateDocs {
-		templateData.GenerateDocumentationFile(outputFolder, object)
+		targetFolder := path.Join(outputFolder, "website", "docs", "r")
+		if err := os.MkdirAll(targetFolder, os.ModePerm); err != nil {
+			log.Println(fmt.Errorf("error creating parent directory %v: %v", targetFolder, err))
+		}
+		targetFilePath := path.Join(targetFolder, fmt.Sprintf("%s.html.markdown", t.FullResourceName(object)))
+		templateData.GenerateDocumentationFile(targetFilePath, object)
 	}
 }
 

--- a/mmv1/templates/terraform/resource.html.markdown.tmpl
+++ b/mmv1/templates/terraform/resource.html.markdown.tmpl
@@ -25,6 +25,41 @@
 #     .github/CONTRIBUTING.md.
 #
 # ----------------------------------------------------------------------------
-
-{{$.ProductMetadata.Name}} {{$.Name}}
+subcategory: "{{$.ProductMetadata.DisplayName}}"
+description: |-
+  {{$.Description -}}
 ---
+
+# {{$.TerraformName}}
+{{- if $.DeprecationMessage }}
+~> **Warning:** {{$.DeprecationMessage}}
+{{- end }}
+
+{{$.Description}}
+
+{{- if eq $.MinVersion "beta"}}
+~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+{{- end }}
+{{ if $.References}}
+To get more information about {{$.Name}}, see:
+
+	{{- if $.References.Api}}
+
+* [API documentation]({{$.References.Api}})
+	{{- end }}
+	{{- if $.References.Guides}}
+* How-to Guides
+		{{- range $title, $link := $.References.Guides }}
+    * [{{$title}}]({{$link}})
+		{{- end }}
+	{{- end }}
+{{- end }}
+{{- if $.Docs.Warning}}
+
+~> **Warning:** {{$.Docs.Warning}}
+{{- end }}
+{{- if $.Docs.Note}}
+
+~> **Note:** {{$.Docs.Note}}
+{{- end }}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

checking in some progress

- created a generic `GenerateFile` function for duplicate file generation logic between resource code, documentation, and the rest of the templates later.
- added some convenience functions like `TerraformName`
- Roughly 1/3 of documentation template so far (most of it is iterating over fields)

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
