### PR TITLE
Remove relay_mode field support

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -1290,20 +1290,9 @@ func ResourceContainerCluster() *schema.Resource {
 										Description: `Whether or not the advanced datapath metrics are enabled.`,
 									},
 									"enable_relay": {
-										Type:          schema.TypeBool,
-										Optional:      true,
-										Description:   `Whether or not Relay is enabled.`,
-										Default:       false,
-										ConflictsWith: []string{"monitoring_config.0.advanced_datapath_observability_config.0.relay_mode"},
-									},
-									"relay_mode": {
-										Type:          schema.TypeString,
-										Optional:      true,
-										Computed:      true,
-										Deprecated:    "Deprecated in favor of enable_relay field. Remove this attribute's configuration as this field will be removed in the next major release and enable_relay will become a required field.",
-										Description:   `Mode used to make Relay available.`,
-										ValidateFunc:  validation.StringInSlice([]string{"DISABLED", "INTERNAL_VPC_LB", "EXTERNAL_LB"}, false),
-										ConflictsWith: []string{"monitoring_config.0.advanced_datapath_observability_config.0.enable_relay"},
+										Type:        schema.TypeBool,
+										Required:    true,
+										Description: `Whether or not Relay is enabled.`,
 									},
 								},
 							},
@@ -5587,21 +5576,10 @@ func expandMonitoringConfig(configured interface{}) *container.MonitoringConfig 
 
 	if v, ok := config["advanced_datapath_observability_config"]; ok && len(v.([]interface{})) > 0 {
 		advanced_datapath_observability_config := v.([]interface{})[0].(map[string]interface{})
-
 		mc.AdvancedDatapathObservabilityConfig = &container.AdvancedDatapathObservabilityConfig{
 			EnableMetrics: advanced_datapath_observability_config["enable_metrics"].(bool),
-		}
-
-		enable_relay := advanced_datapath_observability_config["enable_relay"].(bool)
-		relay_mode := advanced_datapath_observability_config["relay_mode"].(string)
-		if enable_relay {
-			mc.AdvancedDatapathObservabilityConfig.EnableRelay = enable_relay
-		} else if relay_mode == "INTERNAL_VPC_LB" || relay_mode == "EXTERNAL_LB" {
-			mc.AdvancedDatapathObservabilityConfig.RelayMode = relay_mode
-		} else {
-			mc.AdvancedDatapathObservabilityConfig.EnableRelay = enable_relay
-			mc.AdvancedDatapathObservabilityConfig.RelayMode = "DISABLED"
-			mc.AdvancedDatapathObservabilityConfig.ForceSendFields = []string{"EnableRelay"}
+			EnableRelay: advanced_datapath_observability_config["enable_relay"].(bool),
+			ForceSendFields: []string{"EnableRelay"},
 		}
 	}
 
@@ -6496,29 +6474,10 @@ func flattenAdvancedDatapathObservabilityConfig(c *container.AdvancedDatapathObs
 		return nil
 	}
 
-	if c.EnableRelay {
-		return []map[string]interface{}{
-			{
-				"enable_metrics": c.EnableMetrics,
-				"enable_relay":   c.EnableRelay,
-			},
-		}
-	}
-
-	if c.RelayMode == "INTERNAL_VPC_LB" || c.RelayMode == "EXTERNAL_LB" {
-		return []map[string]interface{}{
-			{
-				"enable_metrics": c.EnableMetrics,
-				"relay_mode":     c.RelayMode,
-			},
-		}
-	}
-
 	return []map[string]interface{}{
 		{
 			"enable_metrics": c.EnableMetrics,
-			"enable_relay":   false,
-			"relay_mode":     "DISABLED",
+			"enable_relay":   c.EnableRelay,
 		},
 	}
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -3406,24 +3406,6 @@ func TestAccContainerCluster_withMonitoringConfigAdvancedDatapathObservabilityCo
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
 			},
-			{
-				Config: testAccContainerCluster_withMonitoringConfigAdvancedDatapathObservabilityConfigEnabledOld(clusterName),
-			},
-			{
-				ResourceName:      "google_container_cluster.primary",
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
-			},
-			{
-				Config: testAccContainerCluster_withMonitoringConfigAdvancedDatapathObservabilityConfigDisabledOld(clusterName),
-			},
-			{
-				ResourceName:      "google_container_cluster.primary",
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
-			},
 		},
 	})
 }
@@ -9704,56 +9686,6 @@ resource "google_container_cluster" "primary" {
 `, name, name)
 }
 
-func testAccContainerCluster_withMonitoringConfigAdvancedDatapathObservabilityConfigEnabledOld(name string) string {
-       return fmt.Sprintf(`
-resource "google_compute_network" "container_network" {
-  name                    = "%s-nw"
-  auto_create_subnetworks = false
-}
-
-resource "google_compute_subnetwork" "container_subnetwork" {
-  name                     = google_compute_network.container_network.name
-  network                  = google_compute_network.container_network.name
-  ip_cidr_range            = "10.0.36.0/24"
-  region                   = "us-central1"
-  private_ip_google_access = true
-
-  secondary_ip_range {
-    range_name    = "services-range"
-    ip_cidr_range = "192.168.1.0/24"
-  }
-
-  secondary_ip_range {
-    range_name    = "pod-ranges"
-    ip_cidr_range = "192.168.64.0/22"
-  }
-}
-
-resource "google_container_cluster" "primary" {
-  name               = "%s"
-  location           = "us-central1-a"
-  initial_node_count = 1
-  datapath_provider = "ADVANCED_DATAPATH"
-
-  network    = google_compute_network.container_network.name
-  subnetwork = google_compute_subnetwork.container_subnetwork.name
-  ip_allocation_policy {
-    cluster_secondary_range_name  = google_compute_subnetwork.container_subnetwork.secondary_ip_range[0].range_name
-    services_secondary_range_name = google_compute_subnetwork.container_subnetwork.secondary_ip_range[1].range_name
-  }
-
-  monitoring_config {
-    enable_components = []
-    advanced_datapath_observability_config {
-      enable_metrics = true
-      relay_mode     = "INTERNAL_VPC_LB"
-    }
-  }
-  deletion_protection = false
-}
-`, name, name)
-}
-
 func testAccContainerCluster_withMonitoringConfigAdvancedDatapathObservabilityConfigDisabled(name string) string {
        return fmt.Sprintf(`
 resource "google_compute_network" "container_network" {
@@ -9797,56 +9729,6 @@ resource "google_container_cluster" "primary" {
     advanced_datapath_observability_config {
       enable_metrics = false
       enable_relay   = false
-    }
-  }
-  deletion_protection = false
-}
-`, name, name)
-}
-
-func testAccContainerCluster_withMonitoringConfigAdvancedDatapathObservabilityConfigDisabledOld(name string) string {
-       return fmt.Sprintf(`
-resource "google_compute_network" "container_network" {
-  name                    = "%s-nw"
-  auto_create_subnetworks = false
-}
-
-resource "google_compute_subnetwork" "container_subnetwork" {
-  name                     = google_compute_network.container_network.name
-  network                  = google_compute_network.container_network.name
-  ip_cidr_range            = "10.0.36.0/24"
-  region                   = "us-central1"
-  private_ip_google_access = true
-
-  secondary_ip_range {
-    range_name    = "services-range"
-    ip_cidr_range = "192.168.1.0/24"
-  }
-
-  secondary_ip_range {
-    range_name    = "pod-ranges"
-    ip_cidr_range = "192.168.64.0/22"
-  }
-}
-
-resource "google_container_cluster" "primary" {
-  name               = "%s"
-  location           = "us-central1-a"
-  initial_node_count = 1
-  datapath_provider  = "ADVANCED_DATAPATH"
-
-  network    = google_compute_network.container_network.name
-  subnetwork = google_compute_subnetwork.container_subnetwork.name
-  ip_allocation_policy {
-    cluster_secondary_range_name  = google_compute_subnetwork.container_subnetwork.secondary_ip_range[0].range_name
-    services_secondary_range_name = google_compute_subnetwork.container_subnetwork.secondary_ip_range[1].range_name
-  }
-
-  monitoring_config {
-    enable_components = []
-    advanced_datapath_observability_config {
-      enable_metrics = false
-      relay_mode     = "DISABLED"
     }
   }
   deletion_protection = false

--- a/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
@@ -201,12 +201,12 @@ An empty value now means 300.
 ### `balancing_mode` default value changed
 
 An empty value now means UTILIZATION.
- 
+
 ## Resource: `google_vpc_access_connector`
 
 ### Fields `min_throughput` and `max_throughput` no longer have default values
 
-The fields `min_throughput` and `max_throughput` no longer have default values 
+The fields `min_throughput` and `max_throughput` no longer have default values
 set by the provider. This was necessary to add conflicting field validation, also
 described in this guide.
 
@@ -216,7 +216,7 @@ will default to values present in data returned from the API.
 ### Conflicting field validation added for `min_throughput` and `min_instances`, and `max_throughput` and `max_instances`
 
 The provider will now enforce that `google_vpc_access_connector` resources can only
-include one of `min_throughput` and `min_instances` and one of `max_throughput`and 
+include one of `min_throughput` and `min_instances` and one of `max_throughput` and
 `max_instances`. Previously if a user included all four fields in a resource block
 they would experience a permadiff. This is a result of how `min_instances` and
 `max_instances` fields' values take precedence in the API, and how the API calculates
@@ -232,7 +232,7 @@ that are derived from the API.
 ### Folder deletion now prevented by default with `deletion_protection`
 
 The field `deletion_protection` has been added with a default value of `true`. This field prevents
-Terraform from destroying or recreating the Folder. In 6.0.0, existing folders will have 
+Terraform from destroying or recreating the Folder. In 6.0.0, existing folders will have
 `deletion_protection` set to `true` during the next refresh unless otherwise set in configuration.
 
 **`deletion_protection` does NOT prevent deletion outside of Terraform.**
@@ -246,9 +246,35 @@ and then run `terraform apply` to apply the change.
 
 Previously `lifecycle_rule.condition.age` attirbute was being set zero value by default and `lifecycle_rule.condition.no_age` was introduced to prevent that.
 Now `lifecycle_rule.condition.no_age` is no longer supported and `lifecycle_rule.condition.age` won't set a zero value by default.
-Removed in favor of the field `lifecycle_rule.condition.send_age_if_zero` which can be used to set zero value for `lifecycle_rule.condition.age` attribute. 
+Removed in favor of the field `lifecycle_rule.condition.send_age_if_zero` which can be used to set zero value for `lifecycle_rule.condition.age` attribute.
 
-For a seamless update, if your state today uses `no_age=true`, update it to remove `no_age` and set `send_age_if_zero=false`. If you do not use `no_age=true`, you will need to add `send_age_if_zero=true` to your state to avoid any changes after updating to 6.0.0. 
+For a seamless update, if your state today uses `no_age=true`, update it to remove `no_age` and set `send_age_if_zero=false`. If you do not use `no_age=true`, you will need to add `send_age_if_zero=true` to your state to avoid any changes after updating to 6.0.0.
+
+## Resource: `google_container_cluster`
+
+### `advanced_datapath_observability_config.relay_mode` is now removed
+
+Previously, through `relay_mode` field usage, users could both enable Dataplane V2
+Flow Observability feature (that deploys Hubble relay component) and configure
+managed load balancers. Due to users' needs to have better control over how
+Hubble relay components shall be exposed in their clusters, managed load
+balancer deployments are not supported anymore and users are expected to deploy
+their own load balancers.
+
+If `advanced_datapath_observability_config` is defined, `enable_relay` is now a
+required field instead and users are expected to use this field instead.
+
+Recommended migration from `relay_mode` to `enable_relay` depending on
+`relay_mode` value:
+* `DISABLED`: set `enable_relay` to `false`
+* `INTERNAL_VPC_LB`: set `enable_relay` to `true` and define internal load
+  balancer with VPC scope
+* `EXTERNAL_LB`: set `enable_relay` to `true` and define external load balancer
+  with public access
+
+See exported endpoints for Dataplane V2 Observability feature to learn what
+target you might wish to expose with load balancers:
+https://cloud.google.com/kubernetes-engine/docs/concepts/about-dpv2-observability#gke-dataplane-v2-observability-endpoints
 
 ## Removals
 

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -645,8 +645,7 @@ This block also contains several computed attributes, documented below.
 <a name="nested_advanced_datapath_observability_config"></a>The `advanced_datapath_observability_config` block supports:
 
 * `enable_metrics` - (Required) Whether or not to enable advanced datapath metrics.
-* `enable_relay` - (Optional) Whether or not Relay is enabled.
-* `relay_mode` - (Optional, Deprecated) Mode used to make Relay available. Deprecated in favor of `enable_relay` field. Remove this attribute's configuration as this field will be removed in the next major release and `enable_relay` will become a required field.
+* `enable_relay` - (Required) Whether or not Relay is enabled.
 
 <a name="nested_maintenance_policy"></a>The `maintenance_policy` block supports:
 * `daily_maintenance_window` - (Optional) structure documented below.


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-google/issues/17997

relay_mode field from AdvancedDatapathObservabilityConfig is superseded by enable_relay field and will be deprecated on the provider side in near future.

This is a breaking change according to TF docs and as such, should be released in the next major release. Deprecation of relay_mode field on TF side has already happened more than a month ago, foreshadowing this change through deprecation message.

This field is part of a provider feature that is still in Public Preview and yet to go GA.

```release-note:breaking-change
container: removed deprecated field `advanced_datapath_observability_config.relay_mode` from `google_container_cluster` resource. Users are expected to use `enable_relay` field instead.
```

```release-note:breaking-change
container: made field `advanced_datapath_observability_config.enable_relay` required in `google_container_cluster` resource
```

