### PR TITLE
add ipv6 outputs

### DIFF
--- a/mmv1/products/compute/InterconnectAttachment.yaml
+++ b/mmv1/products/compute/InterconnectAttachment.yaml
@@ -312,3 +312,15 @@ properties:
       - :IPV4_IPV6
       - :IPV4_ONLY
     default_from_api: true
+  - !ruby/object:Api::Type::String
+    name: 'cloudRouterIpv6Address'
+    description: |
+      IPv6 address + prefix length to be configured on Cloud Router
+      Interface for this interconnect attachment.
+    output: true
+  - !ruby/object:Api::Type::String
+    name: 'customerRouterIpv6Address'
+    description: |
+      IPv6 address + prefix length to be configured on the customer
+      router subinterface for this interconnect attachment.
+    output: true


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add Ipv6 outputs to interconnect attachment resource. Fixes https://github.com/hashicorp/terraform-provider-google/issues/17671.

Followup to https://github.com/GoogleCloudPlatform/magic-modules/pull/9890

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `cloud_router_ipv6_address`, `customer_router_ipv6_address` fields to `google_compute_interconnect_attachment` resource
```
