### PR TITLE
Changelog linting

### DIFF
--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -14,6 +14,17 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
         with:
           path: repo
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '^1.21.0'
+
+      - name: Build
+        run: |
+          cd repo/tools/go-changelog/cmd/changelog-pr-body-check
+          go build
+
       - name: Check Changelog
         env:
           GITHUB_OWNER: GoogleCloudPlatform
@@ -21,4 +32,4 @@ jobs:
           GITHUB_TOKEN: ${{github.token}}
         run: |
           cd repo/tools/go-changelog/cmd/changelog-pr-body-check
-          go run . ${{github.event.pull_request.number}}
+          ./changelog-pr-body-check ${{github.event.pull_request.number}}

--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -16,7 +16,7 @@ jobs:
           path: repo
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: '^1.21.0'
 

--- a/.github/workflows/unit-test-go-changelog.yml
+++ b/.github/workflows/unit-test-go-changelog.yml
@@ -20,10 +20,10 @@ jobs:
       
       - name: Build
         run: |
-          cd repo/tools/go-changelog/cmd/changelog-pr-body-check
+          cd tools/go-changelog/cmd/changelog-pr-body-check
           go build
 
       - name: Test
         run: |
-          cd repo/tools/go-changelog
+          cd tools/go-changelog
           go test -v ./...

--- a/.github/workflows/unit-test-go-changelog.yml
+++ b/.github/workflows/unit-test-go-changelog.yml
@@ -1,0 +1,29 @@
+name: unit-tests-go-changelog
+
+permissions: read-all
+
+on:
+  pull_request:
+    paths:
+      - 'tools/go-changelog/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '^1.21.0'
+      
+      - name: Build
+        run: |
+          cd repo/tools/go-changelog/cmd/changelog-pr-body-check
+          go build
+
+      - name: Test
+        run: |
+          cd repo/tools/go-changelog
+          go test -v ./...

--- a/.github/workflows/unit-test-go-changelog.yml
+++ b/.github/workflows/unit-test-go-changelog.yml
@@ -11,10 +11,10 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: '^1.21.0'
       

--- a/tools/go-changelog/cmd/changelog-pr-body-check/main.go
+++ b/tools/go-changelog/cmd/changelog-pr-body-check/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"strconv"
@@ -59,28 +60,21 @@ func main() {
 
 	if errors := entry.Validate(); errors != nil {
 		log.Printf("error parsing changelog entry in %s: %s", entry.Issue, errors)
-		body := "Oops! Some errors are detected for your changelog entries:"
-		for _, err := range errors {
+		body := "\nOops! Some errors are detected for your changelog entries:"
+		for i, err := range errors {
 			switch err.Code {
 			case changelog.EntryErrorNotFound:
-				body += "\n\nIt looks like no changelog entry is attached to" +
-					" this PR. Please include a release note block" +
-					" in the PR body, as described in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/"
+				body += fmt.Sprintf("\n\n Issue %d: It looks like no changelog entry is attached to this PR. Please include a release note block in the PR body, as described in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/", i+1)
 			case changelog.EntryErrorUnknownTypes:
-				body += "\n\nunknown changelog types " + err.Details["type"].(string)
-				body += "\nPlease only use the types listed in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/."
+				body += fmt.Sprintf("\n\n Issue %d: unknown changelog types %v \nPlease only use the types listed in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/.", i+1, err.Details["type"].(string))
 			case changelog.EntryErrorMultipleLines:
-				body += "\n\nmultiple lines are found in changelog entry: " + err.Details["note"].(string)
-				body += "\nPlease only have one CONTENT line per release note block. Use multiple blocks if there are multiple related changes in a single PR."
+				body += fmt.Sprintf("\n\n Issue %d: multiple lines are found in changelog entry: %v \nPlease only have one CONTENT line per release note block. Use multiple blocks if there are multiple related changes in a single PR.", i+1, err.Details["note"].(string))
 			case changelog.EntryErrorInvalidNewReourceFormat:
-				body += "\n\ninvalid resource/datasource format in changelog entry: " + err.Details["note"].(string)
-				body += "\nPlease follow format in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/#type-specific-guidelines-and-examples."
+				body += fmt.Sprintf("\n\n Issue %d: invalid resource/datasource format in changelog entry: %v \nPlease follow format in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/#type-specific-guidelines-and-examples.", i+1, err.Details["note"].(string))
 			case changelog.EntryErrorInvalidEnhancementOrBugFixFormat:
-				body += "\n\ninvalid enhancement/bug fix format in changelog entry: " + err.Details["note"].(string)
-				body += "\nPlease follow format in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/#type-specific-guidelines-and-examples."
+				body += fmt.Sprintf("\n\n Issue %d: invalid enhancement/bug fix format in changelog entry: %v \nPlease follow format in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/#type-specific-guidelines-and-examples.", i+1, err.Details["note"].(string))
 			}
 		}
-		// fmt.Println(body)
-		// log.Fatal(body)
+		log.Fatal(body)
 	}
 }

--- a/tools/go-changelog/cmd/changelog-pr-body-check/main.go
+++ b/tools/go-changelog/cmd/changelog-pr-body-check/main.go
@@ -59,7 +59,6 @@ func main() {
 	}
 
 	if errors := entry.Validate(); errors != nil {
-		log.Printf("error parsing changelog entry in %s: %s", entry.Issue, errors)
 		body := "\nOops! Some errors are detected for your changelog entries:"
 		for i, err := range errors {
 			switch err.Code {

--- a/tools/go-changelog/cmd/changelog-pr-body-check/main.go
+++ b/tools/go-changelog/cmd/changelog-pr-body-check/main.go
@@ -59,19 +59,24 @@ func main() {
 	}
 
 	if errors := entry.Validate(); errors != nil {
-		body := "\nOops! Some errors are detected for your changelog entries:"
+		body := "\nOops! Some errors are detected for your changelog entries:\n"
 		for i, err := range errors {
+			body += fmt.Sprintf("\n* Issue %d\n", i+1)
+			if err.Details != nil {
+				body += fmt.Sprintf("Changelog:\n```release-note:%v\n%v\n```\n", err.Details["type"].(string), err.Details["note"].(string))
+			}
+			body += "Errors:\n"
 			switch err.Code {
 			case changelog.EntryErrorNotFound:
-				body += fmt.Sprintf("\n\n Issue %d: It looks like no changelog entry is attached to this PR. Please include a release note block in the PR body, as described in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/", i+1)
+				body += "- It looks like no changelog entry is attached to this PR. Please include a release note block in the PR body, as described in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/.\n\n"
 			case changelog.EntryErrorUnknownTypes:
-				body += fmt.Sprintf("\n\n Issue %d: unknown changelog types %v \nPlease only use the types listed in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/.", i+1, err.Details["type"].(string))
+				body += "- Unknown changelog types\nPlease only use the types listed in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/.\n\n"
 			case changelog.EntryErrorMultipleLines:
-				body += fmt.Sprintf("\n\n Issue %d: multiple lines are found in changelog entry: %v \nPlease only have one CONTENT line per release note block. Use multiple blocks if there are multiple related changes in a single PR.", i+1, err.Details["note"].(string))
+				body += "- Multiple lines are found in changelog entry \nPlease only have one CONTENT line per release note block. Use multiple blocks if there are multiple related changes in a single PR.\n\n"
 			case changelog.EntryErrorInvalidNewReourceOrDatasourceFormat:
-				body += fmt.Sprintf("\n\n Issue %d: invalid resource/datasource format in changelog entry: %v \nPlease follow format in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/#type-specific-guidelines-and-examples.", i+1, err.Details["note"].(string))
+				body += "- Invalid resource/datasource format\nPlease follow format in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/#type-specific-guidelines-and-examples.\n\n"
 			case changelog.EntryErrorInvalidEnhancementOrBugFixFormat:
-				body += fmt.Sprintf("\n\n Issue %d: invalid enhancement/bug fix format in changelog entry: %v \nPlease follow format in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/#type-specific-guidelines-and-examples.", i+1, err.Details["note"].(string))
+				body += "- Invalid enhancement/bug fix format\nPlease follow format in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/#type-specific-guidelines-and-examples.\n\n"
 			}
 		}
 		log.Fatal(body)

--- a/tools/go-changelog/cmd/changelog-pr-body-check/main.go
+++ b/tools/go-changelog/cmd/changelog-pr-body-check/main.go
@@ -69,7 +69,7 @@ func main() {
 				body += fmt.Sprintf("\n\n Issue %d: unknown changelog types %v \nPlease only use the types listed in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/.", i+1, err.Details["type"].(string))
 			case changelog.EntryErrorMultipleLines:
 				body += fmt.Sprintf("\n\n Issue %d: multiple lines are found in changelog entry: %v \nPlease only have one CONTENT line per release note block. Use multiple blocks if there are multiple related changes in a single PR.", i+1, err.Details["note"].(string))
-			case changelog.EntryErrorInvalidNewReourceFormat:
+			case changelog.EntryErrorInvalidNewReourceOrDatasourceFormat:
 				body += fmt.Sprintf("\n\n Issue %d: invalid resource/datasource format in changelog entry: %v \nPlease follow format in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/#type-specific-guidelines-and-examples.", i+1, err.Details["note"].(string))
 			case changelog.EntryErrorInvalidEnhancementOrBugFixFormat:
 				body += fmt.Sprintf("\n\n Issue %d: invalid enhancement/bug fix format in changelog entry: %v \nPlease follow format in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/#type-specific-guidelines-and-examples.", i+1, err.Details["note"].(string))

--- a/tools/go-changelog/entry.go
+++ b/tools/go-changelog/entry.go
@@ -52,17 +52,12 @@ func (e *EntryValidationError) Error() string {
 	return e.message
 }
 
-// var newResourceRegexp = regexp.MustCompile("`google_[a-z0-9_]+`")
-// var newlineRegexp = regexp.MustCompile(`\n`)
-// var enhancementOrBugFixRegexp = regexp.MustCompile(`^[a-z0-9]+: .+$`)
-
 // Validates that an Entry body contains properly formatted changelog notes
 func (e *Entry) Validate() []*EntryValidationError {
 	notes := NotesFromEntry(*e)
 
 	var errors []*EntryValidationError
 
-	fmt.Println("Checking if changelog entry exists")
 	if len(notes) < 1 {
 		errors = append(errors, &EntryValidationError{
 			message: fmt.Sprintf("no changelog entry found in: %s", string(e.Body)),
@@ -71,73 +66,11 @@ func (e *Entry) Validate() []*EntryValidationError {
 		return errors
 	}
 
-	// var unknownTypes []string
 	for _, note := range notes {
-		fmt.Println(note)
 		err := note.Validate()
 		if err != nil {
 			errors = append(errors, err)
 		}
-		// fmt.Println("Checking for invalid types")
-		// if !TypeValid(note.Type) {
-		// 	// unknownTypes = append(unknownTypes, note.Type)
-		// 	fmt.Println("error: EntryErrorUnknownTypes")
-		// 	errors = append(errors, &EntryValidationError{
-		// 		message: fmt.Sprintf("unknown changelog types %v: please use only the configured changelog entry types: %v", note.Type, TypeValues),
-		// 		Code:    EntryErrorUnknownTypes,
-		// 		Details: map[string]interface{}{
-		// 			"type": note.Type,
-		// 			"note": note.Body,
-		// 		},
-		// 	})
-		// 	continue
-		// }
-
-		// fmt.Println("Checking for newlines")
-		// if newlineRegexp.MatchString(note.Body) {
-		// 	fmt.Println("error: EntryErrorMultipleLines")
-		// 	errors = append(errors, &EntryValidationError{
-		// 		message: fmt.Sprintf("multiple lines are found in changelog entry %v: Please only have one CONTENT line per release note block. Use multiple blocks if there are multiple related changes in a single PR.", note.Body),
-		// 		Code:    EntryErrorMultipleLines,
-		// 		Details: map[string]interface{}{
-		// 			"type": note.Type,
-		// 			"note": note.Body,
-		// 		},
-		// 	})
-		// 	continue
-		// }
-
-		// fmt.Println("Checking for resource/datasource format")
-		// if note.Type == "new-resource" || note.Type == "new-datasource" {
-		// 	if !newResourceRegexp.MatchString(note.Body) {
-		// 		fmt.Println("error: EntryErrorInvalidNewReourceFormat")
-		// 		errors = append(errors, &EntryValidationError{
-		// 			message: fmt.Sprintf("invalid resource/datasource format in changelog entry %v: Please follow format in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/#type-specific-guidelines-and-examples", note.Body),
-		// 			Code:    EntryErrorInvalidNewReourceFormat,
-		// 			Details: map[string]interface{}{
-		// 				"type": note.Type,
-		// 				"note": note.Body,
-		// 			},
-		// 		})
-		// 		continue
-		// 	}
-		// }
-
-		// fmt.Println("Checking for enhancement/bug fix format")
-		// if note.Type == "enhancement" || note.Type == "bug" {
-		// 	if !enhancementOrBugFixRegexp.MatchString(note.Body) {
-		// 		fmt.Println("error: EntryErrorInvalidEnhancementOrBugFixFormat")
-		// 		errors = append(errors, &EntryValidationError{
-		// 			message: fmt.Sprintf("invalid enhancement/bug fix format in changelog entry %v: Please follow format in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/#type-specific-guidelines-and-examples", note.Body),
-		// 			Code:    EntryErrorInvalidEnhancementOrBugFixFormat,
-		// 			Details: map[string]interface{}{
-		// 				"type": note.Type,
-		// 				"note": note.Body,
-		// 			},
-		// 		})
-		// 		continue
-		// 	}
-		// }
 	}
 
 	return errors
@@ -318,24 +251,3 @@ func Diff(repo, ref1, ref2, dir string) (*EntryList, error) {
 	entries.SortByIssue()
 	return entries, nil
 }
-
-// func NoteNewResourceValid(Note string) bool {
-// 	matched, _ := regexp.MatchString("`google_[\\w*]+`", Note)
-// 	fmt.Println("/////////////////////////////////")
-// 	fmt.Println("new resource", matched)
-// 	fmt.Println("/////////////////////////////////")
-// 	return matched
-// }
-
-// func NoteNoNewlineValid(Note string) bool {
-// 	matched, _ := regexp.MatchString(".*\r?\n", Note)
-// 	return !matched
-// }
-
-// func NoteEnhancementOrBugFixValid(Note string) bool {
-// 	matched, _ := regexp.MatchString("\\w*\\: ", Note)
-// 	fmt.Println("/////////////////////////////////")
-// 	fmt.Println("new enhancement", matched)
-// 	fmt.Println("/////////////////////////////////")
-// 	return matched
-// }

--- a/tools/go-changelog/entry.go
+++ b/tools/go-changelog/entry.go
@@ -35,11 +35,11 @@ type EntryList struct {
 type EntryErrorCode string
 
 const (
-	EntryErrorNotFound                         EntryErrorCode = "NOT_FOUND"
-	EntryErrorUnknownTypes                     EntryErrorCode = "UNKNOWN_TYPES"
-	EntryErrorInvalidNewReourceFormat          EntryErrorCode = "INVALID_NEW_RESOURCE_FORMAT"
-	EntryErrorMultipleLines                    EntryErrorCode = "MULTIPLE_LINES"
-	EntryErrorInvalidEnhancementOrBugFixFormat EntryErrorCode = "INVALID_ENHANCEMENT_OR_BUGFIX_FORMAT"
+	EntryErrorNotFound                            EntryErrorCode = "NOT_FOUND"
+	EntryErrorUnknownTypes                        EntryErrorCode = "UNKNOWN_TYPES"
+	EntryErrorInvalidNewReourceOrDatasourceFormat EntryErrorCode = "INVALID_NEW_RESOURCE_OR_DATASOURCE_FORMAT"
+	EntryErrorMultipleLines                       EntryErrorCode = "MULTIPLE_LINES"
+	EntryErrorInvalidEnhancementOrBugFixFormat    EntryErrorCode = "INVALID_ENHANCEMENT_OR_BUGFIX_FORMAT"
 )
 
 type EntryValidationError struct {

--- a/tools/go-changelog/note.go
+++ b/tools/go-changelog/note.go
@@ -38,7 +38,7 @@ var textInBodyREs = []*regexp.Regexp{
 }
 
 var enhancementOrBugFixRegexp = regexp.MustCompile(`^[a-z0-9]+: .+$`)
-var newResourceRegexp = regexp.MustCompile("`google_[a-z0-9_]+`")
+var newResourceOrDatasourceRegexp = regexp.MustCompile("`google_[a-z0-9_]+`")
 var newlineRegexp = regexp.MustCompile(`\n`)
 
 func NotesFromEntry(entry Entry) []Note {
@@ -112,10 +112,10 @@ func (n *Note) Validate() *EntryValidationError {
 	}
 
 	if typ == "new-resource" || typ == "new-datasource" {
-		if !newResourceRegexp.MatchString(content) {
+		if !newResourceOrDatasourceRegexp.MatchString(content) {
 			return &EntryValidationError{
 				message: fmt.Sprintf("invalid resource/datasource format in changelog entry %v: Please follow format in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/#type-specific-guidelines-and-examples", content),
-				Code:    EntryErrorInvalidNewReourceFormat,
+				Code:    EntryErrorInvalidNewReourceOrDatasourceFormat,
 				Details: map[string]interface{}{
 					"type": typ,
 					"note": content,

--- a/tools/go-changelog/note.go
+++ b/tools/go-changelog/note.go
@@ -4,6 +4,7 @@
 package changelog
 
 import (
+	"fmt"
 	"regexp"
 	"sort"
 	"strings"
@@ -18,12 +19,27 @@ type Note struct {
 	Date  time.Time
 }
 
+var TypeValues = []string{
+	"enhancement",
+	"bug",
+	"note",
+	"none",
+	"new-resource",
+	"new-datasource",
+	"deprecation",
+	"breaking-change",
+}
+
 var textInBodyREs = []*regexp.Regexp{
 	regexp.MustCompile("(?ms)^```release-note\r?\n(?P<note>.+?)\r?\n```"),
 	regexp.MustCompile("(?ms)^```releasenote\r?\n(?P<note>.+?)\r?\n```"),
 	regexp.MustCompile("(?ms)^```release-note:(?P<type>[^\r\n]*)\r?\n?(?P<note>.*?)\r?\n?```"),
 	regexp.MustCompile("(?ms)^```releasenote:(?P<type>[^\r\n]*)\r?\n?(?P<note>.*?)\r?\n?```"),
 }
+
+var newResourceRegexp = regexp.MustCompile("`google_[a-z0-9_]+`")
+var newlineRegexp = regexp.MustCompile(`\n`)
+var enhancementOrBugFixRegexp = regexp.MustCompile(`^[a-z0-9]+: .+$`)
 
 func NotesFromEntry(entry Entry) []Note {
 	var res []Note
@@ -48,7 +64,7 @@ func NotesFromEntry(entry Entry) []Note {
 				}
 			}
 
-			note = strings.TrimSpace(note)
+			// note = strings.TrimSpace(note)
 			typ = strings.TrimSpace(typ)
 
 			if note == "" && typ == "" {
@@ -68,6 +84,69 @@ func NotesFromEntry(entry Entry) []Note {
 	return res
 }
 
+func (n *Note) Validate() *EntryValidationError {
+	typ := n.Type
+	content := n.Body
+
+	fmt.Println("Checking for invalid types")
+	if !TypeValid(typ) {
+		// unknownTypes = append(unknownTypes, typ)
+		fmt.Println("error: EntryErrorUnknownTypes")
+		return &EntryValidationError{
+			message: fmt.Sprintf("unknown changelog types %v: please use only the configured changelog entry types: %v", typ, content),
+			Code:    EntryErrorUnknownTypes,
+			Details: map[string]interface{}{
+				"type": typ,
+				"note": content,
+			},
+		}
+	}
+
+	fmt.Println("Checking for newlines")
+	if newlineRegexp.MatchString(content) {
+		fmt.Println("error: EntryErrorMultipleLines")
+		return &EntryValidationError{
+			message: fmt.Sprintf("multiple lines are found in changelog entry %v: Please only have one CONTENT line per release note block. Use multiple blocks if there are multiple related changes in a single PR.", content),
+			Code:    EntryErrorMultipleLines,
+			Details: map[string]interface{}{
+				"type": typ,
+				"note": content,
+			},
+		}
+	}
+
+	fmt.Println("Checking for resource/datasource format")
+	if typ == "new-resource" || typ == "new-datasource" {
+		if !newResourceRegexp.MatchString(content) {
+			fmt.Println("error: EntryErrorInvalidNewReourceFormat")
+			return &EntryValidationError{
+				message: fmt.Sprintf("invalid resource/datasource format in changelog entry %v: Please follow format in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/#type-specific-guidelines-and-examples", content),
+				Code:    EntryErrorInvalidNewReourceFormat,
+				Details: map[string]interface{}{
+					"type": typ,
+					"note": content,
+				},
+			}
+		}
+	}
+
+	fmt.Println("Checking for enhancement/bug fix format")
+	if typ == "enhancement" || typ == "bug" {
+		if !enhancementOrBugFixRegexp.MatchString(content) {
+			fmt.Println("error: EntryErrorInvalidEnhancementOrBugFixFormat")
+			return &EntryValidationError{
+				message: fmt.Sprintf("invalid enhancement/bug fix format in changelog entry %v: Please follow format in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/#type-specific-guidelines-and-examples", content),
+				Code:    EntryErrorInvalidEnhancementOrBugFixFormat,
+				Details: map[string]interface{}{
+					"type": typ,
+					"note": content,
+				},
+			}
+		}
+	}
+	return nil
+}
+
 func SortNotes(res []Note) func(i, j int) bool {
 	return func(i, j int) bool {
 		if res[i].Type < res[j].Type {
@@ -85,4 +164,13 @@ func SortNotes(res []Note) func(i, j int) bool {
 		}
 		return false
 	}
+}
+
+func TypeValid(Type string) bool {
+	for _, a := range TypeValues {
+		if a == Type {
+			return true
+		}
+	}
+	return false
 }

--- a/tools/go-changelog/note.go
+++ b/tools/go-changelog/note.go
@@ -64,7 +64,6 @@ func NotesFromEntry(entry Entry) []Note {
 				}
 			}
 
-			// note = strings.TrimSpace(note)
 			typ = strings.TrimSpace(typ)
 
 			if note == "" && typ == "" {

--- a/tools/go-changelog/note.go
+++ b/tools/go-changelog/note.go
@@ -37,9 +37,9 @@ var textInBodyREs = []*regexp.Regexp{
 	regexp.MustCompile("(?ms)^```releasenote:(?P<type>[^\r\n]*)\r?\n?(?P<note>.*?)\r?\n?```"),
 }
 
+var enhancementOrBugFixRegexp = regexp.MustCompile(`^[a-z0-9]+: .+$`)
 var newResourceRegexp = regexp.MustCompile("`google_[a-z0-9_]+`")
 var newlineRegexp = regexp.MustCompile(`\n`)
-var enhancementOrBugFixRegexp = regexp.MustCompile(`^[a-z0-9]+: .+$`)
 
 func NotesFromEntry(entry Entry) []Note {
 	var res []Note
@@ -84,14 +84,12 @@ func NotesFromEntry(entry Entry) []Note {
 	return res
 }
 
+// Validates if a changelog note is properly formatted
 func (n *Note) Validate() *EntryValidationError {
 	typ := n.Type
 	content := n.Body
 
-	fmt.Println("Checking for invalid types")
 	if !TypeValid(typ) {
-		// unknownTypes = append(unknownTypes, typ)
-		fmt.Println("error: EntryErrorUnknownTypes")
 		return &EntryValidationError{
 			message: fmt.Sprintf("unknown changelog types %v: please use only the configured changelog entry types: %v", typ, content),
 			Code:    EntryErrorUnknownTypes,
@@ -102,9 +100,7 @@ func (n *Note) Validate() *EntryValidationError {
 		}
 	}
 
-	fmt.Println("Checking for newlines")
 	if newlineRegexp.MatchString(content) {
-		fmt.Println("error: EntryErrorMultipleLines")
 		return &EntryValidationError{
 			message: fmt.Sprintf("multiple lines are found in changelog entry %v: Please only have one CONTENT line per release note block. Use multiple blocks if there are multiple related changes in a single PR.", content),
 			Code:    EntryErrorMultipleLines,
@@ -115,10 +111,8 @@ func (n *Note) Validate() *EntryValidationError {
 		}
 	}
 
-	fmt.Println("Checking for resource/datasource format")
 	if typ == "new-resource" || typ == "new-datasource" {
 		if !newResourceRegexp.MatchString(content) {
-			fmt.Println("error: EntryErrorInvalidNewReourceFormat")
 			return &EntryValidationError{
 				message: fmt.Sprintf("invalid resource/datasource format in changelog entry %v: Please follow format in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/#type-specific-guidelines-and-examples", content),
 				Code:    EntryErrorInvalidNewReourceFormat,
@@ -130,10 +124,8 @@ func (n *Note) Validate() *EntryValidationError {
 		}
 	}
 
-	fmt.Println("Checking for enhancement/bug fix format")
 	if typ == "enhancement" || typ == "bug" {
 		if !enhancementOrBugFixRegexp.MatchString(content) {
-			fmt.Println("error: EntryErrorInvalidEnhancementOrBugFixFormat")
 			return &EntryValidationError{
 				message: fmt.Sprintf("invalid enhancement/bug fix format in changelog entry %v: Please follow format in https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/#type-specific-guidelines-and-examples", content),
 				Code:    EntryErrorInvalidEnhancementOrBugFixFormat,

--- a/tools/go-changelog/note_test.go
+++ b/tools/go-changelog/note_test.go
@@ -20,12 +20,75 @@ func TestValidateNote(t *testing.T) {
 				Body: "this is to add a feature",
 			},
 			expectedError: &EntryValidationError{
-				message: fmt.Sprintf("unknown changelog types %v: please use only the configured changelog entry types: %v", "feature", "this is to add a feature"),
-				Code:    EntryErrorUnknownTypes,
-				Details: map[string]interface{}{
-					"type": "feature",
-					"note": "this is to add a feature",
-				},
+				Code: EntryErrorUnknownTypes,
+			},
+		},
+		"newline after changelog content": {
+			changelogNote: Note{
+				Type: "note",
+				Body: "test only change\n",
+			},
+			expectedError: &EntryValidationError{
+				Code: EntryErrorMultipleLines,
+			},
+		},
+		"valid new resource changelog format": {
+			changelogNote: Note{
+				Type: "new-resource",
+				Body: "`google_new_resource`",
+			},
+			expectedError: nil,
+		},
+		"invalid new resource/datasource changelog format: missing backticks": {
+			changelogNote: Note{
+				Type: "new-resource",
+				Body: "google_new_resource",
+			},
+			expectedError: &EntryValidationError{
+				Code: EntryErrorInvalidNewReourceFormat,
+			},
+		},
+		"invalid new resource/datasource changelog format: missing google prefix": {
+			changelogNote: Note{
+				Type: "new-datasource",
+				Body: "`new_datasource`",
+			},
+			expectedError: &EntryValidationError{
+				Code: EntryErrorInvalidNewReourceFormat,
+			},
+		},
+		"invalid new resource/datasource changelog format: including spaces": {
+			changelogNote: Note{
+				Type: "new-datasource",
+				Body: "`google new datasource`",
+			},
+			expectedError: &EntryValidationError{
+				Code: EntryErrorInvalidNewReourceFormat,
+			},
+		},
+		"valid enhancement/bug fix changelog format": {
+			changelogNote: Note{
+				Type: "enhancement",
+				Body: "compute: added a new field to google_resource resource",
+			},
+			expectedError: nil,
+		},
+		"invalid enhancement/bug fix changelog format: missing product": {
+			changelogNote: Note{
+				Type: "enhancement",
+				Body: "added a new field to google_resource resource",
+			},
+			expectedError: &EntryValidationError{
+				Code: EntryErrorInvalidEnhancementOrBugFixFormat,
+			},
+		},
+		"invalid enhancement/bug fix changelog format: incorrect product name": {
+			changelogNote: Note{
+				Type: "enhancement",
+				Body: "compute engine: added a new field to google_resource resource",
+			},
+			expectedError: &EntryValidationError{
+				Code: EntryErrorInvalidEnhancementOrBugFixFormat,
 			},
 		},
 	}
@@ -35,10 +98,17 @@ func TestValidateNote(t *testing.T) {
 		t.Run(tn, func(t *testing.T) {
 			t.Parallel()
 			fmt.Println(tc.changelogNote)
-			error := tc.changelogNote.Validate()
-			if !reflect.DeepEqual(error, tc.expectedError) {
-				t.Errorf("want %v; got %v", tc.expectedError, error)
+			actualError := tc.changelogNote.Validate()
+			if actualError != nil && tc.expectedError != nil {
+				if !reflect.DeepEqual(actualError.Code, tc.expectedError.Code) {
+					t.Errorf("want %v; got %v", tc.expectedError.Code, actualError.Code)
+				}
+			} else if actualError != nil {
+				t.Errorf("want no error; got %v", actualError)
+			} else if tc.expectedError != nil {
+				t.Errorf("want %v; got no error", tc.expectedError)
 			}
+
 		})
 	}
 }

--- a/tools/go-changelog/note_test.go
+++ b/tools/go-changelog/note_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package changelog
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestValidateNote(t *testing.T) {
+	cases := map[string]struct {
+		changelogNote Note
+		expectedError *EntryValidationError
+	}{
+		"invalid type": {
+			changelogNote: Note{
+				Type: "feature",
+				Body: "this is to add a feature",
+			},
+			expectedError: &EntryValidationError{
+				message: fmt.Sprintf("unknown changelog types %v: please use only the configured changelog entry types: %v", "feature", "this is to add a feature"),
+				Code:    EntryErrorUnknownTypes,
+				Details: map[string]interface{}{
+					"type": "feature",
+					"note": "this is to add a feature",
+				},
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		tc := tc
+		t.Run(tn, func(t *testing.T) {
+			t.Parallel()
+			fmt.Println(tc.changelogNote)
+			error := tc.changelogNote.Validate()
+			if !reflect.DeepEqual(error, tc.expectedError) {
+				t.Errorf("want %v; got %v", tc.expectedError, error)
+			}
+		})
+	}
+}

--- a/tools/go-changelog/note_test.go
+++ b/tools/go-changelog/note_test.go
@@ -4,7 +4,6 @@
 package changelog
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 )
@@ -45,7 +44,7 @@ func TestValidateNote(t *testing.T) {
 				Body: "google_new_resource",
 			},
 			expectedError: &EntryValidationError{
-				Code: EntryErrorInvalidNewReourceFormat,
+				Code: EntryErrorInvalidNewReourceOrDatasourceFormat,
 			},
 		},
 		"invalid new resource/datasource changelog format: missing google prefix": {
@@ -54,7 +53,7 @@ func TestValidateNote(t *testing.T) {
 				Body: "`new_datasource`",
 			},
 			expectedError: &EntryValidationError{
-				Code: EntryErrorInvalidNewReourceFormat,
+				Code: EntryErrorInvalidNewReourceOrDatasourceFormat,
 			},
 		},
 		"invalid new resource/datasource changelog format: including spaces": {
@@ -63,7 +62,7 @@ func TestValidateNote(t *testing.T) {
 				Body: "`google new datasource`",
 			},
 			expectedError: &EntryValidationError{
-				Code: EntryErrorInvalidNewReourceFormat,
+				Code: EntryErrorInvalidNewReourceOrDatasourceFormat,
 			},
 		},
 		"valid enhancement/bug fix changelog format": {
@@ -97,7 +96,6 @@ func TestValidateNote(t *testing.T) {
 		tc := tc
 		t.Run(tn, func(t *testing.T) {
 			t.Parallel()
-			fmt.Println(tc.changelogNote)
 			actualError := tc.changelogNote.Validate()
 			if actualError != nil && tc.expectedError != nil {
 				if !reflect.DeepEqual(actualError.Code, tc.expectedError.Code) {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR added a GHA for changelog unit tests and 3 more changelog linting rules:
1. Only one line is allowed per entry
2. changelog for new resource or datasource should be in format "`google_resource/datasource_name`"
3. changelog for enhancement or bug fix should be in format "package: change details"

No chnagelog error: https://github.com/GoogleCloudPlatform/magic-modules/actions/runs/8485433892/job/23250199809

Some example errors: https://github.com/GoogleCloudPlatform/magic-modules/actions/runs/8485475554/job/23250325859
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```