### PR TITLE
Resource .go.tmpl conversion base

### DIFF
--- a/mmv1/api/async.go
+++ b/mmv1/api/async.go
@@ -47,6 +47,7 @@ type Async struct {
 //   check :actions, default: %w[create delete update], type: ::Array, item_type: ::String
 // end
 
+// TODO Q2
 // def allow?(method)
 func (a Async) Allow(method string) bool {
 	return slices.Contains(a.Actions, strings.ToLower(method))

--- a/mmv1/api/async.go
+++ b/mmv1/api/async.go
@@ -47,7 +47,6 @@ type Async struct {
 //   check :actions, default: %w[create delete update], type: ::Array, item_type: ::String
 // end
 
-// TODO Q2
 // def allow?(method)
 func (a Async) Allow(method string) bool {
 	return slices.Contains(a.Actions, strings.ToLower(method))

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -829,6 +829,18 @@ func (r Resource) HasZone() bool {
 	return strings.Contains(r.BaseUrl, "{{zone}}") || strings.Contains(r.CreateUrl, "{{zone}}")
 }
 
+// resource functions needed for template that previously existed in terraform.go but due to how files are being inherited here it was easier to put in here
+// taken wholesale from tpgtools
+func (r Resource) Updatable() bool {
+	for _, p := range r.AllProperties() {
+		if !p.ForceNew && !(!p.Optional && p.Computed) {
+			return true
+		}
+	}
+	return false
+}
+
+
 // ====================
 // Debugging Methods
 // ====================

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -421,7 +421,7 @@ func (r Resource) SensitivePropsToString() string {
 // they will need to be set in every Update.
 
 // def settable_properties
-func (r Resource) settableProperties() []*Type {
+func (r Resource) SettableProperties() []*Type {
 	props := make([]*Type, 0)
 
 	props = google.Reject(r.AllUserProperties(), func(v *Type) bool {

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -764,7 +764,7 @@ func propertiesWithoutCustomUpdate(properties []*Type) []*Type {
 
 // def update_body_properties
 func (r Resource) UpdateBodyProperties() []*Type {
-	updateProp := propertiesWithoutCustomUpdate(r.settableProperties())
+	updateProp := propertiesWithoutCustomUpdate(r.SettableProperties())
 	if r.UpdateVerb == "PATCH" {
 		updateProp = google.Reject(updateProp, func(p *Type) bool {
 			return p.Immutable
@@ -833,7 +833,7 @@ func (r Resource) HasZone() bool {
 // taken wholesale from tpgtools
 func (r Resource) Updatable() bool {
 	for _, p := range r.AllProperties() {
-		if !p.ForceNew && !(!p.Optional && p.Computed) {
+		if !p.Immutable && !(p.Required && p.DefaultFromApi) {
 			return true
 		}
 	}
@@ -960,4 +960,17 @@ func (r Resource) GetIdFormat() string {
 		idFormat = r.SelfLinkUri()
 	}
 	return idFormat
+// ====================
+// Template Methods
+// ====================
+
+// Prints a dot notation path to where the field is nested within the parent
+// object when called on a property. eg: parent.meta.label.foo
+// Redefined on Resource to terminate the calls up the parent chain.
+
+
+// checks a resource for if it has properties that have FlattenObject=true on fields where IgnoreRead=false
+// used to decide whether or not to import "google.golang.org/api/googleapi"
+func (r Resource) FlattenedProperties() []*Type {
+	return google.Select(google.Reject(r.GettableProperties(), func(p *Type) bool { return p.IgnoreRead }), func(p *Type) bool { return p.FlattenObject })
 }

--- a/mmv1/provider/template_data.go
+++ b/mmv1/provider/template_data.go
@@ -15,8 +15,6 @@ package provider
 
 import (
 	"bytes"
-	"fmt"
-	"go/format"
 	"log"
 	"os"
 	"path/filepath"
@@ -53,6 +51,7 @@ var TemplateFunctions = template.FuncMap{
 	"plural":     google.Plural,
 	"contains":   strings.Contains,
 	"join":       strings.Join,
+	"lower": 	  strings.ToLower,
 }
 
 var GA_VERSION = "ga"
@@ -141,13 +140,6 @@ func (td *TemplateData) GenerateFile(filePath, templatePath string, input any, g
 	// Replace import path based on version (beta/alpha)
 	if td.TerraformResourceDirectory != "google" {
 		sourceByte = bytes.Replace(sourceByte, []byte("github.com/hashicorp/terraform-provider-google/google"), []byte(td.TerraformProviderModule+"/"+td.TerraformResourceDirectory), -1)
-	}
-
-	if goFormat {
-		sourceByte, err = format.Source(sourceByte)
-		if err != nil {
-			glog.Error(fmt.Errorf("error formatting %s", filePath))
-		}
 	}
 
 	err = os.WriteFile(filePath, sourceByte, 0644)

--- a/mmv1/provider/template_data.go
+++ b/mmv1/provider/template_data.go
@@ -141,6 +141,13 @@ func (td *TemplateData) GenerateFile(filePath, templatePath string, input any, g
 	if td.TerraformResourceDirectory != "google" {
 		sourceByte = bytes.Replace(sourceByte, []byte("github.com/hashicorp/terraform-provider-google/google"), []byte(td.TerraformProviderModule+"/"+td.TerraformResourceDirectory), -1)
 	}
+	
+	// if goFormat {
+	// 	sourceByte, err = format.Source(sourceByte)
+	// 	if err != nil {
+	// 		glog.Error(fmt.Errorf("error formatting %s", filePath))
+	// 	}
+	// }
 
 	err = os.WriteFile(filePath, sourceByte, 0644)
 	if err != nil {

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -1,16 +1,19 @@
-{{- /* Copyright 2024 Google LLC. All Rights Reserved.
+{{define "SchemaFields"}} .Name {{end}}
+{{define "SchemaSubResource"}} .Name {{end}}
+{{/* the license inside this block applies to this file
+  Copyright 2024 Google LLC. All Rights Reserved.
 
-	Licensed under the Apache License, Version 2.0 (the "License");
-	you may not use this file except in compliance with the License.
-	You may obtain a copy of the License at
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
 
-			http://www.apache.org/licenses/LICENSE-2.0
+      http://www.apache.org/licenses/LICENSE-2.0
 
-	Unless required by applicable law or agreed to in writing, software
-	distributed under the License is distributed on an "AS IS" BASIS,
-	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-	See the License for the specific language governing permissions and
-	limitations under the License. */ -}}
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. */}}
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
@@ -28,4 +31,149 @@
 //
 // ----------------------------------------------------------------------------
 
-// {{$.ProductMetadata.Name}} {{$.Name}}
+package {{ $.ProductMetadata.Name .downcase -}}
+
+import (
+
+    "fmt"
+    "log"
+    "reflect"
+{{if !$.Immutable && $.UpdateMask -}}
+    "strings"
+{{- end}}
+    "time"
+
+    # We list all the v2 imports here, because we run 'goimports' to guess the correct
+    # set of imports, which will never guess the major version correctly.
+    "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+    "github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+    "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+    "github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+    "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+    "github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+    "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+    "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+    "github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
+
+    "{{ ##TODO: importpath() method/attribute ## -}}/tpgresource"
+    transport_tpg "{{ ##TODO: importpath() method/attribute ## -}}/transport"
+    "{{ ##TODO: importpath() method/attribute ## -}}/verify"
+
+{{ if google.Select(google.Reject($.GettableProperties(), func(p *Type) bool { return p.IgnoreRead }), func(p *Type) bool { return p.FlattenObject }) }}
+    "google.golang.org/api/googleapi"
+{{- end}}
+)
+
+{{if $.CustomCode.Constants}} ##TODO Q2 function to compile custom code lines {{- end}}
+
+func Resource{{ $.ResourceName() -}}() *schema.Resource {
+    return &schema.Resource{
+        Create: resource{{ $.ResourceName() -}}Create,
+        Read: resource{{ $.ResourceName() -}}Read,
+{{if $.Updatable() -}}                                           {{/* ##TODO Q2 || $.root_labels? -}} */}}
+        Update: resource{{ $.ResourceName() -}}Update,
+{{- end}}
+        Delete: resource{{ $.ResourceName() -}}Delete,
+
+{{  unless $.ExcludeImport -}}
+        Importer: &schema.ResourceImporter{
+            State: resource{{ $.ResourceName() -}}Import,
+        },
+{{- end}}
+
+        Timeouts: &schema.ResourceTimeout {
+            Create: schema.DefaultTimeout({{ $.Timeouts.InsertMinutes -}} * time.Minute),
+{{if $.Updatable() -}}                                           {{/* ##TODO Q2 || $.root_labels? -}} */}}
+            Update: schema.DefaultTimeout({{ $.Timeouts.UpdateMinutes -}} * time.Minute),
+{{- end}}
+            Delete: schema.DefaultTimeout({{ $.Timeouts.DeleteMinutes -}} * time.Minute),
+        },
+
+{{if $.SchemaVersion -}}
+        SchemaVersion: {{ $.SchemaVersion -}},
+{{- end}}
+{{if $.MigrateState -}}
+        MigrateState: {{ $.MigrateState -}},
+{{- end}}
+{{if $.StateUpgraders -}}
+
+        StateUpgraders: []schema.StateUpgrader{
+{{-       range $v := $.SchemaVersions }}
+          {
+            Type:    resource{{$.PathType}}ResourceV{{$v}}().CoreConfigSchema().ImpliedType(),
+            Upgrade: Resource{{$.PathType}}UpgradeV{{$v}},
+            Version: {{$v}},
+          },
+{{-       end }}
+        },
+{{- end }}
+{{if (($.Project? || $.Region? || $.Zone?) && !$.SkipDefaultCdiff) || $.CustomDiff.len() > 0 -}}
+        CustomizeDiff: customdiff.All(
+{{if $.CustomDiff -}}
+{{          for cdiff in $.CustomDiff-}}
+        {{ cdiff%>,
+{{- end}}
+{{- end}}
+{{if $.Project? && !$.SkipDefaultCdiff -}}
+            tpgresource.DefaultProviderProject,
+{{- end}}
+{{if $.Region? && !$.SkipDefaultCdiff  -}}
+            tpgresource.DefaultProviderRegion,
+{{- end}}
+{{if $.Zone? && !$.SkipDefaultCdiff  -}}
+            tpgresource.DefaultProviderZone,
+{{- end}}
+        ),
+{{- end}}
+
+{{if $.DeprecationMessage %>
+        DeprecationMessage: "{{ $.DeprecationMessage -}}",
+{{- end}}
+
+        Schema: map[string]*schema.Schema{
+##TODO order props?
+{{- range $prop := $.AllUserProperties() }}
+{{template "SchemaFields" $prop}}
+{{- end }}
+{{- if $.VirtualFields -}}
+{{-   range $field := $.VirtualFields }}
+            "{{ $field.Name -}}": {
+                Type: schema.{{ $field.ItemType -}},
+                Optional: true,
+{{      if $field.Immutable -}}
+                ForceNew: true,
+{{-     end}}
+{{      if $field.DefaultValue -}}
+                Default:  {{ $field.Default_Value -}},
+{{-     end}}
+                Description: `{{ $field.Description -}}`,
+            },
+{{-   end}}
+{{- end}}
+
+ ##TODO Q2 function to compile custom code lines ($.CustomCode.extra_schema_entry)
+
+{{if $.Project? -}}
+            "project": {
+                Type:     schema.TypeString,
+                Optional: true,
+                Computed: true,
+                ForceNew: true,
+            },
+{{- end}}
+{{if $.HasSelfLink() -}}
+            "self_link": {
+                Type:     schema.TypeString,
+                Computed: true,
+            },
+{{- end}}
+        },
+        UseJSONNumber: true,
+    }
+}
+
+{{- range $prop := $.AllUserProperties() }}
+{{if $prop.Type == Array && $prop.IsSet && $prop.ItemType == NestedObject}}
+{{template "SchemaSubResource" $prop}}
+{{end}}
+{{- end}}

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -1,5 +1,5 @@
-{{define "SchemaFields"}} .Name {{end}}
-{{define "SchemaSubResource"}} .Name {{end}}
+{{define "SchemaFields"}} {{.Name}} {{end}}
+{{define "SchemaSubResource"}} {{.Name}} (subresource)
 {{/* the license inside this block applies to this file
   Copyright 2024 Google LLC. All Rights Reserved.
 
@@ -13,7 +13,7 @@
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
-  limitations under the License. */}}
+  limitations under the License. */}} {{end}}
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
@@ -31,20 +31,20 @@
 //
 // ----------------------------------------------------------------------------
 
-package {{ $.ProductMetadata.Name .downcase -}}
+package {{ lower $.ProductMetadata.Name }}
 
 import (
 
     "fmt"
     "log"
     "reflect"
-{{if !$.Immutable && $.UpdateMask -}}
+{{- if and (not $.Immutable) ($.UpdateMask) }}
     "strings"
-{{- end}}
+{{- end }}
     "time"
 
-    # We list all the v2 imports here, because we run 'goimports' to guess the correct
-    # set of imports, which will never guess the major version correctly.
+{{/*     # We list all the v2 imports here, because we run 'goimports' to guess the correct */}}
+{{/*     # set of imports, which will never guess the major version correctly. */}}
     "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
     "github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
     "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -55,47 +55,48 @@ import (
     "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
     "github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 
-    "{{ ##TODO: importpath() method/attribute ## -}}/tpgresource"
-    transport_tpg "{{ ##TODO: importpath() method/attribute ## -}}/transport"
-    "{{ ##TODO: importpath() method/attribute ## -}}/verify"
+    "{{/* ##TODO: importpath() method/attribute ## -*/}}/tpgresource"
+    transport_tpg "{{/* ##TODO: importpath() method/attribute ## -*/}}/transport"
+    "{{/* ##TODO: importpath() method/attribute ## -*/}}/verify"
 
-{{ if google.Select(google.Reject($.GettableProperties(), func(p *Type) bool { return p.IgnoreRead }), func(p *Type) bool { return p.FlattenObject }) }}
+{{ if $.FlattenedProperties }}
     "google.golang.org/api/googleapi"
 {{- end}}
 )
 
-{{if $.CustomCode.Constants}} ##TODO Q2 function to compile custom code lines {{- end}}
+{{if $.CustomCode.Constants}} ##TODO Q2 function to compile constants custom code lines {{- end}}
 
-func Resource{{ $.ResourceName() -}}() *schema.Resource {
+func Resource{{ $.ResourceName -}}() *schema.Resource {
     return &schema.Resource{
-        Create: resource{{ $.ResourceName() -}}Create,
-        Read: resource{{ $.ResourceName() -}}Read,
-{{if $.Updatable() -}}                                           {{/* ##TODO Q2 || $.root_labels? -}} */}}
-        Update: resource{{ $.ResourceName() -}}Update,
+        Create: resource{{ $.ResourceName -}}Create,
+        Read: resource{{ $.ResourceName -}}Read,
+{{- if $.Updatable -}}                                           {{/* ##TODO Q2 || $.root_labels? -}} */}}
+        Update: resource{{ $.ResourceName -}}Update,
 {{- end}}
-        Delete: resource{{ $.ResourceName() -}}Delete,
+        Delete: resource{{ $.ResourceName -}}Delete,
 
-{{  unless $.ExcludeImport -}}
+{{-  if not $.ExcludeImport }}
+
         Importer: &schema.ResourceImporter{
-            State: resource{{ $.ResourceName() -}}Import,
+            State: resource{{ $.ResourceName -}}Import,
         },
 {{- end}}
 
         Timeouts: &schema.ResourceTimeout {
             Create: schema.DefaultTimeout({{ $.Timeouts.InsertMinutes -}} * time.Minute),
-{{if $.Updatable() -}}                                           {{/* ##TODO Q2 || $.root_labels? -}} */}}
+{{- if $.Updatable -}}                                           {{/* ##TODO Q2 || $.root_labels? -}} */}}
             Update: schema.DefaultTimeout({{ $.Timeouts.UpdateMinutes -}} * time.Minute),
 {{- end}}
             Delete: schema.DefaultTimeout({{ $.Timeouts.DeleteMinutes -}} * time.Minute),
         },
 
-{{if $.SchemaVersion -}}
+{{- if $.SchemaVersion }}
         SchemaVersion: {{ $.SchemaVersion -}},
 {{- end}}
-{{if $.MigrateState -}}
+{{- if $.MigrateState }}
         MigrateState: {{ $.MigrateState -}},
 {{- end}}
-{{if $.StateUpgraders -}}
+{{- if $.StateUpgraders }}
 
         StateUpgraders: []schema.StateUpgrader{
 {{-       range $v := $.SchemaVersions }}
@@ -107,32 +108,32 @@ func Resource{{ $.ResourceName() -}}() *schema.Resource {
 {{-       end }}
         },
 {{- end }}
-{{if (($.Project? || $.Region? || $.Zone?) && !$.SkipDefaultCdiff) || $.CustomDiff.len() > 0 -}}
+{{if or (and (or $.HasProject $.HasRegion $.HasZone) (not $.SkipDefaultCdiff)) $.CustomDiff }}
         CustomizeDiff: customdiff.All(
-{{if $.CustomDiff -}}
-{{          for cdiff in $.CustomDiff-}}
-        {{ cdiff%>,
+{{- if $.CustomDiff -}}
+{{-          range $cdiff := $.CustomDiff -}}
+        {{ $cdiff }},
 {{- end}}
 {{- end}}
-{{if $.Project? && !$.SkipDefaultCdiff -}}
+{{- if and ($.HasProject) (not $.SkipDefaultCdiff) }}
             tpgresource.DefaultProviderProject,
-{{- end}}
-{{if $.Region? && !$.SkipDefaultCdiff  -}}
+{{- end -}}
+{{if and ($.HasRegion) (not $.SkipDefaultCdiff)  }}
             tpgresource.DefaultProviderRegion,
-{{- end}}
-{{if $.Zone? && !$.SkipDefaultCdiff  -}}
+{{- end -}}
+{{if and ($.HasZone) (not $.SkipDefaultCdiff)  }}
             tpgresource.DefaultProviderZone,
-{{- end}}
+{{- end }}
         ),
 {{- end}}
 
-{{if $.DeprecationMessage %>
+{{- if $.DeprecationMessage }}
         DeprecationMessage: "{{ $.DeprecationMessage -}}",
 {{- end}}
 
         Schema: map[string]*schema.Schema{
 ##TODO order props?
-{{- range $prop := $.AllUserProperties() }}
+{{- range $prop := $.AllUserProperties }}
 {{template "SchemaFields" $prop}}
 {{- end }}
 {{- if $.VirtualFields -}}
@@ -150,10 +151,8 @@ func Resource{{ $.ResourceName() -}}() *schema.Resource {
             },
 {{-   end}}
 {{- end}}
-
  ##TODO Q2 function to compile custom code lines ($.CustomCode.extra_schema_entry)
-
-{{if $.Project? -}}
+{{- if $.HasProject }}
             "project": {
                 Type:     schema.TypeString,
                 Optional: true,
@@ -161,7 +160,7 @@ func Resource{{ $.ResourceName() -}}() *schema.Resource {
                 ForceNew: true,
             },
 {{- end}}
-{{if $.HasSelfLink() -}}
+{{if $.HasSelfLink -}}
             "self_link": {
                 Type:     schema.TypeString,
                 Computed: true,
@@ -172,8 +171,8 @@ func Resource{{ $.ResourceName() -}}() *schema.Resource {
     }
 }
 
-{{- range $prop := $.AllUserProperties() }}
-{{if $prop.Type == Array && $prop.IsSet && $prop.ItemType == NestedObject}}
+{{- range $prop := $.AllUserProperties }}
+{{if and (eq $prop.Type "Array") ($prop.IsSet) (eq $prop.ItemType "NestedObject")}}
 {{template "SchemaSubResource" $prop}}
 {{end}}
 {{- end}}


### PR DESCRIPTION
Converts the top portion of the file up to `create()` minus schema fields. Next PR will be the schema fields.

Currently missing functionality for compiling custom code into the resource file.

Larger piece of logic has been removed at the equivalent within line 99/170 of resource.erb — removed due to only being used in one downstream resource and would require a separate custom function to parse within the `.go.tmpl` in the first place -- could simply add that small piece as relevant to those files as a customize diff function and custom schema entry.