### PR TITLE
remove `pattern` property support in ruby files

### DIFF
--- a/mmv1/api/type.rb
+++ b/mmv1/api/type.rb
@@ -108,9 +108,6 @@ module Api
       # Can only be overridden - we should never set this ourselves.
       attr_reader :new_type
 
-      # A pattern that maps expected user input to expected API input.
-      attr_reader :pattern
-
       # ====================
       # Terraform Overrides
       # ====================
@@ -238,7 +235,6 @@ module Api
       check :update_url, type: ::String
       check :update_id, type: ::String
       check :fingerprint_name, type: ::String
-      check :pattern, type: ::String
 
       check_default_value_property
       check_conflicts

--- a/mmv1/templates/terraform/yaml_conversion_field.erb
+++ b/mmv1/templates/terraform/yaml_conversion_field.erb
@@ -14,8 +14,6 @@
 <%  unless !property.schema_config_mode_attr -%>
     schema_config_mode_attr: <%= property.schema_config_mode_attr %>
 <%  end -%>
-<%  unless property.pattern.nil? -%>
-    pattern: '<%= property.pattern %>'
 <%  end -%>
 <%  unless !property.exclude -%>
     exclude: <%= property.exclude %>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Since we've removed the use of `pattern` field in all yaml files, we also need to remove support for pattern in ruby. This is found in `types.erb` and `yaml_conversion_fields.erb`

This PR will be merged once a soak period of 2 weeks passes.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/17269

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
