### PR TITLE
TeamCity: test utils refactor

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/tests/build_configuration_features.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/build_configuration_features.kt
@@ -17,11 +17,11 @@ import projects.googleCloudRootProject
 class BuildConfigurationFeatureTests {
     @Test
     fun buildShouldFailOnError() {
-        val project = googleCloudRootProject(testContextParameters())
+        val root = googleCloudRootProject(testContextParameters())
 
-        val gaProject = getSubProject(project, gaProjectName)
-        val betaProject = getSubProject(project, betaProjectName)
-        val projectSweeperProject = getSubProject(project, projectSweeperProjectName)
+        val gaProject = getSubProject(root, gaProjectName)
+        val betaProject = getSubProject(root, betaProjectName)
+        val projectSweeperProject = getSubProject(root, projectSweeperProjectName)
 
         (gaProject.subProjects + betaProject.subProjects + projectSweeperProject.subProjects).forEach{p ->
             p.buildTypes.forEach{bt ->
@@ -32,11 +32,11 @@ class BuildConfigurationFeatureTests {
 
     @Test
     fun buildShouldHaveGoTestFeature() {
-        val project = googleCloudRootProject(testContextParameters())
+        val root = googleCloudRootProject(testContextParameters())
 
-        val gaProject = getSubProject(project, gaProjectName)
-        val betaProject = getSubProject(project, betaProjectName)
-        val projectSweeperProject = getSubProject(project, projectSweeperProjectName)
+        val gaProject = getSubProject(root, gaProjectName)
+        val betaProject = getSubProject(root, betaProjectName)
+        val projectSweeperProject = getSubProject(root, projectSweeperProjectName)
 
         (gaProject.subProjects + betaProject.subProjects + projectSweeperProject.subProjects).forEach{p ->
             var exists: ArrayList<Boolean> = arrayListOf()

--- a/mmv1/third_party/terraform/.teamcity/tests/build_configuration_features.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/build_configuration_features.kt
@@ -52,19 +52,19 @@ class BuildConfigurationFeatureTests {
 
     @Test
     fun nonVCRBuildShouldHaveSaveArtifactsToGCS() {
-        val project = googleCloudRootProject(testContextParameters())
+        val root = googleCloudRootProject(testContextParameters())
 
         // Find GA nightly test project
-        var gaNightlyTestProject = getSubProject(project, gaProjectName, nightlyTestsProjectName)
+        var gaNightlyTestProject = getNestedProjectFromRoot(root, gaProjectName, nightlyTestsProjectName)
 
         // Find GA MM Upstream project
-        var gaMMUpstreamProject = getSubProject(project, gaProjectName, mmUpstreamProjectName)
+        var gaMMUpstreamProject = getNestedProjectFromRoot(root, gaProjectName, mmUpstreamProjectName)
 
         // Find Beta nightly test project
-        var betaNightlyTestProject = getSubProject(project, betaProjectName, nightlyTestsProjectName)
+        var betaNightlyTestProject = getNestedProjectFromRoot(root, betaProjectName, nightlyTestsProjectName)
 
         // Find Beta MM Upstream project
-        var betaMMUpstreamProject = getSubProject(project, betaProjectName, mmUpstreamProjectName)
+        var betaMMUpstreamProject = getNestedProjectFromRoot(root, betaProjectName, mmUpstreamProjectName)
 
         (gaNightlyTestProject.buildTypes + gaMMUpstreamProject.buildTypes + betaNightlyTestProject.buildTypes + betaMMUpstreamProject.buildTypes).forEach{bt ->
             var found: Boolean = false

--- a/mmv1/third_party/terraform/.teamcity/tests/build_configuration_features.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/build_configuration_features.kt
@@ -18,18 +18,12 @@ class BuildConfigurationFeatureTests {
     @Test
     fun buildShouldFailOnError() {
         val project = googleCloudRootProject(testContextParameters())
-        // Find Google (GA) project
-        var gaProject: Project? =  project.subProjects.find { p->  p.name == gaProjectName}
-        if (gaProject == null) {
-            fail("Could not find the Google (GA) project")
-        }
-        // Find Google Beta project
-        var betaProject: Project? =  project.subProjects.find { p->  p.name == betaProjectName}
-        if (betaProject == null) {
-            fail("Could not find the Google (GA) project")
-        }
 
-        (gaProject!!.subProjects + betaProject!!.subProjects).forEach{p ->
+        val gaProject = getSubProject(project, gaProjectName)
+        val betaProject = getSubProject(project, betaProjectName)
+        val projectSweeperProject = getSubProject(project, projectSweeperProjectName)
+
+        (gaProject.subProjects + betaProject.subProjects + projectSweeperProject.subProjects).forEach{p ->
             p.buildTypes.forEach{bt ->
                 assertTrue("Build '${bt.id}' should fail on errors!", bt.failureConditions.errorMessage)
             }
@@ -39,18 +33,12 @@ class BuildConfigurationFeatureTests {
     @Test
     fun buildShouldHaveGoTestFeature() {
         val project = googleCloudRootProject(testContextParameters())
-        // Find Google (GA) project
-        var gaProject: Project? =  project.subProjects.find { p->  p.name == gaProjectName}
-        if (gaProject == null) {
-            fail("Could not find the Google (GA) project")
-        }
-        // Find Google Beta project
-        var betaProject: Project? =  project.subProjects.find { p->  p.name == betaProjectName}
-        if (betaProject == null) {
-            fail("Could not find the Google (GA) project")
-        }
 
-        (gaProject!!.subProjects + betaProject!!.subProjects).forEach{p ->
+        val gaProject = getSubProject(project, gaProjectName)
+        val betaProject = getSubProject(project, betaProjectName)
+        val projectSweeperProject = getSubProject(project, projectSweeperProjectName)
+
+        (gaProject.subProjects + betaProject.subProjects + projectSweeperProject.subProjects).forEach{p ->
             var exists: ArrayList<Boolean> = arrayListOf()
             p.buildTypes.forEach{bt ->
                 bt.features.items.forEach { f ->

--- a/mmv1/third_party/terraform/.teamcity/tests/build_configuration_features.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/build_configuration_features.kt
@@ -8,7 +8,6 @@
 package tests
 
 import builds.UseTeamCityGoTest
-import jetbrains.buildServer.configs.kotlin.Project
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test

--- a/mmv1/third_party/terraform/.teamcity/tests/context_parameters.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/context_parameters.kt
@@ -11,7 +11,7 @@ import builds.AccTestConfiguration
 import builds.getBetaAcceptanceTestConfig
 import builds.getGaAcceptanceTestConfig
 import builds.getVcrAcceptanceTestConfig
-import org.junit.Assert
+import org.junit.Assert.fail
 import org.junit.Test
 import kotlin.reflect.full.memberProperties
 
@@ -22,7 +22,7 @@ class ContextParameterHandlingTests {
         for (prop in AccTestConfiguration::class.memberProperties) {
             val value = prop.get(config).toString()
             if (value.contains("Beta")||value.contains("Vcr")) {
-                Assert.fail("Found config value $value which isn't a GA value")
+                fail("Found config value $value which isn't a GA value")
             }
         }
     }
@@ -33,7 +33,7 @@ class ContextParameterHandlingTests {
         for (prop in AccTestConfiguration::class.memberProperties) {
             val value = prop.get(config).toString()
             if (value.contains("Ga")||value.contains("Vcr")) {
-                Assert.fail("Found config value $value which isn't a Beta value")
+                fail("Found config value $value which isn't a Beta value")
             }
         }
     }
@@ -44,7 +44,7 @@ class ContextParameterHandlingTests {
         for (prop in AccTestConfiguration::class.memberProperties) {
             val value = prop.get(config).toString()
             if (value.contains("Ga")||value.contains("Beta")) {
-                Assert.fail("Found config value $value which isn't a VCR value")
+                fail("Found config value $value which isn't a VCR value")
             }
         }
     }

--- a/mmv1/third_party/terraform/.teamcity/tests/nightly_tests_project.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/nightly_tests_project.kt
@@ -27,7 +27,7 @@ class NightlyTestProjectsTests {
 
         // Make assertions about builds in both nightly test projects
         (gaNightlyTestProject.buildTypes + betaNightlyTestProject.buildTypes).forEach{bt ->
-            assertTrue("Build configuration `${bt.name}` contains at least one trigger", bt.triggers.items.isNotEmpty())
+            assertTrue("Build configuration `${bt.name}` should contain at least one trigger", bt.triggers.items.isNotEmpty())
              // Look for at least one CRON trigger
             var found: Boolean = false
             lateinit var schedulingTrigger: ScheduleTrigger
@@ -38,7 +38,8 @@ class NightlyTestProjectsTests {
                     break
                 }
             }
-            assertTrue("Build configuration `${bt.name}` contains a CRON trigger", found)
+
+            assertTrue("Build configuration `${bt.name}` should contain a CRON/'schedulingTrigger' trigger", found)
 
             // Check that nightly test is being ran on main branch
             var isDefault: Boolean = false

--- a/mmv1/third_party/terraform/.teamcity/tests/nightly_tests_project.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/nightly_tests_project.kt
@@ -7,11 +7,9 @@
 
 package tests
 
+import jetbrains.buildServer.configs.kotlin.triggers.ScheduleTrigger
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import jetbrains.buildServer.configs.kotlin.Project
-import jetbrains.buildServer.configs.kotlin.triggers.ScheduleTrigger
-import org.junit.Assert
 import projects.googleCloudRootProject
 
 class NightlyTestProjectsTests {

--- a/mmv1/third_party/terraform/.teamcity/tests/nightly_tests_project.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/nightly_tests_project.kt
@@ -20,10 +20,10 @@ class NightlyTestProjectsTests {
         val project = googleCloudRootProject(testContextParameters())
 
         // Find GA nightly test project
-        var gaNightlyTestProject = getSubProject(project, gaProjectName, nightlyTestsProjectName)
+        var gaNightlyTestProject = getNestedProjectFromRoot(project, gaProjectName, nightlyTestsProjectName)
 
         // Find Beta nightly test project
-        var betaNightlyTestProject = getSubProject(project, betaProjectName, nightlyTestsProjectName)
+        var betaNightlyTestProject = getNestedProjectFromRoot(project, betaProjectName, nightlyTestsProjectName)
 
         // Make assertions about builds in both nightly test projects
         (gaNightlyTestProject.buildTypes + betaNightlyTestProject.buildTypes).forEach{bt ->

--- a/mmv1/third_party/terraform/.teamcity/tests/nightly_tests_project.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/nightly_tests_project.kt
@@ -17,13 +17,13 @@ import projects.googleCloudRootProject
 class NightlyTestProjectsTests {
     @Test
     fun allBuildsShouldHaveTrigger() {
-        val project = googleCloudRootProject(testContextParameters())
+        val root = googleCloudRootProject(testContextParameters())
 
         // Find GA nightly test project
-        var gaNightlyTestProject = getNestedProjectFromRoot(project, gaProjectName, nightlyTestsProjectName)
+        var gaNightlyTestProject = getNestedProjectFromRoot(root, gaProjectName, nightlyTestsProjectName)
 
         // Find Beta nightly test project
-        var betaNightlyTestProject = getNestedProjectFromRoot(project, betaProjectName, nightlyTestsProjectName)
+        var betaNightlyTestProject = getNestedProjectFromRoot(root, betaProjectName, nightlyTestsProjectName)
 
         // Make assertions about builds in both nightly test projects
         (gaNightlyTestProject.buildTypes + betaNightlyTestProject.buildTypes).forEach{bt ->

--- a/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
@@ -121,7 +121,7 @@ class SweeperTests {
         val cronBeta = stBeta.schedulingPolicy as ScheduleTrigger.SchedulingPolicy.Cron
         val stProject = projectSweeper.triggers.items[0] as ScheduleTrigger
         val cronProject = stProject.schedulingPolicy as ScheduleTrigger.SchedulingPolicy.Cron
-        assertTrue("Service sweeper for the GA Nightly Test project is triggered at an earlier hour than the project sweeper", cronGa.hours.toString() < cronProject.hours.toString()) // Values are strings like "11", "12"
-        assertTrue("Service sweeper for the Beta Nightly Test project is triggered at an earlier hour than the project sweeper", cronBeta.hours.toString() < cronProject.hours.toString() )
+        assertTrue("Service sweeper for the GA Nightly Test project should be triggered at an earlier hour than the project sweeper", cronGa.hours.toString() < cronProject.hours.toString()) // Values are strings like "11", "12"
+        assertTrue("Service sweeper for the Beta Nightly Test project should be triggered at an earlier hour than the project sweeper", cronBeta.hours.toString() < cronProject.hours.toString() )
     }
 }

--- a/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
@@ -21,10 +21,10 @@ import projects.googleCloudRootProject
 class SweeperTests {
     @Test
     fun projectSweeperDoesNotSkipProjectSweep() {
-        val project = googleCloudRootProject(testContextParameters())
+        val root = googleCloudRootProject(testContextParameters())
 
         // Find Project sweeper project
-        val projectSweeperProject = getSubProject(project, projectSweeperProjectName)
+        val projectSweeperProject = getSubProject(root, projectSweeperProjectName)
 
         // For the project sweeper to be skipped, SKIP_PROJECT_SWEEPER needs a value
         // See https://github.com/GoogleCloudPlatform/magic-modules/blob/501429790939717ca6dce76dbf4b1b82aef4e9d9/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_sweeper.go#L18-L26
@@ -37,17 +37,17 @@ class SweeperTests {
 
     @Test
     fun serviceSweepersSkipProjectSweeper() {
-        val project = googleCloudRootProject(testContextParameters())
+        val root = googleCloudRootProject(testContextParameters())
 
         // Find GA nightly test project
-        val gaNightlyTestProject = getNestedProjectFromRoot(project, gaProjectName, nightlyTestsProjectName)
+        val gaNightlyTestProject = getNestedProjectFromRoot(root, gaProjectName, nightlyTestsProjectName)
         // Find GA MM Upstream project
-        val gaMmUpstreamProject = getNestedProjectFromRoot(project, gaProjectName, mmUpstreamProjectName)
+        val gaMmUpstreamProject = getNestedProjectFromRoot(root, gaProjectName, mmUpstreamProjectName)
 
         // Find Beta nightly test project
-        val betaNightlyTestProject = getNestedProjectFromRoot(project, betaProjectName, nightlyTestsProjectName)
+        val betaNightlyTestProject = getNestedProjectFromRoot(root, betaProjectName, nightlyTestsProjectName)
         // Find Beta MM Upstream project
-        val betaMmUpstreamProject = getNestedProjectFromRoot(project, betaProjectName, mmUpstreamProjectName)
+        val betaMmUpstreamProject = getNestedProjectFromRoot(root, betaProjectName, mmUpstreamProjectName)
 
         val allProjects: ArrayList<Project> = arrayListOf(gaNightlyTestProject, gaMmUpstreamProject, betaNightlyTestProject, betaMmUpstreamProject)
         allProjects.forEach{ project ->
@@ -64,10 +64,10 @@ class SweeperTests {
 
     @Test
     fun gaNightlyProjectServiceSweeperRunsInGoogle() {
-        val project = googleCloudRootProject(testContextParameters())
+        val root = googleCloudRootProject(testContextParameters())
 
         // Find GA nightly test project
-        val gaNightlyTestProject = getNestedProjectFromRoot(project, gaProjectName, nightlyTestsProjectName)
+        val gaNightlyTestProject = getNestedProjectFromRoot(root, gaProjectName, nightlyTestsProjectName)
 
         // Find sweeper inside
         val sweeper = getBuildFromProject(gaNightlyTestProject, ServiceSweeperName)
@@ -79,10 +79,10 @@ class SweeperTests {
 
     @Test
     fun betaNightlyProjectServiceSweeperRunsInGoogleBeta() {
-        val project = googleCloudRootProject(testContextParameters())
+        val root = googleCloudRootProject(testContextParameters())
 
         // Find Beta nightly test project
-        val betaNightlyTestProject = getNestedProjectFromRoot(project, betaProjectName, nightlyTestsProjectName)
+        val betaNightlyTestProject = getNestedProjectFromRoot(root, betaProjectName, nightlyTestsProjectName)
 
         // Find sweeper inside
         val sweeper: BuildType = getBuildFromProject(betaNightlyTestProject, ServiceSweeperName)

--- a/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
@@ -94,21 +94,18 @@ class SweeperTests {
 
     @Test
     fun projectSweepersRunAfterServiceSweepers() {
-        val project = googleCloudRootProject(testContextParameters())
+        val root = googleCloudRootProject(testContextParameters())
 
         // Find GA nightly test project's service sweeper
-        val gaNightlyTests: Project = getSubProject(project, gaProjectName, nightlyTestsProjectName)
+        val gaNightlyTests: Project = getNestedProjectFromRoot(root, gaProjectName, nightlyTestsProjectName)
         val sweeperGa: BuildType = getBuildFromProject(gaNightlyTests, ServiceSweeperName)
 
         // Find Beta nightly test project's service sweeper
-        val betaNightlyTests : Project = getSubProject(project, betaProjectName, nightlyTestsProjectName)
+        val betaNightlyTests : Project = getNestedProjectFromRoot(root, betaProjectName, nightlyTestsProjectName)
         val sweeperBeta: BuildType = getBuildFromProject(betaNightlyTests, ServiceSweeperName)
 
         // Find Project sweeper project's build
-        val projectSweeperProject : Project? =  project.subProjects.find { p->  p.name == projectSweeperProjectName}
-        if (projectSweeperProject == null) {
-            Assert.fail("Could not find the Project Sweeper project")
-        }
+        val projectSweeperProject = getSubProject(root, projectSweeperProjectName)
         val projectSweeper: BuildType = getBuildFromProject(projectSweeperProject!!, ProjectSweeperName)
         
         // Check only one schedule trigger is on the builds in question

--- a/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
@@ -31,7 +31,7 @@ class SweeperTests {
 
         projectSweeperProject.buildTypes.forEach{bt ->
             val value = bt.params.findRawParam("env.SKIP_PROJECT_SWEEPER")!!.value
-            assertTrue("env.SKIP_PROJECT_SWEEPER is set to an empty value, so project sweepers are NOT skipped. Value = `${value}` ", value == "")
+            assertTrue("env.SKIP_PROJECT_SWEEPER should be set to an empty value, so project sweepers are NOT skipped in the ${projectSweeperProject.name} project. Value = `${value}` ", value == "")
         }
     }
 
@@ -58,7 +58,7 @@ class SweeperTests {
             // See https://github.com/GoogleCloudPlatform/magic-modules/blob/501429790939717ca6dce76dbf4b1b82aef4e9d9/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_sweeper.go#L18-L26
 
             val value = sweeper.params.findRawParam("env.SKIP_PROJECT_SWEEPER")!!.value
-            assertTrue("env.SKIP_PROJECT_SWEEPER is set to a non-empty string in the sweeper build in the ${project.name} project. This means project sweepers are skipped. Value = `${value}` ", value != "")
+            assertTrue("env.SKIP_PROJECT_SWEEPER should be set to a non-empty string so project sweepers are skipped in the ${project.name} project. Value = `${value}` ", value != "")
         }
     }
 

--- a/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
@@ -10,12 +10,11 @@ package tests
 import ProjectSweeperName
 import ServiceSweeperName
 import jetbrains.buildServer.configs.kotlin.BuildType
+import jetbrains.buildServer.configs.kotlin.Project
+import jetbrains.buildServer.configs.kotlin.triggers.ScheduleTrigger
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import jetbrains.buildServer.configs.kotlin.Project
-import jetbrains.buildServer.configs.kotlin.triggers.ScheduleTrigger
-import org.junit.Assert
 import projects.googleCloudRootProject
 
 class SweeperTests {

--- a/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
@@ -24,15 +24,12 @@ class SweeperTests {
         val project = googleCloudRootProject(testContextParameters())
 
         // Find Project sweeper project
-        val projectSweeperProject: Project? =  project.subProjects.find { p->  p.name == projectSweeperProjectName}
-        if (projectSweeperProject == null) {
-            Assert.fail("Could not find the Project Sweeper project")
-        }
+        val projectSweeperProject = getSubProject(project, projectSweeperProjectName)
 
         // For the project sweeper to be skipped, SKIP_PROJECT_SWEEPER needs a value
         // See https://github.com/GoogleCloudPlatform/magic-modules/blob/501429790939717ca6dce76dbf4b1b82aef4e9d9/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_sweeper.go#L18-L26
 
-        projectSweeperProject!!.buildTypes.forEach{bt ->
+        projectSweeperProject.buildTypes.forEach{bt ->
             val value = bt.params.findRawParam("env.SKIP_PROJECT_SWEEPER")!!.value
             assertTrue("env.SKIP_PROJECT_SWEEPER is set to an empty value, so project sweepers are NOT skipped. Value = `${value}` ", value == "")
         }
@@ -43,27 +40,24 @@ class SweeperTests {
         val project = googleCloudRootProject(testContextParameters())
 
         // Find GA nightly test project
-        val gaNightlyTestProject = getSubProject(project, gaProjectName, nightlyTestsProjectName)
+        val gaNightlyTestProject = getNestedProjectFromRoot(project, gaProjectName, nightlyTestsProjectName)
         // Find GA MM Upstream project
-        val gaMmUpstreamProject = getSubProject(project, gaProjectName, mmUpstreamProjectName)
+        val gaMmUpstreamProject = getNestedProjectFromRoot(project, gaProjectName, mmUpstreamProjectName)
 
         // Find Beta nightly test project
-        val betaNightlyTestProject = getSubProject(project, betaProjectName, nightlyTestsProjectName)
+        val betaNightlyTestProject = getNestedProjectFromRoot(project, betaProjectName, nightlyTestsProjectName)
         // Find Beta MM Upstream project
-        val betaMmUpstreamProject = getSubProject(project, betaProjectName, mmUpstreamProjectName)
+        val betaMmUpstreamProject = getNestedProjectFromRoot(project, betaProjectName, mmUpstreamProjectName)
 
         val allProjects: ArrayList<Project> = arrayListOf(gaNightlyTestProject, gaMmUpstreamProject, betaNightlyTestProject, betaMmUpstreamProject)
         allProjects.forEach{ project ->
             // Find sweeper inside
-            val sweeper: BuildType? = project.buildTypes.find { p-> p.name == ServiceSweeperName}
-            if (sweeper == null) {
-                Assert.fail("Could not find the sweeper build in the ${project.name} project")
-            }
+            val sweeper = getBuildFromProject(project, ServiceSweeperName)
 
             // For the project sweeper to be skipped, SKIP_PROJECT_SWEEPER needs a value
             // See https://github.com/GoogleCloudPlatform/magic-modules/blob/501429790939717ca6dce76dbf4b1b82aef4e9d9/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_sweeper.go#L18-L26
 
-            val value = sweeper!!.params.findRawParam("env.SKIP_PROJECT_SWEEPER")!!.value
+            val value = sweeper.params.findRawParam("env.SKIP_PROJECT_SWEEPER")!!.value
             assertTrue("env.SKIP_PROJECT_SWEEPER is set to a non-empty string in the sweeper build in the ${project.name} project. This means project sweepers are skipped. Value = `${value}` ", value != "")
         }
     }
@@ -73,17 +67,13 @@ class SweeperTests {
         val project = googleCloudRootProject(testContextParameters())
 
         // Find GA nightly test project
-        val gaNightlyTestProject = getSubProject(project, gaProjectName, nightlyTestsProjectName)
-
+        val gaNightlyTestProject = getNestedProjectFromRoot(project, gaProjectName, nightlyTestsProjectName)
 
         // Find sweeper inside
-        val sweeper: BuildType? = gaNightlyTestProject!!.buildTypes.find { p-> p.name == ServiceSweeperName}
-        if (sweeper == null) {
-            Assert.fail("Could not find the sweeper build in the Google (GA) Nightly Test project")
-        }
+        val sweeper = getBuildFromProject(gaNightlyTestProject, ServiceSweeperName)
 
         // Check PACKAGE_PATH is in google (not google-beta)
-        val value = sweeper!!.params.findRawParam("PACKAGE_PATH")!!.value
+        val value = sweeper.params.findRawParam("PACKAGE_PATH")!!.value
         assertEquals("./google/sweeper", value)
     }
 
@@ -92,16 +82,13 @@ class SweeperTests {
         val project = googleCloudRootProject(testContextParameters())
 
         // Find Beta nightly test project
-        val betaNightlyTestProject = getSubProject(project, betaProjectName, nightlyTestsProjectName)
+        val betaNightlyTestProject = getNestedProjectFromRoot(project, betaProjectName, nightlyTestsProjectName)
 
         // Find sweeper inside
-        val sweeper: BuildType? = betaNightlyTestProject!!.buildTypes.find { p-> p.name == ServiceSweeperName}
-        if (sweeper == null) {
-            Assert.fail("Could not find the sweeper build in the Google (GA) Nightly Test project")
-        }
+        val sweeper: BuildType = getBuildFromProject(betaNightlyTestProject, ServiceSweeperName)
 
         // Check PACKAGE_PATH is in google-beta
-        val value = sweeper!!.params.findRawParam("PACKAGE_PATH")!!.value
+        val value = sweeper.params.findRawParam("PACKAGE_PATH")!!.value
         assertEquals("./google-beta/sweeper", value)
     }
 

--- a/mmv1/third_party/terraform/.teamcity/tests/test_utils.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/test_utils.kt
@@ -8,10 +8,9 @@
 package tests
 
 import builds.AllContextParameters
-import jetbrains.buildServer.BuildProject
 import jetbrains.buildServer.configs.kotlin.BuildType
 import jetbrains.buildServer.configs.kotlin.Project
-import org.junit.Assert
+import org.junit.Assert.fail
 
 const val gaProjectName = "Google"
 const val betaProjectName = "Google Beta"
@@ -54,26 +53,31 @@ fun testContextParameters(): AllContextParameters {
         "credentialsGCS")
 }
 
-fun getSubProject(rootProject: Project, parentProjectName: String, subProjectName: String): Project {
+// getNestedProjectFromRoot allows you to retrieve a project that's 2 levels deep from the root project,
+// Using the names of the parent and desired project.
+// E.g. Root > Project A > Project B - you need to supply the inputs "Project A" and "Project B"
+fun getNestedProjectFromRoot(root: Project, parentName: String, nestedProjectName: String): Project {
     // Find parent project within root
-    val parentProject: Project? =  rootProject.subProjects.find { p->  p.name == parentProjectName}
-    if (parentProject == null) {
-        Assert.fail("Could not find the $parentProjectName project")
-    }
+    val parent: Project = getSubProject(root, parentName)
     // Find subproject within parent identified above
-    val subProject: Project?  = parentProject!!.subProjects.find { p->  p.name == subProjectName}
-    if (subProject == null) {
-        Assert.fail("Could not find the $subProjectName project")
-    }
+    return getSubProject(parent, nestedProjectName)
+}
 
+// getSubProject allows you to retrieve a project nested inside a given project you've already identified,
+// using its name.
+fun getSubProject(parent: Project, subProjectName: String): Project {
+    val subProject: Project? =  parent.subProjects.find { p->  p.name == subProjectName}
+    if (subProject == null) {
+        fail("Could not find the $subProjectName project inside ${parent.name}")
+    }
     return subProject!!
 }
 
+// getBuildFromProject allows you to retrieve a build configuration from an identified project using its name
 fun getBuildFromProject(parentProject: Project, buildName: String): BuildType {
-    val buildType: BuildType?  = parentProject!!.buildTypes.find { p->  p.name == buildName}
+    val buildType: BuildType?  = parentProject.buildTypes.find { p->  p.name == buildName}
     if (buildType == null) {
-        Assert.fail("Could not find the '$buildName' build in project ${parentProject.name}")
+        fail("Could not find the '$buildName' build in project ${parentProject.name}")
     }
-
     return buildType!!
 }

--- a/mmv1/third_party/terraform/.teamcity/tests/vcs_roots.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/vcs_roots.kt
@@ -7,7 +7,6 @@
 
 package tests
 
-import jetbrains.buildServer.configs.kotlin.Project
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import projects.googleCloudRootProject

--- a/mmv1/third_party/terraform/.teamcity/tests/vcs_roots.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/vcs_roots.kt
@@ -7,6 +7,7 @@
 
 package tests
 
+import jetbrains.buildServer.configs.kotlin.Project
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import projects.googleCloudRootProject
@@ -15,8 +16,22 @@ class VcsTests {
     @Test
     fun buildsHaveCleanCheckOut() {
         val project = googleCloudRootProject(testContextParameters())
-        project.buildTypes.forEach { bt ->
-            assertTrue("Build '${bt.id}' doesn't use clean checkout", bt.vcs.cleanCheckout)
+
+        val gaProject = getSubProject(project, gaProjectName)
+        val betaProject = getSubProject(project, betaProjectName)
+        val projectSweeperProject = getSubProject(project, betaProjectName)
+
+        val allProjects = arrayListOf(gaProject, betaProject, projectSweeperProject)
+
+        allProjects.forEach { p ->
+            p.subProjects.forEach { sp->
+                // Test is created on assumption of project structure having max 2 layers of nested project (Root > Project A > Project B)
+                assertTrue("TeamCity configuration is nested deeper than this test checks; test should be rewritten", sp.subProjects.size == 0)
+
+                sp.buildTypes.forEach{ bt ->
+                    assertTrue("Build '${bt.id}' should use clean checkout", bt.vcs.cleanCheckout)
+                }
+            }
         }
     }
 }

--- a/mmv1/third_party/terraform/.teamcity/tests/vcs_roots.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/vcs_roots.kt
@@ -15,11 +15,11 @@ import projects.googleCloudRootProject
 class VcsTests {
     @Test
     fun buildsHaveCleanCheckOut() {
-        val project = googleCloudRootProject(testContextParameters())
+        val root = googleCloudRootProject(testContextParameters())
 
-        val gaProject = getSubProject(project, gaProjectName)
-        val betaProject = getSubProject(project, betaProjectName)
-        val projectSweeperProject = getSubProject(project, betaProjectName)
+        val gaProject = getSubProject(root, gaProjectName)
+        val betaProject = getSubProject(root, betaProjectName)
+        val projectSweeperProject = getSubProject(root, betaProjectName)
 
         val allProjects = arrayListOf(gaProject, betaProject, projectSweeperProject)
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR:
- updates the test utils used in the tests for the TeamCity config code.
- changes error messages to be framed the correct way

**Test utils:** 

Previously there was a `getSubProject` function that would retrieve a project that was nested 2 levels deep from a starting project. It was always given the root of the TeamCity project and was used to pull out projects from within the Google or Google Beta projects.

Now, `getSubProject` does something more logical given its name. You supply a `Project` and the name of a subproject within it, and it'll return a `Project` object for that subproject. This can be used to make assertions on, etc.

The original functionality of retrieving a project from 2 levels of nesting is now fulfilled by `getNestedProjectFromRoot`, which uses getSubProject internally.

This PR refactors existing acceptance tests to use the new test utils.

**Error message framing**

Messages needed to be rewritten to be pointing out why a given test would fail.

---

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
