### PR TITLE
docs: Correct google_firestore_backup_schedule recurrence descriptions

### DIFF
--- a/mmv1/products/firestore/BackupSchedule.yaml
+++ b/mmv1/products/firestore/BackupSchedule.yaml
@@ -86,7 +86,7 @@ properties:
   - !ruby/object:Api::Type::NestedObject
     name: dailyRecurrence
     description: |
-      For a schedule that runs daily at a specified time.
+      For a schedule that runs daily.
     exactly_one_of:
       - daily_recurrence
       - weekly_recurrence
@@ -97,7 +97,7 @@ properties:
   - !ruby/object:Api::Type::NestedObject
     name: weeklyRecurrence
     description: |
-      For a schedule that runs weekly on a specific day and time.
+      For a schedule that runs weekly on a specific day.
     immutable: true
     exactly_one_of:
       - weekly_recurrence


### PR DESCRIPTION
There was some inaccurate documentation for `google_firestore_backup_schedule`

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
