### PR TITLE
Set default values for object fields when paring Go yaml files

### DIFF
--- a/mmv1/api/async.go
+++ b/mmv1/api/async.go
@@ -17,9 +17,6 @@ import (
 	"github.com/GoogleCloudPlatform/magic-modules/mmv1/google"
 )
 
-// require 'api/object'
-// require 'api/timeout'
-
 // Base class from which other Async classes can inherit.
 type Async struct {
 	// Embed YamlValidator object
@@ -95,6 +92,13 @@ type OpAsync struct {
 	Actions []string
 }
 
+func NewOpAsync() *OpAsync {
+	oa := new(OpAsync)
+	oa.Operation = NewOpAsyncOperation()
+	oa.Actions = []string{"create", "delete", "update"}
+	return oa
+}
+
 // def initialize(operation, result, status, error)
 //   super()
 //   @operation = operation
@@ -134,12 +138,12 @@ type OpAsyncOperation struct {
 }
 
 // def initialize(path, base_url, wait_ms, timeouts)
-//   super()
-//   @path = path
-//   @base_url = base_url
-//   @wait_ms = wait_ms
-//   @timeouts = timeouts
-// end
+func NewOpAsyncOperation() *OpAsyncOperation {
+	//   super()
+	op := new(OpAsyncOperation)
+	op.Timeouts = NewTimeouts()
+	return op
+}
 
 // def validate
 //   super

--- a/mmv1/api/compiler.go
+++ b/mmv1/api/compiler.go
@@ -1,0 +1,31 @@
+// Copyright 2024 Google Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"log"
+	"os"
+
+	"github.com/GoogleCloudPlatform/magic-modules/mmv1/google"
+)
+
+func Compile(yamlPath string, obj interface{}) {
+	objYaml, err := os.ReadFile(yamlPath)
+	if err != nil {
+		log.Fatalf("Cannot open the file: %v", objYaml)
+	}
+
+	yamlValidator := google.YamlValidator{}
+	yamlValidator.Parse(objYaml, obj)
+}

--- a/mmv1/api/product.go
+++ b/mmv1/api/product.go
@@ -17,16 +17,12 @@ import (
 	"log"
 	"strings"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/GoogleCloudPlatform/magic-modules/mmv1/api/product"
 	"github.com/GoogleCloudPlatform/magic-modules/mmv1/google"
 	"golang.org/x/exp/slices"
 )
-
-// require 'api/object'
-// require 'api/product/version'
-// require 'google/logger'
-// require 'compile/core'
-// require 'json'
 
 // Represents a product to be managed
 type Product struct {
@@ -74,15 +70,29 @@ type Product struct {
 	ClientName string `yaml:"client_name"`
 }
 
-func (p *Product) Validate() {
-	// TODO Q1 Rewrite super
-	//     super
-	for _, o := range p.Objects {
-		o.ProductMetadata = p
+func (p *Product) UnmarshalYAML(n *yaml.Node) error {
+	p.Async = NewOpAsync()
+
+	type productAlias Product
+	aliasObj := (*productAlias)(p)
+
+	err := n.Decode(&aliasObj)
+	if err != nil {
+		return err
 	}
 
 	p.SetApiName()
 	p.SetDisplayName()
+
+	return nil
+}
+
+func (p *Product) Validate() {
+	// TODO Q2 Rewrite super
+	//     super
+	for _, o := range p.Objects {
+		o.ProductMetadata = p
+	}
 }
 
 // def validate

--- a/mmv1/api/resource/custom_code.go
+++ b/mmv1/api/resource/custom_code.go
@@ -11,20 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package terraform
-
-import (
-	"github.com/GoogleCloudPlatform/magic-modules/mmv1/google"
-)
-
-// require 'uri'
-// require 'api/object'
-// require 'compile/core'
-// require 'google/golang_utils'
+package resource
 
 // Inserts custom code into terraform resources.
 type CustomCode struct {
-	google.YamlValidator
+	// google.YamlValidator
 
 	// Collection of fields allowed in the CustomCode section for
 	// Terraform.
@@ -39,9 +30,7 @@ type CustomCode struct {
 	// Extra Schema Entries go below all other schema entries in the
 	// resource's Resource.Schema map.  They should be formatted as
 	// entries in the map, e.g. `"foo": &schema.Schema{ ... },`.
-
-	// attr_reader :
-	ExtraSchemaEntry string
+	ExtraSchemaEntry string `yaml:"extra_schema_entry"`
 
 	// ====================
 	// Encoders & Decoders
@@ -54,8 +43,6 @@ type CustomCode struct {
 	// Because the call signature of this function cannot be changed,
 	// the template will place the function header and closing } for
 	// you, and your custom code template should *not* include them.
-
-	// attr_reader :
 	Encoder string
 
 	// The update encoder is the encoder used in Update - if one is
@@ -65,16 +52,12 @@ type CustomCode struct {
 	// Update encoders are only used if object.input is false,
 	// because when object.input is true, only individual fields
 	// can be updated - in that case, use a custom expander.
-
-	// attr_reader :
-	UpdateEncoder string
+	UpdateEncoder string `yaml:"update_encoder"`
 
 	// The decoder is the opposite of the encoder - it's called
 	// after the Read succeeds, rather than before Create / Update
 	// are called.  Like with encoders, the decoder should not
 	// include the function header or closing }.
-
-	// attr_reader :
 	Decoder string
 
 	// =====================
@@ -84,104 +67,74 @@ type CustomCode struct {
 	// things like methods that will be referred to by name elsewhere
 	// (e.g. "fooBarDiffSuppress") and regexes that are necessarily
 	// exported (e.g. "fooBarValidationRegex").
-
-	// attr_reader :
 	Constants string
 
 	// This code is run before the Create call happens.  It's placed
 	// in the Create function, just before the Create call is made.
-
-	// attr_reader :
-	PreCreate string
+	PreCreate string `yaml:"pre_create"`
 
 	// This code is run after the Create call succeeds.  It's placed
 	// in the Create function directly without modification.
-
-	// attr_reader :
-	PostCreate string
+	PostCreate string `yaml:"post_create"`
 
 	// This code is run after the Create call fails before the error is
 	// returned. It's placed in the Create function directly without
 	// modification.
-
-	// attr_reader :
-	PostCreateFailure string
+	PostCreateFailure string `yaml:"post_create_failure"`
 
 	// This code replaces the entire contents of the Create call. It
 	// should be used for resources that don't have normal creation
 	// semantics that cannot be supported well by other MM features.
-
-	// attr_reader :
-	CustomCreate string
+	CustomCreate string `yaml:"custom_create"`
 
 	// This code is run before the Read call happens.  It's placed
 	// in the Read function.
-
-	// attr_reader :
-	PreRead string
+	PreRead string `yaml:"pre_read"`
 
 	// This code is run before the Update call happens.  It's placed
 	// in the Update function, just after the encoder call, before
 	// the Update call.  Just like the encoder, it is only used if
 	// object.input is false.
-
-	// attr_reader :
-	PreUpdate string
+	PreUpdate string `yaml:"pre_update"`
 
 	// This code is run after the Update call happens.  It's placed
 	// in the Update function, just after the call succeeds.
 	// Just like the encoder, it is only used if object.input is
 	// false.
-
-	// attr_reader :
-	PostUpdate string
+	PostUpdate string `yaml:"post_update"`
 
 	// This code replaces the entire contents of the Update call. It
 	// should be used for resources that don't have normal update
 	// semantics that cannot be supported well by other MM features.
-
-	// attr_reader :
-	CustomUpdate string
+	CustomUpdate string `yaml:"custom_update"`
 
 	// This code is run just before the Delete call happens.  It's
 	// useful to prepare an object for deletion, e.g. by detaching
 	// a disk before deleting it.
-
-	// attr_reader :
-	PreDelete string
+	PreDelete string `yaml:"pre_delete"`
 
 	// This code is run just after the Delete call happens.
-
-	// attr_reader :
-	PostDelete string
+	PostDelete string `yaml:"post_delete"`
 
 	// This code replaces the entire delete method.  Since the delete
 	// method's function header can't be changed, the template
 	// inserts that for you - do not include it in your custom code.
-
-	// attr_reader :
-	CustomDelete string
+	CustomDelete string `yaml:"custom_delete"`
 
 	// This code replaces the entire import method.  Since the import
 	// method's function header can't be changed, the template
 	// inserts that for you - do not include it in your custom code.
-
-	// attr_reader :
-	CustomImport string
+	CustomImport string `yaml:"custom_import"`
 
 	// This code is run just after the import method succeeds - it
 	// is useful for parsing attributes that are necessary for
 	// the Read() method to succeed.
-
-	// attr_reader :
-	PostImport string
+	PostImport string `yaml:"post_import"`
 
 	// This code is run in the generated test file to check that the
 	// resource was successfully deleted. Use this if the API responds
 	// with a success HTTP code for deleted resources
-
-	// attr_reader :
-	TestCheckDestroy string
+	TestCheckDestroy string `yaml:"test_check_destroy"`
 }
 
 // def validate

--- a/mmv1/api/resource/docs.go
+++ b/mmv1/api/resource/docs.go
@@ -11,20 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package terraform
-
-import (
-	"github.com/GoogleCloudPlatform/magic-modules/mmv1/google"
-)
-
-// require 'uri'
-// require 'api/object'
-// require 'compile/core'
-// require 'google/golang_utils'
+package resource
 
 // Inserts custom strings into terraform resource docs.
 type Docs struct {
-	google.YamlValidator
+	// google.YamlValidator
 
 	// All these values should be strings, which will be inserted
 	// directly into the terraform resource documentation.  The

--- a/mmv1/api/resource/iam_policy.go
+++ b/mmv1/api/resource/iam_policy.go
@@ -14,7 +14,7 @@
 package resource
 
 import (
-	"github.com/GoogleCloudPlatform/magic-modules/mmv1/google"
+	"gopkg.in/yaml.v3"
 )
 
 // Information about the IAM policy for this resource
@@ -22,145 +22,122 @@ import (
 // and accessed via their parent resource
 // See: https://cloud.google.com/iam/docs/overview
 type IamPolicy struct {
-	google.YamlValidator
+	// google.YamlValidator
 
 	// boolean of if this binding should be generated
-
-	// attr_reader
 	Exclude bool
 
 	// boolean of if this binding should be generated
-
-	// attr_reader
-	ExcludeTgc bool
+	ExcludeTgc bool `yaml:"exclude_tgc"`
 
 	// Boolean of if tests for IAM resources should exclude import test steps
 	// Used to handle situations where typical generated IAM tests cannot import
 	// due to the parent resource having an API-generated id
-
-	// attr_reader
-	SkipImportTest bool
+	SkipImportTest bool `yaml:"skip_import_test"`
 
 	// Character that separates resource identifier from method call in URL
 	// For example, PubSub subscription uses {resource}:getIamPolicy
 	// While Compute subnetwork uses {resource}/getIamPolicy
-
-	// attr_reader
-	MethodNameSeparator string
+	MethodNameSeparator string `yaml:"method_name_separator"`
 
 	// The terraform type of the parent resource if it is not the same as the
 	// IAM resource. The IAP product needs these as its IAM policies refer
 	// to compute resources
-
-	// attr_reader
-	ParentResourceType string
+	ParentResourceType string `yaml:"parent_resource_type"`
 
 	// Some resources allow retrieving the IAM policy with GET requests,
 	// others expect POST requests
-
-	// attr_reader
-	FetchIamPolicyVerb string
+	FetchIamPolicyVerb string `yaml:"fetch_iam_policy_verb"`
 
 	// Last part of URL for fetching IAM policy.
-
-	// attr_reader
-	FetchIamPolicyMethod string
+	FetchIamPolicyMethod string `yaml:"fetch_iam_policy_method"`
 
 	// Some resources allow setting the IAM policy with POST requests,
 	// others expect PUT requests
-
-	// attr_reader
-	SetIamPolicyVerb string
+	SetIamPolicyVerb string `yaml:"set_iam_policy_verb"`
 
 	// Last part of URL for setting IAM policy.
-
-	// attr_reader
-	SetIamPolicyMethod string
+	SetIamPolicyMethod string `yaml:"set_iam_policy_method"`
 
 	// Whether the policy JSON is contained inside of a 'policy' object.
-
-	// attr_reader
-	WrappedPolicyObj bool
+	WrappedPolicyObj bool `yaml:"wrapped_policy_obj"`
 
 	// Certain resources allow different sets of roles to be set with IAM policies
 	// This is a role that is acceptable for the given IAM policy resource for use in tests
-
-	// attr_reader
-	AllowedIamRole string
+	AllowedIamRole string `yaml:"allowed_iam_role"`
 
 	// This is a role that grants create/read/delete for the parent resource for use in tests.
 	// If set, the test runner will receive a binding to this role in _policy tests in order to
 	// avoid getting locked out of the resource.
-
-	// attr_reader
-	AdminIamRole string
+	AdminIamRole string `yaml:"admin_iam_role"`
 
 	// Certain resources need an attribute other than "id" from their parent resource
 	// Especially when a parent is not the same type as the IAM resource
-
-	// attr_reader
-	ParentResourceAttribute string
+	ParentResourceAttribute string `yaml:"parent_resource_attribute"`
 
 	// If the IAM resource test needs a new project to be created, this is the name of the project
-
-	// attr_reader
-	TestProjectName string
+	TestProjectName string `yaml:"test_project_name"`
 
 	// Resource name may need a custom diff suppress function. Default is to use
 	// CompareSelfLinkOrResourceName
-
-	// attr_reader
-	CustomDiffSuppress *string
+	CustomDiffSuppress *string `yaml:"custom_diff_suppress"`
 
 	// Some resources (IAP) use fields named differently from the parent resource.
 	// We need to use the parent's attributes to create an IAM policy, but they may not be
 	// named as the IAM IAM resource expects.
 	// This allows us to specify a file (relative to MM root) containing a partial terraform
 	// config with the test/example attributes of the IAM resource.
-
-	// attr_reader
-	ExampleConfigBody string
+	ExampleConfigBody string `yaml:"example_config_body"`
 
 	// How the API supports IAM conditions
-
-	// attr_reader
-	IamConditionsRequestType string
+	IamConditionsRequestType string `yaml:"iam_conditions_request_type"`
 
 	// Allows us to override the base_url of the resource. This is required for Cloud Run as the
 	// IAM resources use an entirely different base URL from the actual resource
-
-	// attr_reader
-	BaseUrl string
+	BaseUrl string `yaml:"base_url"`
 
 	// Allows us to override the import format of the resource. Useful for Cloud Run where we need
 	// variables that are outside of the base_url qualifiers.
-
-	// attr_reader
-	ImportFormat []string
+	ImportFormat []string `yaml:"import_format"`
 
 	// Allows us to override the self_link of the resource. This is required for Artifact Registry
 	// to prevent breaking changes
-
-	// attr_reader
-	SelfLink string
+	SelfLink string `yaml:"self_link"`
 
 	// [Optional] Version number in the request payload.
 	// if set, it overrides the default IamPolicyVersion
-
-	// attr_reader
-	IamPolicyVersion string
+	IamPolicyVersion string `yaml:"iam_policy_version"`
 
 	// [Optional] Min version to make IAM resources available at
 	// If unset, defaults to 'ga'
-
-	// attr_reader
-	MinVersion string
+	MinVersion string `yaml:"min_version"`
 
 	// [Optional] Check to see if zone value should be replaced with GOOGLE_ZONE in iam tests
 	// Defaults to true
+	SubstituteZoneValue bool `yaml:"substitute_zone_value"`
+}
 
-	// attr_reader
-	SubstituteZoneValue bool
+func (p *IamPolicy) UnmarshalYAML(n *yaml.Node) error {
+	p.MethodNameSeparator = "/"
+	p.FetchIamPolicyVerb = "GET"
+	p.FetchIamPolicyMethod = "getIamPolicy"
+	p.SetIamPolicyVerb = "POST"
+	p.SetIamPolicyMethod = "setIamPolicy"
+	p.WrappedPolicyObj = true
+	p.AllowedIamRole = "roles/viewer"
+	p.ParentResourceAttribute = "id"
+	p.ExampleConfigBody = "templates/terraform/iam/iam_attributes.tf.erb"
+	p.SubstituteZoneValue = true
+
+	type iamPolicyAlias IamPolicy
+	aliasObj := (*iamPolicyAlias)(p)
+
+	err := n.Decode(&aliasObj)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // func (p *IamPolicy) validate() {

--- a/mmv1/api/resource/nested_query.go
+++ b/mmv1/api/resource/nested_query.go
@@ -13,24 +13,15 @@
 
 package resource
 
-import (
-	"github.com/GoogleCloudPlatform/magic-modules/mmv1/google"
-)
-
-// require 'api/object'
-// require 'google/string_utils'
-
 // Metadata for resources that are nested within a parent resource, as
 // a list of resources or single object within the parent.
 // e.g. Fine-grained resources
 type NestedQuery struct {
-	google.YamlValidator
+	// google.YamlValidator
 
 	// A list of keys to traverse in order.
 	// i.e. backendBucket --> cdnPolicy.signedUrlKeyNames
 	// should be ["cdnPolicy", "signedUrlKeyNames"]
-
-	// attr_reader :
 	Keys []string
 
 	// If true, we expect the the nested list to be
@@ -38,9 +29,7 @@ type NestedQuery struct {
 	// than a list of nested resource objects
 	// i.e. backendBucket.cdnPolicy.signedUrlKeyNames is a list of key names
 	// rather than a list of the actual key objects
-
-	// attr_reader :
-	IsListOfIds bool
+	IsListOfIds bool `yaml:"is_list_of_ids"`
 
 	// If true, the resource is created/updated/deleted by patching
 	// the parent resource and appropriate encoders/update_encoders/pre_delete
@@ -51,9 +40,7 @@ type NestedQuery struct {
 	// {
 	//  keys[-1] : list_of_objects
 	// }
-
-	// attr_reader :
-	ModifyByPatch bool
+	ModifyByPatch bool `yaml:"modify_by_patch"`
 }
 
 // def validate

--- a/mmv1/api/resource/validation.go
+++ b/mmv1/api/resource/validation.go
@@ -1,0 +1,29 @@
+// Copyright 2024 Google Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+// Support for schema ValidateFunc functionality.
+type Validation struct {
+	//Google::YamlValidator
+	// Ensures the value matches this regex
+	Regex    string
+	Function string
+}
+
+// def validate
+// super
+
+// check :regex, type: String
+// check :function, type: String
+// end

--- a/mmv1/api/resource/virtual_fields.go
+++ b/mmv1/api/resource/virtual_fields.go
@@ -1,0 +1,57 @@
+// Copyright 2017 Google Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+// Virtual fields are Terraform-only fields that control Terraform's
+// behaviour. They don't map to underlying API fields (although they
+// may map to parameters), and will require custom code to be added to
+// control them.
+//
+// Virtual fields are similar to url_param_only fields in that they create
+// a schema entry which is not read from or submitted to the API. However
+// virtual fields are meant to provide toggles for Terraform-specific behavior in a resource
+// (eg: delete_contents_on_destroy) whereas url_param_only fields _should_
+// be used for url construction.
+//
+// Both are resource level fields and do not make sense, and are also not
+// supported, for nested fields. Nested fields that shouldn't be included
+// in API payloads are better handled with custom expand/encoder logic.
+type VirtualFields struct {
+	//< Google::YamlValidator
+
+	// The name of the field in lower snake case.
+	Name string
+
+	// The description / docs for the field.
+	Description string
+
+	// The API type of the field (defaults to boolean)
+	Type string
+
+	// The default value for the field (defaults to false)
+	DefaultValue bool `yaml:"default_value"`
+
+	// If set to true, changes in the field's value require recreating the
+	// resource.
+	Immutable bool
+}
+
+// def validate
+//   super
+//   check :name, type: String, required: true
+//   check :description, type: String, required: true
+//   check :type, type: Class, default: Api::Type::Boolean
+//   check :default_value, default: false
+//   check :immutable, default: false
+// end

--- a/mmv1/api/timeouts.go
+++ b/mmv1/api/timeouts.go
@@ -17,8 +17,6 @@ import (
 	"github.com/GoogleCloudPlatform/magic-modules/mmv1/google"
 )
 
-// require 'api/object'
-
 // Default timeout for all operation types is 20, the Terraform default (https://www.terraform.io/plugin/sdkv2/resources/retries-and-customizable-timeouts)
 // minutes. This can be overridden for each resource.
 const DEFAULT_INSERT_TIMEOUT_MINUTES = 20
@@ -28,11 +26,8 @@ const DEFAULT_DELETE_TIMEOUT_MINUTES = 20
 // Provides timeout information for the different operation types
 type Timeouts struct {
 	google.YamlValidator
-
 	InsertMinutes int `yaml:"insert_minutes"`
-
 	UpdateMinutes int `yaml:"update_minutes"`
-
 	DeleteMinutes int `yaml:"delete_minutes"`
 }
 

--- a/mmv1/go.mod
+++ b/mmv1/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
-require github.com/golang/glog v1.2.0 // indirect
+require github.com/golang/glog v1.2.0

--- a/mmv1/go.sum
+++ b/mmv1/go.sum
@@ -6,3 +6,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/mmv1/google/extensions.rb
+++ b/mmv1/google/extensions.rb
@@ -18,10 +18,6 @@ class String
     Google::StringUtils.underscore(self)
   end
 
-  def symbolize
-    Google::StringUtils.symbolize(self)
-  end
-
   def first_sentence
     Google::StringUtils.first_sentence(self)
   end

--- a/mmv1/google/string_utils.go
+++ b/mmv1/google/string_utils.go
@@ -14,6 +14,7 @@
 package google
 
 import (
+	"fmt"
 	"log"
 	"regexp"
 	"strings"
@@ -33,57 +34,77 @@ func Underscore(source string) string {
 }
 
 // Converts from PascalCase to Space Separated
-// For example, converts "AccessApproval" to "Access Approval"
+// For example, converts "AccessApproval" to "Access approval"
 func SpaceSeparated(source string) string {
 	tmp := regexp.MustCompile(`([A-Z]+)([A-Z][a-z])`).ReplaceAllString(source, "${1} ${2}")
 	tmp = regexp.MustCompile(`([a-z\d])([A-Z])`).ReplaceAllString(tmp, "${1} ${2}")
 	tmp = strings.ToLower(tmp)
-	tmp = strings.Title(tmp)
+
+	// Capitalize the first letter
+	if len(tmp) != 0 {
+		r := []rune(tmp)
+		r[0] = unicode.ToUpper(r[0])
+		tmp = string(r)
+	}
 	return tmp
 }
 
-//   // Converts a string to space-separated capitalized words
-//   def self.title(source)
-//     ss = space_separated(source)
-//     ss.gsub(/\b(?<!\w['’`()])[a-z]/, &:capitalize)
-//   end
+// // Converts a string to space-separated capitalized words
+// def self.title(source)
+func SpaceSeparatedTitle(source string) string {
+	ss := SpaceSeparated(source)
+	return strings.Title(ss)
+}
 
-//   // rubocop:disable Style/SafeNavigation // support Ruby < 2.3.0
-//   def self.symbolize(key)
-//     key.to_sym unless key.nil?
-//   end
-//   // rubocop:enable Style/SafeNavigation
+// Returns all the characters up until the period (.) or returns text
+// unchanged if there is no period.
+//
+//	def self.first_sentence(text)
+func FirstSentence(text string) string {
+	re := regexp.MustCompile(`[.?!]`)
+	periodPos := re.FindStringIndex(text)
+	if periodPos == nil {
+		return text
+	}
 
-//   // Returns all the characters up until the period (.) or returns text
-//   // unchanged if there is no period.
-//   def self.first_sentence(text)
-//     period_pos = text.index(/[.?!]/)
-//     return text if period_pos.nil?
+	return text[:periodPos[0]+1]
+}
 
-//     text[0, period_pos + 1]
-//   end
+// Returns the plural form of a word
+func Plural(source string) string {
+	// policies -> policies
+	// indices -> indices
+	if strings.HasSuffix(source, "ies") || strings.HasSuffix(source, "es") {
+		return source
+	}
 
-//   // Returns the plural form of a word
-//   def self.plural(source)
-//     // policies -> policies
-//     // indices -> indices
-//     return source if source.end_with?('ies') || source.end_with?('es')
+	// index -> indices
+	if strings.HasSuffix(source, "ex") {
+		re := regexp.MustCompile("ex$")
+		result := re.ReplaceAllString(source, "")
+		return fmt.Sprintf("%sices", result)
+	}
 
-//     // index -> indices
-//     return "//{source.gsub(/ex$/, '')}ices" if source.end_with?('ex')
+	// mesh -> meshes
+	if strings.HasSuffix(source, "esh") {
+		return fmt.Sprintf("%ses", source)
+	}
 
-//     // mesh -> meshes
-//     return "//{source}es" if source.end_with?('esh')
+	// key -> keys
+	// gateway -> gateways
+	if strings.HasSuffix(source, "ey") || strings.HasSuffix(source, "ay") {
+		return fmt.Sprintf("%ss", source)
+	}
 
-//     // key -> keys
-//     // gateway -> gateways
-//     return "//{source}s" if source.end_with?('ey') || source.end_with?('ay')
+	// policy -> policies
+	if strings.HasSuffix(source, "y") {
+		re := regexp.MustCompile("y$")
+		result := re.ReplaceAllString(source, "")
+		return fmt.Sprintf("%sies", result)
+	}
 
-//     // policy -> policies
-//     return "//{source.gsub(/y$/, '')}ies" if source.end_with?('y')
-
-//     "//{source}s"
-//   end
+	return fmt.Sprintf("%ss", source)
+}
 
 func Camelize(term string, firstLetter string) string {
 	if firstLetter != "upper" && firstLetter != "lower" {

--- a/mmv1/google/string_utils.rb
+++ b/mmv1/google/string_utils.rb
@@ -38,12 +38,6 @@ module Google
       ss.gsub(/\b(?<!\w['’`()])[a-z]/, &:capitalize)
     end
 
-    # rubocop:disable Style/SafeNavigation # support Ruby < 2.3.0
-    def self.symbolize(key)
-      key.to_sym unless key.nil?
-    end
-    # rubocop:enable Style/SafeNavigation
-
     # Returns all the characters up until the period (.) or returns text
     # unchanged if there is no period.
     def self.first_sentence(text)

--- a/mmv1/google/string_utils_test.go
+++ b/mmv1/google/string_utils_test.go
@@ -62,42 +62,42 @@ func TestStringPlural(t *testing.T) {
 		expected    string
 	}{
 		{
-			description: "Plura normal string",
+			description: "Plural normal string",
 			term:        "apple",
 			expected:    "apples",
 		},
 		{
-			description: "Plura string ending with ies",
+			description: "Plural string ending with ies",
 			term:        "policies",
 			expected:    "policies",
 		},
 		{
-			description: "Plura snakecase string ending with es",
+			description: "Plural snakecase string ending with es",
 			term:        "indices",
 			expected:    "indices",
 		},
 		{
-			description: "Plura snakecase string ending with ex",
+			description: "Plural snakecase string ending with ex",
 			term:        "index",
 			expected:    "indices",
 		},
 		{
-			description: "Plura snakecase string ending with esh",
+			description: "Plural snakecase string ending with esh",
 			term:        "mesh",
 			expected:    "meshes",
 		},
 		{
-			description: "Plura snakecase string ending with y",
+			description: "Plural snakecase string ending with y",
 			term:        "policy",
 			expected:    "policies",
 		},
 		{
-			description: "Plura snakecase string ending with ey",
+			description: "Plural snakecase string ending with ey",
 			term:        "key",
 			expected:    "keys",
 		},
 		{
-			description: "Plura snakecase string ending with ay",
+			description: "Plural snakecase string ending with ay",
 			term:        "gateway",
 			expected:    "gateways",
 		},

--- a/mmv1/google/string_utils_test.go
+++ b/mmv1/google/string_utils_test.go
@@ -52,3 +52,109 @@ func TestStringCamelize(t *testing.T) {
 		})
 	}
 }
+
+func TestStringPlural(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		description string
+		term        string
+		expected    string
+	}{
+		{
+			description: "Plura normal string",
+			term:        "apple",
+			expected:    "apples",
+		},
+		{
+			description: "Plura string ending with ies",
+			term:        "policies",
+			expected:    "policies",
+		},
+		{
+			description: "Plura snakecase string ending with es",
+			term:        "indices",
+			expected:    "indices",
+		},
+		{
+			description: "Plura snakecase string ending with ex",
+			term:        "index",
+			expected:    "indices",
+		},
+		{
+			description: "Plura snakecase string ending with esh",
+			term:        "mesh",
+			expected:    "meshes",
+		},
+		{
+			description: "Plura snakecase string ending with y",
+			term:        "policy",
+			expected:    "policies",
+		},
+		{
+			description: "Plura snakecase string ending with ey",
+			term:        "key",
+			expected:    "keys",
+		},
+		{
+			description: "Plura snakecase string ending with ay",
+			term:        "gateway",
+			expected:    "gateways",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+
+			if got, want := Plural(tc.term), tc.expected; !reflect.DeepEqual(got, want) {
+				t.Errorf("expected %v to be %v", got, want)
+			}
+		})
+	}
+}
+
+func TestStringFirstSentence(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		description string
+		term        string
+		expected    string
+	}{
+		{
+			description: "sentence end with period",
+			term:        "Lorem ipsum. Dolor sit amet. Elit",
+			expected:    "Lorem ipsum.",
+		},
+		{
+			description: "sentence end with question mark",
+			term:        "Lorem ipsum? Dolor sit amet. Elit",
+			expected:    "Lorem ipsum?",
+		},
+		{
+			description: "sentence end with exclamation mark",
+			term:        "Lorem ipsum! Dolor sit amet. Elit",
+			expected:    "Lorem ipsum!",
+		},
+		{
+			description: "no period returns full string",
+			term:        "Lorem ipsum dolor",
+			expected:    "Lorem ipsum dolor",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+
+			if got, want := FirstSentence(tc.term), tc.expected; !reflect.DeepEqual(got, want) {
+				t.Errorf("expected %v to be %v", got, want)
+			}
+		})
+	}
+}

--- a/mmv1/google/yaml_validator.go
+++ b/mmv1/google/yaml_validator.go
@@ -16,7 +16,7 @@ package google
 import (
 	"log"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // A helper class to validate contents coming from YAML files.

--- a/mmv1/main.go
+++ b/mmv1/main.go
@@ -13,7 +13,6 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/GoogleCloudPlatform/magic-modules/mmv1/api"
-	"github.com/GoogleCloudPlatform/magic-modules/mmv1/google"
 	"github.com/GoogleCloudPlatform/magic-modules/mmv1/provider"
 )
 
@@ -81,8 +80,6 @@ func main() {
 		return false
 	})
 
-	yamlValidator := google.YamlValidator{}
-
 	for _, productName := range allProductFiles {
 		productYamlPath := path.Join(productName, "go_product.yaml")
 
@@ -97,12 +94,8 @@ func main() {
 		if _, err := os.Stat(productYamlPath); err == nil {
 			var resources []*api.Resource = make([]*api.Resource, 0)
 
-			productYaml, err := os.ReadFile(productYamlPath)
-			if err != nil {
-				log.Fatalf("Cannot open the file: %v", productYaml)
-			}
 			productApi := &api.Product{}
-			yamlValidator.Parse(productYaml, productApi)
+			api.Compile(productYamlPath, productApi)
 
 			if !productApi.ExistsAtVersionOrLower(*version) {
 				log.Printf("%s does not have a '%s' version, skipping", productName, *version)
@@ -123,12 +116,8 @@ func main() {
 					continue
 				}
 
-				resourceYaml, err := os.ReadFile(resourceYamlPath)
-				if err != nil {
-					log.Fatalf("Cannot open the file: %v", resourceYamlPath)
-				}
 				resource := &api.Resource{}
-				yamlValidator.Parse(resourceYaml, resource)
+				api.Compile(resourceYamlPath, resource)
 
 				resource.Properties = resource.AddLabelsRelatedFields(resource.PropertiesWithExcluded(), nil)
 
@@ -137,7 +126,6 @@ func main() {
 			}
 
 			// TODO Q2: override resources
-			// log.Printf("resources before sorting %#v", resources)
 
 			// Sort resources by name
 			sort.Slice(resources, func(i, j int) bool {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
1. Add default values for fields when parsing the yaml files
2. Add custom keys for fields when parings the yaml files
3. Move `examples.go`, `docs.go`, `virtual_fields.go` and `validation.go` to `api/resource` folder from `provider/terraform` folder


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
