### PR TITLE
Add Play Integrity & reCAPTCHA Enterprise APIs enablement for App Check examples

### DIFF
--- a/mmv1/templates/terraform/examples/firebase_app_check_play_integrity_config_full.tf.erb
+++ b/mmv1/templates/terraform/examples/firebase_app_check_play_integrity_config_full.tf.erb
@@ -1,3 +1,14 @@
+# Enables the Play Integrity API
+resource "google_project_service" "play_integrity" {
+  provider = google-beta
+
+  project = "<%= ctx[:test_env_vars]['project_id'] %>"
+  service = "playintegrity.googleapis.com"
+
+  # Don't disable the service if the resource block is removed by accident.
+  disable_on_destroy = false
+}
+
 resource "google_firebase_android_app" "default" {
   provider = google-beta
 

--- a/mmv1/templates/terraform/examples/firebase_app_check_play_integrity_config_minimal.tf.erb
+++ b/mmv1/templates/terraform/examples/firebase_app_check_play_integrity_config_minimal.tf.erb
@@ -1,3 +1,14 @@
+# Enables the Play Integrity API
+resource "google_project_service" "play_integrity" {
+  provider = google-beta
+
+  project = "<%= ctx[:test_env_vars]['project_id'] %>"
+  service = "playintegrity.googleapis.com"
+
+  # Don't disable the service if the resource block is removed by accident.
+  disable_on_destroy = false
+}
+
 resource "google_firebase_android_app" "default" {
   provider = google-beta
 

--- a/mmv1/templates/terraform/examples/firebase_app_check_recaptcha_enterprise_config_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/firebase_app_check_recaptcha_enterprise_config_basic.tf.erb
@@ -1,3 +1,14 @@
+# Enables the reCAPTCHA Enterprise API
+resource "google_project_service" "recaptcha_enterprise" {
+  provider = google-beta
+
+  project = "<%= ctx[:test_env_vars]['project_id'] %>"
+  service = "recaptchaenterprise.googleapis.com"
+
+  # Don't disable the service if the resource block is removed by accident.
+  disable_on_destroy = false
+}
+
 resource "google_firebase_web_app" "default" {
   provider = google-beta
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Technically, the Play Integrity API and reCAPTCHA Enterprise is required if the user wants to use them with App Check. Most users would've already enabled it elsewhere prior to arriving at this step, so this is a no-op, but just for the completeness of the example.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
Test & documentation change only.
```
