### PR TITLE
Test Fix: TestAccDataprocCluster_spotWithAuxiliaryNodeGroups

### DIFF
--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
@@ -550,11 +550,12 @@ func TestAccDataprocCluster_spotWithAuxiliaryNodeGroups(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.roles.0", "DRIVER"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.node_group_config.0.num_instances", "2"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.node_group_config.0.machine_type", "n1-standard-2"),
-					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.node_group_config.0.min_cpu_platform", "AMD Rome"),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.node_group_config.0.min_cpu_platform", "Intel Haswell"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.node_group_config.0.disk_config.0.boot_disk_size_gb", "35"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.node_group_config.0.disk_config.0.boot_disk_type", "pd-standard"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.node_group_config.0.disk_config.0.num_local_ssds", "1"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.node_group_config.0.accelerators.0.accelerator_count", "1"),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.node_group_config.0.accelerators.0.accelerator_type_uri", "nvidia-tesla-t4"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group_id", "node-group-id"),
 					testAccCheckDataprocAuxiliaryNodeGroupAccelerator(&cluster, project),
 
@@ -1961,7 +1962,7 @@ resource "google_dataproc_cluster" "with_auxiliary_node_groups" {
         node_group_config{
           num_instances=2
           machine_type="n1-standard-2"
-          min_cpu_platform = "AMD Rome"
+          min_cpu_platform = "Intel Haswell"
           disk_config {
             boot_disk_size_gb = 35
             boot_disk_type = "pd-standard"
@@ -1969,7 +1970,7 @@ resource "google_dataproc_cluster" "with_auxiliary_node_groups" {
           }
           accelerators {
             accelerator_count = 1
-            accelerator_type  = "nvidia-tesla-k80"
+            accelerator_type  = "nvidia-tesla-t4"
           }
         }
       }
@@ -2541,3 +2542,4 @@ resource "google_dataproc_metastore_service" "ms" {
 }
 `, clusterName, serviceId)
 }
+


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/17534

Alter two properties of the Cluster created during testing so that it can be successfully created:

1. Set the `accelerator_type_uri` to `nvidia-tesla-t4`. 
    - This could be `nvidia-tesla-k80`, but that will no longer be usable as of May 1, 2024. See https://cloud.google.com/compute/docs/eol/k80-eol
3. Set the minimum CPU platform to `Intel Haswell`.

I have directly created a VM in GCE with these configurations and seen it run successfully. GCE VM:

```
{
  "cpuPlatform": "Intel Haswell",
  "guestAccelerators": [
    {
      "acceleratorCount": 1,
      "acceleratorType": "projects/REDACTED/zones/us-central1-b/acceleratorTypes/nvidia-tesla-t4"
    }
  ],
  "machineType": "projects/REDACTED/zones/us-central1-b/machineTypes/n1-standard-2",
  "status": "RUNNING",
  ...
}
```

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
