### PR TITLE
Test Fix: Replace Dataproc's usage of K80 in tests with T4

### DIFF
--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
@@ -151,7 +151,7 @@ func TestAccDataprocCluster_withAccelerators(t *testing.T) {
 	var cluster dataproc.Cluster
 
 	project := envvar.GetTestProjectFromEnv()
-	acceleratorType := "nvidia-tesla-k80"
+	acceleratorType := "nvidia-tesla-t4"
 	zone := "us-central1-c"
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
 	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
@@ -193,7 +193,7 @@ func testAccCheckDataprocAuxiliaryNodeGroupAccelerator(cluster *dataproc.Cluster
 
 func testAccCheckDataprocClusterAccelerator(cluster *dataproc.Cluster, project string, masterCount int, workerCount int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		expectedUri := fmt.Sprintf("projects/%s/zones/.*/acceleratorTypes/nvidia-tesla-k80", project)
+		expectedUri := fmt.Sprintf("projects/%s/zones/.*/acceleratorTypes/nvidia-tesla-t4", project)
 		r := regexp.MustCompile(expectedUri)
 
 		master := cluster.Config.MasterConfig.Accelerators


### PR DESCRIPTION
Replace Dataproc's usage of K80 in tests with T4.

GCE has declared K80 EOL and no longer usable as of May 1, 2024. See https://cloud.google.com/compute/docs/eol/k80-eol. 

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
