### PR TITLE
Add `project_number` field to google_storage_bucket resource and datasource, enable providing `project` argument to data source

### DIFF
--- a/mmv1/third_party/terraform/services/storage/data_source_google_storage_bucket.go
+++ b/mmv1/third_party/terraform/services/storage/data_source_google_storage_bucket.go
@@ -12,6 +12,7 @@ func DataSourceGoogleStorageBucket() *schema.Resource {
 
 	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceStorageBucket().Schema)
 
+	tpgresource.AddOptionalFieldsToSchema(dsSchema, "project")
 	tpgresource.AddRequiredFieldsToSchema(dsSchema, "name")
 
 	return &schema.Resource{

--- a/mmv1/third_party/terraform/services/storage/data_source_google_storage_bucket_test.go
+++ b/mmv1/third_party/terraform/services/storage/data_source_google_storage_bucket_test.go
@@ -1,17 +1,19 @@
 package storage_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestAccDataSourceGoogleStorageBucket_basic(t *testing.T) {
 	t.Parallel()
 
-	bucket := "tf-bucket-" + acctest.RandString(t, 10)
+	context := map[string]interface{}{
+		"bucket_name": "tf-bucket-" + acctest.RandString(t, 10),
+	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -19,7 +21,7 @@ func TestAccDataSourceGoogleStorageBucket_basic(t *testing.T) {
 		CheckDestroy:             testAccStorageBucketDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceGoogleStorageBucketConfig(bucket),
+				Config: testAccDataSourceGoogleStorageBucketConfig(context),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores("data.google_storage_bucket.bar", "google_storage_bucket.foo", map[string]struct{}{"force_destroy": {}}),
 				),
@@ -28,10 +30,52 @@ func TestAccDataSourceGoogleStorageBucket_basic(t *testing.T) {
 	})
 }
 
-func testAccDataSourceGoogleStorageBucketConfig(bucketName string) string {
-	return fmt.Sprintf(`
+// Test that the data source can take a project argument, which is used as a way to avoid using Compute API to
+// get project id for the project number returned from the Storage API.
+func TestAccDataSourceGoogleStorageBucket_avoidComputeAPI(t *testing.T) {
+	// Cannot use t.Parallel() if using t.Setenv
+
+	project := envvar.GetTestProjectFromEnv()
+
+	context := map[string]interface{}{
+		"bucket_name":          "tf-bucket-" + acctest.RandString(t, 10),
+		"real_project_id":      project,
+		"incorrect_project_id": "foobar",
+	}
+
+	// Unset ENV so no provider default is available to the data source
+	t.Setenv("GOOGLE_PROJECT", "")
+
+	acctest.VcrTest(t, resource.TestCase{
+		// Removed PreCheck because it wants to enforce GOOGLE_PROJECT being set
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccStorageBucketDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleStorageBucketConfig_setProjectInConfig(context),
+				Check: resource.ComposeTestCheckFunc(
+					// We ignore project to show that the project argument on the data source is retained and isn't impacted
+					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores("data.google_storage_bucket.bar", "google_storage_bucket.foo", map[string]struct{}{"force_destroy": {}, "project": {}}),
+
+					resource.TestCheckResourceAttrSet(
+						"google_storage_bucket.foo", "project_number"),
+					resource.TestCheckResourceAttr(
+						"google_storage_bucket.foo", "project", context["real_project_id"].(string)),
+
+					resource.TestCheckResourceAttrSet(
+						"data.google_storage_bucket.bar", "project_number"),
+					resource.TestCheckResourceAttr(
+						"data.google_storage_bucket.bar", "project", context["incorrect_project_id"].(string)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleStorageBucketConfig(context map[string]interface{}) string {
+	return acctest.Nprintf(`
 resource "google_storage_bucket" "foo" {
-  name     = "%s"
+  name     = "%{bucket_name}"
   location = "US"
 }
 
@@ -41,5 +85,25 @@ data "google_storage_bucket" "bar" {
     google_storage_bucket.foo,
   ]
 }
-`, bucketName)
+`, context)
+}
+
+func testAccDataSourceGoogleStorageBucketConfig_setProjectInConfig(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_storage_bucket" "foo" {
+  project = "%{real_project_id}"
+  name     = "%{bucket_name}"
+  location = "US"
+}
+
+// The project argument here doesn't help the provider retrieve data about the bucket
+// It only serves to stop the data source using the compute API to convert the project number to an id
+data "google_storage_bucket" "bar" {
+  project = "%{incorrect_project_id}"
+  name = google_storage_bucket.foo.name
+  depends_on = [
+    google_storage_bucket.foo,
+  ]
+}
+`, context)
 }

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
@@ -131,6 +131,12 @@ func ResourceStorageBucket() *schema.Resource {
 				Description: `The ID of the project in which the resource belongs. If it is not provided, the provider project is used.`,
 			},
 
+			"project_number": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The project number of the project in which the resource belongs.`,
+			},
+
 			"self_link": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -1717,6 +1723,9 @@ func setStorageBucket(d *schema.ResourceData, config *transport_tpg.Config, res 
 	}
 	if err := d.Set("url", fmt.Sprintf("gs://%s", bucket)); err != nil {
 		return fmt.Errorf("Error setting url: %s", err)
+	}
+	if err := d.Set("project_number", res.ProjectNumber); err != nil {
+		return fmt.Errorf("Error setting project_number: %s", err)
 	}
 	if err := d.Set("storage_class", res.StorageClass); err != nil {
 		return fmt.Errorf("Error setting storage_class: %s", err)

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
@@ -34,6 +34,10 @@ func TestAccStorageBucket_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", "force_destroy", "false"),
+					resource.TestCheckResourceAttr(
+						"google_storage_bucket.bucket", "project", envvar.GetTestProjectFromEnv()),
+					resource.TestCheckResourceAttrSet(
+						"google_storage_bucket.bucket", "project_number"),
 				),
 			},
 			{

--- a/mmv1/third_party/terraform/website/docs/d/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/storage_bucket.html.markdown
@@ -26,6 +26,8 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the bucket.
 
+* `project` - (Optional) The ID of the project in which the resource belongs. If it is not provided, the provider project is used. If no value is supplied in the configuration or through provider defaults then the data source will use the Compute API to find the project id that corresponds to the project number returned from the Storage API. Supplying a value for `project` doesn't influence retrieving data about the bucket but it can be used to prevent use of the Compute API. If you do provide a `project` value ensure that it is the correct value for that bucket; the data source will not check that the project id and project number match.
+
 ## Attributes Reference
 
 See [google_storage_bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket#argument-reference) resource for details of the available attributes.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Closes https://github.com/hashicorp/terraform-provider-google/issues/17166

This PR aims to address an edge case where users do not want to give the identity/service account used by Terraform permissions on the Compute API and want to provision GCS buckets. Previously if a project name was not supplied to the data source via provider defaults then the data source would:
- retrieve information about the bucket from the Storage API, including the project _number_ it's linked to
- call the Compute API to get a human-readable _project id_ for that project number, and use that to populate the `project` field

By letting users set the project field on the data source they can avoid that call to the Compute API. There is a chance that the project id they supply doesn't match the project number linked to the GCS bucket. This isn't ideal, but was [OK'd during triage as it matches the existing behaviour on import](https://github.com/hashicorp/terraform-provider-google/issues/17166#issuecomment-1927651371).

This PR also adds a new field, project_number, to surface the information returned from the Storage API which is guaranteed to be accurate. This enables users to perform any checks etc to verify the project id and number are a correct pairing.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
storage: added `project_number` attribute to `google_storage_bucket` resource and data source
```

```release-note:enhancement
storage: added ability to provide `project` argument to `google_storage_bucket` data source. This will not impact reading the resource's data, instead this helps users avoid calls to the Compute API within the data source.
```
