### PR TITLE
test: Fix missing database for datastore_index test.

### DIFF
--- a/mmv1/products/datastore/Index.yaml
+++ b/mmv1/products/datastore/Index.yaml
@@ -42,6 +42,8 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'datastore_index'
     primary_resource_id: 'default'
+    test_env_vars:
+      project_id: :PROJECT_NAME
     vars:
       property_name_1: 'property_a'
       property_name_2: 'property_b'

--- a/mmv1/templates/terraform/examples/datastore_index.tf.erb
+++ b/mmv1/templates/terraform/examples/datastore_index.tf.erb
@@ -1,3 +1,16 @@
+resource "google_firestore_database" "database" {
+  project     = "<%= ctx[:test_env_vars]['project_id'] %>"
+  # google_datastore_index resources only support the (default) database.
+  # However, google_firestore_index can express any Datastore Mode index
+  # and should be preferred in all cases.
+  name        = "(default)"
+  location_id = "nam5"
+  type        = "DATASTORE_MODE"
+
+  delete_protection_state = "DELETE_PROTECTION_DISABLED"
+  deletion_policy         = "DELETE"
+}
+
 resource "google_datastore_index" "<%= ctx[:primary_resource_id] %>" {
   kind = "foo"
   properties {
@@ -8,4 +21,6 @@ resource "google_datastore_index" "<%= ctx[:primary_resource_id] %>" {
     name = "<%= ctx[:vars]['property_name_2'] %>"
     direction = "ASCENDING"
   }
+  
+  depends_on = [google_firestore_database.database]
 }


### PR DESCRIPTION
Ensure a Firestore Datastore Mode (default) database exists for Datastore Index test.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/17591

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
