### PR TITLE
Fix crash caused by nil value in BigQuery Table

### DIFF
--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
@@ -2355,6 +2355,11 @@ func expandPrimaryKey(configured interface{}) *bigquery.TableConstraintsPrimaryK
 
 	columns := []string{}
 	for _, rawColumn := range raw["columns"].([]interface{}) {
+		if rawColumn == nil {
+			// Terraform reads "" as nil, which ends up crashing when we cast below
+			// sending "" to the API triggers a 400, which is okay.
+			rawColumn = ""
+		}
 		columns = append(columns, rawColumn.(string))
 	}
 	if len(columns) > 0 {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/17708

I don't want to add a test because it's impossible to provision a table with an empty string as the column. This now just triggers the correct 400 from the API rather than crashing

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigquery: fixed a crash when `google_bigquery_table` had a `primary_key.columns` entry set to `""`
```
