### PR TITLE
add autoscaled rollout policy for gke node pools

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
@@ -94,7 +94,11 @@ var schemaBlueGreenSettings = &schema.Schema{
 		Schema: map[string]*schema.Schema{
 			"standard_rollout_policy": {
 				Type:        schema.TypeList,
+				<% if version == "ga" -%>
 				Required:    true,
+				<% else -%>
+				Optional:    true,
+				<% end -%>
 				MaxItems:    1,
 				Description: `Standard rollout policy is the default policy for blue-green.`,
 				Elem: &schema.Resource{
@@ -121,6 +125,17 @@ var schemaBlueGreenSettings = &schema.Schema{
 					},
 				},
 			},
+			<% if version != "ga" -%>
+			"autoscaled_rollout_policy": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: `Autoscaled rollout policy for blue-green.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{},
+				},
+			},
+			<% end -%>
 			"node_pool_soak_duration": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -1068,6 +1083,13 @@ func expandNodePool(d *schema.ResourceData, prefix string) (*container.NodePool,
 
 				np.UpgradeSettings.BlueGreenSettings.StandardRolloutPolicy = standardRolloutPolicy
 			}
+			
+			<% if version != "ga" -%>
+			if v, ok := blueGreenSettingsConfig["autoscaled_rollout_policy"]; ok && v.([]interface{}) != nil {
+				autoscaledRolloutPolicy := &container.AutoscaledRolloutPolicy{}
+				np.UpgradeSettings.BlueGreenSettings.AutoscaledRolloutPolicy = autoscaledRolloutPolicy
+			}
+			<% end -%>
 		}
 	}
 
@@ -1088,6 +1110,17 @@ func flattenNodePoolStandardRolloutPolicy(rp *container.StandardRolloutPolicy) [
 	}
 }
 
+<% if version != "ga" -%>
+func flattenNodePoolAutoscaledRolloutPolicy(rp *container.AutoscaledRolloutPolicy) []map[string]interface{} {
+	if rp == nil {
+		return nil
+	}
+	return []map[string]interface{}{
+		{},
+	}
+}
+<% end -%>
+
 func flattenNodePoolBlueGreenSettings(bg *container.BlueGreenSettings) []map[string]interface{} {
 	if bg == nil {
 		return nil
@@ -1096,6 +1129,9 @@ func flattenNodePoolBlueGreenSettings(bg *container.BlueGreenSettings) []map[str
 		{
 			"node_pool_soak_duration": bg.NodePoolSoakDuration,
 			"standard_rollout_policy": flattenNodePoolStandardRolloutPolicy(bg.StandardRolloutPolicy),
+			<% if version != "ga" -%>
+			"autoscaled_rollout_policy": flattenNodePoolAutoscaledRolloutPolicy(bg.AutoscaledRolloutPolicy),
+			<% end -%>
 		},
 	}
 }
@@ -2054,6 +2090,12 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 					}
 					blueGreenSettings.StandardRolloutPolicy = standardRolloutPolicy
 				}
+
+				<% if version != "ga" -%>
+				if _, ok := blueGreenSettingsConfig["autoscaled_rollout_policy"]; ok {
+					return fmt.Errorf("Autoscaled rollout policy may not be changed, to disable, configure standard rollout policy.")
+				}
+				<% end -%>
 				upgradeSettings.BlueGreenSettings = blueGreenSettings
 			}
 		}

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -915,6 +915,33 @@ func TestAccContainerNodePool_withUpgradeSettings(t *testing.T) {
 	})
 }
 
+<% if version != "ga" -%>
+func TestAccContainerNodePool_withUpgradeSettingsAutoscaledRolloutPolicy(t *testing.T) {
+	t.Parallel()
+
+	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	np := fmt.Sprintf("tf-test-np-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePool_withUpgradeSettingsWithAutoscaledRolloutPolicy(cluster, np, networkName, subnetworkName),
+			},
+			{
+				ResourceName:      "google_container_node_pool.with_upgrade_settings",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+<% end -%>
+
 func TestAccContainerNodePool_withGPU(t *testing.T) {
 	t.Parallel()
 
@@ -3478,6 +3505,43 @@ resource "google_container_node_pool" "with_upgrade_settings" {
 }
 `, clusterName, networkName, subnetworkName, nodePoolName, makeUpgradeSettings(maxSurge, maxUnavailable, strategy, nodePoolSoakDuration, batchNodeCount, batchPercentage, batchSoakDuration))
 }
+
+<% if version != "ga" -%>
+func testAccContainerNodePool_withUpgradeSettingsWithAutoscaledRolloutPolicy(clusterName, nodePoolName, networkName, subnetworkName string) string {
+	return fmt.Sprintf(`
+data "google_container_engine_versions" "central1" {
+  location = "us-central1"
+}
+
+resource "google_container_cluster" "cluster" {
+  name               = "%s"
+  location           = "us-central1"
+  initial_node_count = 1
+  min_master_version = "${data.google_container_engine_versions.central1.latest_master_version}"
+  deletion_protection = false
+  network    = "%s"
+  subnetwork    = "%s"
+}
+
+resource "google_container_node_pool" "with_upgrade_settings" {
+  name = "%s"
+  location = "us-central1"
+  cluster = "${google_container_cluster.cluster.name}"
+  initial_node_count = 1
+  autoscaling {
+	min_node_count = 1
+	max_node_count = 2
+  }
+  upgrade_settings {
+	strategy = "BLUE_GREEN"
+	blue_green_settings {
+		autoscaled_rollout_policy {}
+	}
+  }
+}
+`, clusterName, networkName, subnetworkName, nodePoolName)
+}
+<% end -%>
 
 func testAccContainerNodePool_withGPU(cluster, np, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This PR adds a new feature to the GKE node pools, autoscaled rollout policy for blue green upgrade.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

```release-note:enhancement
release-note:enhancement
```
