### PR TITLE
Made it so that authors will never have their review requested on their own PR

### DIFF
--- a/.ci/magician/cmd/interfaces.go
+++ b/.ci/magician/cmd/interfaces.go
@@ -29,7 +29,7 @@ type GithubClient interface {
 	MergePullRequest(owner, repo, prNumber string) error
 	PostBuildStatus(prNumber, title, state, targetURL, commitSha string) error
 	PostComment(prNumber, comment string) error
-	RequestPullRequestReviewer(prNumber, assignee string) error
+	RequestPullRequestReviewers(prNumber string, reviewers []string) error
 	AddLabels(prNumber string, labels []string) error
 	RemoveLabel(prNumber, label string) error
 	CreateWorkflowDispatchEvent(workflowFileName string, inputs map[string]any) error

--- a/.ci/magician/cmd/mock_github_test.go
+++ b/.ci/magician/cmd/mock_github_test.go
@@ -63,8 +63,8 @@ func (m *mockGithub) GetTeamMembers(organization, team string) ([]github.User, e
 	return m.teamMembers[team], nil
 }
 
-func (m *mockGithub) RequestPullRequestReviewer(prNumber string, reviewer string) error {
-	m.calledMethods["RequestPullRequestReviewer"] = append(m.calledMethods["RequestPullRequestReviewer"], []any{prNumber, reviewer})
+func (m *mockGithub) RequestPullRequestReviewers(prNumber string, reviewers []string) error {
+	m.calledMethods["RequestPullRequestReviewers"] = append(m.calledMethods["RequestPullRequestReviewers"], []any{prNumber, reviewers})
 	return nil
 }
 

--- a/.ci/magician/cmd/request_reviewer.go
+++ b/.ci/magician/cmd/request_reviewer.go
@@ -83,12 +83,10 @@ func execRequestReviewer(prNumber string, gh GithubClient) {
 
 		reviewersToRequest, newPrimaryReviewer := github.ChooseCoreReviewers(requestedReviewers, previousReviewers)
 
-		for _, reviewer := range reviewersToRequest {
-			err = gh.RequestPullRequestReviewer(prNumber, reviewer)
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
-			}
+		err = gh.RequestPullRequestReviewers(prNumber, reviewersToRequest)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
 		}
 
 		if newPrimaryReviewer != "" {

--- a/.ci/magician/cmd/request_reviewer_test.go
+++ b/.ci/magician/cmd/request_reviewer_test.go
@@ -86,8 +86,8 @@ func TestExecRequestReviewer(t *testing.T) {
 			execRequestReviewer("1", gh)
 
 			actualReviewers := []string{}
-			for _, args := range gh.calledMethods["RequestPullRequestReviewer"] {
-				actualReviewers = append(actualReviewers, args[1].(string))
+			for _, args := range gh.calledMethods["RequestPullRequestReviewers"] {
+				actualReviewers = append(actualReviewers, args[1].([]string)...)
 			}
 
 			if tc.expectSpecificReviewers != nil {

--- a/.ci/magician/cmd/request_service_reviewers.go
+++ b/.ci/magician/cmd/request_service_reviewers.go
@@ -123,10 +123,12 @@ func execRequestServiceReviewers(prNumber string, gh GithubClient, enrolledTeams
 		hasReviewer := false
 		reviewerPool := []string{}
 		for _, member := range members {
-			// Exclude PR author
-			if member.Login != pullRequest.User.Login {
-				reviewerPool = append(reviewerPool, member.Login)
+			// Skip PR author
+			if member.Login == pullRequest.User.Login {
+				continue
 			}
+
+			reviewerPool = append(reviewerPool, member.Login)
 			// Don't re-request review if there's an active review request
 			if _, ok := requestedReviewersSet[member.Login]; ok {
 				hasReviewer = true
@@ -142,12 +144,10 @@ func execRequestServiceReviewers(prNumber string, gh GithubClient, enrolledTeams
 		}
 	}
 
-	for _, reviewer := range reviewersToRequest {
-		err = gh.RequestPullRequestReviewer(prNumber, reviewer)
-		if err != nil {
-			fmt.Println(err)
-			exitCode = 1
-		}
+	err = gh.RequestPullRequestReviewers(prNumber, reviewersToRequest)
+	if err != nil {
+		fmt.Println(err)
+		exitCode = 1
 	}
 	if exitCode != 0 {
 		os.Exit(1)

--- a/.ci/magician/cmd/request_service_reviewers_test.go
+++ b/.ci/magician/cmd/request_service_reviewers_test.go
@@ -144,8 +144,8 @@ func TestExecRequestServiceReviewersMembershipChecker(t *testing.T) {
 			execRequestServiceReviewers("1", gh, enrolledTeamsYaml)
 
 			actualReviewers := []string{}
-			for _, args := range gh.calledMethods["RequestPullRequestReviewer"] {
-				actualReviewers = append(actualReviewers, args[1].(string))
+			for _, args := range gh.calledMethods["RequestPullRequestReviewers"] {
+				actualReviewers = append(actualReviewers, args[1].([]string)...)
 			}
 
 			if tc.expectSpecificReviewers != nil {

--- a/.ci/magician/cmd/request_service_reviewers_test.go
+++ b/.ci/magician/cmd/request_service_reviewers_test.go
@@ -82,6 +82,15 @@ func TestExecRequestServiceReviewersMembershipChecker(t *testing.T) {
 			teamMembers:             map[string][]string{"google-x": []string{"googler_team_member"}},
 			expectSpecificReviewers: []string{},
 		},
+		"authors will not be requested on their own PRs even if they left comments on it previously": {
+			pullRequest: github.PullRequest{
+				User:   github.User{Login: "googler_team_member"},
+				Labels: []github.Label{{Name: "service/google-x"}},
+			},
+			teamMembers:             map[string][]string{"google-x": []string{"googler_team_member"}},
+			previousReviewers:       []string{"googler_team_member"},
+			expectSpecificReviewers: []string{},
+		},
 		"other team members be requested even if the author is excluded": {
 			pullRequest: github.PullRequest{
 				User:   github.User{Login: "googler_team_member"},

--- a/.ci/magician/github/set.go
+++ b/.ci/magician/github/set.go
@@ -56,11 +56,11 @@ func (gh *Client) PostComment(prNumber, comment string) error {
 	return nil
 }
 
-func (gh *Client) RequestPullRequestReviewer(prNumber, assignee string) error {
+func (gh *Client) RequestPullRequestReviewers(prNumber string, reviewers []string) error {
 	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/%s/requested_reviewers", prNumber)
 
 	body := map[string][]string{
-		"reviewers":      {assignee},
+		"reviewers":      reviewers,
 		"team_reviewers": {},
 	}
 
@@ -69,7 +69,7 @@ func (gh *Client) RequestPullRequestReviewer(prNumber, assignee string) error {
 		return err
 	}
 
-	fmt.Printf("Successfully added reviewer %s to pull request %s\n", assignee, prNumber)
+	fmt.Printf("Successfully added reviewers %v to pull request %s\n", reviewers, prNumber)
 
 	return nil
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixed https://github.com/hashicorp/terraform-provider-google/issues/17722

Unfortunately it's not possible to avoid exiting because this build step doesn't currently have access to a commit sha, which is necessary for posting a build status (instead of just failing). I'll add it to the yaml config so we have the option later, but I think adding support for that is a lower priority.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
