### PR TITLE
Add `protocol` field for `filestore Instance` product

### DIFF
--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -98,6 +98,15 @@ properties:
       Possible values include: STANDARD, PREMIUM, BASIC_HDD, BASIC_SSD, HIGH_SCALE_SSD, ZONAL, REGIONAL and ENTERPRISE
     required: true
     immutable: true
+  - !ruby/object:Api::Type::Enum
+    name: 'protocol'
+    description: |
+      Either NFSv3, for using NFS version 3 as file sharing protocol,
+      or NFSv4.1, for using NFS version 4.1 as file sharing protocol. The default is NFSv3.
+    default_value: :NFS_V3
+    values:
+      - :NFS_V3
+      - :NFS_V4_1
   - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: |

--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -42,6 +42,12 @@ examples:
     vars:
       instance_name: 'test-instance'
   - !ruby/object:Provider::Terraform::Examples
+    name: 'filestore_instance_protocol'
+    primary_resource_id: 'instance'
+    min_version: beta
+    vars:
+      instance_name: 'test-instance'
+  - !ruby/object:Provider::Terraform::Examples
     name: 'filestore_instance_enterprise'
     primary_resource_id: 'instance'
     # https://github.com/GoogleCloudPlatform/magic-modules/pull/5875#discussion_r844285335
@@ -102,8 +108,12 @@ properties:
     name: 'protocol'
     description: |
       Either NFSv3, for using NFS version 3 as file sharing protocol,
-      or NFSv4.1, for using NFS version 4.1 as file sharing protocol. The default is NFSv3.
+      or NFSv4.1, for using NFS version 4.1 as file sharing protocol. 
+      NFSv4.1 can be used with HIGH_SCALE_SSD, ZONAL, REGIONAL and ENTERPRISE.
+      The default is NFSv3.
     default_value: :NFS_V3
+    min_version: 'beta'
+    immutable: true
     values:
       - :NFS_V3
       - :NFS_V4_1

--- a/mmv1/templates/terraform/examples/filestore_instance_protocol.tf.erb
+++ b/mmv1/templates/terraform/examples/filestore_instance_protocol.tf.erb
@@ -1,0 +1,18 @@
+resource "google_filestore_instance" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+  name     = "<%= ctx[:vars]["instance_name"] %>"
+  location = "us-central1"
+  tier     = "ENTERPRISE"
+  protocol = "NFS_V4_1"
+
+  file_shares {
+    capacity_gb = 1024
+    name        = "share1"
+  }
+
+  networks {
+    network = "default"
+    modes   = ["MODE_IPV4"]
+  }
+
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/17523. As NFSv4.1 is in preview, this feature is available only for `google-beta` provider. 

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources). 
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [make test and make lint](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below. 

**Release Note Template for Downstream PRs (will be copied)**

```release-note
filestore: Added `protocol` property for `google_filestore_instance` instance to support NFSv3 and NFSv4.1
```
