### PR TITLE
docs: fix docs for google_cloud_run_v2 connector

### DIFF
--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -548,7 +548,7 @@ properties:
               - !ruby/object:Api::Type::String
                 name: 'connector'
                 description: |-
-                  VPC Access connector name. Format: projects/{project}/locations/{location}/connectors/{connector}, where {project} can be project id or number.
+                  VPC Access connector name.
               - !ruby/object:Api::Type::Enum
                 name: 'egress'
                 description: |-

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -315,7 +315,7 @@ properties:
           - !ruby/object:Api::Type::String
             name: 'connector'
             description: |-
-              VPC Access connector name. Format: projects/{project}/locations/{location}/connectors/{connector}, where {project} can be project id or number.
+              VPC Access connector name.
           - !ruby/object:Api::Type::Enum
             name: 'egress'
             description: |-

--- a/mmv1/templates/terraform/examples/cloudrunv2_job_vpcaccess.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_job_vpcaccess.tf.erb
@@ -8,7 +8,7 @@ resource "google_cloud_run_v2_job" "<%= ctx[:primary_resource_id] %>" {
         image = "us-docker.pkg.dev/cloudrun/container/hello"
       }
       vpc_access{
-        connector = google_vpc_access_connector.connector.id
+        connector = google_vpc_access_connector.connector.name
         egress = "ALL_TRAFFIC"
       }
     }

--- a/mmv1/templates/terraform/examples/cloudrunv2_service_vpcaccess.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_vpcaccess.tf.erb
@@ -7,7 +7,7 @@ resource "google_cloud_run_v2_service" "<%= ctx[:primary_resource_id] %>" {
       image = "us-docker.pkg.dev/cloudrun/container/hello"
     }
     vpc_access{
-      connector = google_vpc_access_connector.connector.id
+      connector = google_vpc_access_connector.connector.name
       egress = "ALL_TRAFFIC"
     }
   }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The connector seems to be name not id, according to https://cloud.google.com/run/docs/configuring/vpc-connectors#configuring-job
<img width="614" alt="Screenshot 2024-03-30 at 11 59 04" src="https://github.com/GoogleCloudPlatform/magic-modules/assets/883228/a2e31c59-6b47-4403-9343-211ff79c889b">

When you use 

```hcl
    vpc_access {
      # Use the VPC Connector
      connector = google_vpc_access_connector.connector.id
      # all egress from the service should go through the VPC Connector
      egress = "ALL_TRAFFIC"
    }
```

we have diff next time applying

```
  ~ resource "google_cloud_run_v2_service" "test" {

      ~ template {
            # (6 unchanged attributes hidden)

          ~ vpc_access {
              ~ connector = "vpc-connector" -> "projects/<project name>/locations/<location>/connectors/vpc-connector"
                # (1 unchanged attribute hidden)
            }

            # (2 unchanged blocks hidden)
        }

        # (1 unchanged block hidden)
    }
```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:note

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:note
cloudrun: fix description and example for vpc connector in google_cloud_run_v2_job and google_cloud_run_v2_service
```
