### PR TITLE
Go rewrite: import ID formats in doc template

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -14,6 +14,7 @@ package api
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/magic-modules/mmv1/api/product"
@@ -816,4 +817,72 @@ func (r Resource) TerraformName() string {
 		return r.LegacyName
 	}
 	return fmt.Sprintf("google_%s_%s", r.ProductMetadata.TerraformName(), google.Underscore(r.Name))
+}
+
+func (r Resource) ImportIdFormatsFromResource() []string {
+	return ImportIdFormats(r.ImportFormat, r.Identity, r.BaseUrl)
+}
+
+// Returns a list of import id formats for a given resource. If an id
+// contains provider-default values, this fn will return formats both
+// including and omitting the value.
+//
+// If a resource has an explicit import_format value set, that will be the
+// base import url used. Next, the values of `identity` will be used to
+// construct a URL. Finally, `{{name}}` will be used by default.
+//
+// For instance, if the resource base url is:
+//
+//	projects/{{project}}/global/networks
+//
+// It returns 3 formats:
+// a) self_link: projects/{{project}}/global/networks/{{name}}
+// b) short id: {{project}}/{{name}}
+// c) short id w/o defaults: {{name}}
+func ImportIdFormats(importFormat, identity []string, baseUrl string) []string {
+	var idFormats []string
+	if len(importFormat) == 0 {
+		underscoredBaseUrl := baseUrl
+		// TODO Q2: underscore base url needed?
+		// underscored_base_url = base_url.gsub(
+		//     /{{[[:word:]]+}}/, &:underscore
+		//   )
+		if len(identity) == 0 {
+			idFormats = []string{fmt.Sprintf("%s/{{name}}", underscoredBaseUrl)}
+		} else {
+			var transformedIdentity []string
+			for _, id := range identity {
+				transformedIdentity = append(transformedIdentity, fmt.Sprintf("{{%s}}", id))
+			}
+			identityPath := strings.Join(transformedIdentity, "/")
+			idFormats = []string{fmt.Sprintf("%s/{{name}}", identityPath)}
+		}
+	} else {
+		idFormats = importFormat
+	}
+
+	// short id: {{project}}/{{zone}}/{{name}}
+	fieldMarkers := regexp.MustCompile(`{{[[:word:]]+}}`).FindAllString(idFormats[0], -1)
+	shortIdFormat := strings.Join(fieldMarkers, "/")
+
+	// short ids without fields with provider-level defaults:
+
+	// without project
+	fieldMarkers = google.Remove(fieldMarkers, "{{project}}")
+	shortIdDefaultProjectFormat := strings.Join(fieldMarkers, "/")
+
+	// without project or location
+	fieldMarkers = google.Remove(fieldMarkers, "{{region}}")
+	fieldMarkers = google.Remove(fieldMarkers, "{{zone}}")
+	shortIdDefaultFormat := strings.Join(fieldMarkers, "/")
+
+	// If the id format can include `/` characters we cannot allow short forms such as:
+	// `{{project}}/{{%name}}` as there is no way to differentiate between
+	// project-name/resource-name and resource-name/with-slash
+	if !strings.Contains(idFormats[0], "%") {
+		idFormats = append(idFormats, shortIdFormat, shortIdDefaultProjectFormat, shortIdDefaultFormat)
+	}
+
+	// TODO Q2:  id_formats.uniq.reject(&:empty?).sort_by { |i| [i.count('/'), i.count('{{')] }.reverse
+	return idFormats
 }

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -868,12 +868,12 @@ func ImportIdFormats(importFormat, identity []string, baseUrl string) []string {
 	// short ids without fields with provider-level defaults:
 
 	// without project
-	fieldMarkers = google.Remove(fieldMarkers, "{{project}}")
+	fieldMarkers = slices.DeleteFunc(fieldMarkers, func(s string) bool { return s == "{{project}}" })
 	shortIdDefaultProjectFormat := strings.Join(fieldMarkers, "/")
 
 	// without project or location
-	fieldMarkers = google.Remove(fieldMarkers, "{{region}}")
-	fieldMarkers = google.Remove(fieldMarkers, "{{zone}}")
+	fieldMarkers = slices.DeleteFunc(fieldMarkers, func(s string) bool { return s == "{{region}}" })
+	fieldMarkers = slices.DeleteFunc(fieldMarkers, func(s string) bool { return s == "{{zone}}" })
 	shortIdDefaultFormat := strings.Join(fieldMarkers, "/")
 
 	// If the id format can include `/` characters we cannot allow short forms such as:

--- a/mmv1/google/slice_utils.go
+++ b/mmv1/google/slice_utils.go
@@ -13,8 +13,6 @@
 
 package google
 
-import "reflect"
-
 // Returns a new slice containing all of the elements
 // for which the test function returns true in the original slice
 func Select[T any](S []T, test func(T) bool) (ret []T) {
@@ -40,19 +38,4 @@ func Reject[T any](S []T, test func(T) bool) (ret []T) {
 // Concat two slices
 func Concat[T any](S1 []T, S2 []T) (ret []T) {
 	return append(S1, S2...)
-}
-
-// Remove element "value" from array
-func Remove[T any](S []T, value T) (ret []T) {
-	index := -1
-	for i, s := range S {
-		if reflect.DeepEqual(s, value) {
-			index = i
-			break
-		}
-	}
-	if index == -1 {
-		return S
-	}
-	return append(S[:index], S[index+1:]...)
 }

--- a/mmv1/google/slice_utils.go
+++ b/mmv1/google/slice_utils.go
@@ -13,6 +13,8 @@
 
 package google
 
+import "reflect"
+
 // Returns a new slice containing all of the elements
 // for which the test function returns true in the original slice
 func Select[T any](S []T, test func(T) bool) (ret []T) {
@@ -38,4 +40,19 @@ func Reject[T any](S []T, test func(T) bool) (ret []T) {
 // Concat two slices
 func Concat[T any](S1 []T, S2 []T) (ret []T) {
 	return append(S1, S2...)
+}
+
+// Remove element "value" from array
+func Remove[T any](S []T, value T) (ret []T) {
+	index := -1
+	for i, s := range S {
+		if reflect.DeepEqual(s, value) {
+			index = i
+			break
+		}
+	}
+	if index == -1 {
+		return S
+	}
+	return append(S[:index], S[index+1:]...)
 }

--- a/mmv1/templates/terraform/resource.html.markdown.tmpl
+++ b/mmv1/templates/terraform/resource.html.markdown.tmpl
@@ -155,8 +155,7 @@ This resource provides the following
 [Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options:
 
 - `create` - Default is {{$.Timeouts.InsertMinutes}} minutes.
-{{/*TODO: <% if updatable?(object, properties) || object.root_labels? -%> */}}
-- `update` - Default is {{$.Timeouts.UpdateMinutes}} minutes.
+- `update` - Default is {{$.Timeouts.UpdateMinutes}} minutes.{{/*TODO: <% if updatable?(object, properties) || object.root_labels? -%> */}}
 - `delete` - Default is {{$.Timeouts.DeleteMinutes}} minutes.
 
 ## Import
@@ -165,6 +164,33 @@ This resource provides the following
 This resource does not support import.
 {{ else }}
 
-{{$.Name}} can be imported using any of these accepted formats:
 
+{{$.Name}} can be imported using any of these accepted formats:
+{{ range $idFormat := $.ImportIdFormatsFromResource }}
+* `{{$idFormat}}`
+{{- end }}
+
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import {{$.Name}} using one of the formats above. For example:
+
+```tf
+import {
+  id = "{{ index $.ImportIdFormatsFromResource 0 }}"
+  to = {{$.TerraformName}}.default
+}
+```
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), {{$.Name}} can be imported using one of the formats above. For example:
+
+```
+	{{- range $idFormat := $.ImportIdFormatsFromResource }}
+$ terraform import {{$.TerraformName}}.default {{$idFormat}}
+	{{- end }}
+```
 {{ end }}
+
+{{- if or (contains $.BaseUrl "{{project}}") $.SupportsIndirectUserProjectOverride}}
+## User Project Overrides
+
+This resource supports [User Project Overrides](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#user_project_override).
+{{- end }}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Finishes out the bottom of the documentation template with the import formats. This section produces no diffs compared to the original Data Fusion Instance docs.

Remaining TODO in doc templates:
Example blocks and `build_nested_property_documentation` nested templates

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
