### PR TITLE
Remove database resource name constraint in firestore document surface

### DIFF
--- a/mmv1/products/firestore/Document.yaml
+++ b/mmv1/products/firestore/Document.yaml
@@ -36,8 +36,6 @@ docs: !ruby/object:Provider::Terraform::Docs
     `google_app_engine_application` resource with `database_type` set to
     `"CLOUD_FIRESTORE"`. Your Firestore location will be the same as
     the App Engine location specified.
-    Note: The surface does not support configurable database id. Only `(default)`
-    is allowed for the database parameter.
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'firestore_document_basic'


### PR DESCRIPTION
The constraint was removed from Firestore backend.

This should address issue like https://github.com/hashicorp/terraform-provider-google/issues/15550.

```release-note:none
```