### PR TITLE
Run version guard checks on PRs

### DIFF
--- a/.github/workflows/mmv1-check-templates.yml
+++ b/.github/workflows/mmv1-check-templates.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
         with:
           path: repo
           fetch-depth: 0

--- a/.github/workflows/mmv1-check-templates.yml
+++ b/.github/workflows/mmv1-check-templates.yml
@@ -1,0 +1,30 @@
+name: mmv1-check-templates
+
+permissions: read-all
+
+on:
+  pull_request:
+    paths:
+      - 'mmv1/**/*.erb'
+
+jobs:
+  version-guard-check:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          path: repo
+          fetch-depth: 0
+      - name: Merge base branch
+        id: pull_request
+        run: |
+          cd repo
+          git config user.name "modular-magician"
+          git config user.email "magic-modules@google.com"
+          git fetch origin ${{ github.base_ref }} # Fetch the base branch
+          git merge --no-ff origin/${{ github.base_ref }} # Merge with the base branch
+      - name: Check for invalid version guards
+        run: |
+          cd repo/tools/template-check
+          git diff --name-only origin/${{ github.base_ref }} ../../*.erb | sed 's=^=../../=g' | go run main.go

--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.erb
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.erb
@@ -577,9 +577,9 @@ func expandConfidentialInstanceConfig(d tpgresource.TerraformResourceData) *comp
 	prefix := "confidential_instance_config.0"
 	return &compute.ConfidentialInstanceConfig{
 		EnableConfidentialCompute: d.Get(prefix + ".enable_confidential_compute").(bool),
-		<% unless version == "ga" %>
+		<% unless version == "ga" -%>
 		ConfidentialInstanceType: d.Get(prefix + ".confidential_instance_type").(string),
-		<% end %>
+		<% end -%>
 	}
 }
 
@@ -590,9 +590,9 @@ func flattenConfidentialInstanceConfig(ConfidentialInstanceConfig *compute.Confi
 
 	return []map[string]interface{}{{
 		"enable_confidential_compute": ConfidentialInstanceConfig.EnableConfidentialCompute,
-		<% unless version == "ga" %>
+		<% unless version == "ga" -%>
 		"confidential_instance_type": ConfidentialInstanceConfig.ConfidentialInstanceType,
-		<% end %>
+		<% end -%>
 	}}
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_disk_async_replication_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_disk_async_replication_test.go.erb
@@ -1,6 +1,6 @@
 <% autogen_exception -%>
 package compute_test
-<% if version != "ga" -%>
+<% unless version == "ga" -%>
 
 import (
 	"fmt"

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
@@ -994,13 +994,13 @@ be from 0 to 999,999,999 inclusive.`,
 				Description: `The Confidential VM config being used by the instance.  on_host_maintenance has to be set to TERMINATE or this will fail to create.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						<% if version == "ga" %>
+						<% if version == "ga" -%>
 						"enable_confidential_compute": {
 							Type:        schema.TypeBool,
 							Required:    true,
 							Description: `Defines whether the instance should have confidential compute enabled.`,
 						},
-						<% else %>
+						<% else -%>
 						"enable_confidential_compute": {
 							Type:        schema.TypeBool,
 							Optional:    true,
@@ -1016,7 +1016,7 @@ be from 0 to 999,999,999 inclusive.`,
 								If SEV_SNP, min_cpu_platform = "AMD Milan" is currently required.`,
 							AtLeastOneOf: []string{"confidential_instance_config.0.enable_confidential_compute", "confidential_instance_config.0.confidential_instance_type"},
 						},
-						<% end %>
+						<% end -%>
 					},
 				},
 			},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_membership_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_membership_test.go.erb
@@ -189,7 +189,11 @@ func testAccCheckComputeInstanceGroupMembershipDestroyed(t *testing.T, instanceG
 func testAccComputeInstanceGroupMembershipListMembership(t *testing.T, instanceGroupId string) (map[string]struct{}, error) {
   config := acctest.GoogleProviderConfig(t)
 
-  url := fmt.Sprintf("https://www.googleapis.com/compute/<% if version == 'ga' %>v1<% else %>beta<% end %>/%s/listInstances", instanceGroupId)
+  <% if version == 'ga' -%>
+  url := fmt.Sprintf("https://www.googleapis.com/compute/v1/%s/listInstances", instanceGroupId)
+  <% else -%>
+  url := fmt.Sprintf("https://www.googleapis.com/compute/beta/%s/listInstances", instanceGroupId)
+  <% end -%>
   res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
     Config: config,
     Method: "POST",

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
@@ -431,7 +431,7 @@ Google Cloud KMS.`,
 							Description:      `The name of the subnetwork to attach this interface to. The subnetwork must exist in the same region this instance will be created in. Either network or subnetwork must be provided.`,
 						},
 
-						<% if version == 'beta' -%>
+						<% unless version == 'ga' -%>
 						"network_attachment": {
 							Type:             schema.TypeString,
 							Optional:         true,
@@ -870,14 +870,14 @@ be from 0 to 999,999,999 inclusive.`,
 				Description: `The Confidential VM config being used by the instance. on_host_maintenance has to be set to TERMINATE or this will fail to create.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						<% if version == "ga" %>
+						<% if version == "ga" -%>
 						"enable_confidential_compute": {
 							Type:        schema.TypeBool,
 							Required:    true,
 							ForceNew:    true,
 							Description: `Defines whether the instance should have confidential compute enabled.`,
 						},
-						<% else %>
+						<% else -%>
 						"enable_confidential_compute": {
 							Type:        schema.TypeBool,
 							Optional:    true,
@@ -895,7 +895,7 @@ be from 0 to 999,999,999 inclusive.`,
 								If SEV_SNP, min_cpu_platform = "AMD Milan" is currently required.`,
 							AtLeastOneOf: []string{"confidential_instance_config.0.enable_confidential_compute", "confidential_instance_config.0.confidential_instance_type"},
 						},
-						<% end %>
+						<% end -%>
 					},
 				},
 			},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.erb
@@ -772,9 +772,9 @@ func TestAccComputeInstanceTemplate_ConfidentialInstanceConfigMain(t *testing.T)
 	t.Parallel()
 
 	var instanceTemplate compute.InstanceTemplate
-	<% unless version == "ga" %>
+	<% unless version == "ga" -%>
 	var instanceTemplate2 compute.InstanceTemplate
-	<% end %>
+	<% end -%>
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -786,13 +786,13 @@ func TestAccComputeInstanceTemplate_ConfidentialInstanceConfigMain(t *testing.T)
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(t, "google_compute_instance_template.foobar", &instanceTemplate),
 					testAccCheckComputeInstanceTemplateHasConfidentialInstanceConfig(&instanceTemplate, true, "SEV"),
-					<% unless version == "ga" %>
+					<% unless version == "ga" -%>
 					testAccCheckComputeInstanceTemplateExists(t, "google_compute_instance_template.foobar2", &instanceTemplate2),
 					testAccCheckComputeInstanceTemplateHasConfidentialInstanceConfig(&instanceTemplate2, true, ""),
-					<% end %>
+					<% end -%>
 				),
 			},
-			<% unless version == "ga" %>
+			<% unless version == "ga" -%>
 			{
 				Config: testAccComputeInstanceTemplateConfidentialInstanceConfigNoEnable(acctest.RandString(t, 10), "AMD Milan", "SEV_SNP"),
 				Check: resource.ComposeTestCheckFunc(
@@ -802,7 +802,7 @@ func TestAccComputeInstanceTemplate_ConfidentialInstanceConfigMain(t *testing.T)
 					testAccCheckComputeInstanceTemplateHasConfidentialInstanceConfig(&instanceTemplate2, false, "SEV_SNP"),
 				),
 			},
-			<% end %>
+			<% end -%>
 		},
 	})
 }
@@ -1799,11 +1799,11 @@ func testAccCheckComputeInstanceTemplateHasConfidentialInstanceConfig(instanceTe
 		if instanceTemplate.Properties.ConfidentialInstanceConfig.EnableConfidentialCompute != EnableConfidentialCompute {
 			return fmt.Errorf("Wrong ConfidentialInstanceConfig EnableConfidentialCompute: expected %t, got, %t", EnableConfidentialCompute, instanceTemplate.Properties.ConfidentialInstanceConfig.EnableConfidentialCompute)
 		}
-		<% unless version == "ga" %>
+		<% unless version == "ga" -%>
 		if instanceTemplate.Properties.ConfidentialInstanceConfig.ConfidentialInstanceType != ConfidentialInstanceType {
 			return fmt.Errorf("Wrong ConfidentialInstanceConfig ConfidentialInstanceType: expected %s, got, %s", ConfidentialInstanceType, instanceTemplate.Properties.ConfidentialInstanceConfig.ConfidentialInstanceType)
 		}
-		<% end %>
+		<% end -%>
 
 		return nil
 	}
@@ -3124,9 +3124,9 @@ resource "google_compute_instance_template" "foobar" {
 
   confidential_instance_config {
     enable_confidential_compute       = true
-    <% unless version == "ga" %>
+<% unless version == "ga" -%>
     confidential_instance_type        = %q
-    <% end %>
+<% end -%>
   }
 
   scheduling {
@@ -3134,7 +3134,8 @@ resource "google_compute_instance_template" "foobar" {
   }
 
 }
-<% unless version == "ga" %>
+
+<% unless version == "ga" -%>
 resource "google_compute_instance_template" "foobar2" {
   name         = "tf-test-instance2-template-%s"
   machine_type = "n2d-standard-2"
@@ -3158,15 +3159,15 @@ resource "google_compute_instance_template" "foobar2" {
   }
 
 }
-<% end %>
-<% if version == "ga" %>
+<% end -%>
+<% if version == "ga" -%>
 `, suffix)
-<% else %>
+<% else -%>
 `, suffix, confidentialInstanceType, suffix)
-<% end %>
+<% end -%>
 }
 
-<% unless version == "ga" %>
+<% unless version == "ga" -%>
 func testAccComputeInstanceTemplateConfidentialInstanceConfigNoEnable(suffix string, minCpuPlatform, confidentialInstanceType string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image2" {
@@ -3227,7 +3228,7 @@ resource "google_compute_instance_template" "foobar4" {
 }
 `, suffix, minCpuPlatform, confidentialInstanceType, suffix, minCpuPlatform, confidentialInstanceType)
 }
-<% end %>
+<% end -%>
 
 func testAccComputeInstanceTemplateAdvancedMachineFeatures(suffix string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -1804,9 +1804,9 @@ func TestAccComputeInstanceConfidentialInstanceConfigMain(t *testing.T) {
 	t.Parallel()
 
 	var instance compute.Instance
-	<% unless version == "ga" %>
+	<% unless version == "ga" -%>
 	var instance2 compute.Instance
-	<% end %>
+	<% end -%>
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -1819,13 +1819,13 @@ func TestAccComputeInstanceConfidentialInstanceConfigMain(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceHasConfidentialInstanceConfig(&instance, true, "SEV"),
-					<% unless version == "ga" %>
+					<% unless version == "ga" -%>
 					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar2", &instance2),
 					testAccCheckComputeInstanceHasConfidentialInstanceConfig(&instance2, true, ""),
-					<% end %>
+					<% end -%>
 				),
 			},
-			<% unless version == "ga" %>
+			<% unless version == "ga" -%>
 			{
 				Config: testAccComputeInstanceConfidentialInstanceConfigNoEnable(instanceName, "AMD Milan", "SEV_SNP"),
 				Check: resource.ComposeTestCheckFunc(
@@ -1835,7 +1835,7 @@ func TestAccComputeInstanceConfidentialInstanceConfigMain(t *testing.T) {
 					testAccCheckComputeInstanceHasConfidentialInstanceConfig(&instance2, false, "SEV_SNP"),
 				),
 			},
-			<% end %>
+			<% end -%>
 		},
 	})
 }
@@ -3215,7 +3215,7 @@ func testAccCheckComputeInstanceUpdateMachineType(t *testing.T, n string) resour
 	}
 }
 
-<% unless version == "ga"%>
+<% unless version == "ga" -%>
 func TestAccComputeInstance_NetworkAttachment(t *testing.T) {
 	t.Parallel()
 	suffix := fmt.Sprintf("%s", acctest.RandString(t, 10))
@@ -3277,7 +3277,7 @@ func TestAccComputeInstance_NetworkAttachmentUpdate(t *testing.T) {
 		},
 	})
 }
-<% end %>
+<% end -%>
 
 func TestAccComputeInstance_NicStackTypeUpdate(t *testing.T) {
 	t.Parallel()
@@ -3922,7 +3922,7 @@ func testAccCheckComputeInstanceHasNetworkAttachment(instance *compute.Instance,
 		return fmt.Errorf("Network Attachment %s, was not found in the instance template", networkAttachmentName)
 	}
 }
-<% end %>
+<% end -%>
 
 func testAccCheckComputeInstanceHasMachineType(instance *compute.Instance, machineType string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -4024,11 +4024,11 @@ func testAccCheckComputeInstanceHasConfidentialInstanceConfig(instance *compute.
 		if instance.ConfidentialInstanceConfig.EnableConfidentialCompute != EnableConfidentialCompute {
 			return fmt.Errorf("Wrong ConfidentialInstanceConfig EnableConfidentialCompute: expected %t, got, %t", EnableConfidentialCompute, instance.ConfidentialInstanceConfig.EnableConfidentialCompute)
 		}
-		<% unless version == "ga" %>
+		<% unless version == "ga" -%>
 		if instance.ConfidentialInstanceConfig.ConfidentialInstanceType != ConfidentialInstanceType {
 			return fmt.Errorf("Wrong ConfidentialInstanceConfig ConfidentialInstanceType: expected %s, got, %s", ConfidentialInstanceType, instance.ConfidentialInstanceConfig.ConfidentialInstanceType)
 		}
-		<% end %>
+		<% end -%>
 
 		return nil
 	}
@@ -7220,9 +7220,9 @@ resource "google_compute_instance" "foobar" {
 
   confidential_instance_config {
     enable_confidential_compute       = true
-    <% unless version == "ga" %>
+<% unless version == "ga" -%>
     confidential_instance_type        = %q
-    <% end %>
+<% end -%>
   }
 
   scheduling {
@@ -7230,7 +7230,8 @@ resource "google_compute_instance" "foobar" {
   }
 
 }
-<% unless version == "ga" %>
+
+<% unless version == "ga" -%>
 resource "google_compute_instance" "foobar2" {
   name         = "%s2"
   machine_type = "n2d-standard-2"
@@ -7255,15 +7256,15 @@ resource "google_compute_instance" "foobar2" {
   }
 
 }
-<% end %>
-<% if version == "ga" %>
+<% end -%>
+<% if version == "ga" -%>
 `, instance)
-<% else %>
+<% else -%>
 `, instance, confidentialInstanceType, instance)
-<% end %>
+<% end -%>
 }
 
-<% unless version == "ga" %>
+<% unless version == "ga" -%>
 func testAccComputeInstanceConfidentialInstanceConfigNoEnable(instance string, minCpuPlatform, confidentialInstanceType string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image2" {
@@ -7326,7 +7327,7 @@ resource "google_compute_instance" "foobar4" {
 }
 `, instance, minCpuPlatform, confidentialInstanceType, instance, minCpuPlatform, confidentialInstanceType)
 }
-<% end %>
+<% end -%>
 
 func testAccComputeInstance_attributionLabelCreate(instance, add, strategy string) string {
 	return fmt.Sprintf(`
@@ -8854,7 +8855,7 @@ resource "google_compute_instance" "foobar" {
 
 <% end -%>
 
-<% unless version =="ga" -%>
+<% unless version == "ga" -%>
 func testAccComputeInstance_networkAttachment(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
@@ -8989,7 +8990,7 @@ resource "google_compute_instance" "foobar" {
 }
 `, suffix, suffix, suffix, region, suffix, region, suffix, region, suffix, region, suffix, region, networkAttachment)
 }
-<% end %>
+<% end -%>
 
 func testAccComputeInstance_nicStackTypeUpdate(suffix, region, stack_type, instance string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_endpoint_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_endpoint_test.go.erb
@@ -206,7 +206,11 @@ func testAccCheckComputeNetworkEndpointWithPortsDestroyed(t *testing.T, negId st
 func testAccComputeNetworkEndpointListEndpointPorts(t *testing.T, negId string) (map[string]struct{}, error) {
 	config := acctest.GoogleProviderConfig(t)
 
-	url := fmt.Sprintf("https://www.googleapis.com/compute/<% if version == 'ga' %>v1<% else %>beta<% end %>/%s/listNetworkEndpoints", negId)
+	<% if version == 'ga' -%>
+	url := fmt.Sprintf("https://www.googleapis.com/compute/v1/%s/listNetworkEndpoints", negId)
+	<% else -%>
+	url := fmt.Sprintf("https://www.googleapis.com/compute/beta/%s/listNetworkEndpoints", negId)
+	<% end -%>
 	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 		Config: config,
 		Method: "POST",

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_endpoints_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_endpoints_test.go.erb
@@ -286,7 +286,11 @@ func testAccCheckComputeNetworkEndpointsWithAllEndpointsDestroyed(t *testing.T, 
 func testAccComputeNetworkEndpointsListEndpoints(t *testing.T, negId string) ([]interface{}, error) {
 	config := acctest.GoogleProviderConfig(t)
 
-	url := fmt.Sprintf("https://www.googleapis.com/compute/<% if version == 'ga' %>v1<% else %>beta<% end %>/%s/listNetworkEndpoints", negId)
+	<% if version == 'ga' -%>
+	url := fmt.Sprintf("https://www.googleapis.com/compute/v1/%s/listNetworkEndpoints", negId)
+	<% else -%>
+	url := fmt.Sprintf("https://www.googleapis.com/compute/beta/%s/listNetworkEndpoints", negId)
+	<% end -%>
 	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 		Config:    config,
 		Method:    "POST",

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.erb
@@ -823,14 +823,14 @@ be from 0 to 999,999,999 inclusive.`,
 				Description: `The Confidential VM config being used by the instance. on_host_maintenance has to be set to TERMINATE or this will fail to create.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						<% if version == "ga" %>
+						<% if version == "ga" -%>
 						"enable_confidential_compute": {
 							Type:        schema.TypeBool,
 							Required:    true,
 							ForceNew:    true,
 							Description: `Defines whether the instance should have confidential compute enabled.`,
 						},
-						<% else %>
+						<% else -%>
 						"enable_confidential_compute": {
 							Type:        schema.TypeBool,
 							Optional:    true,
@@ -848,7 +848,7 @@ be from 0 to 999,999,999 inclusive.`,
 								If SEV_SNP, min_cpu_platform = "AMD Milan" is currently required.`,
 							AtLeastOneOf: []string{"confidential_instance_config.0.enable_confidential_compute", "confidential_instance_config.0.confidential_instance_type"},
 						},
-						<% end %>
+						<% end -%>
 					},
 				},
 			},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.erb
@@ -686,9 +686,9 @@ func TestAccComputeRegionInstanceTemplate_ConfidentialInstanceConfigMain(t *test
 	t.Parallel()
 
 	var instanceTemplate compute.InstanceTemplate
-	<% unless version == "ga" %>
+	<% unless version == "ga" -%>
 	var instanceTemplate2 compute.InstanceTemplate
-	<% end %>
+	<% end -%>
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.AccTestPreCheck(t) },
@@ -700,13 +700,13 @@ func TestAccComputeRegionInstanceTemplate_ConfidentialInstanceConfigMain(t *test
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeRegionInstanceTemplateExists(t, "google_compute_region_instance_template.foobar", &instanceTemplate),
 					testAccCheckComputeRegionInstanceTemplateHasConfidentialInstanceConfig(&instanceTemplate, true, "SEV"),
-					<% unless version == "ga" %>
+					<% unless version == "ga" -%>
 					testAccCheckComputeRegionInstanceTemplateExists(t, "google_compute_region_instance_template.foobar2", &instanceTemplate2),
 					testAccCheckComputeRegionInstanceTemplateHasConfidentialInstanceConfig(&instanceTemplate2, true, ""),
-					<% end %>
+					<% end -%>
 				),
 			},
-			<% unless version == "ga" %>
+			<% unless version == "ga" -%>
 			{
 				Config: testAccComputeRegionInstanceTemplateConfidentialInstanceConfigNoEnable(acctest.RandString(t, 10), "AMD Milan", "SEV_SNP"),
 				Check: resource.ComposeTestCheckFunc(
@@ -716,7 +716,7 @@ func TestAccComputeRegionInstanceTemplate_ConfidentialInstanceConfigMain(t *test
 					testAccCheckComputeRegionInstanceTemplateHasConfidentialInstanceConfig(&instanceTemplate2, false, "SEV_SNP"),
 				),
 			},
-			<% end %>
+			<% end -%>
 		},
 	})
 }
@@ -1625,11 +1625,11 @@ func testAccCheckComputeRegionInstanceTemplateHasConfidentialInstanceConfig(inst
 		if instanceTemplate.Properties.ConfidentialInstanceConfig.EnableConfidentialCompute != EnableConfidentialCompute {
 			return fmt.Errorf("Wrong ConfidentialInstanceConfig EnableConfidentialCompute: expected %t, got, %t", EnableConfidentialCompute, instanceTemplate.Properties.ConfidentialInstanceConfig.EnableConfidentialCompute)
 		}
-		<% unless version == "ga" %>
+		<% unless version == "ga" -%>
 		if instanceTemplate.Properties.ConfidentialInstanceConfig.ConfidentialInstanceType != ConfidentialInstanceType {
 			return fmt.Errorf("Wrong ConfidentialInstanceConfig ConfidentialInstanceType: expected %s, got, %s", ConfidentialInstanceType, instanceTemplate.Properties.ConfidentialInstanceConfig.ConfidentialInstanceType)
 		}
-		<% end %>
+		<% end -%>
 
 		return nil
 	}
@@ -2776,9 +2776,9 @@ resource "google_compute_region_instance_template" "foobar" {
 
   confidential_instance_config {
     enable_confidential_compute       = true
-    <% unless version == "ga" %>
+<% unless version == "ga" -%>
     confidential_instance_type        = %q
-    <% end %>
+<% end -%>
   }
 
   scheduling {
@@ -2786,7 +2786,8 @@ resource "google_compute_region_instance_template" "foobar" {
   }
 
 }
-<% unless version == "ga" %>
+
+<% unless version == "ga" -%>
 resource "google_compute_region_instance_template" "foobar2" {
   name         = "tf-test-instance2-template-%s"
   machine_type = "n2d-standard-2"
@@ -2811,15 +2812,15 @@ resource "google_compute_region_instance_template" "foobar2" {
   }
 
 }
-<% end %>
-<% if version == "ga" %>
+<% end -%>
+<% if version == "ga" -%>
 `, suffix)
-<% else %>
+<% else -%>
 `, suffix, confidentialInstanceType, suffix)
-<% end %>
+<% end -%>
 }
 
-<% unless version == "ga" %>
+<% unless version == "ga" -%>
 func testAccComputeRegionInstanceTemplateConfidentialInstanceConfigNoEnable(suffix string, minCpuPlatform, confidentialInstanceType string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image2" {
@@ -2882,7 +2883,7 @@ resource "google_compute_region_instance_template" "foobar4" {
 }
 `, suffix, minCpuPlatform, confidentialInstanceType, suffix, minCpuPlatform, confidentialInstanceType)
 }
-<% end %>
+<% end -%>
 
 func testAccComputeRegionInstanceTemplateAdvancedMachineFeatures(suffix string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_network_endpoint_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_network_endpoint_test.go.erb
@@ -182,7 +182,11 @@ func testAccCheckComputeRegionNetworkEndpointWithPortsDestroyed(t *testing.T, ne
 func testAccComputeRegionNetworkEndpointListEndpointPorts(t *testing.T, negId string) (map[string]struct{}, error) {
 	config := acctest.GoogleProviderConfig(t)
 
-	url := fmt.Sprintf("https://www.googleapis.com/compute/<% if version == 'ga' %>v1<% else %>beta<% end %>/%s/listNetworkEndpoints", negId)
+	<% if version == 'ga' -%>
+	url := fmt.Sprintf("https://www.googleapis.com/compute/v1/%s/listNetworkEndpoints", negId)
+	<% else -%>
+	url := fmt.Sprintf("https://www.googleapis.com/compute/beta/%s/listNetworkEndpoints", negId)
+	<% end -%>
 	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 		Config: config,
 		Method: "POST",

--- a/mmv1/third_party/terraform/services/healthcare/resource_healthcare_hl7_v2_store_test.go.erb
+++ b/mmv1/third_party/terraform/services/healthcare/resource_healthcare_hl7_v2_store_test.go.erb
@@ -123,7 +123,7 @@ func TestAccHealthcareHl7V2Store_basic(t *testing.T) {
 }
 
 
-<% unless version == 'ga' %>
+<% unless version == 'ga' -%>
 func TestAccHealthcareHl7V2Store_updateSchema(t *testing.T) {
 	t.Parallel()
 
@@ -203,7 +203,7 @@ resource "google_pubsub_topic" "topic" {
 `, hl7_v2StoreName, datasetName, pubsubTopic)
 }
 
-<% unless version == 'ga' %>
+<% unless version == 'ga' -%>
 func testGoogleHealthcareHl7V2Store_basicSchema(hl7_v2StoreName, datasetName string) string {
 	return fmt.Sprintf(`
 resource "google_healthcare_hl7_v2_store" "default" {

--- a/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_id_test.go.erb
+++ b/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_id_test.go.erb
@@ -1,7 +1,7 @@
 <% autogen_exception -%>
 package iambeta_test
 
-<% unless version == 'ga' %>
+<% unless version == 'ga' -%>
 import (
 	"strings"
 	"testing"

--- a/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_provider_id_test.go.erb
+++ b/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_provider_id_test.go.erb
@@ -1,7 +1,7 @@
 <% autogen_exception -%>
 package iambeta_test
 
-<% unless version == 'ga' %>
+<% unless version == 'ga' -%>
 import (
 	"strings"
 	"testing"

--- a/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_provider_test.go.erb
+++ b/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_provider_test.go.erb
@@ -1,7 +1,7 @@
 <% autogen_exception -%>
 package iambeta_test
 
-<% unless version == 'ga' %>
+<% unless version == 'ga' -%>
 import (
 	"testing"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"

--- a/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_test.go.erb
@@ -1,7 +1,7 @@
 <% autogen_exception -%>
 package iambeta_test
 
-<% unless version == 'ga' %>
+<% unless version == 'ga' -%>
 import (
 	"fmt"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"

--- a/mmv1/third_party/terraform/services/notebooks/resource_notebooks_environment_test.go.erb
+++ b/mmv1/third_party/terraform/services/notebooks/resource_notebooks_environment_test.go.erb
@@ -1,7 +1,7 @@
 <% autogen_exception -%>
 package notebooks_test
 
-<% unless version == 'ga' %>
+<% unless version == 'ga' -%>
 import (
 	"fmt"
 	"testing"

--- a/mmv1/third_party/terraform/services/notebooks/resource_notebooks_instance_container_test.go.erb
+++ b/mmv1/third_party/terraform/services/notebooks/resource_notebooks_instance_container_test.go.erb
@@ -1,7 +1,7 @@
 <% autogen_exception -%>
 package notebooks_test
 
-<% unless version == 'ga' %>
+<% unless version == 'ga' -%>
 import (
 	"fmt"
 	"testing"

--- a/mmv1/third_party/terraform/services/notebooks/resource_notebooks_instance_gpu_test.go.erb
+++ b/mmv1/third_party/terraform/services/notebooks/resource_notebooks_instance_gpu_test.go.erb
@@ -1,7 +1,7 @@
 <% autogen_exception -%>
 package notebooks_test
 
-<% unless version == 'ga' %>
+<% unless version == 'ga' -%>
 import (
 	"fmt"
 	"testing"

--- a/mmv1/third_party/terraform/services/notebooks/resource_notebooks_instance_state_test.go.erb
+++ b/mmv1/third_party/terraform/services/notebooks/resource_notebooks_instance_state_test.go.erb
@@ -1,7 +1,7 @@
 <% autogen_exception -%>
 package notebooks_test
 
-<% unless version == 'ga' %>
+<% unless version == 'ga' -%>
 import (
 	"fmt"
 	"testing"

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.erb
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.erb
@@ -250,7 +250,7 @@ func CompareIpAddressOrSelfLinkOrResourceName(_, old, new string, _ *schema.Reso
 	return CompareSelfLinkOrResourceName("", old, new, nil)
 }
 
-<% if version != "ga" -%>
+<% unless version == "ga" -%>
 // Suppress all diffs, used for Disk.Interface which is a nonfunctional field
 func AlwaysDiffSuppress(_, _, _ string, _ *schema.ResourceData) bool {
 	return true


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This adds the GitHub Action that checks version guards in erb files that were changed.

Confirmation of an invalid version guard being found in a previous commit here https://github.com/GoogleCloudPlatform/magic-modules/actions/runs/8525807220/job/23353642608?pr=10347

This PR also includes changes to all existing erbs so that they pass the checker (to avoid people touching files and then needing to fix them). You can see from the generated diffs that there are only whitespace differences.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
