### PR TITLE
fix: fix breaking change not detecting adding max_size to array

### DIFF
--- a/tools/diff-processor/rules/rules_field.go
+++ b/tools/diff-processor/rules/rules_field.go
@@ -178,8 +178,11 @@ func fieldRule_GrowingMin_func(old, new *schema.Schema, mc MessageContext) strin
 		return ""
 	}
 	message := mc.message
-	if old.MinItems < new.MinItems {
+	if old.MinItems < new.MinItems || old.MinItems == 0 && new.MinItems > 0 {
 		oldMin := fmt.Sprint(old.MinItems)
+		if old.MinItems == 0 {
+			oldMin = "unset"
+		}
 		newMin := fmt.Sprint(new.MinItems)
 		message = strings.ReplaceAll(message, "{{oldMin}}", oldMin)
 		message = strings.ReplaceAll(message, "{{newMin}}", newMin)
@@ -202,9 +205,12 @@ func fieldRule_ShrinkingMax_func(old, new *schema.Schema, mc MessageContext) str
 		return ""
 	}
 	message := mc.message
-	if old.MaxItems > new.MaxItems {
-		oldMax := fmt.Sprint(old.MinItems)
-		newMax := fmt.Sprint(new.MinItems)
+	if old.MaxItems > new.MaxItems || old.MaxItems == 0 && new.MaxItems > 0 {
+		oldMax := fmt.Sprint(old.MaxItems)
+		if old.MaxItems == 0 {
+			oldMax = "unset"
+		}
+		newMax := fmt.Sprint(new.MaxItems)
 		message = strings.ReplaceAll(message, "{{oldMax}}", oldMax)
 		message = strings.ReplaceAll(message, "{{newMax}}", newMax)
 		return populateMessageContext(message, mc)

--- a/tools/diff-processor/rules/rules_field_test.go
+++ b/tools/diff-processor/rules/rules_field_test.go
@@ -435,7 +435,7 @@ var fieldRule_GrowingMinTestCases = []fieldTestCase{
 			MinItems: 1,
 		},
 		newField: &schema.Schema{
-			MaxItems: 1,
+			MinItems: 1,
 		},
 		expectedViolation: false,
 	},
@@ -469,7 +469,7 @@ var fieldRule_GrowingMinTestCases = []fieldTestCase{
 		name:     "field added",
 		oldField: nil,
 		newField: &schema.Schema{
-			MaxItems: 1,
+			MinItems: 1,
 		},
 		expectedViolation: false,
 	},
@@ -480,6 +480,14 @@ var fieldRule_GrowingMinTestCases = []fieldTestCase{
 		},
 		newField:          nil,
 		expectedViolation: false,
+	},
+	{
+		name:     "min unset to defined",
+		oldField: &schema.Schema{},
+		newField: &schema.Schema{
+			MinItems: 2,
+		},
+		expectedViolation: true,
 	},
 }
 
@@ -493,7 +501,7 @@ var fieldRule_ShrinkingMaxTestCases = []fieldTestCase{
 	{
 		name: "control:max - static",
 		oldField: &schema.Schema{
-			MinItems: 2,
+			MaxItems: 2,
 		},
 		newField: &schema.Schema{
 			MaxItems: 2,
@@ -537,10 +545,18 @@ var fieldRule_ShrinkingMaxTestCases = []fieldTestCase{
 	{
 		name: "field removed",
 		oldField: &schema.Schema{
-			MinItems: 2,
+			MaxItems: 2,
 		},
 		newField:          nil,
 		expectedViolation: false,
+	},
+	{
+		name:     "max unset to defined",
+		oldField: &schema.Schema{},
+		newField: &schema.Schema{
+			MaxItems: 2,
+		},
+		expectedViolation: true,
 	},
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fix breaking change detection rule to detect max size from unset to defined, similar to min size. 

https://github.com/hashicorp/terraform-provider-google/issues/17576

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
