### PR TITLE
Fixed permission issues when activating a sub-CA in a different region

### DIFF
--- a/mmv1/third_party/terraform/services/privateca/privateca_ca_utils.go
+++ b/mmv1/third_party/terraform/services/privateca/privateca_ca_utils.go
@@ -228,12 +228,14 @@ func activateSubCAWithFirstPartyIssuer(config *transport_tpg.Config, d *schema.R
 		return fmt.Errorf("Error creating Certificate: %s", err)
 	}
 	signedCACert := res["pemCertificate"]
+	signerCertChain := res["pemCertificateChain"]
 
 	// 4. activate sub CA with the signed CA cert.
 	activateObj := make(map[string]interface{})
 	activateObj["pemCaCertificate"] = signedCACert
 	activateObj["subordinateConfig"] = make(map[string]interface{})
-	activateObj["subordinateConfig"].(map[string]interface{})["certificateAuthority"] = issuer
+	activateObj["subordinateConfig"].(map[string]interface{})["pemIssuerChain"] = make(map[string]interface{})
+	activateObj["subordinateConfig"].(map[string]interface{})["pemIssuerChain"].(map[string]interface{})["pemCertificates"] = signerCertChain
 
 	activateUrl, err := tpgresource.ReplaceVars(d, config, "{{PrivatecaBasePath}}projects/{{project}}/locations/{{location}}/caPools/{{pool}}/certificateAuthorities/{{certificate_authority_id}}:activate")
 	if err != nil {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Specify signer certs chain when activating a sub-CA. This resolves permission issues when activating sub-CA across regions.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
privateca: fixed permission issues when activating a sub-CA in a different region
```
