### PR TITLE
docs: Document that the max allowed retention for Firestore backup schedules is 14 weeks

### DIFF
--- a/mmv1/products/firestore/BackupSchedule.yaml
+++ b/mmv1/products/firestore/BackupSchedule.yaml
@@ -82,7 +82,7 @@ properties:
       At what relative time in the future, compared to its creation time, the backup should be deleted, e.g. keep backups for 7 days.
       A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.5s".
 
-      For a daily backup recurrence, set this to a value up to 7 days. If you set a weekly backup recurrence, set this to a value up to 14 weeks.
+      You can set this to a value up to 14 weeks.
   - !ruby/object:Api::Type::NestedObject
     name: dailyRecurrence
     description: |

--- a/mmv1/templates/terraform/examples/firestore_backup_schedule_daily.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_backup_schedule_daily.tf.erb
@@ -12,7 +12,7 @@ resource "google_firestore_backup_schedule" "<%= ctx[:primary_resource_id] %>" {
   project  = "<%= ctx[:test_env_vars]['project_id'] %>"
   database = google_firestore_database.database.name
 
-  retention = "604800s" // 7 days (maximum possible value for daily backups)
+  retention = "8467200s" // 14 weeks (maximum possible retention)
 
   daily_recurrence {}
 }

--- a/mmv1/templates/terraform/examples/firestore_backup_schedule_weekly.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_backup_schedule_weekly.tf.erb
@@ -12,7 +12,7 @@ resource "google_firestore_backup_schedule" "<%= ctx[:primary_resource_id] %>" {
   project  = "<%= ctx[:test_env_vars]['project_id'] %>"
   database = google_firestore_database.database.name
 
-  retention = "8467200s" // 14 weeks (maximum possible value for weekly backups)
+  retention = "8467200s" // 14 weeks (maximum possible retention)
 
   weekly_recurrence {
     day = "SUNDAY"


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
