### PR TITLE
fixed permission issues when activating a sub-CA in a different region

### DIFF
--- a/mmv1/products/privateca/CertificateAuthority.yaml
+++ b/mmv1/products/privateca/CertificateAuthority.yaml
@@ -653,6 +653,8 @@ properties:
           subordinate CertificateAuthority. This field is used for information
           and usability purposes only. The resource name is in the format
           `projects/*/locations/*/caPools/*/certificateAuthorities/*`.
+        # certificateAuthority is not included in the response since the sub-CA is activated via specifing pemIssuerChain
+        custom_flatten: 'templates/terraform/custom_flatten/privateca_certificate_authority_subordinate_config_certificate_authority.go.erb'
         exactly_one_of:
           - subordinate_config.0.certificate_authority
           - subordinate_config.0.pem_issuer_chain
@@ -662,6 +664,7 @@ properties:
         description: |
           Contains the PEM certificate chain for the issuers of this CertificateAuthority,
           but not pem certificate for this CA itself.
+        default_from_api: true
         exactly_one_of:
           - subordinate_config.0.certificate_authority
           - subordinate_config.0.pem_issuer_chain

--- a/mmv1/templates/terraform/custom_flatten/privateca_certificate_authority_subordinate_config_certificate_authority.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/privateca_certificate_authority_subordinate_config_certificate_authority.go.erb
@@ -1,0 +1,3 @@
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return d.Get("subordinate_config.0.certificate_authority")
+}

--- a/mmv1/third_party/terraform/services/privateca/privateca_ca_utils.go
+++ b/mmv1/third_party/terraform/services/privateca/privateca_ca_utils.go
@@ -228,12 +228,14 @@ func activateSubCAWithFirstPartyIssuer(config *transport_tpg.Config, d *schema.R
 		return fmt.Errorf("Error creating Certificate: %s", err)
 	}
 	signedCACert := res["pemCertificate"]
+	signerCertChain := res["pemCertificateChain"]
 
 	// 4. activate sub CA with the signed CA cert.
 	activateObj := make(map[string]interface{})
 	activateObj["pemCaCertificate"] = signedCACert
 	activateObj["subordinateConfig"] = make(map[string]interface{})
-	activateObj["subordinateConfig"].(map[string]interface{})["certificateAuthority"] = issuer
+	activateObj["subordinateConfig"].(map[string]interface{})["pemIssuerChain"] = make(map[string]interface{})
+	activateObj["subordinateConfig"].(map[string]interface{})["pemIssuerChain"].(map[string]interface{})["pemCertificates"] = signerCertChain
 
 	activateUrl, err := tpgresource.ReplaceVars(d, config, "{{PrivatecaBasePath}}projects/{{project}}/locations/{{location}}/caPools/{{pool}}/certificateAuthorities/{{certificate_authority_id}}:activate")
 	if err != nil {

--- a/mmv1/third_party/terraform/services/privateca/resource_privateca_certificate_authority_test.go
+++ b/mmv1/third_party/terraform/services/privateca/resource_privateca_certificate_authority_test.go
@@ -120,6 +120,33 @@ func TestAccPrivatecaCertificateAuthority_rootCaManageDesiredState(t *testing.T)
 	})
 }
 
+func TestAccPrivatecaCertificateAuthority_subordinateCaActivatedByFirstPartyIssuerOnCreation(t *testing.T) {
+	t.Parallel()
+	acctest.SkipIfVcr(t)
+
+	random_suffix := acctest.RandString(t, 10)
+	context := map[string]interface{}{
+		"root_location": "us-central1",
+		"sub_location":  "australia-southeast1",
+		"random_suffix": random_suffix,
+	}
+
+	resourceName := "google_privateca_certificate_authority.sub-1"
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckPrivatecaCertificateAuthorityDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivatecaCertificateAuthority_privatecaCertificateAuthoritySubordinateWithFirstPartyIssuer(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "state", "ENABLED"),
+				),
+			},
+		},
+	})
+}
+
 func testAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityBasicRoot(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_privateca_certificate_authority" "default" {
@@ -282,6 +309,142 @@ resource "google_privateca_certificate_authority" "default" {
 	key_spec {
 		algorithm = "RSA_PKCS1_4096_SHA256"
 	}
+}
+`, context)
+}
+
+// testAccPrivatecaCertificateAuthority_privatecaCertificateAuthoritySubordinateWithFirstPartyIssuer provides a config
+// which contains
+// * A CaPool for root CA
+// * A root CA
+// * A CaPool for sub CA
+// * A subordinate CA which should be activated by the above root CA
+func testAccPrivatecaCertificateAuthority_privatecaCertificateAuthoritySubordinateWithFirstPartyIssuer(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_privateca_ca_pool" "root-pool" {
+	name     = "root-pool-%{random_suffix}"
+	location = "%{root_location}"
+	tier     = "ENTERPRISE"
+	publishing_options {
+	  publish_ca_cert = true
+	  publish_crl     = true
+	}
+}
+
+resource "google_privateca_certificate_authority" "root-1" {
+	pool = google_privateca_ca_pool.root-pool.name 
+	certificate_authority_id = "tf-test-my-certificate-authority-root-%{random_suffix}"
+	location = "%{root_location}"
+	config {
+		subject_config {
+		subject {
+			organization = "HashiCorp"
+			common_name = "my-certificate-authority"
+		}
+		subject_alt_name {
+			dns_names = ["hashicorp.com"]
+		}
+		}
+		x509_config {
+		ca_options {
+			is_ca = true
+			max_issuer_path_length = 10
+		}
+		key_usage {
+			base_key_usage {
+			digital_signature = true
+			content_commitment = true
+			key_encipherment = false
+			data_encipherment = true
+			key_agreement = true
+			cert_sign = true
+			crl_sign = true
+			decipher_only = true
+			}
+			extended_key_usage {
+			server_auth = true
+			client_auth = false
+			email_protection = true
+			code_signing = true
+			time_stamping = true
+			}
+		}
+		}
+	}
+	lifetime = "86400s"
+	key_spec {
+		algorithm = "RSA_PKCS1_4096_SHA256"
+	}
+
+	// Disable CA deletion related safe checks for easier cleanup.
+	deletion_protection                    = false
+	skip_grace_period                      = true
+	ignore_active_certificates_on_deletion = true
+}
+
+resource "google_privateca_ca_pool" "sub-pool" {
+	name     = "sub-pool-%{random_suffix}"
+	location = "%{sub_location}"
+	tier     = "ENTERPRISE"
+	publishing_options {
+	  publish_ca_cert = true
+	  publish_crl     = true
+	}
+}
+
+resource "google_privateca_certificate_authority" "sub-1" {
+	pool = google_privateca_ca_pool.sub-pool.name 
+	certificate_authority_id = "tf-test-my-certificate-authority-sub-%{random_suffix}"
+	location = "%{sub_location}"
+	subordinate_config {
+		certificate_authority = google_privateca_certificate_authority.root-1.name
+	}
+	config {
+		subject_config {
+		subject {
+			organization = "HashiCorp"
+			common_name = "my-certificate-authority"
+		}
+		subject_alt_name {
+			dns_names = ["hashicorp.com"]
+		}
+		}
+		x509_config {
+		ca_options {
+			is_ca = true
+			max_issuer_path_length = 10
+		}
+		key_usage {
+			base_key_usage {
+			digital_signature = true
+			content_commitment = true
+			key_encipherment = false
+			data_encipherment = true
+			key_agreement = true
+			cert_sign = true
+			crl_sign = true
+			decipher_only = true
+			}
+			extended_key_usage {
+			server_auth = true
+			client_auth = false
+			email_protection = true
+			code_signing = true
+			time_stamping = true
+			}
+		}
+		}
+	}
+	lifetime = "86400s"
+	key_spec {
+		algorithm = "RSA_PKCS1_4096_SHA256"
+	}
+	type = "SUBORDINATE"
+
+	// Disable CA deletion related safe checks for easier cleanup.
+	deletion_protection                    = false
+	skip_grace_period                      = true
+	ignore_active_certificates_on_deletion = true
 }
 `, context)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Specify signer certs chain when activating a sub-CA. This resolves permission issues when activating sub-CA across regions.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
privateca: fixed permission issues when activating a sub-CA in a different region
```
