### PR TITLE
Removed cloudbuild approval link

### DIFF
--- a/.ci/magician/cloudbuild/community.go
+++ b/.ci/magician/cloudbuild/community.go
@@ -41,21 +41,6 @@ func (cb *Client) ApproveCommunityChecker(prNumber, commitSha string) error {
 	return nil
 }
 
-func (cb *Client) GetAwaitingApprovalBuildLink(prNumber, commitSha string) (string, error) {
-	buildId, err := getPendingBuildId(PROJECT_ID, commitSha)
-	if err != nil {
-		return "", err
-	}
-
-	if buildId == "" {
-		return "", fmt.Errorf("failed to find pending build for PR %s", prNumber)
-	}
-
-	targetUrl := fmt.Sprintf("https://console.cloud.google.com/cloud-build/builds;region=global/%s?project=%s", buildId, PROJECT_ID)
-
-	return targetUrl, nil
-}
-
 func getPendingBuildId(projectId, commitSha string) (string, error) {
 	COMMUNITY_CHECKER_TRIGGER, ok := os.LookupEnv("COMMUNITY_CHECKER_TRIGGER")
 	if !ok {

--- a/.ci/magician/cmd/interfaces.go
+++ b/.ci/magician/cmd/interfaces.go
@@ -37,7 +37,6 @@ type GithubClient interface {
 
 type CloudbuildClient interface {
 	ApproveCommunityChecker(prNumber, commitSha string) error
-	GetAwaitingApprovalBuildLink(prNumber, commitSha string) (string, error)
 	TriggerMMPresubmitRuns(commitSha string, substitutions map[string]string) error
 }
 

--- a/.ci/magician/cmd/membership_checker.go
+++ b/.ci/magician/cmd/membership_checker.go
@@ -84,17 +84,6 @@ func execMembershipChecker(prNumber, commitSha string, gh GithubClient, cb Cloud
 		}
 	} else {
 		gh.AddLabels(prNumber, []string{"awaiting-approval"})
-		targetUrl, err := cb.GetAwaitingApprovalBuildLink(prNumber, commitSha)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-
-		err = gh.PostBuildStatus(prNumber, "Approve Build", "success", targetUrl, commitSha)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
 	}
 }
 

--- a/.ci/magician/cmd/membership_checker_test.go
+++ b/.ci/magician/cmd/membership_checker_test.go
@@ -100,14 +100,6 @@ func TestExecMembershipChecker_AmbiguousUserFlow(t *testing.T) {
 		t.Fatalf("Wrong calls for %s, got %v, expected %v", method, calls, expected)
 	}
 
-	method = "GetAwaitingApprovalBuildLink"
-	expected = [][]any{{"pr1", "sha1"}}
-	if calls, ok := cb.calledMethods[method]; !ok {
-		t.Fatal("Awaiting approval build link wasn't gotten from pull request")
-	} else if !reflect.DeepEqual(calls, expected) {
-		t.Fatalf("Wrong calls for %s, got %v, expected %v", method, calls, expected)
-	}
-
 	if _, ok := gh.calledMethods["ApproveCommunityChecker"]; ok {
 		t.Fatal("Incorrectly approved community checker for ambiguous user")
 	}

--- a/.ci/magician/cmd/mock_cloudbuild_test.go
+++ b/.ci/magician/cmd/mock_cloudbuild_test.go
@@ -24,11 +24,6 @@ func (m *mockCloudBuild) ApproveCommunityChecker(prNumber, commitSha string) err
 	return nil
 }
 
-func (m *mockCloudBuild) GetAwaitingApprovalBuildLink(prNumber, commitSha string) (string, error) {
-	m.calledMethods["GetAwaitingApprovalBuildLink"] = append(m.calledMethods["GetAwaitingApprovalBuildLink"], []any{prNumber, commitSha})
-	return "mocked_url", nil
-}
-
 func (m *mockCloudBuild) TriggerMMPresubmitRuns(commitSha string, substitutions map[string]string) error {
 	m.calledMethods["TriggerMMPresubmitRuns"] = append(m.calledMethods["TriggerMMPresubmitRuns"], []any{commitSha, substitutions})
 	return nil


### PR DESCRIPTION
This is no longer necessary because cloudbuild now properly links to the build that needs approval - for example, https://github.com/GoogleCloudPlatform/magic-modules/pull/10358/checks?check_run_id=23384328452

b/328513466#comment18

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
