### PR TITLE
Adding ipv6 support for bgp router peer, router interface and router

### DIFF
--- a/mmv1/products/compute/Router.yaml
+++ b/mmv1/products/compute/Router.yaml
@@ -187,6 +187,16 @@ properties:
           between the two peers. If set, this value must be between 20 and 60.
           The default is 20.
         default_value: 20
+      - !ruby/object:Api::Type::String
+        name: identifierRange
+        default_from_api: true
+        min_version: beta
+        description: |
+          Explicitly specifies a range of valid BGP Identifiers for this Router.
+          It is provided as a link-local IPv4 range (from 169.254.0.0/16), of
+          size at least /30, even if the BGP sessions are over IPv6. It must
+          not overlap with any IPv4 BGP session ranges.Other vendors commonly
+          call this router ID.
   - !ruby/object:Api::Type::Boolean
     name: encryptedInterconnectRouter
     immutable: true

--- a/mmv1/products/compute/Router.yaml
+++ b/mmv1/products/compute/Router.yaml
@@ -195,7 +195,7 @@ properties:
           Explicitly specifies a range of valid BGP Identifiers for this Router.
           It is provided as a link-local IPv4 range (from 169.254.0.0/16), of
           size at least /30, even if the BGP sessions are over IPv6. It must
-          not overlap with any IPv4 BGP session ranges.Other vendors commonly
+          not overlap with any IPv4 BGP session ranges. Other vendors commonly
           call this router ID.
   - !ruby/object:Api::Type::Boolean
     name: encryptedInterconnectRouter

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.erb
@@ -713,9 +713,6 @@ func testAccComputeRouterPeerWithMd5AuthKey(routerName string) string {
     advertised_route_priority = 100
     interface                 = google_compute_router_interface.foobar.name
     peer_ip_address           = "169.254.3.2"
-    <% unless version == 'ga' -%>
-    enable_ipv4               = true
-    <% end -%>
     md5_authentication_key {
       name = "%s-peer-key"
       key = "%s-peer-key-value"
@@ -730,9 +727,6 @@ func testAccComputeRouterPeerWithMd5AuthKey(routerName string) string {
     advertised_route_priority = 100
     interface                 = google_compute_router_interface.foobar1.name
     peer_ip_address           = "169.254.4.2"
-    <% unless version == 'ga' -%>
-    enable_ipv4               = true
-    <% end -%>
     md5_authentication_key {
       name = "%s-peer1-key"
       key = "%s-peer1-key-value"
@@ -838,9 +832,6 @@ func testAccComputeRouterPeerWithMd5AuthKeyUpdate(routerName string) string {
     advertised_route_priority = 100
     interface                 = google_compute_router_interface.foobar.name
     peer_ip_address           = "169.254.3.2"
-    <% unless version == 'ga' -%>
-    enable_ipv4               = true
-    <% end -%>
     md5_authentication_key {
       name = "%s-peer-key"
       key = "%s-peer-key-value"
@@ -855,9 +846,6 @@ func testAccComputeRouterPeerWithMd5AuthKeyUpdate(routerName string) string {
     advertised_route_priority = 100
     interface                 = google_compute_router_interface.foobar1.name
     peer_ip_address           = "169.254.4.2"
-    <% unless version == 'ga' -%>
-    enable_ipv4               = true
-    <% end -%>
     md5_authentication_key {
       name = "%s-peer1-key"
       key = "%s-peer1-key-value-changed"
@@ -1501,10 +1489,6 @@ resource "google_compute_router_peer" "foobar" {
   peer_asn                  = 65515
   advertised_route_priority = 100
   interface                 = google_compute_router_interface.foobar.name
-  <% unless version == 'ga' -%>
-  enable_ipv4               = true
-  <% end -%>
-
   enable_ipv6               = %v
 
 }
@@ -1581,9 +1565,6 @@ resource "google_compute_router_peer" "foobar" {
   peer_asn                  = 65515
   advertised_route_priority = 100
   interface                 = google_compute_router_interface.foobar.name
-  <% unless version == 'ga' -%>
-  enable_ipv4               = true
-  <% end -%>
   enable_ipv6               = %v
   ipv6_nexthop_address      = "2600:2d00:0000:0002:0000:0000:0000:0001"
   peer_ipv6_nexthop_address = "2600:2d00:0:2::2"

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.erb
@@ -713,6 +713,9 @@ func testAccComputeRouterPeerWithMd5AuthKey(routerName string) string {
     advertised_route_priority = 100
     interface                 = google_compute_router_interface.foobar.name
     peer_ip_address           = "169.254.3.2"
+    <% unless version == 'ga' -%>
+    enable_ipv4               = true
+    <% end -%>
     md5_authentication_key {
       name = "%s-peer-key"
       key = "%s-peer-key-value"
@@ -727,6 +730,9 @@ func testAccComputeRouterPeerWithMd5AuthKey(routerName string) string {
     advertised_route_priority = 100
     interface                 = google_compute_router_interface.foobar1.name
     peer_ip_address           = "169.254.4.2"
+    <% unless version == 'ga' -%>
+    enable_ipv4               = true
+    <% end -%>
     md5_authentication_key {
       name = "%s-peer1-key"
       key = "%s-peer1-key-value"
@@ -832,6 +838,9 @@ func testAccComputeRouterPeerWithMd5AuthKeyUpdate(routerName string) string {
     advertised_route_priority = 100
     interface                 = google_compute_router_interface.foobar.name
     peer_ip_address           = "169.254.3.2"
+    <% unless version == 'ga' -%>
+    enable_ipv4               = true
+    <% end -%>
     md5_authentication_key {
       name = "%s-peer-key"
       key = "%s-peer-key-value"
@@ -846,6 +855,9 @@ func testAccComputeRouterPeerWithMd5AuthKeyUpdate(routerName string) string {
     advertised_route_priority = 100
     interface                 = google_compute_router_interface.foobar1.name
     peer_ip_address           = "169.254.4.2"
+    <% unless version == 'ga' -%>
+    enable_ipv4               = true
+    <% end -%>
     md5_authentication_key {
       name = "%s-peer1-key"
       key = "%s-peer1-key-value-changed"
@@ -1489,8 +1501,12 @@ resource "google_compute_router_peer" "foobar" {
   peer_asn                  = 65515
   advertised_route_priority = 100
   interface                 = google_compute_router_interface.foobar.name
+  <% unless version == 'ga' -%>
+  enable_ipv4               = true
+  <% end -%>
 
   enable_ipv6               = %v
+
 }
 `, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, enableIpv6)
 }
@@ -1565,7 +1581,9 @@ resource "google_compute_router_peer" "foobar" {
   peer_asn                  = 65515
   advertised_route_priority = 100
   interface                 = google_compute_router_interface.foobar.name
-
+  <% unless version == 'ga' -%>
+  enable_ipv4               = true
+  <% end -%>
   enable_ipv6               = %v
   ipv6_nexthop_address      = "2600:2d00:0000:0002:0000:0000:0000:0001"
   peer_ipv6_nexthop_address = "2600:2d00:0:2::2"

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package compute_test
 
 import (
@@ -205,6 +206,75 @@ func TestAccComputeRouterPeer_Ipv6Basic(t *testing.T) {
 		},
 	})
 }
+
+<% unless version == 'ga' -%>
+func TestAccComputeRouterPeer_Ipv4Basic(t *testing.T) {
+	t.Parallel()
+
+	routerName := fmt.Sprintf("tf-test-router-%s", acctest.RandString(t, 10))
+	resourceName := "google_compute_router_peer.foobar"
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckComputeRouterPeerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRouterPeerIpv4(routerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRouterPeerExists(
+						t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enable_ipv4", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRouterPeer_UpdateIpv4(t *testing.T) {
+  t.Parallel()
+
+  routerName := fmt.Sprintf("tf-test-router-%s", acctest.RandString(t, 10))
+	resourceName := "google_compute_router_peer.foobar"
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckComputeRouterPeerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRouterPeerIpv4(routerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRouterPeerExists(
+						t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enable_ipv6", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterPeerUpdateIpv4Address(routerName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRouterPeerExists(
+						t, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "enable_ipv4", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+<% end -%>
 
 func TestAccComputeRouterPeer_UpdateIpv6Address(t *testing.T) {
 	t.Parallel()
@@ -1502,3 +1572,177 @@ resource "google_compute_router_peer" "foobar" {
 }
 `, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, enableIpv6)
 }
+
+<% unless version == 'ga' -%>
+func testAccComputeRouterPeerIpv4(routerName string) string {
+	return fmt.Sprintf(`resource "google_compute_network" "foobar" {
+    provider = google-beta
+    name = "%s-net"
+    auto_create_subnetworks = false
+  }
+  
+  resource "google_compute_subnetwork" "foobar" {
+    provider = google-beta
+    name          = "%s-subnet"
+    network       = google_compute_network.foobar.self_link
+    ip_cidr_range = "10.0.0.0/16"
+    region        = "us-central1"
+    stack_type = "IPV4_IPV6"
+    ipv6_access_type = "EXTERNAL" 
+  }
+  
+  resource "google_compute_ha_vpn_gateway" "foobar" {
+    provider = google-beta
+    name    = "%s-gateway"
+    network = google_compute_network.foobar.self_link
+    region  = google_compute_subnetwork.foobar.region
+    stack_type = "IPV4_IPV6"
+  }
+  
+  resource "google_compute_external_vpn_gateway" "external_gateway" {
+    provider = google-beta
+    name            = "%s-external-gateway"
+    redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
+    description     = "An externally managed VPN gateway"
+    interface {
+      id         = 0
+      ip_address = "8.8.8.8"
+    }
+  }
+  
+  resource "google_compute_router" "foobar" {
+    provider = google-beta
+    name    = "%s"
+    region  = google_compute_subnetwork.foobar.region
+    network = google_compute_network.foobar.self_link
+    bgp {
+      asn = 64514
+    }
+  }
+  
+  resource "google_compute_vpn_tunnel" "foobar" {
+    provider = google-beta
+    name               = "%s-tunnel"
+    region             = google_compute_subnetwork.foobar.region
+    vpn_gateway = google_compute_ha_vpn_gateway.foobar.id
+    peer_external_gateway           = google_compute_external_vpn_gateway.external_gateway.id
+    peer_external_gateway_interface = 0  
+    shared_secret      = "unguessable"
+    router             = google_compute_router.foobar.name
+    vpn_gateway_interface           = 0
+  }
+  
+  resource "google_compute_router_interface" "foobar" {
+    provider = google-beta
+    name       = "%s-interface"
+    router     = google_compute_router.foobar.name
+    region     = google_compute_router.foobar.region
+    vpn_tunnel = google_compute_vpn_tunnel.foobar.name
+    ip_range   = "fdff:1::1:1/126"
+  }
+  
+  resource "google_compute_router_peer" "foobar" {
+    provider = google-beta
+    name                      = "%s-peer"
+    router                    = google_compute_router.foobar.name
+    region                    = google_compute_router.foobar.region
+    peer_asn                  = 65515
+    advertised_route_priority = 100
+    interface                 = google_compute_router_interface.foobar.name
+    ip_address                = "fdff:1::1:1"
+    peer_ip_address           = "fdff:1::1:2"
+
+    enable_ipv4               = true
+    enable_ipv6               = true
+    ipv4_nexthop_address      = "169.254.1.1"
+    peer_ipv4_nexthop_address = "169.254.1.2"
+  }
+  `, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
+}
+
+func testAccComputeRouterPeerUpdateIpv4Address(routerName string) string {
+	return fmt.Sprintf(`resource "google_compute_network" "foobar" {
+    provider = google-beta
+    name = "%s-net"
+    auto_create_subnetworks = false
+  }
+  
+  resource "google_compute_subnetwork" "foobar" {
+    provider = google-beta
+    name          = "%s-subnet"
+    network       = google_compute_network.foobar.self_link
+    ip_cidr_range = "10.0.0.0/16"
+    region        = "us-central1"
+    stack_type = "IPV4_IPV6"
+    ipv6_access_type = "EXTERNAL" 
+  }
+  
+  resource "google_compute_ha_vpn_gateway" "foobar" {
+    provider = google-beta
+    name    = "%s-gateway"
+    network = google_compute_network.foobar.self_link
+    region  = google_compute_subnetwork.foobar.region
+    stack_type = "IPV4_IPV6"
+  }
+  
+  resource "google_compute_external_vpn_gateway" "external_gateway" {
+    provider = google-beta
+    name            = "%s-external-gateway"
+    redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
+    description     = "An externally managed VPN gateway"
+    interface {
+      id         = 0
+      ip_address = "8.8.8.8"
+    }
+  }
+  
+  resource "google_compute_router" "foobar" {
+    provider = google-beta
+    name    = "%s"
+    region  = google_compute_subnetwork.foobar.region
+    network = google_compute_network.foobar.self_link
+    bgp {
+      asn = 64514
+    }
+  }
+  
+  resource "google_compute_vpn_tunnel" "foobar" {
+    provider = google-beta
+    name               = "%s-tunnel"
+    region             = google_compute_subnetwork.foobar.region
+    vpn_gateway = google_compute_ha_vpn_gateway.foobar.id
+    peer_external_gateway           = google_compute_external_vpn_gateway.external_gateway.id
+    peer_external_gateway_interface = 0  
+    shared_secret      = "unguessable"
+    router             = google_compute_router.foobar.name
+    vpn_gateway_interface           = 0
+  }
+  
+  resource "google_compute_router_interface" "foobar" {
+    provider = google-beta
+    name       = "%s-interface"
+    router     = google_compute_router.foobar.name
+    region     = google_compute_router.foobar.region
+    vpn_tunnel = google_compute_vpn_tunnel.foobar.name
+    ip_range   = "fdff:1::1:1/126"
+  }
+  
+  resource "google_compute_router_peer" "foobar" {
+    provider = google-beta
+    name                      = "%s-peer"
+    router                    = google_compute_router.foobar.name
+    region                    = google_compute_router.foobar.region
+    peer_asn                  = 65515
+    advertised_route_priority = 100
+    interface                 = google_compute_router_interface.foobar.name
+    ip_address                = "fdff:1::1:1"
+    peer_ip_address           = "fdff:1::1:2"
+
+    enable_ipv4               = true
+    enable_ipv6               = true
+    ipv4_nexthop_address      = "169.254.1.2"
+    peer_ipv4_nexthop_address = "169.254.1.1"
+  }
+  `, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
+}
+<% end -%>

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.erb
@@ -208,34 +208,7 @@ func TestAccComputeRouterPeer_Ipv6Basic(t *testing.T) {
 }
 
 <% unless version == 'ga' -%>
-func TestAccComputeRouterPeer_Ipv4Basic(t *testing.T) {
-	t.Parallel()
-
-	routerName := fmt.Sprintf("tf-test-router-%s", acctest.RandString(t, 10))
-	resourceName := "google_compute_router_peer.foobar"
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
-		CheckDestroy:             testAccCheckComputeRouterPeerDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccComputeRouterPeerIpv4(routerName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeRouterPeerExists(
-						t, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "enable_ipv4", "true"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccComputeRouterPeer_UpdateIpv4(t *testing.T) {
+func TestAccComputeRouterPeer_Ipv4BasicCreateUpdate(t *testing.T) {
   t.Parallel()
 
   routerName := fmt.Sprintf("tf-test-router-%s", acctest.RandString(t, 10))
@@ -250,7 +223,7 @@ func TestAccComputeRouterPeer_UpdateIpv4(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeRouterPeerExists(
 						t, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "enable_ipv6", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enable_ipv4", "true"),
 				),
 			},
 			{
@@ -264,6 +237,8 @@ func TestAccComputeRouterPeer_UpdateIpv4(t *testing.T) {
 					testAccCheckComputeRouterPeerExists(
 						t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "enable_ipv4", "true"),
+          resource.TestCheckResourceAttr(resourceName, "ipv4_nexthop_address", "169.254.1.2"),
+          resource.TestCheckResourceAttr(resourceName, "peer_ipv4_nexthop_address", "169.254.1.1"),
 				),
 			},
 			{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_interface.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_interface.go.erb
@@ -13,8 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	<% if version == "ga" -%>
-	<% else -%>
+	<% unless version == "ga" -%>
 	"github.com/hashicorp/terraform-provider-google/google/verify"
 	<% end -%>
 	"google.golang.org/api/googleapi"

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_interface.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_interface.go.erb
@@ -13,7 +13,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	<% if version == "ga" -%>
+	<% else -%>
 	"github.com/hashicorp/terraform-provider-google/google/verify"
+	<% end -%>
 	"google.golang.org/api/googleapi"
 
 <% if version == "ga" -%>

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_interface.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_interface.go.erb
@@ -88,7 +88,8 @@ func ResourceComputeRouterInterface() *schema.Resource {
 			"ip_version": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:       true,
+				ForceNew:     true,
+				Computed:     true,
 				ValidateFunc: verify.ValidateEnum([]string{"IPV4", "IPV6"}),
 				Description:  `IP version of this interface.`,
 			},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_interface.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_interface.go.erb
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/verify"
 	"google.golang.org/api/googleapi"
 
 <% if version == "ga" -%>
@@ -80,6 +81,15 @@ func ResourceComputeRouterInterface() *schema.Resource {
 				AtLeastOneOf:   []string{"ip_range", "interconnect_attachment", "subnetwork", "vpn_tunnel"},
 				Description:    `The IP address and range of the interface. The IP range must be in the RFC3927 link-local IP space. Changing this forces a new interface to be created.`,
 			},
+			<% unless version == 'ga' -%>
+			"ip_version": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:       true,
+				ValidateFunc: verify.ValidateEnum([]string{"IPV4", "IPV6"}),
+				Description:  `IP version of this interface.`,
+			},
+			<% end -%>
 			"private_ip_address": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -178,6 +188,12 @@ func resourceComputeRouterInterfaceCreate(d *schema.ResourceData, meta interface
 		iface.IpRange = ipRangeVal.(string)
 	}
 
+	<% unless version == 'ga' -%>
+	if ipVersionVal, ok := d.GetOk("ip_version"); ok {
+		iface.IpVersion = ipVersionVal.(string)
+	}
+	<% end -%>
+
 	if privateIpVal, ok := d.GetOk("private_ip_address"); ok {
 		iface.PrivateIpAddress = privateIpVal.(string)
 	}
@@ -269,6 +285,11 @@ func resourceComputeRouterInterfaceRead(d *schema.ResourceData, meta interface{}
 			if err := d.Set("ip_range", iface.IpRange); err != nil {
 				return fmt.Errorf("Error setting ip_range: %s", err)
 			}
+			<% unless version == 'ga' -%>
+			if err := d.Set("ip_version", iface.IpVersion); err != nil {
+				return fmt.Errorf("Error setting ip_version: %s", err)
+			}
+			<% end -%>
 			if err := d.Set("private_ip_address", iface.PrivateIpAddress); err != nil {
 				return fmt.Errorf("Error setting private_ip_address: %s", err)
 			}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_interface_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_interface_test.go.erb
@@ -120,6 +120,54 @@ func TestAccComputeRouterInterface_withPrivateIpAddress(t *testing.T) {
 	})
 }
 
+<% unless version == 'ga' -%>
+func TestAccComputeRouterInterface_withIPVersionV4(t *testing.T) {
+	t.Parallel()
+
+	routerName := fmt.Sprintf("tf-test-router-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckComputeRouterInterfaceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRouterInterfaceWithIpVersionIPV4(routerName),
+				Check: testAccCheckComputeRouterInterfaceExists(
+					t, "google_compute_router_interface.foobar"),
+			},
+			{
+				ResourceName:      "google_compute_router_interface.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRouterInterface_withIPVersionV6(t *testing.T) {
+	t.Parallel()
+
+	routerName := fmt.Sprintf("tf-test-router-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckComputeRouterInterfaceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRouterInterfaceWithIpVersionIPV6(routerName),
+				Check: testAccCheckComputeRouterInterfaceExists(
+					t, "google_compute_router_interface.foobar"),
+			},
+			{
+				ResourceName:      "google_compute_router_interface.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+<% end -%>
+
 func testAccCheckComputeRouterInterfaceDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
@@ -512,3 +560,73 @@ resource "google_compute_router_interface" "foobar" {
 }
 `, routerName, routerName, routerName, routerName, routerName)
 }
+
+<% unless version == 'ga' -%>
+func testAccComputeRouterInterfaceWithIpVersionIPV6(routerName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  provider = google-beta
+  name = "%s-net"
+}
+
+resource "google_compute_subnetwork" "foobar" {
+  provider = google-beta
+  name          = "%s-subnet"
+  network       = google_compute_network.foobar.self_link
+  ip_cidr_range = "10.0.0.0/16"
+}
+
+resource "google_compute_router" "foobar" {
+  provider = google-beta
+  name    = "%s"
+  network = google_compute_network.foobar.self_link
+  bgp {
+    asn = 64514
+  }
+}
+
+resource "google_compute_router_interface" "foobar" {
+  provider = google-beta
+  name     = "%s-interface"
+  router   = google_compute_router.foobar.name
+  region   = google_compute_router.foobar.region
+  ip_range = "fdff:1::1:1/126"
+  ip_version = "IPV6"
+}
+`, routerName, routerName, routerName, routerName)
+}
+
+func testAccComputeRouterInterfaceWithIpVersionIPV4(routerName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  provider = google-beta
+  name = "%s-net"
+}
+
+resource "google_compute_subnetwork" "foobar" {
+  provider = google-beta
+  name          = "%s-subnet"
+  network       = google_compute_network.foobar.self_link
+  ip_cidr_range = "10.0.0.0/16"
+}
+
+resource "google_compute_router" "foobar" {
+  provider = google-beta
+  name    = "%s"
+  network = google_compute_network.foobar.self_link
+  bgp {
+    asn = 64514
+  }
+}
+
+resource "google_compute_router_interface" "foobar" {
+  provider = google-beta
+  name     = "%s-interface"
+  router   = google_compute_router.foobar.name
+  region   = google_compute_router.foobar.region
+  ip_range = "169.254.3.1/30"
+  ip_version = "IPV4"
+}
+`, routerName, routerName, routerName, routerName)
+}
+<% end -%>

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_interface_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_interface_test.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package compute_test
 
 import (

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
@@ -32,15 +32,6 @@ func ipv6RepresentationDiffSuppress(_, old, new string, d *schema.ResourceData) 
 	return oldIp.Equal(newIp)
 }
 
-func isIPv4Address(input string) bool {
-	ip := net.ParseIP(input)
-	return ip != nil && ip.To4() != nil
-}
-
-func interfaceToString(value interface{}) string {
-	return fmt.Sprintf("%v", value)
-}
-
 func ResourceComputeRouterBgpPeer() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceComputeRouterBgpPeerCreate,
@@ -1142,7 +1133,6 @@ func flattenNestedComputeRouterBgpPeerEnableIpv6(v interface{}, d *schema.Resour
 
 <% unless version == 'ga' -%>
 func flattenNestedComputeRouterBgpPeerEnableIpv4(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
-	log.Printf("[DEBUG] printing value for enable_ipv4 that we are going to set %v)", v)
 	return v
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
@@ -32,6 +32,15 @@ func ipv6RepresentationDiffSuppress(_, old, new string, d *schema.ResourceData) 
 	return oldIp.Equal(newIp)
 }
 
+func isIPv4Address(input string) bool {
+	ip := net.ParseIP(input)
+	return ip != nil && ip.To4() != nil
+}
+
+func interfaceToString(value interface{}) string {
+	return fmt.Sprintf("%v", value)
+}
+
 func ResourceComputeRouterBgpPeer() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceComputeRouterBgpPeerCreate,
@@ -207,14 +216,14 @@ The default is true.`,
 				Description: `Enable IPv6 traffic over BGP Peer. If not specified, it is disabled by default.`,
 				Default:     false,
 			},
-			<% unless version == 'ga' -%>
+<% unless version == 'ga' -%>
 			"enable_ipv4": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: `Enable IPv4 traffic over BGP Peer. It is enabled by default if the peerIpAddress is version 4.`,
 				Default:     false,
 			},
-			<% end -%>
+<% end -%>
 			"ip_address": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -233,7 +242,7 @@ The address must be in the range 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64.
 If you do not specify the next hop addresses, Google Cloud automatically
 assigns unused addresses from the 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64 range for you.`,
 			},
-			<% unless version == 'ga' -%>
+<% unless version == 'ga' -%>
 			"ipv4_nexthop_address": {
 				Type:         schema.TypeString,
 				Computed:     true,
@@ -241,7 +250,7 @@ assigns unused addresses from the 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64 range
 				ValidateFunc: verify.ValidateIpAddress,
 				Description:  `IPv4 address of the interface inside Google Cloud Platform.`,
 			},
-			<% end -%>
+<% end -%>
 			"peer_ip_address": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -260,7 +269,7 @@ The address must be in the range 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64.
 If you do not specify the next hop addresses, Google Cloud automatically
 assigns unused addresses from the 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64 range for you.`,
 			},
-			<% unless version == 'ga' -%>
+<% unless version == 'ga' -%>
 			"peer_ipv4_nexthop_address": {
 				Type:         schema.TypeString,
 				Computed:     true,
@@ -268,7 +277,7 @@ assigns unused addresses from the 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64 range
 				ValidateFunc: verify.ValidateIpAddress,
 				Description:  `IPv4 address of the BGP interface outside Google Cloud Platform.`,
 			},
-			<% end -%>
+<% end -%>
 			"region": {
 				Type:             schema.TypeString,
 				Computed:         true,
@@ -421,12 +430,19 @@ func resourceComputeRouterBgpPeerCreate(d *schema.ResourceData, meta interface{}
 	} else if v, ok := d.GetOkExists("enable_ipv6"); ok || !reflect.DeepEqual(v, enableIpv6Prop) {
 		obj["enableIpv6"] = enableIpv6Prop
 	}
-	<% unless version == 'ga' -%>
+<% unless version == 'ga' -%>
 	enableIpv4Prop, err := expandNestedComputeRouterBgpPeerEnableIpv4(d.Get("enable_ipv4"), d, config)
 	if err != nil {
 		return err
 	} else if v, ok := d.GetOkExists("enable_ipv4"); ok || !reflect.DeepEqual(v, enableIpv4Prop) {
-		obj["enableIpv4"] = enableIpv4Prop
+		//If peerIpaddress is ipv4, then enable_ipv4 should be true
+		peerIpAddressString := interfaceToString(peerIpAddressProp)
+		isIpV4 := isIPv4Address(peerIpAddressString)
+		if isIpV4 {
+			obj["enableIpv4"] = interface{}(true)
+		} else {
+			obj["enableIpv4"] = enableIpv4Prop
+		}
 	}
 	ipv4NexthopAddressProp, err := expandNestedComputeRouterBgpPeerIpv4NexthopAddress(d.Get("ipv4_nexthop_address"), d, config)
 	if err != nil {
@@ -440,7 +456,7 @@ func resourceComputeRouterBgpPeerCreate(d *schema.ResourceData, meta interface{}
 	} else if v, ok := d.GetOkExists("peer_ipv6_nexthop_address"); !tpgresource.IsEmptyValue(reflect.ValueOf(peerIpv4NexthopAddressProp)) && (ok || !reflect.DeepEqual(v, peerIpv4NexthopAddressProp)) {
 		obj["peerIpv4NexthopAddress"] = peerIpv4NexthopAddressProp
 	}
-	<% end -%>
+<% end -%>
 	ipv6NexthopAddressProp, err := expandNestedComputeRouterBgpPeerIpv6NexthopAddress(d.Get("ipv6_nexthop_address"), d, config)
 	if err != nil {
 		return err
@@ -632,7 +648,7 @@ func resourceComputeRouterBgpPeerRead(d *schema.ResourceData, meta interface{}) 
 	if err := d.Set("enable_ipv6", flattenNestedComputeRouterBgpPeerEnableIpv6(res["enableIpv6"], d, config)); err != nil {
 		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
 	}
-	<% unless version == 'ga' -%>
+<% unless version == 'ga' -%>
 	if err := d.Set("enable_ipv4", flattenNestedComputeRouterBgpPeerEnableIpv4(res["enableIpv4"], d, config)); err != nil {
 		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
 	}
@@ -642,7 +658,7 @@ func resourceComputeRouterBgpPeerRead(d *schema.ResourceData, meta interface{}) 
 	if err := d.Set("peer_ipv4_nexthop_address", flattenNestedComputeRouterBgpPeerPeerIpv4NexthopAddress(res["peerIpv4NexthopAddress"], d, config)); err != nil {
 		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
 	}
-	<% end -%>
+<% end -%>
 	if err := d.Set("ipv6_nexthop_address", flattenNestedComputeRouterBgpPeerIpv6NexthopAddress(res["ipv6NexthopAddress"], d, config)); err != nil {
 		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
 	}
@@ -738,12 +754,19 @@ func resourceComputeRouterBgpPeerUpdate(d *schema.ResourceData, meta interface{}
 	} else if v, ok := d.GetOkExists("enable_ipv6"); ok || !reflect.DeepEqual(v, enableIpv6Prop) {
 		obj["enableIpv6"] = enableIpv6Prop
 	}
-	<% unless version == 'ga' -%>
+<% unless version == 'ga' -%>
 	enableIpv4Prop, err := expandNestedComputeRouterBgpPeerEnableIpv4(d.Get("enable_ipv4"), d, config)
 	if err != nil {
 		return err
 	} else if v, ok := d.GetOkExists("enable_ipv4"); ok || !reflect.DeepEqual(v, enableIpv4Prop) {
-		obj["enableIpv4"] = enableIpv4Prop
+		//If peerIpaddress is ipv4, then enable_ipv4 should be true
+		peerIpAddressString := interfaceToString(peerIpAddressProp)
+		isIpV4 := isIPv4Address(peerIpAddressString)
+		if isIpV4 {
+			obj["enableIpv4"] = interface{}(true)
+		} else {
+			obj["enableIpv4"] = enableIpv4Prop
+		}
 	}
 	ipv4NexthopAddressProp, err := expandNestedComputeRouterBgpPeerIpv4NexthopAddress(d.Get("ipv4_nexthop_address"), d, config)
 	if err != nil {
@@ -757,7 +780,7 @@ func resourceComputeRouterBgpPeerUpdate(d *schema.ResourceData, meta interface{}
 	} else if v, ok := d.GetOkExists("peer_ipv4_nexthop_address"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, peerIpv4NexthopAddressProp)) {
 		obj["peerIpv4NexthopAddress"] = peerIpv4NexthopAddressProp
 	}
-	<% end -%>
+<% end -%>
 	ipv6NexthopAddressProp, err := expandNestedComputeRouterBgpPeerIpv6NexthopAddress(d.Get("ipv6_nexthop_address"), d, config)
 	if err != nil {
 		return err

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
@@ -221,7 +221,7 @@ The default is true.`,
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: `Enable IPv4 traffic over BGP Peer. It is enabled by default if the peerIpAddress is version 4.`,
-				Default:     false,
+				Computed:    true,
 			},
 <% end -%>
 			"ip_address": {
@@ -435,14 +435,7 @@ func resourceComputeRouterBgpPeerCreate(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return err
 	} else if v, ok := d.GetOkExists("enable_ipv4"); ok || !reflect.DeepEqual(v, enableIpv4Prop) {
-		//If peerIpaddress is ipv4, then enable_ipv4 should be true
-		peerIpAddressString := interfaceToString(peerIpAddressProp)
-		isIpV4 := isIPv4Address(peerIpAddressString)
-		if isIpV4 {
-			obj["enableIpv4"] = interface{}(true)
-		} else {
-			obj["enableIpv4"] = enableIpv4Prop
-		}
+		obj["enableIpv4"] = enableIpv4Prop
 	}
 	ipv4NexthopAddressProp, err := expandNestedComputeRouterBgpPeerIpv4NexthopAddress(d.Get("ipv4_nexthop_address"), d, config)
 	if err != nil {
@@ -759,14 +752,7 @@ func resourceComputeRouterBgpPeerUpdate(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return err
 	} else if v, ok := d.GetOkExists("enable_ipv4"); ok || !reflect.DeepEqual(v, enableIpv4Prop) {
-		//If peerIpaddress is ipv4, then enable_ipv4 should be true
-		peerIpAddressString := interfaceToString(peerIpAddressProp)
-		isIpV4 := isIPv4Address(peerIpAddressString)
-		if isIpV4 {
-			obj["enableIpv4"] = interface{}(true)
-		} else {
-			obj["enableIpv4"] = enableIpv4Prop
-		}
+		obj["enableIpv4"] = enableIpv4Prop
 	}
 	ipv4NexthopAddressProp, err := expandNestedComputeRouterBgpPeerIpv4NexthopAddress(d.Get("ipv4_nexthop_address"), d, config)
 	if err != nil {
@@ -1156,6 +1142,7 @@ func flattenNestedComputeRouterBgpPeerEnableIpv6(v interface{}, d *schema.Resour
 
 <% unless version == 'ga' -%>
 func flattenNestedComputeRouterBgpPeerEnableIpv4(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	log.Printf("[DEBUG] printing value for enable_ipv4 that we are going to set %v)", v)
 	return v
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
@@ -207,6 +207,14 @@ The default is true.`,
 				Description: `Enable IPv6 traffic over BGP Peer. If not specified, it is disabled by default.`,
 				Default:     false,
 			},
+			<% unless version == 'ga' -%>
+			"enable_ipv4": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Enable IPv4 traffic over BGP Peer. It is enabled by default if the peerIpAddress is version 4.`,
+				Default:     false,
+			},
+			<% end -%>
 			"ip_address": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -225,6 +233,15 @@ The address must be in the range 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64.
 If you do not specify the next hop addresses, Google Cloud automatically
 assigns unused addresses from the 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64 range for you.`,
 			},
+			<% unless version == 'ga' -%>
+			"ipv4_nexthop_address": {
+				Type:         schema.TypeString,
+				Computed:     true,
+				Optional:     true,
+				ValidateFunc: verify.ValidateIpAddress,
+				Description:  `IPv4 address of the interface inside Google Cloud Platform.`,
+			},
+			<% end -%>
 			"peer_ip_address": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -243,6 +260,15 @@ The address must be in the range 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64.
 If you do not specify the next hop addresses, Google Cloud automatically
 assigns unused addresses from the 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64 range for you.`,
 			},
+			<% unless version == 'ga' -%>
+			"peer_ipv4_nexthop_address": {
+				Type:         schema.TypeString,
+				Computed:     true,
+				Optional:     true,
+				ValidateFunc: verify.ValidateIpAddress,
+				Description:  `IPv4 address of the BGP interface outside Google Cloud Platform.`,
+			},
+			<% end -%>
 			"region": {
 				Type:             schema.TypeString,
 				Computed:         true,
@@ -395,6 +421,26 @@ func resourceComputeRouterBgpPeerCreate(d *schema.ResourceData, meta interface{}
 	} else if v, ok := d.GetOkExists("enable_ipv6"); ok || !reflect.DeepEqual(v, enableIpv6Prop) {
 		obj["enableIpv6"] = enableIpv6Prop
 	}
+	<% unless version == 'ga' -%>
+	enableIpv4Prop, err := expandNestedComputeRouterBgpPeerEnableIpv4(d.Get("enable_ipv4"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("enable_ipv4"); ok || !reflect.DeepEqual(v, enableIpv4Prop) {
+		obj["enableIpv4"] = enableIpv4Prop
+	}
+	ipv4NexthopAddressProp, err := expandNestedComputeRouterBgpPeerIpv4NexthopAddress(d.Get("ipv4_nexthop_address"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("ipv4_nexthop_address"); !tpgresource.IsEmptyValue(reflect.ValueOf(ipv4NexthopAddressProp)) && (ok || !reflect.DeepEqual(v, ipv4NexthopAddressProp)) {
+		obj["ipv4NexthopAddress"] = ipv4NexthopAddressProp
+	}
+	peerIpv4NexthopAddressProp, err := expandNestedComputeRouterBgpPeerPeerIpv4NexthopAddress(d.Get("peer_ipv4_nexthop_address"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("peer_ipv6_nexthop_address"); !tpgresource.IsEmptyValue(reflect.ValueOf(peerIpv4NexthopAddressProp)) && (ok || !reflect.DeepEqual(v, peerIpv4NexthopAddressProp)) {
+		obj["peerIpv4NexthopAddress"] = peerIpv4NexthopAddressProp
+	}
+	<% end -%>
 	ipv6NexthopAddressProp, err := expandNestedComputeRouterBgpPeerIpv6NexthopAddress(d.Get("ipv6_nexthop_address"), d, config)
 	if err != nil {
 		return err
@@ -586,6 +632,17 @@ func resourceComputeRouterBgpPeerRead(d *schema.ResourceData, meta interface{}) 
 	if err := d.Set("enable_ipv6", flattenNestedComputeRouterBgpPeerEnableIpv6(res["enableIpv6"], d, config)); err != nil {
 		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
 	}
+	<% unless version == 'ga' -%>
+	if err := d.Set("enable_ipv4", flattenNestedComputeRouterBgpPeerEnableIpv4(res["enableIpv4"], d, config)); err != nil {
+		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
+	}
+	if err := d.Set("ipv4_nexthop_address", flattenNestedComputeRouterBgpPeerIpv4NexthopAddress(res["ipv4NexthopAddress"], d, config)); err != nil {
+		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
+	}
+	if err := d.Set("peer_ipv4_nexthop_address", flattenNestedComputeRouterBgpPeerPeerIpv4NexthopAddress(res["peerIpv4NexthopAddress"], d, config)); err != nil {
+		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
+	}
+	<% end -%>
 	if err := d.Set("ipv6_nexthop_address", flattenNestedComputeRouterBgpPeerIpv6NexthopAddress(res["ipv6NexthopAddress"], d, config)); err != nil {
 		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
 	}
@@ -681,6 +738,26 @@ func resourceComputeRouterBgpPeerUpdate(d *schema.ResourceData, meta interface{}
 	} else if v, ok := d.GetOkExists("enable_ipv6"); ok || !reflect.DeepEqual(v, enableIpv6Prop) {
 		obj["enableIpv6"] = enableIpv6Prop
 	}
+	<% unless version == 'ga' -%>
+	enableIpv4Prop, err := expandNestedComputeRouterBgpPeerEnableIpv4(d.Get("enable_ipv4"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("enable_ipv4"); ok || !reflect.DeepEqual(v, enableIpv4Prop) {
+		obj["enableIpv4"] = enableIpv4Prop
+	}
+	ipv4NexthopAddressProp, err := expandNestedComputeRouterBgpPeerIpv4NexthopAddress(d.Get("ipv4_nexthop_address"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("ipv4_nexthop_address"); !tpgresource.IsEmptyValue(reflect.ValueOf(ipv4NexthopAddressProp)) && (ok || !reflect.DeepEqual(v, ipv4NexthopAddressProp)) {
+		obj["ipv4NexthopAddress"] = ipv4NexthopAddressProp
+	}
+	peerIpv4NexthopAddressProp, err := expandNestedComputeRouterBgpPeerPeerIpv4NexthopAddress(d.Get("peer_ipv4_nexthop_address"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("peer_ipv4_nexthop_address"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, peerIpv4NexthopAddressProp)) {
+		obj["peerIpv4NexthopAddress"] = peerIpv4NexthopAddressProp
+	}
+	<% end -%>
 	ipv6NexthopAddressProp, err := expandNestedComputeRouterBgpPeerIpv6NexthopAddress(d.Get("ipv6_nexthop_address"), d, config)
 	if err != nil {
 		return err
@@ -1054,6 +1131,20 @@ func flattenNestedComputeRouterBgpPeerEnableIpv6(v interface{}, d *schema.Resour
 	return v
 }
 
+<% unless version == 'ga' -%>
+func flattenNestedComputeRouterBgpPeerEnableIpv4(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenNestedComputeRouterBgpPeerIpv4NexthopAddress(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenNestedComputeRouterBgpPeerPeerIpv4NexthopAddress(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+<% end -%>
+
 func flattenNestedComputeRouterBgpPeerIpv6NexthopAddress(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	return v
 }
@@ -1240,6 +1331,20 @@ func expandNestedComputeRouterBgpPeerRouterApplianceInstance(v interface{}, d tp
 func expandNestedComputeRouterBgpPeerEnableIpv6(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
 	return v, nil
 }
+
+<% unless version == 'ga' -%>
+func expandNestedComputeRouterBgpPeerEnableIpv4(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandNestedComputeRouterBgpPeerIpv4NexthopAddress(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandNestedComputeRouterBgpPeerPeerIpv4NexthopAddress(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+<% end-%>
 
 func expandNestedComputeRouterBgpPeerIpv6NexthopAddress(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
 	return v, nil

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_test.go.erb
@@ -1,3 +1,6 @@
+<% autogen_exception -%>
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
 package compute_test
 
 import (
@@ -155,6 +158,66 @@ func TestAccComputeRouter_updateAddRemoveBGP(t *testing.T) {
 	})
 }
 
+<% unless version == 'ga' -%>
+func TestAccCompouteRouter_addIdentifierRangeBgp(t *testing T){
+	t.Parallel()
+
+	testId := acctest.RandString(t, 10)
+	routerName := fmt.Sprintf("tf-test-router-%s", testId)
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckComputeRouterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRouter_addIdentifierRangeBgp(routerName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_compute_router.foobar", "bgp.0.identifier_range", "169.254.8.8/29"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_router.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRouter_updateIdentifierRangeBgp(t *testing.T) {
+	t.Parallel()
+
+	testId := acctest.RandString(t, 10)
+	routerName := fmt.Sprintf("tf-test-router-%s", testId)
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckComputeRouterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRouter_addIdentifierRangeBgp(routerName),
+			},
+			{
+				ResourceName:      "google_compute_router.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouter_updateIdentifierRangeBgp(routerName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_compute_router.foobar", "bgp.0.identifier_range", "169.254.8.8/30"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_router.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+<% end -%>
+
 func testAccComputeRouterBasic(routerName, resourceRegion string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
@@ -251,3 +314,63 @@ resource "google_compute_router" "foobar" {
 }
 `, routerName, routerName, resourceRegion, routerName)
 }
+
+<% unless version == 'ga' -%>
+func testAccComputeRouter_addIdentifierRangeBgp(routerName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  provider = google-beta
+  name                    = "%s-net"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_router" "foobar" {
+  provider = google-beta
+  name    = "%s"
+  network = google_compute_network.foobar.name
+  bgp {
+    asn               = 64514
+    advertise_mode    = "CUSTOM"
+    advertised_groups = ["ALL_SUBNETS"]
+    advertised_ip_ranges {
+      range = "1.2.3.4"
+    }
+    advertised_ip_ranges {
+      range = "6.7.0.0/16"
+    }
+	identifier_range = "169.254.8.8/29"
+    keepalive_interval = 25
+  }
+}
+`, routerName, routerName)
+}
+
+func testAccComputeRouter_updateIdentifierRangeBgp(routerName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  provider = google-beta
+  name                    = "%s-net"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_router" "foobar" {
+  provider = google-beta
+  name    = "%s"
+  network = google_compute_network.foobar.name
+  bgp {
+    asn               = 64514
+    advertise_mode    = "CUSTOM"
+    advertised_groups = ["ALL_SUBNETS"]
+    advertised_ip_ranges {
+      range = "1.2.3.4"
+    }
+    advertised_ip_ranges {
+      range = "6.7.0.0/16"
+    }
+	identifier_range = "169.254.8.8/30"
+    keepalive_interval = 25
+  }
+}
+`, routerName, routerName)
+}
+<% end -%>

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_test.go.erb
@@ -1,6 +1,4 @@
 <% autogen_exception -%>
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
 package compute_test
 
 import (
@@ -159,7 +157,7 @@ func TestAccComputeRouter_updateAddRemoveBGP(t *testing.T) {
 }
 
 <% unless version == 'ga' -%>
-func TestAccCompouteRouter_addIdentifierRangeBgp(t *testing T){
+func TestAccCompouteRouter_addIdentifierRangeBgp(t *testing.T){
 	t.Parallel()
 
 	testId := acctest.RandString(t, 10)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_test.go.erb
@@ -157,32 +157,7 @@ func TestAccComputeRouter_updateAddRemoveBGP(t *testing.T) {
 }
 
 <% unless version == 'ga' -%>
-func TestAccCompouteRouter_addIdentifierRangeBgp(t *testing.T){
-	t.Parallel()
-
-	testId := acctest.RandString(t, 10)
-	routerName := fmt.Sprintf("tf-test-router-%s", testId)
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
-		CheckDestroy:             testAccCheckComputeRouterDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccComputeRouter_addIdentifierRangeBgp(routerName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("google_compute_router.foobar", "bgp.0.identifier_range", "169.254.8.8/29"),
-				),
-			},
-			{
-				ResourceName:      "google_compute_router.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccComputeRouter_updateIdentifierRangeBgp(t *testing.T) {
+func TestAccComputeRouter_addAndUpdateIdentifierRangeBgp(t *testing.T) {
 	t.Parallel()
 
 	testId := acctest.RandString(t, 10)

--- a/mmv1/third_party/terraform/website/docs/r/compute_router_interface.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_router_interface.html.markdown
@@ -40,6 +40,9 @@ In addition to the above required fields, a router interface must have specified
 * `ip_range` - (Optional) IP address and range of the interface. The IP range must be
     in the RFC3927 link-local IP space. Changing this forces a new interface to be created.
 
+* `ip_version` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+    IP version of this interface. Can be either IPV4 or IPV6.
+
 * `vpn_tunnel` - (Optional) The name or resource link to the VPN tunnel this
     interface will be linked to. Changing this forces a new interface to be created. Only
     one of `vpn_tunnel`, `interconnect_attachment` or `subnetwork` can be specified.

--- a/mmv1/third_party/terraform/website/docs/r/compute_router_peer.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_router_peer.html.markdown
@@ -282,6 +282,10 @@ The following arguments are supported:
   (Optional)
   Enable IPv6 traffic over BGP Peer. If not specified, it is disabled by default.
 
+* `enable_ipv4` -
+  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+  Enable IPv4 traffic over BGP Peer. It is enabled by default if the peerIpAddress is version 4.
+
 * `ipv6_nexthop_address` -
   (Optional)
   IPv6 address of the interface inside Google Cloud Platform.
@@ -289,12 +293,20 @@ The following arguments are supported:
   If you do not specify the next hop addresses, Google Cloud automatically
   assigns unused addresses from the 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64 range for you.
 
+* `ipv4_nexthop_address` -
+  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+  IPv4 address of the interface inside Google Cloud Platform.
+
 * `peer_ipv6_nexthop_address` -
   (Optional)
   IPv6 address of the BGP interface outside Google Cloud Platform.
   The address must be in the range 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64.
   If you do not specify the next hop addresses, Google Cloud automatically
   assigns unused addresses from the 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64 range for you.
+
+* `peer_ipv4_nexthop_address` -
+  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+  IPv4 address of the BGP interface outside Google Cloud Platform.
 
 * `region` -
   (Optional)


### PR DESCRIPTION
Adding ipv6 support for bgp router peer, router interface and router. Related to b/309454013


**Release Note Template for Downstream PRs*

```release-note:enhancement 
compute: added `identifier_range` field to `google_compute_router` resource (beta)
```

```release-note:enhancement 
compute: added `ip_version` field to `google_compute_router_interface` resource (beta)
```

```release-note:enhancement 
compute: added `enable_ipv4`, `ipv4_nexthop_address` and `peer_ipv4_nexthop_address` fields to `google_compute_router_peer` resource (beta)
```
