### PR TITLE
Add sweeper for firestore_database_instance

### DIFF
--- a/mmv1/third_party/terraform/services/firestore/resource_firestore_database_sweeper.go
+++ b/mmv1/third_party/terraform/services/firestore/resource_firestore_database_sweeper.go
@@ -1,0 +1,122 @@
+package firestore
+
+import (
+	"context"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/sweeper"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func init() {
+	sweeper.AddTestSweepers("FirestoreDatabase", testSweepFirestoreDatabase)
+}
+
+// At the time of writing, the CI only passes us-central1 as the region
+func testSweepFirestoreDatabase(region string) error {
+	resourceName := "FirestoreDatabase"
+	log.Printf("[INFO][SWEEPER_LOG] Starting sweeper for %s", resourceName)
+
+	config, err := sweeper.SharedConfigForRegion(region)
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error getting shared config for region: %s", err)
+		return err
+	}
+
+	err = config.LoadAndValidate(context.Background())
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error loading: %s", err)
+		return err
+	}
+
+	t := &testing.T{}
+	billingId := envvar.GetTestBillingAccountFromEnv(t)
+
+	// Setup variables to replace in list template
+	d := &tpgresource.ResourceDataMock{
+		FieldsInSchema: map[string]interface{}{
+			"project":         config.Project,
+			"region":          region,
+			"location":        region,
+			"zone":            "-",
+			"billing_account": billingId,
+		},
+	}
+
+	listTemplate := strings.Split("https://firestore.googleapis.com/v1/projects/{{project}}/databases", "?")[0]
+	listUrl, err := tpgresource.ReplaceVars(d, config, listTemplate)
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error preparing sweeper list url: %s", err)
+		return nil
+	}
+
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   config.Project,
+		RawURL:    listUrl,
+		UserAgent: config.UserAgent,
+	})
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)
+		return nil
+	}
+
+	resourceList, ok := res["databases"]
+	if !ok {
+		log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
+		return nil
+	}
+
+	rl := resourceList.([]interface{})
+
+	log.Printf("[INFO][SWEEPER_LOG] Found %d items in %s list response.", len(rl), resourceName)
+	// Keep count of items that aren't sweepable for logging.
+	nonPrefixCount := 0
+	for _, ri := range rl {
+		obj := ri.(map[string]interface{})
+		if obj["name"] == nil {
+			log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
+			return nil
+		}
+
+		name := tpgresource.GetResourceNameFromSelfLink(obj["name"].(string))
+		// Skip resources that shouldn't be sweeped
+		if !sweeper.IsSweepableTestResource(name) {
+			nonPrefixCount++
+			continue
+		}
+
+		deleteTemplate := "https://firestore.googleapis.com/v1/projects/{{project}}/databases/{{name}}"
+		deleteUrl, err := tpgresource.ReplaceVars(d, config, deleteTemplate)
+		if err != nil {
+			log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
+			return nil
+		}
+		deleteUrl = deleteUrl + name
+
+		// Don't wait on operations as we may have a lot to delete
+		_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "DELETE",
+			Project:   config.Project,
+			RawURL:    deleteUrl,
+			UserAgent: config.UserAgent,
+		})
+		if err != nil {
+			log.Printf("[INFO][SWEEPER_LOG] Error deleting for url %s : %s", deleteUrl, err)
+		} else {
+			log.Printf("[INFO][SWEEPER_LOG] Sent delete request for %s resource: %s", resourceName, name)
+		}
+	}
+
+	if nonPrefixCount > 0 {
+		log.Printf("[INFO][SWEEPER_LOG] %d items were non-sweepable and skipped.", nonPrefixCount)
+	}
+
+	return nil
+}


### PR DESCRIPTION
[sweeper got removed](https://github.com/ScottSuarez/magic-modules/blob/054f1c5671e47f5cb27b8722ab372b3331c00f9f/mmv1/provider/terraform.rb#L798) in the addition of a [pre_delete function](https://github.com/ScottSuarez/magic-modules/blob/054f1c5671e47f5cb27b8722ab372b3331c00f9f/mmv1/products/firestore/Database.yaml#L153). 

We hit quota limit of 100 instances on both our ci projects. This caused test failures on [ga](https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_GoogleCloud_GOOGLE_NIGHTLYTESTS_GOOGLE_PACKAGE_FIRESTORE/127754?buildTab=tests&status=failed) and [beta](https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_GoogleCloud_GOOGLE_BETA_NIGHTLYTESTS_GOOGLEBETA_PACKAGE_FIRESTORE/127954?buildTab=tests&status=failed).

Already ran this locally so projects are clean. 
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
