### PR TITLE
Made presubmit cloudbuild workflows only use GCS logging

### DIFF
--- a/.ci/gcb-community-checker.yml
+++ b/.ci/gcb-community-checker.yml
@@ -73,6 +73,8 @@ steps:
         - $_BASE_BRANCH
 
 logsBucket: 'gs://cloudbuild-community-checker-logs'
+options:
+  logging: GCS_ONLY
 availableSecrets:
   secretManager:
     - versionName: projects/673497134629/secrets/github-magician-token-generate-diffs-magic-modules/versions/latest

--- a/.ci/gcb-contributor-membership-checker.yml
+++ b/.ci/gcb-contributor-membership-checker.yml
@@ -70,6 +70,8 @@ steps:
       - $COMMIT_SHA
 
 logsBucket: 'gs://cloudbuild-membership-checker-logs'
+options:
+  logging: GCS_ONLY
 availableSecrets:
   secretManager:
     - versionName: projects/673497134629/secrets/github-magician-token-generate-diffs-magic-modules/versions/latest

--- a/.ci/gcb-generate-diffs-new.yml
+++ b/.ci/gcb-generate-diffs-new.yml
@@ -286,6 +286,8 @@ options:
     machineType: 'N1_HIGHCPU_32'
 
 logsBucket: 'gs://cloudbuild-generate-diffs-logs'
+options:
+  logging: GCS_ONLY
 availableSecrets:
   secretManager:
     - versionName: projects/673497134629/secrets/github-magician-token-generate-diffs-downstreams/versions/latest


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This isn't strictly necessary but I would expect it to eliminate errors related to Logs Writer permissions like on https://console.cloud.google.com/cloud-build/builds/e3cb7030-84d4-4cde-9ca9-80ae1bf0103b?project=graphite-docker-images&e=-13802955&mods=logs_tg_staging

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
