### PR TITLE
Add ignore_read_extra for subordinate_config

### DIFF
--- a/mmv1/products/privateca/CertificateAuthority.yaml
+++ b/mmv1/products/privateca/CertificateAuthority.yaml
@@ -86,6 +86,7 @@ examples:
       deletion_protection: 'false'
     ignore_read_extra:
       - 'deletion_protection'
+      - 'subordinate_config.0.certificate_authority'
   - !ruby/object:Provider::Terraform::Examples
     # Skip test because it depends on a beta resource, but PrivateCA does
     # not have a beta endpoint


### PR DESCRIPTION
Fix test failure caused by https://github.com/GoogleCloudPlatform/magic-modules/pull/10354

https://github.com/GoogleCloudPlatform/magic-modules/pull/10354 added a custom_flatten  for `subordinate_config.0.certificate_authority`. 


Quote https://googlecloudplatform.github.io/magic-modules/develop/permadiff/#ignore_read, 
> You will also need to add the field to ignore_read_extra on any examples that are used to generate tests; this will cause tests to ignore the field when checking that the values in the API match the user’s configuration.


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
