### PR TITLE
Show diff for computed nested labels fields when creating resources

### DIFF
--- a/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.erb
@@ -554,6 +554,76 @@ func TestAccCloudRunServiceMigration_withLabels(t *testing.T) {
 	})
 }
 
+func TestAccCloudRunService_withComputedLabels(t *testing.T) {
+  // Skip it in VCR test because of the randomness of uuid in "labels" field
+  // which causes the replaying mode after recording mode failing in VCR test
+  acctest.SkipIfVcr(t)
+  t.Parallel()
+
+  name := "tftest-cloudrun-" + acctest.RandString(t, 6)
+  project := envvar.GetTestProjectFromEnv()
+
+  acctest.VcrTest(t, resource.TestCase{
+    PreCheck:     func() { acctest.AccTestPreCheck(t) },
+    ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {},
+		},
+    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+    Steps: []resource.TestStep{
+      {
+        Config:            testAccCloudRunService_withComputedLabels(name, project, "10", "600"),
+      },
+      {
+        ResourceName:            "google_cloud_run_service.default",
+        ImportState:             true,
+        ImportStateVerify:       true,
+        ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "metadata.0.annotations", "metadata.0.labels", "metadata.0.terraform_labels", "status.0.conditions"},
+      },
+    },
+  })
+}
+
+func testAccCloudRunService_withComputedLabels(name, project, concurrency, timeoutSeconds string) string {
+  return fmt.Sprintf(`
+resource "random_uuid" "test" {
+}
+
+resource "google_cloud_run_service" "default" {
+  name     = "%s"
+  location = "us-central1"
+
+  metadata {
+    namespace = "%s"
+    annotations = {
+      env = "${random_uuid.test.result}"
+    }
+    labels = {
+      key1 = "${random_uuid.test.result}"
+    }
+  }
+
+  template {
+    spec {
+      containers {
+        image = "gcr.io/cloudrun/hello"
+        ports {
+          container_port = 8080
+        }
+      }
+      container_concurrency = %s
+      timeout_seconds = %s
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+    tag             = "magic-module"
+  }
+}
+`, name, project, concurrency, timeoutSeconds)
+}
+
 func testAccCloudRunService_withProviderDefaultLabels(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 provider "google" {

--- a/mmv1/third_party/terraform/tpgresource/annotations.go
+++ b/mmv1/third_party/terraform/tpgresource/annotations.go
@@ -54,8 +54,8 @@ func SetMetadataAnnotationsDiff(_ context.Context, d *schema.ResourceDiff, meta 
 
 	// Fix the bug that the computed and nested "annotations" field disappears from the terraform plan.
 	// https://github.com/hashicorp/terraform-provider-google/issues/17756
-	// The bug is introducted by SetNew on "metadata" field with the object including "effective_annotations".
-	// "effective_annotations" cannot be set directrly due to a bug that SetNew doesn't work on nested fields
+	// The bug is introduced by SetNew on "metadata" field with the object including "effective_annotations".
+	// "effective_annotations" cannot be set directly due to a bug that SetNew doesn't work on nested fields
 	// in terraform sdk.
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/459
 	if !d.GetRawPlan().GetAttr("metadata").AsValueSlice()[0].GetAttr("annotations").IsWhollyKnown() {

--- a/mmv1/third_party/terraform/tpgresource/annotations.go
+++ b/mmv1/third_party/terraform/tpgresource/annotations.go
@@ -52,6 +52,16 @@ func SetMetadataAnnotationsDiff(_ context.Context, d *schema.ResourceDiff, meta 
 		return nil
 	}
 
+	// Fix the bug that the computed and nested "annotations" field disappears from the terraform plan.
+	// https://github.com/hashicorp/terraform-provider-google/issues/17756
+	// The bug is introducted by SetNew on "metadata" field with the object including "effective_annotations".
+	// "effective_annotations" cannot be set directrly due to a bug that SetNew doesn't work on nested fields
+	// in terraform sdk.
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/459
+	if !d.GetRawPlan().GetAttr("metadata").AsValueSlice()[0].GetAttr("annotations").IsWhollyKnown() {
+		return nil
+	}
+
 	raw := d.Get("metadata.0.annotations")
 	if raw == nil {
 		return nil

--- a/mmv1/third_party/terraform/tpgresource/labels.go
+++ b/mmv1/third_party/terraform/tpgresource/labels.go
@@ -139,8 +139,8 @@ func SetMetadataLabelsDiff(_ context.Context, d *schema.ResourceDiff, meta inter
 
 	// Fix the bug that the computed and nested "labels" field disappears from the terraform plan.
 	// https://github.com/hashicorp/terraform-provider-google/issues/17756
-	// The bug is introducted by SetNew on "metadata" field with the object including terraform_labels and effective_labels.
-	// "terraform_labels" and "effective_labels" cannot be set directrly due to a bug that SetNew doesn't work on nested fields
+	// The bug is introduced by SetNew on "metadata" field with the object including terraform_labels and effective_labels.
+	// "terraform_labels" and "effective_labels" cannot be set directly due to a bug that SetNew doesn't work on nested fields
 	// in terraform sdk.
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/459
 	if !d.GetRawPlan().GetAttr("metadata").AsValueSlice()[0].GetAttr("labels").IsWhollyKnown() {

--- a/mmv1/third_party/terraform/tpgresource/labels.go
+++ b/mmv1/third_party/terraform/tpgresource/labels.go
@@ -137,6 +137,16 @@ func SetMetadataLabelsDiff(_ context.Context, d *schema.ResourceDiff, meta inter
 		return nil
 	}
 
+	// Fix the bug that the computed and nested "labels" field disappears from the terraform plan.
+	// https://github.com/hashicorp/terraform-provider-google/issues/17756
+	// The bug is introducted by SetNew on "metadata" field with the object including terraform_labels and effective_labels.
+	// "terraform_labels" and "effective_labels" cannot be set directrly due to a bug that SetNew doesn't work on nested fields
+	// in terraform sdk.
+	// https://github.com/hashicorp/terraform-plugin-sdk/issues/459
+	if !d.GetRawPlan().GetAttr("metadata").AsValueSlice()[0].GetAttr("labels").IsWhollyKnown() {
+		return nil
+	}
+
 	raw := d.Get("metadata.0.labels")
 	if raw == nil {
 		return nil


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
fixes https://github.com/hashicorp/terraform-provider-google/issues/17756

Error
```
Error: Provider produced inconsistent final plan
│ 
│ When expanding the plan for module.cloud_run.google_cloud_run_service.main
│ to include new values learned so far during apply, provider
│ "registry.terraform.io/hashicorp/google-beta" produced an invalid new value
│ for .metadata[0].labels: was null, but now
```

Resource `google_cloud_run_service` and `google_cloud_run_domain_mapping` have nested labels fields `metadata.0.labels` and `metadata.0.annotations`. 

In the CustomizeDiff function [SetMetadataLabelsDiff](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/third_party/terraform/tpgresource/labels.go#L134), `SetNew` is applied on "metadata" field with the object including `terraform_labels` and `effective_labels`. It introduced two bugs.
1. when creating resource, computed `metadata.0.labels` and `metadata.0.annotations` fields don't appear in terraform plan  
2. After creating the resource with the normal labels value, and then updating the labels fields with the computed value will fail, similar to root labels field  https://github.com/hashicorp/terraform-provider-google/issues/16217. 
This bug cannot be fixed with the similar way in https://github.com/GoogleCloudPlatform/magic-modules/pull/10182.
The reason is that `metadata.0.terraform_labels` and `metadat.0.effective_labels` fields cannot be set to computed due to a bug that SetNew doesn't work on nested fields
in terraform sdk https://github.com/hashicorp/terraform-plugin-sdk/issues/459

The solution to fix these two bugs in my mind is to move `terraform_labels` and `effective_labels` to root level in provider release 6.0.
Before the release 6.0, the first bug can be fixed in this PR and I don't find an easy way to fix the second bug.
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
cloudrun: fixed the bug that computed `metadata.0.labels` and `metadata.0.annotations` fields don't appear in terraform plan when creating resource `google_cloud_run_service` and `google_cloud_run_domain_mapping`
```
