### PR TITLE
Add support for intercept_children in sinks

### DIFF
--- a/mmv1/third_party/terraform/services/logging/resource_logging_folder_sink.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_folder_sink.go
@@ -38,6 +38,13 @@ func ResourceLoggingFolderSink() *schema.Resource {
 		Default:     false,
 		Description: `Whether or not to include children folders in the sink export. If true, logs associated with child projects are also exported; otherwise only logs relating to the provided folder are included.`,
 	}
+	schm.Schema["intercept_children"] = &schema.Schema{
+		Type:        schema.TypeBool,
+		Optional:    true,
+		ForceNew:    true,
+		Default:     false,
+		Description: `Whether or not to intercept logs from child projects. If true, matching logs will not match with sinks in child resources, except _Required sinks. This sink will be visible to child resources when listing sinks.`,
+	}
 
 	return schm
 }
@@ -52,6 +59,7 @@ func resourceLoggingFolderSinkCreate(d *schema.ResourceData, meta interface{}) e
 	folder := resourcemanager.ParseFolderId(d.Get("folder"))
 	id, sink := expandResourceLoggingSink(d, "folders", folder)
 	sink.IncludeChildren = d.Get("include_children").(bool)
+	sink.InterceptChildren = d.Get("intercept_children").(bool)
 
 	// The API will reject any requests that don't explicitly set 'uniqueWriterIdentity' to true.
 	_, err = config.NewLoggingClient(userAgent).Folders.Sinks.Create(id.parent(), sink).UniqueWriterIdentity(true).Do()
@@ -83,6 +91,10 @@ func resourceLoggingFolderSinkRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error setting include_children: %s", err)
 	}
 
+	if err := d.Set("intercept_children", sink.InterceptChildren); err != nil {
+		return fmt.Errorf("Error setting intercept_children: %s", err)
+	}
+
 	return nil
 }
 
@@ -94,10 +106,12 @@ func resourceLoggingFolderSinkUpdate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	sink, updateMask := expandResourceLoggingSinkForUpdate(d)
-	// It seems the API might actually accept an update for include_children; this is not in the list of updatable
+	// It seems the API might actually accept an update for these; this is not in the list of updatable
 	// properties though and might break in the future. Always include the value to prevent it changing.
 	sink.IncludeChildren = d.Get("include_children").(bool)
+	sink.InterceptChildren = d.Get("intercept_children").(bool)
 	sink.ForceSendFields = append(sink.ForceSendFields, "IncludeChildren")
+	sink.ForceSendFields = append(sink.ForceSendFields, "InterceptChildren")
 
 	// The API will reject any requests that don't explicitly set 'uniqueWriterIdentity' to true.
 	_, err = config.NewLoggingClient(userAgent).Folders.Sinks.Patch(d.Id(), sink).

--- a/mmv1/third_party/terraform/services/logging/resource_logging_folder_sink_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_folder_sink_test.go
@@ -335,8 +335,51 @@ func testAccCheckLoggingFolderSink(sink *logging.LogSink, n string) resource.Tes
 			return fmt.Errorf("mismatch on include_children: api has %v but client has %v", sink.IncludeChildren, includeChildren)
 		}
 
+		interceptChildren := false
+		if attributes["intercept_children"] != "" {
+			includeChildren, err = strconv.ParseBool(attributes["intercept_children"])
+			if err != nil {
+				return err
+			}
+		}
+		if sink.InterceptChildren != interceptChildren {
+			return fmt.Errorf("mismatch on intercept_children: api has %v but client has %v", sink.InterceptChildren, interceptChildren)
+		}
+
 		return nil
 	}
+}
+
+func TestAccLoggingFolderSink_updateInterceptChildren(t *testing.T) {
+	t.Parallel()
+
+	sinkName := "tf-test-sink-" + acctest.RandString(t, 10)
+	folderName := "intercepting-sink-folder"
+	folderParent := "organizations/" + envvar.GetTestOrgFromEnv(t)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckLoggingFolderSinkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingFolderSink_intercept_updated(sinkName, true, folderName, folderParent),
+			},
+			{
+				ResourceName:      "google_logging_folder_sink.intercept_update",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccLoggingFolderSink_intercept_updated(sinkName, false, folderName, folderParent),
+			},
+			{
+				ResourceName:      "google_logging_folder_sink.intercept_update",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
 }
 
 func testAccLoggingFolderSink_basic(sinkName, bucketName, folderName, folderParent string) string {
@@ -524,4 +567,22 @@ resource "google_folder" "my-folder" {
   display_name = "%s"
   parent       = "%s"
 }`, sinkName, envvar.GetTestProjectFromEnv(), envvar.GetTestProjectFromEnv(), bqDatasetID, folderName, folderParent)
+}
+
+func testAccLoggingFolderSink_intercept_updated(sinkName string, intercept_children bool, folderName string, folderParent string) string {
+	return fmt.Sprintf(`
+resource "google_logging_folder_sink" "intercept_update" {
+  name             = "%s"
+  folder           = "${google_folder.intercept_folder.folder_id}"
+  destination      = "logging.googleapis.com/projects/%s"
+  filter           = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
+  include_children = true
+  intercept_children = %t
+}
+
+resource "google_folder" "intercept_folder" {
+  display_name = "%s"
+  parent       = "%s"
+}
+`, sinkName, envvar.GetTestProjectFromEnv(), envvar.GetTestProjectFromEnv(), intercept_children, folderName, folderParent)
 }

--- a/mmv1/third_party/terraform/services/logging/resource_logging_organization_sink.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_organization_sink.go
@@ -36,6 +36,13 @@ func ResourceLoggingOrganizationSink() *schema.Resource {
 		Default:     false,
 		Description: `Whether or not to include children organizations in the sink export. If true, logs associated with child projects are also exported; otherwise only logs relating to the provided organization are included.`,
 	}
+	schm.Schema["intercept_children"] = &schema.Schema{
+		Type:        schema.TypeBool,
+		Optional:    true,
+		ForceNew:    true,
+		Default:     false,
+		Description: `Whether or not to intercept logs from child projects. If true, matching logs will not match with sinks in child resources, except _Required sinks. This sink will be visible to child resources when listing sinks.`,
+	}
 
 	return schm
 }
@@ -50,6 +57,7 @@ func resourceLoggingOrganizationSinkCreate(d *schema.ResourceData, meta interfac
 	org := d.Get("org_id").(string)
 	id, sink := expandResourceLoggingSink(d, "organizations", org)
 	sink.IncludeChildren = d.Get("include_children").(bool)
+	sink.InterceptChildren = d.Get("intercept_children").(bool)
 
 	// Must use a unique writer, since all destinations are in projects.
 	// The API will reject any requests that don't explicitly set 'uniqueWriterIdentity' to true.
@@ -82,6 +90,10 @@ func resourceLoggingOrganizationSinkRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error setting include_children: %s", err)
 	}
 
+	if err := d.Set("intercept_children", sink.InterceptChildren); err != nil {
+		return fmt.Errorf("Error setting intercept_children: %s", err)
+	}
+
 	return nil
 }
 
@@ -93,10 +105,12 @@ func resourceLoggingOrganizationSinkUpdate(d *schema.ResourceData, meta interfac
 	}
 
 	sink, updateMask := expandResourceLoggingSinkForUpdate(d)
-	// It seems the API might actually accept an update for include_children; this is not in the list of updatable
+	// It seems the API might actually accept an update for these; this is not in the list of updatable
 	// properties though and might break in the future. Always include the value to prevent it changing.
 	sink.IncludeChildren = d.Get("include_children").(bool)
+	sink.InterceptChildren = d.Get("intercept_children").(bool)
 	sink.ForceSendFields = append(sink.ForceSendFields, "IncludeChildren")
+	sink.ForceSendFields = append(sink.ForceSendFields, "InterceptChildren")
 
 	// The API will reject any requests that don't explicitly set 'uniqueWriterIdentity' to true.
 	_, err = config.NewLoggingClient(userAgent).Organizations.Sinks.Patch(d.Id(), sink).

--- a/mmv1/third_party/terraform/services/logging/resource_logging_organization_sink_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_organization_sink_test.go
@@ -264,8 +264,50 @@ func testAccCheckLoggingOrganizationSink(sink *logging.LogSink, n string) resour
 			return fmt.Errorf("mismatch on include_children: api has %v but client has %v", sink.IncludeChildren, includeChildren)
 		}
 
+		interceptChildren := false
+		if attributes["intercept_children"] != "" {
+			includeChildren, err = strconv.ParseBool(attributes["intercept_children"])
+			if err != nil {
+				return err
+			}
+		}
+		if sink.InterceptChildren != interceptChildren {
+			return fmt.Errorf("mismatch on intercept_children: api has %v but client has %v", sink.InterceptChildren, interceptChildren)
+		}
+
 		return nil
 	}
+}
+
+func TestAccLoggingOrganizationSink_updateInterceptChildren(t *testing.T) {
+	t.Parallel()
+
+	orgId := envvar.GetTestOrgFromEnv(t)
+	sinkName := "tf-test-sink-" + acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckLoggingOrganizationSinkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingOrganizationSink_intercept_updated(sinkName, orgId, true),
+			},
+			{
+				ResourceName:      "google_logging_organization_sink.intercept_update",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccLoggingOrganizationSink_intercept_updated(sinkName, orgId, false),
+			},
+			{
+				ResourceName:      "google_logging_organization_sink.intercept_update",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
 }
 
 func testAccLoggingOrganizationSink_basic(sinkName, bucketName, orgId string) string {
@@ -395,4 +437,16 @@ resource "google_bigquery_dataset" "logging_sink" {
   dataset_id  = "%s"
   description = "Log sink (generated during acc test of terraform-provider-google(-beta))."
 }`, sinkName, orgId, envvar.GetTestProjectFromEnv(), envvar.GetTestProjectFromEnv(), bqDatasetID)
+}
+
+func testAccLoggingOrganizationSink_intercept_updated(sinkName, orgId string, intercept_children bool) string {
+	return fmt.Sprintf(`
+resource "google_logging_organization_sink" "intercept_update" {
+  name             = "%s"
+  org_id           = "%s"
+  destination      = "logging.googleapis.com/projects/%s"
+  filter           = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
+  include_children = true
+  intercept_children = %t
+}`, sinkName, orgId, envvar.GetTestProjectFromEnv(), envvar.GetTestProjectFromEnv(), intercept_children)
 }


### PR DESCRIPTION
Add support for recently created `intercept_children` property on log sinks, used for intercepting aggregated sinks. Docs for feature: https://cloud.google.com/logging/docs/export/aggregated_sinks



**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
logging: added `intercept_children` field to `google_logging_organization_sink` and `google_logging_folder_sink` resources
```
