### PR TITLE
Added IAM propagation delay to TestAccDataprocCluster_withServiceAcc

### DIFF
--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
@@ -2224,6 +2224,13 @@ resource "google_project_iam_member" "service_account" {
   member = "serviceAccount:${google_service_account.service_account.email}"
 }
 
+# Wait for IAM propagation
+resource "time_sleep" "wait_120_seconds" {
+  depends_on = [google_project_iam_member.service_account]
+
+  create_duration = "120s"
+}
+
 resource "google_dataproc_cluster" "with_service_account" {
   name   = "dproc-cluster-test-%s"
   region = "us-central1"
@@ -2261,7 +2268,7 @@ resource "google_dataproc_cluster" "with_service_account" {
     }
   }
 
-  depends_on = [google_project_iam_member.service_account]
+  depends_on = [time_sleep.wait_120_seconds]
 }
 `, sa, rnd, subnetworkName)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixed https://github.com/hashicorp/terraform-provider-google/issues/11907

dataproc.worker role grants permissions on storage buckets: https://cloud.google.com/dataproc/docs/concepts/iam/iam

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
