### PR TITLE
Change supported machine type to fix CHD tests.

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -1850,6 +1850,7 @@ func TestAccComputeInstance_confidentialHyperDiskBootDisk(t *testing.T) {
 		"key_ring":              kms.KeyRing.Name,
 		"key_name":              kms.CryptoKey.Name,
 		"zone":                  "us-central1-a",
+		"machine_type":          "n2-standard-16",
 
 	}
 
@@ -1859,6 +1860,7 @@ func TestAccComputeInstance_confidentialHyperDiskBootDisk(t *testing.T) {
 		"key_ring" :             context_1["key_ring"],
 		"key_name":              context_1["key_name"],
 		"zone":                  context_1["zone"],
+		"machine_type":          "c3d-standard-16",
 	}
 
 
@@ -7419,7 +7421,7 @@ resource "google_kms_crypto_key_iam_member" "crypto_key" {
 
 resource "google_compute_instance" "foobar" {
   name         = "%{instance_name}"
-  machine_type = "h3-standard-88"
+  machine_type = "%{machine_type}"
   zone         = "%{zone}"
 
   boot_disk {


### PR DESCRIPTION
Change supported machine type to fix confidential hyperdisk tests.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/17378

```release-note:none

```

