### PR TITLE
Allowed modifying request headers via pre_create, pre_update, or pre_delete custom code

### DIFF
--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -267,6 +267,7 @@ func resource<%= object.resource_name -%>Create(d *schema.ResourceData, meta int
       billingProject = bp
     }
 
+    headers := make(http.Header)
 <%= lines(compile(pwd + '/' + object.custom_code.pre_create)) if object.custom_code.pre_create -%>
     res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
         Config: config,
@@ -276,6 +277,7 @@ func resource<%= object.resource_name -%>Create(d *schema.ResourceData, meta int
         UserAgent: userAgent,
         Body: obj,
         Timeout: d.Timeout(schema.TimeoutCreate),
+        Headers: headers,
 <%    if object.error_retry_predicates -%>
         ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_retry_predicates.join(',') -%>},
 <%    end -%>
@@ -539,6 +541,7 @@ func resource<%= object.resource_name -%>Read(d *schema.ResourceData, meta inter
       billingProject = bp
     }
 
+    headers := make(http.Header)
     <%= lines(compile(pwd + '/' + object.custom_code.pre_read)) if object.custom_code.pre_read -%>
     res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
         Config: config,
@@ -546,6 +549,7 @@ func resource<%= object.resource_name -%>Read(d *schema.ResourceData, meta inter
         Project: billingProject,
         RawURL: url,
         UserAgent: userAgent,
+        Headers: headers,
 <%  if object.error_retry_predicates -%>
         ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_retry_predicates.join(',') -%>},
 <%  end -%>
@@ -737,6 +741,7 @@ func resource<%= object.resource_name -%>Update(d *schema.ResourceData, meta int
     }
 
     log.Printf("[DEBUG] Updating <%= object.name -%> %q: %#v", d.Id(), obj)
+    headers := make(http.Header)
 <%= lines(compile(pwd + '/templates/terraform/update_mask.erb')) if object.update_mask -%>
 <%= lines(compile(pwd + '/' + object.custom_code.pre_update)) if object.custom_code.pre_update -%>
 <%      if object.nested_query&.modify_by_patch -%>
@@ -769,6 +774,7 @@ if len(updateMask) > 0 {
         UserAgent: userAgent,
         Body: obj,
         Timeout: d.Timeout(schema.TimeoutUpdate),
+        Headers: headers,
 <%      if object.error_retry_predicates -%>
         ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_retry_predicates.join(',') -%>},
 <%      end -%>
@@ -911,6 +917,8 @@ if len(updateMask) > 0 {
         }
 
 
+
+        headers := make(http.Header)
 <%= lines(compile(pwd + '/' + object.custom_code.pre_update)) if object.custom_code.pre_update -%>
 <%        if object.supports_indirect_user_project_override -%>
         if parts := regexp.MustCompile(`projects\/([^\/]+)\/`).FindStringSubmatch(url); parts != nil {
@@ -931,6 +939,7 @@ if len(updateMask) > 0 {
             UserAgent: userAgent,
             Body: obj,
             Timeout: d.Timeout(schema.TimeoutUpdate),
+            Headers: headers,
 <%        if object.error_retry_predicates -%>
             ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_retry_predicates.join(',') -%>},
 <%        end -%>
@@ -1056,6 +1065,7 @@ func resource<%= object.resource_name -%>Delete(d *schema.ResourceData, meta int
       billingProject = bp
     }
 
+    headers := make(http.Header)
 <%= lines(compile(pwd + '/' + object.custom_code.pre_delete)) if object.custom_code.pre_delete -%>
 
     log.Printf("[DEBUG] Deleting <%= object.name -%> %q", d.Id())
@@ -1067,6 +1077,7 @@ func resource<%= object.resource_name -%>Delete(d *schema.ResourceData, meta int
         UserAgent: userAgent,
         Body: obj,
         Timeout: d.Timeout(schema.TimeoutDelete),
+        Headers: headers,
 <%      if object.error_retry_predicates -%>
         ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{<%= object.error_retry_predicates.join(',') -%>},
 <%      end -%>

--- a/mmv1/third_party/terraform/transport/transport.go
+++ b/mmv1/third_party/terraform/transport/transport.go
@@ -24,12 +24,13 @@ type SendRequestOptions struct {
 	UserAgent            string
 	Body                 map[string]any
 	Timeout              time.Duration
+	Headers              http.Header
 	ErrorRetryPredicates []RetryErrorPredicateFunc
 	ErrorAbortPredicates []RetryErrorPredicateFunc
 }
 
 func SendRequest(opt SendRequestOptions) (map[string]interface{}, error) {
-	reqHeaders := make(http.Header)
+	reqHeaders := opt.Headers
 	reqHeaders.Set("User-Agent", opt.UserAgent)
 	reqHeaders.Set("Content-Type", "application/json")
 


### PR DESCRIPTION
Resolved https://github.com/hashicorp/terraform-provider-google/issues/16331.

The specific resource issue this was blocking (https://github.com/hashicorp/terraform-provider-google/issues/15550) was resolved separately so no changes are needed there.

Given we don't have a clear idea of what features we might need to support in the future, and this does not currently seem to be a common use case, I don't want to implement any kind of special MM field at this time; however, this change would be necessary for any changes to MM fields in the future as well.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
