### PR TITLE
Fix issue in GA version of resource_parallelstore_instance_test.go

### DIFF
--- a/mmv1/third_party/terraform/services/parallelstore/resource_parallelstore_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/parallelstore/resource_parallelstore_instance_test.go.erb
@@ -1,7 +1,7 @@
 <% autogen_exception -%>
+package parallelstore_test
 
 <% unless version == 'ga' -%>
-package parallelstore_test
 import (
 	"testing"
 


### PR DESCRIPTION
Addresses issue identified here : https://github.com/GoogleCloudPlatform/magic-modules/pull/9910#issuecomment-2047428662

The test file generated into the GA provider needs to have a package name, [like this example](https://github.com/hashicorp/magic-modules/blob/e93e811188d812d43d993ba8af9dcb351a630001/mmv1/third_party/terraform/services/apigateway/resource_api_gateway_api_config_test.go.erb#L1-L3). 

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
