### PR TITLE
Drop IAM resources from EkmConnection tests.

### DIFF
--- a/mmv1/third_party/terraform/services/kms/resource_kms_ekm_connection_test.go
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_ekm_connection_test.go
@@ -60,16 +60,6 @@ data "google_project" "vpc-project" {
 }
 data "google_project" "project" {
 }
-resource "google_project_iam_member" "add_sdviewer" {
-  project = data.google_project.vpc-project.number
-  role    = "roles/servicedirectory.viewer"
-  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-ekms.iam.gserviceaccount.com"
-}
-resource "google_project_iam_member" "add_pscAuthorizedService" {
-  project = data.google_project.vpc-project.number
-  role    = "roles/servicedirectory.pscAuthorizedService"
-  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-ekms.iam.gserviceaccount.com"
-}
 resource "google_kms_ekm_connection" "example-ekmconnection" {
   name            	= "tf_test_ekmconnection_example%{random_suffix}"
   location		= "us-central1"
@@ -79,12 +69,8 @@ resource "google_kms_ekm_connection" "example-ekmconnection" {
       hostname 			 = data.google_secret_manager_secret_version.hostname.secret_data
       server_certificates        {
       		raw_der	= data.google_secret_manager_secret_version.raw_der.secret_data
-      	}
-    }
-  depends_on = [
-    	google_project_iam_member.add_pscAuthorizedService,
-   	google_project_iam_member.add_sdviewer
-   ]
+      }
+  }
 }
 `, context)
 }
@@ -108,16 +94,6 @@ data "google_secret_manager_secret_version" "servicedirectoryservice" {
   secret = "external-servicedirectoryservice"
   project = "315636579862"
 }
-resource "google_project_iam_member" "add_sdviewer_updateekmconnection" {
-  project = data.google_project.vpc-project.number
-  role    = "roles/servicedirectory.viewer"
-  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-ekms.iam.gserviceaccount.com"
-}
-resource "google_project_iam_member" "add_pscAuthorizedService_updateekmconnection" {
-  project = data.google_project.vpc-project.number
-  role    = "roles/servicedirectory.pscAuthorizedService"
-  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-ekms.iam.gserviceaccount.com"
-}
 resource "google_kms_ekm_connection" "example-ekmconnection" {
   name            	= "tf_test_ekmconnection_example%{random_suffix}"
   location     		= "us-central1"
@@ -128,12 +104,8 @@ resource "google_kms_ekm_connection" "example-ekmconnection" {
       hostname 			 = data.google_secret_manager_secret_version.hostname.secret_data
       server_certificates        {
       		raw_der	= data.google_secret_manager_secret_version.raw_der.secret_data
-      	}
+      }
   }
-  depends_on = [
-    	google_project_iam_member.add_pscAuthorizedService_updateekmconnection,
-   	google_project_iam_member.add_sdviewer_updateekmconnection
-   ]
 }
 `, context)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This should fix issue [#17535](https://github.com/hashicorp/terraform-provider-google/issues/17535), the IAM permissions are being reset after each run but the test passed when permissions were granted manually.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
