### PR TITLE
Fix Terraform updates for instances with Google ML Integration enabled

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.erb
@@ -1939,8 +1939,8 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 		instance.InstanceType = d.Get("instance_type").(string)
 	}
 
-	// Database Version is required for enabling Google ML integration.
-	if d.HasChange("settings.0.enable_google_ml_integration") {
+	// Database Version is required for all calls with Google ML integration enabled or it will be rejected by the API.
+	if d.Get("settings.0.enable_google_ml_integration").(bool) {
 		instance.DatabaseVersion = databaseVersion
 	}
 

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -1364,7 +1364,17 @@ func TestAccSqlDatabaseInstance_EnableGoogleMlIntegration(t *testing.T) {
 		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testGoogleSqlDatabaseInstance_EnableGoogleMlIntegration(masterID, true, "POSTGRES_14"),
+				Config: testGoogleSqlDatabaseInstance_EnableGoogleMlIntegration(masterID, true, "POSTGRES_14", "db-custom-2-13312"),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "root_password"},
+			},
+			// Test that updates to other settings work after google-ml-integration is enabled
+			{
+				Config: testGoogleSqlDatabaseInstance_EnableGoogleMlIntegration(masterID, true, "POSTGRES_14", "db-custom-2-10240"),
 			},
 			{
 				ResourceName:            "google_sql_database_instance.instance",
@@ -1373,7 +1383,7 @@ func TestAccSqlDatabaseInstance_EnableGoogleMlIntegration(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection", "root_password"},
 			},
 			{
-				Config: testGoogleSqlDatabaseInstance_EnableGoogleMlIntegration(masterID, false, "POSTGRES_14"),
+				Config: testGoogleSqlDatabaseInstance_EnableGoogleMlIntegration(masterID, false, "POSTGRES_14", "db-custom-2-10240"),
 			},
 			{
 				ResourceName:            "google_sql_database_instance.instance",
@@ -3889,7 +3899,7 @@ resource "google_sql_database_instance" "instance" {
 `, masterID, dbVersion, masterID, pointInTimeRecoveryEnabled)
 }
 
-func testGoogleSqlDatabaseInstance_EnableGoogleMlIntegration(masterID int, enableGoogleMlIntegration bool, dbVersion string) string {
+func testGoogleSqlDatabaseInstance_EnableGoogleMlIntegration(masterID int, enableGoogleMlIntegration bool, dbVersion string, tier string) string {
 	return fmt.Sprintf(`
 resource "google_sql_database_instance" "instance" {
   name                = "tf-test-%d"
@@ -3898,11 +3908,11 @@ resource "google_sql_database_instance" "instance" {
   deletion_protection = false
   root_password		  = "rand-pwd-%d"
   settings {
-    tier = "db-custom-2-13312"
+    tier = "%s"
 	enable_google_ml_integration = %t
   }
 }
-`, masterID, dbVersion, masterID, enableGoogleMlIntegration)
+`, masterID, dbVersion, masterID, tier, enableGoogleMlIntegration)
 }
 
 func testGoogleSqlDatabaseInstance_BackupRetention(masterID int) string {


### PR DESCRIPTION
This pull request addresses a bug where Terraform would fail to include the required database version when updating metadata for instances with the enable_google_ml_integration flag set to true. This resulted in API rejection of those update requests. Added acctest and verified that the change passes locally.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/17819

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
sql: fixed issues with updating the `enable_google_ml_integration` field in `google_sql_database_instance` resource
```
