### PR TITLE
DO NOT MERGE - Revert "Fix issue in GA version of resource_parallelstore_instance_test.go"

### DIFF
--- a/mmv1/third_party/terraform/services/parallelstore/resource_parallelstore_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/parallelstore/resource_parallelstore_instance_test.go.erb
@@ -1,7 +1,7 @@
 <% autogen_exception -%>
-package parallelstore_test
 
 <% unless version == 'ga' -%>
+package parallelstore_test
 import (
 	"testing"
 


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#10406

This is being used to test https://github.com/hashicorp/terraform-provider-google/pull/17818. We should see a failure in the unit tests.