### PR TITLE
Add beta version to networkconnectivity.produc.yaml

### DIFF
--- a/mmv1/products/networkconnectivity/product.yaml
+++ b/mmv1/products/networkconnectivity/product.yaml
@@ -20,3 +20,6 @@ versions:
   - !ruby/object:Api::Product::Version
     name: ga
     base_url: https://networkconnectivity.googleapis.com/v1/
+  - !ruby/object:Api::Product::Version
+    name: beta
+    base_url: https://networkconnectivity.googleapis.com/v1beta/


### PR DESCRIPTION
Add beta api version to mmv1/products/networkconnectivity/product.yaml. This is needed to add RegionalEndpoint resource to magic-modules

Pbluc API doc for the new resource to be added: https://cloud.google.com/network-connectivity/docs/reference/networkconnectivity/rest/v1beta/projects.locations.regionalEndpoints

If your PR is still work in progress, please create it in draft mode

```release-note:none
This is not a breaking change, this change is only to enable adding a new resource in beta version.
```
