### PR TITLE
Fix the index of boundary error for metadata field

### DIFF
--- a/mmv1/third_party/terraform/tpgresource/annotations.go
+++ b/mmv1/third_party/terraform/tpgresource/annotations.go
@@ -58,7 +58,8 @@ func SetMetadataAnnotationsDiff(_ context.Context, d *schema.ResourceDiff, meta 
 	// "effective_annotations" cannot be set directly due to a bug that SetNew doesn't work on nested fields
 	// in terraform sdk.
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/459
-	if !d.GetRawPlan().GetAttr("metadata").AsValueSlice()[0].GetAttr("annotations").IsWhollyKnown() {
+	values := d.GetRawPlan().GetAttr("metadata").AsValueSlice()
+	if len(values) > 0 && !values[0].GetAttr("annotations").IsWhollyKnown() {
 		return nil
 	}
 

--- a/mmv1/third_party/terraform/tpgresource/labels.go
+++ b/mmv1/third_party/terraform/tpgresource/labels.go
@@ -143,7 +143,8 @@ func SetMetadataLabelsDiff(_ context.Context, d *schema.ResourceDiff, meta inter
 	// "terraform_labels" and "effective_labels" cannot be set directly due to a bug that SetNew doesn't work on nested fields
 	// in terraform sdk.
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/459
-	if !d.GetRawPlan().GetAttr("metadata").AsValueSlice()[0].GetAttr("labels").IsWhollyKnown() {
+	values := d.GetRawPlan().GetAttr("metadata").AsValueSlice()
+	if len(values) > 0 && !values[0].GetAttr("labels").IsWhollyKnown() {
 		return nil
 	}
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The index of boundary panic causes some test failing during nightly tests.

All tests passed with this change in CI https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_GoogleCloud_GOOGLE_MMUPSTREAMTESTS_GOOGLE_PACKAGE_CLOUDRUN/131944?buildTab=tests

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
