### PR TITLE
Fix template-check to ignore files that have been deleted

### DIFF
--- a/.github/workflows/mmv1-check-templates.yml
+++ b/.github/workflows/mmv1-check-templates.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Check for invalid version guards
         run: |
           cd repo/tools/template-check
-          git diff --name-only origin/${{ github.base_ref }} ../../*.erb | sed 's=^=../../=g' | go run main.go
+          git diff --name-only --diff-filter=d origin/${{ github.base_ref }} ../../*.erb | sed 's=^=../../=g' | go run main.go


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes issue where deleting an erb file would trigger the check on that file, which would fail because the file doesn't exist. The lowercase `d` means exclude "Delete" diffs.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
