### PR TITLE
feat: add custom SKI support

### DIFF
--- a/mmv1/products/privateca/Certificate.yaml
+++ b/mmv1/products/privateca/Certificate.yaml
@@ -66,6 +66,14 @@ examples:
       ca_pool_id: 'my-pool'
     test_env_vars:
       project: :PROJECT_NAME
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'privateca_certificate_custom_ski'
+    primary_resource_id: 'default'
+    vars:
+      certificate_name: 'my-certificate'
+      ca_pool_id: 'my-pool'
+    test_env_vars:
+      project: :PROJECT_NAME
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   pre_create: templates/terraform/pre_create/privateca_certificate.go.erb
 parameters:
@@ -1049,6 +1057,19 @@ properties:
                   - config.0.subject_config.0.subject_alt_name.0.email_addresses
                   - config.0.subject_config.0.subject_alt_name.0.ip_addresses
                 immutable: true
+      - !ruby/object:Api::Type::NestedObject
+        name: 'subjectKeyId'
+        description:
+          When specified this provides a custom SKI to be used in the certificate.
+          This should only be used to maintain a SKI of an existing CA originally
+          created outside CA service, which was not generated using method (1)
+          described in RFC 5280 section 4.2.1.2..
+        immutable: true
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'keyId'
+            description: The value of the KeyId in lowercase hexidecimal.
+            immutable: true
       - !ruby/object:Api::Type::NestedObject
         name: 'publicKey'
         required: true

--- a/mmv1/products/privateca/CertificateAuthority.yaml
+++ b/mmv1/products/privateca/CertificateAuthority.yaml
@@ -111,6 +111,26 @@ examples:
       deletion_protection: 'false'
     ignore_read_extra:
       - 'deletion_protection'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'privateca_certificate_authority_custom_ski'
+    primary_resource_id: 'default'
+      # Multiple IAM bindings on the same key cause non-determinism
+    skip_vcr: true
+    vars:
+      kms_key_name: 'projects/keys-project/locations/us-central1/keyRings/key-ring/cryptoKeys/crypto-key'
+      certificate_authority_id: 'my-certificate-authority'
+      pool_name: 'ca-pool'
+      pool_location: 'us-central1'
+      deletion_protection: 'true'
+    test_vars_overrides:
+      kms_key_name:
+        'acctest.BootstrapKMSKeyWithPurposeInLocation(t, "ASYMMETRIC_SIGN",
+        "us-central1").CryptoKey.Name'
+      pool_name: 'acctest.BootstrapSharedCaPoolInLocation(t, "us-central1")'
+      pool_location: '"us-central1"'
+      deletion_protection: 'false'
+    ignore_read_extra:
+      - 'deletion_protection'
 virtual_fields:
   - !ruby/object:Api::Type::Boolean
     name: 'deletion_protection'
@@ -205,6 +225,19 @@ properties:
     required: true
     immutable: true
     properties:
+      - !ruby/object:Api::Type::NestedObject
+        name: 'subjectKeyId'
+        description:
+          When specified this provides a custom SKI to be used in the certificate.
+          This should only be used to maintain a SKI of an existing CA originally
+          created outside CA service, which was not generated using method (1)
+          described in RFC 5280 section 4.2.1.2..
+        immutable: true
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'keyId'
+            description: The value of the KeyId in lowercase hexidecimal.
+            immutable: true
       - !ruby/object:Api::Type::NestedObject
         name: 'x509Config'
         required: true

--- a/mmv1/templates/terraform/examples/privateca_certificate_authority_custom_ski.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_authority_custom_ski.tf.erb
@@ -1,0 +1,53 @@
+# [START privateca_create_ca]
+resource "google_privateca_certificate_authority" "<%= ctx[:primary_resource_id] %>" {
+ // This example assumes this pool already exists.
+ // Pools cannot be deleted in normal test circumstances, so we depend on static pools
+  pool = "<%= ctx[:vars]["pool_name"] %>"
+  certificate_authority_id = "<%= ctx[:vars]["certificate_authority_id"] %>"
+  location = "<%= ctx[:vars]["pool_location"] %>"
+  deletion_protection = "<%= ctx[:vars]["deletion_protection"] %>"
+  config {
+    subject_config {
+      subject {
+        organization = "HashiCorp"
+        common_name = "my-certificate-authority"
+      }
+      subject_alt_name {
+        dns_names = ["hashicorp.com"]
+      }
+    }
+    subject_key_id {
+        key_id = "4cf3372289b1d411b999dbb9ebcd44744b6b2fca"
+    }
+    x509_config {
+      ca_options {
+        is_ca = true
+        max_issuer_path_length = 10
+      }
+      key_usage {
+        base_key_usage {
+          digital_signature = true
+          content_commitment = true
+          key_encipherment = false
+          data_encipherment = true
+          key_agreement = true
+          cert_sign = true
+          crl_sign = true
+          decipher_only = true
+        }
+        extended_key_usage {
+          server_auth = true
+          client_auth = false
+          email_protection = true
+          code_signing = true
+          time_stamping = true
+        }
+      }
+    }
+  }
+  lifetime = "86400s"
+  key_spec {
+    cloud_kms_key_version = "<%= ctx[:vars]["kms_key_name"] %>/cryptoKeyVersions/1"
+  }
+}
+# [END privateca_create_ca]

--- a/mmv1/templates/terraform/examples/privateca_certificate_custom_ski.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_custom_ski.tf.erb
@@ -1,0 +1,93 @@
+# [START privateca_create_certificate]
+resource "google_privateca_ca_pool" "default" {
+  location = "us-central1"
+  name = "<%= ctx[:vars]["ca_pool_id"] %>"
+  tier = "ENTERPRISE"
+}
+
+resource "google_privateca_certificate_authority" "default" {
+  location = "us-central1"
+  pool = google_privateca_ca_pool.default.name
+  certificate_authority_id = "my-authority"
+  config {
+    subject_config {
+      subject {
+        organization = "HashiCorp"
+        common_name = "my-certificate-authority"
+      }
+      subject_alt_name {
+        dns_names = ["hashicorp.com"]
+      }
+    }
+    x509_config {
+      ca_options {
+        is_ca = true
+      }
+      key_usage {
+        base_key_usage {
+          digital_signature = true
+          cert_sign = true
+          crl_sign = true
+        }
+        extended_key_usage {
+          server_auth = true
+        }
+      }
+    }
+  }
+  lifetime = "86400s"
+  key_spec {
+    algorithm = "RSA_PKCS1_4096_SHA256"
+  }
+
+  // Disable CA deletion related safe checks for easier cleanup.
+  deletion_protection                    = false
+  skip_grace_period                      = true
+  ignore_active_certificates_on_deletion = true
+}
+
+
+resource "google_privateca_certificate" "<%= ctx[:primary_resource_id] %>" {
+  location = "us-central1"
+  pool = google_privateca_ca_pool.default.name
+  name = "<%= ctx[:vars]["certificate_name"] %>"
+  lifetime = "860s"
+  config {
+    subject_config  {
+      subject {
+        common_name = "san1.example.com"
+        country_code = "us"
+        organization = "google"
+        organizational_unit = "enterprise"
+        locality = "mountain view"
+        province = "california"
+        street_address = "1600 amphitheatre parkway"
+        postal_code = "94109"
+      }
+    }
+    subject_key_id {
+      key_id = "4cf3372289b1d411b999dbb9ebcd44744b6b2fca"
+    }
+    x509_config {
+      ca_options {
+        is_ca = false
+      }
+      key_usage {
+        base_key_usage {
+          crl_sign = true
+        }
+        extended_key_usage {
+          server_auth = true
+        }
+      }
+    }
+    public_key {
+      format = "PEM"
+      key = filebase64("test-fixtures/rsa_public.pem")
+    }
+  }
+  // Certificates require an authority to exist in the pool, though they don't
+  // need to be explicitly connected to it
+  depends_on = [google_privateca_certificate_authority.default]
+}
+# [END privateca_create_certificate]


### PR DESCRIPTION
This changes adds a field which can be used during the creation of CertificateAuthority or Certificate resources within Certificate Authority Service (AKA PrivateCA). It allows customers to put a different Subject Key Identifier


-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
privateca: added 'subjectKeyId' field to 'Certificate' and 'CertificateAuthority' resources
```
