### PR TITLE
Support custom masking routine in google_bigquery_datapolicy_data_policy

### DIFF
--- a/mmv1/products/bigquerydatapolicy/DataPolicy.yaml
+++ b/mmv1/products/bigquerydatapolicy/DataPolicy.yaml
@@ -44,10 +44,20 @@ examples:
     name: 'bigquery_datapolicy_data_policy_basic'
     primary_resource_id: 'data_policy'
     primary_resource_name:
-      'fmt.Sprintf("tf_test_data_policy%s", context["random_suffix"])'
+      'fmt.Sprintf("tf_test_data_policy_id%s", context["random_suffix"])'
     vars:
-      data_policy_id: 'data_policy'
+      data_policy_id: 'data_policy_id'
       taxonomy: 'taxonomy'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'bigquery_datapolicy_data_policy_with_custom_masking_routine'
+    primary_resource_id: 'data_policy'
+    primary_resource_name:
+      'fmt.Sprintf("tf_test_data_policy_id%s", context["random_suffix"])'
+    vars:
+      data_policy_id: 'data_policy_id'
+      taxonomy: 'taxonomy'
+      dataset_id: 'dataset_id'
+      routine_id: 'routine_id'
 properties:
   - !ruby/object:Api::Type::String
     name: name
@@ -88,7 +98,6 @@ properties:
     properties:
       - !ruby/object:Api::Type::Enum
         name: 'predefinedExpression'
-        required: true
         description: |-
           The available masking rules. Learn more here: https://cloud.google.com/bigquery/docs/column-data-masking-intro#masking_options.
         values:
@@ -99,3 +108,13 @@ properties:
           - :FIRST_FOUR_CHARACTERS
           - :EMAIL_MASK
           - :DATE_YEAR_MASK
+        exactly_one_of:
+          - predefinedExpression
+          - routine
+      - !ruby/object:Api::Type::String
+        name: 'routine'
+        description: |-
+          The name of the BigQuery routine that contains the custom masking routine, in the format of projects/{projectNumber}/datasets/{dataset_id}/routines/{routine_id}.
+        exactly_one_of:
+          - predefinedExpression
+          - routine

--- a/mmv1/templates/terraform/examples/bigquery_datapolicy_data_policy_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_datapolicy_data_policy_basic.tf.erb
@@ -1,19 +1,19 @@
 resource "google_bigquery_datapolicy_data_policy" "<%= ctx[:primary_resource_id] %>" {
-    location         = "us-central1"
-    data_policy_id   = "<%= ctx[:vars]['data_policy_id'] %>"
-    policy_tag       = google_data_catalog_policy_tag.policy_tag.name
-    data_policy_type = "COLUMN_LEVEL_SECURITY_POLICY"
-  }
+  location         = "us-central1"
+  data_policy_id   = "<%= ctx[:vars]['data_policy_id'] %>"
+  policy_tag       = google_data_catalog_policy_tag.policy_tag.name
+  data_policy_type = "COLUMN_LEVEL_SECURITY_POLICY"
+}
 
-  resource "google_data_catalog_policy_tag" "policy_tag" {
-    taxonomy     = google_data_catalog_taxonomy.taxonomy.id
-    display_name = "Low security"
-    description  = "A policy tag normally associated with low security items"
-  }
-  
-  resource "google_data_catalog_taxonomy" "taxonomy" {
-    region                 = "us-central1"
-    display_name           = "<%= ctx[:vars]['taxonomy'] %>"
-    description            = "A collection of policy tags"
-    activated_policy_types = ["FINE_GRAINED_ACCESS_CONTROL"]
-  }
+resource "google_data_catalog_policy_tag" "policy_tag" {
+  taxonomy     = google_data_catalog_taxonomy.taxonomy.id
+  display_name = "Low security"
+  description  = "A policy tag normally associated with low security items"
+}
+
+resource "google_data_catalog_taxonomy" "taxonomy" {
+  region                 = "us-central1"
+  display_name           = "<%= ctx[:vars]['taxonomy'] %>"
+  description            = "A collection of policy tags"
+  activated_policy_types = ["FINE_GRAINED_ACCESS_CONTROL"]
+}

--- a/mmv1/templates/terraform/examples/bigquery_datapolicy_data_policy_with_custom_masking_routine.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_datapolicy_data_policy_with_custom_masking_routine.tf.erb
@@ -1,0 +1,44 @@
+data "google_project" "project" {
+}
+
+resource "google_bigquery_datapolicy_data_policy" "<%= ctx[:primary_resource_id] %>" {
+  location         = "us-central1"
+  data_policy_id   = "<%= ctx[:vars]['data_policy_id'] %>"
+  policy_tag       = google_data_catalog_policy_tag.policy_tag.name
+  data_policy_type = "DATA_MASKING_POLICY"
+  data_masking_policy {
+    routine = format("projects/%s/datasets/%s/routines/%s", data.google_project.project.number, google_bigquery_routine.custom_masking_routine.dataset_id, google_bigquery_routine.custom_masking_routine.routine_id)
+  }
+}
+
+resource "google_data_catalog_policy_tag" "policy_tag" {
+  taxonomy     = google_data_catalog_taxonomy.taxonomy.id
+  display_name = "Low security"
+  description  = "A policy tag normally associated with low security items"
+}
+
+resource "google_data_catalog_taxonomy" "taxonomy" {
+  region                 = "us-central1"
+  display_name           = "<%= ctx[:vars]['taxonomy'] %>"
+  description            = "A collection of policy tags"
+  activated_policy_types = ["FINE_GRAINED_ACCESS_CONTROL"]
+}
+
+resource "google_bigquery_dataset" "dataset" {
+  dataset_id = "<%= ctx[:vars]['dataset_id'] %>"
+  location   = "us-central1"
+}
+
+resource "google_bigquery_routine" "custom_masking_routine" {
+  dataset_id           = google_bigquery_dataset.dataset.dataset_id
+  routine_id           = "<%= ctx[:vars]['routine_id'] %>"
+  routine_type         = "SCALAR_FUNCTION"
+  language             = "SQL"
+  data_governance_type = "DATA_MASKING"
+  definition_body      = "SAFE.REGEXP_REPLACE(ssn, '[0-9]', 'X')"
+  arguments {
+    name               = "ssn"
+    data_type          = "{\"typeKind\" :  \"STRING\"}"
+  }
+  return_type          = "{\"typeKind\" :  \"STRING\"}"
+}

--- a/mmv1/templates/terraform/examples/bigquery_routine_data_governance_type.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_routine_data_governance_type.tf.erb
@@ -14,5 +14,4 @@ resource "google_bigquery_routine" "custom_masking_routine" {
 	  data_type = "{\"typeKind\" :  \"STRING\"}"
 	} 
 	return_type = "{\"typeKind\" :  \"STRING\"}"
-  }
-  
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/17341.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigquery: added `routine` field to `google_bigquery_datapolicy_data_policy` resource
```
