### PR TITLE
Add field controlPlaneIp to the WorkstationCluster.yaml spec

### DIFF
--- a/mmv1/products/workstations/WorkstationCluster.yaml
+++ b/mmv1/products/workstations/WorkstationCluster.yaml
@@ -117,7 +117,7 @@ properties:
   - !ruby/object:Api::Type::String
     name: "controlPlaneIp"
     description: |
-      The private IP address of the control plane for this workstation cluster. 
+      The private IP address of the control plane for this workstation cluster.
       Workstation VMs need access to this IP address to work with the service, so make sure that your firewall rules allow egress from the workstation VMs to this address.
     output: true
   - !ruby/object:Api::Type::String

--- a/mmv1/products/workstations/WorkstationCluster.yaml
+++ b/mmv1/products/workstations/WorkstationCluster.yaml
@@ -115,6 +115,12 @@ properties:
       Name of the Compute Engine subnetwork in which instances associated with this cluster will be created.
       Must be part of the subnetwork specified for this cluster.
   - !ruby/object:Api::Type::String
+    name: "controlPlaneIp"
+    description: |
+      The private IP address of the control plane for this workstation cluster. 
+      Workstation VMs need access to this IP address to work with the service, so make sure that your firewall rules allow egress from the workstation VMs to this address.
+    output: true
+  - !ruby/object:Api::Type::String
     name: "displayName"
     description: |
       Human-readable name for this resource.


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/17022

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
workstations: added output-only field `control_plane_ip` to `google_workstations_workstation_cluster` resource (beta)
```
