### PR TITLE
Made apigee organization sort properties in state by config order

### DIFF
--- a/docs/content/develop/permadiff.md
+++ b/docs/content/develop/permadiff.md
@@ -226,7 +226,7 @@ In tests, add the field to `ImportStateVerifyIgnore` on any relevant import step
 
 ## API returns a list in a different order than was sent {#list-order}
 
-For an Array of string values (or nested objects with unique string identifiers), use the `SortStringsByConfigOrder` or `SortMapsByConfigOrder` helper functions to sort the API response to match the order in the user's configuration. This will also simplify diffs if new values are added or removed.
+For an Array of unique string values (or nested objects with unique string identifiers), use the `SortStringsByConfigOrder` or `SortMapsByConfigOrder` helper functions to sort the API response to match the order in the user's configuration. This will also simplify diffs if new values are added or removed.
 
 {{< tabs "diff_suppress_list" >}}
 

--- a/mmv1/products/apigee/Organization.yaml
+++ b/mmv1/products/apigee/Organization.yaml
@@ -60,8 +60,6 @@ examples:
     test_env_vars:
       org_id: :ORG_ID
       billing_account: :BILLING_ACCT
-    ignore_read_extra:
-      - properties
     skip_docs:
       true
       # Resource creation race
@@ -78,8 +76,6 @@ examples:
     test_env_vars:
       org_id: :ORG_ID
       billing_account: :BILLING_ACCT
-    ignore_read_extra:
-      - properties
     skip_docs:
       true
       # Resource creation race
@@ -103,8 +99,6 @@ examples:
       beta
       # Resource creation race
     skip_vcr: true
-    ignore_read_extra:
-      - properties
   - !ruby/object:Provider::Terraform::Examples
     name: 'apigee_organization_cloud_full_disable_vpc_peering'
     skip_test:
@@ -235,6 +229,7 @@ properties:
       - !ruby/object:Api::Type::Array
         name: 'property'
         description: List of all properties in the object.
+        custom_flatten: 'templates/terraform/custom_flatten/apigee_organization_property.go.erb'
         item_type: !ruby/object:Api::Type::NestedObject
           properties:
             - !ruby/object:Api::Type::String

--- a/mmv1/products/apigee/Organization.yaml
+++ b/mmv1/products/apigee/Organization.yaml
@@ -52,71 +52,79 @@ examples:
     name: 'apigee_organization_cloud_basic'
     skip_test:
       true
-      # This is a more verbose version of the above that creates all
-      # the resources needed for the acceptance test.
+  # This is a more verbose version of the above that creates all
+  # the resources needed for the acceptance test.
   - !ruby/object:Provider::Terraform::Examples
     name: 'apigee_organization_cloud_basic_test'
     primary_resource_id: 'org'
     test_env_vars:
       org_id: :ORG_ID
       billing_account: :BILLING_ACCT
+    ignore_read_extra:
+      - properties
     skip_docs:
       true
-      # Resource creation race
+    # Resource creation race
     skip_vcr: true
   - !ruby/object:Provider::Terraform::Examples
     name: 'apigee_organization_cloud_basic_disable_vpc_peering'
     skip_test:
       true
-      # This is a more verbose version of the above that creates all
-      # the resources needed for the acceptance test.
+  # This is a more verbose version of the above that creates all
+  # the resources needed for the acceptance test.
   - !ruby/object:Provider::Terraform::Examples
     name: 'apigee_organization_cloud_basic_disable_vpc_peering_test'
     primary_resource_id: 'org'
     test_env_vars:
       org_id: :ORG_ID
       billing_account: :BILLING_ACCT
+    ignore_read_extra:
+      - properties
     skip_docs:
       true
-      # Resource creation race
+    # Resource creation race
     skip_vcr: true
   - !ruby/object:Provider::Terraform::Examples
     name: 'apigee_organization_cloud_full'
     skip_test:
       true
-      # This is a more verbose version of the above that creates all
-      # the resources needed for the acceptance test. While all Apigee
-      # resources in this test are in the GA API, we depend on a service
-      # identity resource which is only available in the beta provider.
+  # This is a more verbose version of the above that creates all
+  # the resources needed for the acceptance test. While all Apigee
+  # resources in this test are in the GA API, we depend on a service
+  # identity resource which is only available in the beta provider.
   - !ruby/object:Provider::Terraform::Examples
     name: 'apigee_organization_cloud_full_test'
     primary_resource_id: 'org'
     test_env_vars:
       org_id: :ORG_ID
       billing_account: :BILLING_ACCT
+    ignore_read_extra:
+      - properties
     skip_docs: true
     min_version:
       beta
-      # Resource creation race
+    # Resource creation race
     skip_vcr: true
   - !ruby/object:Provider::Terraform::Examples
     name: 'apigee_organization_cloud_full_disable_vpc_peering'
     skip_test:
       true
-      # This is a more verbose version of the above that creates all
-      # the resources needed for the acceptance test. While all Apigee
-      # resources in this test are in the GA API, we depend on a service
-      # identity resource which is only available in the beta provider.
+  # This is a more verbose version of the above that creates all
+  # the resources needed for the acceptance test. While all Apigee
+  # resources in this test are in the GA API, we depend on a service
+  # identity resource which is only available in the beta provider.
   - !ruby/object:Provider::Terraform::Examples
     name: 'apigee_organization_cloud_full_disable_vpc_peering_test'
     primary_resource_id: 'org'
     test_env_vars:
       org_id: :ORG_ID
       billing_account: :BILLING_ACCT
+    ignore_read_extra:
+      - properties
     skip_docs: true
     min_version:
       beta
-      # Resource creation race
+    # Resource creation race
     skip_vcr: true
   - !ruby/object:Provider::Terraform::Examples
     name: 'apigee_organization_retention_test'
@@ -127,7 +135,7 @@ examples:
     skip_docs: true
     min_version:
       beta
-      # Resource creation race
+    # Resource creation race
     skip_vcr: true
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/apigee_organization.go.erb

--- a/mmv1/templates/terraform/custom_flatten/apigee_organization_property.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/apigee_organization_property.go.erb
@@ -1,0 +1,42 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2024 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return v
+	}
+	l := v.([]interface{})
+	apiData := make([]map[string]interface{}, 0, len(l))
+	for _, raw := range l {
+		original := raw.(map[string]interface{})
+		if len(original) < 1 {
+			// Do not include empty json objects coming back from the api
+			continue
+		}
+		apiData = append(apiData, map[string]interface{}{
+			"name":  original["name"],
+			"value": original["value"],
+		})
+	}
+	configData := []map[string]interface{}{}
+	for _, item := range d.Get("properties.0.property").([]interface{}) {
+		configData = append(configData, item.(map[string]interface{}))
+	}
+	sorted, err := tpgresource.SortMapsByConfigOrder(configData, apiData, "name")
+	if err != nil {
+		log.Printf("[ERROR] Could not support API response for properties.0.property: %s", err)
+		return apiData
+	}
+	return sorted
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Use the new function introduced in https://github.com/GoogleCloudPlatform/magic-modules/pull/10410 to order apigee properties according to the order in config. Resolved https://github.com/hashicorp/terraform-provider-google/issues/16243. Resolved https://github.com/hashicorp/terraform-provider-google/issues/13274.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
apigee: fixed permadiff in ordering of `google_apigee_organization.properties.property`.
```
