### PR TITLE
Revert logging change - appears to have slowed build speed

### DIFF
--- a/.ci/gcb-community-checker.yml
+++ b/.ci/gcb-community-checker.yml
@@ -73,8 +73,6 @@ steps:
         - $_BASE_BRANCH
 
 logsBucket: 'gs://cloudbuild-community-checker-logs'
-options:
-  logging: GCS_ONLY
 availableSecrets:
   secretManager:
     - versionName: projects/673497134629/secrets/github-magician-token-generate-diffs-magic-modules/versions/latest

--- a/.ci/gcb-contributor-membership-checker.yml
+++ b/.ci/gcb-contributor-membership-checker.yml
@@ -70,8 +70,6 @@ steps:
       - $COMMIT_SHA
 
 logsBucket: 'gs://cloudbuild-membership-checker-logs'
-options:
-  logging: GCS_ONLY
 availableSecrets:
   secretManager:
     - versionName: projects/673497134629/secrets/github-magician-token-generate-diffs-magic-modules/versions/latest

--- a/.ci/gcb-generate-diffs-new.yml
+++ b/.ci/gcb-generate-diffs-new.yml
@@ -286,8 +286,6 @@ options:
     machineType: 'N1_HIGHCPU_32'
 
 logsBucket: 'gs://cloudbuild-generate-diffs-logs'
-options:
-  logging: GCS_ONLY
 availableSecrets:
   secretManager:
     - versionName: projects/673497134629/secrets/github-magician-token-generate-diffs-downstreams/versions/latest


### PR DESCRIPTION
After this change cloud build speed slowed dramatically.

Let's revert this and add [logging.logWriter](https://cloud.google.com/iam/docs/understanding-roles#logging.logWriter) to the associated SAs

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
