### PR TITLE
Adding the support for secret version delayed destroy in the terraform provider

### DIFF
--- a/mmv1/products/secretmanager/Secret.yaml
+++ b/mmv1/products/secretmanager/Secret.yaml
@@ -39,6 +39,11 @@ examples:
     vars:
       secret_id: 'secret'
   - !ruby/object:Provider::Terraform::Examples
+    name: 'secret_with_version_destroy_ttl'
+    primary_resource_id: 'secret-with-version-destroy-ttl'
+    vars:
+      secret_id: 'secret'
+  - !ruby/object:Provider::Terraform::Examples
     name: 'secret_with_automatic_cmek'
     primary_resource_id: 'secret-with-automatic-cmek'
     vars:
@@ -115,6 +120,14 @@ properties:
 
       An object containing a list of "key": value pairs. Example:
       { "name": "wrench", "mass": "1.3kg", "count": "3" }.
+  - !ruby/object:Api::Type::String
+    name: versionDestroyTtl
+    description: |
+      Secret Version TTL after destruction request.
+      This is a part of the delayed delete feature on Secret Version.
+      For secret with versionDestroyTtl>0, version destruction doesn't happen immediately
+      on calling destroy instead the version goes to a disabled state and
+      the actual destruction happens after this TTL expires.
   - !ruby/object:Api::Type::NestedObject
     name: replication
     required: true

--- a/mmv1/products/secretmanager/SecretVersion.yaml
+++ b/mmv1/products/secretmanager/SecretVersion.yaml
@@ -125,11 +125,6 @@ properties:
     output: true
     description: |
       The time at which the Secret was destroyed. Only present if state is DESTROYED.
-  - !ruby/object:Api::Type::String
-    name: scheduledDestroyTime
-    output: true
-    description: |
-      The time at which the Secret was destroyed. Only present if state is DESTROYED. 
   - !ruby/object:Api::Type::NestedObject
     name: payload
     description: The secret payload of the SecretVersion.

--- a/mmv1/products/secretmanager/SecretVersion.yaml
+++ b/mmv1/products/secretmanager/SecretVersion.yaml
@@ -125,6 +125,11 @@ properties:
     output: true
     description: |
       The time at which the Secret was destroyed. Only present if state is DESTROYED.
+  - !ruby/object:Api::Type::String
+    name: scheduledDestroyTime
+    output: true
+    description: |
+      The time at which the Secret was destroyed. Only present if state is DESTROYED. 
   - !ruby/object:Api::Type::NestedObject
     name: payload
     description: The secret payload of the SecretVersion.

--- a/mmv1/templates/terraform/examples/secret_with_version_destroy_ttl.tf.erb
+++ b/mmv1/templates/terraform/examples/secret_with_version_destroy_ttl.tf.erb
@@ -1,0 +1,9 @@
+resource "google_secret_manager_secret" "<%= ctx[:primary_resource_id] %>" {
+  secret_id = "<%= ctx[:vars]['secret_id'] %>"
+
+  version_destroy_ttl = "2592000s"
+
+  replication {
+    auto {}
+  }
+}

--- a/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_test.go.erb
+++ b/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_test.go.erb
@@ -379,6 +379,58 @@ func TestAccSecretManagerSecret_ttlUpdate(t *testing.T) {
 	})
 }
 
+func TestAccSecretManagerSecret_versionDestroyTtlUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerSecretDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretManagerSecret_withoutVersionDestroyTtl(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_secret.secret-basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerSecret_basic(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_secret.secret-basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerSecret_versionDestroyTtlUpdate(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_secret.secret-basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerSecret_withoutVersionDestroyTtl(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_secret.secret-basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
 func TestAccSecretManagerSecret_updateBetweenTtlAndExpireTime(t *testing.T) {
 	t.Parallel()
 
@@ -1099,6 +1151,55 @@ resource "google_secret_manager_secret" "secret-basic" {
   }
 
   ttl = "7200s"
+
+}
+`, context)
+}
+
+func testAccSecretManagerSecret_withoutVersionDestroyTtl(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_secret" "secret-basic" {
+  secret_id = "tf-test-secret-%{random_suffix}"
+
+  labels = {
+    label = "my-label"
+  }
+
+  replication {
+    user_managed {
+      replicas {
+        location = "us-central1"
+      }
+      replicas {
+        location = "us-east1"
+      }
+    }
+  }
+}
+`, context)
+}
+
+func testAccSecretManagerSecret_versionDestroyTtlUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_secret" "secret-basic" {
+  secret_id = "tf-test-secret-%{random_suffix}"
+
+  labels = {
+    label = "my-label"
+  }
+
+  replication {
+    user_managed {
+      replicas {
+        location = "us-central1"
+      }
+      replicas {
+        location = "us-east1"
+      }
+    }
+  }
+
+  ttl = "86400s"
 
 }
 `, context)

--- a/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_test.go.erb
+++ b/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_test.go.erb
@@ -1199,7 +1199,7 @@ resource "google_secret_manager_secret" "secret-basic" {
     }
   }
 
-  ttl = "86400s"
+  version_destroy_ttl = "86400s"
 
 }
 `, context)

--- a/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_test.go.erb
+++ b/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_test.go.erb
@@ -401,15 +401,6 @@ func TestAccSecretManagerSecret_versionDestroyTtlUpdate(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
 			},
 			{
-				Config: testAccSecretManagerSecret_basic(context),
-			},
-			{
-				ResourceName:            "google_secret_manager_secret.secret-basic",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
-			},
-			{
 				Config: testAccSecretManagerSecret_versionDestroyTtlUpdate(context),
 			},
 			{


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
secretmanager: added `version_destroy_ttl` field to `google_secret_manager_secret` resource
```

