### PR TITLE
Fix Stretch Private Cloud creation in vmwareengine

### DIFF
--- a/mmv1/products/vmwareengine/PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/PrivateCloud.yaml
@@ -199,6 +199,20 @@ properties:
                 This number must always be one of `nodeType.availableCustomCoreCounts`.
                 If zero is provided max value from `nodeType.availableCustomCoreCounts` will be used.
                 This cannot be changed once the PrivateCloud is created.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'stretchedClusterConfig'
+        description: |
+          The stretched cluster configuration for the private cloud.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'preferredLocation'
+            description: |
+              Zone that will remain operational when connection between the two zones is lost.
+          - !ruby/object:Api::Type::String
+            name: 'secondaryLocation'
+            description: |
+              Additional zone for a higher level of availability and load balancing.
+
 
   - !ruby/object:Api::Type::NestedObject
     name: 'hcx'
@@ -298,13 +312,3 @@ properties:
       - :STANDARD
       - :TIME_LIMITED
       - :STRETCHED
-
-  - !ruby/object:Api::Type::String
-    name: 'preferredZone'
-    description: |
-      The preferred single failure domain within a region.
-
-  - !ruby/object:Api::Type::String
-    name: 'secondaryZone'
-    description: |
-      The secondary single failure domain within a region.


### PR DESCRIPTION
This PR contains some resource refactoring and bug fixes based on the manual testing of Stretch PCs and is a continuation of #10340. These changes were manually tested by performing CRUD operations on a Stretch Private Cloud using terraform. 

Please note that currently stretch private clouds need at least 6 nodes (for context, a majority of current vmareengine resource tests use a 1 node PC). Further, it is currently only supported in 3 regions, and all of them are full with customer nodes. Hence, it would not be possible to nightly run stretch PC tests on Terraform. 

**Release Note Template for Downstream PRs (will be copied)**

```release-note: bug
vmwareengine: fixed stretched cluster creation in `google_vmwareengine_private_cloud`
```
