### PR TITLE
Fix typo in Document.yaml

### DIFF
--- a/mmv1/products/firestore/Document.yaml
+++ b/mmv1/products/firestore/Document.yaml
@@ -82,7 +82,7 @@ properties:
     name: name
     output: true
     description: |
-      A server defined name for this index. Format:
+      A server defined name for this document. Format:
       `projects/{{project_id}}/databases/{{database_id}}/documents/{{path}}/{{document_id}}`
   - !ruby/object:Api::Type::String
     name: path


### PR DESCRIPTION
Fixes a copy-paste error in Document.yaml, where we accidentally described a Document as an Index.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
