### PR TITLE
Add "path" property to rewrite config for firebase hosting version

### DIFF
--- a/mmv1/products/firebasehosting/Version.yaml
+++ b/mmv1/products/firebasehosting/Version.yaml
@@ -38,6 +38,14 @@ examples:
     test_env_vars:
       project_id: :PROJECT_NAME
   - !ruby/object:Provider::Terraform::Examples
+    name: 'firebasehosting_version_path'
+    min_version: 'beta'
+    primary_resource_id: 'default'
+    vars:
+      site_id: site-id
+    test_env_vars:
+      project_id: :PROJECT_NAME
+  - !ruby/object:Provider::Terraform::Examples
     name: 'firebasehosting_version_cloud_run'
     min_version: 'beta'
     primary_resource_id: 'default'
@@ -113,17 +121,27 @@ properties:
                 - glob
                 - regex
             - !ruby/object:Api::Type::String
+              name: path
+              description:
+                The URL path to rewrite the request to.
+              exactly_one_of:
+                - path
+                - function
+                - run
+            - !ruby/object:Api::Type::String
               name: function
               description:
                 The function to proxy requests to. Must match the exported
                 function name exactly.
               exactly_one_of:
+                - path
                 - function
                 - run
             - !ruby/object:Api::Type::NestedObject
               name: run
               description: The request will be forwarded to Cloud Run.
               exactly_one_of:
+                - path
                 - function
                 - run
               properties:

--- a/mmv1/templates/terraform/examples/firebasehosting_version_path.tf.erb
+++ b/mmv1/templates/terraform/examples/firebasehosting_version_path.tf.erb
@@ -1,0 +1,23 @@
+resource "google_firebase_hosting_site" "default" {
+  provider = google-beta
+  project  = "<%= ctx[:test_env_vars]['project_id'] %>"
+  site_id  = "<%= ctx[:vars]['site_id'] %>"
+}
+
+resource "google_firebase_hosting_version" "default" {
+  provider = google-beta
+  site_id  = google_firebase_hosting_site.default.site_id
+  config {
+    rewrites {
+      glob = "**"
+      path = "/index.html"
+    }
+  }
+}
+
+resource "google_firebase_hosting_release" "default" {
+  provider     = google-beta
+  site_id      = google_firebase_hosting_site.default.site_id
+  version_name = google_firebase_hosting_version.default.name
+  message      = "Path Rewrite"
+}


### PR DESCRIPTION
This PR adds a `path` property to `google_firebase_hosting_version.config.rewrites`.

The respective API property is documented here: https://firebase.google.com/docs/reference/hosting/rest/v1beta1/sites.versions#rewrite

This property is useful when running a Single Page Application (SPA) that uses `pushState` on Firebase Hosting, as explained here: https://firebase.google.com/docs/hosting/full-config#rewrites

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
firebasehosting: added `path` field to `google_firebase_hosting_version`
```