### PR TITLE
[dns_record_set] change primary-backup -> failover in docs

### DIFF
--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
@@ -167,7 +167,7 @@ func ResourceDnsRecordSet() *schema.Resource {
 						"primary_backup": {
 							Type:        schema.TypeList,
 							Optional:    true,
-							Description: "The configuration for a primary-backup policy with global to regional failover. Queries are responded to with the global primary targets, but if none of the primary targets are healthy, then we fallback to a regional failover policy.",
+							Description: "The configuration for a failover policy with global to regional failover. Queries are responded to with the global primary targets, but if none of the primary targets are healthy, then we fallback to a regional failover policy.",
 							MaxItems:    1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{

--- a/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
@@ -277,7 +277,7 @@ The following arguments are supported:
 * `enable_geo_fencing` - (Optional) Specifies whether to enable fencing for geo queries.
 
 * `primary_backup` - (Optional) The configuration for a failover policy with global to regional failover. Queries are responded to with the global primary targets, but if none of the primary targets are healthy, then we fallback to a regional failover policy.
-    Structure is [document below](#nested_primary_backup).
+    Structure is [documented below](#nested_primary_backup).
 
 <a name="nested_wrr"></a>The `wrr` block supports:
 

--- a/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
@@ -177,7 +177,7 @@ resource "google_dns_record_set" "geo" {
 }
 ```
 
-#### Primary-Backup
+#### Failover
 
 ```hcl
 resource "google_dns_record_set" "a" {
@@ -276,8 +276,8 @@ The following arguments are supported:
 
 * `enable_geo_fencing` - (Optional) Specifies whether to enable fencing for geo queries.
 
-* `primary_backup` - (Optional) The configuration for a primary-backup policy with global to regional failover. Queries are responded to with the global primary targets, but if none of the primary targets are healthy, then we fallback to a regional failover policy.
-    Structure is [documented below](#nested_primary_backup).
+* `primary_backup` - (Optional) The configuration for a failover policy with global to regional failover. Queries are responded to with the global primary targets, but if none of the primary targets are healthy, then we fallback to a regional failover policy.
+    Structure is [document below](#nested_primary_backup).
 
 <a name="nested_wrr"></a>The `wrr` block supports:
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
b/277747354

References to "Primary-Backup" in the dns_record_set documentation have been changed to "Failover".

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
