### PR TITLE
Update TeamCity to use the GA Terraform 1.8.0 release

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/constants.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/constants.kt
@@ -16,7 +16,7 @@ const val DefaultStartHour = 4
 const val DefaultParallelism = 6
 
 // specifies the default version of Terraform Core which should be used for testing
-const val DefaultTerraformCoreVersion = "1.2.5"
+const val DefaultTerraformCoreVersion = "1.8.0"
 
 // This represents a cron view of days of the week
 const val DefaultDaysOfWeek = "*"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR will make all builds in TeamCity default to using Terraform 1.8.0.

Previously [we made TeamCity use the 1.8.0-rc1 release candidate](https://github.com/GoogleCloudPlatform/magic-modules/pull/10276) and then identified some bugs that impacted acceptance tests. Those issues were raised internally and the GA release of 1.8.0 includes the fixes.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
