### PR TITLE
Add resource tags to BigQuery Table

### DIFF
--- a/mmv1/products/bigquery/Table.yaml
+++ b/mmv1/products/bigquery/Table.yaml
@@ -508,3 +508,11 @@ properties:
                     - :INTEGER
                     - :FLOAT
                     - :BOOLEAN
+  - !ruby/object:Api::Type::KeyValuePairs
+        name: 'resourceTags'
+        min_version: beta
+        description: |
+          The tags attached to this table. Tag keys are globally unique. Tag key is expected to be
+          in the namespaced format, for example "123456789012/environment" where 123456789012 is the
+          ID of the parent organization or project resource for this tag key. Tag value is expected
+          to be the short name, for example "Production".

--- a/mmv1/products/bigquery/Table.yaml
+++ b/mmv1/products/bigquery/Table.yaml
@@ -509,10 +509,10 @@ properties:
                     - :FLOAT
                     - :BOOLEAN
   - !ruby/object:Api::Type::KeyValuePairs
-        name: 'resourceTags'
-        min_version: beta
-        description: |
-          The tags attached to this table. Tag keys are globally unique. Tag key is expected to be
-          in the namespaced format, for example "123456789012/environment" where 123456789012 is the
-          ID of the parent organization or project resource for this tag key. Tag value is expected
-          to be the short name, for example "Production".
+    name: 'resourceTags'
+    min_version: beta
+    description: |
+      The tags attached to this table. Tag keys are globally unique. Tag key is expected to be
+      in the namespaced format, for example "123456789012/environment" where 123456789012 is the
+      ID of the parent organization or project resource for this tag key. Tag value is expected
+      to be the short name, for example "Production".

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.erb
@@ -1799,6 +1799,10 @@ func resourceBigQueryTableColumnDrop(config *transport_tpg.Config, userAgent str
 		return err
 	}
 
+	if table.Schema == nil {
+		return nil
+	}
+
 	newTableFields := map[string]bool{}
 	for _, field := range table.Schema.Fields {
 		newTableFields[field.Name] = true
@@ -1836,6 +1840,18 @@ func resourceBigQueryTableDelete(d *schema.ResourceData, meta interface{}) error
 	if d.Get("deletion_protection").(bool) {
 		return fmt.Errorf("cannot destroy instance without setting deletion_protection=false and running `terraform apply`")
 	}
+	<% unless version == 'ga' -%>
+	if v, ok := d.GetOk("resource_tags"); ok {
+		var resourceTags []string
+
+		for k, v := range v.(map[string]interface{}) {
+			resourceTags = append(resourceTags, fmt.Sprintf("%s:%s", k, v.(string)))
+		}
+
+		return fmt.Errorf("cannot destroy instance without clearing the following resource tags: %v", resourceTags)
+	}
+
+	<% end -%>
 	config := meta.(*transport_tpg.Config)
 	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.erb
@@ -1429,15 +1429,7 @@ func resourceTable(d *schema.ResourceData, meta interface{}) (*bigquery.Table, e
 	}
 
   <% unless version == 'ga' -%>
-	if v, ok := d.GetOk("resource_tags"); ok {
-		resourceTags := map[string]string{}
-
-		for k, v := range v.(map[string]interface{}) {
-			resourceTags[k] = v.(string)
-		}
-
-		table.ResourceTags = resourceTags
-	}
+	table.ResourceTags = tpgresource.ExpandStringMap(d, "resource_tags")
 
 	<% end -%>
 	return table, nil
@@ -1838,7 +1830,7 @@ func resourceBigQueryTableColumnDrop(config *transport_tpg.Config, userAgent str
 
 func resourceBigQueryTableDelete(d *schema.ResourceData, meta interface{}) error {
 	if d.Get("deletion_protection").(bool) {
-		return fmt.Errorf("cannot destroy instance without setting deletion_protection=false and running `terraform apply`")
+		return fmt.Errorf("cannot destroy table %v without setting deletion_protection=false and running `terraform apply`", d.Id())
 	}
 	<% unless version == 'ga' -%>
 	if v, ok := d.GetOk("resource_tags"); ok {
@@ -1848,7 +1840,7 @@ func resourceBigQueryTableDelete(d *schema.ResourceData, meta interface{}) error
 			resourceTags = append(resourceTags, fmt.Sprintf("%s:%s", k, v.(string)))
 		}
 
-		return fmt.Errorf("cannot destroy instance without clearing the following resource tags: %v", resourceTags)
+		return fmt.Errorf("cannot destroy table %v without clearing the following resource tags: %v", d.Id(), resourceTags)
 	}
 
 	<% end -%>

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package bigquery
 
 import (
@@ -1305,6 +1306,14 @@ func ResourceBigQueryTable() *schema.Resource {
 					},
 				},
 			},
+			<% unless version == 'ga' -%>
+			"resource_tags": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The tags attached to this table. Tag keys are globally unique. Tag key is expected to be in the namespaced format, for example "123456789012/environment" where 123456789012 is the ID of the parent organization or project resource for this tag key. Tag value is expected to be the short name, for example "Production".`,
+			},
+			<% end -%>
 		},
 		UseJSONNumber: true,
 	}
@@ -1419,6 +1428,18 @@ func resourceTable(d *schema.ResourceData, meta interface{}) (*bigquery.Table, e
 		table.TableConstraints = tableConstraints
 	}
 
+  <% unless version == 'ga' -%>
+	if v, ok := d.GetOk("resource_tags"); ok {
+		resourceTags := map[string]string{}
+
+		for k, v := range v.(map[string]interface{}) {
+			resourceTags[k] = v.(string)
+		}
+
+		table.ResourceTags = resourceTags
+	}
+
+	<% end -%>
 	return table, nil
 }
 
@@ -1692,6 +1713,12 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	<% unless version == 'ga' -%>
+	if err := d.Set("resource_tags", res.ResourceTags); err != nil {
+		return fmt.Errorf("Error setting resource tags: %s", err)
+	}
+
+  <% end -%>
 	// TODO: Update when the Get API fields for TableReplicationInfo are available in the client library.
 	url, err := tpgresource.ReplaceVars(d, config, "{{BigQueryBasePath}}projects/{{project}}/datasets/{{dataset_id}}/tables/{{table_id}}")
 	if err != nil {

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
@@ -1557,13 +1557,15 @@ func TestAccBigQueryTable_TableReplicationInfo_WithReplicationInterval(t *testin
 func TestAccBigQueryTable_ResourceTags(t *testing.T) {
 	t.Parallel()
 
-	projectID := envvar.GetTestProjectFromEnv()
-  datasetID := fmt.Sprintf("tf_test_dataset_%s", acctest.RandString(t, 10))
-	tableID := fmt.Sprintf("tf_test_table_%s", acctest.RandString(t, 10))
-	tagKeyName1 := fmt.Sprintf("tf_test_tag_key1_%s", acctest.RandString(t, 10))
-	tagValueName1 := fmt.Sprintf("tf_test_tag_value1_%s", acctest.RandString(t, 10))
-	tagKeyName2 := fmt.Sprintf("tf_test_tag_key2_%s", acctest.RandString(t, 10))
-	tagValueName2 := fmt.Sprintf("tf_test_tag_value2_%s", acctest.RandString(t, 10))
+	context := map[string]interface{}{
+		"project_id": envvar.GetTestProjectFromEnv(),
+		"dataset_id": fmt.Sprintf("tf_test_dataset_%s", acctest.RandString(t, 10)),
+		"table_id"  : fmt.Sprintf("tf_test_table_%s", acctest.RandString(t, 10)),
+		"tag_key_name1": fmt.Sprintf("tf_test_tag_key1_%s", acctest.RandString(t, 10)),
+		"tag_value_name1": fmt.Sprintf("tf_test_tag_value1_%s", acctest.RandString(t, 10)),
+		"tag_key_name2": fmt.Sprintf("tf_test_tag_key2_%s", acctest.RandString(t, 10)),
+		"tag_value_name2": fmt.Sprintf("tf_test_tag_value2_%s", acctest.RandString(t, 10)),
+	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -1571,7 +1573,7 @@ func TestAccBigQueryTable_ResourceTags(t *testing.T) {
 		CheckDestroy: testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigQueryTableWithResourceTags(projectID, datasetID, tableID, tagKeyName1, tagValueName1),
+				Config: testAccBigQueryTableWithResourceTags(context),
 			},
 			{
 				ResourceName:            "google_bigquery_table.test",
@@ -1580,7 +1582,17 @@ func TestAccBigQueryTable_ResourceTags(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccBigQueryTableWithResourceTagsUpdate(projectID, datasetID, tableID, tagKeyName1, tagValueName1, tagKeyName2, tagValueName2),
+				Config: testAccBigQueryTableWithResourceTagsUpdate(context),
+			},
+			{
+				ResourceName:            "google_bigquery_table.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			// testAccBigQueryTableWithResourceTagsDestroy must be called at the end of this test to clear the resource tag bindings of the table before deletion.
+			{
+				Config: testAccBigQueryTableWithResourceTagsDestroy(context),
 			},
 			{
 				ResourceName:            "google_bigquery_table.test",
@@ -3963,75 +3975,26 @@ resource "time_sleep" "wait_10_seconds_last" {
 }
 
 <% unless version == 'ga' -%>
-func testAccBigQueryTableWithResourceTags(projectID, datasetID, tableID, tagKeyName, tagValueName string) string {
-	return fmt.Sprintf(`
-resource "google_tags_tag_key" "key" {
-  provider = google-beta
-
-  parent = "projects/%s"
-  short_name = "%s"
-}
-
-resource "google_tags_tag_value" "value" {
-  provider = google-beta
-
-  parent = "tagKeys/${google_tags_tag_key.key.name}"
-  short_name = "%s"
-}
-
-resource "google_bigquery_dataset" "test" {
-  provider = google-beta
-
-  dataset_id = "%s"
-}
-
-resource "google_bigquery_table" "test" {
-  provider = google-beta
-
-  deletion_protection = false
-  dataset_id = "${google_bigquery_dataset.test.dataset_id}"
-  table_id   = "%s"
-  resource_tags = {
-    "%s/%s" = "%s"
-  }
-}
-`, projectID, tagKeyName, tagValueName, datasetID, tableID, projectID, tagKeyName, tagValueName)
-}
-
-func testAccBigQueryTableWithResourceTagsUpdate(projectID, datasetID, tableID, tagKeyName1, tagValueName1, tagKeyName2, tagValueName2 string) string {
-	return fmt.Sprintf(`
+func testAccBigQueryTableWithResourceTags(context map[string]interface{}) string {
+	return acctest.Nprintf(`
 resource "google_tags_tag_key" "key1" {
   provider = google-beta
 
-  parent = "projects/%s"
-  short_name = "%s"
+  parent = "projects/%{project_id}"
+  short_name = "%{tag_key_name1}"
 }
 
 resource "google_tags_tag_value" "value1" {
   provider = google-beta
 
   parent = "tagKeys/${google_tags_tag_key.key1.name}"
-  short_name = "%s"
-}
-
-resource "google_tags_tag_key" "key2" {
-  provider = google-beta
-
-  parent = "projects/%s"
-  short_name = "%s"
-}
-
-resource "google_tags_tag_value" "value2" {
-  provider = google-beta
-
-  parent = "tagKeys/${google_tags_tag_key.key2.name}"
-  short_name = "%s"
+  short_name = "%{tag_value_name1}"
 }
 
 resource "google_bigquery_dataset" "test" {
   provider = google-beta
 
-  dataset_id = "%s"
+  dataset_id = "%{dataset_id}"
 }
 
 resource "google_bigquery_table" "test" {
@@ -4039,13 +4002,109 @@ resource "google_bigquery_table" "test" {
 
   deletion_protection = false
   dataset_id = "${google_bigquery_dataset.test.dataset_id}"
-  table_id   = "%s"
+  table_id   = "%{table_id}"
   resource_tags = {
-    "%s/%s" = "%s"
-    "%s/%s" = "%s"
+    "%{project_id}/${google_tags_tag_key.key1.short_name}" = "${google_tags_tag_value.value1.short_name}"
   }
 }
-`, projectID, tagKeyName1, tagValueName1, projectID, tagKeyName2, tagValueName2, datasetID, tableID, projectID, tagKeyName1, tagValueName1, projectID, tagKeyName2, tagValueName2)
+`, context)
+}
+
+func testAccBigQueryTableWithResourceTagsUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_tags_tag_key" "key1" {
+  provider = google-beta
+
+  parent = "projects/%{project_id}"
+  short_name = "%{tag_key_name1}"
+}
+
+resource "google_tags_tag_value" "value1" {
+  provider = google-beta
+
+  parent = "tagKeys/${google_tags_tag_key.key1.name}"
+  short_name = "%{tag_value_name1}"
+}
+
+resource "google_tags_tag_key" "key2" {
+  provider = google-beta
+
+  parent = "projects/%{project_id}"
+  short_name = "%{tag_key_name2}"
+}
+
+resource "google_tags_tag_value" "value2" {
+  provider = google-beta
+
+  parent = "tagKeys/${google_tags_tag_key.key2.name}"
+  short_name = "%{tag_value_name2}"
+}
+
+resource "google_bigquery_dataset" "test" {
+  provider = google-beta
+
+  dataset_id = "%{dataset_id}"
+}
+
+resource "google_bigquery_table" "test" {
+  provider = google-beta
+
+  deletion_protection = false
+  dataset_id = "${google_bigquery_dataset.test.dataset_id}"
+  table_id   = "%{table_id}"
+  resource_tags = {
+    "%{project_id}/${google_tags_tag_key.key1.short_name}" = "${google_tags_tag_value.value1.short_name}"
+    "%{project_id}/${google_tags_tag_key.key2.short_name}" = "${google_tags_tag_value.value2.short_name}"
+  }
+}
+`, context)
+}
+
+func testAccBigQueryTableWithResourceTagsDestroy(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_tags_tag_key" "key1" {
+  provider = google-beta
+
+  parent = "projects/%{project_id}"
+  short_name = "%{tag_key_name1}"
+}
+
+resource "google_tags_tag_value" "value1" {
+  provider = google-beta
+
+  parent = "tagKeys/${google_tags_tag_key.key1.name}"
+  short_name = "%{tag_value_name1}"
+}
+
+resource "google_tags_tag_key" "key2" {
+  provider = google-beta
+
+  parent = "projects/%{project_id}"
+  short_name = "%{tag_key_name2}"
+}
+
+resource "google_tags_tag_value" "value2" {
+  provider = google-beta
+
+  parent = "tagKeys/${google_tags_tag_key.key2.name}"
+  short_name = "%{tag_value_name2}"
+}
+
+resource "google_bigquery_dataset" "test" {
+  provider = google-beta
+
+  dataset_id = "%{dataset_id}"
+}
+
+resource "google_bigquery_table" "test" {
+  provider = google-beta
+
+  deletion_protection = false
+  dataset_id = "${google_bigquery_dataset.test.dataset_id}"
+  table_id   = "%{table_id}"
+  resource_tags = {}
+}
+`, context)
 }
 
 <% end -%>

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package bigquery_test
 
 import (
@@ -1552,6 +1553,46 @@ func TestAccBigQueryTable_TableReplicationInfo_WithReplicationInterval(t *testin
 	})
 }
 
+<% unless version == 'ga' -%>
+func TestAccBigQueryTable_ResourceTags(t *testing.T) {
+	t.Parallel()
+
+	projectID := envvar.GetTestProjectFromEnv()
+  datasetID := fmt.Sprintf("tf_test_dataset_%s", acctest.RandString(t, 10))
+	tableID := fmt.Sprintf("tf_test_table_%s", acctest.RandString(t, 10))
+	tagKeyName1 := fmt.Sprintf("tf_test_tag_key1_%s", acctest.RandString(t, 10))
+	tagValueName1 := fmt.Sprintf("tf_test_tag_value1_%s", acctest.RandString(t, 10))
+	tagKeyName2 := fmt.Sprintf("tf_test_tag_key2_%s", acctest.RandString(t, 10))
+	tagValueName2 := fmt.Sprintf("tf_test_tag_value2_%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy: testAccCheckBigQueryTableDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryTableWithResourceTags(projectID, datasetID, tableID, tagKeyName1, tagValueName1),
+			},
+			{
+				ResourceName:            "google_bigquery_table.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccBigQueryTableWithResourceTagsUpdate(projectID, datasetID, tableID, tagKeyName1, tagValueName1, tagKeyName2, tagValueName2),
+			},
+			{
+				ResourceName:            "google_bigquery_table.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+<% end -%>
 func testAccCheckBigQueryExtData(t *testing.T, expectedQuoteChar string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		for _, rs := range s.RootModule().Resources {
@@ -3921,6 +3962,93 @@ resource "time_sleep" "wait_10_seconds_last" {
 `, sourceDatasetID, sourceTableID, sourceMVJobID, sourceDatasetID, sourceMVID, sourceDatasetID, sourceTableID, projectID, sourceMVID, replicaDatasetID, replicaMVID, projectID, sourceMVID, replicationIntervalExpr, dropMVJobID, sourceDatasetID, sourceMVID)
 }
 
+<% unless version == 'ga' -%>
+func testAccBigQueryTableWithResourceTags(projectID, datasetID, tableID, tagKeyName, tagValueName string) string {
+	return fmt.Sprintf(`
+resource "google_tags_tag_key" "key" {
+  provider = google-beta
+
+  parent = "projects/%s"
+  short_name = "%s"
+}
+
+resource "google_tags_tag_value" "value" {
+  provider = google-beta
+
+  parent = "tagKeys/${google_tags_tag_key.key.name}"
+  short_name = "%s"
+}
+
+resource "google_bigquery_dataset" "test" {
+  provider = google-beta
+
+  dataset_id = "%s"
+}
+
+resource "google_bigquery_table" "test" {
+  provider = google-beta
+
+  deletion_protection = false
+  dataset_id = "${google_bigquery_dataset.test.dataset_id}"
+  table_id   = "%s"
+  resource_tags = {
+    "%s/%s" = "%s"
+  }
+}
+`, projectID, tagKeyName, tagValueName, datasetID, tableID, projectID, tagKeyName, tagValueName)
+}
+
+func testAccBigQueryTableWithResourceTagsUpdate(projectID, datasetID, tableID, tagKeyName1, tagValueName1, tagKeyName2, tagValueName2 string) string {
+	return fmt.Sprintf(`
+resource "google_tags_tag_key" "key1" {
+  provider = google-beta
+
+  parent = "projects/%s"
+  short_name = "%s"
+}
+
+resource "google_tags_tag_value" "value1" {
+  provider = google-beta
+
+  parent = "tagKeys/${google_tags_tag_key.key1.name}"
+  short_name = "%s"
+}
+
+resource "google_tags_tag_key" "key2" {
+  provider = google-beta
+
+  parent = "projects/%s"
+  short_name = "%s"
+}
+
+resource "google_tags_tag_value" "value2" {
+  provider = google-beta
+
+  parent = "tagKeys/${google_tags_tag_key.key2.name}"
+  short_name = "%s"
+}
+
+resource "google_bigquery_dataset" "test" {
+  provider = google-beta
+
+  dataset_id = "%s"
+}
+
+resource "google_bigquery_table" "test" {
+  provider = google-beta
+
+  deletion_protection = false
+  dataset_id = "${google_bigquery_dataset.test.dataset_id}"
+  table_id   = "%s"
+  resource_tags = {
+    "%s/%s" = "%s"
+    "%s/%s" = "%s"
+  }
+}
+`, projectID, tagKeyName1, tagValueName1, projectID, tagKeyName2, tagValueName2, datasetID, tableID, projectID, tagKeyName1, tagValueName1, projectID, tagKeyName2, tagValueName2)
+}
+
+<% end -%>
 var TEST_CSV = `lifelock,LifeLock,,web,Tempe,AZ,1-May-07,6850000,USD,b
 lifelock,LifeLock,,web,Tempe,AZ,1-Oct-06,6000000,USD,a
 lifelock,LifeLock,,web,Tempe,AZ,1-Jan-08,25000000,USD,c


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds support for resource tags to BigQuery Table.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigquery: added `resource_tags` field to `google_bigquery_table` resource
```
