### PR TITLE
Adding zone distribution mode in the Cluster resource for Memorystore Redis cluster

### DIFF
--- a/mmv1/products/redis/Cluster.yaml
+++ b/mmv1/products/redis/Cluster.yaml
@@ -62,6 +62,19 @@ examples:
       prevent_destroy: 'false'
     oics_vars_overrides:
       prevent_destroy: 'false'
+  - !ruby/object:Provider::Terraform::Examples
+    name: "redis_cluster_ha_single_zone"
+    primary_resource_id: "cluster-ha-single-zone"
+    vars:
+      cluster_name: "ha-cluster-single-zone"
+      policy_name: "mypolicy"
+      subnet_name: "mysubnet"
+      network_name: "mynetwork"
+      prevent_destroy: 'true'
+    test_vars_overrides:
+      prevent_destroy: 'false'
+    oics_vars_overrides:
+      prevent_destroy: 'false'
 properties:
   - !ruby/object:Api::Type::Time
     name: createTime
@@ -123,6 +136,24 @@ properties:
     default_from_api: true
     immutable: true
     required: false
+  - !ruby/object:Api::Type::NestedObject
+    name: zoneDistributionConfig
+    description: Immutable. Zone distribution config for Memorystore Redis cluster.
+    immutable: true
+    properties:
+      - !ruby/object:Api::Type::Enum
+        name: mode
+        description: |
+          Immutable. The mode for zone distribution for Memorystore Redis cluster.
+          If not provided, MULTI_ZONE will be used as default
+        values:
+          - :MULTI_ZONE
+          - :SINGLE_ZONE
+        default_from_api: true
+      - !ruby/object:Api::Type::String
+        name: zone
+        description: |
+          Immutable. The zone for single zone Memorystore Redis cluster.
   - !ruby/object:Api::Type::Array
     name: 'pscConfigs'
     description: |

--- a/mmv1/templates/terraform/examples/redis_cluster_ha.tf.erb
+++ b/mmv1/templates/terraform/examples/redis_cluster_ha.tf.erb
@@ -12,6 +12,9 @@ resource "google_redis_cluster" "<%= ctx[:primary_resource_id] %>" {
   redis_configs = {
     maxmemory-policy	= "volatile-ttl"
   }
+  zone_distribution_config {
+    mode = "MULTI_ZONE"
+  }
   depends_on = [
     google_network_connectivity_service_connection_policy.default
   ]

--- a/mmv1/templates/terraform/examples/redis_cluster_ha_single_zone.tf.erb
+++ b/mmv1/templates/terraform/examples/redis_cluster_ha_single_zone.tf.erb
@@ -1,28 +1,25 @@
-resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
-  name           = "{{index $.Vars "cluster_name"}}"
+resource "google_redis_cluster" "<%= ctx[:primary_resource_id] %>" {
+  name           = "<%= ctx[:vars]['cluster_name'] %>"
   shard_count    = 3
   psc_configs {
     network = google_compute_network.producer_net.id
   }
   region = "us-central1"
-  replica_count = 1
-  node_type = "REDIS_SHARED_CORE_NANO"
-  transit_encryption_mode = "TRANSIT_ENCRYPTION_MODE_DISABLED"
-  authorization_mode = "AUTH_MODE_DISABLED"
   zone_distribution_config {
-    mode = "MULTI_ZONE"
+    mode = "SINGLE_ZONE"
+    zone = "us-central1-f"
   }
   depends_on = [
     google_network_connectivity_service_connection_policy.default
   ]
 
   lifecycle {
-    prevent_destroy = {{index $.Vars "prevent_destroy"}}
+    prevent_destroy = <%= ctx[:vars]['prevent_destroy'] %>
   }
 }
 
 resource "google_network_connectivity_service_connection_policy" "default" {
-  name = "{{index $.Vars "policy_name"}}"
+  name = "<%= ctx[:vars]['policy_name'] %>"
   location = "us-central1"
   service_class = "gcp-memorystore-redis"
   description   = "my basic service connection policy"
@@ -33,13 +30,13 @@ resource "google_network_connectivity_service_connection_policy" "default" {
 }
 
 resource "google_compute_subnetwork" "producer_subnet" {
-  name          = "{{index $.Vars "subnet_name"}}"
+  name          = "<%= ctx[:vars]['subnet_name'] %>"
   ip_cidr_range = "10.0.0.248/29"
   region        = "us-central1"
   network       = google_compute_network.producer_net.id
 }
 
 resource "google_compute_network" "producer_net" {
-  name                    = "{{index $.Vars "network_name"}}"
+  name                    = "<%= ctx[:vars]['network_name'] %>"
   auto_create_subnetworks = false
 }

--- a/mmv1/third_party/terraform/services/redis/resource_redis_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/redis/resource_redis_cluster_test.go.erb
@@ -23,7 +23,7 @@ func TestAccRedisCluster_createClusterWithNodeType(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// create cluster with replica count 1
-				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 1, shardCount: 3, preventDestroy: true, nodeType: "REDIS_STANDARD_SMALL"}),
+				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 1, shardCount: 3, preventDestroy: true, nodeType: "REDIS_STANDARD_SMALL", zoneDistributionMode: "MULTI_ZONE"}),
 			},
 			{
 				ResourceName:            "google_redis_cluster.test",
@@ -33,10 +33,40 @@ func TestAccRedisCluster_createClusterWithNodeType(t *testing.T) {
 			},
 			{
 				// clean up the resource
-				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 0, shardCount: 3, preventDestroy: false, nodeType: "REDIS_STANDARD_SMALL"}),
+				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 0, shardCount: 3, preventDestroy: false, nodeType: "REDIS_STANDARD_SMALL", zoneDistributionMode: "MULTI_ZONE"}),
 			},
 		},
 	})
+}
+
+
+// Validate zone distribution for the cluster.
+func TestAccRedisCluster_createClusterWithZoneDistribution(t *testing.T) {
+        t.Parallel()
+
+        name := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+
+        acctest.VcrTest(t, resource.TestCase{
+                PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+                ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+                CheckDestroy:             testAccCheckRedisClusterDestroyProducer(t),
+                Steps: []resource.TestStep{
+                        {
+                                // create cluster with replica count 1
+                                Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 0, shardCount: 3, preventDestroy: false, zoneDistributionMode: "SINGLE_ZONE", zone: "us-central1-b"}),
+                        },
+                        {
+                                ResourceName:      "google_redis_cluster.test",
+                                ImportState:       true,
+                                ImportStateVerify: true,
+                                ImportStateVerifyIgnore: []string{"psc_configs"},
+                        },
+                        {
+                                // clean up the resource
+                                Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 0, shardCount: 3, preventDestroy: false, zoneDistributionMode: "SINGLE_ZONE", zone: "us-central1-b"}),
+                        },
+                },
+        })
 }
 
 // Validate that replica count is updated for the cluster
@@ -52,7 +82,7 @@ func TestAccRedisCluster_updateReplicaCount(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// create cluster with replica count 1
-				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 1, shardCount: 3, preventDestroy: true}),
+				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 1, shardCount: 3, preventDestroy: true, zoneDistributionMode: "MULTI_ZONE"}),
 			},
 			{
 				ResourceName:            "google_redis_cluster.test",
@@ -62,7 +92,7 @@ func TestAccRedisCluster_updateReplicaCount(t *testing.T) {
 			},
 			{
 				// update replica count to 2
-				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 2, shardCount: 3, preventDestroy: true}),
+				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 2, shardCount: 3, preventDestroy: true, zoneDistributionMode: "MULTI_ZONE"}),
 			},
 			{
 				ResourceName:            "google_redis_cluster.test",
@@ -72,11 +102,11 @@ func TestAccRedisCluster_updateReplicaCount(t *testing.T) {
 			},
 			{
 				// clean up the resource
-				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 1, shardCount: 3, preventDestroy: false}),
+				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 1, shardCount: 3, preventDestroy: false, zoneDistributionMode: "MULTI_ZONE"}),
 			},
 			{
 				// update replica count to 0
-				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 0, shardCount: 3, preventDestroy: true}),
+				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 0, shardCount: 3, preventDestroy: true, zoneDistributionMode: "MULTI_ZONE"}),
 			},
 			{
 				ResourceName:            "google_redis_cluster.test",
@@ -86,7 +116,7 @@ func TestAccRedisCluster_updateReplicaCount(t *testing.T) {
 			},
 			{
 				// clean up the resource
-				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 0, shardCount: 3, preventDestroy: false}),
+				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 0, shardCount: 3, preventDestroy: false, zoneDistributionMode: "MULTI_ZONE"}),
 			},
 		},
 	})
@@ -105,7 +135,7 @@ func TestAccRedisCluster_updateShardCount(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// create cluster with shard count 3
-				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 1, shardCount: 3, preventDestroy: true}),
+				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 1, shardCount: 3, preventDestroy: true, zoneDistributionMode: "MULTI_ZONE"}),
 			},
 			{
 				ResourceName:            "google_redis_cluster.test",
@@ -115,7 +145,7 @@ func TestAccRedisCluster_updateShardCount(t *testing.T) {
 			},
 			{
 				// update shard count to 5
-				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 1, shardCount: 5, preventDestroy: true}),
+				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 1, shardCount: 5, preventDestroy: true, zoneDistributionMode: "MULTI_ZONE"}),
 			},
 			{
 				ResourceName:            "google_redis_cluster.test",
@@ -125,7 +155,7 @@ func TestAccRedisCluster_updateShardCount(t *testing.T) {
 			},
 			{
 				// clean up the resource
-				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 1, shardCount: 5, preventDestroy: false}),
+				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, replicaCount: 1, shardCount: 5, preventDestroy: false, zoneDistributionMode: "MULTI_ZONE"}),
 			},
 		},
 	})
@@ -147,6 +177,7 @@ func TestAccRedisCluster_updateRedisConfigs(t *testing.T) {
 				Config: createOrUpdateRedisCluster(&ClusterParams{
 					name:           name,
 					shardCount:     3,
+					zoneDistributionMode: "MULTI_ZONE",
 					redisConfigs: map[string]string{
 						"maxmemory-policy": "volatile-ttl",
 					}}),
@@ -162,6 +193,7 @@ func TestAccRedisCluster_updateRedisConfigs(t *testing.T) {
 				Config: createOrUpdateRedisCluster(&ClusterParams{
 					name:           name,
 					shardCount:     3,
+					zoneDistributionMode: "MULTI_ZONE",
 					redisConfigs: map[string]string{
 						"maxmemory-policy":  "allkeys-lru",
 						"maxmemory-clients": "90%",
@@ -175,7 +207,7 @@ func TestAccRedisCluster_updateRedisConfigs(t *testing.T) {
 			},
 			{
 				// remove all redis configs
-				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, shardCount: 3}),
+				Config: createOrUpdateRedisCluster(&ClusterParams{name: name, shardCount: 3, zoneDistributionMode: "MULTI_ZONE"}),
 			},
 
 		},
@@ -183,12 +215,14 @@ func TestAccRedisCluster_updateRedisConfigs(t *testing.T) {
 }
 
 type ClusterParams struct {
-	name           string
-	replicaCount   int
-	shardCount     int
-	preventDestroy bool
-	nodeType       string
-	redisConfigs   map[string]string
+	name                 string
+	replicaCount   			 int
+	shardCount     			 int
+	preventDestroy 			 bool
+	nodeType             string
+	redisConfigs         map[string]string
+	zoneDistributionMode string
+	zone 								 string
 }
 
 func createOrUpdateRedisCluster(params *ClusterParams) string {
@@ -202,6 +236,16 @@ func createOrUpdateRedisCluster(params *ClusterParams) string {
 	var strBuilder strings.Builder
 	for key, value := range params.redisConfigs {
 		strBuilder.WriteString(fmt.Sprintf("%s =  \"%s\"\n", key, value))
+	}
+
+	zoneDistributionConfigBlock := ``
+	if params.zoneDistributionMode != "" {
+		zoneDistributionConfigBlock = fmt.Sprintf(`
+		zone_distribution_config {
+			mode = "%s"
+			zone = "%s"
+		}
+		`, params.zoneDistributionMode, params.zone)
 	}
 
 	return fmt.Sprintf(`
@@ -218,6 +262,7 @@ resource "google_redis_cluster" "test" {
 	redis_configs = {
 		%s
 	}
+  %s
 	depends_on = [
 			google_network_connectivity_service_connection_policy.default
 		]
@@ -249,7 +294,7 @@ resource "google_compute_network" "producer_net" {
 	name                    = "%s"
 	auto_create_subnetworks = false
 }
-`, params.name, params.replicaCount, params.shardCount, params.nodeType, strBuilder.String(), lifecycleBlock, params.name, params.name, params.name)
+`, params.name, params.replicaCount, params.shardCount, params.nodeType, strBuilder.String(), zoneDistributionConfigBlock, lifecycleBlock, params.name, params.name, params.name)
 }
 
 <% end -%>


### PR DESCRIPTION
Adding `zone_distribution_config` field to `google_redis_cluster` to allow creation of single zone clusters.

If this PR is for Terraform, I acknowledge that I have:

 - Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
 -  Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests). \
- [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [make test and make lint](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests. \
- [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

```release-note:enhancement
redis: added `zone_distribution_config` field to `google_redis_cluster`
```
