### PR TITLE
Add OwnershipScope to the Billing Budget resource

### DIFF
--- a/mmv1/products/billingbudget/Budget.yaml
+++ b/mmv1/products/billingbudget/Budget.yaml
@@ -482,7 +482,7 @@ properties:
   - !ruby/object:Api::Type::Enum
     name: ownershipScope
     description: |
-      The ownership scope of the budget. The ownership scope and users' 
+      The ownership scope of the budget. The ownership scope and users'
       IAM permissions determine who has full access to the budget's data.
     values:
       - :OWNERSHIP_SCOPE_UNSPECIFIED

--- a/mmv1/products/billingbudget/Budget.yaml
+++ b/mmv1/products/billingbudget/Budget.yaml
@@ -479,3 +479,12 @@ properties:
           when a threshold is exceeded. Default recipients are
           those with Billing Account Administrators and Billing
           Account Users IAM roles for the target account.
+  - !ruby/object:Api::Type::Enum
+    name: ownershipScope
+    description: |
+      The ownership scope of the budget. The ownership scope and users' 
+      IAM permissions determine who has full access to the budget's data.
+    values:
+      - :OWNERSHIP_SCOPE_UNSPECIFIED
+      - :ALL_USERS
+      - :BILLING_ACCOUNT

--- a/mmv1/templates/terraform/examples/billing_budget_optional.tf.erb
+++ b/mmv1/templates/terraform/examples/billing_budget_optional.tf.erb
@@ -17,6 +17,8 @@ resource "google_billing_budget" "<%= ctx[:primary_resource_id] %>" {
     disable_default_iam_recipients = true
     pubsub_topic = google_pubsub_topic.<%= ctx[:primary_resource_id] %>.id
   }
+
+  ownership_scope = "BILLING_ACCOUNT"
 }
 
 resource "google_pubsub_topic" "<%= ctx[:primary_resource_id] %>" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

I noticed that the Billing Budget API has a field to configure [OwnershipScope](https://cloud.google.com/billing/docs/reference/budget/rest/v1/billingAccounts.budgets#OwnershipScope).  I need this for one of my customers, so I went ahead and added that field to the Budget resource.   

FIXES https://github.com/hashicorp/terraform-provider-google/issues/17862

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
billing: added `ownership_scope` field to `google_billing_budget` resource
```
