### PR TITLE
go rewrite - Finish test template

### DIFF
--- a/mmv1/templates/terraform/examples/base_configs/test_file.go.tmpl
+++ b/mmv1/templates/terraform/examples/base_configs/test_file.go.tmpl
@@ -43,7 +43,7 @@ func TestAcc{{ $e.TestSlug $.Res.ProductMetadata.Name $.Res.Name }}(t *testing.T
 	{{- end }}
 	t.Parallel()
 
-	context := map[string]interface{} {
+	context := map[string]interface{}{
 	{{- range $varKey, $varVal := $e.TestEnvVars }}
 		{{- if eq $varVal $.ORGID }}
 		"{{$varKey}}": envvar.GetTestOrgFromEnv(t),
@@ -119,10 +119,59 @@ func TestAcc{{ $e.TestSlug $.Res.ProductMetadata.Name $.Res.Name }}(t *testing.T
 
 func testAcc{{ $e.TestSlug $.Res.ProductMetadata.Name $.Res.Name }}(context map[string]interface{}) string {
   return acctest.Nprintf(`
-{{ $e.HCLText }}
+{{ $e.TestHCLText -}}
 `, context)
 }
 
-{{- end }}
+{{ end }}
 
-{{/*TODO Q2: Destroy Producer */}}
+{{ if not $.Res.SkipDelete }}
+func testAccCheck{{ $.Res.ResourceName }}DestroyProducer(t *testing.T) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		for name, rs := range s.RootModule().Resources {
+			if rs.Type != "{{ $.Res.TerraformName }}" {
+				continue
+			}
+			if strings.HasPrefix(name, "data.") {
+				continue
+			}
+	{{- if $.Res.CustomCode.TestCheckDestroy }}
+{{/*TODO Q2: Custom template for TestCheckDestroy */}}
+	{{- else }}
+
+		config := acctest.GoogleProviderConfig(t)
+
+		url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{"{{"}}{{$.Res.ProductMetadata.Name}}{{"BasePath}}"}}{{$.Res.SelfLinkUri}}")
+		if err != nil {
+			return err
+		}
+
+		billingProject := ""
+
+		if config.BillingProject != "" {
+			billingProject = config.BillingProject
+		}
+
+			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config: config,
+			Method: "{{ camelize $.Res.ReadVerb "upper" }}",
+			Project: billingProject,
+			RawURL: url,
+			UserAgent: config.UserAgent,
+		{{- if $.Res.ErrorRetryPredicates }}
+			ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{ {{- join $.Res.ErrorRetryPredicates "," -}} },
+		{{- end }}
+		{{- if $.Res.ErrorAbortPredicates }}
+			ErrorAbortPredicates: []transport_tpg.RetryErrorPredicateFunc{ {{- join $.Res.ErrorAbortPredicates "," -}} },
+		{{- end }}
+		})
+		if err == nil {
+				return fmt.Errorf("{{ $.Res.ResourceName }} still exists at %s", url)
+			}
+	{{- end }}
+		}
+
+		return nil
+	}
+}
+{{- end }}

--- a/mmv1/templates/terraform/resource.html.markdown.tmpl
+++ b/mmv1/templates/terraform/resource.html.markdown.tmpl
@@ -83,7 +83,7 @@ values will be stored in the raw state as plain text: {{ $.SensitivePropsToStrin
 
 
 ```hcl
-{{ $e.HCLText }}
+{{ $e.DocumentationHCLText -}}
 ```
 	{{- end }}
 {{- end }}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

- Differentiates Documentation examples vs Test examples
- Adds TestCheckDestroy to test template

Generates an exact copy of `google-beta/services/datafusion/resource_data_fusion_instance_generated_test.go` except for an extra import of 
```
	"github.com/hashicorp/terraform-provider-google-beta/google-beta/envvar"
```
Which I think can be resolved by running go imports elsewhere.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
