### PR TITLE
Add ignore_read_extra to IntegrationConnectors Connection status fields

### DIFF
--- a/mmv1/products/integrationconnectors/Connection.yaml
+++ b/mmv1/products/integrationconnectors/Connection.yaml
@@ -42,12 +42,16 @@ examples:
     primary_resource_id: "pubsubconnection"
     vars:
       connection_name: "test-pubsub"
+    ignore_read_extra:
+      - 'status.0.description'
   - !ruby/object:Provider::Terraform::Examples
     name: "integration_connectors_connection_advanced"
     primary_resource_id: "zendeskconnection"
     vars:
       connection_name: "test-zendesk"
       secret_id: "test-secret"
+    ignore_read_extra:
+      - 'status.0.description'
   - !ruby/object:Provider::Terraform::Examples
     name: "integration_connectors_connection_sa"
     primary_resource_id: "zendeskconnection"
@@ -55,6 +59,8 @@ examples:
       connection_name: "test-zendesk"
       secret_id: "test-secret"
     skip_docs: true
+    ignore_read_extra:
+      - 'status.0.description'
   - !ruby/object:Provider::Terraform::Examples
     name: "integration_connectors_connection_oauth"
     primary_resource_id: "boxconnection"
@@ -62,6 +68,8 @@ examples:
       connection_name: "test-box"
       secret_id: "test-secret"
     skip_docs: true
+    ignore_read_extra:
+      - 'status.0.description'
   - !ruby/object:Provider::Terraform::Examples
     name: "integration_connectors_connection_oauth_ssh"
     primary_resource_id: "boxconnection"
@@ -69,6 +77,8 @@ examples:
       connection_name: "test-box"
       secret_id: "test-secret"
     skip_docs: true
+    ignore_read_extra:
+      - 'status.0.description'
   - !ruby/object:Provider::Terraform::Examples
     name: "integration_connectors_connection_oauth_cc"
     primary_resource_id: "boxconnection"
@@ -76,6 +86,8 @@ examples:
       connection_name: "test-box"
       secret_id: "test-secret"
     skip_docs: true
+    ignore_read_extra:
+      - 'status.0.description'
   - !ruby/object:Provider::Terraform::Examples
     name: "integration_connectors_connection_oauth_jwt"
     primary_resource_id: "boxconnection"
@@ -83,6 +95,8 @@ examples:
       connection_name: "test-box"
       secret_id: "test-secret"
     skip_docs: true
+    ignore_read_extra:
+      - 'status.0.description'
 async: !ruby/object:Api::OpAsync
   operation: !ruby/object:Api::OpAsync::Operation
     path: "name"


### PR DESCRIPTION
…n tests

Part of https://github.com/hashicorp/terraform-provider-google/issues/16720, doesn't resolve the error code 13's. Status fields are volatile fields that are allowed to have their values change between the original state and imported state in import checks.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
