### PR TITLE
Use vars for resource ids in SecurityPosture

### DIFF
--- a/mmv1/products/securityposture/Posture.yaml
+++ b/mmv1/products/securityposture/Posture.yaml
@@ -23,18 +23,12 @@ references: !ruby/object:Api::Resource::ReferenceLinks
     'Create and deploy a posture': 'https://cloud.google.com/security-command-center/docs/how-to-use-security-posture'
 import_format: ['{{%parent}}/locations/{{location}}/postures/{{posture_id}}']
 base_url: '{{parent}}/locations/{{location}}/postures'
-
 self_link: '{{parent}}/locations/{{location}}/postures/{{posture_id}}'
-
 create_url: '{{parent}}/locations/{{location}}/postures?postureId={{posture_id}}'
-
 update_url: '{{parent}}/locations/{{location}}/postures/{{posture_id}}?revisionId={{revision_id}}'
 update_verb: :PATCH
-
 update_mask: true
-
 delete_url: '{{parent}}/locations/{{location}}/postures/{{posture_id}}'
-
 autogen_async: true
 # Sets parameters for handling operations returned by the API.
 async: !ruby/object:Api::OpAsync
@@ -49,9 +43,11 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'securityposture_posture_basic'
     primary_resource_id: 'posture1'
+    vars:
+      posture_id: "posture_1"
+      deployment_id: "posture_deployment_1"
     test_env_vars:
       org_id: :ORG_ID
-
 parameters:
   - !ruby/object:Api::Type::String
     name: 'parent'

--- a/mmv1/products/securityposture/Posture.yaml
+++ b/mmv1/products/securityposture/Posture.yaml
@@ -44,8 +44,7 @@ examples:
     name: 'securityposture_posture_basic'
     primary_resource_id: 'posture1'
     vars:
-      posture_id: "posture_1"
-      deployment_id: "posture_deployment_1"
+      posture_id: "posture_example"
     test_env_vars:
       org_id: :ORG_ID
 parameters:

--- a/mmv1/products/securityposture/PostureDeployment.yaml
+++ b/mmv1/products/securityposture/PostureDeployment.yaml
@@ -37,7 +37,8 @@ examples:
     name: 'securityposture_posture_deployment_basic'
     primary_resource_id: 'postureDeployment'
     vars:
-      posture_id: "posture_example"
+      posture_id: "posture_1"
+      deployment_id: "posture_deployment_1"
     test_env_vars:
       org_id: :ORG_ID
       project_number: :PROJECT_NUMBER

--- a/mmv1/products/securityposture/PostureDeployment.yaml
+++ b/mmv1/products/securityposture/PostureDeployment.yaml
@@ -25,12 +25,9 @@ references: !ruby/object:Api::Resource::ReferenceLinks
 import_format: ['{{%parent}}/locations/{{location}}/postureDeployments/{{posture_deployment_id}}']
 base_url: '{{parent}}/locations/{{location}}/postureDeployments'
 self_link: '{{parent}}/locations/{{location}}/postureDeployments/{{posture_deployment_id}}'
-
 create_url: '{{parent}}/locations/{{location}}/postureDeployments?postureDeploymentId={{posture_deployment_id}}'
 update_verb: :PATCH
 update_mask: true
-
-
 autogen_async: true
 async: !ruby/object:Api::OpAsync
   operation: !ruby/object:Api::OpAsync::Operation
@@ -39,10 +36,11 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'securityposture_posture_deployment_basic'
     primary_resource_id: 'postureDeployment'
+    vars:
+      posture_id: "posture_example"
     test_env_vars:
       org_id: :ORG_ID
       project_number: :PROJECT_NUMBER
-
 parameters:
   - !ruby/object:Api::Type::String
     name: parent
@@ -65,7 +63,6 @@ parameters:
     immutable: true
     required: true
     url_param_only: true
-
 properties:
   - !ruby/object:Api::Type::String
     name: 'name'

--- a/mmv1/templates/terraform/examples/securityposture_posture_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/securityposture_posture_basic.tf.erb
@@ -1,5 +1,5 @@
 resource "google_securityposture_posture" "<%= ctx[:primary_resource_id] %>"{
-  posture_id  = "posture_example"
+  posture_id  = "<%= ctx[:vars]['posture_id'] %>"
   parent      = "organizations/<%= ctx[:test_env_vars]['org_id'] %>"
   location    = "global"
   state       = "ACTIVE"
@@ -16,8 +16,8 @@ resource "google_securityposture_posture" "<%= ctx[:primary_resource_id] %>"{
             enforce = true
             condition {
             	description = "condition description"
-            	expression = "resource.matchTag('org_id/tag_key_short_name,'tag_value_short_name')"
-            	title = "a CEL condition"
+            	expression  = "resource.matchTag('org_id/tag_key_short_name,'tag_value_short_name')"
+            	title       = "a CEL condition"
             }
           }
         }
@@ -28,9 +28,9 @@ resource "google_securityposture_posture" "<%= ctx[:primary_resource_id] %>"{
       constraint {
         org_policy_constraint_custom {
           custom_constraint {
-            name         = "organizations/<%= ctx[:test_env_vars]['org_id'] %>/customConstraints/custom.disableGkeAutoUpgrade"
-            display_name = "Disable GKE auto upgrade"
-            description  = "Only allow GKE NodePool resource to be created or updated if AutoUpgrade is not enabled where this custom constraint is enforced."
+            name           = "organizations/<%= ctx[:test_env_vars]['org_id'] %>/customConstraints/custom.disableGkeAutoUpgrade"
+            display_name   = "Disable GKE auto upgrade"
+            description    = "Only allow GKE NodePool resource to be created or updated if AutoUpgrade is not enabled where this custom constraint is enforced."
             action_type    = "ALLOW"
             condition      = "resource.management.autoUpgrade == false"
             method_types   = ["CREATE", "UPDATE"]

--- a/mmv1/templates/terraform/examples/securityposture_posture_deployment_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/securityposture_posture_deployment_basic.tf.erb
@@ -1,12 +1,12 @@
 resource "google_securityposture_posture" "posture_1" {
-    posture_id          = "posture_1"
-    parent = "organizations/<%= ctx[:test_env_vars]['org_id'] %>"
-    location = "global"
-    state = "ACTIVE"
+    posture_id  = "<%= ctx[:vars]['posture_id'] %>"
+    parent      = "organizations/<%= ctx[:test_env_vars]['org_id'] %>"
+    location    = "global"
+    state       = "ACTIVE"
     description = "a new posture"
     policy_sets {
         policy_set_id = "org_policy_set"
-        description = "set of org policies"
+        description   = "set of org policies"
         policies {
             policy_id = "policy_1"
             constraint {
@@ -22,11 +22,11 @@ resource "google_securityposture_posture" "posture_1" {
 }
 
 resource "google_securityposture_posture_deployment" "<%= ctx[:primary_resource_id] %>" {
-    posture_deployment_id          = "posture_deployment_1"
-    parent = "organizations/<%= ctx[:test_env_vars]['org_id'] %>"
-    location = "global"
-    description = "a new posture deployment"
-    target_resource = "projects/<%= ctx[:test_env_vars]['project_number'] %>"
-    posture_id = google_securityposture_posture.posture_1.name
-    posture_revision_id = google_securityposture_posture.posture_1.revision_id
+    posture_deployment_id = "<%= ctx[:vars]['deployment_id'] %>"
+    parent                = "organizations/<%= ctx[:test_env_vars]['org_id'] %>"
+    location              = "global"
+    description           = "a new posture deployment"
+    target_resource       = "projects/<%= ctx[:test_env_vars]['project_number'] %>"
+    posture_id            = google_securityposture_posture.posture_1.name
+    posture_revision_id   = google_securityposture_posture.posture_1.revision_id
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This should address a flake in https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_GoogleCloud_GOOGLE_NIGHTLYTESTS_GOOGLE_PACKAGE_SECURITYPOSTURE/134862?buildTab=overview&expandBuildDeploymentsSection=false&hideTestsFromDependencies=false&expandBuildTestsSection=true&hideProblemsFromDependencies=false&expandBuildChangesSection=true

I cleaned up some whitespace/did some reformatting in the process here, as well as renamed posture.yaml to Posture.yaml. Sorry for the noise! Appending &w=1 to the URL (or clicking "No Whitespace") will suppress most of those.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
