### PR TITLE
Revert "Upgrade gunicorn in test fixture"

### DIFF
--- a/mmv1/third_party/terraform/services/appengine/test-fixtures/hello-world-flask/requirements.txt
+++ b/mmv1/third_party/terraform/services/appengine/test-fixtures/hello-world-flask/requirements.txt
@@ -1,2 +1,2 @@
 Flask==1.1.1
-gunicorn==22.0.0
+gunicorn==20.0.4


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#10469

This ultimately fails, see the VCR failures in https://github.com/GoogleCloudPlatform/magic-modules/pull/10476. It didn't fail on the initial PR because there were no Go code changes & therefore didn't trigger a VCR run.

```release-note:none
```