### PR TITLE
Added missing newline to generate_downstream.go logs

### DIFF
--- a/.ci/magician/cmd/generate_downstream.go
+++ b/.ci/magician/cmd/generate_downstream.go
@@ -325,7 +325,7 @@ func createCommit(scratchRepo *source.Repo, commitMessage string, rnr ExecRunner
 	}
 
 	commitSha = strings.TrimSpace(commitSha)
-	fmt.Printf("Commit sha on the branch is: `%s`", commitSha)
+	fmt.Printf("Commit sha on the branch is: `%s`\n", commitSha)
 
 	return commitSha, err
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

See https://pantheon.corp.google.com/cloud-build/builds;region=global/d273282c-f170-4003-ab42-8c57ff42b892;step=8?project=graphite-docker-images&e=-13802955&mods=logs_tg_staging for example of the issue

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
