### PR TITLE
Made base transport layer force ipv4 usage if ipv6 is not supported

### DIFF
--- a/mmv1/third_party/terraform/transport/config.go.erb
+++ b/mmv1/third_party/terraform/transport/config.go.erb
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -28,6 +29,8 @@ import (
 
 	"github.com/hashicorp/terraform-provider-google/google/verify"
 
+	"golang.org/x/net/http2"
+	"golang.org/x/net/nettest"
 	"golang.org/x/oauth2"
 	"google.golang.org/grpc"
 	googleoauth "golang.org/x/oauth2/google"
@@ -82,6 +85,7 @@ import (
 	"google.golang.org/api/storage/v1"
 	"google.golang.org/api/storagetransfer/v1"
 	"google.golang.org/api/transport"
+	apihttp "google.golang.org/api/transport/http"
 )
 
 type ProviderMeta struct {
@@ -429,6 +433,39 @@ func SetEndpointDefaults(d *schema.ResourceData) error {
 	return nil
 }
 
+// baseTransport returns the base HTTP transport. It starts with the
+// default transport and makes some tweaks to match best practices
+// from google-api-go-client, as well as ensuring that IPv6 does
+// not get used in environments that don't support it.
+func baseTransport() (http.RoundTripper, error) {
+	trans := http.DefaultTransport.(*http.Transport).Clone()
+	// Increase MaxIdleConnsPerHost due to reported performance issues under load in the
+	// GCS client.
+	trans.MaxIdleConnsPerHost = 100
+
+	// Configure the ReadIdleTimeout HTTP/2 option for the
+	// transport. This allows broken idle connections to be pruned more quickly,
+	// preventing the client from attempting to re-use connections that will no
+	// longer work. http2Trans is discarded after configuration.
+	http2Trans, err := http2.ConfigureTransports(trans)
+	if err != nil {
+		return trans, err
+	}
+	http2Trans.ReadIdleTimeout = time.Second * 31
+
+	// Override dialer so that we don't try IPv6 if it's not supported.
+	// https://github.com/golang/go/issues/25321
+	trans.DialContext = func(ctx context.Context, network string, addr string) (net.Conn, error) {
+		d := &net.Dialer{}
+		if !nettest.SupportsIPv6() {
+			return d.DialContext(ctx, "tcp4", addr)
+		}
+		return d.DialContext(ctx, network, addr)
+	}
+
+	return trans, nil
+}
+
 func (c *Config) LoadAndValidate(ctx context.Context) error {
 	if len(c.Scopes) == 0 {
 		c.Scopes = DefaultClientScopes
@@ -445,8 +482,13 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 
 	cleanCtx := context.WithValue(ctx, oauth2.HTTPClient, cleanhttp.DefaultClient())
 
-	// 1. MTLS TRANSPORT/CLIENT - sets up proper auth headers
-	client, _, err := transport.NewHTTPClient(cleanCtx, option.WithTokenSource(tokenSource))
+	// 1. Set up base HTTP transport and configure token auth / API communication
+	base, err := baseTransport()
+	if err != nil {
+		return err
+	}
+
+	transport, err := apihttp.NewTransport(cleanCtx, base, option.WithTokenSource(tokenSource))
 	if err != nil {
 		return err
 	}
@@ -458,7 +500,7 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 	}
 
 	// 2. Logging Transport - ensure we log HTTP requests to GCP APIs.
-	loggingTransport := logging.NewTransport("Google", client.Transport)
+	loggingTransport := logging.NewTransport("Google", transport)
 
 	// 3. Retry Transport - retries common temporary errors
 	// Keep order for wrapping logging so we log each retried request as well.
@@ -479,8 +521,8 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 		headerTransport.Set("X-Goog-User-Project", c.BillingProject)
 	}
 
-	// Set final transport value.
-	client.Transport = headerTransport
+	// Create http client
+	client := &http.Client{Transport: headerTransport}
 
 	// This timeout is a timeout per HTTP request, not per logical operation.
 	client.Timeout = c.synchronousTimeout()


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/6782

Workaround for https://github.com/golang/go/issues/25321

Note that while I was able to reproduce the Go issue, I was not able to reproduce the TF issue - there seems to be some amount of randomness in terms of when it presents. However, this seems to be the best option for working around the issue.

This PR also removes a lot of complexity that was previously implicitly part of our transport setup via [transport.NewHTTPClient](https://github.com/googleapis/google-api-go-client/blob/707b9b287dc37fb07c2553c0391f83995f1420a6/transport/http/dial.go#L32) and that was mostly unused. (I traced through the code to boil it down to the ~10 or so~ 6 lines we were actually using.)

yaqs/47302089738551296

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
provider: Forced HTTP requests to use ipv4 on systems with ipv6 disabled, such as Cloud Shell.
```
