### PR TITLE
Add Go env vars to setup guide

### DIFF
--- a/docs/content/get-started/generate-providers.md
+++ b/docs/content/get-started/generate-providers.md
@@ -37,12 +37,12 @@ If you are familiar with Docker or Podman, you may want to use the experimental 
    ```
 1. [Install go](https://go.dev/doc/install)
 1. Add the following values to your environment settings such as `.bashrc`:
-  ```bash
-   # Add Go binaries to GOPATH
-   export PATH=$PATH:$(go env GOPATH)/bin
+   ```bash
    # Add GOPATH variable for convenience
    export GOPATH=$(go env GOPATH)
-  ```
+   # Add Go binaries to PATH
+   export PATH=$PATH:$(go env GOPATH)/bin
+   ```
 1. Install goimports
    ```bash
    go install golang.org/x/tools/cmd/goimports@latest

--- a/docs/content/get-started/generate-providers.md
+++ b/docs/content/get-started/generate-providers.md
@@ -36,6 +36,13 @@ If you are familiar with Docker or Podman, you may want to use the experimental 
    rbenv install 3.1.0
    ```
 1. [Install go](https://go.dev/doc/install)
+1. Add the following values to your environment settings such as `.bashrc`:
+  ```bash
+   # Add Go binaries to GOPATH
+   export PATH=$PATH:$(go env GOPATH)/bin
+   # Add GOPATH variable for convenience
+   export GOPATH=$(go env GOPATH)
+  ```
 1. Install goimports
    ```bash
    go install golang.org/x/tools/cmd/goimports@latest


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

https://go.dev/doc/install never actually has you set a GOPATH env var, although we rely on it in our clone and generate commands. Using $GOPATH is technically an override for the default `GOPATH` accessible through `go env GOPATH`, but we can just explicitly set the default value here. The defaults `~/go` for the most part, and anyone who did something different should be able to figure out where to deviate.

Additionally, we expect `go install` of `goimports` to work, but it doesn't by default. Users will eventually end up on a blog that instructs them to add GOPATH/bin to their PATH. Again, not covered by the default install commands.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
