### PR TITLE
Update alloydb sweeper to sweep secondary clusters

### DIFF
--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_sweeper.go.erb
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_sweeper.go.erb
@@ -48,10 +48,11 @@ func testSweepAlloydbCluster(region string) error {
 		},
 	}
 
+        // manual change: use aggregated list instead of sweeper-specific location. This will clear secondary clusters.
 <% unless version == 'ga' -%>
-	listTemplate := strings.Split("https://alloydb.googleapis.com/v1beta/projects/{{project}}/locations/{{location}}/clusters", "?")[0]
+	listTemplate := strings.Split("https://alloydb.googleapis.com/v1beta/projects/{{project}}/locations/-/clusters", "?")[0]
 <% else -%>
-	listTemplate := strings.Split("https://alloydb.googleapis.com/v1/projects/{{project}}/locations/{{location}}/clusters", "?")[0]
+	listTemplate := strings.Split("https://alloydb.googleapis.com/v1/projects/{{project}}/locations/-/clusters", "?")[0]
 <% end -%>
 	listUrl, err := tpgresource.ReplaceVars(d, config, listTemplate)
 	if err != nil {
@@ -84,33 +85,23 @@ func testSweepAlloydbCluster(region string) error {
 	nonPrefixCount := 0
 	for _, ri := range rl {
 		obj := ri.(map[string]interface{})
-		var name string
-		// Id detected in the delete URL, attempt to use id.
-		if obj["id"] != nil {
-			name = tpgresource.GetResourceNameFromSelfLink(obj["id"].(string))
-		} else if obj["name"] != nil {
-			name = tpgresource.GetResourceNameFromSelfLink(obj["name"].(string))
-		} else {
-			log.Printf("[INFO][SWEEPER_LOG] %s resource name and id were nil", resourceName)
-			return nil
-		}
+
+		// manual patch: use raw name for url instead of constructing it, so that resource locations are supplied through aggregated list
+		// manual patch: Using the force=true ensures that we delete instances as well.
+		name := obj["name"].(string)
+		shortname = tpgresource.GetResourceNameFromSelfLink(name)
 		// Skip resources that shouldn't be sweeped
-		if !sweeper.IsSweepableTestResource(name) {
+		if !sweeper.IsSweepableTestResource(shortname) {
 			nonPrefixCount++
 			continue
 		}
 
 		<% unless version == 'ga' -%>
-			deleteTemplate := "https://alloydb.googleapis.com/v1beta/projects/{{project}}/locations/{{location}}/clusters/{{cluster_id}}"
+		deleteTemplate := "https://alloydb.googleapis.com/v1beta/%s?force=true"
 		<% else -%>
-			deleteTemplate := "https://alloydb.googleapis.com/v1/projects/{{project}}/locations/{{location}}/clusters/{{cluster_id}}"
+		deleteTemplate := "https://alloydb.googleapis.com/v1/%s?force=true"
 		<% end -%>
-		deleteUrl, err := tpgresource.ReplaceVars(d, config, deleteTemplate)
-		if err != nil {
-			log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
-			return nil
-		}
-		deleteUrl = deleteUrl + name + "?force=true"
+		deleteUrl := fmt.Sprintf(deleteTemplate, name)
 
 		// Don't wait on operations as we may have a lot to delete
 		_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
@@ -123,7 +114,7 @@ func testSweepAlloydbCluster(region string) error {
 		if err != nil {
 			log.Printf("[INFO][SWEEPER_LOG] Error deleting for url %s : %s", deleteUrl, err)
 		} else {
-			log.Printf("[INFO][SWEEPER_LOG] Sent delete request for %s resource: %s", resourceName, name)
+			log.Printf("[INFO][SWEEPER_LOG] Sent delete request for %s resource: %s", name, shortname)
 		}
 	}
 

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_sweeper.go.erb
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_sweeper.go.erb
@@ -48,7 +48,7 @@ func testSweepAlloydbCluster(region string) error {
 		},
 	}
 
-        // manual change: use aggregated list instead of sweeper-specific location. This will clear secondary clusters.
+	// manual patch: use aggregated list instead of sweeper-specific location. This will clear secondary clusters.
 <% unless version == 'ga' -%>
 	listTemplate := strings.Split("https://alloydb.googleapis.com/v1beta/projects/{{project}}/locations/-/clusters", "?")[0]
 <% else -%>

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_sweeper.go.erb
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_sweeper.go.erb
@@ -3,6 +3,7 @@ package alloydb
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 	"testing"
@@ -89,7 +90,7 @@ func testSweepAlloydbCluster(region string) error {
 		// manual patch: use raw name for url instead of constructing it, so that resource locations are supplied through aggregated list
 		// manual patch: Using the force=true ensures that we delete instances as well.
 		name := obj["name"].(string)
-		shortname = tpgresource.GetResourceNameFromSelfLink(name)
+		shortname := tpgresource.GetResourceNameFromSelfLink(name)
 		// Skip resources that shouldn't be sweeped
 		if !sweeper.IsSweepableTestResource(shortname) {
 			nonPrefixCount++


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

We currently sweep us-central1, which only deletes primary clusters. However, primary clusters can only be deleted if their secondary is deleted. This won't guarantee we sweep completely in one pass, but will mean that we clean up any primary+secondary pairs in two passes.

Note that there a force parameter on delete- that deletes instances, which are children of clusters, and does not appear to delete secondary clusters.

I ran this locally to test it, with: `GOOGLE_USE_DEFAULT_CREDENTIALS=true GOOGLE_PROJECT=ci-test-project-nightly-ga make testacc TEST=./google-beta/sweeper TESTARGS='-sweep=us-central1 -sweep-run=AlloydbCluster'`

Here's the results: https://console.cloud.google.com/alloydb/clusters?e=-13802955&mods=logs_tg_staging&project=ci-test-project-nightly-ga

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
