### PR TITLE
Add version guard to google_composer_user_workloads_secret

### DIFF
--- a/mmv1/third_party/terraform/services/composer/resource_composer_user_workloads_secret.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_user_workloads_secret.go.erb
@@ -1,6 +1,8 @@
 <% autogen_exception -%>
 package composer
 
+<% unless version == 'ga' -%>
+
 import (
 	"fmt"
 	"log"
@@ -266,3 +268,5 @@ func (n *UserWorkloadsSecretsName) ResourceName() string {
 func (n *UserWorkloadsSecretsName) ParentName() string {
 	return fmt.Sprintf("projects/%s/locations/%s/environments/%s", n.Project, n.Region, n.Environment)
 }
+
+<% end -%>

--- a/mmv1/third_party/terraform/services/composer/resource_composer_user_workloads_secret_test.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_user_workloads_secret_test.go.erb
@@ -1,6 +1,8 @@
 <% autogen_exception -%>
 package composer_test
 
+<% unless version == 'ga' -%>
+
 import (
 	"fmt"
 	"testing"
@@ -176,3 +178,5 @@ func testAccComposerUserWorkloadsSecretDestroyed(t *testing.T) func(s *terraform
 		return nil
 	}
 }
+
+<% end -%>

--- a/mmv1/third_party/terraform/website/docs/r/composer_user_workloads_secret.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_user_workloads_secret.html.markdown
@@ -6,6 +6,9 @@ description: |-
 
 # google\_composer\_user\_workloads\_secret
 
+~> **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
+See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
+
 User workloads Secret used by Airflow tasks that run with Kubernetes Executor or KubernetesPodOperator. 
 Intended for Composer 3 Environments.
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Followup to https://github.com/GoogleCloudPlatform/magic-modules/pull/10466

This was causing failing tests in GA, where the resource was not registered. Fully version guard all source files, and add beta resource warning to docs.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
No release note- the original is in line for the 5.27.0 cut, and this change should be merged in time.
```
