### PR TITLE
Add serviceAgentAuthentication for Uptime Checks

### DIFF
--- a/mmv1/products/monitoring/UptimeCheckConfig.yaml
+++ b/mmv1/products/monitoring/UptimeCheckConfig.yaml
@@ -223,8 +223,9 @@ properties:
           - http_check.0.use_ssl
           - http_check.0.mask_headers
         description:
-          The authentication information. Optional when creating an HTTP check;
-          defaults to empty.
+          The authentication information using username and password.
+          Optional when creating an HTTP check; defaults to empty.
+          Do not use with other authentication fields.
         properties:
           - !ruby/object:Api::Type::String
             name: password
@@ -236,6 +237,18 @@ properties:
             name: username
             required: true
             description: The username to authenticate.
+      - !ruby/object:Api::Type::NestedObject
+        name: serviceAgentAuthentication
+        description: The authentication information using the Monitoring Service Agent.
+          Optional when creating an HTTPS check; defaults to empty.
+          Do not use with other authentication fields.
+        properties:
+          - !ruby/object:Api::Type::Enum
+            name: type
+            description: The type of authentication to use.
+            values:
+              - :SERVICE_AGENT_AUTHENTICATION_TYPE_UNSPECIFIED
+              - :OIDC_TOKEN
       - !ruby/object:Api::Type::Integer
         name: port
         at_least_one_of:

--- a/mmv1/templates/terraform/examples/uptime_check_config_https.tf.erb
+++ b/mmv1/templates/terraform/examples/uptime_check_config_https.tf.erb
@@ -7,6 +7,9 @@ resource "google_monitoring_uptime_check_config" "<%= ctx[:primary_resource_id] 
     port = "443"
     use_ssl = true
     validate_ssl = true
+    service_agent_authentication {
+      type = "OIDC_TOKEN"
+    }
   }
 
   monitored_resource {


### PR DESCRIPTION
Adds new fields to match the UptimeCheckConfigs service

```release-note:enhancement
monitoring: added `serviceAgentAuthentication` to `UptimeCheckConfig` resource
```
