### PR TITLE
Use data google_kms(_key_ring | _crypto_key) instead of resource

### DIFF
--- a/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job_test.go.erb
@@ -299,8 +299,9 @@ func TestAccDataflowFlexTemplateJob_withKmsKey(t *testing.T) {
 
 	randStr := acctest.RandString(t, 10)
 	job := "tf-test-dataflow-job-" + randStr
-	key_ring := "tf-test-dataflow-kms-ring-" + randStr
-	crypto_key := "tf-test-dataflow-kms-key-" + randStr
+	kms := acctest.BootstrapKMSKeyInLocation(t, "us-central1")
+	key_ring := kms.KeyRing.Name
+	crypto_key := kms.CryptoKey.Name
 	bucket := "tf-test-dataflow-bucket-" + randStr
 	topic := "tf-test-topic" + randStr
 

--- a/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job_test.go.erb
@@ -1331,15 +1331,14 @@ resource "google_storage_bucket_object" "schema" {
 EOF
 }
 
-resource "google_kms_key_ring" "keyring" {
+data "google_kms_key_ring" "keyring" {
   name     = "%s"
   location = "global"
 }
 
-resource "google_kms_crypto_key" "crypto_key" {
+data "google_kms_crypto_key" "crypto_key" {
   name            = "%s"
-  key_ring        = google_kms_key_ring.keyring.id
-  rotation_period = "100000s"
+  key_ring        = data.google_kms_key_ring.keyring.id
 }
 
 data "google_storage_bucket_object" "flex_template" {
@@ -1358,7 +1357,7 @@ resource "google_dataflow_flex_template_job" "flex_job_kms" {
   labels = {
    "my_labels" = "value"
   }
-  kms_key_name		= google_kms_crypto_key.crypto_key.id
+  kms_key_name		= data.google_kms_crypto_key.crypto_key.id
 
 }
 `, topicName, bucket, key_ring, crypto_key, job)

--- a/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job_test.go.erb
@@ -1348,7 +1348,7 @@ resource "google_dataflow_flex_template_job" "flex_job_kms" {
   labels = {
    "my_labels" = "value"
   }
-  kms_key_name		= data.google_kms_crypto_key.crypto_key.id
+  kms_key_name		= "%s"
 
 }
 `, topicName, bucket, crypto_key, job)

--- a/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job_test.go.erb
@@ -1351,7 +1351,7 @@ resource "google_dataflow_flex_template_job" "flex_job_kms" {
   kms_key_name		= data.google_kms_crypto_key.crypto_key.id
 
 }
-`, topicName, bucket, key_ring, crypto_key, job)
+`, topicName, bucket, crypto_key, job)
 }
 
 func testAccDataflowFlexTemplateJob_additionalExperiments(job, bucket, topicName string, experiments []string) string {

--- a/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job_test.go.erb
@@ -1332,16 +1332,6 @@ resource "google_storage_bucket_object" "schema" {
 EOF
 }
 
-data "google_kms_key_ring" "keyring" {
-  name     = "%s"
-  location = "global"
-}
-
-data "google_kms_crypto_key" "crypto_key" {
-  name            = "%s"
-  key_ring        = data.google_kms_key_ring.keyring.id
-}
-
 data "google_storage_bucket_object" "flex_template" {
   name   = "latest/flex/Streaming_Data_Generator"
   bucket = "dataflow-templates"

--- a/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job_test.go.erb
@@ -300,7 +300,6 @@ func TestAccDataflowFlexTemplateJob_withKmsKey(t *testing.T) {
 	randStr := acctest.RandString(t, 10)
 	job := "tf-test-dataflow-job-" + randStr
 	kms := acctest.BootstrapKMSKeyInLocation(t, "us-central1")
-	key_ring := kms.KeyRing.Name
 	crypto_key := kms.CryptoKey.Name
 	bucket := "tf-test-dataflow-bucket-" + randStr
 	topic := "tf-test-topic" + randStr

--- a/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job_test.go.erb
@@ -300,7 +300,8 @@ func TestAccDataflowFlexTemplateJob_withKmsKey(t *testing.T) {
 	randStr := acctest.RandString(t, 10)
 	job := "tf-test-dataflow-job-" + randStr
 	kms := acctest.BootstrapKMSKeyInLocation(t, "us-central1")
-	crypto_key := kms.CryptoKey.Name
+	keyRing := kms.KeyRing.Name
+	cryptoKey := kms.CryptoKey.Name
 	bucket := "tf-test-dataflow-bucket-" + randStr
 	topic := "tf-test-topic" + randStr
 
@@ -318,7 +319,7 @@ func TestAccDataflowFlexTemplateJob_withKmsKey(t *testing.T) {
 		CheckDestroy:             testAccCheckDataflowJobDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataflowFlexTemplateJob_kms(job, key_ring, crypto_key, bucket, topic),
+				Config: testAccDataflowFlexTemplateJob_kms(job, keyRing, cryptoKey, bucket, topic),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataflowFlexJobExists(t, "google_dataflow_flex_template_job.flex_job_kms", false),
 				),


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR fixes https://github.com/hashicorp/terraform-provider-google/issues/17773 refactoring mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job_test.go.erb to reference pre-existing google_kms_key_ring and google_kms_crypto_key, instead of creating/destroying new ones for each test.

To validate this PR, per [generate-providers](https://googlecloudplatform.github.io/magic-modules/get-started/generate-providers/) and [run-tests](https://googlecloudplatform.github.io/magic-modules/develop/test/run-tests/) documentation:

1. Generated the provider changes (google-beta only):

```
make provider VERSION=beta OUTPUT_PATH="$GOPATH/src/github.com/hashicorp/terraform-provider-google-beta" PRODUCT=dataflow
```

2. Create Google Cloud project environment

I created a clean, unused Google Cloud project, enabling the minimally permissive IAM roles to the default service account as well as turn on KMS, Dataflow, and other required API services.

3. Ran tests

Set the required environment variables.

```
export GOOGLE_USE_DEFAULT_CREDENTIALS=true
export GOOGLE_ZONE=us-west1-a
export GOOGLE_REGION=us-west1
export GOOGLE_PROJECT=<GCP project ID not shown>
```

Ran the tests.

```
cd $GOPATH/src/github.com/hashicorp/terraform-provider-google-beta
make testacc TEST=./google-beta/services/dataflow TESTARGS='-run=TestAccDataflowFlexTemplateJob_withKmsKey'
```

4. Validated output and Dataflow Job

```
==> Checking that code complies with gofmt requirements...
go vet
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google-beta/services/dataflow -v -run=TestAccDataflowFlexTemplateJob_withKmsKey -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google-beta/version.ProviderVersion=acc"
=== RUN   TestAccDataflowFlexTemplateJob_withKmsKey
=== PAUSE TestAccDataflowFlexTemplateJob_withKmsKey
=== CONT  TestAccDataflowFlexTemplateJob_withKmsKey
--- PASS: TestAccDataflowFlexTemplateJob_withKmsKey (354.30s)
PASS
ok      github.com/hashicorp/terraform-provider-google-beta/google-beta/services/dataflow       354.431s
```

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
