### PR TITLE
correct doc for ghe example

### DIFF
--- a/mmv1/templates/terraform/examples/cloudbuildv2_repository_ghe_doc.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuildv2_repository_ghe_doc.tf.erb
@@ -64,6 +64,6 @@ resource "google_cloudbuildv2_connection" "my-connection" {
 resource "google_cloudbuildv2_repository" "my-repository" {
   name = "my-terraform-ghe-repo"
   location = "us-central1"
-  parent_connection = google_cloudbuildv2_connection.my-connection.id
+  parent_connection = google_cloudbuildv2_connection.my-connection.name
   remote_uri = "https://ghe.com/hashicorp/terraform-provider-google.git"
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Correct the doc example where it incorrectly uses `connection.id` instead of `connection.name` for the parent field. 

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
```release-note:none
```
