### PR TITLE
Fix universe_domain for ADC and access token auth cases

### DIFF
--- a/mmv1/third_party/terraform/provider/provider.go.erb
+++ b/mmv1/third_party/terraform/provider/provider.go.erb
@@ -383,7 +383,9 @@ func ProviderConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 
 	// Verify that universe domains match between credentials and configuration
 	if v, ok := d.GetOk("universe_domain"); ok {
-		if v.(string) != config.UniverseDomain {
+		if config.UniverseDomain == "" {
+			return nil, diag.FromErr(fmt.Errorf("Universe domain mismatch: '%s' supplied directly to Terraform with no matching universe domain in credentials. Credentials with no 'universe_domain' set are assumed to be in the default universe.", v))
+		} else if v.(string) != config.UniverseDomain {
 			return nil, diag.FromErr(fmt.Errorf("Universe domain mismatch: '%s' does not match the universe domain '%s' supplied directly to Terraform. The 'universe_domain' provider configuration must match the universe domain supplied by credentials.", config.UniverseDomain, v))
 		}
 	} else if config.UniverseDomain != "" && config.UniverseDomain != "googleapis.com" {

--- a/mmv1/third_party/terraform/provider/provider.go.erb
+++ b/mmv1/third_party/terraform/provider/provider.go.erb
@@ -3,7 +3,6 @@ package provider
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"strings"

--- a/mmv1/third_party/terraform/provider/provider.go.erb
+++ b/mmv1/third_party/terraform/provider/provider.go.erb
@@ -279,35 +279,11 @@ func ProviderConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 		})
 	}
 	
-	// set universe_domain based on the service account key file.
-	if config.Credentials != "" {
-		contents, _, err := verify.PathOrContents(config.Credentials)
-		if err != nil {
-			return nil, diag.FromErr(fmt.Errorf("error loading service account credentials: %s", err))
-		}
-		var content map[string]any
-
-		if err := json.Unmarshal([]byte(contents), &content); err != nil {
-			return nil, diag.FromErr(err)
-		}
-
-		if content["universe_domain"] != nil {
-			config.UniverseDomain = content["universe_domain"].(string)
-		}
+	// Default the universe domain to the configured value if set
+	if v, ok := d.GetOk("universe_domain"); ok {
+		config.UniverseDomain = v.(string)
 	}
-	
-	// Check if the user provided a value from the universe_domain field other than the default
-	if v, ok := d.GetOk("universe_domain"); ok && v.(string) != "googleapis.com" {
-		if config.UniverseDomain == "" {
-			return nil, diag.FromErr(fmt.Errorf("Universe domain mismatch: '%s' supplied directly to Terraform with no matching universe domain in credentials. Credentials with no 'universe_domain' set are assumed to be in the default universe.", v))
-		} else if v.(string) != config.UniverseDomain {
-			if _, err := os.Stat(config.Credentials); err == nil {
-				return nil, diag.FromErr(fmt.Errorf("Universe domain mismatch: '%s' does not match the universe domain '%s' already set in the credential file '%s'. The 'universe_domain' provider configuration can not be used to override the universe domain that is defined in the active credential.  Set the 'universe_domain' provider configuration when universe domain information is not already available in the credential, e.g. when authenticating with a JWT token.", v, config.UniverseDomain, config.Credentials))
-			} else {
-				return nil, diag.FromErr(fmt.Errorf("Universe domain mismatch: '%s' does not match the universe domain '%s' supplied directly to Terraform. The 'universe_domain' provider configuration can not be used to override the universe domain that is defined in the active credential.  Set the 'universe_domain' provider configuration when universe domain information is not already available in the credential, e.g. when authenticating with a JWT token.", v, config.UniverseDomain))
-			}
-		}
-	}
+
 	// Configure DCL basePath
 	transport_tpg.ProviderDCLConfigure(d, &config)
 	
@@ -404,6 +380,15 @@ func ProviderConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 	}
 	if err := config.LoadAndValidate(stopCtx); err != nil {
 		return nil, diag.FromErr(err)
+	}
+
+	// Verify that universe domains match between credentials and configuration
+	if v, ok := d.GetOk("universe_domain"); ok {
+		if v.(string) != config.UniverseDomain {
+			return nil, diag.FromErr(fmt.Errorf("Universe domain mismatch: '%s' does not match the universe domain '%s' supplied directly to Terraform. The 'universe_domain' provider configuration must match the universe domain supplied by credentials.", config.UniverseDomain, v))
+		}
+	} else if config.UniverseDomain != "" && config.UniverseDomain != "googleapis.com" {
+		return nil, diag.FromErr(fmt.Errorf("Universe domain mismatch: Universe domain '%s' was found in credentials without a corresponding 'universe_domain' provider configuration set. Please set 'universe_domain' to '%s' or use different credentials.", config.UniverseDomain, config.UniverseDomain))
 	}
 
 	return &config, nil

--- a/mmv1/third_party/terraform/provider/provider.go.erb
+++ b/mmv1/third_party/terraform/provider/provider.go.erb
@@ -278,7 +278,7 @@ func ProviderConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 		})
 	}
 	
-	// Default the universe domain to the configured value if set
+	// Set the universe domain to the configured value, if any
 	if v, ok := d.GetOk("universe_domain"); ok {
 		config.UniverseDomain = v.(string)
 	}
@@ -383,7 +383,7 @@ func ProviderConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 
 	// Verify that universe domains match between credentials and configuration
 	if v, ok := d.GetOk("universe_domain"); ok {
-		if config.UniverseDomain == "" && v.(string) != "googleapis.com" {
+		if config.UniverseDomain == "" && v.(string) != "googleapis.com" { // v can't be "", as it wouldn't pass `ok` above
 			return nil, diag.FromErr(fmt.Errorf("Universe domain mismatch: '%s' supplied directly to Terraform with no matching universe domain in credentials. Credentials with no 'universe_domain' set are assumed to be in the default universe.", v))
 		} else if v.(string) != config.UniverseDomain && !(config.UniverseDomain == "" && v.(string) == "googleapis.com") {
 			return nil, diag.FromErr(fmt.Errorf("Universe domain mismatch: '%s' does not match the universe domain '%s' supplied directly to Terraform. The 'universe_domain' provider configuration must match the universe domain supplied by credentials.", config.UniverseDomain, v))

--- a/mmv1/third_party/terraform/provider/provider.go.erb
+++ b/mmv1/third_party/terraform/provider/provider.go.erb
@@ -383,9 +383,9 @@ func ProviderConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 
 	// Verify that universe domains match between credentials and configuration
 	if v, ok := d.GetOk("universe_domain"); ok {
-		if config.UniverseDomain == "" {
+		if config.UniverseDomain == "" && v.(string) != "googleapis.com" {
 			return nil, diag.FromErr(fmt.Errorf("Universe domain mismatch: '%s' supplied directly to Terraform with no matching universe domain in credentials. Credentials with no 'universe_domain' set are assumed to be in the default universe.", v))
-		} else if v.(string) != config.UniverseDomain {
+		} else if v.(string) != config.UniverseDomain && !(config.UniverseDomain == "" && v.(string) == "googleapis.com") {
 			return nil, diag.FromErr(fmt.Errorf("Universe domain mismatch: '%s' does not match the universe domain '%s' supplied directly to Terraform. The 'universe_domain' provider configuration must match the universe domain supplied by credentials.", config.UniverseDomain, v))
 		}
 	} else if config.UniverseDomain != "" && config.UniverseDomain != "googleapis.com" {

--- a/mmv1/third_party/terraform/provider/universe/universe_domain_compute_test.go
+++ b/mmv1/third_party/terraform/provider/universe/universe_domain_compute_test.go
@@ -49,6 +49,9 @@ func TestAccDefaultUniverseDomainDisk(t *testing.T) {
 }
 
 func TestAccDefaultUniverseDomain_doesNotMatchExplicit(t *testing.T) {
+	// Need a way to mock credentials or only run in an environment with TPC creds
+	t.Skip()
+
 	universeDomainFake := "fakedomain.test"
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/provider/universe/universe_domain_compute_test.go
+++ b/mmv1/third_party/terraform/provider/universe/universe_domain_compute_test.go
@@ -49,9 +49,6 @@ func TestAccDefaultUniverseDomainDisk(t *testing.T) {
 }
 
 func TestAccDefaultUniverseDomain_doesNotMatchExplicit(t *testing.T) {
-	// Need a way to mock credentials or only run in an environment with TPC creds
-	t.Skip()
-
 	universeDomainFake := "fakedomain.test"
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/transport/config.go.erb
+++ b/mmv1/third_party/terraform/transport/config.go.erb
@@ -604,15 +604,7 @@ func (c *Config) getTokenSource(clientScopes []string, initialCredentialsOnly bo
 	creds, err := c.GetCredentials(clientScopes, initialCredentialsOnly)
 	if err != nil {
 		return nil, fmt.Errorf("%s", err)
-	}	
-
-	ud, err := creds.GetUniverseDomain()
-	if err != nil {
-		log.Printf("[WARN] Error retrieving universe domain: %s", err)
-	} else if ud != "googleapis.com" { // Only overwrite if the universe domain is different from the default
-		c.UniverseDomain = ud
 	}
-
 	return creds.TokenSource, nil
 }
 
@@ -1144,6 +1136,7 @@ type StaticTokenSource struct {
 // If initialCredentialsOnly is true, don't follow the impersonation settings and return the initial set of creds
 // instead.
 func (c *Config) GetCredentials(clientScopes []string, initialCredentialsOnly bool) (googleoauth.Credentials, error) {
+	// UniverseDomain defaults to the previously set provider-configured value for access tokens
 	if c.AccessToken != "" {
 		contents, _, err := verify.PathOrContents(c.AccessToken)
 		if err != nil {
@@ -1167,10 +1160,23 @@ func (c *Config) GetCredentials(clientScopes []string, initialCredentialsOnly bo
 		}, nil
 	}
 
+	// UniverseDomain is set by the credential file's "universe_domain" field
 	if c.Credentials != "" {
 		contents, _, err := verify.PathOrContents(c.Credentials)
 		if err != nil {
 			return googleoauth.Credentials{}, fmt.Errorf("error loading credentials: %s", err)
+		}
+
+		var content map[string]any
+		if err := json.Unmarshal([]byte(contents), &content); err != nil {
+			return googleoauth.Credentials{}, fmt.Errorf("error unmarshaling credentials: %s", err)
+		}
+
+		if content["universe_domain"] != nil {
+			c.UniverseDomain = content["universe_domain"].(string)
+		} else {
+			// Unset UniverseDomain if not found in credentials file
+			c.UniverseDomain = ""
 		}
 
 		if c.ImpersonateServiceAccount != "" && !initialCredentialsOnly {
@@ -1202,33 +1208,51 @@ func (c *Config) GetCredentials(clientScopes []string, initialCredentialsOnly bo
 		}
 	}
 
+	var creds *googleoauth.Credentials
+	var err error
 	if c.ImpersonateServiceAccount != "" && !initialCredentialsOnly {
 		opts := option.ImpersonateCredentials(c.ImpersonateServiceAccount, c.ImpersonateServiceAccountDelegates...)
-		creds, err := transport.Creds(context.TODO(), opts, option.WithScopes(clientScopes...))
+		creds, err = transport.Creds(context.TODO(), opts, option.WithScopes(clientScopes...))
 		if err != nil {
 			return googleoauth.Credentials{}, err
 		}
+	} else {
+		log.Printf("[INFO] Authenticating using DefaultClient...")
+		log.Printf("[INFO]   -- Scopes: %s", clientScopes)
 
-		return *creds, nil
-	}
-
-	log.Printf("[INFO] Authenticating using DefaultClient...")
-	log.Printf("[INFO]   -- Scopes: %s", clientScopes)
-
-	if c.UniverseDomain != "" && c.UniverseDomain != "googleapis.com" {
-		log.Printf("[INFO]   -- Sending JwtWithScope option")
-		creds, err := transport.Creds(context.Background(), option.WithScopes(clientScopes...), internaloption.EnableJwtWithScope())
-		if err != nil {
-			return googleoauth.Credentials{}, fmt.Errorf("Attempted to load application default credentials since neither `credentials` nor `access_token` was set in the provider block.  No credentials loaded. To use your gcloud credentials, run 'gcloud auth application-default login'.  Original error: %w", err)
+		if c.UniverseDomain != "" && c.UniverseDomain != "googleapis.com" {
+			log.Printf("[INFO]   -- Sending JwtWithScope option")
+			creds, err = transport.Creds(context.Background(), option.WithScopes(clientScopes...), internaloption.EnableJwtWithScope())
+			if err != nil {
+				return googleoauth.Credentials{}, fmt.Errorf("Attempted to load application default credentials since neither `credentials` nor `access_token` was set in the provider block.  No credentials loaded. To use your gcloud credentials, run 'gcloud auth application-default login'.  Original error: %w", err)
+			}
+		} else {
+			creds, err = transport.Creds(context.Background(), option.WithScopes(clientScopes...))
+			if err != nil {
+				return googleoauth.Credentials{}, fmt.Errorf("Attempted to load application default credentials since neither `credentials` nor `access_token` was set in the provider block.  No credentials loaded. To use your gcloud credentials, run 'gcloud auth application-default login'.  Original error: %w", err)
+			}
 		}
-		return *creds, nil
 	}
 
-	creds, err := transport.Creds(context.Background(), option.WithScopes(clientScopes...))
-	if err != nil {
-		return googleoauth.Credentials{}, fmt.Errorf("Attempted to load application default credentials since neither `credentials` nor `access_token` was set in the provider block.  No credentials loaded. To use your gcloud credentials, run 'gcloud auth application-default login'.  Original error: %w", err)
+	if creds.JSON != nil {
+		var content map[string]any
+		if err := json.Unmarshal([]byte(creds.JSON), &content); err != nil {
+			log.Printf("[WARN] error unmarshaling credentials, skipping Universe Domain detection")
+		} else if content["universe_domain"] != nil {
+			c.UniverseDomain = content["universe_domain"].(string)
+		} else {
+			// Unset UniverseDomain if not found in ADC credentials file
+			c.UniverseDomain = ""
+		}
+	} else {
+		// creds.GetUniverseDomain may retrieve a domain from the metadata server
+		ud, err := creds.GetUniverseDomain()
+		if err != nil {
+			log.Printf("[WARN] Error retrieving universe domain: %s", err)
+		}
+		c.UniverseDomain = ud
 	}
-	
+
 	return *creds, nil
 }
 

--- a/mmv1/third_party/terraform/transport/config.go.erb
+++ b/mmv1/third_party/terraform/transport/config.go.erb
@@ -604,7 +604,15 @@ func (c *Config) getTokenSource(clientScopes []string, initialCredentialsOnly bo
 	creds, err := c.GetCredentials(clientScopes, initialCredentialsOnly)
 	if err != nil {
 		return nil, fmt.Errorf("%s", err)
+	}	
+
+	ud, err := creds.GetUniverseDomain()
+	if err != nil {
+		log.Printf("[WARN] Error retrieving universe domain: %s", err)
+	} else if ud != "googleapis.com" { // Only overwrite if the universe domain is different from the default
+		c.UniverseDomain = ud
 	}
+
 	return creds.TokenSource, nil
 }
 

--- a/mmv1/third_party/terraform/transport/config.go.erb
+++ b/mmv1/third_party/terraform/transport/config.go.erb
@@ -1238,6 +1238,7 @@ func (c *Config) GetCredentials(clientScopes []string, initialCredentialsOnly bo
 		var content map[string]any
 		if err := json.Unmarshal([]byte(creds.JSON), &content); err != nil {
 			log.Printf("[WARN] error unmarshaling credentials, skipping Universe Domain detection")
+			c.UniverseDomain = ""
 		} else if content["universe_domain"] != nil {
 			c.UniverseDomain = content["universe_domain"].(string)
 		} else {

--- a/mmv1/third_party/terraform/transport/config.go.erb
+++ b/mmv1/third_party/terraform/transport/config.go.erb
@@ -1136,7 +1136,7 @@ type StaticTokenSource struct {
 // If initialCredentialsOnly is true, don't follow the impersonation settings and return the initial set of creds
 // instead.
 func (c *Config) GetCredentials(clientScopes []string, initialCredentialsOnly bool) (googleoauth.Credentials, error) {
-	// UniverseDomain defaults to the previously set provider-configured value for access tokens
+	// UniverseDomain is assumed to be the previously set provider-configured value for access tokens
 	if c.AccessToken != "" {
 		contents, _, err := verify.PathOrContents(c.AccessToken)
 		if err != nil {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

https://github.com/GoogleCloudPlatform/magic-modules/pull/9799 was too heavy handed and completely broke ADC and auth token access when `universe_domain` was configured in Terraform.

This PR sets the universe domain based the following logic:
**Pre-auth**
- Set universe domain to configured value initially as a default

**Auth**
- access token: keep default UD
- credentials file: set to `universe_domain` in file, unset if not found
- ADC:
	- JSON exists: set to `universe_domain` in JSON, unset if not found
	- JSON doesn't exist: call creds.UniverseDomain()

**Post-auth**
- compare credentials UD to configured UD and throw an error if they don't match


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
provider: fixed application default credential and access token authorization when `universe_domain` is set
```
