### PR TITLE
Add autoscaling to DPMS terraform

### DIFF
--- a/mmv1/products/metastore/Service.yaml
+++ b/mmv1/products/metastore/Service.yaml
@@ -143,6 +143,26 @@ examples:
     primary_resource_id: 'backup'
     vars:
       metastore_service_name: 'backup'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'dataproc_metastore_service_autoscaling_max_scaling_factor'
+    primary_resource_id: 'test_resource'
+    vars:
+      metastore_service_name: 'test-service'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'dataproc_metastore_service_autoscaling_min_and_max_scaling_factor'
+    primary_resource_id: 'test_resource'
+    vars:
+      metastore_service_name: 'test-service'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'dataproc_metastore_service_autoscaling_min_scaling_factor'
+    primary_resource_id: 'test_resource'
+    vars:
+      metastore_service_name: 'test-service'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'dataproc_metastore_service_autoscaling_no_limit_config'
+    primary_resource_id: 'test_resource'
+    vars:
+      metastore_service_name: 'test-service'
 parameters:
   - !ruby/object:Api::Type::String
     name: 'serviceId'
@@ -228,6 +248,7 @@ properties:
         exactly_one_of:
           - scaling_config.0.instance_size
           - scaling_config.0.scaling_factor
+          - scaling_config.0.autoscaling_config
         conflicts:
           - tier
         values:
@@ -241,6 +262,33 @@ properties:
         description: |
           Scaling factor, in increments of 0.1 for values less than 1.0, and increments of 1.0 for values greater than 1.0.
         required: false
+      - !ruby/object:Api::Type::NestedObject
+        name: 'autoscalingConfig'
+        min_version: beta
+        description: |
+          Represents the autoscaling configuration of a metastore service.
+        required: false
+        properties:
+          - !ruby/object:Api::Type::Boolean
+            name: 'autoscalingEnabled'
+            description: |
+              Defines whether autoscaling is enabled. The default value is false.
+          - !ruby/object:Api::Type::NestedObject
+            name: 'limitConfig'
+            default_from_api: true
+            description: |
+              Represents the limit configuration of a metastore service.
+            properties:
+              - !ruby/object:Api::Type::Double
+                name: 'minScalingFactor'
+                description: |
+                  The minimum scaling factor that the service will autoscale to. The default value is 0.1.
+                default_from_api: true
+              - !ruby/object:Api::Type::Double
+                name: 'maxScalingFactor'
+                description: |
+                  The maximum scaling factor that the service will autoscale to. The default value is 6.0.
+                default_from_api: true
   - !ruby/object:Api::Type::NestedObject
     name: 'scheduledBackup'
     description: |

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_autoscaling_max_scaling_factor.tf.erb
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_autoscaling_max_scaling_factor.tf.erb
@@ -1,0 +1,21 @@
+resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" {
+  service_id = "<%= ctx[:vars]['metastore_service_name'] %>"
+  location   = "us-central1"
+
+  # DPMS 2 requires SPANNER database type, and does not require
+  # a maintenance window.
+  database_type = "SPANNER"
+
+  hive_metastore_config {
+    version           = "3.1.2"
+  }
+
+  scaling_config {
+    autoscaling_config {
+      autoscaling_enabled = true
+      limit_config {
+        max_scaling_factor = 1.0
+      }
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_autoscaling_min_and_max_scaling_factor.tf.erb
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_autoscaling_min_and_max_scaling_factor.tf.erb
@@ -1,0 +1,22 @@
+resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" {
+  service_id = "<%= ctx[:vars]['metastore_service_name'] %>"
+  location   = "us-central1"
+
+  # DPMS 2 requires SPANNER database type, and does not require
+  # a maintenance window.
+  database_type = "SPANNER"
+
+  hive_metastore_config {
+    version           = "3.1.2"
+  }
+
+  scaling_config {
+    autoscaling_config {
+      autoscaling_enabled = true
+      limit_config {
+        min_scaling_factor = 0.1
+        max_scaling_factor = 1.0
+      }
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_autoscaling_min_scaling_factor.tf.erb
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_autoscaling_min_scaling_factor.tf.erb
@@ -1,0 +1,21 @@
+resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" {
+  service_id = "<%= ctx[:vars]['metastore_service_name'] %>"
+  location   = "us-central1"
+
+  # DPMS 2 requires SPANNER database type, and does not require
+  # a maintenance window.
+  database_type = "SPANNER"
+
+  hive_metastore_config {
+    version           = "3.1.2"
+  }
+
+  scaling_config {
+    autoscaling_config {
+      autoscaling_enabled = true
+      limit_config {
+        min_scaling_factor = 0.1
+      }
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_autoscaling_no_limit_config.tf.erb
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_autoscaling_no_limit_config.tf.erb
@@ -1,0 +1,18 @@
+resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" {
+  service_id = "<%= ctx[:vars]['metastore_service_name'] %>"
+  location   = "us-central1"
+
+  # DPMS 2 requires SPANNER database type, and does not require
+  # a maintenance window.
+  database_type = "SPANNER"
+
+  hive_metastore_config {
+    version           = "3.1.2"
+  }
+
+  scaling_config {
+    autoscaling_config {
+      autoscaling_enabled = true
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/go/dataproc_metastore_service_autoscaling_max_scaling_factor.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/dataproc_metastore_service_autoscaling_max_scaling_factor.tf.tmpl
@@ -1,0 +1,21 @@
+resource "google_dataproc_metastore_service" "{{$.PrimaryResourceId}}" {
+  service_id = "{{index $.Vars "metastore_service_name"}}"
+  location   = "us-central1"
+
+  # DPMS 2 requires SPANNER database type, and does not require
+  # a maintenance window.
+  database_type = "SPANNER"
+
+  hive_metastore_config {
+    version           = "3.1.2"
+  }
+
+  scaling_config {
+    autoscaling_config {
+      autoscaling_enabled = true
+      limit_config {
+        max_scaling_factor = 1.0
+      }
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/go/dataproc_metastore_service_autoscaling_min_and_max_scaling_factor.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/dataproc_metastore_service_autoscaling_min_and_max_scaling_factor.tf.tmpl
@@ -1,0 +1,22 @@
+resource "google_dataproc_metastore_service" "{{$.PrimaryResourceId}}" {
+  service_id = "{{index $.Vars "metastore_service_name"}}"
+  location   = "us-central1"
+
+  # DPMS 2 requires SPANNER database type, and does not require
+  # a maintenance window.
+  database_type = "SPANNER"
+
+  hive_metastore_config {
+    version           = "3.1.2"
+  }
+
+  scaling_config {
+    autoscaling_config {
+      autoscaling_enabled = true
+      limit_config {
+        min_scaling_factor = 0.1
+        max_scaling_factor = 1.0
+      }
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/go/dataproc_metastore_service_autoscaling_min_scaling_factor.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/dataproc_metastore_service_autoscaling_min_scaling_factor.tf.tmpl
@@ -1,0 +1,21 @@
+resource "google_dataproc_metastore_service" "{{$.PrimaryResourceId}}" {
+  service_id = "{{index $.Vars "metastore_service_name"}}"
+  location   = "us-central1"
+
+  # DPMS 2 requires SPANNER database type, and does not require
+  # a maintenance window.
+  database_type = "SPANNER"
+
+  hive_metastore_config {
+    version           = "3.1.2"
+  }
+
+  scaling_config {
+    autoscaling_config {
+      autoscaling_enabled = true
+      limit_config {
+        min_scaling_factor = 0.1
+      }
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/go/dataproc_metastore_service_autoscaling_no_limit_config.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/dataproc_metastore_service_autoscaling_no_limit_config.tf.tmpl
@@ -1,0 +1,18 @@
+resource "google_dataproc_metastore_service" "{{$.PrimaryResourceId}}" {
+  service_id = "{{index $.Vars "metastore_service_name"}}"
+  location   = "us-central1"
+
+  # DPMS 2 requires SPANNER database type, and does not require
+  # a maintenance window.
+  database_type = "SPANNER"
+
+  hive_metastore_config {
+    version           = "3.1.2"
+  }
+
+  scaling_config {
+    autoscaling_config {
+      autoscaling_enabled = true
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the `scaling_config` field to the `google_dataproc_metastore_service` beta resource. This PR fixes [17949](https://github.com/hashicorp/terraform-provider-google/issues/17949)
The `autoscaling_config` field enables the user to create a [DPMS2](https://cloud.google.com/dataproc-metastore/docs/core-concepts#versioning-2) service with autoscaling enabled using Terraform.

If this PR is for Terraform, I acknowledge that I have:

* [x]  Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
* [x]  Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
* [x]  [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
* [x]  [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
* [x]  Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dataprocmetastore: added `autoscaling_config` field to `google_dataproc_metastore_service` resource
```