### PR TITLE
test: adding test for example_google_compute_network_endpoint_group r…

### DIFF
--- a/mmv1/third_party/tgc/tests/data/example_google_compute_network_endpoint_group.json
+++ b/mmv1/third_party/tgc/tests/data/example_google_compute_network_endpoint_group.json
@@ -1,0 +1,36 @@
+[
+    {
+        "name": "//compute.googleapis.com/projects/{{.Provider.project}}/global/networks/neg-network",
+        "asset_type": "compute.googleapis.com/Network",
+        "resource": {
+            "version": "beta",
+            "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/beta/rest",
+            "discovery_name": "Network",
+            "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
+            "data": {
+                "autoCreateSubnetworks": false,
+                "name": "neg-network"
+            }
+        },
+        "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}"
+    },
+    {
+        "name": "//compute.googleapis.com/projects/{{.Provider.project}}/regions/us-central1/subnetworks/neg-subnetwork",
+        "asset_type": "compute.googleapis.com/Subnetwork",
+        "resource": {
+            "version": "beta",
+            "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/beta/rest",
+            "discovery_name": "Subnetwork",
+            "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
+            "data": {
+                "ipCidrRange": "10.0.0.0/16",
+                "logConfig": {
+                    "enable": false
+                },
+                "name": "neg-subnetwork",
+                "region": "projects/{{.Provider.project}}/global/regions/us-central1"
+            }
+        },
+        "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}"
+    }
+]

--- a/mmv1/third_party/tgc/tests/data/example_google_compute_network_endpoint_group.tf
+++ b/mmv1/third_party/tgc/tests/data/example_google_compute_network_endpoint_group.tf
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> 3.84"
+    }
+  }
+}
+
+provider "google" {
+  {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
+}
+
+resource "google_compute_network_endpoint_group" "neg" {
+  name         = "my-lb-neg"
+  network      = google_compute_network.default.id
+  subnetwork   = google_compute_subnetwork.default.id
+  default_port = "90"
+  zone         = "us-central1-a"
+}
+
+resource "google_compute_network" "default" {
+  name                    = "neg-network"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "neg-subnetwork"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.default.id
+}


### PR DESCRIPTION
Adding tests for resource asset type compute.googleapis.com/NetworkEndpointGroup which touchs the google terraform conversion.

```release-note:none
```

