### PR TITLE
fix: update resource template to remove beta and remove egress

### DIFF
--- a/mmv1/templates/terraform/examples/cloudrunv2_service_directvpc.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_directvpc.tf.erb
@@ -1,7 +1,7 @@
 resource "google_cloud_run_v2_service" "<%= ctx[:primary_resource_id] %>" {
   name     = "<%= ctx[:vars]['cloud_run_service_name'] %>"
   location = "us-central1"
-  launch_stage = "BETA"
+  launch_stage = "GA"
   template {
     containers {
       image = "us-docker.pkg.dev/cloudrun/container/hello"
@@ -12,7 +12,6 @@ resource "google_cloud_run_v2_service" "<%= ctx[:primary_resource_id] %>" {
         subnetwork = "default"
         tags = ["tag1", "tag2", "tag3"]
       }
-      egress = "ALL_TRAFFIC"
     }
   }
 }


### PR DESCRIPTION
as per @steren egress is not needed; additionally Direct VPC egress for Cloud Run services is now GA: https://cloud.google.com/run/docs/release-notes#April_24_2024

<!-- AUTOCHANGELOG for Downstream PRs.

```release-note:none

```
