### PR TITLE
Make storage bucket object respect custom endpoints

### DIFF
--- a/mmv1/third_party/terraform/services/storage/data_source_google_storage_bucket_object.go
+++ b/mmv1/third_party/terraform/services/storage/data_source_google_storage_bucket_object.go
@@ -41,7 +41,10 @@ func dataSourceGoogleStorageBucketObjectRead(d *schema.ResourceData, meta interf
 		name = url.QueryEscape(name)
 	}
 	// Using REST apis because the storage go client doesn't support folders
-	url := fmt.Sprintf("https://www.googleapis.com/storage/v1/b/%s/o/%s", bucket, name)
+	url, err := tpgresource.ReplaceVars(d, config, fmt.Sprintf("{{StorageBasePath}}b/%s/o/%s", bucket, name))
+	if err != nil {
+		return fmt.Errorf("Error formatting url for storage bucket object: %s", err)
+	}
 
 	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 		Config:    config,

--- a/mmv1/third_party/terraform/services/storage/data_source_google_storage_bucket_objects.go
+++ b/mmv1/third_party/terraform/services/storage/data_source_google_storage_bucket_objects.go
@@ -70,7 +70,10 @@ func datasourceGoogleStorageBucketObjectsRead(d *schema.ResourceData, meta inter
 
 	for {
 		bucket := d.Get("bucket").(string)
-		url := fmt.Sprintf("https://storage.googleapis.com/storage/v1/b/%s/o", bucket)
+		url, err := tpgresource.ReplaceVars(d, config, fmt.Sprintf("{{StorageBasePath}}b/%s/o", bucket))
+		if err != nil {
+			return err
+		}
 
 		if v, ok := d.GetOk("match_glob"); ok {
 			params["matchGlob"] = v.(string)
@@ -80,7 +83,7 @@ func datasourceGoogleStorageBucketObjectsRead(d *schema.ResourceData, meta inter
 			params["prefix"] = v.(string)
 		}
 
-		url, err := transport_tpg.AddQueryParams(url, params)
+		url, err = transport_tpg.AddQueryParams(url, params)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
fixes https://github.com/hashicorp/terraform-provider-google/issues/17939

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
storage: fixed an issue where `google_storage_bucket_object` and `google_storage_bucket_objects` data sources would ignore custom endpoints
```
