### PR TITLE
Add database_id section in firebase rule release sample

### DIFF
--- a/tpgtools/overrides/firebaserules/samples/release/firestore_release.tf.tmpl
+++ b/tpgtools/overrides/firebaserules/samples/release/firestore_release.tf.tmpl
@@ -1,5 +1,5 @@
 resource "google_firebaserules_release" "primary" {
-  name         = "cloud.firestore"
+  name         = "cloud.firestore/{{database}}"
   ruleset_name = "projects/{{project}}/rulesets/${google_firebaserules_ruleset.firestore.name}"
   project      = "{{project}}"
 

--- a/tpgtools/overrides/firebaserules/samples/release/firestore_release.yaml
+++ b/tpgtools/overrides/firebaserules/samples/release/firestore_release.yaml
@@ -21,3 +21,5 @@ resource: ./firestore_release.tf.tmpl
 variables:
 - name: project
   type: project
+- name: database
+  type: resource_name


### PR DESCRIPTION
Improve the documentation to explain how to use Firebase Rule with Firestore named database

```release-note:none

```
