### PR TITLE
fix:update resource template to remove beta and egree

### DIFF
--- a/mmv1/templates/terraform/examples/cloudrunv2_job_directvpc.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_job_directvpc.tf.erb
@@ -1,7 +1,7 @@
 resource "google_cloud_run_v2_job" "<%= ctx[:primary_resource_id] %>" {
   name     = "<%= ctx[:vars]['cloud_run_job_name'] %>"
   location = "us-central1"
-  launch_stage = "BETA"
+  launch_stage = "GA"
   template {
     template{
       containers {
@@ -13,7 +13,6 @@ resource "google_cloud_run_v2_job" "<%= ctx[:primary_resource_id] %>" {
           subnetwork = "default"
           tags = ["tag1", "tag2", "tag3"]
         }
-        egress = "ALL_TRAFFIC"
       }
     }
   }


### PR DESCRIPTION
as per @steren egress is not needed; additionally Direct VPC egress for Cloud Run jobs is now GA: https://cloud.google.com/run/docs/release-notes#April_24_2024

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
