### PR TITLE
Set PC test to  asia-south1

### DIFF
--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_address_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_external_address_test.go
@@ -17,7 +17,7 @@ func TestAccVmwareengineExternalAddress_vmwareEngineExternalAddressUpdate(t *tes
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"region":          "southamerica-east1", // using region with low node utilization.
+		"region":          "asia-south1", // using region with low node utilization.
 		"random_suffix":   acctest.RandString(t, 10),
 		"org_id":          envvar.GetTestOrgFromEnv(t),
 		"billing_account": envvar.GetTestBillingAccountFromEnv(t),

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
@@ -14,11 +14,10 @@ import (
 )
 
 func TestAccVmwareenginePrivateCloud_vmwareEnginePrivateCloudUpdate(t *testing.T) {
-	acctest.SkipIfVcr(t)
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"region":          "southamerica-west1",
+		"region":          "asia-south1",
 		"random_suffix":   acctest.RandString(t, 10),
 		"org_id":          envvar.GetTestOrgFromEnv(t),
 		"billing_account": envvar.GetTestBillingAccountFromEnv(t),


### PR DESCRIPTION
Setting region as asia-south1 to check the availability of GCVE nodes in the region for the presubmit project `ci-test-project-188019`. Please ignore this PR for now. I will update the PR for submission based on the test results. 

```release-note:none

```
