### PR TITLE
feat: datastream sql server connection profile/stream

### DIFF
--- a/mmv1/products/datastream/ConnectionProfile.yaml
+++ b/mmv1/products/datastream/ConnectionProfile.yaml
@@ -74,6 +74,7 @@ examples:
     skip_test: true
   - !ruby/object:Provider::Terraform::Examples
     name: 'datastream_connection_profile_sql_server'
+    min_version: beta
     primary_resource_id: 'default'
     skip_test: true
     vars:
@@ -312,6 +313,7 @@ properties:
           Database for the PostgreSQL connection.
   - !ruby/object:Api::Type::NestedObject
     name: 'sqlServerProfile'
+    min_version: beta
     exactly_one_of:
       - oracle_profile
       - gcs_profile

--- a/mmv1/products/datastream/ConnectionProfile.yaml
+++ b/mmv1/products/datastream/ConnectionProfile.yaml
@@ -107,6 +107,7 @@ properties:
       - mysql_profile
       - bigquery_profile
       - postgresql_profile
+      - sql_server_profile
     description: |
       Oracle database profile.
     properties:
@@ -148,6 +149,7 @@ properties:
       - mysql_profile
       - bigquery_profile
       - postgresql_profile
+      - sql_server_profile
     description: |
       Cloud Storage bucket profile.
     properties:
@@ -168,6 +170,7 @@ properties:
       - mysql_profile
       - bigquery_profile
       - postgresql_profile
+      - sql_server_profile
     description: |
       MySQL database profile.
     properties:
@@ -250,6 +253,7 @@ properties:
       - mysql_profile
       - bigquery_profile
       - postgresql_profile
+      - sql_server_profile
     description: |
       BigQuery warehouse profile.
     properties: []
@@ -261,6 +265,7 @@ properties:
       - mysql_profile
       - bigquery_profile
       - postgresql_profile
+      - sql_server_profile
     description: |
       PostgreSQL database profile.
     properties:
@@ -291,6 +296,46 @@ properties:
         required: true
         description: |
           Database for the PostgreSQL connection.
+  - !ruby/object:Api::Type::NestedObject
+    name: 'sqlServerProfile'
+    min_version: beta
+    exactly_one_of:
+      - oracle_profile
+      - gcs_profile
+      - mysql_profile
+      - bigquery_profile
+      - postgresql_profile
+      - sql_server_profile
+    description: |
+      SQL Server database profile.
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'hostname'
+        required: true
+        description: |
+          Hostname for the SQL Server connection.
+      - !ruby/object:Api::Type::Integer
+        name: 'port'
+        default_value: 1433
+        description: |
+          Port for the SQL Server connection.
+      - !ruby/object:Api::Type::String
+        name: 'username'
+        required: true
+        description: |
+          Username for the SQL Server connection.
+      - !ruby/object:Api::Type::String
+        name: 'password'
+        required: true
+        description: |
+          Password for the SQL Server connection.
+        sensitive: true
+        custom_flatten: templates/terraform/custom_flatten/datastream_connection_profile_sql_server_profile_password.go.erb
+      - !ruby/object:Api::Type::String
+        name: 'database'
+        required: true
+        description: |
+          Database for the SQL Server connection.
   - !ruby/object:Api::Type::NestedObject
     name: 'forwardSshConnectivity'
     description: |

--- a/mmv1/products/datastream/ConnectionProfile.yaml
+++ b/mmv1/products/datastream/ConnectionProfile.yaml
@@ -72,6 +72,21 @@ examples:
     oics_vars_overrides:
       deletion_protection: 'false'
     skip_test: true
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'datastream_connection_profile_sql_server'
+    min_version: beta
+    primary_resource_id: 'default'
+    skip_test: true
+    vars:
+      database_name: 'db'
+      database_password: 'password'
+      database_user: 'user'
+      deletion_protection: 'true'
+      source_connection_profile_id: 'source-profile'
+      sql_server_name: 'sql-server'
+      sql_server_root_password: 'root-password'
+    test_vars_overrides:
+      deletion_protection: 'false'
 parameters:
   - !ruby/object:Api::Type::String
     name: connectionProfileId

--- a/mmv1/products/datastream/ConnectionProfile.yaml
+++ b/mmv1/products/datastream/ConnectionProfile.yaml
@@ -74,7 +74,6 @@ examples:
     skip_test: true
   - !ruby/object:Provider::Terraform::Examples
     name: 'datastream_connection_profile_sql_server'
-    min_version: beta
     primary_resource_id: 'default'
     skip_test: true
     vars:
@@ -313,7 +312,6 @@ properties:
           Database for the PostgreSQL connection.
   - !ruby/object:Api::Type::NestedObject
     name: 'sqlServerProfile'
-    min_version: beta
     exactly_one_of:
       - oracle_profile
       - gcs_profile

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -1432,11 +1432,6 @@ properties:
                               output: true
                               description: |
                                 Column scale.
-                            - !ruby/object:Api::Type::String
-                              name: 'encoding'
-                              output: true
-                              description: |
-                                Column encoding.
                             - !ruby/object:Api::Type::Boolean
                               name: 'primaryKey'
                               output: true

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -864,11 +864,6 @@ properties:
                                   output: true
                                   description: |
                                     Column scale.
-                                - !ruby/object:Api::Type::String
-                                  name: 'encoding'
-                                  output: true
-                                  description: |
-                                    Column encoding.
                                 - !ruby/object:Api::Type::Boolean
                                   name: 'primaryKey'
                                   output: true

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -109,12 +109,18 @@ examples:
       destination_connection_profile_id: 'destination-profile'
   - !ruby/object:Provider::Terraform::Examples
     name: 'datastream_stream_sql_server'
+    min_version: beta
     primary_resource_id: 'default'
     skip_test: true
     vars:
-      stream_id: 'my-stream'
-      source_connection_profile_id: 'source-profile'
+      database_name: 'db'
+      database_password: 'password'
+      database_user: 'user'
       destination_connection_profile_id: 'destination-profile'
+      source_connection_profile_id: 'source-profile'
+      sql_server_name: 'sql-server'
+      sql_server_root_password: 'root-password'
+      stream_id: 'stream'
   - !ruby/object:Provider::Terraform::Examples
     name: 'datastream_stream_postgresql_bigquery_dataset_id'
     primary_resource_id: 'default'

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -970,8 +970,7 @@ properties:
             name: 'maxConcurrentCdcTasks'
             send_empty_value: true
             description: |
-              Maximum number of concurrent CDC tasks. The number should be non negative.
-              If not set (or set to 0), the system's default value will be used.
+              Max concurrent CDC tasks.
             default_from_api: true
             validation: !ruby/object:Provider::Terraform::Validation
               function: 'validation.IntAtLeast(0)'
@@ -979,8 +978,7 @@ properties:
             name: 'maxConcurrentBackfillTasks'
             send_empty_value: true
             description: |
-              Maximum number of concurrent backfill tasks. The number should be non negative.
-              If not set (or set to 0), the system's default value will be used.
+              Max concurrent backfill tasks.
             default_from_api: true
             validation: !ruby/object:Provider::Terraform::Validation
               function: 'validation.IntAtLeast(0)'

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -116,11 +116,14 @@ examples:
       database_name: 'db'
       database_password: 'password'
       database_user: 'user'
+      deletion_protection: 'true'
       destination_connection_profile_id: 'destination-profile'
       source_connection_profile_id: 'source-profile'
       sql_server_name: 'sql-server'
       sql_server_root_password: 'root-password'
       stream_id: 'stream'
+    test_vars_overrides:
+      deletion_protection: 'false'
   - !ruby/object:Provider::Terraform::Examples
     name: 'datastream_stream_postgresql_bigquery_dataset_id'
     primary_resource_id: 'default'

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -946,11 +946,6 @@ properties:
                                   output: true
                                   description: |
                                     Column scale.
-                                - !ruby/object:Api::Type::String
-                                  name: 'encoding'
-                                  output: true
-                                  description: |
-                                    Column encoding.
                                 - !ruby/object:Api::Type::Boolean
                                   name: 'primaryKey'
                                   output: true

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -11,26 +11,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
----
-!ruby/object:Api::Resource
-name: "Stream"
-base_url: "projects/{{project}}/locations/{{location}}/streams"
-create_url: "projects/{{project}}/locations/{{location}}/streams?streamId={{stream_id}}"
-self_link: "projects/{{project}}/locations/{{location}}/streams/{{stream_id}}"
+--- !ruby/object:Api::Resource
+name: 'Stream'
+base_url: 'projects/{{project}}/locations/{{location}}/streams'
+create_url: 'projects/{{project}}/locations/{{location}}/streams?streamId={{stream_id}}'
+self_link: 'projects/{{project}}/locations/{{location}}/streams/{{stream_id}}'
 update_verb: :PATCH
 update_mask: true
 references: !ruby/object:Api::Resource::ReferenceLinks
   guides:
-    "Official Documentation": "https://cloud.google.com/datastream/docs/create-a-stream"
-  api: "https://cloud.google.com/datastream/docs/reference/rest/v1/projects.locations.streams"
+    'Official Documentation': 'https://cloud.google.com/datastream/docs/create-a-stream'
+  api: 'https://cloud.google.com/datastream/docs/reference/rest/v1/projects.locations.streams'
 description: |
   A resource representing streaming data from a source to a destination.
 id_format: projects/{{project}}/locations/{{location}}/streams/{{stream_id}}
 import_format:
-  ["projects/{{project}}/locations/{{location}}/streams/{{stream_id}}"]
+  ['projects/{{project}}/locations/{{location}}/streams/{{stream_id}}']
 virtual_fields:
   - !ruby/object:Api::Type::Enum
-    name: "desired_state"
+    name: 'desired_state'
     description: |
       Desired state of the Stream. Set this field to `RUNNING` to start the stream, and `PAUSED` to pause the stream.
     values:
@@ -39,115 +38,118 @@ virtual_fields:
       - :PAUSED
     default_value: :NOT_STARTED
 custom_code: !ruby/object:Provider::Terraform::CustomCode
-  constants: "templates/terraform/constants/datastream_stream.go.erb"
-  post_create: "templates/terraform/post_create/datastream_stream.go.erb"
-  post_import: "templates/terraform/post_import/datastream_stream.go.erb"
-  pre_update: "templates/terraform/pre_update/datastream_stream.go.erb"
-  post_update: "templates/terraform/post_update/datastream_stream.go.erb"
-  encoder: "templates/terraform/encoders/datastream_stream.go.erb"
-custom_diff: ["resourceDatastreamStreamCustomDiff"]
+  constants: 'templates/terraform/constants/datastream_stream.go.erb'
+  post_create: 'templates/terraform/post_create/datastream_stream.go.erb'
+  post_import: 'templates/terraform/post_import/datastream_stream.go.erb'
+  pre_update: 'templates/terraform/pre_update/datastream_stream.go.erb'
+  post_update: 'templates/terraform/post_update/datastream_stream.go.erb'
+  encoder: 'templates/terraform/encoders/datastream_stream.go.erb'
+custom_diff: [
+  'resourceDatastreamStreamCustomDiff',
+]
 examples:
   - !ruby/object:Provider::Terraform::Examples
-    name: "datastream_stream_basic"
+    name: 'datastream_stream_basic'
     pull_external: true
-    primary_resource_id: "default"
+    primary_resource_id: 'default'
     skip_docs:
       true
       # Random provider
     skip_vcr: true
     vars:
-      stream_id: "my-stream"
-      private_connection_id: "my-connection"
-      network_name: "my-network"
-      source_connection_profile_id: "source-profile"
-      database_instance_name: "my-instance"
-      deletion_protection: "true"
-      bucket_name: "my-bucket"
-      destination_connection_profile_id: "destination-profile"
+      stream_id: 'my-stream'
+      private_connection_id: 'my-connection'
+      network_name: 'my-network'
+      source_connection_profile_id: 'source-profile'
+      database_instance_name: 'my-instance'
+      deletion_protection: 'true'
+      bucket_name: 'my-bucket'
+      destination_connection_profile_id: 'destination-profile'
     test_vars_overrides:
-      deletion_protection: "false"
+      deletion_protection: 'false'
     oics_vars_overrides:
-      deletion_protection: "false"
+      deletion_protection: 'false'
   - !ruby/object:Provider::Terraform::Examples
-    name: "datastream_stream_full"
+    name: 'datastream_stream_full'
     pull_external: true
     primary_resource_id:
-      "default"
+      'default'
       # Random provider
     skip_vcr: true
     vars:
-      stream_id: "my-stream"
-      private_connection_id: "my-connection"
-      network_name: "my-network"
-      source_connection_profile_id: "source-profile"
-      database_instance_name: "my-instance"
-      deletion_protection: "true"
-      bucket_name: "my-bucket"
-      destination_connection_profile_id: "destination-profile"
-      stream_cmek: "kms-name"
+      stream_id: 'my-stream'
+      private_connection_id: 'my-connection'
+      network_name: 'my-network'
+      source_connection_profile_id: 'source-profile'
+      database_instance_name: 'my-instance'
+      deletion_protection: 'true'
+      bucket_name: 'my-bucket'
+      destination_connection_profile_id: 'destination-profile'
+      stream_cmek: 'kms-name'
     test_vars_overrides:
-      deletion_protection: "false"
+      deletion_protection: 'false'
       stream_cmek: 'acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
     oics_vars_overrides:
-      deletion_protection: "false"
+      deletion_protection: 'false'
   - !ruby/object:Provider::Terraform::Examples
-    name: "datastream_stream_postgresql"
-    primary_resource_id: "default"
+    name: 'datastream_stream_postgresql'
+    primary_resource_id: 'default'
     skip_test: true
     vars:
-      stream_id: "my-stream"
-      source_connection_profile_id: "source-profile"
-      destination_connection_profile_id: "destination-profile"
+      stream_id: 'my-stream'
+      source_connection_profile_id: 'source-profile'
+      destination_connection_profile_id: 'destination-profile'
   - !ruby/object:Provider::Terraform::Examples
-    name: "datastream_stream_oracle"
-    primary_resource_id: "default"
+    name: 'datastream_stream_oracle'
+    primary_resource_id: 'default'
     skip_test: true
     vars:
-      stream_id: "my-stream"
-      source_connection_profile_id: "source-profile"
-      destination_connection_profile_id: "destination-profile"
+      stream_id: 'my-stream'
+      source_connection_profile_id: 'source-profile'
+      destination_connection_profile_id: 'destination-profile'
   - !ruby/object:Provider::Terraform::Examples
-    name: "datastream_stream_sql_server"
-    primary_resource_id: "default"
+    name: 'datastream_stream_sql_server'
+    primary_resource_id: 'default'
     skip_test: true
     vars:
-      stream_id: "my-stream"
-      source_connection_profile_id: "source-profile"
-      destination_connection_profile_id: "destination-profile"
+      stream_id: 'my-stream'
+      source_connection_profile_id: 'source-profile'
+      destination_connection_profile_id: 'destination-profile'
   - !ruby/object:Provider::Terraform::Examples
-    name: "datastream_stream_postgresql_bigquery_dataset_id"
-    primary_resource_id: "default"
+    name: 'datastream_stream_postgresql_bigquery_dataset_id'
+    primary_resource_id: 'default'
     vars:
-      dataset_id: "postgres"
-      stream_id: "postgres-bigquery"
-      dest_connection_profile_id: "dest-profile"
-      instance_name: "instance-name"
-      sql_user_name: "my-user"
-      source_connection_profile_id: "source-profile"
+      dataset_id: 'postgres'
+      stream_id: 'postgres-bigquery'
+      dest_connection_profile_id: 'dest-profile'
+      instance_name: 'instance-name'
+      sql_user_name: 'my-user'
+      source_connection_profile_id: 'source-profile'
     pull_external: true
     # Random provider
     skip_vcr: true
   - !ruby/object:Provider::Terraform::Examples
-    name: "datastream_stream_bigquery"
+    name: 'datastream_stream_bigquery'
     pull_external: true
     primary_resource_id:
-      "default"
+      'default'
       # Random provider
     skip_vcr: true
     vars:
-      stream_id: "my-stream"
-      private_connection_id: "my-connection"
-      network_name: "my-network"
-      source_connection_profile_id: "source-profile"
-      database_instance_name: "my-instance"
-      deletion_protection: "true"
-      destination_connection_profile_id: "destination-profile"
-      bigquery_destination_table_kms_key_name: "bigquery-kms-name"
+      stream_id: 'my-stream'
+      private_connection_id: 'my-connection'
+      network_name: 'my-network'
+      source_connection_profile_id: 'source-profile'
+      database_instance_name: 'my-instance'
+      deletion_protection: 'true'
+      destination_connection_profile_id: 'destination-profile'
+      bigquery_destination_table_kms_key_name: 'bigquery-kms-name'
     test_vars_overrides:
-      deletion_protection: "false"
-      bigquery_destination_table_kms_key_name: 'acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
+      deletion_protection: 'false'
+      bigquery_destination_table_kms_key_name:
+        'acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
     oics_vars_overrides:
-      deletion_protection: "false"
+      deletion_protection: 'false'
 parameters:
   - !ruby/object:Api::Type::String
     name: streamId
@@ -157,7 +159,7 @@ parameters:
     immutable: true
     url_param_only: true
   - !ruby/object:Api::Type::String
-    name: "location"
+    name: 'location'
     description: |
       The name of the location this stream is located in.
     required: true
@@ -165,31 +167,31 @@ parameters:
     url_param_only: true
 properties:
   - !ruby/object:Api::Type::String
-    name: "name"
+    name: 'name'
     output: true
     description: The stream's name.
   - !ruby/object:Api::Type::KeyValueLabels
-    name: "labels"
+    name: 'labels'
     description: Labels.
   - !ruby/object:Api::Type::String
-    name: "displayName"
+    name: 'displayName'
     required: true
     description: Display name.
   - !ruby/object:Api::Type::NestedObject
-    name: "sourceConfig"
+    name: 'sourceConfig'
     required: true
     description: |
       Source connection profile configuration.
     properties:
       - !ruby/object:Api::Type::String
-        name: "sourceConnectionProfile"
+        name: 'sourceConnectionProfile'
         immutable: true
         required: true
         description: |
           Source connection profile resource. Format: projects/{project}/locations/{location}/connectionProfiles/{name}
-        diff_suppress_func: "tpgresource.ProjectNumberDiffSuppress"
+        diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
       - !ruby/object:Api::Type::NestedObject
-        name: "mysqlSourceConfig"
+        name: 'mysqlSourceConfig'
         allow_empty_object: true
         send_empty_value: true
         exactly_one_of:
@@ -201,12 +203,12 @@ properties:
           MySQL data source configuration.
         properties:
           - !ruby/object:Api::Type::NestedObject
-            name: "includeObjects"
+            name: 'includeObjects'
             description: |
               MySQL objects to retrieve from the source.
             properties:
               - !ruby/object:Api::Type::Array
-                name: "mysqlDatabases"
+                name: 'mysqlDatabases'
                 required: true
                 min_size: 1
                 description: |
@@ -216,12 +218,12 @@ properties:
                     MySQL database.
                   properties:
                     - !ruby/object:Api::Type::String
-                      name: "database"
+                      name: 'database'
                       required: true
                       description: |
                         Database name.
                     - !ruby/object:Api::Type::Array
-                      name: "mysqlTables"
+                      name: 'mysqlTables'
                       min_size: 1
                       description: |
                         Tables in the database.
@@ -230,12 +232,12 @@ properties:
                           MySQL table.
                         properties:
                           - !ruby/object:Api::Type::String
-                            name: "table"
+                            name: 'table'
                             required: true
                             description: |
                               Table name.
                           - !ruby/object:Api::Type::Array
-                            name: "mysqlColumns"
+                            name: 'mysqlColumns'
                             min_size: 1
                             description: |
                               MySQL columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
@@ -244,42 +246,42 @@ properties:
                                 MySQL Column.
                               properties:
                                 - !ruby/object:Api::Type::String
-                                  name: "column"
+                                  name: 'column'
                                   description: |
                                     Column name.
                                 - !ruby/object:Api::Type::String
-                                  name: "dataType"
+                                  name: 'dataType'
                                   description: |
                                     The MySQL data type. Full data types list can be found here:
                                     https://dev.mysql.com/doc/refman/8.0/en/data-types.html
                                 - !ruby/object:Api::Type::Integer
-                                  name: "length"
+                                  name: 'length'
                                   output: true
                                   description: |
                                     Column length.
                                 - !ruby/object:Api::Type::String
-                                  name: "collation"
+                                  name: 'collation'
                                   description: |
                                     Column collation.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: "primaryKey"
+                                  name: 'primaryKey'
                                   description: |
                                     Whether or not the column represents a primary key.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: "nullable"
+                                  name: 'nullable'
                                   description: |
                                     Whether or not the column can accept a null value.
                                 - !ruby/object:Api::Type::Integer
-                                  name: "ordinalPosition"
+                                  name: 'ordinalPosition'
                                   description: |
                                     The ordinal position of the column in the table.
           - !ruby/object:Api::Type::NestedObject
-            name: "excludeObjects"
+            name: 'excludeObjects'
             description: |
               MySQL objects to exclude from the stream.
             properties:
               - !ruby/object:Api::Type::Array
-                name: "mysqlDatabases"
+                name: 'mysqlDatabases'
                 required: true
                 min_size: 1
                 description: |
@@ -289,12 +291,12 @@ properties:
                     MySQL database.
                   properties:
                     - !ruby/object:Api::Type::String
-                      name: "database"
+                      name: 'database'
                       required: true
                       description: |
                         Database name.
                     - !ruby/object:Api::Type::Array
-                      name: "mysqlTables"
+                      name: 'mysqlTables'
                       min_size: 1
                       description: |
                         Tables in the database.
@@ -303,12 +305,12 @@ properties:
                           MySQL table.
                         properties:
                           - !ruby/object:Api::Type::String
-                            name: "table"
+                            name: 'table'
                             required: true
                             description: |
                               Table name.
                           - !ruby/object:Api::Type::Array
-                            name: "mysqlColumns"
+                            name: 'mysqlColumns'
                             min_size: 1
                             description: |
                               MySQL columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
@@ -317,55 +319,55 @@ properties:
                                 MySQL Column.
                               properties:
                                 - !ruby/object:Api::Type::String
-                                  name: "column"
+                                  name: 'column'
                                   description: |
                                     Column name.
                                 - !ruby/object:Api::Type::String
-                                  name: "dataType"
+                                  name: 'dataType'
                                   description: |
                                     The MySQL data type. Full data types list can be found here:
                                     https://dev.mysql.com/doc/refman/8.0/en/data-types.html
                                 - !ruby/object:Api::Type::Integer
-                                  name: "length"
+                                  name: 'length'
                                   output: true
                                   description: |
                                     Column length.
                                 - !ruby/object:Api::Type::String
-                                  name: "collation"
+                                  name: 'collation'
                                   description: |
                                     Column collation.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: "primaryKey"
+                                  name: 'primaryKey'
                                   description: |
                                     Whether or not the column represents a primary key.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: "nullable"
+                                  name: 'nullable'
                                   description: |
                                     Whether or not the column can accept a null value.
                                 - !ruby/object:Api::Type::Integer
-                                  name: "ordinalPosition"
+                                  name: 'ordinalPosition'
                                   description: |
                                     The ordinal position of the column in the table.
           - !ruby/object:Api::Type::Integer
-            name: "maxConcurrentCdcTasks"
+            name: 'maxConcurrentCdcTasks'
             send_empty_value: true
             description: |
               Maximum number of concurrent CDC tasks. The number should be non negative.
               If not set (or set to 0), the system's default value will be used.
             default_from_api: true
             validation: !ruby/object:Provider::Terraform::Validation
-              function: "validation.IntAtLeast(0)"
+              function: 'validation.IntAtLeast(0)'
           - !ruby/object:Api::Type::Integer
-            name: "maxConcurrentBackfillTasks"
+            name: 'maxConcurrentBackfillTasks'
             send_empty_value: true
             description: |
               Maximum number of concurrent backfill tasks. The number should be non negative.
               If not set (or set to 0), the system's default value will be used.
             default_from_api: true
             validation: !ruby/object:Provider::Terraform::Validation
-              function: "validation.IntAtLeast(0)"
+              function: 'validation.IntAtLeast(0)'
       - !ruby/object:Api::Type::NestedObject
-        name: "oracleSourceConfig"
+        name: 'oracleSourceConfig'
         allow_empty_object: true
         send_empty_value: true
         exactly_one_of:
@@ -377,12 +379,12 @@ properties:
           MySQL data source configuration.
         properties:
           - !ruby/object:Api::Type::NestedObject
-            name: "includeObjects"
+            name: 'includeObjects'
             description: |
               Oracle objects to retrieve from the source.
             properties:
               - !ruby/object:Api::Type::Array
-                name: "oracleSchemas"
+                name: 'oracleSchemas'
                 required: true
                 min_size: 1
                 description: |
@@ -392,12 +394,12 @@ properties:
                     MySQL database.
                   properties:
                     - !ruby/object:Api::Type::String
-                      name: "schema"
+                      name: 'schema'
                       required: true
                       description: |
                         Schema name.
                     - !ruby/object:Api::Type::Array
-                      name: "oracleTables"
+                      name: 'oracleTables'
                       min_size: 1
                       description: |
                         Tables in the database.
@@ -406,12 +408,12 @@ properties:
                           Oracle table.
                         properties:
                           - !ruby/object:Api::Type::String
-                            name: "table"
+                            name: 'table'
                             required: true
                             description: |
                               Table name.
                           - !ruby/object:Api::Type::Array
-                            name: "oracleColumns"
+                            name: 'oracleColumns'
                             min_size: 1
                             description: |
                               Oracle columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
@@ -420,56 +422,56 @@ properties:
                                 Oracle Column.
                               properties:
                                 - !ruby/object:Api::Type::String
-                                  name: "column"
+                                  name: 'column'
                                   description: |
                                     Column name.
                                 - !ruby/object:Api::Type::String
-                                  name: "dataType"
+                                  name: 'dataType'
                                   description: |
                                     The Oracle data type. Full data types list can be found here:
                                     https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Data-Types.html
                                 - !ruby/object:Api::Type::Integer
-                                  name: "length"
+                                  name: 'length'
                                   output: true
                                   description: |
                                     Column length.
                                 - !ruby/object:Api::Type::Integer
-                                  name: "precision"
+                                  name: 'precision'
                                   output: true
                                   description: |
                                     Column precision.
                                 - !ruby/object:Api::Type::Integer
-                                  name: "scale"
+                                  name: 'scale'
                                   output: true
                                   description: |
                                     Column scale.
                                 - !ruby/object:Api::Type::String
-                                  name: "encoding"
+                                  name: 'encoding'
                                   output: true
                                   description: |
                                     Column encoding.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: "primaryKey"
+                                  name: 'primaryKey'
                                   output: true
                                   description: |
                                     Whether or not the column represents a primary key.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: "nullable"
+                                  name: 'nullable'
                                   output: true
                                   description: |
                                     Whether or not the column can accept a null value.
                                 - !ruby/object:Api::Type::Integer
-                                  name: "ordinalPosition"
+                                  name: 'ordinalPosition'
                                   output: true
                                   description: |
                                     The ordinal position of the column in the table.
           - !ruby/object:Api::Type::NestedObject
-            name: "excludeObjects"
+            name: 'excludeObjects'
             description: |
               Oracle objects to exclude from the stream.
             properties:
               - !ruby/object:Api::Type::Array
-                name: "oracleSchemas"
+                name: 'oracleSchemas'
                 required: true
                 min_size: 1
                 description: |
@@ -479,12 +481,12 @@ properties:
                     MySQL database.
                   properties:
                     - !ruby/object:Api::Type::String
-                      name: "schema"
+                      name: 'schema'
                       required: true
                       description: |
                         Schema name.
                     - !ruby/object:Api::Type::Array
-                      name: "oracleTables"
+                      name: 'oracleTables'
                       min_size: 1
                       description: |
                         Tables in the database.
@@ -493,12 +495,12 @@ properties:
                           Oracle table.
                         properties:
                           - !ruby/object:Api::Type::String
-                            name: "table"
+                            name: 'table'
                             required: true
                             description: |
                               Table name.
                           - !ruby/object:Api::Type::Array
-                            name: "oracleColumns"
+                            name: 'oracleColumns'
                             min_size: 1
                             description: |
                               Oracle columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
@@ -507,83 +509,83 @@ properties:
                                 Oracle Column.
                               properties:
                                 - !ruby/object:Api::Type::String
-                                  name: "column"
+                                  name: 'column'
                                   description: |
                                     Column name.
                                 - !ruby/object:Api::Type::String
-                                  name: "dataType"
+                                  name: 'dataType'
                                   description: |
                                     The Oracle data type. Full data types list can be found here:
                                     https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Data-Types.html
                                 - !ruby/object:Api::Type::Integer
-                                  name: "length"
+                                  name: 'length'
                                   output: true
                                   description: |
                                     Column length.
                                 - !ruby/object:Api::Type::Integer
-                                  name: "precision"
+                                  name: 'precision'
                                   output: true
                                   description: |
                                     Column precision.
                                 - !ruby/object:Api::Type::Integer
-                                  name: "scale"
+                                  name: 'scale'
                                   output: true
                                   description: |
                                     Column scale.
                                 - !ruby/object:Api::Type::String
-                                  name: "encoding"
+                                  name: 'encoding'
                                   output: true
                                   description: |
                                     Column encoding.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: "primaryKey"
+                                  name: 'primaryKey'
                                   output: true
                                   description: |
                                     Whether or not the column represents a primary key.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: "nullable"
+                                  name: 'nullable'
                                   output: true
                                   description: |
                                     Whether or not the column can accept a null value.
                                 - !ruby/object:Api::Type::Integer
-                                  name: "ordinalPosition"
+                                  name: 'ordinalPosition'
                                   output: true
                                   description: |
                                     The ordinal position of the column in the table.
           - !ruby/object:Api::Type::Integer
-            name: "maxConcurrentCdcTasks"
+            name: 'maxConcurrentCdcTasks'
             send_empty_value: true
             description: |
               Maximum number of concurrent CDC tasks. The number should be non negative.
               If not set (or set to 0), the system's default value will be used.
             default_from_api: true
             validation: !ruby/object:Provider::Terraform::Validation
-              function: "validation.IntAtLeast(0)"
+              function: 'validation.IntAtLeast(0)'
           - !ruby/object:Api::Type::Integer
-            name: "maxConcurrentBackfillTasks"
+            name: 'maxConcurrentBackfillTasks'
             send_empty_value: true
             description: |
               Maximum number of concurrent backfill tasks. The number should be non negative.
               If not set (or set to 0), the system's default value will be used.
             default_from_api: true
             validation: !ruby/object:Provider::Terraform::Validation
-              function: "validation.IntAtLeast(0)"
+              function: 'validation.IntAtLeast(0)'
           - !ruby/object:Api::Type::NestedObject
-            name: "dropLargeObjects"
+            name: 'dropLargeObjects'
             allow_empty_object: true
             send_empty_value: true
             description: |
               Configuration to drop large object values.
             properties: []
           - !ruby/object:Api::Type::NestedObject
-            name: "streamLargeObjects"
+            name: 'streamLargeObjects'
             allow_empty_object: true
             send_empty_value: true
             description: |
               Configuration to drop large object values.
             properties: []
       - !ruby/object:Api::Type::NestedObject
-        name: "postgresqlSourceConfig"
+        name: 'postgresqlSourceConfig'
         allow_empty_object: true
         send_empty_value: true
         exactly_one_of:
@@ -595,12 +597,12 @@ properties:
           PostgreSQL data source configuration.
         properties:
           - !ruby/object:Api::Type::NestedObject
-            name: "includeObjects"
+            name: 'includeObjects'
             description: |
               PostgreSQL objects to retrieve from the source.
             properties:
               - !ruby/object:Api::Type::Array
-                name: "postgresqlSchemas"
+                name: 'postgresqlSchemas'
                 required: true
                 min_size: 1
                 description: |
@@ -610,12 +612,12 @@ properties:
                     PostgreSQL schema.
                   properties:
                     - !ruby/object:Api::Type::String
-                      name: "schema"
+                      name: 'schema'
                       required: true
                       description: |
                         Database name.
                     - !ruby/object:Api::Type::Array
-                      name: "postgresqlTables"
+                      name: 'postgresqlTables'
                       min_size: 1
                       description: |
                         Tables in the schema.
@@ -624,12 +626,12 @@ properties:
                           PostgreSQL table.
                         properties:
                           - !ruby/object:Api::Type::String
-                            name: "table"
+                            name: 'table'
                             required: true
                             description: |
                               Table name.
                           - !ruby/object:Api::Type::Array
-                            name: "postgresqlColumns"
+                            name: 'postgresqlColumns'
                             min_size: 1
                             description: |
                               PostgreSQL columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
@@ -638,48 +640,48 @@ properties:
                                 PostgreSQL Column.
                               properties:
                                 - !ruby/object:Api::Type::String
-                                  name: "column"
+                                  name: 'column'
                                   description: |
                                     Column name.
                                 - !ruby/object:Api::Type::String
-                                  name: "dataType"
+                                  name: 'dataType'
                                   description: |
                                     The PostgreSQL data type. Full data types list can be found here:
                                     https://www.postgresql.org/docs/current/datatype.html
                                 - !ruby/object:Api::Type::Integer
-                                  name: "length"
+                                  name: 'length'
                                   output: true
                                   description: |
                                     Column length.
                                 - !ruby/object:Api::Type::Integer
-                                  name: "precision"
+                                  name: 'precision'
                                   output: true
                                   description: |
                                     Column precision.
                                 - !ruby/object:Api::Type::Integer
-                                  name: "scale"
+                                  name: 'scale'
                                   output: true
                                   description: |
                                     Column scale.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: "primaryKey"
+                                  name: 'primaryKey'
                                   description: |
                                     Whether or not the column represents a primary key.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: "nullable"
+                                  name: 'nullable'
                                   description: |
                                     Whether or not the column can accept a null value.
                                 - !ruby/object:Api::Type::Integer
-                                  name: "ordinalPosition"
+                                  name: 'ordinalPosition'
                                   description: |
                                     The ordinal position of the column in the table.
           - !ruby/object:Api::Type::NestedObject
-            name: "excludeObjects"
+            name: 'excludeObjects'
             description: |
               PostgreSQL objects to exclude from the stream.
             properties:
               - !ruby/object:Api::Type::Array
-                name: "postgresqlSchemas"
+                name: 'postgresqlSchemas'
                 required: true
                 min_size: 1
                 description: |
@@ -689,12 +691,12 @@ properties:
                     PostgreSQL schema.
                   properties:
                     - !ruby/object:Api::Type::String
-                      name: "schema"
+                      name: 'schema'
                       required: true
                       description: |
                         Database name.
                     - !ruby/object:Api::Type::Array
-                      name: "postgresqlTables"
+                      name: 'postgresqlTables'
                       min_size: 1
                       description: |
                         Tables in the schema.
@@ -703,12 +705,12 @@ properties:
                           PostgreSQL table.
                         properties:
                           - !ruby/object:Api::Type::String
-                            name: "table"
+                            name: 'table'
                             required: true
                             description: |
                               Table name.
                           - !ruby/object:Api::Type::Array
-                            name: "postgresqlColumns"
+                            name: 'postgresqlColumns'
                             min_size: 1
                             description: |
                               PostgreSQL columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
@@ -717,64 +719,64 @@ properties:
                                 PostgreSQL Column.
                               properties:
                                 - !ruby/object:Api::Type::String
-                                  name: "column"
+                                  name: 'column'
                                   description: |
                                     Column name.
                                 - !ruby/object:Api::Type::String
-                                  name: "dataType"
+                                  name: 'dataType'
                                   description: |
                                     The PostgreSQL data type. Full data types list can be found here:
                                     https://www.postgresql.org/docs/current/datatype.html
                                 - !ruby/object:Api::Type::Integer
-                                  name: "length"
+                                  name: 'length'
                                   output: true
                                   description: |
                                     Column length.
                                 - !ruby/object:Api::Type::Integer
-                                  name: "precision"
+                                  name: 'precision'
                                   output: true
                                   description: |
                                     Column precision.
                                 - !ruby/object:Api::Type::Integer
-                                  name: "scale"
+                                  name: 'scale'
                                   output: true
                                   description: |
                                     Column scale.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: "primaryKey"
+                                  name: 'primaryKey'
                                   description: |
                                     Whether or not the column represents a primary key.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: "nullable"
+                                  name: 'nullable'
                                   description: |
                                     Whether or not the column can accept a null value.
                                 - !ruby/object:Api::Type::Integer
-                                  name: "ordinalPosition"
+                                  name: 'ordinalPosition'
                                   description: |
                                     The ordinal position of the column in the table.
           - !ruby/object:Api::Type::String
-            name: "replicationSlot"
+            name: 'replicationSlot'
             required: true
             description: |
               The name of the logical replication slot that's configured with
               the pgoutput plugin.
           - !ruby/object:Api::Type::String
-            name: "publication"
+            name: 'publication'
             required: true
             description: |
               The name of the publication that includes the set of all tables
               that are defined in the stream's include_objects.
           - !ruby/object:Api::Type::Integer
-            name: "maxConcurrentBackfillTasks"
+            name: 'maxConcurrentBackfillTasks'
             send_empty_value: true
             description: |
               Maximum number of concurrent backfill tasks. The number should be non
               negative. If not set (or set to 0), the system's default value will be used.
             default_from_api: true
             validation: !ruby/object:Provider::Terraform::Validation
-              function: "validation.IntAtLeast(0)"
+              function: 'validation.IntAtLeast(0)'
       - !ruby/object:Api::Type::NestedObject
-        name: "sqlServerSourceConfig"
+        name: 'sqlServerSourceConfig'
         min_version: beta
         allow_empty_object: true
         send_empty_value: true
@@ -784,15 +786,15 @@ properties:
           - source_config.0.postgresql_source_config
           - source_config.0.sql_server_source_config
         description: |
-          SQl Server data source configuration.
+          SQL Server data source configuration.
         properties:
           - !ruby/object:Api::Type::NestedObject
-            name: "includeObjects"
+            name: 'includeObjects'
             description: |
               SQL Server objects to retrieve from the source.
             properties:
               - !ruby/object:Api::Type::Array
-                name: "schemas"
+                name: 'schemas'
                 required: true
                 min_size: 1
                 description: |
@@ -802,12 +804,12 @@ properties:
                     SQL Server database.
                   properties:
                     - !ruby/object:Api::Type::String
-                      name: "schema"
+                      name: 'schema'
                       required: true
                       description: |
                         Schema name.
                     - !ruby/object:Api::Type::Array
-                      name: "tables"
+                      name: 'tables'
                       min_size: 1
                       description: |
                         Tables in the database.
@@ -816,12 +818,12 @@ properties:
                           SQL Server table.
                         properties:
                           - !ruby/object:Api::Type::String
-                            name: "table"
+                            name: 'table'
                             required: true
                             description: |
                               Table name.
                           - !ruby/object:Api::Type::Array
-                            name: "columns"
+                            name: 'columns'
                             min_size: 1
                             description: |
                               SQL Server columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
@@ -830,56 +832,56 @@ properties:
                                 SQL Server Column.
                               properties:
                                 - !ruby/object:Api::Type::String
-                                  name: "column"
+                                  name: 'column'
                                   description: |
                                     Column name.
                                 - !ruby/object:Api::Type::String
-                                  name: "dataType"
+                                  name: 'dataType'
                                   description: |
                                     The SQL Server data type. Full data types list can be found here:
                                     https://learn.microsoft.com/en-us/sql/t-sql/data-types/data-types-transact-sql?view=sql-server-ver16
                                 - !ruby/object:Api::Type::Integer
-                                  name: "length"
+                                  name: 'length'
                                   output: true
                                   description: |
                                     Column length.
                                 - !ruby/object:Api::Type::Integer
-                                  name: "precision"
+                                  name: 'precision'
                                   output: true
                                   description: |
                                     Column precision.
                                 - !ruby/object:Api::Type::Integer
-                                  name: "scale"
+                                  name: 'scale'
                                   output: true
                                   description: |
                                     Column scale.
                                 - !ruby/object:Api::Type::String
-                                  name: "encoding"
+                                  name: 'encoding'
                                   output: true
                                   description: |
                                     Column encoding.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: "primaryKey"
+                                  name: 'primaryKey'
                                   output: true
                                   description: |
                                     Whether or not the column represents a primary key.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: "nullable"
+                                  name: 'nullable'
                                   output: true
                                   description: |
                                     Whether or not the column can accept a null value.
                                 - !ruby/object:Api::Type::Integer
-                                  name: "ordinalPosition"
+                                  name: 'ordinalPosition'
                                   output: true
                                   description: |
                                     The ordinal position of the column in the table.
           - !ruby/object:Api::Type::NestedObject
-            name: "excludeObjects"
+            name: 'excludeObjects'
             description: |
               SQL Server objects to exclude from the stream.
             properties:
               - !ruby/object:Api::Type::Array
-                name: "schemas"
+                name: 'schemas'
                 required: true
                 min_size: 1
                 description: |
@@ -889,12 +891,12 @@ properties:
                     SQL Server database.
                   properties:
                     - !ruby/object:Api::Type::String
-                      name: "schema"
+                      name: 'schema'
                       required: true
                       description: |
                         Schema name.
                     - !ruby/object:Api::Type::Array
-                      name: "tables"
+                      name: 'tables'
                       min_size: 1
                       description: |
                         Tables in the database.
@@ -903,12 +905,12 @@ properties:
                           SQL Server table.
                         properties:
                           - !ruby/object:Api::Type::String
-                            name: "table"
+                            name: 'table'
                             required: true
                             description: |
                               Table name.
                           - !ruby/object:Api::Type::Array
-                            name: "columns"
+                            name: 'columns'
                             min_size: 1
                             description: |
                               SQL Server columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
@@ -917,82 +919,82 @@ properties:
                                 SQL Server Column.
                               properties:
                                 - !ruby/object:Api::Type::String
-                                  name: "column"
+                                  name: 'column'
                                   description: |
                                     Column name.
                                 - !ruby/object:Api::Type::String
-                                  name: "dataType"
+                                  name: 'dataType'
                                   description: |
                                     The SQL Server data type. Full data types list can be found here:
                                     https://learn.microsoft.com/en-us/sql/t-sql/data-types/data-types-transact-sql?view=sql-server-ver16
                                 - !ruby/object:Api::Type::Integer
-                                  name: "length"
+                                  name: 'length'
                                   output: true
                                   description: |
                                     Column length.
                                 - !ruby/object:Api::Type::Integer
-                                  name: "precision"
+                                  name: 'precision'
                                   output: true
                                   description: |
                                     Column precision.
                                 - !ruby/object:Api::Type::Integer
-                                  name: "scale"
+                                  name: 'scale'
                                   output: true
                                   description: |
                                     Column scale.
                                 - !ruby/object:Api::Type::String
-                                  name: "encoding"
+                                  name: 'encoding'
                                   output: true
                                   description: |
                                     Column encoding.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: "primaryKey"
+                                  name: 'primaryKey'
                                   output: true
                                   description: |
                                     Whether or not the column represents a primary key.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: "nullable"
+                                  name: 'nullable'
                                   output: true
                                   description: |
                                     Whether or not the column can accept a null value.
                                 - !ruby/object:Api::Type::Integer
-                                  name: "ordinalPosition"
+                                  name: 'ordinalPosition'
                                   output: true
                                   description: |
                                     The ordinal position of the column in the table.
           - !ruby/object:Api::Type::Integer
-            name: "maxConcurrentCdcTasks"
+            name: 'maxConcurrentCdcTasks'
             send_empty_value: true
             description: |
               Maximum number of concurrent CDC tasks. The number should be non negative.
               If not set (or set to 0), the system's default value will be used.
             default_from_api: true
             validation: !ruby/object:Provider::Terraform::Validation
-              function: "validation.IntAtLeast(0)"
+              function: 'validation.IntAtLeast(0)'
           - !ruby/object:Api::Type::Integer
-            name: "maxConcurrentBackfillTasks"
+            name: 'maxConcurrentBackfillTasks'
             send_empty_value: true
             description: |
               Maximum number of concurrent backfill tasks. The number should be non negative.
               If not set (or set to 0), the system's default value will be used.
             default_from_api: true
             validation: !ruby/object:Provider::Terraform::Validation
-              function: "validation.IntAtLeast(0)"
+              function: 'validation.IntAtLeast(0)'
   - !ruby/object:Api::Type::NestedObject
-    name: "destinationConfig"
+    name: 'destinationConfig'
     required: true
     description: |
       Destination connection profile configuration.
     properties:
       - !ruby/object:Api::Type::String
-        name: "destinationConnectionProfile"
+        name: 'destinationConnectionProfile'
         immutable: true
         required: true
         description: |
           Destination connection profile resource. Format: projects/{project}/locations/{location}/connectionProfiles/{name}
-        diff_suppress_func: "tpgresource.ProjectNumberDiffSuppress"
+        diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
       - !ruby/object:Api::Type::NestedObject
-        name: "gcsDestinationConfig"
+        name: 'gcsDestinationConfig'
         exactly_one_of:
           - destination_config.0.gcs_destination_config
           - destination_config.0.bigquery_destination_config
@@ -1000,22 +1002,22 @@ properties:
           A configuration for how data should be loaded to Cloud Storage.
         properties:
           - !ruby/object:Api::Type::String
-            name: "path"
+            name: 'path'
             description: |
               Path inside the Cloud Storage bucket to write data to.
           - !ruby/object:Api::Type::Integer
-            name: "fileRotationMb"
+            name: 'fileRotationMb'
             description: |
               The maximum file size to be saved in the bucket.
             default_from_api: true
           - !ruby/object:Api::Type::String
-            name: "fileRotationInterval"
+            name: 'fileRotationInterval'
             description: |
               The maximum duration for which new events are added before a file is closed and a new file is created.
               A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s". Defaults to 900s.
             default_from_api: true
           - !ruby/object:Api::Type::NestedObject
-            name: "avroFileFormat"
+            name: 'avroFileFormat'
             exactly_one_of:
               - destination_config.0.gcs_destination_config.0.avro_file_format
               - destination_config.0.gcs_destination_config.0.json_file_format
@@ -1025,7 +1027,7 @@ properties:
               AVRO file format configuration.
             properties: []
           - !ruby/object:Api::Type::NestedObject
-            name: "jsonFileFormat"
+            name: 'jsonFileFormat'
             exactly_one_of:
               - destination_config.0.gcs_destination_config.0.avro_file_format
               - destination_config.0.gcs_destination_config.0.json_file_format
@@ -1033,21 +1035,21 @@ properties:
               JSON file format configuration.
             properties:
               - !ruby/object:Api::Type::Enum
-                name: "schemaFileFormat"
+                name: 'schemaFileFormat'
                 description: |
                   The schema file format along JSON data files.
                 values:
                   - NO_SCHEMA_FILE
                   - AVRO_SCHEMA_FILE
               - !ruby/object:Api::Type::Enum
-                name: "compression"
+                name: 'compression'
                 description: |
                   Compression of the loaded JSON file.
                 values:
                   - NO_COMPRESSION
                   - GZIP
       - !ruby/object:Api::Type::NestedObject
-        name: "bigqueryDestinationConfig"
+        name: 'bigqueryDestinationConfig'
         exactly_one_of:
           - destination_config.0.gcs_destination_config
           - destination_config.0.bigquery_destination_config
@@ -1055,14 +1057,14 @@ properties:
           A configuration for how data should be loaded to Cloud Storage.
         properties:
           - !ruby/object:Api::Type::String
-            name: "dataFreshness"
+            name: 'dataFreshness'
             description: |
               The guaranteed data freshness (in seconds) when querying tables created by the stream.
               Editing this field will only affect new tables created in the future, but existing tables
               will not be impacted. Lower values mean that queries will return fresher data, but may result in higher cost.
               A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s". Defaults to 900s.
           - !ruby/object:Api::Type::NestedObject
-            name: "singleTargetDataset"
+            name: 'singleTargetDataset'
             exactly_one_of:
               - destination_config.0.bigquery_destination_config.0.single_target_dataset
               - destination_config.0.bigquery_destination_config.0.source_hierarchy_datasets
@@ -1070,15 +1072,15 @@ properties:
               A single target dataset to which all data will be streamed.
             properties:
               - !ruby/object:Api::Type::String
-                name: "datasetId"
+                name: 'datasetId'
                 required: true
                 description: |
                   Dataset ID in the format projects/{project}/datasets/{dataset_id} or
                   {project}:{dataset_id}
-                custom_expand: "templates/terraform/custom_expand/datastream_stream_dataset_id.go.erb"
+                custom_expand: 'templates/terraform/custom_expand/datastream_stream_dataset_id.go.erb'
                 diff_suppress_func: resourceDatastreamStreamDatabaseIdDiffSuppress
           - !ruby/object:Api::Type::NestedObject
-            name: "sourceHierarchyDatasets"
+            name: 'sourceHierarchyDatasets'
             exactly_one_of:
               - destination_config.0.bigquery_destination_config.0.single_target_dataset
               - destination_config.0.bigquery_destination_config.0.source_hierarchy_datasets
@@ -1086,24 +1088,24 @@ properties:
               Destination datasets are created so that hierarchy of the destination data objects matches the source hierarchy.
             properties:
               - !ruby/object:Api::Type::NestedObject
-                name: "datasetTemplate"
+                name: 'datasetTemplate'
                 required: true
                 description: |
                   Dataset template used for dynamic dataset creation.
                 properties:
                   - !ruby/object:Api::Type::String
-                    name: "location"
+                    name: 'location'
                     required: true
                     description: |
                       The geographic location where the dataset should reside.
                       See https://cloud.google.com/bigquery/docs/locations for supported locations.
                   - !ruby/object:Api::Type::String
-                    name: "datasetIdPrefix"
+                    name: 'datasetIdPrefix'
                     description: |
                       If supplied, every created dataset will have its name prefixed by the provided value.
                       The prefix and name will be separated by an underscore. i.e. _.
                   - !ruby/object:Api::Type::String
-                    name: "kmsKeyName"
+                    name: 'kmsKeyName'
                     immutable: true
                     description: |
                       Describes the Cloud KMS encryption key that will be used to protect destination BigQuery
@@ -1111,11 +1113,11 @@ properties:
                       encryption key. i.e. projects/{project}/locations/{location}/keyRings/{key_ring}/cryptoKeys/{cryptoKey}.
                       See https://cloud.google.com/bigquery/docs/customer-managed-encryption for more information.
   - !ruby/object:Api::Type::String
-    name: "state"
+    name: 'state'
     description: The state of the stream.
     output: true
   - !ruby/object:Api::Type::NestedObject
-    name: "backfillAll"
+    name: 'backfillAll'
     exactly_one_of:
       - backfill_all
       - backfill_none
@@ -1125,12 +1127,12 @@ properties:
       Backfill strategy to automatically backfill the Stream's objects. Specific objects can be excluded.
     properties:
       - !ruby/object:Api::Type::NestedObject
-        name: "mysqlExcludedObjects"
+        name: 'mysqlExcludedObjects'
         description: |
           MySQL data source objects to avoid backfilling.
         properties:
           - !ruby/object:Api::Type::Array
-            name: "mysqlDatabases"
+            name: 'mysqlDatabases'
             required: true
             min_size: 1
             description: |
@@ -1140,12 +1142,12 @@ properties:
                 MySQL database.
               properties:
                 - !ruby/object:Api::Type::String
-                  name: "database"
+                  name: 'database'
                   required: true
                   description: |
                     Database name.
                 - !ruby/object:Api::Type::Array
-                  name: "mysqlTables"
+                  name: 'mysqlTables'
                   min_size: 1
                   description: |
                     Tables in the database.
@@ -1154,12 +1156,12 @@ properties:
                       MySQL table.
                     properties:
                       - !ruby/object:Api::Type::String
-                        name: "table"
+                        name: 'table'
                         required: true
                         description: |
                           Table name.
                       - !ruby/object:Api::Type::Array
-                        name: "mysqlColumns"
+                        name: 'mysqlColumns'
                         min_size: 1
                         description: |
                           MySQL columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
@@ -1168,42 +1170,42 @@ properties:
                             MySQL Column.
                           properties:
                             - !ruby/object:Api::Type::String
-                              name: "column"
+                              name: 'column'
                               description: |
                                 Column name.
                             - !ruby/object:Api::Type::String
-                              name: "dataType"
+                              name: 'dataType'
                               description: |
                                 The MySQL data type. Full data types list can be found here:
                                 https://dev.mysql.com/doc/refman/8.0/en/data-types.html
                             - !ruby/object:Api::Type::Integer
-                              name: "length"
+                              name: 'length'
                               output: true
                               description: |
                                 Column length.
                             - !ruby/object:Api::Type::String
-                              name: "collation"
+                              name: 'collation'
                               description: |
                                 Column collation.
                             - !ruby/object:Api::Type::Boolean
-                              name: "primaryKey"
+                              name: 'primaryKey'
                               description: |
                                 Whether or not the column represents a primary key.
                             - !ruby/object:Api::Type::Boolean
-                              name: "nullable"
+                              name: 'nullable'
                               description: |
                                 Whether or not the column can accept a null value.
                             - !ruby/object:Api::Type::Integer
-                              name: "ordinalPosition"
+                              name: 'ordinalPosition'
                               description: |
                                 The ordinal position of the column in the table.
       - !ruby/object:Api::Type::NestedObject
-        name: "postgresqlExcludedObjects"
+        name: 'postgresqlExcludedObjects'
         description: |
           PostgreSQL data source objects to avoid backfilling.
         properties:
           - !ruby/object:Api::Type::Array
-            name: "postgresqlSchemas"
+            name: 'postgresqlSchemas'
             required: true
             min_size: 1
             description: |
@@ -1213,12 +1215,12 @@ properties:
                 PostgreSQL schema.
               properties:
                 - !ruby/object:Api::Type::String
-                  name: "schema"
+                  name: 'schema'
                   required: true
                   description: |
                     Database name.
                 - !ruby/object:Api::Type::Array
-                  name: "postgresqlTables"
+                  name: 'postgresqlTables'
                   min_size: 1
                   description: |
                     Tables in the schema.
@@ -1227,12 +1229,12 @@ properties:
                       PostgreSQL table.
                     properties:
                       - !ruby/object:Api::Type::String
-                        name: "table"
+                        name: 'table'
                         required: true
                         description: |
                           Table name.
                       - !ruby/object:Api::Type::Array
-                        name: "postgresqlColumns"
+                        name: 'postgresqlColumns'
                         min_size: 1
                         description: |
                           PostgreSQL columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
@@ -1241,48 +1243,48 @@ properties:
                             PostgreSQL Column.
                           properties:
                             - !ruby/object:Api::Type::String
-                              name: "column"
+                              name: 'column'
                               description: |
                                 Column name.
                             - !ruby/object:Api::Type::String
-                              name: "dataType"
+                              name: 'dataType'
                               description: |
                                 The PostgreSQL data type. Full data types list can be found here:
                                 https://www.postgresql.org/docs/current/datatype.html
                             - !ruby/object:Api::Type::Integer
-                              name: "length"
+                              name: 'length'
                               output: true
                               description: |
                                 Column length.
                             - !ruby/object:Api::Type::Integer
-                              name: "precision"
+                              name: 'precision'
                               output: true
                               description: |
                                 Column precision.
                             - !ruby/object:Api::Type::Integer
-                              name: "scale"
+                              name: 'scale'
                               output: true
                               description: |
                                 Column scale.
                             - !ruby/object:Api::Type::Boolean
-                              name: "primaryKey"
+                              name: 'primaryKey'
                               description: |
                                 Whether or not the column represents a primary key.
                             - !ruby/object:Api::Type::Boolean
-                              name: "nullable"
+                              name: 'nullable'
                               description: |
                                 Whether or not the column can accept a null value.
                             - !ruby/object:Api::Type::Integer
-                              name: "ordinalPosition"
+                              name: 'ordinalPosition'
                               description: |
                                 The ordinal position of the column in the table.
       - !ruby/object:Api::Type::NestedObject
-        name: "oracleExcludedObjects"
+        name: 'oracleExcludedObjects'
         description: |
           PostgreSQL data source objects to avoid backfilling.
         properties:
           - !ruby/object:Api::Type::Array
-            name: "oracleSchemas"
+            name: 'oracleSchemas'
             required: true
             min_size: 1
             description: |
@@ -1292,12 +1294,12 @@ properties:
                 MySQL database.
               properties:
                 - !ruby/object:Api::Type::String
-                  name: "schema"
+                  name: 'schema'
                   required: true
                   description: |
                     Schema name.
                 - !ruby/object:Api::Type::Array
-                  name: "oracleTables"
+                  name: 'oracleTables'
                   min_size: 1
                   description: |
                     Tables in the database.
@@ -1306,12 +1308,12 @@ properties:
                       Oracle table.
                     properties:
                       - !ruby/object:Api::Type::String
-                        name: "table"
+                        name: 'table'
                         required: true
                         description: |
                           Table name.
                       - !ruby/object:Api::Type::Array
-                        name: "oracleColumns"
+                        name: 'oracleColumns'
                         min_size: 1
                         description: |
                           Oracle columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
@@ -1320,58 +1322,57 @@ properties:
                             Oracle Column.
                           properties:
                             - !ruby/object:Api::Type::String
-                              name: "column"
+                              name: 'column'
                               description: |
                                 Column name.
                             - !ruby/object:Api::Type::String
-                              name: "dataType"
+                              name: 'dataType'
                               description: |
                                 The Oracle data type. Full data types list can be found here:
                                 https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Data-Types.html
                             - !ruby/object:Api::Type::Integer
-                              name: "length"
+                              name: 'length'
                               output: true
                               description: |
                                 Column length.
                             - !ruby/object:Api::Type::Integer
-                              name: "precision"
+                              name: 'precision'
                               output: true
                               description: |
                                 Column precision.
                             - !ruby/object:Api::Type::Integer
-                              name: "scale"
+                              name: 'scale'
                               output: true
                               description: |
                                 Column scale.
                             - !ruby/object:Api::Type::String
-                              name: "encoding"
+                              name: 'encoding'
                               output: true
                               description: |
                                 Column encoding.
                             - !ruby/object:Api::Type::Boolean
-                              name: "primaryKey"
+                              name: 'primaryKey'
                               output: true
                               description: |
                                 Whether or not the column represents a primary key.
                             - !ruby/object:Api::Type::Boolean
-                              name: "nullable"
+                              name: 'nullable'
                               output: true
                               description: |
                                 Whether or not the column can accept a null value.
                             - !ruby/object:Api::Type::Integer
-                              name: "ordinalPosition"
+                              name: 'ordinalPosition'
                               output: true
                               description: |
                                 The ordinal position of the column in the table.
       - !ruby/object:Api::Type::NestedObject
-        name: "sqlServerExcludedObjects"
+        name: 'sqlServerExcludedObjects'
         min_version: beta
-        required: false
         description: |
           SQL Server data source objects to avoid backfilling.
         properties:
           - !ruby/object:Api::Type::Array
-            name: "schemas"
+            name: 'schemas'
             required: true
             min_size: 1
             description: |
@@ -1381,12 +1382,12 @@ properties:
                 SQL Server database.
               properties:
                 - !ruby/object:Api::Type::String
-                  name: "schema"
+                  name: 'schema'
                   required: true
                   description: |
                     Schema name.
                 - !ruby/object:Api::Type::Array
-                  name: "tables"
+                  name: 'tables'
                   min_size: 1
                   description: |
                     Tables in the database.
@@ -1395,12 +1396,12 @@ properties:
                       SQL Server table.
                     properties:
                       - !ruby/object:Api::Type::String
-                        name: "table"
+                        name: 'table'
                         required: true
                         description: |
                           Table name.
                       - !ruby/object:Api::Type::Array
-                        name: "columns"
+                        name: 'columns'
                         min_size: 1
                         description: |
                           SQL Server columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
@@ -1409,51 +1410,51 @@ properties:
                             SQL Server Column.
                           properties:
                             - !ruby/object:Api::Type::String
-                              name: "column"
+                              name: 'column'
                               description: |
                                 Column name.
                             - !ruby/object:Api::Type::String
-                              name: "dataType"
+                              name: 'dataType'
                               description: |
                                 The SQL Server data type. Full data types list can be found here:
                                 https://learn.microsoft.com/en-us/sql/t-sql/data-types/data-types-transact-sql?view=sql-server-ver16
                             - !ruby/object:Api::Type::Integer
-                              name: "length"
+                              name: 'length'
                               output: true
                               description: |
                                 Column length.
                             - !ruby/object:Api::Type::Integer
-                              name: "precision"
+                              name: 'precision'
                               output: true
                               description: |
                                 Column precision.
                             - !ruby/object:Api::Type::Integer
-                              name: "scale"
+                              name: 'scale'
                               output: true
                               description: |
                                 Column scale.
                             - !ruby/object:Api::Type::String
-                              name: "encoding"
+                              name: 'encoding'
                               output: true
                               description: |
                                 Column encoding.
                             - !ruby/object:Api::Type::Boolean
-                              name: "primaryKey"
+                              name: 'primaryKey'
                               output: true
                               description: |
                                 Whether or not the column represents a primary key.
                             - !ruby/object:Api::Type::Boolean
-                              name: "nullable"
+                              name: 'nullable'
                               output: true
                               description: |
                                 Whether or not the column can accept a null value.
                             - !ruby/object:Api::Type::Integer
-                              name: "ordinalPosition"
+                              name: 'ordinalPosition'
                               output: true
                               description: |
                                 The ordinal position of the column in the table.
   - !ruby/object:Api::Type::NestedObject
-    name: "backfillNone"
+    name: 'backfillNone'
     exactly_one_of:
       - backfill_all
       - backfill_none
@@ -1463,7 +1464,7 @@ properties:
       Backfill strategy to disable automatic backfill for the Stream's objects.
     properties: []
   - !ruby/object:Api::Type::String
-    name: "customerManagedEncryptionKey"
+    name: 'customerManagedEncryptionKey'
     immutable: true
     description: |
       A reference to a KMS encryption key. If provided, it will be used to encrypt the data. If left blank, data

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -440,37 +440,30 @@ properties:
                                     https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Data-Types.html
                                 - !ruby/object:Api::Type::Integer
                                   name: 'length'
-                                  output: true
                                   description: |
                                     Column length.
                                 - !ruby/object:Api::Type::Integer
                                   name: 'precision'
-                                  output: true
                                   description: |
                                     Column precision.
                                 - !ruby/object:Api::Type::Integer
                                   name: 'scale'
-                                  output: true
                                   description: |
                                     Column scale.
                                 - !ruby/object:Api::Type::String
                                   name: 'encoding'
-                                  output: true
                                   description: |
                                     Column encoding.
                                 - !ruby/object:Api::Type::Boolean
                                   name: 'primaryKey'
-                                  output: true
                                   description: |
                                     Whether or not the column represents a primary key.
                                 - !ruby/object:Api::Type::Boolean
                                   name: 'nullable'
-                                  output: true
                                   description: |
                                     Whether or not the column can accept a null value.
                                 - !ruby/object:Api::Type::Integer
                                   name: 'ordinalPosition'
-                                  output: true
                                   description: |
                                     The ordinal position of the column in the table.
           - !ruby/object:Api::Type::NestedObject
@@ -527,37 +520,30 @@ properties:
                                     https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Data-Types.html
                                 - !ruby/object:Api::Type::Integer
                                   name: 'length'
-                                  output: true
                                   description: |
                                     Column length.
                                 - !ruby/object:Api::Type::Integer
                                   name: 'precision'
-                                  output: true
                                   description: |
                                     Column precision.
                                 - !ruby/object:Api::Type::Integer
                                   name: 'scale'
-                                  output: true
                                   description: |
                                     Column scale.
                                 - !ruby/object:Api::Type::String
                                   name: 'encoding'
-                                  output: true
                                   description: |
                                     Column encoding.
                                 - !ruby/object:Api::Type::Boolean
                                   name: 'primaryKey'
-                                  output: true
                                   description: |
                                     Whether or not the column represents a primary key.
                                 - !ruby/object:Api::Type::Boolean
                                   name: 'nullable'
-                                  output: true
                                   description: |
                                     Whether or not the column can accept a null value.
                                 - !ruby/object:Api::Type::Integer
                                   name: 'ordinalPosition'
-                                  output: true
                                   description: |
                                     The ordinal position of the column in the table.
           - !ruby/object:Api::Type::Integer

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -109,6 +109,7 @@ examples:
       destination_connection_profile_id: 'destination-profile'
   - !ruby/object:Provider::Terraform::Examples
     name: 'datastream_stream_sql_server'
+    min_version: beta
     primary_resource_id: 'default'
     skip_test: true
     vars:
@@ -771,6 +772,7 @@ properties:
               function: 'validation.IntAtLeast(0)'
       - !ruby/object:Api::Type::NestedObject
         name: 'sqlServerSourceConfig'
+        min_version: beta
         allow_empty_object: true
         send_empty_value: true
         exactly_one_of:
@@ -1353,6 +1355,7 @@ properties:
                                 The ordinal position of the column in the table.
       - !ruby/object:Api::Type::NestedObject
         name: 'sqlServerExcludedObjects'
+        min_version: beta
         description: |
           SQL Server data source objects to avoid backfilling.
         properties:

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -441,30 +441,37 @@ properties:
                                     https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Data-Types.html
                                 - !ruby/object:Api::Type::Integer
                                   name: 'length'
+                                  output: true
                                   description: |
                                     Column length.
                                 - !ruby/object:Api::Type::Integer
                                   name: 'precision'
+                                  output: true
                                   description: |
                                     Column precision.
                                 - !ruby/object:Api::Type::Integer
                                   name: 'scale'
+                                  output: true
                                   description: |
                                     Column scale.
                                 - !ruby/object:Api::Type::String
                                   name: 'encoding'
+                                  output: true
                                   description: |
                                     Column encoding.
                                 - !ruby/object:Api::Type::Boolean
                                   name: 'primaryKey'
+                                  output: true
                                   description: |
                                     Whether or not the column represents a primary key.
                                 - !ruby/object:Api::Type::Boolean
                                   name: 'nullable'
+                                  output: true
                                   description: |
                                     Whether or not the column can accept a null value.
                                 - !ruby/object:Api::Type::Integer
                                   name: 'ordinalPosition'
+                                  output: true
                                   description: |
                                     The ordinal position of the column in the table.
           - !ruby/object:Api::Type::NestedObject
@@ -521,30 +528,37 @@ properties:
                                     https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Data-Types.html
                                 - !ruby/object:Api::Type::Integer
                                   name: 'length'
+                                  output: true
                                   description: |
                                     Column length.
                                 - !ruby/object:Api::Type::Integer
                                   name: 'precision'
+                                  output: true
                                   description: |
                                     Column precision.
                                 - !ruby/object:Api::Type::Integer
                                   name: 'scale'
+                                  output: true
                                   description: |
                                     Column scale.
                                 - !ruby/object:Api::Type::String
                                   name: 'encoding'
+                                  output: true
                                   description: |
                                     Column encoding.
                                 - !ruby/object:Api::Type::Boolean
                                   name: 'primaryKey'
+                                  output: true
                                   description: |
                                     Whether or not the column represents a primary key.
                                 - !ruby/object:Api::Type::Boolean
                                   name: 'nullable'
+                                  output: true
                                   description: |
                                     Whether or not the column can accept a null value.
                                 - !ruby/object:Api::Type::Integer
                                   name: 'ordinalPosition'
+                                  output: true
                                   description: |
                                     The ordinal position of the column in the table.
           - !ruby/object:Api::Type::Integer

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -109,7 +109,6 @@ examples:
       destination_connection_profile_id: 'destination-profile'
   - !ruby/object:Provider::Terraform::Examples
     name: 'datastream_stream_sql_server'
-    min_version: beta
     primary_resource_id: 'default'
     skip_test: true
     vars:
@@ -786,7 +785,6 @@ properties:
               function: 'validation.IntAtLeast(0)'
       - !ruby/object:Api::Type::NestedObject
         name: 'sqlServerSourceConfig'
-        min_version: beta
         allow_empty_object: true
         send_empty_value: true
         exactly_one_of:
@@ -1369,7 +1367,6 @@ properties:
                                 The ordinal position of the column in the table.
       - !ruby/object:Api::Type::NestedObject
         name: 'sqlServerExcludedObjects'
-        min_version: beta
         description: |
           SQL Server data source objects to avoid backfilling.
         properties:

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -11,25 +11,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
---- !ruby/object:Api::Resource
-name: 'Stream'
-base_url: 'projects/{{project}}/locations/{{location}}/streams'
-create_url: 'projects/{{project}}/locations/{{location}}/streams?streamId={{stream_id}}'
-self_link: 'projects/{{project}}/locations/{{location}}/streams/{{stream_id}}'
+---
+!ruby/object:Api::Resource
+name: "Stream"
+base_url: "projects/{{project}}/locations/{{location}}/streams"
+create_url: "projects/{{project}}/locations/{{location}}/streams?streamId={{stream_id}}"
+self_link: "projects/{{project}}/locations/{{location}}/streams/{{stream_id}}"
 update_verb: :PATCH
 update_mask: true
 references: !ruby/object:Api::Resource::ReferenceLinks
   guides:
-    'Official Documentation': 'https://cloud.google.com/datastream/docs/create-a-stream'
-  api: 'https://cloud.google.com/datastream/docs/reference/rest/v1/projects.locations.streams'
+    "Official Documentation": "https://cloud.google.com/datastream/docs/create-a-stream"
+  api: "https://cloud.google.com/datastream/docs/reference/rest/v1/projects.locations.streams"
 description: |
   A resource representing streaming data from a source to a destination.
 id_format: projects/{{project}}/locations/{{location}}/streams/{{stream_id}}
 import_format:
-  ['projects/{{project}}/locations/{{location}}/streams/{{stream_id}}']
+  ["projects/{{project}}/locations/{{location}}/streams/{{stream_id}}"]
 virtual_fields:
   - !ruby/object:Api::Type::Enum
-    name: 'desired_state'
+    name: "desired_state"
     description: |
       Desired state of the Stream. Set this field to `RUNNING` to start the stream, and `PAUSED` to pause the stream.
     values:
@@ -38,110 +39,115 @@ virtual_fields:
       - :PAUSED
     default_value: :NOT_STARTED
 custom_code: !ruby/object:Provider::Terraform::CustomCode
-  constants: 'templates/terraform/constants/datastream_stream.go.erb'
-  post_create: 'templates/terraform/post_create/datastream_stream.go.erb'
-  post_import: 'templates/terraform/post_import/datastream_stream.go.erb'
-  pre_update: 'templates/terraform/pre_update/datastream_stream.go.erb'
-  post_update: 'templates/terraform/post_update/datastream_stream.go.erb'
-  encoder: 'templates/terraform/encoders/datastream_stream.go.erb'
-custom_diff: [
-  'resourceDatastreamStreamCustomDiff',
-]
+  constants: "templates/terraform/constants/datastream_stream.go.erb"
+  post_create: "templates/terraform/post_create/datastream_stream.go.erb"
+  post_import: "templates/terraform/post_import/datastream_stream.go.erb"
+  pre_update: "templates/terraform/pre_update/datastream_stream.go.erb"
+  post_update: "templates/terraform/post_update/datastream_stream.go.erb"
+  encoder: "templates/terraform/encoders/datastream_stream.go.erb"
+custom_diff: ["resourceDatastreamStreamCustomDiff"]
 examples:
   - !ruby/object:Provider::Terraform::Examples
-    name: 'datastream_stream_basic'
+    name: "datastream_stream_basic"
     pull_external: true
-    primary_resource_id: 'default'
+    primary_resource_id: "default"
     skip_docs:
       true
       # Random provider
     skip_vcr: true
     vars:
-      stream_id: 'my-stream'
-      private_connection_id: 'my-connection'
-      network_name: 'my-network'
-      source_connection_profile_id: 'source-profile'
-      database_instance_name: 'my-instance'
-      deletion_protection: 'true'
-      bucket_name: 'my-bucket'
-      destination_connection_profile_id: 'destination-profile'
+      stream_id: "my-stream"
+      private_connection_id: "my-connection"
+      network_name: "my-network"
+      source_connection_profile_id: "source-profile"
+      database_instance_name: "my-instance"
+      deletion_protection: "true"
+      bucket_name: "my-bucket"
+      destination_connection_profile_id: "destination-profile"
     test_vars_overrides:
-      deletion_protection: 'false'
+      deletion_protection: "false"
     oics_vars_overrides:
-      deletion_protection: 'false'
+      deletion_protection: "false"
   - !ruby/object:Provider::Terraform::Examples
-    name: 'datastream_stream_full'
+    name: "datastream_stream_full"
     pull_external: true
     primary_resource_id:
-      'default'
+      "default"
       # Random provider
     skip_vcr: true
     vars:
-      stream_id: 'my-stream'
-      private_connection_id: 'my-connection'
-      network_name: 'my-network'
-      source_connection_profile_id: 'source-profile'
-      database_instance_name: 'my-instance'
-      deletion_protection: 'true'
-      bucket_name: 'my-bucket'
-      destination_connection_profile_id: 'destination-profile'
-      stream_cmek: 'kms-name'
+      stream_id: "my-stream"
+      private_connection_id: "my-connection"
+      network_name: "my-network"
+      source_connection_profile_id: "source-profile"
+      database_instance_name: "my-instance"
+      deletion_protection: "true"
+      bucket_name: "my-bucket"
+      destination_connection_profile_id: "destination-profile"
+      stream_cmek: "kms-name"
     test_vars_overrides:
-      deletion_protection: 'false'
+      deletion_protection: "false"
       stream_cmek: 'acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
     oics_vars_overrides:
-      deletion_protection: 'false'
+      deletion_protection: "false"
   - !ruby/object:Provider::Terraform::Examples
-    name: 'datastream_stream_postgresql'
-    primary_resource_id: 'default'
+    name: "datastream_stream_postgresql"
+    primary_resource_id: "default"
     skip_test: true
     vars:
-      stream_id: 'my-stream'
-      source_connection_profile_id: 'source-profile'
-      destination_connection_profile_id: 'destination-profile'
+      stream_id: "my-stream"
+      source_connection_profile_id: "source-profile"
+      destination_connection_profile_id: "destination-profile"
   - !ruby/object:Provider::Terraform::Examples
-    name: 'datastream_stream_oracle'
-    primary_resource_id: 'default'
+    name: "datastream_stream_oracle"
+    primary_resource_id: "default"
     skip_test: true
     vars:
-      stream_id: 'my-stream'
-      source_connection_profile_id: 'source-profile'
-      destination_connection_profile_id: 'destination-profile'
+      stream_id: "my-stream"
+      source_connection_profile_id: "source-profile"
+      destination_connection_profile_id: "destination-profile"
   - !ruby/object:Provider::Terraform::Examples
-    name: 'datastream_stream_postgresql_bigquery_dataset_id'
-    primary_resource_id: 'default'
+    name: "datastream_stream_sql_server"
+    primary_resource_id: "default"
+    skip_test: true
     vars:
-      dataset_id: 'postgres'
-      stream_id: 'postgres-bigquery'
-      dest_connection_profile_id: 'dest-profile'
-      instance_name: 'instance-name'
-      sql_user_name: 'my-user'
-      source_connection_profile_id: 'source-profile'
+      stream_id: "my-stream"
+      source_connection_profile_id: "source-profile"
+      destination_connection_profile_id: "destination-profile"
+  - !ruby/object:Provider::Terraform::Examples
+    name: "datastream_stream_postgresql_bigquery_dataset_id"
+    primary_resource_id: "default"
+    vars:
+      dataset_id: "postgres"
+      stream_id: "postgres-bigquery"
+      dest_connection_profile_id: "dest-profile"
+      instance_name: "instance-name"
+      sql_user_name: "my-user"
+      source_connection_profile_id: "source-profile"
     pull_external: true
     # Random provider
     skip_vcr: true
   - !ruby/object:Provider::Terraform::Examples
-    name: 'datastream_stream_bigquery'
+    name: "datastream_stream_bigquery"
     pull_external: true
     primary_resource_id:
-      'default'
+      "default"
       # Random provider
     skip_vcr: true
     vars:
-      stream_id: 'my-stream'
-      private_connection_id: 'my-connection'
-      network_name: 'my-network'
-      source_connection_profile_id: 'source-profile'
-      database_instance_name: 'my-instance'
-      deletion_protection: 'true'
-      destination_connection_profile_id: 'destination-profile'
-      bigquery_destination_table_kms_key_name: 'bigquery-kms-name'
+      stream_id: "my-stream"
+      private_connection_id: "my-connection"
+      network_name: "my-network"
+      source_connection_profile_id: "source-profile"
+      database_instance_name: "my-instance"
+      deletion_protection: "true"
+      destination_connection_profile_id: "destination-profile"
+      bigquery_destination_table_kms_key_name: "bigquery-kms-name"
     test_vars_overrides:
-      deletion_protection: 'false'
-      bigquery_destination_table_kms_key_name:
-        'acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
+      deletion_protection: "false"
+      bigquery_destination_table_kms_key_name: 'acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
     oics_vars_overrides:
-      deletion_protection: 'false'
+      deletion_protection: "false"
 parameters:
   - !ruby/object:Api::Type::String
     name: streamId
@@ -151,7 +157,7 @@ parameters:
     immutable: true
     url_param_only: true
   - !ruby/object:Api::Type::String
-    name: 'location'
+    name: "location"
     description: |
       The name of the location this stream is located in.
     required: true
@@ -159,31 +165,31 @@ parameters:
     url_param_only: true
 properties:
   - !ruby/object:Api::Type::String
-    name: 'name'
+    name: "name"
     output: true
     description: The stream's name.
   - !ruby/object:Api::Type::KeyValueLabels
-    name: 'labels'
+    name: "labels"
     description: Labels.
   - !ruby/object:Api::Type::String
-    name: 'displayName'
+    name: "displayName"
     required: true
     description: Display name.
   - !ruby/object:Api::Type::NestedObject
-    name: 'sourceConfig'
+    name: "sourceConfig"
     required: true
     description: |
       Source connection profile configuration.
     properties:
       - !ruby/object:Api::Type::String
-        name: 'sourceConnectionProfile'
+        name: "sourceConnectionProfile"
         immutable: true
         required: true
         description: |
           Source connection profile resource. Format: projects/{project}/locations/{location}/connectionProfiles/{name}
-        diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
+        diff_suppress_func: "tpgresource.ProjectNumberDiffSuppress"
       - !ruby/object:Api::Type::NestedObject
-        name: 'mysqlSourceConfig'
+        name: "mysqlSourceConfig"
         allow_empty_object: true
         send_empty_value: true
         exactly_one_of:
@@ -195,12 +201,12 @@ properties:
           MySQL data source configuration.
         properties:
           - !ruby/object:Api::Type::NestedObject
-            name: 'includeObjects'
+            name: "includeObjects"
             description: |
               MySQL objects to retrieve from the source.
             properties:
               - !ruby/object:Api::Type::Array
-                name: 'mysqlDatabases'
+                name: "mysqlDatabases"
                 required: true
                 min_size: 1
                 description: |
@@ -210,12 +216,12 @@ properties:
                     MySQL database.
                   properties:
                     - !ruby/object:Api::Type::String
-                      name: 'database'
+                      name: "database"
                       required: true
                       description: |
                         Database name.
                     - !ruby/object:Api::Type::Array
-                      name: 'mysqlTables'
+                      name: "mysqlTables"
                       min_size: 1
                       description: |
                         Tables in the database.
@@ -224,12 +230,12 @@ properties:
                           MySQL table.
                         properties:
                           - !ruby/object:Api::Type::String
-                            name: 'table'
+                            name: "table"
                             required: true
                             description: |
                               Table name.
                           - !ruby/object:Api::Type::Array
-                            name: 'mysqlColumns'
+                            name: "mysqlColumns"
                             min_size: 1
                             description: |
                               MySQL columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
@@ -238,42 +244,42 @@ properties:
                                 MySQL Column.
                               properties:
                                 - !ruby/object:Api::Type::String
-                                  name: 'column'
+                                  name: "column"
                                   description: |
                                     Column name.
                                 - !ruby/object:Api::Type::String
-                                  name: 'dataType'
+                                  name: "dataType"
                                   description: |
                                     The MySQL data type. Full data types list can be found here:
                                     https://dev.mysql.com/doc/refman/8.0/en/data-types.html
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'length'
+                                  name: "length"
                                   output: true
                                   description: |
                                     Column length.
                                 - !ruby/object:Api::Type::String
-                                  name: 'collation'
+                                  name: "collation"
                                   description: |
                                     Column collation.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: 'primaryKey'
+                                  name: "primaryKey"
                                   description: |
                                     Whether or not the column represents a primary key.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: 'nullable'
+                                  name: "nullable"
                                   description: |
                                     Whether or not the column can accept a null value.
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'ordinalPosition'
+                                  name: "ordinalPosition"
                                   description: |
                                     The ordinal position of the column in the table.
           - !ruby/object:Api::Type::NestedObject
-            name: 'excludeObjects'
+            name: "excludeObjects"
             description: |
               MySQL objects to exclude from the stream.
             properties:
               - !ruby/object:Api::Type::Array
-                name: 'mysqlDatabases'
+                name: "mysqlDatabases"
                 required: true
                 min_size: 1
                 description: |
@@ -283,12 +289,12 @@ properties:
                     MySQL database.
                   properties:
                     - !ruby/object:Api::Type::String
-                      name: 'database'
+                      name: "database"
                       required: true
                       description: |
                         Database name.
                     - !ruby/object:Api::Type::Array
-                      name: 'mysqlTables'
+                      name: "mysqlTables"
                       min_size: 1
                       description: |
                         Tables in the database.
@@ -297,12 +303,12 @@ properties:
                           MySQL table.
                         properties:
                           - !ruby/object:Api::Type::String
-                            name: 'table'
+                            name: "table"
                             required: true
                             description: |
                               Table name.
                           - !ruby/object:Api::Type::Array
-                            name: 'mysqlColumns'
+                            name: "mysqlColumns"
                             min_size: 1
                             description: |
                               MySQL columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
@@ -311,55 +317,55 @@ properties:
                                 MySQL Column.
                               properties:
                                 - !ruby/object:Api::Type::String
-                                  name: 'column'
+                                  name: "column"
                                   description: |
                                     Column name.
                                 - !ruby/object:Api::Type::String
-                                  name: 'dataType'
+                                  name: "dataType"
                                   description: |
                                     The MySQL data type. Full data types list can be found here:
                                     https://dev.mysql.com/doc/refman/8.0/en/data-types.html
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'length'
+                                  name: "length"
                                   output: true
                                   description: |
                                     Column length.
                                 - !ruby/object:Api::Type::String
-                                  name: 'collation'
+                                  name: "collation"
                                   description: |
                                     Column collation.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: 'primaryKey'
+                                  name: "primaryKey"
                                   description: |
                                     Whether or not the column represents a primary key.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: 'nullable'
+                                  name: "nullable"
                                   description: |
                                     Whether or not the column can accept a null value.
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'ordinalPosition'
+                                  name: "ordinalPosition"
                                   description: |
                                     The ordinal position of the column in the table.
           - !ruby/object:Api::Type::Integer
-            name: 'maxConcurrentCdcTasks'
+            name: "maxConcurrentCdcTasks"
             send_empty_value: true
             description: |
               Maximum number of concurrent CDC tasks. The number should be non negative.
               If not set (or set to 0), the system's default value will be used.
             default_from_api: true
             validation: !ruby/object:Provider::Terraform::Validation
-              function: 'validation.IntAtLeast(0)'
+              function: "validation.IntAtLeast(0)"
           - !ruby/object:Api::Type::Integer
-            name: 'maxConcurrentBackfillTasks'
+            name: "maxConcurrentBackfillTasks"
             send_empty_value: true
             description: |
               Maximum number of concurrent backfill tasks. The number should be non negative.
               If not set (or set to 0), the system's default value will be used.
             default_from_api: true
             validation: !ruby/object:Provider::Terraform::Validation
-              function: 'validation.IntAtLeast(0)'
+              function: "validation.IntAtLeast(0)"
       - !ruby/object:Api::Type::NestedObject
-        name: 'oracleSourceConfig'
+        name: "oracleSourceConfig"
         allow_empty_object: true
         send_empty_value: true
         exactly_one_of:
@@ -371,12 +377,12 @@ properties:
           MySQL data source configuration.
         properties:
           - !ruby/object:Api::Type::NestedObject
-            name: 'includeObjects'
+            name: "includeObjects"
             description: |
               Oracle objects to retrieve from the source.
             properties:
               - !ruby/object:Api::Type::Array
-                name: 'oracleSchemas'
+                name: "oracleSchemas"
                 required: true
                 min_size: 1
                 description: |
@@ -386,12 +392,12 @@ properties:
                     MySQL database.
                   properties:
                     - !ruby/object:Api::Type::String
-                      name: 'schema'
+                      name: "schema"
                       required: true
                       description: |
                         Schema name.
                     - !ruby/object:Api::Type::Array
-                      name: 'oracleTables'
+                      name: "oracleTables"
                       min_size: 1
                       description: |
                         Tables in the database.
@@ -400,12 +406,12 @@ properties:
                           Oracle table.
                         properties:
                           - !ruby/object:Api::Type::String
-                            name: 'table'
+                            name: "table"
                             required: true
                             description: |
                               Table name.
                           - !ruby/object:Api::Type::Array
-                            name: 'oracleColumns'
+                            name: "oracleColumns"
                             min_size: 1
                             description: |
                               Oracle columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
@@ -414,56 +420,56 @@ properties:
                                 Oracle Column.
                               properties:
                                 - !ruby/object:Api::Type::String
-                                  name: 'column'
+                                  name: "column"
                                   description: |
                                     Column name.
                                 - !ruby/object:Api::Type::String
-                                  name: 'dataType'
+                                  name: "dataType"
                                   description: |
                                     The Oracle data type. Full data types list can be found here:
                                     https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Data-Types.html
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'length'
+                                  name: "length"
                                   output: true
                                   description: |
                                     Column length.
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'precision'
+                                  name: "precision"
                                   output: true
                                   description: |
                                     Column precision.
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'scale'
+                                  name: "scale"
                                   output: true
                                   description: |
                                     Column scale.
                                 - !ruby/object:Api::Type::String
-                                  name: 'encoding'
+                                  name: "encoding"
                                   output: true
                                   description: |
                                     Column encoding.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: 'primaryKey'
+                                  name: "primaryKey"
                                   output: true
                                   description: |
                                     Whether or not the column represents a primary key.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: 'nullable'
+                                  name: "nullable"
                                   output: true
                                   description: |
                                     Whether or not the column can accept a null value.
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'ordinalPosition'
+                                  name: "ordinalPosition"
                                   output: true
                                   description: |
                                     The ordinal position of the column in the table.
           - !ruby/object:Api::Type::NestedObject
-            name: 'excludeObjects'
+            name: "excludeObjects"
             description: |
               Oracle objects to exclude from the stream.
             properties:
               - !ruby/object:Api::Type::Array
-                name: 'oracleSchemas'
+                name: "oracleSchemas"
                 required: true
                 min_size: 1
                 description: |
@@ -473,12 +479,12 @@ properties:
                     MySQL database.
                   properties:
                     - !ruby/object:Api::Type::String
-                      name: 'schema'
+                      name: "schema"
                       required: true
                       description: |
                         Schema name.
                     - !ruby/object:Api::Type::Array
-                      name: 'oracleTables'
+                      name: "oracleTables"
                       min_size: 1
                       description: |
                         Tables in the database.
@@ -487,12 +493,12 @@ properties:
                           Oracle table.
                         properties:
                           - !ruby/object:Api::Type::String
-                            name: 'table'
+                            name: "table"
                             required: true
                             description: |
                               Table name.
                           - !ruby/object:Api::Type::Array
-                            name: 'oracleColumns'
+                            name: "oracleColumns"
                             min_size: 1
                             description: |
                               Oracle columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
@@ -501,83 +507,83 @@ properties:
                                 Oracle Column.
                               properties:
                                 - !ruby/object:Api::Type::String
-                                  name: 'column'
+                                  name: "column"
                                   description: |
                                     Column name.
                                 - !ruby/object:Api::Type::String
-                                  name: 'dataType'
+                                  name: "dataType"
                                   description: |
                                     The Oracle data type. Full data types list can be found here:
                                     https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Data-Types.html
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'length'
+                                  name: "length"
                                   output: true
                                   description: |
                                     Column length.
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'precision'
+                                  name: "precision"
                                   output: true
                                   description: |
                                     Column precision.
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'scale'
+                                  name: "scale"
                                   output: true
                                   description: |
                                     Column scale.
                                 - !ruby/object:Api::Type::String
-                                  name: 'encoding'
+                                  name: "encoding"
                                   output: true
                                   description: |
                                     Column encoding.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: 'primaryKey'
+                                  name: "primaryKey"
                                   output: true
                                   description: |
                                     Whether or not the column represents a primary key.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: 'nullable'
+                                  name: "nullable"
                                   output: true
                                   description: |
                                     Whether or not the column can accept a null value.
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'ordinalPosition'
+                                  name: "ordinalPosition"
                                   output: true
                                   description: |
                                     The ordinal position of the column in the table.
           - !ruby/object:Api::Type::Integer
-            name: 'maxConcurrentCdcTasks'
+            name: "maxConcurrentCdcTasks"
             send_empty_value: true
             description: |
               Maximum number of concurrent CDC tasks. The number should be non negative.
               If not set (or set to 0), the system's default value will be used.
             default_from_api: true
             validation: !ruby/object:Provider::Terraform::Validation
-              function: 'validation.IntAtLeast(0)'
+              function: "validation.IntAtLeast(0)"
           - !ruby/object:Api::Type::Integer
-            name: 'maxConcurrentBackfillTasks'
+            name: "maxConcurrentBackfillTasks"
             send_empty_value: true
             description: |
               Maximum number of concurrent backfill tasks. The number should be non negative.
               If not set (or set to 0), the system's default value will be used.
             default_from_api: true
             validation: !ruby/object:Provider::Terraform::Validation
-              function: 'validation.IntAtLeast(0)'
+              function: "validation.IntAtLeast(0)"
           - !ruby/object:Api::Type::NestedObject
-            name: 'dropLargeObjects'
+            name: "dropLargeObjects"
             allow_empty_object: true
             send_empty_value: true
             description: |
               Configuration to drop large object values.
             properties: []
           - !ruby/object:Api::Type::NestedObject
-            name: 'streamLargeObjects'
+            name: "streamLargeObjects"
             allow_empty_object: true
             send_empty_value: true
             description: |
               Configuration to drop large object values.
             properties: []
       - !ruby/object:Api::Type::NestedObject
-        name: 'postgresqlSourceConfig'
+        name: "postgresqlSourceConfig"
         allow_empty_object: true
         send_empty_value: true
         exactly_one_of:
@@ -589,12 +595,12 @@ properties:
           PostgreSQL data source configuration.
         properties:
           - !ruby/object:Api::Type::NestedObject
-            name: 'includeObjects'
+            name: "includeObjects"
             description: |
               PostgreSQL objects to retrieve from the source.
             properties:
               - !ruby/object:Api::Type::Array
-                name: 'postgresqlSchemas'
+                name: "postgresqlSchemas"
                 required: true
                 min_size: 1
                 description: |
@@ -604,12 +610,12 @@ properties:
                     PostgreSQL schema.
                   properties:
                     - !ruby/object:Api::Type::String
-                      name: 'schema'
+                      name: "schema"
                       required: true
                       description: |
                         Database name.
                     - !ruby/object:Api::Type::Array
-                      name: 'postgresqlTables'
+                      name: "postgresqlTables"
                       min_size: 1
                       description: |
                         Tables in the schema.
@@ -618,12 +624,12 @@ properties:
                           PostgreSQL table.
                         properties:
                           - !ruby/object:Api::Type::String
-                            name: 'table'
+                            name: "table"
                             required: true
                             description: |
                               Table name.
                           - !ruby/object:Api::Type::Array
-                            name: 'postgresqlColumns'
+                            name: "postgresqlColumns"
                             min_size: 1
                             description: |
                               PostgreSQL columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
@@ -632,48 +638,48 @@ properties:
                                 PostgreSQL Column.
                               properties:
                                 - !ruby/object:Api::Type::String
-                                  name: 'column'
+                                  name: "column"
                                   description: |
                                     Column name.
                                 - !ruby/object:Api::Type::String
-                                  name: 'dataType'
+                                  name: "dataType"
                                   description: |
                                     The PostgreSQL data type. Full data types list can be found here:
                                     https://www.postgresql.org/docs/current/datatype.html
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'length'
+                                  name: "length"
                                   output: true
                                   description: |
                                     Column length.
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'precision'
+                                  name: "precision"
                                   output: true
                                   description: |
                                     Column precision.
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'scale'
+                                  name: "scale"
                                   output: true
                                   description: |
                                     Column scale.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: 'primaryKey'
+                                  name: "primaryKey"
                                   description: |
                                     Whether or not the column represents a primary key.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: 'nullable'
+                                  name: "nullable"
                                   description: |
                                     Whether or not the column can accept a null value.
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'ordinalPosition'
+                                  name: "ordinalPosition"
                                   description: |
                                     The ordinal position of the column in the table.
           - !ruby/object:Api::Type::NestedObject
-            name: 'excludeObjects'
+            name: "excludeObjects"
             description: |
               PostgreSQL objects to exclude from the stream.
             properties:
               - !ruby/object:Api::Type::Array
-                name: 'postgresqlSchemas'
+                name: "postgresqlSchemas"
                 required: true
                 min_size: 1
                 description: |
@@ -683,12 +689,12 @@ properties:
                     PostgreSQL schema.
                   properties:
                     - !ruby/object:Api::Type::String
-                      name: 'schema'
+                      name: "schema"
                       required: true
                       description: |
                         Database name.
                     - !ruby/object:Api::Type::Array
-                      name: 'postgresqlTables'
+                      name: "postgresqlTables"
                       min_size: 1
                       description: |
                         Tables in the schema.
@@ -697,12 +703,12 @@ properties:
                           PostgreSQL table.
                         properties:
                           - !ruby/object:Api::Type::String
-                            name: 'table'
+                            name: "table"
                             required: true
                             description: |
                               Table name.
                           - !ruby/object:Api::Type::Array
-                            name: 'postgresqlColumns'
+                            name: "postgresqlColumns"
                             min_size: 1
                             description: |
                               PostgreSQL columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
@@ -711,64 +717,64 @@ properties:
                                 PostgreSQL Column.
                               properties:
                                 - !ruby/object:Api::Type::String
-                                  name: 'column'
+                                  name: "column"
                                   description: |
                                     Column name.
                                 - !ruby/object:Api::Type::String
-                                  name: 'dataType'
+                                  name: "dataType"
                                   description: |
                                     The PostgreSQL data type. Full data types list can be found here:
                                     https://www.postgresql.org/docs/current/datatype.html
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'length'
+                                  name: "length"
                                   output: true
                                   description: |
                                     Column length.
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'precision'
+                                  name: "precision"
                                   output: true
                                   description: |
                                     Column precision.
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'scale'
+                                  name: "scale"
                                   output: true
                                   description: |
                                     Column scale.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: 'primaryKey'
+                                  name: "primaryKey"
                                   description: |
                                     Whether or not the column represents a primary key.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: 'nullable'
+                                  name: "nullable"
                                   description: |
                                     Whether or not the column can accept a null value.
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'ordinalPosition'
+                                  name: "ordinalPosition"
                                   description: |
                                     The ordinal position of the column in the table.
           - !ruby/object:Api::Type::String
-            name: 'replicationSlot'
+            name: "replicationSlot"
             required: true
             description: |
               The name of the logical replication slot that's configured with
               the pgoutput plugin.
           - !ruby/object:Api::Type::String
-            name: 'publication'
+            name: "publication"
             required: true
             description: |
               The name of the publication that includes the set of all tables
               that are defined in the stream's include_objects.
           - !ruby/object:Api::Type::Integer
-            name: 'maxConcurrentBackfillTasks'
+            name: "maxConcurrentBackfillTasks"
             send_empty_value: true
             description: |
               Maximum number of concurrent backfill tasks. The number should be non
               negative. If not set (or set to 0), the system's default value will be used.
             default_from_api: true
             validation: !ruby/object:Provider::Terraform::Validation
-              function: 'validation.IntAtLeast(0)'
+              function: "validation.IntAtLeast(0)"
       - !ruby/object:Api::Type::NestedObject
-        name: 'sqlServerSourceConfig'
+        name: "sqlServerSourceConfig"
         min_version: beta
         allow_empty_object: true
         send_empty_value: true
@@ -781,12 +787,12 @@ properties:
           SQl Server data source configuration.
         properties:
           - !ruby/object:Api::Type::NestedObject
-            name: 'includeObjects'
+            name: "includeObjects"
             description: |
               SQL Server objects to retrieve from the source.
             properties:
               - !ruby/object:Api::Type::Array
-                name: 'schemas'
+                name: "schemas"
                 required: true
                 min_size: 1
                 description: |
@@ -796,12 +802,12 @@ properties:
                     SQL Server database.
                   properties:
                     - !ruby/object:Api::Type::String
-                      name: 'schema'
+                      name: "schema"
                       required: true
                       description: |
                         Schema name.
                     - !ruby/object:Api::Type::Array
-                      name: 'tables'
+                      name: "tables"
                       min_size: 1
                       description: |
                         Tables in the database.
@@ -810,12 +816,12 @@ properties:
                           SQL Server table.
                         properties:
                           - !ruby/object:Api::Type::String
-                            name: 'table'
+                            name: "table"
                             required: true
                             description: |
                               Table name.
                           - !ruby/object:Api::Type::Array
-                            name: 'columns'
+                            name: "columns"
                             min_size: 1
                             description: |
                               SQL Server columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
@@ -824,56 +830,56 @@ properties:
                                 SQL Server Column.
                               properties:
                                 - !ruby/object:Api::Type::String
-                                  name: 'column'
+                                  name: "column"
                                   description: |
                                     Column name.
                                 - !ruby/object:Api::Type::String
-                                  name: 'dataType'
+                                  name: "dataType"
                                   description: |
                                     The SQL Server data type. Full data types list can be found here:
                                     https://learn.microsoft.com/en-us/sql/t-sql/data-types/data-types-transact-sql?view=sql-server-ver16
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'length'
+                                  name: "length"
                                   output: true
                                   description: |
                                     Column length.
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'precision'
+                                  name: "precision"
                                   output: true
                                   description: |
                                     Column precision.
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'scale'
+                                  name: "scale"
                                   output: true
                                   description: |
                                     Column scale.
                                 - !ruby/object:Api::Type::String
-                                  name: 'encoding'
+                                  name: "encoding"
                                   output: true
                                   description: |
                                     Column encoding.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: 'primaryKey'
+                                  name: "primaryKey"
                                   output: true
                                   description: |
                                     Whether or not the column represents a primary key.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: 'nullable'
+                                  name: "nullable"
                                   output: true
                                   description: |
                                     Whether or not the column can accept a null value.
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'ordinalPosition'
+                                  name: "ordinalPosition"
                                   output: true
                                   description: |
                                     The ordinal position of the column in the table.
           - !ruby/object:Api::Type::NestedObject
-            name: 'excludeObjects'
+            name: "excludeObjects"
             description: |
               SQL Server objects to exclude from the stream.
             properties:
               - !ruby/object:Api::Type::Array
-                name: 'schemas'
+                name: "schemas"
                 required: true
                 min_size: 1
                 description: |
@@ -883,12 +889,12 @@ properties:
                     SQL Server database.
                   properties:
                     - !ruby/object:Api::Type::String
-                      name: 'schema'
+                      name: "schema"
                       required: true
                       description: |
                         Schema name.
                     - !ruby/object:Api::Type::Array
-                      name: 'tables'
+                      name: "tables"
                       min_size: 1
                       description: |
                         Tables in the database.
@@ -897,12 +903,12 @@ properties:
                           SQL Server table.
                         properties:
                           - !ruby/object:Api::Type::String
-                            name: 'table'
+                            name: "table"
                             required: true
                             description: |
                               Table name.
                           - !ruby/object:Api::Type::Array
-                            name: 'columns'
+                            name: "columns"
                             min_size: 1
                             description: |
                               SQL Server columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
@@ -911,82 +917,82 @@ properties:
                                 SQL Server Column.
                               properties:
                                 - !ruby/object:Api::Type::String
-                                  name: 'column'
+                                  name: "column"
                                   description: |
                                     Column name.
                                 - !ruby/object:Api::Type::String
-                                  name: 'dataType'
+                                  name: "dataType"
                                   description: |
                                     The SQL Server data type. Full data types list can be found here:
                                     https://learn.microsoft.com/en-us/sql/t-sql/data-types/data-types-transact-sql?view=sql-server-ver16
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'length'
+                                  name: "length"
                                   output: true
                                   description: |
                                     Column length.
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'precision'
+                                  name: "precision"
                                   output: true
                                   description: |
                                     Column precision.
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'scale'
+                                  name: "scale"
                                   output: true
                                   description: |
                                     Column scale.
                                 - !ruby/object:Api::Type::String
-                                  name: 'encoding'
+                                  name: "encoding"
                                   output: true
                                   description: |
                                     Column encoding.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: 'primaryKey'
+                                  name: "primaryKey"
                                   output: true
                                   description: |
                                     Whether or not the column represents a primary key.
                                 - !ruby/object:Api::Type::Boolean
-                                  name: 'nullable'
+                                  name: "nullable"
                                   output: true
                                   description: |
                                     Whether or not the column can accept a null value.
                                 - !ruby/object:Api::Type::Integer
-                                  name: 'ordinalPosition'
+                                  name: "ordinalPosition"
                                   output: true
                                   description: |
                                     The ordinal position of the column in the table.
           - !ruby/object:Api::Type::Integer
-            name: 'maxConcurrentCdcTasks'
+            name: "maxConcurrentCdcTasks"
             send_empty_value: true
             description: |
               Maximum number of concurrent CDC tasks. The number should be non negative.
               If not set (or set to 0), the system's default value will be used.
             default_from_api: true
             validation: !ruby/object:Provider::Terraform::Validation
-              function: 'validation.IntAtLeast(0)'
+              function: "validation.IntAtLeast(0)"
           - !ruby/object:Api::Type::Integer
-            name: 'maxConcurrentBackfillTasks'
+            name: "maxConcurrentBackfillTasks"
             send_empty_value: true
             description: |
               Maximum number of concurrent backfill tasks. The number should be non negative.
               If not set (or set to 0), the system's default value will be used.
             default_from_api: true
             validation: !ruby/object:Provider::Terraform::Validation
-              function: 'validation.IntAtLeast(0)'
+              function: "validation.IntAtLeast(0)"
   - !ruby/object:Api::Type::NestedObject
-    name: 'destinationConfig'
+    name: "destinationConfig"
     required: true
     description: |
       Destination connection profile configuration.
     properties:
       - !ruby/object:Api::Type::String
-        name: 'destinationConnectionProfile'
+        name: "destinationConnectionProfile"
         immutable: true
         required: true
         description: |
           Destination connection profile resource. Format: projects/{project}/locations/{location}/connectionProfiles/{name}
-        diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
+        diff_suppress_func: "tpgresource.ProjectNumberDiffSuppress"
       - !ruby/object:Api::Type::NestedObject
-        name: 'gcsDestinationConfig'
+        name: "gcsDestinationConfig"
         exactly_one_of:
           - destination_config.0.gcs_destination_config
           - destination_config.0.bigquery_destination_config
@@ -994,22 +1000,22 @@ properties:
           A configuration for how data should be loaded to Cloud Storage.
         properties:
           - !ruby/object:Api::Type::String
-            name: 'path'
+            name: "path"
             description: |
               Path inside the Cloud Storage bucket to write data to.
           - !ruby/object:Api::Type::Integer
-            name: 'fileRotationMb'
+            name: "fileRotationMb"
             description: |
               The maximum file size to be saved in the bucket.
             default_from_api: true
           - !ruby/object:Api::Type::String
-            name: 'fileRotationInterval'
+            name: "fileRotationInterval"
             description: |
               The maximum duration for which new events are added before a file is closed and a new file is created.
               A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s". Defaults to 900s.
             default_from_api: true
           - !ruby/object:Api::Type::NestedObject
-            name: 'avroFileFormat'
+            name: "avroFileFormat"
             exactly_one_of:
               - destination_config.0.gcs_destination_config.0.avro_file_format
               - destination_config.0.gcs_destination_config.0.json_file_format
@@ -1019,7 +1025,7 @@ properties:
               AVRO file format configuration.
             properties: []
           - !ruby/object:Api::Type::NestedObject
-            name: 'jsonFileFormat'
+            name: "jsonFileFormat"
             exactly_one_of:
               - destination_config.0.gcs_destination_config.0.avro_file_format
               - destination_config.0.gcs_destination_config.0.json_file_format
@@ -1027,21 +1033,21 @@ properties:
               JSON file format configuration.
             properties:
               - !ruby/object:Api::Type::Enum
-                name: 'schemaFileFormat'
+                name: "schemaFileFormat"
                 description: |
                   The schema file format along JSON data files.
                 values:
                   - NO_SCHEMA_FILE
                   - AVRO_SCHEMA_FILE
               - !ruby/object:Api::Type::Enum
-                name: 'compression'
+                name: "compression"
                 description: |
                   Compression of the loaded JSON file.
                 values:
                   - NO_COMPRESSION
                   - GZIP
       - !ruby/object:Api::Type::NestedObject
-        name: 'bigqueryDestinationConfig'
+        name: "bigqueryDestinationConfig"
         exactly_one_of:
           - destination_config.0.gcs_destination_config
           - destination_config.0.bigquery_destination_config
@@ -1049,14 +1055,14 @@ properties:
           A configuration for how data should be loaded to Cloud Storage.
         properties:
           - !ruby/object:Api::Type::String
-            name: 'dataFreshness'
+            name: "dataFreshness"
             description: |
               The guaranteed data freshness (in seconds) when querying tables created by the stream.
               Editing this field will only affect new tables created in the future, but existing tables
               will not be impacted. Lower values mean that queries will return fresher data, but may result in higher cost.
               A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s". Defaults to 900s.
           - !ruby/object:Api::Type::NestedObject
-            name: 'singleTargetDataset'
+            name: "singleTargetDataset"
             exactly_one_of:
               - destination_config.0.bigquery_destination_config.0.single_target_dataset
               - destination_config.0.bigquery_destination_config.0.source_hierarchy_datasets
@@ -1064,15 +1070,15 @@ properties:
               A single target dataset to which all data will be streamed.
             properties:
               - !ruby/object:Api::Type::String
-                name: 'datasetId'
+                name: "datasetId"
                 required: true
                 description: |
                   Dataset ID in the format projects/{project}/datasets/{dataset_id} or
                   {project}:{dataset_id}
-                custom_expand: 'templates/terraform/custom_expand/datastream_stream_dataset_id.go.erb'
+                custom_expand: "templates/terraform/custom_expand/datastream_stream_dataset_id.go.erb"
                 diff_suppress_func: resourceDatastreamStreamDatabaseIdDiffSuppress
           - !ruby/object:Api::Type::NestedObject
-            name: 'sourceHierarchyDatasets'
+            name: "sourceHierarchyDatasets"
             exactly_one_of:
               - destination_config.0.bigquery_destination_config.0.single_target_dataset
               - destination_config.0.bigquery_destination_config.0.source_hierarchy_datasets
@@ -1080,24 +1086,24 @@ properties:
               Destination datasets are created so that hierarchy of the destination data objects matches the source hierarchy.
             properties:
               - !ruby/object:Api::Type::NestedObject
-                name: 'datasetTemplate'
+                name: "datasetTemplate"
                 required: true
                 description: |
                   Dataset template used for dynamic dataset creation.
                 properties:
                   - !ruby/object:Api::Type::String
-                    name: 'location'
+                    name: "location"
                     required: true
                     description: |
                       The geographic location where the dataset should reside.
                       See https://cloud.google.com/bigquery/docs/locations for supported locations.
                   - !ruby/object:Api::Type::String
-                    name: 'datasetIdPrefix'
+                    name: "datasetIdPrefix"
                     description: |
                       If supplied, every created dataset will have its name prefixed by the provided value.
                       The prefix and name will be separated by an underscore. i.e. _.
                   - !ruby/object:Api::Type::String
-                    name: 'kmsKeyName'
+                    name: "kmsKeyName"
                     immutable: true
                     description: |
                       Describes the Cloud KMS encryption key that will be used to protect destination BigQuery
@@ -1105,11 +1111,11 @@ properties:
                       encryption key. i.e. projects/{project}/locations/{location}/keyRings/{key_ring}/cryptoKeys/{cryptoKey}.
                       See https://cloud.google.com/bigquery/docs/customer-managed-encryption for more information.
   - !ruby/object:Api::Type::String
-    name: 'state'
+    name: "state"
     description: The state of the stream.
     output: true
   - !ruby/object:Api::Type::NestedObject
-    name: 'backfillAll'
+    name: "backfillAll"
     exactly_one_of:
       - backfill_all
       - backfill_none
@@ -1119,12 +1125,12 @@ properties:
       Backfill strategy to automatically backfill the Stream's objects. Specific objects can be excluded.
     properties:
       - !ruby/object:Api::Type::NestedObject
-        name: 'mysqlExcludedObjects'
+        name: "mysqlExcludedObjects"
         description: |
           MySQL data source objects to avoid backfilling.
         properties:
           - !ruby/object:Api::Type::Array
-            name: 'mysqlDatabases'
+            name: "mysqlDatabases"
             required: true
             min_size: 1
             description: |
@@ -1134,12 +1140,12 @@ properties:
                 MySQL database.
               properties:
                 - !ruby/object:Api::Type::String
-                  name: 'database'
+                  name: "database"
                   required: true
                   description: |
                     Database name.
                 - !ruby/object:Api::Type::Array
-                  name: 'mysqlTables'
+                  name: "mysqlTables"
                   min_size: 1
                   description: |
                     Tables in the database.
@@ -1148,12 +1154,12 @@ properties:
                       MySQL table.
                     properties:
                       - !ruby/object:Api::Type::String
-                        name: 'table'
+                        name: "table"
                         required: true
                         description: |
                           Table name.
                       - !ruby/object:Api::Type::Array
-                        name: 'mysqlColumns'
+                        name: "mysqlColumns"
                         min_size: 1
                         description: |
                           MySQL columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
@@ -1162,42 +1168,42 @@ properties:
                             MySQL Column.
                           properties:
                             - !ruby/object:Api::Type::String
-                              name: 'column'
+                              name: "column"
                               description: |
                                 Column name.
                             - !ruby/object:Api::Type::String
-                              name: 'dataType'
+                              name: "dataType"
                               description: |
                                 The MySQL data type. Full data types list can be found here:
                                 https://dev.mysql.com/doc/refman/8.0/en/data-types.html
                             - !ruby/object:Api::Type::Integer
-                              name: 'length'
+                              name: "length"
                               output: true
                               description: |
                                 Column length.
                             - !ruby/object:Api::Type::String
-                              name: 'collation'
+                              name: "collation"
                               description: |
                                 Column collation.
                             - !ruby/object:Api::Type::Boolean
-                              name: 'primaryKey'
+                              name: "primaryKey"
                               description: |
                                 Whether or not the column represents a primary key.
                             - !ruby/object:Api::Type::Boolean
-                              name: 'nullable'
+                              name: "nullable"
                               description: |
                                 Whether or not the column can accept a null value.
                             - !ruby/object:Api::Type::Integer
-                              name: 'ordinalPosition'
+                              name: "ordinalPosition"
                               description: |
                                 The ordinal position of the column in the table.
       - !ruby/object:Api::Type::NestedObject
-        name: 'postgresqlExcludedObjects'
+        name: "postgresqlExcludedObjects"
         description: |
           PostgreSQL data source objects to avoid backfilling.
         properties:
           - !ruby/object:Api::Type::Array
-            name: 'postgresqlSchemas'
+            name: "postgresqlSchemas"
             required: true
             min_size: 1
             description: |
@@ -1207,12 +1213,12 @@ properties:
                 PostgreSQL schema.
               properties:
                 - !ruby/object:Api::Type::String
-                  name: 'schema'
+                  name: "schema"
                   required: true
                   description: |
                     Database name.
                 - !ruby/object:Api::Type::Array
-                  name: 'postgresqlTables'
+                  name: "postgresqlTables"
                   min_size: 1
                   description: |
                     Tables in the schema.
@@ -1221,12 +1227,12 @@ properties:
                       PostgreSQL table.
                     properties:
                       - !ruby/object:Api::Type::String
-                        name: 'table'
+                        name: "table"
                         required: true
                         description: |
                           Table name.
                       - !ruby/object:Api::Type::Array
-                        name: 'postgresqlColumns'
+                        name: "postgresqlColumns"
                         min_size: 1
                         description: |
                           PostgreSQL columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
@@ -1235,48 +1241,48 @@ properties:
                             PostgreSQL Column.
                           properties:
                             - !ruby/object:Api::Type::String
-                              name: 'column'
+                              name: "column"
                               description: |
                                 Column name.
                             - !ruby/object:Api::Type::String
-                              name: 'dataType'
+                              name: "dataType"
                               description: |
                                 The PostgreSQL data type. Full data types list can be found here:
                                 https://www.postgresql.org/docs/current/datatype.html
                             - !ruby/object:Api::Type::Integer
-                              name: 'length'
+                              name: "length"
                               output: true
                               description: |
                                 Column length.
                             - !ruby/object:Api::Type::Integer
-                              name: 'precision'
+                              name: "precision"
                               output: true
                               description: |
                                 Column precision.
                             - !ruby/object:Api::Type::Integer
-                              name: 'scale'
+                              name: "scale"
                               output: true
                               description: |
                                 Column scale.
                             - !ruby/object:Api::Type::Boolean
-                              name: 'primaryKey'
+                              name: "primaryKey"
                               description: |
                                 Whether or not the column represents a primary key.
                             - !ruby/object:Api::Type::Boolean
-                              name: 'nullable'
+                              name: "nullable"
                               description: |
                                 Whether or not the column can accept a null value.
                             - !ruby/object:Api::Type::Integer
-                              name: 'ordinalPosition'
+                              name: "ordinalPosition"
                               description: |
                                 The ordinal position of the column in the table.
       - !ruby/object:Api::Type::NestedObject
-        name: 'oracleExcludedObjects'
+        name: "oracleExcludedObjects"
         description: |
           PostgreSQL data source objects to avoid backfilling.
         properties:
           - !ruby/object:Api::Type::Array
-            name: 'oracleSchemas'
+            name: "oracleSchemas"
             required: true
             min_size: 1
             description: |
@@ -1286,12 +1292,12 @@ properties:
                 MySQL database.
               properties:
                 - !ruby/object:Api::Type::String
-                  name: 'schema'
+                  name: "schema"
                   required: true
                   description: |
                     Schema name.
                 - !ruby/object:Api::Type::Array
-                  name: 'oracleTables'
+                  name: "oracleTables"
                   min_size: 1
                   description: |
                     Tables in the database.
@@ -1300,12 +1306,12 @@ properties:
                       Oracle table.
                     properties:
                       - !ruby/object:Api::Type::String
-                        name: 'table'
+                        name: "table"
                         required: true
                         description: |
                           Table name.
                       - !ruby/object:Api::Type::Array
-                        name: 'oracleColumns'
+                        name: "oracleColumns"
                         min_size: 1
                         description: |
                           Oracle columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
@@ -1314,58 +1320,58 @@ properties:
                             Oracle Column.
                           properties:
                             - !ruby/object:Api::Type::String
-                              name: 'column'
+                              name: "column"
                               description: |
                                 Column name.
                             - !ruby/object:Api::Type::String
-                              name: 'dataType'
+                              name: "dataType"
                               description: |
                                 The Oracle data type. Full data types list can be found here:
                                 https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Data-Types.html
                             - !ruby/object:Api::Type::Integer
-                              name: 'length'
+                              name: "length"
                               output: true
                               description: |
                                 Column length.
                             - !ruby/object:Api::Type::Integer
-                              name: 'precision'
+                              name: "precision"
                               output: true
                               description: |
                                 Column precision.
                             - !ruby/object:Api::Type::Integer
-                              name: 'scale'
+                              name: "scale"
                               output: true
                               description: |
                                 Column scale.
                             - !ruby/object:Api::Type::String
-                              name: 'encoding'
+                              name: "encoding"
                               output: true
                               description: |
                                 Column encoding.
                             - !ruby/object:Api::Type::Boolean
-                              name: 'primaryKey'
+                              name: "primaryKey"
                               output: true
                               description: |
                                 Whether or not the column represents a primary key.
                             - !ruby/object:Api::Type::Boolean
-                              name: 'nullable'
+                              name: "nullable"
                               output: true
                               description: |
                                 Whether or not the column can accept a null value.
                             - !ruby/object:Api::Type::Integer
-                              name: 'ordinalPosition'
+                              name: "ordinalPosition"
                               output: true
                               description: |
                                 The ordinal position of the column in the table.
       - !ruby/object:Api::Type::NestedObject
-        name: 'sqlServerExcludedObjects'
+        name: "sqlServerExcludedObjects"
         min_version: beta
         required: false
         description: |
           SQL Server data source objects to avoid backfilling.
         properties:
           - !ruby/object:Api::Type::Array
-            name: 'schemas'
+            name: "schemas"
             required: true
             min_size: 1
             description: |
@@ -1375,12 +1381,12 @@ properties:
                 SQL Server database.
               properties:
                 - !ruby/object:Api::Type::String
-                  name: 'schema'
+                  name: "schema"
                   required: true
                   description: |
                     Schema name.
                 - !ruby/object:Api::Type::Array
-                  name: 'tables'
+                  name: "tables"
                   min_size: 1
                   description: |
                     Tables in the database.
@@ -1389,12 +1395,12 @@ properties:
                       SQL Server table.
                     properties:
                       - !ruby/object:Api::Type::String
-                        name: 'table'
+                        name: "table"
                         required: true
                         description: |
                           Table name.
                       - !ruby/object:Api::Type::Array
-                        name: 'columns'
+                        name: "columns"
                         min_size: 1
                         description: |
                           SQL Server columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
@@ -1403,51 +1409,51 @@ properties:
                             SQL Server Column.
                           properties:
                             - !ruby/object:Api::Type::String
-                              name: 'column'
+                              name: "column"
                               description: |
                                 Column name.
                             - !ruby/object:Api::Type::String
-                              name: 'dataType'
+                              name: "dataType"
                               description: |
                                 The SQL Server data type. Full data types list can be found here:
                                 https://learn.microsoft.com/en-us/sql/t-sql/data-types/data-types-transact-sql?view=sql-server-ver16
                             - !ruby/object:Api::Type::Integer
-                              name: 'length'
+                              name: "length"
                               output: true
                               description: |
                                 Column length.
                             - !ruby/object:Api::Type::Integer
-                              name: 'precision'
+                              name: "precision"
                               output: true
                               description: |
                                 Column precision.
                             - !ruby/object:Api::Type::Integer
-                              name: 'scale'
+                              name: "scale"
                               output: true
                               description: |
                                 Column scale.
                             - !ruby/object:Api::Type::String
-                              name: 'encoding'
+                              name: "encoding"
                               output: true
                               description: |
                                 Column encoding.
                             - !ruby/object:Api::Type::Boolean
-                              name: 'primaryKey'
+                              name: "primaryKey"
                               output: true
                               description: |
                                 Whether or not the column represents a primary key.
                             - !ruby/object:Api::Type::Boolean
-                              name: 'nullable'
+                              name: "nullable"
                               output: true
                               description: |
                                 Whether or not the column can accept a null value.
                             - !ruby/object:Api::Type::Integer
-                              name: 'ordinalPosition'
+                              name: "ordinalPosition"
                               output: true
                               description: |
-                                The ordinal position of the column in the table.                          
+                                The ordinal position of the column in the table.
   - !ruby/object:Api::Type::NestedObject
-    name: 'backfillNone'
+    name: "backfillNone"
     exactly_one_of:
       - backfill_all
       - backfill_none
@@ -1457,7 +1463,7 @@ properties:
       Backfill strategy to disable automatic backfill for the Stream's objects.
     properties: []
   - !ruby/object:Api::Type::String
-    name: 'customerManagedEncryptionKey'
+    name: "customerManagedEncryptionKey"
     immutable: true
     description: |
       A reference to a KMS encryption key. If provided, it will be used to encrypt the data. If left blank, data

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -190,6 +190,7 @@ properties:
           - source_config.0.mysql_source_config
           - source_config.0.oracle_source_config
           - source_config.0.postgresql_source_config
+          - source_config.0.sql_server_source_config
         description: |
           MySQL data source configuration.
         properties:
@@ -365,6 +366,7 @@ properties:
           - source_config.0.mysql_source_config
           - source_config.0.oracle_source_config
           - source_config.0.postgresql_source_config
+          - source_config.0.sql_server_source_config
         description: |
           MySQL data source configuration.
         properties:
@@ -582,6 +584,7 @@ properties:
           - source_config.0.mysql_source_config
           - source_config.0.oracle_source_config
           - source_config.0.postgresql_source_config
+          - source_config.0.sql_server_source_config
         description: |
           PostgreSQL data source configuration.
         properties:
@@ -761,6 +764,211 @@ properties:
             description: |
               Maximum number of concurrent backfill tasks. The number should be non
               negative. If not set (or set to 0), the system's default value will be used.
+            default_from_api: true
+            validation: !ruby/object:Provider::Terraform::Validation
+              function: 'validation.IntAtLeast(0)'
+      - !ruby/object:Api::Type::NestedObject
+        name: 'sqlServerSourceConfig'
+        min_version: beta
+        allow_empty_object: true
+        send_empty_value: true
+        exactly_one_of:
+          - source_config.0.mysql_source_config
+          - source_config.0.oracle_source_config
+          - source_config.0.postgresql_source_config
+          - source_config.0.sql_server_source_config
+        description: |
+          SQl Server data source configuration.
+        properties:
+          - !ruby/object:Api::Type::NestedObject
+            name: 'includeObjects'
+            description: |
+              SQL Server objects to retrieve from the source.
+            properties:
+              - !ruby/object:Api::Type::Array
+                name: 'schemas'
+                required: true
+                min_size: 1
+                description: |
+                  SQL Server schemas/databases in the database server
+                item_type: !ruby/object:Api::Type::NestedObject
+                  description: |
+                    SQL Server database.
+                  properties:
+                    - !ruby/object:Api::Type::String
+                      name: 'schema'
+                      required: true
+                      description: |
+                        Schema name.
+                    - !ruby/object:Api::Type::Array
+                      name: 'tables'
+                      min_size: 1
+                      description: |
+                        Tables in the database.
+                      item_type: !ruby/object:Api::Type::NestedObject
+                        description: |
+                          SQL Server table.
+                        properties:
+                          - !ruby/object:Api::Type::String
+                            name: 'table'
+                            required: true
+                            description: |
+                              Table name.
+                          - !ruby/object:Api::Type::Array
+                            name: 'columns'
+                            min_size: 1
+                            description: |
+                              SQL Server columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
+                            item_type: !ruby/object:Api::Type::NestedObject
+                              description: |
+                                SQL Server Column.
+                              properties:
+                                - !ruby/object:Api::Type::String
+                                  name: 'column'
+                                  description: |
+                                    Column name.
+                                - !ruby/object:Api::Type::String
+                                  name: 'dataType'
+                                  description: |
+                                    The SQL Server data type. Full data types list can be found here:
+                                    https://learn.microsoft.com/en-us/sql/t-sql/data-types/data-types-transact-sql?view=sql-server-ver16
+                                - !ruby/object:Api::Type::Integer
+                                  name: 'length'
+                                  output: true
+                                  description: |
+                                    Column length.
+                                - !ruby/object:Api::Type::Integer
+                                  name: 'precision'
+                                  output: true
+                                  description: |
+                                    Column precision.
+                                - !ruby/object:Api::Type::Integer
+                                  name: 'scale'
+                                  output: true
+                                  description: |
+                                    Column scale.
+                                - !ruby/object:Api::Type::String
+                                  name: 'encoding'
+                                  output: true
+                                  description: |
+                                    Column encoding.
+                                - !ruby/object:Api::Type::Boolean
+                                  name: 'primaryKey'
+                                  output: true
+                                  description: |
+                                    Whether or not the column represents a primary key.
+                                - !ruby/object:Api::Type::Boolean
+                                  name: 'nullable'
+                                  output: true
+                                  description: |
+                                    Whether or not the column can accept a null value.
+                                - !ruby/object:Api::Type::Integer
+                                  name: 'ordinalPosition'
+                                  output: true
+                                  description: |
+                                    The ordinal position of the column in the table.
+          - !ruby/object:Api::Type::NestedObject
+            name: 'excludeObjects'
+            description: |
+              SQL Server objects to exclude from the stream.
+            properties:
+              - !ruby/object:Api::Type::Array
+                name: 'schemas'
+                required: true
+                min_size: 1
+                description: |
+                  SQL Server schemas/databases in the database server
+                item_type: !ruby/object:Api::Type::NestedObject
+                  description: |
+                    SQL Server database.
+                  properties:
+                    - !ruby/object:Api::Type::String
+                      name: 'schema'
+                      required: true
+                      description: |
+                        Schema name.
+                    - !ruby/object:Api::Type::Array
+                      name: 'tables'
+                      min_size: 1
+                      description: |
+                        Tables in the database.
+                      item_type: !ruby/object:Api::Type::NestedObject
+                        description: |
+                          SQL Server table.
+                        properties:
+                          - !ruby/object:Api::Type::String
+                            name: 'table'
+                            required: true
+                            description: |
+                              Table name.
+                          - !ruby/object:Api::Type::Array
+                            name: 'columns'
+                            min_size: 1
+                            description: |
+                              SQL Server columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
+                            item_type: !ruby/object:Api::Type::NestedObject
+                              description: |
+                                SQL Server Column.
+                              properties:
+                                - !ruby/object:Api::Type::String
+                                  name: 'column'
+                                  description: |
+                                    Column name.
+                                - !ruby/object:Api::Type::String
+                                  name: 'dataType'
+                                  description: |
+                                    The SQL Server data type. Full data types list can be found here:
+                                    https://learn.microsoft.com/en-us/sql/t-sql/data-types/data-types-transact-sql?view=sql-server-ver16
+                                - !ruby/object:Api::Type::Integer
+                                  name: 'length'
+                                  output: true
+                                  description: |
+                                    Column length.
+                                - !ruby/object:Api::Type::Integer
+                                  name: 'precision'
+                                  output: true
+                                  description: |
+                                    Column precision.
+                                - !ruby/object:Api::Type::Integer
+                                  name: 'scale'
+                                  output: true
+                                  description: |
+                                    Column scale.
+                                - !ruby/object:Api::Type::String
+                                  name: 'encoding'
+                                  output: true
+                                  description: |
+                                    Column encoding.
+                                - !ruby/object:Api::Type::Boolean
+                                  name: 'primaryKey'
+                                  output: true
+                                  description: |
+                                    Whether or not the column represents a primary key.
+                                - !ruby/object:Api::Type::Boolean
+                                  name: 'nullable'
+                                  output: true
+                                  description: |
+                                    Whether or not the column can accept a null value.
+                                - !ruby/object:Api::Type::Integer
+                                  name: 'ordinalPosition'
+                                  output: true
+                                  description: |
+                                    The ordinal position of the column in the table.
+          - !ruby/object:Api::Type::Integer
+            name: 'maxConcurrentCdcTasks'
+            send_empty_value: true
+            description: |
+              Maximum number of concurrent CDC tasks. The number should be non negative.
+              If not set (or set to 0), the system's default value will be used.
+            default_from_api: true
+            validation: !ruby/object:Provider::Terraform::Validation
+              function: 'validation.IntAtLeast(0)'
+          - !ruby/object:Api::Type::Integer
+            name: 'maxConcurrentBackfillTasks'
+            send_empty_value: true
+            description: |
+              Maximum number of concurrent backfill tasks. The number should be non negative.
+              If not set (or set to 0), the system's default value will be used.
             default_from_api: true
             validation: !ruby/object:Provider::Terraform::Validation
               function: 'validation.IntAtLeast(0)'
@@ -1149,6 +1357,95 @@ properties:
                               output: true
                               description: |
                                 The ordinal position of the column in the table.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'sqlServerExcludedObjects'
+        min_version: beta
+        required: false
+        description: |
+          SQL Server data source objects to avoid backfilling.
+        properties:
+          - !ruby/object:Api::Type::Array
+            name: 'schemas'
+            required: true
+            min_size: 1
+            description: |
+              SQL Server schemas/databases in the database server
+            item_type: !ruby/object:Api::Type::NestedObject
+              description: |
+                SQL Server database.
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: 'schema'
+                  required: true
+                  description: |
+                    Schema name.
+                - !ruby/object:Api::Type::Array
+                  name: 'tables'
+                  min_size: 1
+                  description: |
+                    Tables in the database.
+                  item_type: !ruby/object:Api::Type::NestedObject
+                    description: |
+                      SQL Server table.
+                    properties:
+                      - !ruby/object:Api::Type::String
+                        name: 'table'
+                        required: true
+                        description: |
+                          Table name.
+                      - !ruby/object:Api::Type::Array
+                        name: 'columns'
+                        min_size: 1
+                        description: |
+                          SQL Server columns in the schema. When unspecified as part of include/exclude objects, includes/excludes everything.
+                        item_type: !ruby/object:Api::Type::NestedObject
+                          description: |
+                            SQL Server Column.
+                          properties:
+                            - !ruby/object:Api::Type::String
+                              name: 'column'
+                              description: |
+                                Column name.
+                            - !ruby/object:Api::Type::String
+                              name: 'dataType'
+                              description: |
+                                The SQL Server data type. Full data types list can be found here:
+                                https://learn.microsoft.com/en-us/sql/t-sql/data-types/data-types-transact-sql?view=sql-server-ver16
+                            - !ruby/object:Api::Type::Integer
+                              name: 'length'
+                              output: true
+                              description: |
+                                Column length.
+                            - !ruby/object:Api::Type::Integer
+                              name: 'precision'
+                              output: true
+                              description: |
+                                Column precision.
+                            - !ruby/object:Api::Type::Integer
+                              name: 'scale'
+                              output: true
+                              description: |
+                                Column scale.
+                            - !ruby/object:Api::Type::String
+                              name: 'encoding'
+                              output: true
+                              description: |
+                                Column encoding.
+                            - !ruby/object:Api::Type::Boolean
+                              name: 'primaryKey'
+                              output: true
+                              description: |
+                                Whether or not the column represents a primary key.
+                            - !ruby/object:Api::Type::Boolean
+                              name: 'nullable'
+                              output: true
+                              description: |
+                                Whether or not the column can accept a null value.
+                            - !ruby/object:Api::Type::Integer
+                              name: 'ordinalPosition'
+                              output: true
+                              description: |
+                                The ordinal position of the column in the table.                          
   - !ruby/object:Api::Type::NestedObject
     name: 'backfillNone'
     exactly_one_of:

--- a/mmv1/products/datastream/product.yaml
+++ b/mmv1/products/datastream/product.yaml
@@ -17,6 +17,9 @@ versions:
   - !ruby/object:Api::Product::Version
     name: ga
     base_url: https://datastream.googleapis.com/v1/
+  - !ruby/object:Api::Product::Version
+    name: beta
+    base_url: https://datastream.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 async: !ruby/object:Api::OpAsync

--- a/mmv1/products/datastream/product.yaml
+++ b/mmv1/products/datastream/product.yaml
@@ -17,9 +17,6 @@ versions:
   - !ruby/object:Api::Product::Version
     name: ga
     base_url: https://datastream.googleapis.com/v1/
-  - !ruby/object:Api::Product::Version
-    name: beta
-    base_url: https://datastream.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 async: !ruby/object:Api::OpAsync

--- a/mmv1/templates/terraform/custom_flatten/datastream_connection_profile_sql_server_profile_password.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/datastream_connection_profile_sql_server_profile_password.go.erb
@@ -1,0 +1,18 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2022 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+<%# Workaround for https://github.com/hashicorp/terraform-provider-google/issues/12410 %>
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return d.Get("sql_server_profile.0.password")
+}

--- a/mmv1/templates/terraform/custom_flatten/go/datastream_connection_profile_sql_server_profile_password.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/go/datastream_connection_profile_sql_server_profile_password.go.tmpl
@@ -1,0 +1,16 @@
+{{- /*
+	The license inside this block applies to this file
+	Copyright 2024 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/}}
+{{- /* Workaround for https://github.com/hashicorp/terraform-provider-google/issues/12410 */}}
+func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return d.Get("sql_server_profile.0.password")
+}

--- a/mmv1/templates/terraform/examples/datastream_connection_profile_sql_server.tf.erb
+++ b/mmv1/templates/terraform/examples/datastream_connection_profile_sql_server.tf.erb
@@ -1,0 +1,63 @@
+resource "google_sql_database_instance" "instance" {
+	provider            = google-beta
+    name                = "<%= ctx[:vars]['sql_server_name'] %>"
+    database_version    = "SQLSERVER_2019_STANDARD"
+    region              = "us-central1"
+    root_password       = "<%= ctx[:vars]['sql_server_root_password'] %>"
+    deletion_protection = "<%= ctx[:vars]['deletion_protection'] %>"
+
+    settings {
+        tier = "db-custom-2-4096"
+        ip_configuration {
+            // Datastream IPs will vary by region.
+            // https://cloud.google.com/datastream/docs/ip-allowlists-and-regions
+            authorized_networks {
+                value = "34.71.242.81"
+            }
+
+            authorized_networks {
+                value = "34.72.28.29"
+            }
+
+            authorized_networks {
+                value = "34.67.6.157"
+            }
+
+            authorized_networks {
+                value = "34.67.234.134"
+            }
+
+            authorized_networks {
+                value = "34.72.239.218"
+            }
+        }
+    }
+}
+
+resource "google_sql_database" "db" {
+	provider   = google-beta
+    name       = "<%= ctx[:vars]['database_name'] %>"
+    instance   = google_sql_database_instance.instance.name
+}
+
+resource "google_sql_user" "user" {
+    provider = google-beta
+    name     = "<%= ctx[:vars]['database_user'] %>"
+    instance = google_sql_database_instance.instance.name
+    password = "<%= ctx[:vars]['database_password'] %>"
+}
+
+resource "google_datastream_connection_profile" "default" {
+    provider              = google-beta
+    display_name          = "SQL Server Source"
+    location              = "us-central1"
+    connection_profile_id = "<%= ctx[:vars]['source_connection_profile_id'] %>"
+
+    sql_server_profile {
+        hostname = google_sql_database_instance.instance.public_ip_address
+        port     = 1433
+        username = google_sql_user.user.name
+        password = google_sql_user.user.password
+        database = google_sql_database.db.name
+    }
+}

--- a/mmv1/templates/terraform/examples/datastream_stream_sql_server.tf.erb
+++ b/mmv1/templates/terraform/examples/datastream_stream_sql_server.tf.erb
@@ -1,106 +1,108 @@
 resource "google_sql_database_instance" "instance" {
-  name                = "<%= ctx[:vars]['sql_server_name'] %>"
-  database_version    = "SQLSERVER_2019_STANDARD"
-  region              = "us-central1"
-  root_password       = "<%= ctx[:vars]['sql_server_root_password'] %>"
-  deletion_protection = false
+    provider            = google-beta
+    name                = "<%= ctx[:vars]['sql_server_name'] %>"
+    database_version    = "SQLSERVER_2019_STANDARD"
+    region              = "us-central1"
+    root_password       = "<%= ctx[:vars]['sql_server_root_password'] %>"
+    deletion_protection = "<%= ctx[:vars]['deletion_protection'] %>"
 
-  settings {
-    tier = "db-custom-2-4096"
-    ip_configuration {
-      // Datastream IPs will vary by region.
-      // https://cloud.google.com/datastream/docs/ip-allowlists-and-regions
-      authorized_networks {
-        value = "34.71.242.81"
-      }
+    settings {
+        tier = "db-custom-2-4096"
+        ip_configuration {
+            // Datastream IPs will vary by region.
+            // https://cloud.google.com/datastream/docs/ip-allowlists-and-regions
+            authorized_networks {
+                value = "34.71.242.81"
+            }
 
-      authorized_networks {
-        value = "34.72.28.29"
-      }
+            authorized_networks {
+                value = "34.72.28.29"
+            }
 
-      authorized_networks {
-        value = "34.67.6.157"
-      }
+            authorized_networks {
+                value = "34.67.6.157"
+            }
 
-      authorized_networks {
-        value = "34.67.234.134"
-      }
+            authorized_networks {
+                value = "34.67.234.134"
+            }
 
-      authorized_networks {
-        value = "34.72.239.218"
-      }
+            authorized_networks {
+                value = "34.72.239.218"
+            }
+        }
     }
-  }
 }
 
 resource "google_sql_database" "db" {
-  name       = "<%= ctx[:vars]['database_name'] %>"
-  instance   = google_sql_database_instance.instance.name
-  depends_on = [google_sql_user.user]
+    provider   = google-beta
+    name       = "<%= ctx[:vars]['database_name'] %>"
+    instance   = google_sql_database_instance.instance.name
+    depends_on = [google_sql_user.user]
 }
 
 resource "google_sql_user" "user" {
-  name     = "<%= ctx[:vars]['database_user'] %>"
-  instance = google_sql_database_instance.instance.name
-  password = "<%= ctx[:vars]['database_password'] %>"
+    provider = google-beta
+    name     = "<%= ctx[:vars]['database_user'] %>"
+    instance = google_sql_database_instance.instance.name
+    password = "<%= ctx[:vars]['database_password'] %>"
 }
 
 resource "google_datastream_connection_profile" "source" {
-  provider              = google-beta
-  display_name          = "SQL Server Source"
-  location              = "us-central1"
-  connection_profile_id = "<%= ctx[:vars]['source_connection_profile_id'] %>"
+    provider              = google-beta
+    display_name          = "SQL Server Source"
+    location              = "us-central1"
+    connection_profile_id = "<%= ctx[:vars]['source_connection_profile_id'] %>"
 
-  sql_server_profile {
-    hostname = google_sql_database_instance.instance.public_ip_address
-    port     = 1433
-    username = google_sql_user.user.name
-    password = google_sql_user.user.password
-    database = google_sql_database.db.name
-  }
+    sql_server_profile {
+        hostname = google_sql_database_instance.instance.public_ip_address
+        port     = 1433
+        username = google_sql_user.user.name
+        password = google_sql_user.user.password
+        database = google_sql_database.db.name
+    }
 }
 
 resource "google_datastream_connection_profile" "destination" {
-  provider              = google-beta
-  display_name          = "BigQuery Destination"
-  location              = "us-central1"
-  connection_profile_id = "<%= ctx[:vars]['destination_connection_profile_id'] %>"
+    provider              = google-beta
+    display_name          = "BigQuery Destination"
+    location              = "us-central1"
+    connection_profile_id = "<%= ctx[:vars]['destination_connection_profile_id'] %>"
 
-  bigquery_profile {}
+    bigquery_profile {}
 }
 
-resource "google_datastream_stream" "stream" {
-  provider = google-beta
+resource "google_datastream_stream" "default" {
+    provider     = google-beta
+    display_name = "SQL Server to BigQuery"
+    location     = "us-central1"
+    stream_id    = "<%= ctx[:vars]['stream_id'] %>"
 
-  display_name = "SQL Server to BigQuery"
-  location     = "us-central1"
-  stream_id    = "<%= ctx[:vars]['stream_id'] %>"
-
-  source_config {
-    source_connection_profile = google_datastream_connection_profile.source.id
-    sql_server_source_config {
-      include_objects {
-        schemas {
-          schema = "schema"
-          tables {
-            table = "table"
-          }
+    source_config {
+        source_connection_profile = google_datastream_connection_profile.source.id
+        sql_server_source_config {
+            include_objects {
+                schemas {
+                    schema = "schema"
+                    tables {
+                        table = "table"
+                    }
+                }
+            }
         }
-      }
     }
-  }
 
-  destination_config {
-    destination_connection_profile = google_datastream_connection_profile.destination.id
-    bigquery_destination_config {
-      data_freshness = "900s"
-      source_hierarchy_datasets {
-        dataset_template {
-          location = "us-central1"
+    destination_config {
+        destination_connection_profile = google_datastream_connection_profile.destination.id
+        bigquery_destination_config {
+            data_freshness = "900s"
+            source_hierarchy_datasets {
+                dataset_template {
+                    location = "us-central1"
+                }
+            }
         }
-      }
     }
-  }
 
-  backfill_none {}
+    backfill_none {}
 }

--- a/mmv1/templates/terraform/examples/datastream_stream_sql_server.tf.erb
+++ b/mmv1/templates/terraform/examples/datastream_stream_sql_server.tf.erb
@@ -1,88 +1,108 @@
-resource "google_datastream_connection_profile" "source" {
-    provider              = google-beta
-    display_name          = "SQL Server Source"
-    location              = "us-central1"
-    connection_profile_id = "<%= ctx[:vars]['source_connection_profile_id'] %>"
+resource "google_sql_database_instance" "instance" {
+  name                = "<%= ctx[:vars]['sql_server_name'] %>"
+  database_version    = "SQLSERVER_2019_STANDARD"
+  region              = "us-central1"
+  root_password       = "<%= ctx[:vars]['sql_server_root_password'] %>"
+  deletion_protection = false
 
-    profile {
-        hostname = "hostname"
-        port     = 1433
-        username = "user"
-        password = "pass"
-        database = "db"
+  settings {
+    tier = "db-custom-2-4096"
+    ip_configuration {
+      // Datastream IPs will vary by region.
+      // https://cloud.google.com/datastream/docs/ip-allowlists-and-regions
+      authorized_networks {
+        value = "34.71.242.81"
+      }
+
+      authorized_networks {
+        value = "34.72.28.29"
+      }
+
+      authorized_networks {
+        value = "34.67.6.157"
+      }
+
+      authorized_networks {
+        value = "34.67.234.134"
+      }
+
+      authorized_networks {
+        value = "34.72.239.218"
+      }
     }
+  }
+}
+
+resource "google_sql_database" "db" {
+  provider   = google-beta
+  name       = "<%= ctx[:vars]['database_name'] %>"
+  instance   = google_sql_database_instance.instance.name
+  depends_on = [google_sql_user.user]
+}
+
+resource "google_sql_user" "user" {
+  provider = google-beta
+  name     = "<%= ctx[:vars]['database_user'] %>"
+  instance = google_sql_database_instance.instance.name
+  password = "<%= ctx[:vars]['database_password'] %>"
+}
+
+resource "google_datastream_connection_profile" "source" {
+  provider              = google-beta
+  display_name          = "SQL Server Source"
+  location              = "us-central1"
+  connection_profile_id = "<%= ctx[:vars]['source_connection_profile_id'] %>"
+
+  sql_server_profile {
+    hostname = google_sql_database_instance.instance.public_ip_address
+    port     = 1433
+    username = google_sql_user.user.name
+    password = google_sql_user.user.password
+    database = google_sql_database.db.name
+  }
 }
 
 resource "google_datastream_connection_profile" "destination" {
-    provider              = google-beta
-    display_name          = "BigQuery Destination"
-    location              = "us-central1"
-    connection_profile_id = "<%= ctx[:vars]['destination_connection_profile_id'] %>"
+  provider              = google-beta
+  display_name          = "BigQuery Destination"
+  location              = "us-central1"
+  connection_profile_id = "<%= ctx[:vars]['destination_connection_profile_id'] %>"
 
-    bigquery_profile {}
+  bigquery_profile {}
 }
 
-resource "google_datastream_stream" "default" {
-    provider     = google-beta
-    display_name = "SQL Server to BigQuery"
-    location     = "us-central1"
-    stream_id    = "<%= ctx[:vars]['stream_id'] %>"
-    desired_state = "RUNNING"
+resource "google_datastream_stream" "stream" {
+  provider = google-beta
 
-    source_config {
-        source_connection_profile = google_datastream_connection_profile.source.id
-        sql_server_source_config {
-            max_concurrent_cdc_tasks = 8
-            max_concurrent_backfill_tasks = 12
-            include_objects {
-                schemas {
-                    schema = "schema"
-                    tables {
-                        table = "table"
-                        columns {
-                            column = "column"
-                        }
-                    }
-                }
-            }
-            exclude_objects {
-                schemas {
-                    schema = "schema"
-                    tables {
-                        table = "table"
-                        columns {
-                            column = "column"
-                        }
-                    }
-                }
-            }
-            drop_large_objects {}
-		    }
-    }
+  display_name = "SQL Server to BigQuery"
+  location     = "us-central1"
+  stream_id    = "<%= ctx[:vars]['stream_id'] %>"
 
-    destination_config {
-        destination_connection_profile = google_datastream_connection_profile.destination.id
-        bigquery_destination_config {
-            data_freshness = "900s"
-            source_hierarchy_datasets {
-                dataset_template {
-                    location = "us-central1"
-                }
-            }
+  source_config {
+    source_connection_profile = google_datastream_connection_profile.source.id
+    sql_server_source_config {
+      include_objects {
+        schemas {
+          schema = "schema"
+          tables {
+            table = "table"
+          }
         }
+      }
     }
+  }
 
-    backfill_all {
-        sql_server_excluded_objects {
-            schemas {
-                schema = "schema"
-                tables {
-                    table = "table"
-                    columns {
-                        column = "column"
-                    }
-                }
-            }
+  destination_config {
+    destination_connection_profile = google_datastream_connection_profile.destination.id
+    bigquery_destination_config {
+      data_freshness = "900s"
+      source_hierarchy_datasets {
+        dataset_template {
+          location = "us-central1"
         }
+      }
     }
+  }
+
+  backfill_none {}
 }

--- a/mmv1/templates/terraform/examples/datastream_stream_sql_server.tf.erb
+++ b/mmv1/templates/terraform/examples/datastream_stream_sql_server.tf.erb
@@ -1,0 +1,88 @@
+resource "google_datastream_connection_profile" "source" {
+    provider              = google-beta
+    display_name          = "SQL Server Source"
+    location              = "us-central1"
+    connection_profile_id = "<%= ctx[:vars]['source_connection_profile_id'] %>"
+
+    profile {
+        hostname = "hostname"
+        port     = 1433
+        username = "user"
+        password = "pass"
+        database = "db"
+    }
+}
+
+resource "google_datastream_connection_profile" "destination" {
+    provider              = google-beta
+    display_name          = "BigQuery Destination"
+    location              = "us-central1"
+    connection_profile_id = "<%= ctx[:vars]['destination_connection_profile_id'] %>"
+
+    bigquery_profile {}
+}
+
+resource "google_datastream_stream" "default" {
+    provider     = google-beta
+    display_name = "SQL Server to BigQuery"
+    location     = "us-central1"
+    stream_id    = "<%= ctx[:vars]['stream_id'] %>"
+    desired_state = "RUNNING"
+
+    source_config {
+        source_connection_profile = google_datastream_connection_profile.source.id
+        sql_server_source_config {
+            max_concurrent_cdc_tasks = 8
+            max_concurrent_backfill_tasks = 12
+            include_objects {
+                schemas {
+                    schema = "schema"
+                    tables {
+                        table = "table"
+                        columns {
+                            column = "column"
+                        }
+                    }
+                }
+            }
+            exclude_objects {
+                schemas {
+                    schema = "schema"
+                    tables {
+                        table = "table"
+                        columns {
+                            column = "column"
+                        }
+                    }
+                }
+            }
+            drop_large_objects {}
+		    }
+    }
+
+    destination_config {
+        destination_connection_profile = google_datastream_connection_profile.destination.id
+        bigquery_destination_config {
+            data_freshness = "900s"
+            source_hierarchy_datasets {
+                dataset_template {
+                    location = "us-central1"
+                }
+            }
+        }
+    }
+
+    backfill_all {
+        sql_server_excluded_objects {
+            schemas {
+                schema = "schema"
+                tables {
+                    table = "table"
+                    columns {
+                        column = "column"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/mmv1/templates/terraform/examples/datastream_stream_sql_server.tf.erb
+++ b/mmv1/templates/terraform/examples/datastream_stream_sql_server.tf.erb
@@ -34,14 +34,12 @@ resource "google_sql_database_instance" "instance" {
 }
 
 resource "google_sql_database" "db" {
-  provider   = google-beta
   name       = "<%= ctx[:vars]['database_name'] %>"
   instance   = google_sql_database_instance.instance.name
   depends_on = [google_sql_user.user]
 }
 
 resource "google_sql_user" "user" {
-  provider = google-beta
   name     = "<%= ctx[:vars]['database_user'] %>"
   instance = google_sql_database_instance.instance.name
   password = "<%= ctx[:vars]['database_password'] %>"

--- a/mmv1/templates/terraform/examples/go/datastream_connection_profile_sql_server.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/datastream_connection_profile_sql_server.tf.tmpl
@@ -1,0 +1,63 @@
+resource "google_sql_database_instance" "instance" {
+    provider            = google-beta
+    name                = "{{index $.Vars "sql_server_name"}}"
+    database_version    = "SQLSERVER_2019_STANDARD"
+    region              = "us-central1"
+    root_password       = "{{index $.Vars "sql_server_root_password"}}"
+    deletion_protection = "{{index $.Vars "deletion_protection"}}"
+
+    settings {
+        tier = "db-custom-2-4096"
+        ip_configuration {
+            // Datastream IPs will vary by region.
+            // https://cloud.google.com/datastream/docs/ip-allowlists-and-regions
+            authorized_networks {
+                value = "34.71.242.81"
+            }
+
+            authorized_networks {
+                value = "34.72.28.29"
+            }
+
+            authorized_networks {
+                value = "34.67.6.157"
+            }
+
+            authorized_networks {
+                value = "34.67.234.134"
+            }
+
+            authorized_networks {
+                value = "34.72.239.218"
+            }
+        }
+    }
+}
+
+resource "google_sql_database" "db" {
+    provider   = google-beta
+    name       = "{{index $.Vars "database_name"}}"
+    instance   = google_sql_database_instance.instance.name
+}
+
+resource "google_sql_user" "user" {
+    provider = google-beta
+    name     = "{{index $.Vars "database_user"}}"
+    instance = google_sql_database_instance.instance.name
+    password = "{{index $.Vars "database_password"}}"
+}
+
+resource "google_datastream_connection_profile" "default" {
+    provider              = google-beta
+    display_name          = "SQL Server Source"
+    location              = "us-central1"
+    connection_profile_id = "{{index $.Vars "source_connection_profile_id"}}"
+
+    sql_server_profile {
+        hostname = google_sql_database_instance.instance.public_ip_address
+        port     = 1433
+        username = google_sql_user.user.name
+        password = google_sql_user.user.password
+        database = google_sql_database.db.name
+    }
+}

--- a/mmv1/templates/terraform/examples/go/datastream_stream_sql_server.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/datastream_stream_sql_server.tf.tmpl
@@ -34,14 +34,12 @@ resource "google_sql_database_instance" "instance" {
 }
 
 resource "google_sql_database" "db" {
-  provider   = google-beta
   name       = "{{index $.Vars "database_name"}}"
   instance   = google_sql_database_instance.instance.name
   depends_on = [google_sql_user.user]
 }
 
 resource "google_sql_user" "user" {
-  provider = google-beta
   name     = "{{index $.Vars "database_user"}}"
   instance = google_sql_database_instance.instance.name
   password = "{{index $.Vars "database_password"}}"

--- a/mmv1/templates/terraform/examples/go/datastream_stream_sql_server.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/datastream_stream_sql_server.tf.tmpl
@@ -1,0 +1,88 @@
+resource "google_datastream_connection_profile" "source" {
+    provider              = google-beta
+    display_name          = "SQL Server Source"
+    location              = "us-central1"
+    connection_profile_id = "{{index $.Vars "source_connection_profile_id"}}"
+
+    profile {
+        hostname = "hostname"
+        port     = 1433
+        username = "user"
+        password = "pass"
+        database = "db"
+    }
+}
+
+resource "google_datastream_connection_profile" "destination" {
+    provider              = google-beta
+    display_name          = "BigQuery Destination"
+    location              = "us-central1"
+    connection_profile_id = "{{index $.Vars "destination_connection_profile_id"}}"
+
+    bigquery_profile {}
+}
+
+resource "google_datastream_stream" "default" {
+    provider     = google-beta
+    display_name = "SQL Server to BigQuery"
+    location     = "us-central1"
+    stream_id    = "{{index $.Vars "stream_id"}}"
+    desired_state = "RUNNING"
+
+    source_config {
+        source_connection_profile = google_datastream_connection_profile.source.id
+        sql_server_source_config {
+            max_concurrent_cdc_tasks = 8
+            max_concurrent_backfill_tasks = 12
+            include_objects {
+                schemas {
+                    schema = "schema"
+                    tables {
+                        table = "table"
+                        columns {
+                            column = "column"
+                        }
+                    }
+                }
+            }
+            exclude_objects {
+                schemas {
+                    schema = "schema"
+                    tables {
+                        table = "table"
+                        columns {
+                            column = "column"
+                        }
+                    }
+                }
+            }
+            drop_large_objects {}
+		    }
+    }
+
+    destination_config {
+        destination_connection_profile = google_datastream_connection_profile.destination.id
+        bigquery_destination_config {
+            data_freshness = "900s"
+            source_hierarchy_datasets {
+                dataset_template {
+                    location = "us-central1"
+                }
+            }
+        }
+    }
+
+    backfill_all {
+        sql_server_excluded_objects {
+            schemas {
+                schema = "schema"
+                tables {
+                    table = "table"
+                    columns {
+                        column = "column"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/mmv1/templates/terraform/examples/go/datastream_stream_sql_server.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/datastream_stream_sql_server.tf.tmpl
@@ -1,106 +1,108 @@
 resource "google_sql_database_instance" "instance" {
-  name                = "{{index $.Vars "sql_server_name"}}"
-  database_version    = "SQLSERVER_2019_STANDARD"
-  region              = "us-central1"
-  root_password       = "{{index $.Vars "sql_server_root_password"}}"
-  deletion_protection = false
+    provider            = google-beta
+    name                = "{{index $.Vars "sql_server_name"}}"
+    database_version    = "SQLSERVER_2019_STANDARD"
+    region              = "us-central1"
+    root_password       = "{{index $.Vars "sql_server_root_password"}}"
+    deletion_protection = "{{index $.Vars "deletion_protection"}}"
 
-  settings {
-    tier = "db-custom-2-4096"
-    ip_configuration {
-      // Datastream IPs will vary by region.
-      // https://cloud.google.com/datastream/docs/ip-allowlists-and-regions
-      authorized_networks {
-        value = "34.71.242.81"
-      }
+    settings {
+        tier = "db-custom-2-4096"
+        ip_configuration {
+            // Datastream IPs will vary by region.
+            // https://cloud.google.com/datastream/docs/ip-allowlists-and-regions
+            authorized_networks {
+                value = "34.71.242.81"
+            }
 
-      authorized_networks {
-        value = "34.72.28.29"
-      }
+            authorized_networks {
+                value = "34.72.28.29"
+            }
 
-      authorized_networks {
-        value = "34.67.6.157"
-      }
+            authorized_networks {
+                value = "34.67.6.157"
+            }
 
-      authorized_networks {
-        value = "34.67.234.134"
-      }
+            authorized_networks {
+                value = "34.67.234.134"
+            }
 
-      authorized_networks {
-        value = "34.72.239.218"
-      }
+            authorized_networks {
+                value = "34.72.239.218"
+            }
+        }
     }
-  }
 }
 
 resource "google_sql_database" "db" {
-  name       = "{{index $.Vars "database_name"}}"
-  instance   = google_sql_database_instance.instance.name
-  depends_on = [google_sql_user.user]
+    provider   = google-beta
+    name       = "{{index $.Vars "database_name"}}"
+    instance   = google_sql_database_instance.instance.name
+    depends_on = [google_sql_user.user]
 }
 
 resource "google_sql_user" "user" {
-  name     = "{{index $.Vars "database_user"}}"
-  instance = google_sql_database_instance.instance.name
-  password = "{{index $.Vars "database_password"}}"
+    provider = google-beta
+    name     = "{{index $.Vars "database_user"}}"
+    instance = google_sql_database_instance.instance.name
+    password = "{{index $.Vars "database_password"}}"
 }
 
 resource "google_datastream_connection_profile" "source" {
-  provider              = google-beta
-  display_name          = "SQL Server Source"
-  location              = "us-central1"
-  connection_profile_id = "{{index $.Vars "source_connection_profile_id"}}"
+    provider              = google-beta
+    display_name          = "SQL Server Source"
+    location              = "us-central1"
+    connection_profile_id = "{{index $.Vars "source_connection_profile_id"}}"
 
-  sql_server_profile {
-    hostname = google_sql_database_instance.instance.public_ip_address
-    port     = 1433
-    username = google_sql_user.user.name
-    password = google_sql_user.user.password
-    database = google_sql_database.db.name
-  }
+    sql_server_profile {
+        hostname = google_sql_database_instance.instance.public_ip_address
+        port     = 1433
+        username = google_sql_user.user.name
+        password = google_sql_user.user.password
+        database = google_sql_database.db.name
+    }
 }
 
 resource "google_datastream_connection_profile" "destination" {
-  provider              = google-beta
-  display_name          = "BigQuery Destination"
-  location              = "us-central1"
-  connection_profile_id = "{{index $.Vars "destination_connection_profile_id"}}"
+    provider              = google-beta
+    display_name          = "BigQuery Destination"
+    location              = "us-central1"
+    connection_profile_id = "{{index $.Vars "destination_connection_profile_id"}}"
 
-  bigquery_profile {}
+    bigquery_profile {}
 }
 
-resource "google_datastream_stream" "stream" {
-  provider = google-beta
+resource "google_datastream_stream" "default" {
+    provider     = google-beta
+    display_name = "SQL Server to BigQuery"
+    location     = "us-central1"
+    stream_id    = "{{index $.Vars "stream_id"}}"
 
-  display_name = "SQL Server to BigQuery"
-  location     = "us-central1"
-  stream_id    = "{{index $.Vars "stream_id"}}"
-
-  source_config {
-    source_connection_profile = google_datastream_connection_profile.source.id
-    sql_server_source_config {
-      include_objects {
-        schemas {
-          schema = "schema"
-          tables {
-            table = "table"
-          }
+    source_config {
+        source_connection_profile = google_datastream_connection_profile.source.id
+        sql_server_source_config {
+            include_objects {
+                schemas {
+                    schema = "schema"
+                    tables {
+                        table = "table"
+                    }
+                }
+            }
         }
-      }
     }
-  }
 
-  destination_config {
-    destination_connection_profile = google_datastream_connection_profile.destination.id
-    bigquery_destination_config {
-      data_freshness = "900s"
-      source_hierarchy_datasets {
-        dataset_template {
-          location = "us-central1"
+    destination_config {
+        destination_connection_profile = google_datastream_connection_profile.destination.id
+        bigquery_destination_config {
+            data_freshness = "900s"
+            source_hierarchy_datasets {
+                dataset_template {
+                    location = "us-central1"
+                }
+            }
         }
-      }
     }
-  }
 
-  backfill_none {}
+    backfill_none {}
 }

--- a/mmv1/templates/terraform/examples/go/datastream_stream_sql_server.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/datastream_stream_sql_server.tf.tmpl
@@ -1,88 +1,108 @@
-resource "google_datastream_connection_profile" "source" {
-    provider              = google-beta
-    display_name          = "SQL Server Source"
-    location              = "us-central1"
-    connection_profile_id = "{{index $.Vars "source_connection_profile_id"}}"
+resource "google_sql_database_instance" "instance" {
+  name                = "{{index $.Vars "sql_server_name"}}"
+  database_version    = "SQLSERVER_2019_STANDARD"
+  region              = "us-central1"
+  root_password       = "{{index $.Vars "sql_server_root_password"}}"
+  deletion_protection = false
 
-    profile {
-        hostname = "hostname"
-        port     = 1433
-        username = "user"
-        password = "pass"
-        database = "db"
+  settings {
+    tier = "db-custom-2-4096"
+    ip_configuration {
+      // Datastream IPs will vary by region.
+      // https://cloud.google.com/datastream/docs/ip-allowlists-and-regions
+      authorized_networks {
+        value = "34.71.242.81"
+      }
+
+      authorized_networks {
+        value = "34.72.28.29"
+      }
+
+      authorized_networks {
+        value = "34.67.6.157"
+      }
+
+      authorized_networks {
+        value = "34.67.234.134"
+      }
+
+      authorized_networks {
+        value = "34.72.239.218"
+      }
     }
+  }
+}
+
+resource "google_sql_database" "db" {
+  provider   = google-beta
+  name       = "{{index $.Vars "database_name"}}"
+  instance   = google_sql_database_instance.instance.name
+  depends_on = [google_sql_user.user]
+}
+
+resource "google_sql_user" "user" {
+  provider = google-beta
+  name     = "{{index $.Vars "database_user"}}"
+  instance = google_sql_database_instance.instance.name
+  password = "{{index $.Vars "database_password"}}"
+}
+
+resource "google_datastream_connection_profile" "source" {
+  provider              = google-beta
+  display_name          = "SQL Server Source"
+  location              = "us-central1"
+  connection_profile_id = "{{index $.Vars "source_connection_profile_id"}}"
+
+  sql_server_profile {
+    hostname = google_sql_database_instance.instance.public_ip_address
+    port     = 1433
+    username = google_sql_user.user.name
+    password = google_sql_user.user.password
+    database = google_sql_database.db.name
+  }
 }
 
 resource "google_datastream_connection_profile" "destination" {
-    provider              = google-beta
-    display_name          = "BigQuery Destination"
-    location              = "us-central1"
-    connection_profile_id = "{{index $.Vars "destination_connection_profile_id"}}"
+  provider              = google-beta
+  display_name          = "BigQuery Destination"
+  location              = "us-central1"
+  connection_profile_id = "{{index $.Vars "destination_connection_profile_id"}}"
 
-    bigquery_profile {}
+  bigquery_profile {}
 }
 
-resource "google_datastream_stream" "default" {
-    provider     = google-beta
-    display_name = "SQL Server to BigQuery"
-    location     = "us-central1"
-    stream_id    = "{{index $.Vars "stream_id"}}"
-    desired_state = "RUNNING"
+resource "google_datastream_stream" "stream" {
+  provider = google-beta
 
-    source_config {
-        source_connection_profile = google_datastream_connection_profile.source.id
-        sql_server_source_config {
-            max_concurrent_cdc_tasks = 8
-            max_concurrent_backfill_tasks = 12
-            include_objects {
-                schemas {
-                    schema = "schema"
-                    tables {
-                        table = "table"
-                        columns {
-                            column = "column"
-                        }
-                    }
-                }
-            }
-            exclude_objects {
-                schemas {
-                    schema = "schema"
-                    tables {
-                        table = "table"
-                        columns {
-                            column = "column"
-                        }
-                    }
-                }
-            }
-            drop_large_objects {}
-		    }
-    }
+  display_name = "SQL Server to BigQuery"
+  location     = "us-central1"
+  stream_id    = "{{index $.Vars "stream_id"}}"
 
-    destination_config {
-        destination_connection_profile = google_datastream_connection_profile.destination.id
-        bigquery_destination_config {
-            data_freshness = "900s"
-            source_hierarchy_datasets {
-                dataset_template {
-                    location = "us-central1"
-                }
-            }
+  source_config {
+    source_connection_profile = google_datastream_connection_profile.source.id
+    sql_server_source_config {
+      include_objects {
+        schemas {
+          schema = "schema"
+          tables {
+            table = "table"
+          }
         }
+      }
     }
+  }
 
-    backfill_all {
-        sql_server_excluded_objects {
-            schemas {
-                schema = "schema"
-                tables {
-                    table = "table"
-                    columns {
-                        column = "column"
-                    }
-                }
-            }
+  destination_config {
+    destination_connection_profile = google_datastream_connection_profile.destination.id
+    bigquery_destination_config {
+      data_freshness = "900s"
+      source_hierarchy_datasets {
+        dataset_template {
+          location = "us-central1"
         }
+      }
     }
+  }
+
+  backfill_none {}
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds datastream connection profile and stream configuration for sql server.
Fixes https://github.com/hashicorp/terraform-provider-google/issues/17981

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
datastream: added sql server connection profile/stream configuration
```
