### PR TITLE
bigquery_table - add support for `external_data_configuration.bigtable_options`

### DIFF
--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.erb
@@ -514,7 +514,7 @@ func ResourceBigQueryTable() *schema.Resource {
 						"source_format": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: ` Please see sourceFormat under ExternalDataConfiguration in Bigquery's public API documentation (https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#externaldataconfiguration) for supported formats. To use "GOOGLE_SHEETS" the scopes must include "googleapis.com/auth/drive.readonly".`,
+							Description: `Please see sourceFormat under ExternalDataConfiguration in Bigquery's public API documentation (https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#externaldataconfiguration) for supported formats. To use "GOOGLE_SHEETS" the scopes must include "googleapis.com/auth/drive.readonly".`,
 							ValidateFunc: validation.StringInSlice([]string{
 								"CSV", "GOOGLE_SHEETS", "NEWLINE_DELIMITED_JSON", "AVRO", "ICEBERG", "DATASTORE_BACKUP", "PARQUET", "ORC", "BIGTABLE",
 							}, false),
@@ -620,7 +620,7 @@ func ResourceBigQueryTable() *schema.Resource {
 							Type:        schema.TypeList,
 							Optional:    true,
 							MaxItems:    1,
-							Description: `Additional properties to set if sourceFormat is set to JSON."`,
+							Description: `Additional properties to set if sourceFormat is set to JSON.`,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"encoding": {
@@ -641,11 +641,105 @@ func ResourceBigQueryTable() *schema.Resource {
 							Description:  `Load option to be used together with sourceFormat newline-delimited JSON to indicate that a variant of JSON is being loaded. To load newline-delimited GeoJSON, specify GEOJSON (and sourceFormat must be set to NEWLINE_DELIMITED_JSON).`,
 						},
 
+						"bigtable_options": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							MaxItems:    1,
+							Description: `Additional options if sourceFormat is set to BIGTABLE.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"column_family": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										Description: `A list of column families to expose in the table schema along with their types. This list restricts the column families that can be referenced in queries and specifies their value types. You can use this list to do type conversions - see the 'type' field for more details. If you leave this list empty, all column families are present in the table schema and their values are read as BYTES. During a query only the column families referenced in that query are read from Bigtable.`,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"column": {
+													Type:        schema.TypeList,
+													Optional:    true,
+													Description: `A List of columns that should be exposed as individual fields as opposed to a list of (column name, value) pairs. All columns whose qualifier matches a qualifier in this list can be accessed as Other columns can be accessed as a list through column field`,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"qualifier_encoded": {
+																Type:        schema.TypeString,
+																Optional:    true,
+																Description: `Qualifier of the column. Columns in the parent column family that has this exact qualifier are exposed as . field. If the qualifier is valid UTF-8 string, it can be specified in the qualifierString field. Otherwise, a base-64 encoded value must be set to qualifierEncoded. The column field name is the same as the column qualifier. However, if the qualifier is not a valid BigQuery field identifier i.e. does not match [a-zA-Z][a-zA-Z0-9_]*, a valid identifier must be provided as fieldName.`,
+															},
+															"qualifier_string": {
+																Type:        schema.TypeString,
+																Optional:    true,
+																Description: `Qualifier string.`,
+															},
+															"field_name": {
+																Type:        schema.TypeString,
+																Optional:    true,
+																Description: `If the qualifier is not a valid BigQuery field identifier i.e. does not match [a-zA-Z][a-zA-Z0-9_]*, a valid identifier must be provided as the column field name and is used as field name in queries.`,
+															},
+															"type": {
+																Type:        schema.TypeString,
+																Optional:    true,
+																Description: `The type to convert the value in cells of this column. The values are expected to be encoded using HBase Bytes.toBytes function when using the BINARY encoding value. Following BigQuery types are allowed (case-sensitive): "BYTES", "STRING", "INTEGER", "FLOAT", "BOOLEAN", "JSON", Default type is "BYTES". 'type' can also be set at the column family level. However, the setting at this level takes precedence if 'type' is set at both levels.`,
+															},
+															"encoding": {
+																Type:        schema.TypeString,
+																Optional:    true,
+																Description: `The encoding of the values when the type is not STRING. Acceptable encoding values are: TEXT - indicates values are alphanumeric text strings. BINARY - indicates values are encoded using HBase Bytes.toBytes family of functions. 'encoding' can also be set at the column family level. However, the setting at this level takes precedence if 'encoding' is set at both levels.`,
+															},
+															"only_read_latest": {
+																Type:        schema.TypeBool,
+																Optional:    true,
+																Description: `If this is set, only the latest version of value in this column are exposed. 'onlyReadLatest' can also be set at the column family level. However, the setting at this level takes precedence if 'onlyReadLatest' is set at both levels.`,
+															},
+														},
+													},
+												},
+												"family_id": {
+													Type:        schema.TypeString,
+													Optional:    true,
+													Description: `Identifier of the column family.`,
+												},
+												"type": {
+													Type:        schema.TypeString,
+													Optional:    true,
+													Description: `The type to convert the value in cells of this column family. The values are expected to be encoded using HBase Bytes.toBytes function when using the BINARY encoding value. Following BigQuery types are allowed (case-sensitive): "BYTES", "STRING", "INTEGER", "FLOAT", "BOOLEAN", "JSON". Default type is BYTES. This can be overridden for a specific column by listing that column in 'columns' and specifying a type for it.`,
+												},
+												"encoding": {
+													Type:        schema.TypeString,
+													Optional:    true,
+													Description: `The encoding of the values when the type is not STRING. Acceptable encoding values are: TEXT - indicates values are alphanumeric text strings. BINARY - indicates values are encoded using HBase Bytes.toBytes family of functions. This can be overridden for a specific column by listing that column in 'columns' and specifying an encoding for it.`,
+												},
+												"only_read_latest": {
+													Type:        schema.TypeBool,
+													Optional:    true,
+													Description: `If this is set only the latest version of value are exposed for all columns in this column family. This can be overridden for a specific column by listing that column in 'columns' and specifying a different setting for that column.`,
+												},
+											},
+										},
+									},
+									"ignore_unspecified_column_families": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Description: `If field is true, then the column families that are not specified in columnFamilies list are not exposed in the table schema. Otherwise, they are read with BYTES type values. The default value is false.`,
+									},
+									"read_rowkey_as_string": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Description: `If field is true, then the rowkey column families will be read and converted to string. Otherwise they are read with BYTES type values and users need to manually cast them with CAST if necessary. The default value is false.`,
+									},
+									"output_column_families_as_json": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Description: `If field is true, then each column family will be read as a single JSON column. Otherwise they are read as a repeated cell structure containing timestamp/value tuples. The default value is false.`,
+									},
+								},
+							},
+						},
+
 						"parquet_options": {
 							Type:        schema.TypeList,
 							Optional:    true,
 							MaxItems:    1,
-							Description: `Additional properties to set if sourceFormat is set to PARQUET."`,
+							Description: `Additional properties to set if sourceFormat is set to PARQUET.`,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"enum_as_string": {
@@ -674,7 +768,7 @@ func ResourceBigQueryTable() *schema.Resource {
 									"range": {
 										Type:        schema.TypeString,
 										Optional:    true,
-										Description: `Range of a sheet to query from. Only used when non-empty. At least one of range or skip_leading_rows must be set. Typical format: "sheet_name!top_left_cell_id:bottom_right_cell_id" For example: "sheet1!A1:B20"`,
+										Description: `Range of a sheet to query from. Only used when non-empty. At least one of range or skip_leading_rows must be set. Typical format: "sheet_name!top_left_cell_id:bottom_right_cell_id" For example: "sheet1!A1:B20`,
 										AtLeastOneOf: []string{
 											"external_data_configuration.0.google_sheets_options.0.skip_leading_rows",
 											"external_data_configuration.0.google_sheets_options.0.range",
@@ -1902,6 +1996,9 @@ func expandExternalDataConfiguration(cfg interface{}) (*bigquery.ExternalDataCon
 	if v, ok := raw["json_options"]; ok {
 		edc.JsonOptions = expandJsonOptions(v)
 	}
+	if v, ok := raw["bigtable_options"]; ok {
+		edc.BigtableOptions = expandBigtableOptions(v)
+	}
 	if v, ok := raw["google_sheets_options"]; ok {
 		edc.GoogleSheetsOptions = expandGoogleSheetsOptions(v)
 	}
@@ -1989,6 +2086,10 @@ func flattenExternalDataConfiguration(edc *bigquery.ExternalDataConfiguration) (
 
 	if edc.JsonOptions != nil {
 		result["json_options"] = flattenJsonOptions(edc.JsonOptions)
+	}
+
+	if edc.BigtableOptions != nil {
+		result["bigtable_options"] = flattenBigtableOptions(edc.BigtableOptions)
 	}
 
 	if edc.IgnoreUnknownValues {
@@ -2219,6 +2320,164 @@ func flattenParquetOptions(opts *bigquery.ParquetOptions) []map[string]interface
 	}
 
 	return []map[string]interface{}{result}
+}
+
+func expandBigtableOptions(configured interface{}) *bigquery.BigtableOptions {
+	if len(configured.([]interface{})) == 0 {
+		return nil
+	}
+
+	raw := configured.([]interface{})[0].(map[string]interface{})
+	opts := &bigquery.BigtableOptions{}
+
+	crs := []*bigquery.BigtableColumnFamily{}
+	if v, ok := raw["column_family"]; ok {
+		for _, columnFamily := range v.([]interface{}) {
+			crs = append(crs, expandBigtableColumnFamily(columnFamily))
+		}
+
+		if len(crs) > 0 {
+			opts.ColumnFamilies = crs
+		}
+	}
+
+	if v, ok := raw["ignore_unspecified_column_families"]; ok {
+		opts.IgnoreUnspecifiedColumnFamilies = v.(bool)
+	}
+
+	if v, ok := raw["read_rowkey_as_string"]; ok {
+		opts.ReadRowkeyAsString = v.(bool)
+	}
+
+	if v, ok := raw["output_column_families_as_json"]; ok {
+		opts.OutputColumnFamiliesAsJson = v.(bool)
+	}
+
+	return opts
+}
+
+func flattenBigtableOptions(opts *bigquery.BigtableOptions) []map[string]interface{} {
+	result := map[string]interface{}{}
+
+	if opts.ColumnFamilies != nil {
+		result["column_family"] = flattenBigtableColumnFamily(opts.ColumnFamilies)
+	}
+
+	if opts.IgnoreUnspecifiedColumnFamilies {
+		result["ignore_unspecified_column_families"] = opts.IgnoreUnspecifiedColumnFamilies
+	}
+
+	if opts.ReadRowkeyAsString {
+		result["read_rowkey_as_string"] = opts.ReadRowkeyAsString
+	}
+
+	if opts.OutputColumnFamiliesAsJson {
+		result["output_column_families_as_json"] = opts.OutputColumnFamiliesAsJson
+	}
+
+	return []map[string]interface{}{result}
+}
+
+func expandBigtableColumnFamily(configured interface{}) *bigquery.BigtableColumnFamily {
+	raw := configured.(map[string]interface{})
+
+	opts := &bigquery.BigtableColumnFamily{}
+
+	crs := []*bigquery.BigtableColumn{}
+	if v, ok := raw["column"]; ok {
+		for _, column := range v.([]interface{}) {
+			crs = append(crs, expandBigtableColumn(column))
+		}
+
+		if len(crs) > 0 {
+			opts.Columns = crs
+		}
+	}
+
+	if v, ok := raw["family_id"]; ok {
+		opts.FamilyId = v.(string)
+	}
+
+	if v, ok := raw["type"]; ok {
+		opts.Type = v.(string)
+	}
+
+	if v, ok := raw["encoding"]; ok {
+		opts.Encoding = v.(string)
+	}
+
+	if v, ok := raw["only_read_latest"]; ok {
+		opts.OnlyReadLatest = v.(bool)
+	}
+
+	return opts
+}
+
+func flattenBigtableColumnFamily(edc []*bigquery.BigtableColumnFamily) []map[string]interface{} {
+	results := []map[string]interface{}{}
+
+	for _, fr := range edc {
+		result := map[string]interface{}{}
+		if fr.Columns != nil {
+			result["column"] = flattenBigtableColumn(fr.Columns)
+		}
+		result["family_id"] = fr.FamilyId
+		result["type"] = fr.Type
+		result["encoding"] = fr.Encoding
+		result["only_read_latest"] = fr.OnlyReadLatest
+		results = append(results, result)
+	}
+
+	return results
+}
+
+func expandBigtableColumn(configured interface{}) *bigquery.BigtableColumn {
+	raw := configured.(map[string]interface{})
+
+	opts := &bigquery.BigtableColumn{}
+	
+	if v, ok := raw["qualifier_encoded"]; ok {
+		opts.QualifierEncoded = v.(string)
+	}
+
+	if v, ok := raw["qualifier_string"]; ok {
+		opts.QualifierString = v.(string)
+	}
+
+	if v, ok := raw["field_name"]; ok {
+		opts.FieldName = v.(string)
+	}
+
+	if v, ok := raw["type"]; ok {
+		opts.Type = v.(string)
+	}
+
+	if v, ok := raw["encoding"]; ok {
+		opts.Encoding = v.(string)
+	}
+
+	if v, ok := raw["only_read_latest"]; ok {
+		opts.OnlyReadLatest = v.(bool)
+	}
+
+	return opts
+}
+
+func flattenBigtableColumn(edc []*bigquery.BigtableColumn) []map[string]interface{} {
+	results := []map[string]interface{}{}
+
+	for _, fr := range edc {
+		result := map[string]interface{}{}
+		result["qualifier_encoded"] = fr.QualifierEncoded
+		result["qualifier_string"] = fr.QualifierString
+		result["field_name"] = fr.FieldName
+		result["type"] = fr.Type
+		result["encoding"] = fr.Encoding
+		result["only_read_latest"] = fr.OnlyReadLatest
+		results = append(results, result)
+	}
+
+	return results
 }
 
 func expandJsonOptions(configured interface{}) *bigquery.JsonOptions {

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
@@ -1118,6 +1118,37 @@ func TestAccBigQueryDataTable_bigtable(t *testing.T) {
 	})
 }
 
+func TestAccBigQueryDataTable_bigtable_options(t *testing.T) {
+	// bigtable instance does not use the shared HTTP client, this test creates an instance
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 8),
+		"project":       envvar.GetTestProjectFromEnv(),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryTableFromBigtableOptions(context),
+			},
+			{
+				ResourceName:            "google_bigquery_table.table",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccBigQueryTableFromBigtable(context),
+			},
+		},
+	})
+}
+
 func TestAccBigQueryDataTable_sheet(t *testing.T) {
 	t.Parallel()
 
@@ -3279,6 +3310,77 @@ resource "google_bigquery_dataset" "dataset" {
   friendly_name               = "test"
   description                 = "This is a test description"
   location                    = "EU"
+  default_table_expiration_ms = 3600000
+  labels = {
+    env = "default"
+  }
+}
+`, context)
+}
+
+func testAccBigQueryTableFromBigtableOptions(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_bigtable_instance" "instance" {
+  name = "tf-test-bigtable-inst-%{random_suffix}"
+  cluster {
+    cluster_id = "tf-test-bigtable-%{random_suffix}"
+    zone       = "us-central1-b"
+  }
+  instance_type = "DEVELOPMENT"
+  deletion_protection = false
+}
+resource "google_bigtable_table" "table" {
+  name          = "%{random_suffix}"
+  instance_name = google_bigtable_instance.instance.name
+  column_family {
+    family = "cf-%{random_suffix}-first"
+  }
+  column_family {
+    family = "cf-%{random_suffix}-second"
+  }
+}
+resource "google_bigquery_table" "table" {
+  deletion_protection = false
+  dataset_id = google_bigquery_dataset.dataset.dataset_id
+  table_id   = "tf_test_bigtable_%{random_suffix}"
+  external_data_configuration {
+    autodetect            = true
+    source_format         = "BIGTABLE"
+    ignore_unknown_values = true
+    source_uris = [
+    "https://googleapis.com/bigtable/${google_bigtable_table.table.id}",
+    ]
+	bigtable_options {
+      column_family {
+        family_id        = "cf-%{random_suffix}-first"
+		column {
+			field_name       = "cf-%{random_suffix}-first"
+			type             = "STRING"
+			encoding         = "TEXT"
+			only_read_latest = true
+		  }
+		type             = "STRING"
+		encoding         = "TEXT"
+		only_read_latest = true
+	  }
+      column_family {
+        family_id        = "cf-%{random_suffix}-second"
+		type             = "STRING"
+		encoding         = "TEXT"
+		only_read_latest = false
+	  }
+      ignore_unspecified_column_families = true
+      read_rowkey_as_string              = true
+      output_column_families_as_json     = true
+	}
+  }
+}
+resource "google_bigquery_dataset" "dataset" {
+  dataset_id                  = "tf_test_ds_%{random_suffix}"
+  friendly_name               = "test"
+  description                 = "This is a test description"
+  location                    = "EU"
+  delete_contents_on_destroy  = true
   default_table_expiration_ms = 3600000
   labels = {
     env = "default"

--- a/mmv1/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -187,6 +187,9 @@ in Terraform state, a `terraform destroy` or `terraform apply` that would delete
 * `csv_options` (Optional) - Additional properties to set if
     `source_format` is set to "CSV". Structure is [documented below](#nested_csv_options).
 
+* `bigtable_options` (Optional) - Additional properties to set if
+    `source_format` is set to "BIGTABLE". Structure is [documented below](#nested_bigtable_options).
+
 * `json_options` (Optional) - Additional properties to set if
     `source_format` is set to "JSON". Structure is [documented below](#nested_json_options).
 
@@ -275,6 +278,30 @@ in Terraform state, a `terraform destroy` or `terraform apply` that would delete
 
 * `skip_leading_rows` (Optional) - The number of rows at the top of a CSV
     file that BigQuery will skip when reading the data.
+
+<a name="nested_bigtable_options"></a>The `bigtable_options` block supports:
+
+* `column_family` (Optional) - A list of column families to expose in the table schema along with their types. This list restricts the column families that can be referenced in queries and specifies their value types. You can use this list to do type conversions - see the 'type' field for more details. If you leave this list empty, all column families are present in the table schema and their values are read as BYTES. During a query only the column families referenced in that query are read from Bigtable.  Structure is [documented below](#nested_column_family).
+* `ignore_unspecified_column_families` (Optional) - If field is true, then the column families that are not specified in columnFamilies list are not exposed in the table schema. Otherwise, they are read with BYTES type values. The default value is false.
+* `read_rowkey_as_string` (Optional) - If field is true, then the rowkey column families will be read and converted to string. Otherwise they are read with BYTES type values and users need to manually cast them with CAST if necessary. The default value is false.
+* `output_column_families_as_json` (Optional) - If field is true, then each column family will be read as a single JSON column. Otherwise they are read as a repeated cell structure containing timestamp/value tuples. The default value is false.
+
+<a name="nested_column_family"></a>The `column_family` block supports:
+
+* `column` (Optional) - A List of columns that should be exposed as individual fields as opposed to a list of (column name, value) pairs. All columns whose qualifier matches a qualifier in this list can be accessed as Other columns can be accessed as a list through column field.  Structure is [documented below](#nested_column).
+* `family_id` (Optional) - Identifier of the column family.
+* `type` (Optional) - The type to convert the value in cells of this column family. The values are expected to be encoded using HBase Bytes.toBytes function when using the BINARY encoding value. Following BigQuery types are allowed (case-sensitive): "BYTES", "STRING", "INTEGER", "FLOAT", "BOOLEAN", "JSON". Default type is BYTES. This can be overridden for a specific column by listing that column in 'columns' and specifying a type for it.
+* `encoding` (Optional) - The encoding of the values when the type is not STRING. Acceptable encoding values are: TEXT - indicates values are alphanumeric text strings. BINARY - indicates values are encoded using HBase Bytes.toBytes family of functions. This can be overridden for a specific column by listing that column in 'columns' and specifying an encoding for it.
+* `only_read_latest` (Optional) - If this is set only the latest version of value are exposed for all columns in this column family. This can be overridden for a specific column by listing that column in 'columns' and specifying a different setting for that column.
+
+<a name="nested_column"></a>The `column` block supports:
+
+* `qualifier_encoded` (Optional) - Qualifier of the column. Columns in the parent column family that has this exact qualifier are exposed as . field. If the qualifier is valid UTF-8 string, it can be specified in the qualifierString field. Otherwise, a base-64 encoded value must be set to qualifierEncoded. The column field name is the same as the column qualifier. However, if the qualifier is not a valid BigQuery field identifier i.e. does not match [a-zA-Z][a-zA-Z0-9_]*, a valid identifier must be provided as fieldName.
+* `qualifier_string` (Optional) - Qualifier string.
+* `field_name` (Optional) - If the qualifier is not a valid BigQuery field identifier i.e. does not match [a-zA-Z][a-zA-Z0-9_]*, a valid identifier must be provided as the column field name and is used as field name in queries.
+* `type` (Optional) - The type to convert the value in cells of this column. The values are expected to be encoded using HBase Bytes.toBytes function when using the BINARY encoding value. Following BigQuery types are allowed (case-sensitive): "BYTES", "STRING", "INTEGER", "FLOAT", "BOOLEAN", "JSON", Default type is "BYTES". 'type' can also be set at the column family level. However, the setting at this level takes precedence if 'type' is set at both levels.
+* `encoding` (Optional) - The encoding of the values when the type is not STRING. Acceptable encoding values are: TEXT - indicates values are alphanumeric text strings. BINARY - indicates values are encoded using HBase Bytes.toBytes family of functions. 'encoding' can also be set at the column family level. However, the setting at this level takes precedence if 'encoding' is set at both levels.
+* `only_read_latest` (Optional) - If this is set, only the latest version of value in this column are exposed. 'onlyReadLatest' can also be set at the column family level. However, the setting at this level takes precedence if 'onlyReadLatest' is set at both levels.
 
 <a name="nested_json_options"></a>The `json_options` block supports:
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigquery: added `external_data_configuration.bigtable_options` to `google_bigquery_table`
```
