### PR TITLE
Adding SOA Deletion short-circuit

### DIFF
--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
@@ -457,14 +457,17 @@ func resourceDnsRecordSetDelete(d *schema.ResourceData, meta interface{}) error 
 
 	zone := d.Get("managed_zone").(string)
 
-	// NS records must always have a value, so we short-circuit delete
-	// this allows terraform delete to work, but may have unexpected
-	// side-effects when deleting just that record set.
+	// NS and SOA records on the root zone must always have a value,
+	// so we short-circuit delete this allows terraform delete to work,
+	// but may have unexpected side-effects when deleting just that
+	// record set.
 	// Unfortunately, you can set NS records on subdomains, and those
 	// CAN and MUST be deleted, so we need to retrieve the managed zone,
 	// check if what we're looking at is a subdomain, and only not delete
 	// if it's not actually a subdomain
-	if d.Get("type").(string) == "NS" {
+	// This does not apply to SOA, as they can only be set on the root
+	// zone.
+	if d.Get("type").(string) == "NS" || d.Get("type").(string) == "SOA" {
 		mz, err := config.NewDnsClient(userAgent).ManagedZones.Get(project, zone).Do()
 		if err != nil {
 			return fmt.Errorf("Error retrieving managed zone %q from %q: %s", zone, project, err)
@@ -472,7 +475,7 @@ func resourceDnsRecordSetDelete(d *schema.ResourceData, meta interface{}) error 
 		domain := mz.DnsName
 
 		if domain == d.Get("name").(string) {
-			log.Println("[DEBUG] NS records can't be deleted due to API restrictions, so they're being left in place. See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set for more information.")
+			log.Printf("[DEBUG] root-level %s records can't be deleted due to API restrictions, so they're being left in place. See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set for more information.\n", d.Get("type").(string))
 			return nil
 		}
 	}

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.erb
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.erb
@@ -208,6 +208,30 @@ func TestAccDNSRecordSet_secondaryNS(t *testing.T) {
 	})
 }
 
+// tracks fix for https://github.com/hashicorp/terraform-provider-google/issues/12827
+func TestAccDNSRecordSet_deletionSOA(t *testing.T) {
+	t.Parallel()
+
+	zoneName := fmt.Sprintf("dnszone-test-soa-%s", acctest.RandString(t, 10))
+	recordSetName := "google_dns_managed_zone.parent-zone.dns_name"
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDnsRecordSetDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDnsRecordSet_SOA(zoneName, recordSetName, 300),
+			},
+			{
+				ResourceName:      "google_dns_record_set.foobar",
+				ImportStateId:     fmt.Sprintf("projects/%s/managedZones/%s/rrsets/%s.hashicorptest.com./SOA", envvar.GetTestProjectFromEnv(), zoneName, zoneName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccDNSRecordSet_quotedTXT(t *testing.T) {
 	t.Parallel()
 
@@ -677,6 +701,25 @@ resource "google_dns_record_set" "foobar" {
   ttl          = %d
 }
 `, zoneName, zoneName, zoneName, ttl)
+}
+
+
+func testAccDnsRecordSet_SOA(name string, recordSetName string, ttl int) string {
+	return fmt.Sprintf(`
+resource "google_dns_managed_zone" "parent-zone" {
+  name        = "%s"
+  dns_name    = "%s.hashicorptest.com."
+  description = "Test Description"
+}
+
+resource "google_dns_record_set" "foobar" {
+  managed_zone = google_dns_managed_zone.parent-zone.name
+  name         = %s
+  type         = "SOA"
+  rrdatas      = ["ns-cloud-a1.googledomains.com. cloud-dns-hostmaster.google.com. 629010464 900 900 1800 60"]
+  ttl          = %d
+}
+`, name, name, recordSetName, ttl)
 }
 
 func testAccDnsRecordSet_quotedTXT(name string, ttl int) string {

--- a/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
@@ -9,7 +9,7 @@ description: |-
 Manages a set of DNS records within Google Cloud DNS. For more information see [the official documentation](https://cloud.google.com/dns/records/) and
 [API](https://cloud.google.com/dns/api/v1/resourceRecordSets).
 
-~> **Note:** The provider treats this resource as an authoritative record set. This means existing records (including the default records) for the given type will be overwritten when you create this resource in Terraform. In addition, the Google Cloud DNS API requires NS records to be present at all times, so Terraform will not actually remove NS records during destroy but will report that it did.
+~> **Note:** The provider treats this resource as an authoritative record set. This means existing records (including the default records) for the given type will be overwritten when you create this resource in Terraform. In addition, the Google Cloud DNS API requires NS and SOA records to be present at all times, so Terraform will not actually remove NS or SOA records on the root of the zone during destroy but will report that it did.
 
 ## Example Usage
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Added short-circuit deletion for SOA-Records on the root-zone with corresponding tests and documentation. A new PR since https://github.com/GoogleCloudPlatform/magic-modules/pull/6724 was stale.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/12827
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
dns: fixed bug where the deletion of manages zones that have a SOA-Record set with terraform did not work
```