### PR TITLE
Add KMS support for the google_bigquery_connection resource

### DIFF
--- a/mmv1/products/bigqueryconnection/Connection.yaml
+++ b/mmv1/products/bigqueryconnection/Connection.yaml
@@ -133,7 +133,7 @@ examples:
       database_instance_name: 'my-database-instance'
       username: 'user'
       deletion_protection: 'true'
-      kms_key_name: 'bq-key'
+      kms_key_name: 'projects/project/locations/us-central1/keyRings/us-central1/cryptoKeys/bq-key'
     test_vars_overrides:
       deletion_protection: 'false'
       kms_key_name: 'acctest.BootstrapKMSKey(t).CryptoKey.Name'

--- a/mmv1/products/bigqueryconnection/Connection.yaml
+++ b/mmv1/products/bigqueryconnection/Connection.yaml
@@ -125,6 +125,25 @@ examples:
     primary_resource_id: "connection"
     vars:
       connection_id: "my-connection"
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'bigquery_connection_kms'
+    pull_external: true
+    primary_resource_id:
+      'connection'
+    # Random provider
+    skip_vcr: true
+    vars:
+      database_instance_name: 'my-database-instance'
+      username: 'user'
+      deletion_protection: 'true'
+      kms_key_ring: 'bq-connection'
+      kms_key_name: 'bq-key'
+    test_vars_overrides:
+      deletion_protection: 'false'
+    oics_vars_overrides:
+      deletion_protection: 'false'
+    ignore_read_extra:
+      - 'cloud_sql.0.credential'  # password removed
 properties:
   - !ruby/object:Api::Type::String
     name: name
@@ -164,6 +183,12 @@ properties:
     output: true
     description: |
       True if the connection has credential assigned.
+  - !ruby/object:Api::Type::String
+    name: 'kmsKeyName'
+    description: |
+      Optional. The Cloud KMS key that is used for encryption.
+
+      Example: projects/[kms_project_id]/locations/[region]/keyRings/[key_region]/cryptoKeys/[key]
   - !ruby/object:Api::Type::NestedObject
     name: 'cloudSql'
     description: Connection properties specific to the Cloud SQL.

--- a/mmv1/products/bigqueryconnection/Connection.yaml
+++ b/mmv1/products/bigqueryconnection/Connection.yaml
@@ -129,9 +129,7 @@ examples:
     name: 'bigquery_connection_kms'
     pull_external: true
     primary_resource_id:
-      'connection'
-    # Random provider
-    skip_vcr: true
+      'bq-connection-cmek'
     vars:
       database_instance_name: 'my-database-instance'
       username: 'user'

--- a/mmv1/products/bigqueryconnection/Connection.yaml
+++ b/mmv1/products/bigqueryconnection/Connection.yaml
@@ -127,7 +127,6 @@ examples:
       connection_id: "my-connection"
   - !ruby/object:Provider::Terraform::Examples
     name: 'bigquery_connection_kms'
-    pull_external: true
     primary_resource_id:
       'bq-connection-cmek'
     vars:

--- a/mmv1/products/bigqueryconnection/Connection.yaml
+++ b/mmv1/products/bigqueryconnection/Connection.yaml
@@ -134,10 +134,14 @@ examples:
       database_instance_name: 'my-database-instance'
       username: 'user'
       deletion_protection: 'true'
-      kms_key_ring: 'bq-connection'
       kms_key_name: 'bq-key'
     test_vars_overrides:
       deletion_protection: 'false'
+      kms_key_name: 'acctest.BootstrapKMSKey(t).CryptoKey.Name'
+      policyChanged:
+        "acctest.BootstrapPSARole(t, \"bq-\", \"bigquery-encryption\",
+        \"roles/cloudkms.cryptoKeyEncrypterDecrypter\"\
+        )"
     oics_vars_overrides:
       deletion_protection: 'false'
     ignore_read_extra:

--- a/mmv1/templates/terraform/examples/bigquery_connection_kms.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_connection_kms.tf.erb
@@ -41,10 +41,6 @@ resource "google_bigquery_connection" "<%= ctx[:primary_resource_id] %>" {
     }
 }
 
-resource "google_project_service_identity" "default" {
-    service = "bigquery.googleapis.com"
-}
-
 resource "google_kms_key_ring" "default" {
     name     = "<%= ctx[:vars]['kms_key_ring'] %>"
     location = "us"
@@ -55,8 +51,11 @@ resource "google_kms_crypto_key" "default" {
     key_ring = google_kms_key_ring.default.id
 }
 
+data "google_project" "project" {
+}
+
 resource "google_kms_crypto_key_iam_member" "default" {
     crypto_key_id = google_kms_crypto_key.default.id
-    member        = google_project_service_identity.default.email
+    member        = "serviceAccount:bq-${data.google_project.project.number}@bigquery-encryption.iam.gserviceaccount.com"
     role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 }

--- a/mmv1/templates/terraform/examples/bigquery_connection_kms.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_connection_kms.tf.erb
@@ -1,0 +1,62 @@
+resource "google_sql_database_instance" "instance" {
+    name             = "<%= ctx[:vars]['database_instance_name'] %>"
+    database_version = "POSTGRES_11"
+    region           = "us-central1"
+    settings {
+		tier = "db-f1-micro"
+	}
+
+    deletion_protection  = "<%= ctx[:vars]['deletion_protection'] %>"
+}
+
+resource "google_sql_database" "db" {
+    instance = google_sql_database_instance.instance.name
+    name     = "db"
+}
+
+resource "random_password" "pwd" {
+    length = 16
+    special = false
+}
+
+resource "google_sql_user" "user" {
+    name = "<%= ctx[:vars]['username'] %>"
+    instance = google_sql_database_instance.instance.name
+    password = random_password.pwd.result
+}
+
+resource "google_bigquery_connection" "<%= ctx[:primary_resource_id] %>" {
+    friendly_name = "👋"
+    description   = "a riveting description"
+    location      = "US"
+    kms_key_name  = google_kms_crypto_key.default.id
+    cloud_sql {
+        instance_id = google_sql_database_instance.instance.connection_name
+        database    = google_sql_database.db.name
+        type        = "POSTGRES"
+        credential {
+          username = google_sql_user.user.name
+          password = google_sql_user.user.password
+        }
+    }
+}
+
+resource "google_project_service_identity" "default" {
+    service = "bigquery.googleapis.com"
+}
+
+resource "google_kms_key_ring" "default" {
+    name     = "<%= ctx[:vars]['kms_key_ring'] %>"
+    location = "us"
+}
+
+resource "google_kms_crypto_key" "default" {
+    name     = "<%= ctx[:vars]['kms_key_name'] %>"
+    key_ring = google_kms_key_ring.default.id
+}
+
+resource "google_kms_crypto_key_iam_member" "default" {
+    crypto_key_id = google_kms_crypto_key.default.id
+    member        = google_project_service_identity.default.email
+    role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+}

--- a/mmv1/templates/terraform/examples/bigquery_connection_kms.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_connection_kms.tf.erb
@@ -14,22 +14,17 @@ resource "google_sql_database" "db" {
     name     = "db"
 }
 
-resource "random_password" "pwd" {
-    length = 16
-    special = false
-}
-
 resource "google_sql_user" "user" {
     name = "<%= ctx[:vars]['username'] %>"
     instance = google_sql_database_instance.instance.name
-    password = random_password.pwd.result
+    password = "tf-test-my-password%{random_suffix}"
 }
 
 resource "google_bigquery_connection" "<%= ctx[:primary_resource_id] %>" {
     friendly_name = "👋"
     description   = "a riveting description"
     location      = "US"
-    kms_key_name  = google_kms_crypto_key.default.id
+    kms_key_name  = "<%= ctx[:vars]['kms_key_name'] %>"
     cloud_sql {
         instance_id = google_sql_database_instance.instance.connection_name
         database    = google_sql_database.db.name
@@ -41,21 +36,11 @@ resource "google_bigquery_connection" "<%= ctx[:primary_resource_id] %>" {
     }
 }
 
-resource "google_kms_key_ring" "default" {
-    name     = "<%= ctx[:vars]['kms_key_ring'] %>"
-    location = "us"
-}
-
-resource "google_kms_crypto_key" "default" {
-    name     = "<%= ctx[:vars]['kms_key_name'] %>"
-    key_ring = google_kms_key_ring.default.id
-}
-
 data "google_project" "project" {
 }
 
 resource "google_kms_crypto_key_iam_member" "default" {
-    crypto_key_id = google_kms_crypto_key.default.id
+    crypto_key_id = "<%= ctx[:vars]['kms_key_name'] %>"
     member        = "serviceAccount:bq-${data.google_project.project.number}@bigquery-encryption.iam.gserviceaccount.com"
     role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 }

--- a/mmv1/templates/terraform/examples/bigquery_connection_kms.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_connection_kms.tf.erb
@@ -36,11 +36,3 @@ resource "google_bigquery_connection" "<%= ctx[:primary_resource_id] %>" {
     }
 }
 
-data "google_project" "project" {
-}
-
-resource "google_kms_crypto_key_iam_member" "default" {
-    crypto_key_id = "<%= ctx[:vars]['kms_key_name'] %>"
-    member        = "serviceAccount:bq-${data.google_project.project.number}@bigquery-encryption.iam.gserviceaccount.com"
-    role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-}


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/17955

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute:  added the 'kms_key_name` field to the 'google_bigquery_connection` resource
```
