### PR TITLE
Set enable_control_plane_v2 field to immutable

### DIFF
--- a/mmv1/products/gkeonprem/VmwareCluster.yaml
+++ b/mmv1/products/gkeonprem/VmwareCluster.yaml
@@ -535,6 +535,7 @@ properties:
     name: 'enableControlPlaneV2'
     description: Enable control plane V2. Default to false.
     immutable: true
+    default_value: true
   - !ruby/object:Api::Type::Boolean
     name: 'disableBundledIngress'
     description: Disable bundled ingress.

--- a/mmv1/products/gkeonprem/VmwareCluster.yaml
+++ b/mmv1/products/gkeonprem/VmwareCluster.yaml
@@ -535,7 +535,6 @@ properties:
     name: 'enableControlPlaneV2'
     description: Enable control plane V2. Default to false.
     immutable: true
-    default_value: true
   - !ruby/object:Api::Type::Boolean
     name: 'disableBundledIngress'
     description: Disable bundled ingress.

--- a/mmv1/products/gkeonprem/VmwareCluster.yaml
+++ b/mmv1/products/gkeonprem/VmwareCluster.yaml
@@ -534,6 +534,7 @@ properties:
   - !ruby/object:Api::Type::Boolean
     name: 'enableControlPlaneV2'
     description: Enable control plane V2. Default to false.
+    immutable: true
   - !ruby/object:Api::Type::Boolean
     name: 'disableBundledIngress'
     description: Disable bundled ingress.

--- a/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_vmware_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_vmware_cluster_test.go.erb
@@ -464,7 +464,6 @@ func testAccGkeonpremVmwareCluster_vmwareClusterUpdateManualLb(context map[strin
       advanced_networking = true
     }
     vm_tracking_enabled = false
-    enable_control_plane_v2 = false
     disable_bundled_ingress = false
     upgrade_policy {
       control_plane_only = true


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

According to https://cloud.google.com/anthos/clusters/docs/on-prem/latest/how-to/user-cluster-configuration-file-1.29#enablecontrolplanev2-field, the field should be immutable 

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
gkeonprem: set `enable_control_plane_v2` field to immutable in `google_gkeonprem_vmware_cluster` resource
```
