### PR TITLE
Allow deletion of resource_bigquery_table when it still has associated resource tags

### DIFF
--- a/mmv1/products/bigquery/Table.yaml
+++ b/mmv1/products/bigquery/Table.yaml
@@ -516,3 +516,10 @@ properties:
       in the namespaced format, for example "123456789012/environment" where 123456789012 is the
       ID of the parent organization or project resource for this tag key. Tag value is expected
       to be the short name, for example "Production".
+virtual_fields:
+  - !ruby/object:Api::Type::Boolean
+    name: 'allow_resource_tags_on_deletion'
+    min_version: beta
+    description: |
+      Whether or not to allow table deletion when there are still resource tags attached.
+    default_value: false

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.erb
@@ -1832,18 +1832,6 @@ func resourceBigQueryTableDelete(d *schema.ResourceData, meta interface{}) error
 	if d.Get("deletion_protection").(bool) {
 		return fmt.Errorf("cannot destroy table %v without setting deletion_protection=false and running `terraform apply`", d.Id())
 	}
-	<% unless version == 'ga' -%>
-	if v, ok := d.GetOk("resource_tags"); ok {
-		var resourceTags []string
-
-		for k, v := range v.(map[string]interface{}) {
-			resourceTags = append(resourceTags, fmt.Sprintf("%s:%s", k, v.(string)))
-		}
-
-		return fmt.Errorf("cannot destroy table %v without clearing the following resource tags: %v", d.Id(), resourceTags)
-	}
-
-	<% end -%>
 	config := meta.(*transport_tpg.Config)
 	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.erb
@@ -2686,9 +2686,11 @@ func resourceBigQueryTableImport(d *schema.ResourceData, meta interface{}) ([]*s
 	if err := d.Set("deletion_protection", true); err != nil {
 		return nil, fmt.Errorf("Error setting deletion_protection: %s", err)
 	}
+	<% unless version == 'ga' -%>
 	if err := d.Set("allow_resource_tags_on_deletion", false); err != nil {
 		return nil, fmt.Errorf("Error setting allow_resource_tags_on_deletion: %s", err)
 	}
+	<% end -%>
 
 	// Replace import id for the resource id
 	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/datasets/{{dataset_id}}/tables/{{table_id}}")

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.erb
@@ -1157,6 +1157,15 @@ func ResourceBigQueryTable() *schema.Resource {
 				Description: `Whether or not to allow Terraform to destroy the instance. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply that would delete the instance will fail.`,
 			},
 
+			<% unless version == 'ga' -%>
+			"allow_resource_tags_on_deletion": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: `Whether or not to allow table deletion when there are still resource tags attached.`,
+			},
+
+			<% end -%>
 			// TableConstraints: [Optional] Defines the primary key and foreign keys.
 			"table_constraints": {
 				Type:        schema.TypeList,
@@ -1832,6 +1841,20 @@ func resourceBigQueryTableDelete(d *schema.ResourceData, meta interface{}) error
 	if d.Get("deletion_protection").(bool) {
 		return fmt.Errorf("cannot destroy table %v without setting deletion_protection=false and running `terraform apply`", d.Id())
 	}
+	<% unless version == 'ga' -%>
+	if v, ok := d.GetOk("resource_tags"); ok {
+		if !d.Get("allow_resource_tags_on_deletion").(bool) {
+			var resourceTags []string
+
+			for k, v := range v.(map[string]interface{}) {
+				resourceTags = append(resourceTags, fmt.Sprintf("%s:%s", k, v.(string)))
+			}
+
+			return fmt.Errorf("cannot destroy table %v without unsetting the following resource tags or setting allow_resource_tags_on_deletion=true: %v", d.Id(), resourceTags)
+		}
+	}
+
+	<% end -%>
 	config := meta.(*transport_tpg.Config)
 	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {
@@ -2662,6 +2685,9 @@ func resourceBigQueryTableImport(d *schema.ResourceData, meta interface{}) ([]*s
 	// Explicitly set virtual fields to default values on import
 	if err := d.Set("deletion_protection", true); err != nil {
 		return nil, fmt.Errorf("Error setting deletion_protection: %s", err)
+	}
+	if err := d.Set("allow_resource_tags_on_deletion", false); err != nil {
+		return nil, fmt.Errorf("Error setting allow_resource_tags_on_deletion: %s", err)
 	}
 
 	// Replace import id for the resource id

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
@@ -1579,7 +1579,7 @@ func TestAccBigQueryTable_ResourceTags(t *testing.T) {
 				ResourceName:            "google_bigquery_table.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"deletion_protection"},
+				ImportStateVerifyIgnore: []string{"deletion_protection", "allow_resource_tags_on_deletion"},
 			},
 			{
 				Config: testAccBigQueryTableWithResourceTagsUpdate(context),
@@ -1588,7 +1588,7 @@ func TestAccBigQueryTable_ResourceTags(t *testing.T) {
 				ResourceName:            "google_bigquery_table.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"deletion_protection"},
+				ImportStateVerifyIgnore: []string{"deletion_protection", "allow_resource_tags_on_deletion"},
 			},
 			// testAccBigQueryTableWithResourceTagsDestroy must be called at the end of this test to clear the resource tag bindings of the table before deletion.
 			{
@@ -1598,7 +1598,7 @@ func TestAccBigQueryTable_ResourceTags(t *testing.T) {
 				ResourceName:            "google_bigquery_table.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"deletion_protection"},
+				ImportStateVerifyIgnore: []string{"deletion_protection", "allow_resource_tags_on_deletion"},
 			},
 		},
 	})
@@ -4001,6 +4001,7 @@ resource "google_bigquery_table" "test" {
   provider = google-beta
 
   deletion_protection = false
+	allow_resource_tags_on_deletion = true
   dataset_id = "${google_bigquery_dataset.test.dataset_id}"
   table_id   = "%{table_id}"
   resource_tags = {
@@ -4050,6 +4051,7 @@ resource "google_bigquery_table" "test" {
   provider = google-beta
 
   deletion_protection = false
+	allow_resource_tags_on_deletion = true
   dataset_id = "${google_bigquery_dataset.test.dataset_id}"
   table_id   = "%{table_id}"
   resource_tags = {
@@ -4100,6 +4102,7 @@ resource "google_bigquery_table" "test" {
   provider = google-beta
 
   deletion_protection = false
+	allow_resource_tags_on_deletion = true
   dataset_id = "${google_bigquery_dataset.test.dataset_id}"
   table_id   = "%{table_id}"
   resource_tags = {}

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.erb
@@ -4001,7 +4001,7 @@ resource "google_bigquery_table" "test" {
   provider = google-beta
 
   deletion_protection = false
-	allow_resource_tags_on_deletion = true
+  allow_resource_tags_on_deletion = true
   dataset_id = "${google_bigquery_dataset.test.dataset_id}"
   table_id   = "%{table_id}"
   resource_tags = {
@@ -4051,7 +4051,7 @@ resource "google_bigquery_table" "test" {
   provider = google-beta
 
   deletion_protection = false
-	allow_resource_tags_on_deletion = true
+  allow_resource_tags_on_deletion = true
   dataset_id = "${google_bigquery_dataset.test.dataset_id}"
   table_id   = "%{table_id}"
   resource_tags = {
@@ -4102,7 +4102,7 @@ resource "google_bigquery_table" "test" {
   provider = google-beta
 
   deletion_protection = false
-	allow_resource_tags_on_deletion = true
+  allow_resource_tags_on_deletion = true
   dataset_id = "${google_bigquery_dataset.test.dataset_id}"
   table_id   = "%{table_id}"
   resource_tags = {}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Allow deletion of resource_bigquery_table when it still has associated resource tags.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigquery: added `allow_resource_tags_on_deletion` to `google_bigquery_table` to allow deletion of table when it still has associated resource tags (beta)
```
