### PR TITLE
bump metastore federation to ga

### DIFF
--- a/mmv1/products/metastore/Federation.yaml
+++ b/mmv1/products/metastore/Federation.yaml
@@ -13,7 +13,6 @@
 
 --- !ruby/object:Api::Resource
 name: 'Federation'
-min_version: beta
 base_url: 'projects/{{project}}/locations/{{location}}/federations'
 create_url: 'projects/{{project}}/locations/{{location}}/federations?federationId={{federation_id}}'
 self_link: 'projects/{{project}}/locations/{{location}}/federations/{{federation_id}}'
@@ -54,7 +53,6 @@ examples:
     name: 'dataproc_metastore_federation_basic'
     skip_test: true  # https://github.com/hashicorp/terraform-provider-google/issues/13710
     primary_resource_id: 'default'
-    min_version: beta
     primary_resource_name:
       'fmt.Sprintf("tf-test-metastore-fed%s", context["random_suffix"])'
     vars:
@@ -64,7 +62,6 @@ examples:
     name: 'dataproc_metastore_federation_bigquery'
     skip_test: true  # https://github.com/hashicorp/terraform-provider-google/issues/13710
     primary_resource_id: 'default'
-    min_version: beta
     primary_resource_name:
       'fmt.Sprintf("tf-test-metastore-fed%s", context["random_suffix"])'
     vars:

--- a/mmv1/templates/terraform/examples/dataproc_metastore_federation_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_federation_basic.tf.erb
@@ -1,5 +1,4 @@
 resource "google_dataproc_metastore_federation" "<%= ctx[:primary_resource_id] %>" {
-  provider      = google-beta
   location      = "us-central1"
   federation_id = "<%= ctx[:vars]['metastore_federation_name'] %>"
   version       = "3.1.2"
@@ -12,7 +11,6 @@ resource "google_dataproc_metastore_federation" "<%= ctx[:primary_resource_id] %
 }
 
 resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" {
-  provider   = google-beta
   service_id = "<%= ctx[:vars]['metastore_federation_name'] %>"
   location   = "us-central1"
   tier       = "DEVELOPER"

--- a/mmv1/templates/terraform/examples/dataproc_metastore_federation_bigquery.tf.erb
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_federation_bigquery.tf.erb
@@ -28,6 +28,4 @@ resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" 
   }
 }
 
-data "google_project" "project" {
-  provider      = google-beta
-}
+data "google_project" "project" {}

--- a/mmv1/templates/terraform/examples/dataproc_metastore_federation_bigquery.tf.erb
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_federation_bigquery.tf.erb
@@ -1,5 +1,4 @@
 resource "google_dataproc_metastore_federation" "<%= ctx[:primary_resource_id] %>" {
-  provider      = google-beta
   location      = "us-central1"
   federation_id = "<%= ctx[:vars]['metastore_federation_name'] %>"
   version       = "3.1.2"
@@ -18,7 +17,6 @@ resource "google_dataproc_metastore_federation" "<%= ctx[:primary_resource_id] %
 }
 
 resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" {
-  provider   = google-beta
   service_id = "<%= ctx[:vars]['metastore_federation_name'] %>"
   location   = "us-central1"
   tier       = "DEVELOPER"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dataprocmetastore: promoted `google_dataproc_metastore_federation` to GA
```
