### PR TITLE
bigqueryanalyticshub - add support for sharing settings to data exchange

### DIFF
--- a/mmv1/products/bigqueryanalyticshub/DataExchange.yaml
+++ b/mmv1/products/bigqueryanalyticshub/DataExchange.yaml
@@ -49,6 +49,26 @@ examples:
     vars:
       data_exchange_id: 'my_data_exchange'
       description: 'example data exchange'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'bigquery_analyticshub_data_exchange_sharing'
+    primary_resource_id: 'data_exchange'
+    primary_resource_name: "fmt.Sprintf(\"tf_test_my_data_exchange%s\",
+      context[\"\
+      random_suffix\"])"
+    region_override: 'US'
+    vars:
+      data_exchange_id: 'my_data_exchange'
+      description: 'example data exchange'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'bigquery_analyticshub_data_exchange_sharing_dcr'
+    primary_resource_id: 'data_exchange'
+    primary_resource_name: "fmt.Sprintf(\"tf_test_my_data_exchange%s\",
+      context[\"\
+      random_suffix\"])"
+    region_override: 'US'
+    vars:
+      data_exchange_id: 'my_data_exchange'
+      description: 'example data exchange'
 properties:
   - !ruby/object:Api::Type::String
     name: name
@@ -96,3 +116,31 @@ properties:
     name: icon
     description: |-
       Base64 encoded image representing the data exchange.
+  - !ruby/object:Api::Type::NestedObject
+    name: sharingEnvironmentConfig
+    description: Configurable data sharing environment option for a data exchange.
+    allow_empty_object: true
+    send_empty_value: true
+    default_from_api: true
+    properties:
+      - !ruby/object:Api::Type::NestedObject
+        name: defaultExchangeConfig
+        description: Default Analytics Hub data exchange, used for secured data sharing.
+        immutable: true
+        allow_empty_object: true
+        send_empty_value: true
+        default_from_api: true
+        exactly_one_of: 
+          - sharing_environment_config.0.default_exchange_config
+          - sharing_environment_config.0.dcr_exchange_config  
+        properties: []
+      - !ruby/object:Api::Type::NestedObject
+        name: dcrExchangeConfig  
+        description: Data Clean Room (DCR), used for privacy-safe and secured data sharing.
+        immutable: true
+        allow_empty_object: true
+        send_empty_value: true
+        exactly_one_of: 
+          - sharing_environment_config.0.default_exchange_config
+          - sharing_environment_config.0.dcr_exchange_config
+        properties: []

--- a/mmv1/templates/terraform/examples/bigquery_analyticshub_data_exchange_sharing.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_analyticshub_data_exchange_sharing.tf.erb
@@ -1,0 +1,10 @@
+resource "google_bigquery_analytics_hub_data_exchange" "<%= ctx[:primary_resource_id] %>" {
+  location         = "US"
+  data_exchange_id = "<%= ctx[:vars]['data_exchange_id'] %>"
+  display_name     = "<%= ctx[:vars]['data_exchange_id'] %>"
+  description      = "<%= ctx[:vars]['description'] %>"
+
+  sharing_environment_config {
+    default_exchange_config {}
+  }
+}

--- a/mmv1/templates/terraform/examples/bigquery_analyticshub_data_exchange_sharing_dcr.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_analyticshub_data_exchange_sharing_dcr.tf.erb
@@ -1,0 +1,10 @@
+resource "google_bigquery_analytics_hub_data_exchange" "<%= ctx[:primary_resource_id] %>" {
+  location         = "US"
+  data_exchange_id = "<%= ctx[:vars]['data_exchange_id'] %>"
+  display_name     = "<%= ctx[:vars]['data_exchange_id'] %>"
+  description      = "<%= ctx[:vars]['description'] %>"
+
+  sharing_environment_config {
+    dcr_exchange_config {}
+  }
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigqueryanalyticshub - add support for sharing_environment_config to google_bigquery_analytics_hub_data_exchange
```
