### PR TITLE
[#9353] Make cloud router sort advertised_ip_ranges in state by config order

### DIFF
--- a/mmv1/products/compute/Router.yaml
+++ b/mmv1/products/compute/Router.yaml
@@ -53,12 +53,16 @@ examples:
     vars:
       router_name: 'my-router'
       network_name: 'my-network'
+    ignore_read_extra:
+      - advertisedIpRanges
   - !ruby/object:Provider::Terraform::Examples
     name: 'compute_router_encrypted_interconnect'
     primary_resource_id: 'encrypted-interconnect-router'
     vars:
       router_name: 'test-router'
       network_name: 'test-network'
+    ignore_read_extra:
+      - advertisedIpRanges
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   constants: templates/terraform/constants/router.go.erb
 custom_diff: [
@@ -173,6 +177,7 @@ properties:
               description: |
                 User-specified description for the IP range.
               send_empty_value: true
+        custom_flatten: 'templates/terraform/custom_flatten/compute_router_property.go.erb'
       - !ruby/object:Api::Type::Integer
         name: keepaliveInterval
         description: |

--- a/mmv1/products/compute/Router.yaml
+++ b/mmv1/products/compute/Router.yaml
@@ -172,12 +172,12 @@ properties:
                 The IP range to advertise. The value must be a
                 CIDR-formatted string.
               send_empty_value: true
+              custom_flatten: 'templates/terraform/custom_flatten/compute_router_range.go.erb'
             - !ruby/object:Api::Type::String
               name: description
               description: |
                 User-specified description for the IP range.
               send_empty_value: true
-        custom_flatten: 'templates/terraform/custom_flatten/compute_router_range.go.erb'
       - !ruby/object:Api::Type::Integer
         name: keepaliveInterval
         description: |

--- a/mmv1/products/compute/Router.yaml
+++ b/mmv1/products/compute/Router.yaml
@@ -177,7 +177,7 @@ properties:
               description: |
                 User-specified description for the IP range.
               send_empty_value: true
-        custom_flatten: 'templates/terraform/custom_flatten/compute_router_property.go.erb'
+        custom_flatten: 'templates/terraform/custom_flatten/compute_router_range.go.erb'
       - !ruby/object:Api::Type::Integer
         name: keepaliveInterval
         description: |

--- a/mmv1/products/compute/Router.yaml
+++ b/mmv1/products/compute/Router.yaml
@@ -163,6 +163,7 @@ properties:
           ranges will be advertised in addition to any specified groups.
           Leave this field blank to advertise no custom IP ranges.
         send_empty_value: true
+        custom_flatten: 'templates/terraform/custom_flatten/compute_router_range.go.erb'
         item_type: !ruby/object:Api::Type::NestedObject
           properties:
             - !ruby/object:Api::Type::String
@@ -172,7 +173,6 @@ properties:
                 The IP range to advertise. The value must be a
                 CIDR-formatted string.
               send_empty_value: true
-              custom_flatten: 'templates/terraform/custom_flatten/compute_router_range.go.erb'
             - !ruby/object:Api::Type::String
               name: description
               description: |

--- a/mmv1/templates/terraform/custom_flatten/compute_router_property.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/compute_router_property.go.erb
@@ -1,0 +1,42 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2024 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return v
+	}
+	l := v.([]interface{})
+	apiData := make([]map[string]interface{}, 0, len(l))
+	for _, raw := range l {
+		original := raw.(map[string]interface{})
+		if len(original) < 1 {
+			// Do not include empty json objects coming back from the api
+			continue
+		}
+		apiData = append(apiData, map[string]interface{}{
+			"description": original["description"],
+			"range":  original["range"],
+		})
+	}
+	configData := []map[string]interface{}{}
+	for _, item := range d.Get("properties.0.property").([]interface{}) {
+		configData = append(configData, item.(map[string]interface{}))
+	}
+	sorted, err := tpgresource.SortMapsByConfigOrder(configData, apiData, "range")
+	if err != nil {
+		log.Printf("[ERROR] Could not support API response for properties.0.property: %s", err)
+		return apiData
+	}
+	return sorted
+}

--- a/mmv1/templates/terraform/custom_flatten/compute_router_range.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/compute_router_range.go.erb
@@ -12,7 +12,7 @@
 	# See the License for the specific language governing permissions and
 	# limitations under the License.
 -%>
-func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+func flatten<%= prefix -%><%= titlelize_range(range) -%>(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	if v == nil {
 		return v
 	}
@@ -35,7 +35,7 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d 
 	}
 	sorted, err := tpgresource.SortMapsByConfigOrder(configData, apiData, "range")
 	if err != nil {
-		log.Printf("[ERROR] Could not support API response for properties.0.property: %s", err)
+		log.Printf("[ERROR] Could not support API response for advertisedIpRanges.0.range: %s", err)
 		return apiData
 	}
 	return sorted

--- a/mmv1/templates/terraform/custom_flatten/compute_router_range.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/compute_router_range.go.erb
@@ -30,7 +30,7 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d 
 		})
 	}
 	configData := []map[string]interface{}{}
-	for _, item := range d.Get("properties.0.property").([]interface{}) {
+	for _, item := range d.Get("advertisedIpRanges.0.range").([]interface{}) {
 		configData = append(configData, item.(map[string]interface{}))
 	}
 	sorted, err := tpgresource.SortMapsByConfigOrder(configData, apiData, "range")

--- a/mmv1/templates/terraform/custom_flatten/compute_router_range.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/compute_router_range.go.erb
@@ -12,7 +12,7 @@
 	# See the License for the specific language governing permissions and
 	# limitations under the License.
 -%>
-func flatten<%= prefix -%><%= titlelize_property(range) -%>(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	if v == nil {
 		return v
 	}

--- a/mmv1/templates/terraform/custom_flatten/compute_router_range.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/compute_router_range.go.erb
@@ -12,7 +12,7 @@
 	# See the License for the specific language governing permissions and
 	# limitations under the License.
 -%>
-func flatten<%= prefix -%><%= titlelize_range(range) -%>(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+func flatten<%= prefix -%><%= titlelize_property(range) -%>(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	if v == nil {
 		return v
 	}

--- a/mmv1/templates/terraform/custom_flatten/compute_router_range.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/compute_router_range.go.erb
@@ -30,8 +30,10 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d 
 		})
 	}
 	configData := []map[string]interface{}{}
-	for _, item := range d.Get("advertisedIpRanges.0.range").([]interface{}) {
-		configData = append(configData, item.(map[string]interface{}))
+	if v, ok := d.GetOk("advertised_ip_ranges"); ok {
+		for _, item := range v.([]interface{}) {
+			configData = append(configData, item.(map[string]interface{}))
+		}
 	}
 	sorted, err := tpgresource.SortMapsByConfigOrder(configData, apiData, "range")
 	if err != nil {


### PR DESCRIPTION
Use the new function introduced in https://github.com/GoogleCloudPlatform/magic-modules/pull/10410 to order advertised_ip_ranges properties according to the order in config.

Pre-6.0.0 fix for [hashicorp/terraform-provider-google/issues/9353](https://github.com/hashicorp/terraform-provider-google/issues/9353).

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed permadiff in ordering of `advertised_ip_ranges.range` field on `google_compute_router` resource.
```
