### PR TITLE
Ncc rep resource

### DIFF
--- a/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
+++ b/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
@@ -46,7 +46,7 @@ async: !ruby/object:Api::OpAsync
 
 examples:
   - !ruby/object:Provider::Terraform::Examples
-    name: 'network_connectivity_regional_endpoints_regional_access'
+    name: 'network_connectivity_regional_endpoint_regional_access'
     primary_resource_id: 'default'
     vars:
       rep_name: 'my-rep'
@@ -56,7 +56,7 @@ examples:
       rep_network: 'my-network'
       rep_subnetwork: 'my-subnetwork'
   - !ruby/object:Provider::Terraform::Examples
-    name: 'network_connectivity_regional_endpoints_global_access'
+name: 'network_connectivity_regional_endpoint_global_access'
     primary_resource_id: 'default'
     vars:
       rep_name: 'my-rep'

--- a/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
+++ b/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
@@ -100,10 +100,12 @@ properties:
     name: 'network'
     description: |
       The name of the VPC network for this private regional endpoint. Format: `projects/{project}/global/networks/{network}`
+    default_from_api: true
   - !ruby/object:Api::Type::String
     name: 'subnetwork'
     description: |
       The name of the subnetwork from which the IP address will be allocated. Format: `projects/{project}/regions/{region}/subnetworks/{subnetwork}`
+    default_from_api: true
   - !ruby/object:Api::Type::Enum
     name: accessType
     required: true

--- a/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
+++ b/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
@@ -47,7 +47,6 @@ examples:
     primary_resource_id: 'default'
     vars:
       rep_name: 'my-rep'
-      rep_address: 'my-address'
       rep_network: 'my-network'
       rep_subnetwork: 'my-subnetwork'
   - !ruby/object:Provider::Terraform::Examples
@@ -55,7 +54,6 @@ examples:
     primary_resource_id: 'default'
     vars:
       rep_name: 'my-rep'
-      rep_address: 'my-address'
       rep_network: 'my-network'
       rep_subnetwork: 'my-subnetwork'
 

--- a/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
+++ b/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
@@ -121,3 +121,4 @@ properties:
     name: 'address'
     description: |
       The IP Address of the Regional Endpoint. When no address is provided, an IP from the subnetwork is allocated. Use one of the following formats: * IPv4 address as in `10.0.0.1` * Address resource URI as in `projects/{project}/regions/{region}/addresses/{address_name}`
+    default_from_api: true

--- a/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
+++ b/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
@@ -46,15 +46,25 @@ async: !ruby/object:Api::OpAsync
 
 examples:
   - !ruby/object:Provider::Terraform::Examples
-    name: 'regional_endpoints_regional_access_with_address_input'
+    name: 'regional_endpoints_regional_access'
     primary_resource_id: 'default'
     vars:
-      name: 'my-rep'
-      target_gogole_api: 'spanner.me-central2.p.rep.googleapis.com'
-      access_type: 'REGIONAL'
-      address: 'projects/my-project/regions/my-region/addresses/my-address'
-      network: 'projects/my-project/global/networks/my-network'
-      subnetwork: 'projects/my-project/regions/my-region/subnetworks/my-subnetwork'
+      rep_name: 'my-rep'
+      rep_target_google_api: 'spanner.me-central2.p.rep.googleapis.com'
+      rep_access_type: 'REGIONAL'
+      rep_address: 'my-address'
+      rep_network: 'my-network'
+      rep_subnetwork: 'my-subnetwork'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'regional_endpoints_global_access'
+    primary_resource_id: 'default'
+    vars:
+      rep_name: 'my-rep'
+      rep_target_google_api: 'spanner.me-central2.p.rep.googleapis.com'
+      rep_access_type: 'GLOBAL'
+      rep_address: 'my-address'
+      rep_network: 'my-network'
+      rep_subnetwork: 'my-subnetwork'
 
 parameters:
   - !ruby/object:Api::Type::String

--- a/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
+++ b/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
@@ -123,4 +123,6 @@ properties:
     name: 'address'
     description: |
       The IP Address of the Regional Endpoint. When no address is provided, an IP from the subnetwork is allocated. Use one of the following formats: * IPv4 address as in `10.0.0.1` * Address resource URI as in `projects/{project}/regions/{region}/addresses/{address_name}`
+      
+      ~> **Note:** This field accepts both a reference to a Compute Address resource, which is the resource name of which format is given in the description, and IP literal value. If the user chooses to input a reserved address value; they need to make sure that the reserved address is in IPv4 version, its purpose is GCE_ENDPOINT, its type is INTERNAL and its status is RESERVED. If the user chooses to input an IP literal, they need to make sure that it's a valid IPv4 address (x.x.x.x) within the subnetwork.
     default_from_api: true

--- a/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
+++ b/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
@@ -18,8 +18,7 @@ description: |
 references: !ruby/object:Api::Resource::ReferenceLinks
   guides:
     'Access regional Google APIs through endpoints': 'https://cloud.google.com/vpc/docs/access-regional-google-apis-endpoints'
-  api: 'https://cloud.google.com/network-connectivity/docs/reference/networkconnectivity/rest/v1beta/projects.locations.regionalEndpoints'
-min_version: beta
+  api: 'https://cloud.google.com/network-connectivity/docs/reference/networkconnectivity/rest/v1/projects.locations.regionalEndpoints'
 base_url: 'projects/{{project}}/locations/{{location}}/regionalEndpoints'
 self_link: 'projects/{{project}}/locations/{{location}}/regionalEndpoints/{{name}}'
 immutable: true

--- a/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
+++ b/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
@@ -1,0 +1,118 @@
+# Copyright 2024 Google Inc.
+# # Licensed under the Apache License, Version 2.0 (the "License");
+# # you may not use this file except in compliance with the License.
+# # You may obtain a copy of the License at
+# #
+# #     http://www.apache.org/licenses/LICENSE-2.0
+# #
+# # Unless required by applicable law or agreed to in writing, software
+# # distributed under the License is distributed on an "AS IS" BASIS,
+# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# # See the License for the specific language governing permissions and
+# # limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'RegionalEndpoint'
+description: |
+  Regional Private Service Connect (PSC) endpoint resource.
+references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+    'Access regional Google APIs through endpoints': 'https://cloud.google.com/vpc/docs/access-regional-google-apis-endpoints'
+  api: 'https://cloud.google.com/network-connectivity/docs/reference/networkconnectivity/rest/v1beta/projects.locations.regionalEndpoints'
+min_version: beta
+base_url: 'projects/{{project}}/locations/{{location}}/regionalEndpoints'
+self_link: 'projects/{{project}}/locations/{{location}}/regionalEndpoints/{{name}}'
+immutable: true
+timeouts: !ruby/object:Api::Timeouts
+  insert_minutes: 20
+  delete_minutes: 20
+create_url: 'projects/{{project}}/locations/{{location}}/regionalEndpoints?regional_endpoint_id={{name}}'
+delete_url: 'projects/{{project}}/locations/{{location}}/regionalEndpoints/{{name}}'
+autogen_async: true
+async: !ruby/object:Api::OpAsync
+  actions: ['create', 'delete']
+  operation: !ruby/object:Api::OpAsync::Operation
+    base_url: '{{op_id}}'
+  result: !ruby/object:Api::OpAsync::Result
+    path: 'response'
+  status: !ruby/object:Api::OpAsync::Status
+    path: 'done'
+    complete: true
+    allowed:
+      - true
+      - false
+  error: !ruby/object:Api::OpAsync::Error
+    path: 'error'
+    message: 'message'
+
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'regional_endpoints_regional_access_with_address_input'
+    primary_resource_id: 'default'
+    vars:
+      name: 'my-rep'
+      target_gogole_api: 'spanner.me-central2.p.rep.googleapis.com'
+      access_type: 'REGIONAL'
+      address: 'projects/my-project/regions/my-region/addresses/my-address'
+      network: 'projects/my-project/global/networks/my-network'
+      subnetwork: 'projects/my-project/regions/my-region/subnetworks/my-subnetwork'
+
+parameters:
+  - !ruby/object:Api::Type::String
+    name: 'name'
+    output: true
+    immutable: true
+    url_param_only: true
+    description: |
+      The name of a RegionalEndpoint. Format: `projects/{project}/locations/{location}/regionalEndpoints/{regional_endpoint}`.
+
+properties:
+  - !ruby/object:Api::Type::Time
+    name: 'createTime'
+    output: true
+    description: |
+      Time when the RegionalEndpoint was created.
+  - !ruby/object:Api::Type::Time
+    name: 'updateTime'
+    output: true
+    description: |
+      Time when the RegionalEndpoint was updated.
+  - !ruby/object:Api::Type::KeyValueLabels
+    name: 'labels'
+    description: |
+      User-defined labels.
+  - !ruby/object:Api::Type::String
+    name: 'description'
+    description: |
+      A description of this resource.
+  - !ruby/object:Api::Type::String
+    name: 'targetGoogleApi'
+    required: true
+    description: |
+      The service endpoint this private regional endpoint connects to. Format: `{apiname}.{region}.p.rep.googleapis.com` Example: \"cloudkms.us-central1.p.rep.googleapis.com\".
+  - !ruby/object:Api::Type::String
+    name: 'network'
+    description: |
+      The name of the VPC network for this private regional endpoint. Format: `projects/{project}/global/networks/{network}`
+  - !ruby/object:Api::Type::String
+    name: 'subnetwork'
+    description: |
+      The name of the subnetwork from which the IP address will be allocated. Format: `projects/{project}/regions/{region}/subnetworks/{subnetwork}`
+  - !ruby/object:Api::Type::Enum
+    name: accessType
+    required: true
+    description: |
+      The access type of this regional endpoint. This field is reflected in the PSC Forwarding Rule configuration to enable global access.
+    values:
+      - :ACCESS_TYPE_UNSPECIFIED
+      - :GLOBAL
+      - :REGIONAL
+  - !ruby/object:Api::Type::String
+    name: 'pscForwardingRule'
+    output: true
+    description: |
+      The resource reference of the PSC Forwarding Rule created on behalf of the customer. Format: `//compute.googleapis.com/projects/{project}/regions/{region}/forwardingRules/{forwarding_rule_name}`
+  - !ruby/object:Api::Type::String
+    name: 'address'
+    description: |
+      The IP Address of the Regional Endpoint. When no address is provided, an IP from the subnetwork is allocated. Use one of the following formats: * IPv4 address as in `10.0.0.1` * Address resource URI as in `projects/{project}/regions/{region}/addresses/{address_name}`

--- a/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
+++ b/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
@@ -123,6 +123,6 @@ properties:
     name: 'address'
     description: |
       The IP Address of the Regional Endpoint. When no address is provided, an IP from the subnetwork is allocated. Use one of the following formats: * IPv4 address as in `10.0.0.1` * Address resource URI as in `projects/{project}/regions/{region}/addresses/{address_name}`
-      
+
       ~> **Note:** This field accepts both a reference to a Compute Address resource, which is the resource name of which format is given in the description, and IP literal value. If the user chooses to input a reserved address value; they need to make sure that the reserved address is in IPv4 version, its purpose is GCE_ENDPOINT, its type is INTERNAL and its status is RESERVED. If the user chooses to input an IP literal, they need to make sure that it's a valid IPv4 address (x.x.x.x) within the subnetwork.
     default_from_api: true

--- a/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
+++ b/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
@@ -46,7 +46,7 @@ async: !ruby/object:Api::OpAsync
 
 examples:
   - !ruby/object:Provider::Terraform::Examples
-    name: 'regional_endpoints_regional_access'
+    name: 'network_connectivity_regional_endpoints_regional_access'
     primary_resource_id: 'default'
     vars:
       rep_name: 'my-rep'
@@ -56,7 +56,7 @@ examples:
       rep_network: 'my-network'
       rep_subnetwork: 'my-subnetwork'
   - !ruby/object:Provider::Terraform::Examples
-    name: 'regional_endpoints_global_access'
+    name: 'network_connectivity_regional_endpoints_global_access'
     primary_resource_id: 'default'
     vars:
       rep_name: 'my-rep'

--- a/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
+++ b/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
@@ -60,6 +60,7 @@ examples:
 parameters:
   - !ruby/object:Api::Type::String
     name: 'name'
+    required: true
     immutable: true
     url_param_only: true
     description: |

--- a/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
+++ b/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
@@ -22,9 +22,6 @@ references: !ruby/object:Api::Resource::ReferenceLinks
 base_url: 'projects/{{project}}/locations/{{location}}/regionalEndpoints'
 self_link: 'projects/{{project}}/locations/{{location}}/regionalEndpoints/{{name}}'
 immutable: true
-timeouts: !ruby/object:Api::Timeouts
-  insert_minutes: 20
-  delete_minutes: 20
 create_url: 'projects/{{project}}/locations/{{location}}/regionalEndpoints?regional_endpoint_id={{name}}'
 delete_url: 'projects/{{project}}/locations/{{location}}/regionalEndpoints/{{name}}'
 autogen_async: true
@@ -49,7 +46,6 @@ examples:
     name: 'network_connectivity_regional_endpoint_regional_access'
     primary_resource_id: 'default'
     vars:
-      rep_name: 'my-rep'
       rep_target_google_api: 'spanner.me-central2.p.rep.googleapis.com'
       rep_access_type: 'REGIONAL'
       rep_address: 'my-address'
@@ -59,7 +55,6 @@ examples:
     name: 'network_connectivity_regional_endpoint_global_access'
     primary_resource_id: 'default'
     vars:
-      rep_name: 'my-rep'
       rep_target_google_api: 'spanner.me-central2.p.rep.googleapis.com'
       rep_access_type: 'GLOBAL'
       rep_address: 'my-address'
@@ -74,6 +69,13 @@ parameters:
     url_param_only: true
     description: |
       The name of a RegionalEndpoint. Format: `projects/{project}/locations/{location}/regionalEndpoints/{regional_endpoint}`.
+  - !ruby/object:Api::Type::String
+    name: 'location'
+    required: true
+    immutable: true
+    url_param_only: true
+    description: |
+      The location of the RegionalEndpoint.
 
 properties:
   - !ruby/object:Api::Type::Time
@@ -113,7 +115,6 @@ properties:
     description: |
       The access type of this regional endpoint. This field is reflected in the PSC Forwarding Rule configuration to enable global access.
     values:
-      - :ACCESS_TYPE_UNSPECIFIED
       - :GLOBAL
       - :REGIONAL
   - !ruby/object:Api::Type::String

--- a/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
+++ b/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
@@ -47,7 +47,6 @@ examples:
     primary_resource_id: 'default'
     vars:
       rep_name: 'my-rep'
-      rep_target_google_api: 'spanner.me-central2.p.rep.googleapis.com'
       rep_address: 'my-address'
       rep_network: 'my-network'
       rep_subnetwork: 'my-subnetwork'
@@ -56,7 +55,6 @@ examples:
     primary_resource_id: 'default'
     vars:
       rep_name: 'my-rep'
-      rep_target_google_api: 'spanner.me-central2.p.rep.googleapis.com'
       rep_address: 'my-address'
       rep_network: 'my-network'
       rep_subnetwork: 'my-subnetwork'

--- a/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
+++ b/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
@@ -46,8 +46,8 @@ examples:
     name: 'network_connectivity_regional_endpoint_regional_access'
     primary_resource_id: 'default'
     vars:
+      rep_name: 'my-rep'
       rep_target_google_api: 'spanner.me-central2.p.rep.googleapis.com'
-      rep_access_type: 'REGIONAL'
       rep_address: 'my-address'
       rep_network: 'my-network'
       rep_subnetwork: 'my-subnetwork'
@@ -55,8 +55,8 @@ examples:
     name: 'network_connectivity_regional_endpoint_global_access'
     primary_resource_id: 'default'
     vars:
+      rep_name: 'my-rep'
       rep_target_google_api: 'spanner.me-central2.p.rep.googleapis.com'
-      rep_access_type: 'GLOBAL'
       rep_address: 'my-address'
       rep_network: 'my-network'
       rep_subnetwork: 'my-subnetwork'
@@ -64,11 +64,10 @@ examples:
 parameters:
   - !ruby/object:Api::Type::String
     name: 'name'
-    output: true
     immutable: true
     url_param_only: true
     description: |
-      The name of a RegionalEndpoint. Format: `projects/{project}/locations/{location}/regionalEndpoints/{regional_endpoint}`.
+      The name of the RegionalEndpoint.
   - !ruby/object:Api::Type::String
     name: 'location'
     required: true

--- a/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
+++ b/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
@@ -56,7 +56,7 @@ examples:
       rep_network: 'my-network'
       rep_subnetwork: 'my-subnetwork'
   - !ruby/object:Provider::Terraform::Examples
-name: 'network_connectivity_regional_endpoint_global_access'
+    name: 'network_connectivity_regional_endpoint_global_access'
     primary_resource_id: 'default'
     vars:
       rep_name: 'my-rep'

--- a/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_global_access.tf.erb
+++ b/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_global_access.tf.erb
@@ -14,6 +14,7 @@ resource "google_compute_address" "my_address" {
   name       = "<%= ctx[:vars]['rep_address'] %>"
   region     = "us-central1"
   subnetwork = google_compute_subnetwork.my_subnetwork.id
+  address_type = "INTERNAL"
   purpose    = "GCE_ENDPOINT"
   ip_version = "IPV4"
 }

--- a/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_global_access.tf.erb
+++ b/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_global_access.tf.erb
@@ -5,18 +5,9 @@ resource "google_compute_network" "my_network" {
 
 resource "google_compute_subnetwork" "my_subnetwork" {
   name          = "<%= ctx[:vars]['rep_subnetwork'] %>"
-  ip_cidr_range = "10.0.0.0/16"
+  ip_cidr_range = "192.168.0.0/24"
   region        = "us-central1"
   network       = google_compute_network.my_network.id
-}
-
-resource "google_compute_address" "my_address" {
-  name       = "<%= ctx[:vars]['rep_address'] %>"
-  region     = "us-central1"
-  subnetwork = google_compute_subnetwork.my_subnetwork.id
-  address_type = "INTERNAL"
-  purpose    = "GCE_ENDPOINT"
-  ip_version = "IPV4"
 }
 
 resource "google_network_connectivity_regional_endpoint" "<%= ctx[:primary_resource_id] %>" {
@@ -24,7 +15,7 @@ resource "google_network_connectivity_regional_endpoint" "<%= ctx[:primary_resou
   location          = "us-central1"
   target_google_api = "boqcodelabjaimin-pa.us-central1.p.rep.googleapis.com"
   access_type       = "GLOBAL"
-  address           = google_compute_address.my_address.id
+  address           = "192.168.0.4"
   network           = google_compute_network.my_network.id
   subnetwork        = google_compute_subnetwork.my_subnetwork.id
 }

--- a/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_global_access.tf.erb
+++ b/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_global_access.tf.erb
@@ -22,7 +22,7 @@ resource "google_compute_address" "my_address" {
 resource "google_network_connectivity_regional_endpoint" "<%= ctx[:primary_resource_id] %>" {
   name              = "<%= ctx[:vars]['rep_name'] %>"
   location          = "us-central1"
-  target_google_api = "<%= ctx[:vars]['rep_target_gogole_api'] %>"
+  target_google_api = "spanner.me-central2.p.rep.googleapis.com"
   access_type       = "GLOBAL"
   address           = google_compute_address.my_address.id
   network           = google_compute_network.my_network.id

--- a/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_global_access.tf.erb
+++ b/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_global_access.tf.erb
@@ -15,7 +15,7 @@ resource "google_compute_address" "my_address" {
   region     = "us-central1"
   subnetwork = google_compute_subnetwork.my_subnetwork.id
   purpose    = "GCE_ENDPOINT"
-  ip-version = "IPV4"
+  ip_version = "IPV4"
 }
 
 resource "google_network_connectivity_regional_endpoint" "<%= ctx[:primary_resource_id] %>" {

--- a/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_global_access.tf.erb
+++ b/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_global_access.tf.erb
@@ -19,7 +19,6 @@ resource "google_compute_address" "my_address" {
 }
 
 resource "google_network_connectivity_regional_endpoint" "<%= ctx[:primary_resource_id] %>" {
-  name              = "<%= ctx[:vars]['rep_name'] %>"
   target_google_api = "<%= ctx[:vars]['rep_target_gogole_api'] %>"
   access_type       = "GLOBAL"
   address           = google_compute_address.my_address.id

--- a/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_global_access.tf.erb
+++ b/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_global_access.tf.erb
@@ -21,6 +21,7 @@ resource "google_compute_address" "my_address" {
 
 resource "google_network_connectivity_regional_endpoint" "<%= ctx[:primary_resource_id] %>" {
   name              = "<%= ctx[:vars]['rep_name'] %>"
+  location          = "us-central1"
   target_google_api = "<%= ctx[:vars]['rep_target_gogole_api'] %>"
   access_type       = "GLOBAL"
   address           = google_compute_address.my_address.id

--- a/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_global_access.tf.erb
+++ b/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_global_access.tf.erb
@@ -1,0 +1,28 @@
+resource "google_compute_network" "my_network" {
+  name                    = "<%= ctx[:vars]['rep_network'] %>"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "my_subnetwork" {
+  name          = "<%= ctx[:vars]['rep_subnetwork'] %>"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.my_network.id
+}
+
+resource "google_compute_address" "my_address" {
+  name       = "<%= ctx[:vars]['rep_address'] %>"
+  region     = "us-central1"
+  subnetwork = google_compute_subnetwork.my_subnetwork.id
+  purpose    = "GCE_ENDPOINT"
+  ip-version = "IPV4"
+}
+
+resource "google_network_connectivity_regional_endpoint" "<%= ctx[:primary_resource_id] %>" {
+  name              = "<%= ctx[:vars]['rep_name'] %>"
+  target_google_api = "<%= ctx[:vars]['rep_target_gogole_api'] %>"
+  access_type       = "GLOBAL"
+  address           = google_compute_address.my_address.id
+  network           = google_compute_network.my_network.id
+  subnetwork        = google_compute_subnetwork.my_subnetwork.id
+}

--- a/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_global_access.tf.erb
+++ b/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_global_access.tf.erb
@@ -22,7 +22,7 @@ resource "google_compute_address" "my_address" {
 resource "google_network_connectivity_regional_endpoint" "<%= ctx[:primary_resource_id] %>" {
   name              = "<%= ctx[:vars]['rep_name'] %>"
   location          = "us-central1"
-  target_google_api = "spanner.me-central2.p.rep.googleapis.com"
+  target_google_api = "boqcodelabjaimin-pa.us-central1.p.rep.googleapis.com"
   access_type       = "GLOBAL"
   address           = google_compute_address.my_address.id
   network           = google_compute_network.my_network.id

--- a/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_global_access.tf.erb
+++ b/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_global_access.tf.erb
@@ -20,6 +20,7 @@ resource "google_compute_address" "my_address" {
 }
 
 resource "google_network_connectivity_regional_endpoint" "<%= ctx[:primary_resource_id] %>" {
+  name              = "<%= ctx[:vars]['rep_name'] %>"
   target_google_api = "<%= ctx[:vars]['rep_target_gogole_api'] %>"
   access_type       = "GLOBAL"
   address           = google_compute_address.my_address.id

--- a/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.erb
+++ b/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.erb
@@ -27,5 +27,4 @@ resource "google_network_connectivity_regional_endpoint" "<%= ctx[:primary_resou
   subnetwork        = google_compute_subnetwork.my_subnetwork.id
   description       = "My RegionalEndpoint targeting Google API spanner.me-central2.p.rep.googleapis.com"
   labels            = {env = "default"}
-  project           = "my-project"
 }

--- a/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.erb
+++ b/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.erb
@@ -1,0 +1,28 @@
+resource "google_compute_network" "my_network" {
+  name                    = "<%= ctx[:vars]['rep_network'] %>"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "my_subnetwork" {
+  name          = "<%= ctx[:vars]['rep_subnetwork'] %>"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.my_network.id
+}
+
+resource "google_compute_address" "my_address" {
+  name       = "<%= ctx[:vars]['rep_address'] %>"
+  region     = "us-central1"
+  subnetwork = google_compute_subnetwork.my_subnetwork.id
+  purpose    = "GCE_ENDPOINT"
+  ip-version = "IPV4"
+}
+
+resource "google_network_connectivity_regional_endpoint" "<%= ctx[:primary_resource_id] %>" {
+  name              = "<%= ctx[:vars]['rep_name'] %>"
+  target_google_api = "<%= ctx[:vars]['rep_target_gogole_api'] %>"
+  access_type       = "REGIONAL"
+  address           = google_compute_address.my_address.id
+  network           = google_compute_network.my_network.id
+  subnetwork        = google_compute_subnetwork.my_subnetwork.id
+}

--- a/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.erb
+++ b/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.erb
@@ -22,7 +22,7 @@ resource "google_compute_address" "my_address" {
 resource "google_network_connectivity_regional_endpoint" "<%= ctx[:primary_resource_id] %>" {
   name              = "<%= ctx[:vars]['rep_name'] %>"
   location          = "us-central1"
-  target_google_api = "<%= ctx[:vars]['rep_target_gogole_api'] %>"
+  target_google_api = "spanner.me-central2.p.rep.googleapis.com"
   access_type       = "REGIONAL"
   address           = google_compute_address.my_address.id
   network           = google_compute_network.my_network.id

--- a/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.erb
+++ b/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.erb
@@ -20,6 +20,7 @@ resource "google_compute_address" "my_address" {
 }
 
 resource "google_network_connectivity_regional_endpoint" "<%= ctx[:primary_resource_id] %>" {
+  name              = "<%= ctx[:vars]['rep_name'] %>"
   target_google_api = "<%= ctx[:vars]['rep_target_gogole_api'] %>"
   access_type       = "REGIONAL"
   address           = google_compute_address.my_address.id

--- a/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.erb
+++ b/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.erb
@@ -15,7 +15,7 @@ resource "google_compute_address" "my_address" {
   region     = "us-central1"
   subnetwork = google_compute_subnetwork.my_subnetwork.id
   purpose    = "GCE_ENDPOINT"
-  ip-version = "IPV4"
+  ip_version = "IPV4"
 }
 
 resource "google_network_connectivity_regional_endpoint" "<%= ctx[:primary_resource_id] %>" {

--- a/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.erb
+++ b/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.erb
@@ -5,18 +5,9 @@ resource "google_compute_network" "my_network" {
 
 resource "google_compute_subnetwork" "my_subnetwork" {
   name          = "<%= ctx[:vars]['rep_subnetwork'] %>"
-  ip_cidr_range = "10.0.0.0/16"
+  ip_cidr_range = "192.168.0.0/24"
   region        = "us-central1"
   network       = google_compute_network.my_network.id
-}
-
-resource "google_compute_address" "my_address" {
-  name         = "<%= ctx[:vars]['rep_address'] %>"
-  region       = "us-central1"
-  subnetwork   = google_compute_subnetwork.my_subnetwork.id
-  address_type = "INTERNAL"
-  purpose      = "GCE_ENDPOINT"
-  ip_version   = "IPV4"
 }
 
 resource "google_network_connectivity_regional_endpoint" "<%= ctx[:primary_resource_id] %>" {
@@ -24,7 +15,7 @@ resource "google_network_connectivity_regional_endpoint" "<%= ctx[:primary_resou
   location          = "us-central1"
   target_google_api = "boqcodelabjaimin-pa.us-central1.p.rep.googleapis.com"
   access_type       = "REGIONAL"
-  address           = google_compute_address.my_address.id
+  address           = "192.168.0.5"
   network           = google_compute_network.my_network.id
   subnetwork        = google_compute_subnetwork.my_subnetwork.id
   description       = "My RegionalEndpoint targeting Google API boqcodelabjaimin-pa.us-central1.p.rep.googleapis.com"

--- a/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.erb
+++ b/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.erb
@@ -11,11 +11,12 @@ resource "google_compute_subnetwork" "my_subnetwork" {
 }
 
 resource "google_compute_address" "my_address" {
-  name       = "<%= ctx[:vars]['rep_address'] %>"
-  region     = "us-central1"
-  subnetwork = google_compute_subnetwork.my_subnetwork.id
-  purpose    = "GCE_ENDPOINT"
-  ip_version = "IPV4"
+  name         = "<%= ctx[:vars]['rep_address'] %>"
+  region       = "us-central1"
+  subnetwork   = google_compute_subnetwork.my_subnetwork.id
+  address_type = "INTERNAL"
+  purpose      = "GCE_ENDPOINT"
+  ip_version   = "IPV4"
 }
 
 resource "google_network_connectivity_regional_endpoint" "<%= ctx[:primary_resource_id] %>" {

--- a/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.erb
+++ b/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.erb
@@ -25,4 +25,7 @@ resource "google_network_connectivity_regional_endpoint" "<%= ctx[:primary_resou
   address           = google_compute_address.my_address.id
   network           = google_compute_network.my_network.id
   subnetwork        = google_compute_subnetwork.my_subnetwork.id
+  description       = "My RegionalEndpoint targeting Google API spanner.me-central2.p.rep.googleapis.com"
+  labels            = {env = "default"}
+  project           = "my-project"
 }

--- a/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.erb
+++ b/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.erb
@@ -19,7 +19,6 @@ resource "google_compute_address" "my_address" {
 }
 
 resource "google_network_connectivity_regional_endpoint" "<%= ctx[:primary_resource_id] %>" {
-  name              = "<%= ctx[:vars]['rep_name'] %>"
   target_google_api = "<%= ctx[:vars]['rep_target_gogole_api'] %>"
   access_type       = "REGIONAL"
   address           = google_compute_address.my_address.id

--- a/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.erb
+++ b/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.erb
@@ -21,6 +21,7 @@ resource "google_compute_address" "my_address" {
 
 resource "google_network_connectivity_regional_endpoint" "<%= ctx[:primary_resource_id] %>" {
   name              = "<%= ctx[:vars]['rep_name'] %>"
+  location          = "us-central1"
   target_google_api = "<%= ctx[:vars]['rep_target_gogole_api'] %>"
   access_type       = "REGIONAL"
   address           = google_compute_address.my_address.id

--- a/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.erb
+++ b/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.erb
@@ -22,11 +22,11 @@ resource "google_compute_address" "my_address" {
 resource "google_network_connectivity_regional_endpoint" "<%= ctx[:primary_resource_id] %>" {
   name              = "<%= ctx[:vars]['rep_name'] %>"
   location          = "us-central1"
-  target_google_api = "spanner.me-central2.p.rep.googleapis.com"
+  target_google_api = "boqcodelabjaimin-pa.us-central1.p.rep.googleapis.com"
   access_type       = "REGIONAL"
   address           = google_compute_address.my_address.id
   network           = google_compute_network.my_network.id
   subnetwork        = google_compute_subnetwork.my_subnetwork.id
-  description       = "My RegionalEndpoint targeting Google API spanner.me-central2.p.rep.googleapis.com"
+  description       = "My RegionalEndpoint targeting Google API boqcodelabjaimin-pa.us-central1.p.rep.googleapis.com"
   labels            = {env = "default"}
 }


### PR DESCRIPTION
Add a new resource `google_network_connectivity_regional_endpoint` in v1 API version under product `networkconnectivity`.
Discovery doc: https://networkconnectivity.googleapis.com/$discovery/rest?version=v1

```release-note:new-resource
`google_network_connectivity_regional_endpoint`
```
