### PR TITLE
[AlloyDB] Private Service Connect Support

### DIFF
--- a/mmv1/products/alloydb/Cluster.yaml
+++ b/mmv1/products/alloydb/Cluster.yaml
@@ -208,6 +208,7 @@ properties:
     exactly_one_of:
       - network
       - network_config.0.network
+      - psc_config.0.psc_enabled
     default_from_api: true
     deprecation_message: >-
       `network` is deprecated and will be removed in a future major release. Instead, use `network_config` to define the network configuration.
@@ -227,6 +228,7 @@ properties:
         exactly_one_of:
           - network
           - network_config.0.network
+          - psc_config.0.psc_enabled
         description: |
           The resource link for the VPC network in which cluster resources are created and from which they are accessible via Private IP. The network must belong to the same project as the cluster.
           It is specified in the form: "projects/{projectNumber}/global/networks/{network_id}".
@@ -264,6 +266,13 @@ properties:
     default_from_api: true
     description: |
       The database engine major version. This is an optional field and it's populated at the Cluster creation time. This field cannot be changed after cluster creation.
+  - !ruby/object:Api::Type::NestedObject
+    name: 'pscConfig'
+    description: 'Configuration for Private Service Connect (PSC) for the cluster.'
+    properties:
+      - !ruby/object:Api::Type::Boolean
+        name: 'pscEnabled'
+        description: 'Create an instance that allows connections from Private Service Connect endpoints to the instance.'
   - !ruby/object:Api::Type::NestedObject
     name: 'initialUser'
     description: |

--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -280,6 +280,31 @@ properties:
               - :ENCRYPTED_ONLY
               - :ALLOW_UNENCRYPTED_AND_ENCRYPTED
   - !ruby/object:Api::Type::NestedObject
+    name: 'pscInstanceConfig'
+    default_from_api: true
+    description: |
+      Configuration for Private Service Connect (PSC) for the instance.
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'serviceAttachmentLink'
+        output: true
+        description: |
+          The service attachment created when Private Service Connect (PSC) is enabled for the instance.
+          The name of the resource will be in the format of
+          `projects/<alloydb-tenant-project-number>/regions/<region-name>/serviceAttachments/<service-attachment-name>`
+      - !ruby/object:Api::Type::Array
+        name: allowedConsumerProjects
+        item_type: Api::Type::String
+        description: |
+          List of consumer projects that are allowed to create PSC endpoints to service-attachments to this instance.
+        diff_suppress_func: tpgresource.ProjectNumberDiffSuppressWithoutPrefix
+      - !ruby/object:Api::Type::String
+        name: 'pscDnsName'
+        output: true
+        description: |
+          The DNS name of the instance for PSC connectivity.
+          Name convention: <uid>.<uid>.<region>.alloydb-psc.goog
+  - !ruby/object:Api::Type::NestedObject
     name: 'networkConfig'
     description: |
       Instance level network configuration.

--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -296,7 +296,7 @@ properties:
         name: allowedConsumerProjects
         item_type: Api::Type::String
         description: |
-          List of consumer projects that are allowed to create PSC endpoints to service-attachments to this instance.
+          List of consumer projects that are allowed to create PSC endpoints to service-attachments to this instance. This should be specified as a list of project numbers only.
         diff_suppress_func: tpgresource.ProjectNumberDiffSuppressWithoutPrefix
       - !ruby/object:Api::Type::String
         name: 'pscDnsName'

--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -296,8 +296,8 @@ properties:
         name: allowedConsumerProjects
         item_type: Api::Type::String
         description: |
-          List of consumer projects that are allowed to create PSC endpoints to service-attachments to this instance. This should be specified as a list of project numbers only.
-        diff_suppress_func: tpgresource.ProjectNumberDiffSuppressWithoutPrefix
+          List of consumer projects that are allowed to create PSC endpoints to service-attachments to this instance.
+          This should be specified as a list of project numbers only.
       - !ruby/object:Api::Type::String
         name: 'pscDnsName'
         output: true

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_test.go
@@ -1295,3 +1295,39 @@ resource "google_compute_network" "default" {
 data "google_project" "project" {}
 `, context)
 }
+
+// Ensures cluster creation succeeds for a Private Service Connect enabled cluster.
+func TestAccAlloydbCluster_withPrivateServiceConnect(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckAlloydbClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlloydbCluster_withPrivateServiceConnect(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_alloydb_cluster.default", "psc_config.0.psc_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAlloydbCluster_withPrivateServiceConnect(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_alloydb_cluster" "default" {
+  cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
+  location   = "us-central1"
+  psc_config {
+    psc_enabled = true
+  }
+}
+data "google_project" "project" {}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
@@ -704,3 +704,80 @@ data "google_compute_network" "default" {
 }
 `, context)
 }
+
+func TestAccAlloydbInstance_updatePscInstanceConfig(t *testing.T) {
+	t.Parallel()
+
+	random_suffix := acctest.RandString(t, 10)
+	context := map[string]interface{}{
+		"random_suffix": random_suffix,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckAlloydbInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlloydbInstance_pscInstanceConfig(context),
+			},
+			{
+				Config: testAccAlloydbInstance_updatePscInstanceConfigAllowlist(context),
+			},
+		},
+	})
+}
+
+func testAccAlloydbInstance_pscInstanceConfig(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_alloydb_instance" "default" {
+  cluster       = google_alloydb_cluster.default.name
+  instance_id   = "tf-test-alloydb-instance%{random_suffix}"
+  instance_type = "PRIMARY"
+  machine_config {
+    cpu_count = 2
+  }
+  psc_instance_config {
+	allowed_consumer_projects = ["vmiglani-playground-psc"]
+  }
+}
+resource "google_alloydb_cluster" "default" {
+  cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
+  location   = "us-central1"
+  psc_config {
+	psc_enabled = true
+  }
+  initial_user {
+    password = "tf-test-alloydb-cluster%{random_suffix}"
+  }
+}
+data "google_project" "project" {}
+`, context)
+}
+
+func testAccAlloydbInstance_updatePscInstanceConfigAllowlist(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_alloydb_instance" "default" {
+  cluster       = google_alloydb_cluster.default.name
+  instance_id   = "tf-test-alloydb-instance%{random_suffix}"
+  instance_type = "PRIMARY"
+  machine_config {
+    cpu_count = 2
+  }
+  psc_instance_config {
+	allowed_consumer_projects = ["vmiglani-playground-psc", "alloydb-psc-cep"]
+  }
+}
+resource "google_alloydb_cluster" "default" {
+  cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
+  location   = "us-central1"
+  psc_config {
+	psc_enabled = true
+  }
+  initial_user {
+    password = "tf-test-alloydb-cluster%{random_suffix}"
+  }
+}
+data "google_project" "project" {}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
@@ -738,7 +738,7 @@ resource "google_alloydb_instance" "default" {
     cpu_count = 2
   }
   psc_instance_config {
-	allowed_consumer_projects = ["vmiglani-playground-psc"]
+	allowed_consumer_projects = ["${data.google_project.project.number}"]
   }
 }
 resource "google_alloydb_cluster" "default" {
@@ -765,7 +765,7 @@ resource "google_alloydb_instance" "default" {
     cpu_count = 2
   }
   psc_instance_config {
-	allowed_consumer_projects = ["vmiglani-playground-psc", "alloydb-psc-cep"]
+	allowed_consumer_projects = ["${data.google_project.project.number}", "1044355742748"]
   }
 }
 resource "google_alloydb_cluster" "default" {

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.erb
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.erb
@@ -293,6 +293,19 @@ func ProjectNumberDiffSuppress(_, old, new string, _ *schema.ResourceData) bool 
 	return a2 == b2
 }
 
+// Suppress diffs when the value read from api
+// has the project number instead of the project name.
+// This function suppresses the difference when the project ID is not prefixed with the string "projects".
+func ProjectNumberDiffSuppressWithoutPrefix(_, old, new string, _ *schema.ResourceData) bool {
+	var a2, b2 string
+	reN := regexp.MustCompile("\\d+")
+	re := regexp.MustCompile("[^/]+")
+	replacement := []byte("equal")
+	a2 = string(reN.ReplaceAll([]byte(old), replacement))
+	b2 = string(re.ReplaceAll([]byte(new), replacement))
+	return a2 == b2
+}
+
 func IsNewResource(diff TerraformResourceDiff) bool {
 	name := diff.Get("name")
 	return name.(string) == ""

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.erb
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.erb
@@ -293,19 +293,6 @@ func ProjectNumberDiffSuppress(_, old, new string, _ *schema.ResourceData) bool 
 	return a2 == b2
 }
 
-// Suppress diffs when the value read from api
-// has the project number instead of the project name.
-// This function suppresses the difference when the project ID is not prefixed with the string "projects".
-func ProjectNumberDiffSuppressWithoutPrefix(_, old, new string, _ *schema.ResourceData) bool {
-	var a2, b2 string
-	reN := regexp.MustCompile("\\d+")
-	re := regexp.MustCompile("[^/]+")
-	replacement := []byte("equal")
-	a2 = string(reN.ReplaceAll([]byte(old), replacement))
-	b2 = string(re.ReplaceAll([]byte(new), replacement))
-	return a2 == b2
-}
-
 func IsNewResource(diff TerraformResourceDiff) bool {
 	name := diff.Get("name")
 	return name.(string) == ""


### PR DESCRIPTION
Description:
Changes for supporting Private Service Connect (PSC) in Terraform.

Issue - https://b.corp.google.com/issues/313702463

```release-note:enhancement
alloydb: added `psc_config` field to `google_alloydb_cluster` resource
```
```release-note:enhancement
alloydb: added `psc_instance_config` field to `google_alloydb_instance` resource
```
```release-note:none
alloydb: added`psc_config.0.psc_enabled` to the `exactly_one_of` field network restrictions to `google_alloydb_cluster` resource```