### PR TITLE
Fix the bug to check key_diff_suppress_func in templates

### DIFF
--- a/mmv1/products/sourcerepo/Repository.yaml
+++ b/mmv1/products/sourcerepo/Repository.yaml
@@ -102,6 +102,5 @@ properties:
             If unspecified, it defaults to the compute engine default service account.
 
           default_from_api: true
-    key_diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
     key_expander: 'expandSourceRepoRepositoryPubsubConfigsTopic'
     set_hash_func: 'resourceSourceRepoRepositoryPubSubConfigsHash'

--- a/mmv1/templates/terraform/schema_property.erb
+++ b/mmv1/templates/terraform/schema_property.erb
@@ -152,7 +152,7 @@
 			"<%= property.key_name -%>": {
 				Type:     schema.TypeString,
 				Required: true,
-				<% if !property.diff_suppress_func.nil? -%>
+				<% if !property.key_diff_suppress_func.nil? -%>
 					DiffSuppressFunc: <%= property.key_diff_suppress_func %>,
 				<% end -%>
 				<% if force_new?(property, object) -%>

--- a/mmv1/templates/terraform/schema_property.go.tmpl
+++ b/mmv1/templates/terraform/schema_property.go.tmpl
@@ -138,7 +138,7 @@ Possible values: ["{{ join .EnumValues "\",\"" }}"]
 			"{{ .KeyName -}}": {
 				Type:     schema.TypeString,
 				Required: true,
-				{{ if .DiffSuppressFunc -}}
+				{{ if .KeyDiffSuppressFunc -}}
 					DiffSuppressFunc: {{ .KeyDiffSuppressFunc }},
 				{{ end -}}
 				{{ if .Immutable -}}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
` key_diff_suppress_func` instead of `diff_suppress_func` should be checked in the template to add it when generating resources

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
