### PR TITLE
[#17865] Move NGFW Enterprise resources to GA

### DIFF
--- a/mmv1/products/networksecurity/FirewallEndpoint.yaml
+++ b/mmv1/products/networksecurity/FirewallEndpoint.yaml
@@ -16,7 +16,6 @@ name: 'FirewallEndpoint'
 base_url: '{{parent}}/locations/{{location}}/firewallEndpoints'
 create_url: '{{parent}}/locations/{{location}}/firewallEndpoints?firewallEndpointId={{name}}'
 self_link: '{{parent}}/locations/{{location}}/firewallEndpoints/{{name}}'
-min_version: beta
 update_verb: :PATCH
 update_mask: true
 description: |

--- a/mmv1/products/networksecurity/FirewallEndpoint.yaml
+++ b/mmv1/products/networksecurity/FirewallEndpoint.yaml
@@ -31,7 +31,7 @@ docs: !ruby/object:Provider::Terraform::Docs
     `billing_project_id` you defined.
 references:
   !ruby/object:Api::Resource::ReferenceLinks
-  api: 'https://cloud.google.com/firewall/docs/reference/network-security/rest/v1beta1/organizations.locations.firewallEndpoints'
+  api: 'https://cloud.google.com/firewall/docs/reference/network-security/rest/v1/organizations.locations.firewallEndpoints'
   guides:
     'Firewall endpoint overview': 'https://cloud.google.com/firewall/docs/about-firewall-endpoints'
     'Create and associate firewall endpoints': 'https://cloud.google.com/firewall/docs/configure-firewall-endpoints'
@@ -52,7 +52,6 @@ examples:
     name: 'network_security_firewall_endpoint_basic'
     primary_resource_id: 'default'
     skip_test: true   # update tests will take care of create and update. Firewall endpoint creation is too long.
-    min_version: beta
     vars:
       resource_name: 'my-firewall-endpoint'
     test_env_vars:

--- a/mmv1/products/networksecurity/FirewallEndpointAssociation.yaml
+++ b/mmv1/products/networksecurity/FirewallEndpointAssociation.yaml
@@ -16,7 +16,6 @@ name: 'FirewallEndpointAssociation'
 base_url: '{{parent}}/locations/{{location}}/firewallEndpointAssociations'
 create_url: '{{parent}}/locations/{{location}}/firewallEndpointAssociations?firewallEndpointAssociationId={{name}}'
 self_link: '{{parent}}/locations/{{location}}/firewallEndpointAssociations/{{name}}'
-min_version: beta
 update_verb: :PATCH
 update_mask: true
 description: |
@@ -46,7 +45,6 @@ examples:
     # Handwritten test will take care of creates and updates.
     # Firewall endpoint association creation is subjet to firewall endpoint creation which is long and expensive.
     skip_test: true
-    min_version: beta
     vars:
       resource_name_prefix: 'my-firewall-endpoint'
     test_env_vars:

--- a/mmv1/products/networksecurity/FirewallEndpointAssociation.yaml
+++ b/mmv1/products/networksecurity/FirewallEndpointAssociation.yaml
@@ -25,7 +25,7 @@ description: |
   the attached firewall endpoint.
 references:
   !ruby/object:Api::Resource::ReferenceLinks
-  api: 'https://cloud.google.com/firewall/docs/reference/network-security/rest/v1beta1/projects.locations.firewallEndpointAssociations#FirewallEndpointAssociation'
+  api: 'https://cloud.google.com/firewall/docs/reference/network-security/rest/v1/projects.locations.firewallEndpointAssociations#FirewallEndpointAssociation'
   guides:
     'Firewall endpoint overview': 'https://cloud.google.com/firewall/docs/about-firewall-endpoints'
     'Create and associate firewall endpoints': 'https://cloud.google.com/firewall/docs/configure-firewall-endpoints'

--- a/mmv1/products/networksecurity/SecurityProfile.yaml
+++ b/mmv1/products/networksecurity/SecurityProfile.yaml
@@ -22,7 +22,7 @@ description: |
   A security profile defines the behavior associated to a profile type.
 references:
   !ruby/object:Api::Resource::ReferenceLinks
-  api: 'https://cloud.google.com/firewall/docs/reference/network-security/rest/v1beta1/projects.locations.securityProfiles'
+  api: 'https://cloud.google.com/firewall/docs/reference/network-security/rest/v1/projects.locations.securityProfiles'
   guides:
     'Create and manage security profiles': 'https://cloud.google.com/firewall/docs/configure-security-profiles'
 async: !ruby/object:Api::OpAsync

--- a/mmv1/products/networksecurity/SecurityProfile.yaml
+++ b/mmv1/products/networksecurity/SecurityProfile.yaml
@@ -16,7 +16,6 @@ name: 'SecurityProfile'
 base_url: '{{parent}}/locations/{{location}}/securityProfiles'
 create_url: '{{parent}}/locations/{{location}}/securityProfiles?securityProfileId={{name}}'
 self_link: '{{parent}}/locations/{{location}}/securityProfiles/{{name}}'
-min_version: beta
 update_verb: :PATCH
 update_mask: true
 description: |
@@ -35,7 +34,6 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'network_security_security_profile_basic'
     primary_resource_id: 'default'
-    min_version: beta
     vars:
       resource_name: 'my-security-profile'
     test_env_vars:
@@ -43,7 +41,6 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'network_security_security_profile_overrides'
     primary_resource_id: 'default'
-    min_version: beta
     vars:
       resource_name: 'my-security-profile'
     test_env_vars:

--- a/mmv1/products/networksecurity/SecurityProfileGroup.yaml
+++ b/mmv1/products/networksecurity/SecurityProfileGroup.yaml
@@ -22,7 +22,7 @@ description: |
   A security profile group defines a container for security profiles.
 references:
   !ruby/object:Api::Resource::ReferenceLinks
-  api: 'https://cloud.google.com/firewall/docs/reference/network-security/rest/v1beta1/organizations.locations.securityProfileGroups'
+  api: 'https://cloud.google.com/firewall/docs/reference/network-security/rest/v1/organizations.locations.securityProfileGroups'
   guides:
     'Security profile groups overview': 'https://cloud.google.com/firewall/docs/about-security-profile-groups'
     'Create and manage security profile groups': 'https://cloud.google.com/firewall/docs/configure-security-profile-groups'

--- a/mmv1/products/networksecurity/SecurityProfileGroup.yaml
+++ b/mmv1/products/networksecurity/SecurityProfileGroup.yaml
@@ -16,7 +16,6 @@ name: 'SecurityProfileGroup'
 base_url: '{{parent}}/locations/{{location}}securityProfileGroups'
 create_url: '{{parent}}/locations/{{location}}/securityProfileGroups?securityProfileGroupId={{name}}'
 self_link: '{{parent}}/locations/{{location}}/securityProfileGroups/{{name}}'
-min_version: beta
 update_verb: :PATCH
 update_mask: true
 description: |
@@ -36,7 +35,6 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'network_security_security_profile_group_basic'
     primary_resource_id: 'default'
-    min_version: beta
     test_env_vars:
       org_id: :ORG_ID
     vars:

--- a/mmv1/products/networksecurity/TlsInspectionPolicy.yaml
+++ b/mmv1/products/networksecurity/TlsInspectionPolicy.yaml
@@ -22,7 +22,7 @@ description:
   'The TlsInspectionPolicy resource contains references to CA pools in
   Certificate Authority Service and associated metadata.'
 references: !ruby/object:Api::Resource::ReferenceLinks
-  api: 'https://cloud.google.com/secure-web-proxy/docs/reference/network-security/rest/v1beta1/projects.locations.tlsInspectionPolicies'
+  api: 'https://cloud.google.com/secure-web-proxy/docs/reference/network-security/rest/v1/projects.locations.tlsInspectionPolicies'
   guides:
     'Use TlsInspectionPolicy': 'https://cloud.google.com/secure-web-proxy/docs/tls-inspection-overview'
 async: !ruby/object:Api::OpAsync

--- a/mmv1/products/networksecurity/TlsInspectionPolicy.yaml
+++ b/mmv1/products/networksecurity/TlsInspectionPolicy.yaml
@@ -16,7 +16,6 @@ name: 'TlsInspectionPolicy'
 base_url: 'projects/{{project}}/locations/{{location}}/tlsInspectionPolicies'
 create_url: 'projects/{{project}}/locations/{{location}}/tlsInspectionPolicies?tlsInspectionPolicyId={{name}}'
 self_link: 'projects/{{project}}/locations/{{location}}/tlsInspectionPolicies/{{name}}'
-min_version: beta
 update_verb: :PATCH
 update_mask: true
 description:
@@ -51,7 +50,6 @@ import_format:
   ['projects/{{project}}/locations/{{location}}/tlsInspectionPolicies/{{name}}']
 examples:
   - !ruby/object:Provider::Terraform::Examples
-    min_version: beta
     name: 'network_security_tls_inspection_policy_basic'
     primary_resource_id: 'default'
     vars:

--- a/mmv1/products/networksecurity/TlsInspectionPolicy.yaml
+++ b/mmv1/products/networksecurity/TlsInspectionPolicy.yaml
@@ -50,6 +50,7 @@ import_format:
   ['projects/{{project}}/locations/{{location}}/tlsInspectionPolicies/{{name}}']
 examples:
   - !ruby/object:Provider::Terraform::Examples
+    min_version: beta
     name: 'network_security_tls_inspection_policy_basic'
     primary_resource_id: 'default'
     vars:

--- a/mmv1/products/networksecurity/TlsInspectionPolicy.yaml
+++ b/mmv1/products/networksecurity/TlsInspectionPolicy.yaml
@@ -50,7 +50,6 @@ import_format:
   ['projects/{{project}}/locations/{{location}}/tlsInspectionPolicies/{{name}}']
 examples:
   - !ruby/object:Provider::Terraform::Examples
-    min_version: beta
     name: 'network_security_tls_inspection_policy_basic'
     primary_resource_id: 'default'
     vars:

--- a/mmv1/templates/terraform/examples/network_security_firewall_endpoint_association_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/network_security_firewall_endpoint_association_basic.tf.erb
@@ -1,5 +1,4 @@
 resource "google_network_security_firewall_endpoint" "<%= ctx[:primary_resource_id] %>" {
-  provider    = google-beta
   name        = "<%= ctx[:vars]['resource_name_prefix'] %>"
   parent      = "organizations/<%= ctx[:test_env_vars]['org_id'] %>"
   location    = "us-central1-a"
@@ -10,7 +9,6 @@ resource "google_network_security_firewall_endpoint" "<%= ctx[:primary_resource_
 }
 
 resource "google_network_security_firewall_endpoint_association" "<%= ctx[:primary_resource_id] %>_association" {
-  provider    = google-beta
   name        = "<%= ctx[:vars]['resource_name_prefix'] %>-association"
   parent      = "projects/<%= ctx[:test_env_vars]['project'] %>"
   location    = "us-central1-a"

--- a/mmv1/templates/terraform/examples/network_security_firewall_endpoint_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/network_security_firewall_endpoint_basic.tf.erb
@@ -1,5 +1,4 @@
 resource "google_network_security_firewall_endpoint" "<%= ctx[:primary_resource_id] %>" {
-  provider           = google-beta
   name               = "<%= ctx[:vars]['resource_name'] %>"
   parent             = "organizations/<%= ctx[:test_env_vars]['org_id'] %>"
   location           = "us-central1-a"

--- a/mmv1/templates/terraform/examples/network_security_security_profile_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/network_security_security_profile_basic.tf.erb
@@ -1,5 +1,4 @@
 resource "google_network_security_security_profile" "<%= ctx[:primary_resource_id] %>" {
-  provider    = google-beta
   name        = "<%= ctx[:vars]['resource_name'] %>"
   parent      = "organizations/<%= ctx[:test_env_vars]['org_id'] %>"
   description = "my description"

--- a/mmv1/templates/terraform/examples/network_security_security_profile_group_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/network_security_security_profile_group_basic.tf.erb
@@ -1,5 +1,4 @@
 resource "google_network_security_security_profile_group" "<%= ctx[:primary_resource_id] %>" {
-  provider                  = google-beta
   name                      = "<%= ctx[:vars]['security_profile_group_name'] %>"
   parent                    = "organizations/<%= ctx[:test_env_vars]['org_id'] %>"
   description               = "my description"
@@ -11,7 +10,6 @@ resource "google_network_security_security_profile_group" "<%= ctx[:primary_reso
 }
 
 resource "google_network_security_security_profile" "security_profile" {
-    provider    = google-beta
     name        = "<%= ctx[:vars]['security_profile_name'] %>"
     type        = "THREAT_PREVENTION"
     parent      = "organizations/<%= ctx[:test_env_vars]['org_id'] %>"

--- a/mmv1/templates/terraform/examples/network_security_security_profile_overrides.tf.erb
+++ b/mmv1/templates/terraform/examples/network_security_security_profile_overrides.tf.erb
@@ -1,5 +1,4 @@
 resource "google_network_security_security_profile" "<%= ctx[:primary_resource_id] %>" {
-  provider    = google-beta
   name        = "<%= ctx[:vars]['resource_name'] %>"
   parent      = "organizations/<%= ctx[:test_env_vars]['org_id'] %>"
   description = "my description"

--- a/mmv1/templates/terraform/examples/network_security_tls_inspection_policy_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/network_security_tls_inspection_policy_basic.tf.erb
@@ -76,6 +76,8 @@ resource "google_privateca_ca_pool_iam_member" "tls_inspection_permission" {
 }
 
 resource "google_network_security_tls_inspection_policy" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+
   name     = "<%= ctx[:vars]['resource_name'] %>"
   location = "us-central1"
   ca_pool  = google_privateca_ca_pool.default.id

--- a/mmv1/templates/terraform/examples/network_security_tls_inspection_policy_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/network_security_tls_inspection_policy_basic.tf.erb
@@ -76,7 +76,6 @@ resource "google_privateca_ca_pool_iam_member" "tls_inspection_permission" {
 }
 
 resource "google_network_security_tls_inspection_policy" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
   name     = "<%= ctx[:vars]['resource_name'] %>"
   location = "us-central1"
   ca_pool  = google_privateca_ca_pool.default.id

--- a/mmv1/templates/terraform/examples/network_security_tls_inspection_policy_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/network_security_tls_inspection_policy_basic.tf.erb
@@ -1,5 +1,4 @@
 resource "google_privateca_ca_pool" "default" {
-  provider = google-beta
   name      = "<%= ctx[:vars]['privateca_ca_pool_name'] %>"
   location  = "us-central1"
   tier     = "DEVOPS"
@@ -23,22 +22,20 @@ resource "google_privateca_ca_pool" "default" {
   }
 }
 
-
 resource "google_privateca_certificate_authority" "default" {
-  provider = google-beta
-  pool = google_privateca_ca_pool.default.name
-  certificate_authority_id = "<%= ctx[:vars]['privateca_certificate_authority_id'] %>"
-  location = "us-central1"
-  lifetime = "86400s"
-  type = "SELF_SIGNED"
-  deletion_protection = false
-  skip_grace_period = true
+  pool                                   = google_privateca_ca_pool.default.name
+  certificate_authority_id               = "<%= ctx[:vars]['privateca_certificate_authority_id'] %>"
+  location                               = "us-central1"
+  lifetime                               = "86400s"
+  type                                   = "SELF_SIGNED"
+  deletion_protection                    = false
+  skip_grace_period                      = true
   ignore_active_certificates_on_deletion = true
   config {
     subject_config {
       subject {
         organization = "Test LLC"
-        common_name = "my-ca"
+        common_name  = "my-ca"
       }
     }
     x509_config {
@@ -48,7 +45,7 @@ resource "google_privateca_certificate_authority" "default" {
       key_usage {
         base_key_usage {
           cert_sign = true
-          crl_sign = true
+          crl_sign  = true
         }
         extended_key_usage {
           server_auth = false
@@ -62,25 +59,19 @@ resource "google_privateca_certificate_authority" "default" {
 }
 
 resource "google_project_service_identity" "ns_sa" {
-  provider = google-beta
-
   service = "networksecurity.googleapis.com"
 }
 
 resource "google_privateca_ca_pool_iam_member" "tls_inspection_permission" {
-  provider = google-beta
-
   ca_pool = google_privateca_ca_pool.default.id
-  role = "roles/privateca.certificateManager"
-  member = "serviceAccount:${google_project_service_identity.ns_sa.email}"
+  role    = "roles/privateca.certificateManager"
+  member  = "serviceAccount:${google_project_service_identity.ns_sa.email}"
 }
 
 resource "google_network_security_tls_inspection_policy" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
-
-  name     = "<%= ctx[:vars]['resource_name'] %>"
-  location = "us-central1"
-  ca_pool  = google_privateca_ca_pool.default.id
+  name                  = "<%= ctx[:vars]['resource_name'] %>"
+  location              = "us-central1"
+  ca_pool               = google_privateca_ca_pool.default.id
   exclude_public_ca_set = false
-  depends_on = [google_privateca_ca_pool.default, google_privateca_certificate_authority.default, google_privateca_ca_pool_iam_member.tls_inspection_permission]
+  depends_on            = [google_privateca_ca_pool.default, google_privateca_certificate_authority.default, google_privateca_ca_pool_iam_member.tls_inspection_permission]
 }

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_firewall_endpoint_association_test.go.erb
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_firewall_endpoint_association_test.go.erb
@@ -1,6 +1,4 @@
-<% autogen_exception -%>
 package networksecurity_test
-<% unless version == 'ga' -%>
 
 import (
 	"fmt"
@@ -220,5 +218,3 @@ func testAccCheckNetworkSecurityFirewallEndpointAssociationDestroyProducer(t *te
 		return nil
 	}
 }
-
-<% end -%>

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_firewall_endpoint_association_test.go.erb
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_firewall_endpoint_association_test.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package networksecurity_test
 
 import (

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_firewall_endpoint_test.go.erb
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_firewall_endpoint_test.go.erb
@@ -1,6 +1,4 @@
-<% autogen_exception -%>
 package networksecurity_test
-<% unless version == 'ga' -%>
 
 import (
 	"fmt"
@@ -123,5 +121,3 @@ func testAccCheckNetworkSecurityFirewallEndpointDestroyProducer(t *testing.T) fu
 		return nil
 	}
 }
-
-<% end -%>

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_firewall_endpoint_test.go.erb
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_firewall_endpoint_test.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package networksecurity_test
 
 import (

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_security_profile_group_test.go.erb
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_security_profile_group_test.go.erb
@@ -1,6 +1,4 @@
-<% autogen_exception -%>
 package networksecurity_test
-<% unless version == 'ga' -%>
 
 import (
 	"fmt"
@@ -101,5 +99,3 @@ resource "google_network_security_security_profile_group" "foobar" {
 }
 `, randomSuffix, orgId, randomSuffix, orgId, randomSuffix, orgId)
 }
-
-<% end -%>

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_security_profile_group_test.go.erb
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_security_profile_group_test.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package networksecurity_test
 
 import (

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_security_profile_test.go.erb
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_security_profile_test.go.erb
@@ -1,6 +1,4 @@
-<% autogen_exception -%>
 package networksecurity_test
-<% unless version == 'ga' -%>
 
 import (
 	"fmt"
@@ -89,5 +87,3 @@ resource "google_network_security_security_profile" "foobar" {
 }
 `, randomSuffix, orgId)
 }
-
-<% end -%>

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_security_profile_test.go.erb
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_security_profile_test.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package networksecurity_test
 
 import (

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_tls_inspection_policy_test.go.erb
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_tls_inspection_policy_test.go.erb
@@ -1,6 +1,5 @@
 <% autogen_exception -%>
 package networksecurity_test
-<% unless version == 'ga' -%>
 
 import (
 	"fmt"
@@ -206,5 +205,3 @@ resource "google_network_security_tls_inspection_policy" "foobar" {
 }
 `, caPoolName, certificateAuthorityName, tlsInspectionPolicyName)
 }
-
-<% end -%>

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_tls_inspection_policy_test.go.erb
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_tls_inspection_policy_test.go.erb
@@ -1,6 +1,4 @@
-<% autogen_exception -%>
 package networksecurity_test
-<% unless version == 'ga' -%>
 
 import (
 	"fmt"
@@ -206,5 +204,3 @@ resource "google_network_security_tls_inspection_policy" "foobar" {
 }
 `, caPoolName, certificateAuthorityName, tlsInspectionPolicyName)
 }
-
-<% end -%>

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_tls_inspection_policy_test.go.erb
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_tls_inspection_policy_test.go.erb
@@ -1,5 +1,6 @@
 <% autogen_exception -%>
 package networksecurity_test
+<% unless version == 'ga' -%>
 
 import (
 	"fmt"
@@ -205,3 +206,5 @@ resource "google_network_security_tls_inspection_policy" "foobar" {
 }
 `, caPoolName, certificateAuthorityName, tlsInspectionPolicyName)
 }
+
+<% end -%>

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_tls_inspection_policy_test.go.erb
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_tls_inspection_policy_test.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package networksecurity_test
 
 import (


### PR DESCRIPTION
Move NGFW Enterprise resources to GA.

Fixes [hashicorp/terraform-provider-google/issues/17865](https://github.com/hashicorp/terraform-provider-google/issues/17865)

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See / for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
networksecurity: promoted `google_network_security_security_profile`, `google_network_security_security_profile_group`, `google_network_security_firewall_endpoint`, and `google_network_security_firewall_endpoint_association` resources to GA.
```
