### PR TITLE
Add support for `google_compute_target_http_proxy` to TGC

### DIFF
--- a/mmv1/templates/tgc/resource_converters.go.erb
+++ b/mmv1/templates/tgc/resource_converters.go.erb
@@ -49,6 +49,7 @@ func ResourceConverters() map[string][]cai.ResourceConverter {
 		"google_compute_snapshot":                         {compute.ResourceConverterComputeSnapshot()},
 		"google_compute_subnetwork":                       {compute.ResourceConverterComputeSubnetwork()},
 		"google_compute_ssl_policy":                       {compute.ResourceConverterComputeSslPolicy()},
+		"google_compute_target_http_proxy": 			   {compute.ResourceConverterComputeTargetHttpProxy()},
 		"google_compute_target_https_proxy":               {compute.ResourceConverterComputeTargetHttpsProxy()},
 		"google_compute_target_ssl_proxy":                 {compute.ResourceConverterComputeTargetSslProxy()},
 		"google_dns_managed_zone":                         {dns.ResourceConverterDNSManagedZone()},

--- a/mmv1/third_party/tgc/tests/data/example_google_compute_target_http_proxy.json
+++ b/mmv1/third_party/tgc/tests/data/example_google_compute_target_http_proxy.json
@@ -1,0 +1,19 @@
+[
+    {
+        "name": "//compute.googleapis.com/projects/{{.Provider.project}}/global/targetHttpProxies/test-proxy",
+        "asset_type": "compute.googleapis.com/TargetHttpProxy",
+        "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}",
+        "resource": {
+            "version": "beta",
+            "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/compute/beta/rest",
+            "discovery_name": "TargetHttpProxy",
+            "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
+            "data": {
+                "name": "test-proxy"
+            }
+        },
+        "ancestors": [
+            "organizations/{{.OrgID}}"
+        ]
+    }
+]

--- a/mmv1/third_party/tgc/tests/data/example_google_compute_target_http_proxy.tf
+++ b/mmv1/third_party/tgc/tests/data/example_google_compute_target_http_proxy.tf
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google-beta"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
+provider "google" {
+  {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
+}
+
+resource "google_compute_target_http_proxy" "default" {
+  name    = "test-proxy"
+  url_map = google_compute_url_map.default.id
+}
+
+resource "google_compute_url_map" "default" {
+  name            = "url-map"
+  default_service = google_compute_backend_service.default.id
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name            = "allpaths"
+    default_service = google_compute_backend_service.default.id
+
+    path_rule {
+      paths   = ["/*"]
+      service = google_compute_backend_service.default.id
+    }
+  }
+}
+
+resource "google_compute_backend_service" "default" {
+  name        = "backend-service"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = [google_compute_http_health_check.default.id]
+}
+
+resource "google_compute_http_health_check" "default" {
+  name               = "http-health-check"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}


### PR DESCRIPTION
adding new tests for compute.googleapis.com/TargetHttpProxy
```release-note:none
```