### PR TITLE
Remove cluster update validation for primary to secondary

### DIFF
--- a/mmv1/templates/terraform/pre_update/alloydb_cluster.go.erb
+++ b/mmv1/templates/terraform/pre_update/alloydb_cluster.go.erb
@@ -1,8 +1,3 @@
-// Restrict modification of cluster_type from PRIMARY to SECONDARY as it is an invalid operation
-if d.HasChange("cluster_type") && d.Get("cluster_type") == "SECONDARY" {
-    return fmt.Errorf("Can not convert a primary cluster to a secondary cluster.")
-}
-
 // Restrict setting secondary_config if cluster_type is PRIMARY
 if d.Get("cluster_type") == "PRIMARY" && !tpgresource.IsEmptyValue(reflect.ValueOf(d.Get("secondary_config"))) {
     return fmt.Errorf("Can not set secondary config for primary cluster.")


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Remove cluster update validation for cluster_type update from PRIMARY to SECONDARY as it is handled by the backend API

Verified with `terraform apply`
 Error: Error updating Cluster "projects/$projectName/locations/$locationName/clusters/primary-cluster": googleapi: Error 400: The request was invalid: updating field cluster_type is not supported (current value: PRIMARY, specified value: SECONDARY)
│ Details:
│ [
│   {
│     "@type": "type.googleapis.com/google.rpc.DebugInfo",
│     "detail": "generic::invalid_argument: The request was invalid: updating field cluster_type is not supported (current value: PRIMARY, specified value: SECONDARY)",
│     "stackEntries": [
| ......
│    ]

```release-note:none

```
