### PR TITLE
Adding support for Cloud DNS Additive VPC Scope for GKE, currently in preview

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -2046,6 +2046,13 @@ func ResourceContainerCluster() *schema.Resource {
 				Description: `Configuration for Cloud DNS for Kubernetes Engine.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						<% unless version == 'ga' -%>
+						"additive_vpc_scope_dns_domain": {
+							Type:         schema.TypeString,
+							Description:  `Enable additive VPC scope DNS in a GKE cluster.`,
+							Optional:     true,
+						},
+						<% end -%>
 						"cluster_dns": {
 							Type:         schema.TypeString,
 							Default:      "PROVIDER_UNSPECIFIED",
@@ -5313,9 +5320,12 @@ func expandDnsConfig(configured interface{}) *container.DNSConfig {
 
 	config := l[0].(map[string]interface{})
 	return &container.DNSConfig{
-		ClusterDns:       config["cluster_dns"].(string),
-		ClusterDnsScope:  config["cluster_dns_scope"].(string),
-		ClusterDnsDomain: config["cluster_dns_domain"].(string),
+<% unless version == 'ga' -%>
+		AdditiveVpcScopeDnsDomain: 	config["additive_vpc_scope_dns_domain"].(string),
+<% end -%>
+		ClusterDns:       			config["cluster_dns"].(string),
+		ClusterDnsScope:  			config["cluster_dns_scope"].(string),
+		ClusterDnsDomain: 			config["cluster_dns_domain"].(string),
 	}
 }
 
@@ -6187,9 +6197,12 @@ func flattenDnsConfig(c *container.DNSConfig) []map[string]interface{} {
 	}
 	return []map[string]interface{}{
 		{
-			"cluster_dns":        c.ClusterDns,
-			"cluster_dns_scope":  c.ClusterDnsScope,
-			"cluster_dns_domain": c.ClusterDnsDomain,
+<% unless version == 'ga' -%>
+			"additive_vpc_scope_dns_domain": 	c.AdditiveVpcScopeDnsDomain,
+<% end -%>
+			"cluster_dns":        				c.ClusterDns,
+			"cluster_dns_scope":  				c.ClusterDnsScope,
+			"cluster_dns_domain": 				c.ClusterDnsDomain,
 		},
 	}
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -490,6 +490,31 @@ func TestAccContainerCluster_withFQDNNetworkPolicy(t *testing.T) {
 }
 <% end -%>
 
+<% unless version == 'ga' -%>
+func TestAccContainerCluster_withAdditiveVPC(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withAdditiveVPC(clusterName),
+			},
+			{
+				ResourceName:      "google_container_cluster.cluster",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
+			},
+		},
+	})
+}
+<% end -%>
+
 func TestAccContainerCluster_withMasterAuthConfig_NoCert(t *testing.T) {
 	t.Parallel()
 
@@ -632,6 +657,24 @@ resource "google_container_cluster" "cluster" {
 }
 <% end -%>
 
+<% unless version == 'ga' -%>
+func testAccContainerCluster_withAdditiveVPC(clusterName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "cluster" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+
+  dns_config {
+    cluster_dns = "CLOUD_DNS"
+    additive_vpc_scope_dns_domain = "test.com"
+    cluster_dns_scope = "CLUSTER_SCOPE"
+  }
+  deletion_protection = false
+}
+`, clusterName)
+}
+<% end -%>
 
 <% unless version == 'ga' -%>
 func testAccContainerCluster_withFQDNNetworkPolicy(clusterName string, enabled bool) string {

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1287,6 +1287,8 @@ linux_node_config {
 
 <a name="nested_dns_config"></a>The `dns_config` block supports:
 
+* `additive_vpc_scope_dns_domain` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) This will enable Cloud DNS additive VPC scope. Must provide a domain name that is unique within the VPC. For this to work `cluster_dns = "CLOUD_DNS"` and `cluster_dns_scope = "CLUSTER_SCOPE"` must both be set as well.
+
 * `cluster_dns` - (Optional) Which in-cluster DNS provider should be used. `PROVIDER_UNSPECIFIED` (default) or `PLATFORM_DEFAULT` or `CLOUD_DNS`.
 
 * `cluster_dns_scope` - (Optional) The scope of access to cluster DNS records. `DNS_SCOPE_UNSPECIFIED` (default) or `CLUSTER_SCOPE` or `VPC_SCOPE`.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This is adding support for google_container_clusters to be able to enable Cloud DNS with additive VPC scope, which is currently in preview.

[GitHub Issue](https://github.com/hashicorp/terraform-provider-google/issues/18020)

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added `additive_vpc_scope_dns_domain` field inside of the `dns_config` section of `google_container_cluster` resource
```
