### PR TITLE
Added support for "TLS_JA3_FINGERPRINT" and "USER_IP" options for enforceOnKey field in "compute_security_policy" and "compute_security_policy_rule"

### DIFF
--- a/mmv1/products/compute/SecurityPolicyRule.yaml
+++ b/mmv1/products/compute/SecurityPolicyRule.yaml
@@ -283,6 +283,146 @@ properties:
 
       * throttle: limit client traffic to the configured threshold. Configure parameters for this action in rateLimitOptions. Requires rateLimitOptions to be set for this.
     required: true
+  - !ruby/object:Api::Type::NestedObject
+    name: 'rateLimitOptions'
+    description: |
+      Must be specified if the action is "rate_based_ban" or "throttle". Cannot be specified for any other actions.
+    update_mask_fields:
+      - 'rateLimitOptions.rateLimitThreshold'
+      - 'rateLimitOptions.conformAction'
+      - 'rateLimitOptions.exceedRedirectOptions'
+      - 'rateLimitOptions.exceedAction'
+      - 'rateLimitOptions.enforceOnKey'
+      - 'rateLimitOptions.enforceOnKeyName'
+      - 'rateLimitOptions.enforceOnKeyConfigs'
+      - 'rateLimitOptions.banThreshold'
+      - 'rateLimitOptions.banDurationSec'
+    properties:
+      - !ruby/object:Api::Type::NestedObject
+        name: 'rateLimitThreshold'
+        description: |
+          Threshold at which to begin ratelimiting.
+        properties:
+          - !ruby/object:Api::Type::Integer
+            name: 'count'
+            description: |
+              Number of HTTP(S) requests for calculating the threshold.
+          - !ruby/object:Api::Type::Integer
+            name: 'intervalSec'
+            description: |
+              Interval over which the threshold is computed.
+      - !ruby/object:Api::Type::String
+        name: 'conformAction'
+        description: |
+          Action to take for requests that are under the configured rate limit threshold.
+          Valid option is "allow" only.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'exceedRedirectOptions'
+        description: |
+          Parameters defining the redirect action that is used as the exceed action. Cannot be specified if the exceed action is not redirect. This field is only supported in Global Security Policies of type CLOUD_ARMOR.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'type'
+            description: |
+              Type of the redirect action.
+          - !ruby/object:Api::Type::String
+            name: 'target'
+            description: |
+              Target for the redirect action. This is required if the type is EXTERNAL_302 and cannot be specified for GOOGLE_RECAPTCHA.
+      - !ruby/object:Api::Type::String
+        name: 'exceedAction'
+        description: |
+          Action to take for requests that are above the configured rate limit threshold, to either deny with a specified HTTP response code, or redirect to a different endpoint.
+          Valid options are deny(STATUS), where valid values for STATUS are 403, 404, 429, and 502.
+      - !ruby/object:Api::Type::Enum
+        name: 'enforceOnKey'
+        description: |
+          Determines the key to enforce the rateLimitThreshold on. Possible values are:
+          * ALL: A single rate limit threshold is applied to all the requests matching this rule. This is the default value if "enforceOnKey" is not configured.
+          * IP: The source IP address of the request is the key. Each IP has this limit enforced separately.
+          * HTTP_HEADER: The value of the HTTP header whose name is configured under "enforceOnKeyName". The key value is truncated to the first 128 bytes of the header value. If no such header is present in the request, the key type defaults to ALL.
+          * XFF_IP: The first IP address (i.e. the originating client IP address) specified in the list of IPs under X-Forwarded-For HTTP header. If no such header is present or the value is not a valid IP, the key defaults to the source IP address of the request i.e. key type IP.
+          * HTTP_COOKIE: The value of the HTTP cookie whose name is configured under "enforceOnKeyName". The key value is truncated to the first 128 bytes of the cookie value. If no such cookie is present in the request, the key type defaults to ALL.
+          * HTTP_PATH: The URL path of the HTTP request. The key value is truncated to the first 128 bytes.
+          * SNI: Server name indication in the TLS session of the HTTPS request. The key value is truncated to the first 128 bytes. The key type defaults to ALL on a HTTP session.
+          * REGION_CODE: The country/region from which the request originates.
+          * TLS_JA3_FINGERPRINT: JA3 TLS/SSL fingerprint if the client connects using HTTPS, HTTP/2 or HTTP/3. If not available, the key type defaults to ALL.
+          * USER_IP: The IP address of the originating client, which is resolved based on "userIpRequestHeaders" configured with the security policy. If there is no "userIpRequestHeaders" configuration or an IP address cannot be resolved from it, the key type defaults to IP.
+        values:
+          - :ALL
+          - :IP
+          - :HTTP_HEADER
+          - :XFF_IP
+          - :HTTP_COOKIE
+          - :HTTP_PATH
+          - :SNI
+          - :REGION_CODE
+          - :TLS_JA3_FINGERPRINT
+          - :USER_IP
+      - !ruby/object:Api::Type::String
+        name: 'enforceOnKeyName'
+        description: |
+          Rate limit key name applicable only for the following key types:
+          HTTP_HEADER -- Name of the HTTP header whose value is taken as the key value.
+          HTTP_COOKIE -- Name of the HTTP cookie whose value is taken as the key value.
+      - !ruby/object:Api::Type::Array
+        name: 'enforceOnKeyConfigs'
+        description: |
+          If specified, any combination of values of enforceOnKeyType/enforceOnKeyName is treated as the key on which ratelimit threshold/action is enforced.
+          You can specify up to 3 enforceOnKeyConfigs.
+          If enforceOnKeyConfigs is specified, enforceOnKey must not be specified.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::Enum
+              name: 'enforceOnKeyType'
+              description: |
+                Determines the key to enforce the rateLimitThreshold on. Possible values are:
+                * ALL: A single rate limit threshold is applied to all the requests matching this rule. This is the default value if "enforceOnKeyConfigs" is not configured.
+                * IP: The source IP address of the request is the key. Each IP has this limit enforced separately.
+                * HTTP_HEADER: The value of the HTTP header whose name is configured under "enforceOnKeyName". The key value is truncated to the first 128 bytes of the header value. If no such header is present in the request, the key type defaults to ALL.
+                * XFF_IP: The first IP address (i.e. the originating client IP address) specified in the list of IPs under X-Forwarded-For HTTP header. If no such header is present or the value is not a valid IP, the key defaults to the source IP address of the request i.e. key type IP.
+                * HTTP_COOKIE: The value of the HTTP cookie whose name is configured under "enforceOnKeyName". The key value is truncated to the first 128 bytes of the cookie value. If no such cookie is present in the request, the key type defaults to ALL.
+                * HTTP_PATH: The URL path of the HTTP request. The key value is truncated to the first 128 bytes.
+                * SNI: Server name indication in the TLS session of the HTTPS request. The key value is truncated to the first 128 bytes. The key type defaults to ALL on a HTTP session.
+                * REGION_CODE: The country/region from which the request originates.
+                * TLS_JA3_FINGERPRINT: JA3 TLS/SSL fingerprint if the client connects using HTTPS, HTTP/2 or HTTP/3. If not available, the key type defaults to ALL.
+                * USER_IP: The IP address of the originating client, which is resolved based on "userIpRequestHeaders" configured with the security policy. If there is no "userIpRequestHeaders" configuration or an IP address cannot be resolved from it, the key type defaults to IP.
+              values:
+                - :ALL
+                - :IP
+                - :HTTP_HEADER
+                - :XFF_IP
+                - :HTTP_COOKIE
+                - :HTTP_PATH
+                - :SNI
+                - :REGION_CODE
+                - :TLS_JA3_FINGERPRINT
+                - :USER_IP
+            - !ruby/object:Api::Type::String
+              name: 'enforceOnKeyName'
+              description: |
+                Rate limit key name applicable only for the following key types:
+                HTTP_HEADER -- Name of the HTTP header whose value is taken as the key value.
+                HTTP_COOKIE -- Name of the HTTP cookie whose value is taken as the key value.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'banThreshold'
+        description: |
+          Can only be specified if the action for the rule is "rate_based_ban".
+          If specified, the key will be banned for the configured 'banDurationSec' when the number of requests that exceed the 'rateLimitThreshold' also exceed this 'banThreshold'.
+        properties:
+          - !ruby/object:Api::Type::Integer
+            name: 'count'
+            description: |
+              Number of HTTP(S) requests for calculating the threshold.
+          - !ruby/object:Api::Type::Integer
+            name: 'intervalSec'
+            description: |
+              Interval over which the threshold is computed.
+      - !ruby/object:Api::Type::Integer
+        name: 'banDurationSec'
+        description: |
+          Can only be specified if the action for the rule is "rate_based_ban".
+          If specified, determines the time (in seconds) the traffic will continue to be banned by the rate limit after the rate falls below the threshold.
   - !ruby/object:Api::Type::Boolean
     name: 'preview'
     description: |

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.erb
@@ -271,7 +271,7 @@ func ResourceComputeSecurityPolicy() *schema.Resource {
 										Type:         schema.TypeString,
 										Optional:     true,
 										Description:  `Determines the key to enforce the rateLimitThreshold on`,
-										ValidateFunc: validation.StringInSlice([]string{"ALL", "IP", "HTTP_HEADER", "XFF_IP", "HTTP_COOKIE", "HTTP_PATH", "SNI", "REGION_CODE", ""}, false),
+										ValidateFunc: validation.StringInSlice([]string{"ALL", "IP", "HTTP_HEADER", "XFF_IP", "HTTP_COOKIE", "HTTP_PATH", "SNI", "REGION_CODE", "TLS_JA3_FINGERPRINT", "USER_IP", ""}, false),
 									},
 
 									"enforce_on_key_name": {
@@ -291,7 +291,7 @@ func ResourceComputeSecurityPolicy() *schema.Resource {
 													Type:         schema.TypeString,
 													Optional:     true,
 													Description:  `Determines the key to enforce the rate_limit_threshold on`,
-													ValidateFunc: validation.StringInSlice([]string{"ALL", "IP", "HTTP_HEADER", "XFF_IP", "HTTP_COOKIE", "HTTP_PATH", "SNI", "REGION_CODE"}, false),
+													ValidateFunc: validation.StringInSlice([]string{"ALL", "IP", "HTTP_HEADER", "XFF_IP", "HTTP_COOKIE", "HTTP_PATH", "SNI", "REGION_CODE", "TLS_JA3_FINGERPRINT", "USER_IP"}, false),
 												},
 												"enforce_on_key_name": {
 													Type:        schema.TypeString,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_rule_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_rule_test.go.erb
@@ -2,6 +2,7 @@
 package compute_test
 
 import (
+  "fmt"
   "regexp"
 	"testing"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
@@ -139,6 +140,121 @@ func TestAccComputeSecurityPolicyRule_withPreconfiguredWafConfig(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckNoResourceAttr("google_compute_security_policy_rule.policy_rule", "preconfigured_waf_config.0"),
 				),
+			},
+			{
+				ResourceName:      "google_compute_security_policy_rule.policy_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeSecurityPolicyRule_withRateLimit_withEnforceOnKeyConfigs(t *testing.T) {
+	t.Parallel()
+
+	spName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeSecurityPolicyRuleDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSecurityPolicyRule_withRateLimitOptions_withEnforceOnKeyConfigs(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy_rule.policy_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeSecurityPolicyRule_withRateLimitOption_withMultipleEnforceOnKeyConfigs(t *testing.T) {
+	t.Parallel()
+
+	spName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeSecurityPolicyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSecurityPolicyRule_withRateLimitOption_withMultipleEnforceOnKeyConfigs(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy_rule.policy_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeSecurityPolicyRule_withRateLimitOption_withMultipleEnforceOnKeyConfigs2(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy_rule.policy_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+
+func TestAccComputeSecurityPolicyRule_EnforceOnKeyUpdates(t *testing.T) {
+	t.Parallel()
+
+	spName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeSecurityPolicyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSecurityPolicyRule_withRateLimitOptions_withoutRateLimitOptions(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy_rule.policy_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeSecurityPolicyRule_withRateLimitOptions_withEnforceOnKeyName(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy_rule.policy_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeSecurityPolicyRule_withRateLimitOptions_withEnforceOnKey(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy_rule.policy_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeSecurityPolicyRule_withRateLimitOptions_withEnforceOnKeyConfigs(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy_rule.policy_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeSecurityPolicyRule_withRateLimitOptions_withEnforceOnKey(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy_rule.policy_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeSecurityPolicyRule_withRateLimitOptions_withEnforceOnKeyName(spName),
 			},
 			{
 				ResourceName:      "google_compute_security_policy_rule.policy_rule",
@@ -451,4 +567,247 @@ resource "google_compute_security_policy_rule" "policy_rule" {
   preview = false
 }
 `, context)
+}
+
+func testAccComputeSecurityPolicyRule_withRateLimitOptions_withEnforceOnKey(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+  name        = "%s"
+  description = "basic policy base"
+}
+
+resource "google_compute_security_policy_rule" "policy_rule" {
+  security_policy = google_compute_security_policy.policy.name
+  description     = "throttle rule withEnforceOnKey"
+  action          = "throttle"
+  priority        = "100"
+  
+  match {
+    versioned_expr = "SRC_IPS_V1"
+    config {
+      src_ip_ranges = ["*"]
+    }
+  }
+
+  rate_limit_options {
+    conform_action = "allow"
+    exceed_action = "redirect"
+
+    enforce_on_key = "IP"
+
+    exceed_redirect_options {
+      type = "EXTERNAL_302"
+      target = "https://www.example.com"
+    }
+
+    rate_limit_threshold {
+      count = 10
+      interval_sec = 60
+    }
+  }
+}
+`, spName)
+}
+
+func testAccComputeSecurityPolicyRule_withRateLimitOptions_withEnforceOnKeyConfigs(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+  name        = "%s"
+  description = "basic policy base"
+}
+
+resource "google_compute_security_policy_rule" "policy_rule" {
+  security_policy = google_compute_security_policy.policy.name
+  description     = "throttle rule withEnforceOnKeyConfigs"
+  action          = "throttle"
+  priority        = "100"
+
+  match {
+    versioned_expr = "SRC_IPS_V1"
+    config {
+      src_ip_ranges = ["*"]
+    }
+  }
+
+  rate_limit_options {
+    conform_action = "allow"
+    exceed_action = "redirect"
+
+    enforce_on_key = ""
+
+    enforce_on_key_configs {
+      enforce_on_key_type = "IP"
+    }
+    exceed_redirect_options {
+      type = "EXTERNAL_302"
+      target = "https://www.example.com"
+    }
+
+    rate_limit_threshold {
+      count = 10
+      interval_sec = 60
+    }
+  }
+}
+`, spName)
+}
+
+func testAccComputeSecurityPolicyRule_withRateLimitOption_withMultipleEnforceOnKeyConfigs(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+  name        = "%s"
+  description = "basic policy base"
+}
+
+resource "google_compute_security_policy_rule" "policy_rule" {
+  security_policy = google_compute_security_policy.policy.name
+  description     = "throttle rule with withMultipleEnforceOnKeyConfigs"
+  action          = "throttle"
+  priority        = "100"
+
+  match {
+    versioned_expr = "SRC_IPS_V1"
+    config {
+      src_ip_ranges = ["*"]
+    }
+  }
+
+  rate_limit_options {
+    conform_action = "allow"
+    exceed_action = "deny(429)"
+
+    rate_limit_threshold {
+      count = 10
+      interval_sec = 60
+    }
+
+    enforce_on_key = ""
+
+    enforce_on_key_configs {
+      enforce_on_key_type = "HTTP_PATH"
+    }
+
+    enforce_on_key_configs {
+      enforce_on_key_type = "HTTP_HEADER"
+      enforce_on_key_name = "user-agent"
+    }
+
+    enforce_on_key_configs {
+      enforce_on_key_type = "REGION_CODE"
+    }
+  }
+}
+`, spName)
+}
+
+func testAccComputeSecurityPolicyRule_withRateLimitOption_withMultipleEnforceOnKeyConfigs2(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+  name        = "%s"
+  description = "basic policy base"
+}
+
+resource "google_compute_security_policy_rule" "policy_rule" {
+  security_policy = google_compute_security_policy.policy.name
+  description     = "throttle rule withMultipleEnforceOnKeyConfigs2"
+  action          = "throttle"
+  priority        = "100"
+
+  match {
+    versioned_expr = "SRC_IPS_V1"
+    config {
+      src_ip_ranges = ["*"]
+    }
+  }
+
+  rate_limit_options {
+    conform_action = "allow"
+    exceed_action = "deny(429)"
+
+    rate_limit_threshold {
+      count = 10
+      interval_sec = 60
+    }
+
+    enforce_on_key = ""
+
+    enforce_on_key_configs {
+      enforce_on_key_type = "REGION_CODE"
+    }
+
+    enforce_on_key_configs {
+      enforce_on_key_type = "TLS_JA3_FINGERPRINT"
+    }
+
+    enforce_on_key_configs {
+      enforce_on_key_type = "USER_IP"
+    }
+  }
+}
+
+`, spName)
+}
+
+func testAccComputeSecurityPolicyRule_withRateLimitOptions_withoutRateLimitOptions(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+  name        = "%s"
+  description = "basic policy base"
+}
+
+resource "google_compute_security_policy_rule" "policy_rule" {
+  security_policy = google_compute_security_policy.policy.name
+  description     = "basic policy rule withoutRateLimitOptions"
+  action          = "deny(403)"
+  priority        = "100"
+  match {
+    versioned_expr = "SRC_IPS_V1"
+    config {
+      src_ip_ranges = ["*"]
+    }
+  }
+}
+
+`, spName)
+}
+
+func testAccComputeSecurityPolicyRule_withRateLimitOptions_withEnforceOnKeyName(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+  name        = "%s"
+  description = "basic policy base"
+}
+
+resource "google_compute_security_policy_rule" "policy_rule" {
+  security_policy = google_compute_security_policy.policy.name
+  description     = "throttle rule withEnforceOnKeyName"
+  action          = "throttle"
+  priority        = "100"
+
+  match {
+    versioned_expr = "SRC_IPS_V1"
+    config {
+      src_ip_ranges = ["*"]
+    }
+  }
+
+  rate_limit_options {
+    conform_action = "allow"
+    exceed_action = "redirect"
+
+    enforce_on_key = "HTTP_HEADER"
+    enforce_on_key_name = "user-agent"
+
+    exceed_redirect_options {
+      type = "EXTERNAL_302"
+      target = "https://www.example.com"
+    }
+
+    rate_limit_threshold {
+      count = 10
+      interval_sec = 60
+    }
+  }
+}
+`, spName)
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_rule_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_rule_test.go.erb
@@ -150,6 +150,38 @@ func TestAccComputeSecurityPolicyRule_withPreconfiguredWafConfig(t *testing.T) {
 	})
 }
 
+func TestAccComputeSecurityPolicyRule_withRateLimitOptions(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeSecurityPolicyRuleDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSecurityPolicyRule_withRateLimitOptionsCreate(context),
+			},
+      {
+        ResourceName:      "google_compute_security_policy_rule.policy_rule",
+        ImportState:       true,
+        ImportStateVerify: true,
+      },
+      {
+        Config: testAccComputeSecurityPolicyRule_withRateLimitOptionsUpdate(context),
+      },
+      {
+        ResourceName:      "google_compute_security_policy_rule.policy_rule",
+        ImportState:       true,
+        ImportStateVerify: true,
+      },
+    },
+  })
+}
+
 func TestAccComputeSecurityPolicyRule_withRateLimit_withEnforceOnKeyConfigs(t *testing.T) {
 	t.Parallel()
 
@@ -566,6 +598,82 @@ resource "google_compute_security_policy_rule" "policy_rule" {
   }
   preview = false
 }
+`, context)
+}
+
+func testAccComputeSecurityPolicyRule_withRateLimitOptionsCreate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+  resource "google_compute_security_policy" "default" {
+    name        = "tf-test%{random_suffix}"
+    description = "basic global security policy"
+  }
+
+  resource "google_compute_security_policy_rule" "policy_rule" {
+    security_policy = google_compute_security_policy.default.name
+    description     = "rule create with rate limit"
+    priority        = 101
+    action          = "rate_based_ban"
+    rate_limit_options {
+      rate_limit_threshold {
+        count = 500
+        interval_sec = 10
+      }
+      conform_action = "allow"
+      exceed_action = "deny(404)"
+      enforce_on_key = "ALL"
+      ban_threshold {
+        count = 750
+        interval_sec = 180
+      }
+      ban_duration_sec = 180
+    }
+    match {
+      config {
+        src_ip_ranges = [
+          "*"
+        ]
+      }
+      versioned_expr = "SRC_IPS_V1"
+    }
+  }
+`, context)
+}
+
+func testAccComputeSecurityPolicyRule_withRateLimitOptionsUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+  resource "google_compute_security_policy" "default" {
+    name        = "tf-test%{random_suffix}"
+    description = "basic global security policy"
+  }
+
+  resource "google_compute_security_policy_rule" "policy_rule" {
+    security_policy = google_compute_security_policy.default.name
+    description     = "rule update with rate limit update"
+    priority        = 101
+    action          = "rate_based_ban"
+    rate_limit_options {
+      rate_limit_threshold {
+        count = 1000
+        interval_sec = 30
+      }
+      conform_action = "allow"
+      exceed_action = "deny(404)"
+      enforce_on_key = "ALL"
+      ban_threshold {
+        count = 2000
+        interval_sec = 180
+      }
+      ban_duration_sec = 300
+    }
+    match {
+      config {
+        src_ip_ranges = [
+          "*"
+        ]
+      }
+      versioned_expr = "SRC_IPS_V1"
+    }
+  }
 `, context)
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
@@ -375,6 +375,14 @@ func TestAccComputeSecurityPolicy_withRateLimitOption_withMultipleEnforceOnKeyCo
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccComputeSecurityPolicy_withRateLimitOption_withMultipleEnforceOnKeyConfigs2(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -1360,7 +1368,7 @@ resource "google_compute_security_policy" "policy" {
 				src_ip_ranges = ["*"]
 			}
 		}
-		description = "default rule"
+		description = "default rule withEnforceOnKey"
 
 		rate_limit_options {
 			conform_action = "allow"
@@ -1398,7 +1406,7 @@ resource "google_compute_security_policy" "policy" {
 				src_ip_ranges = ["*"]
 			}
 		}
-		description = "default rule"
+		description = "default rule withoutRateLimitOptions"
 	}
 }
 `, spName)
@@ -1419,7 +1427,7 @@ resource "google_compute_security_policy" "policy" {
 				src_ip_ranges = ["*"]
 			}
 		}
-		description = "default rule"
+		description = "default rule withEnforceOnKeyName"
 
 		rate_limit_options {
 			conform_action = "allow"
@@ -1458,7 +1466,7 @@ resource "google_compute_security_policy" "policy" {
 				src_ip_ranges = ["*"]
 			}
 		}
-		description = "default rule"
+		description = "default rule withEnforceOnKeyConfigs"
 
 		rate_limit_options {
 			conform_action = "allow"
@@ -1499,7 +1507,7 @@ resource "google_compute_security_policy" "policy" {
 				src_ip_ranges = ["*"]
 			}
 		}
-		description = "default rule"
+		description = "default rule withMultipleEnforceOnKeyConfigs"
 
 		rate_limit_options {
 			conform_action = "allow"
@@ -1523,6 +1531,51 @@ resource "google_compute_security_policy" "policy" {
 
 			enforce_on_key_configs {
 				enforce_on_key_type = "REGION_CODE"
+			}
+		}
+	}
+}
+`, spName)
+}
+
+func testAccComputeSecurityPolicy_withRateLimitOption_withMultipleEnforceOnKeyConfigs2(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+	name        = "%s"
+	description = "throttle rule with enforce_on_key_configs"
+
+	rule {
+		action   = "throttle"
+		priority = "2147483647"
+		match {
+			versioned_expr = "SRC_IPS_V1"
+			config {
+				src_ip_ranges = ["*"]
+			}
+		}
+		description = "default rule withMultipleEnforceOnKeyConfigs2"
+
+		rate_limit_options {
+			conform_action = "allow"
+			exceed_action = "deny(429)"
+
+			rate_limit_threshold {
+				count = 10
+				interval_sec = 60
+			}
+
+			enforce_on_key = ""
+
+			enforce_on_key_configs {
+				enforce_on_key_type = "REGION_CODE"
+			}
+
+			enforce_on_key_configs {
+				enforce_on_key_type = "TLS_JA3_FINGERPRINT"
+			}
+
+			enforce_on_key_configs {
+				enforce_on_key_type = "USER_IP"
 			}
 		}
 	}


### PR DESCRIPTION
Adds support for "TLS_JA3_FINGERPRINT" and "USER_IP" options for "rateLimitOptions.enforceOnKey" field in compute_security_policy;
Also adds support for "rateLimitOptions" fields for compute_security_policy_rule;

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/17469

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Added 'rateLimitOptions' field to 'google_compute_security_policy_rule' resource;
```
```release-note:enhancement
compute: Added 'TLS_JA3_FINGERPRINT' and 'USER_IP' options in field 'rateLimitOptions.enforceOnKey' to 'google_compute_security_policy' resource;
```