### PR TITLE
Adding ReadOnly field in the description of terraform_labels google project

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
@@ -120,7 +120,7 @@ func ResourceGoogleProject() *schema.Resource {
 			"terraform_labels": {
 				Type:        schema.TypeMap,
 				Computed:    true,
-				Description: `The combination of labels configured directly on the resource and default labels configured on the provider.`,
+				Description: `(ReadOnly) The combination of labels configured directly on the resource and default labels configured on the provider.`,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
The PR adds ReadOnly to the googler project terraform_labels documentation and it addresses https://github.com/hashicorp/terraform-provider-google/issues/16952

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
resourcemanager: added readonly in the terraform_labels documentation
```