### PR TITLE
[#17030] NGFW: Add securityProfileGroup argument tests to hierarchical and network firewall policies

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_firewall_policy_rule_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_firewall_policy_rule_test.go.erb
@@ -26,7 +26,7 @@ func TestAccComputeFirewallPolicyRule_update(t *testing.T) {
 				Config: testAccComputeFirewallPolicyRule_start(context),
 			},
 			{
-				ResourceName:      "google_compute_firewall_policy_rule.default",
+				ResourceName:      "google_compute_firewall_policy_rule.fw_policy_rule1",
 				ImportState:       true,
 				ImportStateVerify: true,
 				// Referencing using ID causes import to fail
@@ -36,7 +36,7 @@ func TestAccComputeFirewallPolicyRule_update(t *testing.T) {
 				Config: testAccComputeFirewallPolicyRule_update(context),
 			},
 			{
-				ResourceName:      "google_compute_firewall_policy_rule.default",
+				ResourceName:      "google_compute_firewall_policy_rule.fw_policy_rule1",
 				ImportState:       true,
 				ImportStateVerify: true,
 				// Referencing using ID causes import to fail
@@ -46,7 +46,7 @@ func TestAccComputeFirewallPolicyRule_update(t *testing.T) {
 				Config: testAccComputeFirewallPolicyRule_removeConfigs(context),
 			},
 			{
-				ResourceName:      "google_compute_firewall_policy_rule.default",
+				ResourceName:      "google_compute_firewall_policy_rule.fw_policy_rule1",
 				ImportState:       true,
 				ImportStateVerify: true,
 				// Referencing using ID causes import to fail
@@ -56,7 +56,7 @@ func TestAccComputeFirewallPolicyRule_update(t *testing.T) {
 				Config: testAccComputeFirewallPolicyRule_start(context),
 			},
 			{
-				ResourceName:      "google_compute_firewall_policy_rule.default",
+				ResourceName:      "google_compute_firewall_policy_rule.fw_policy_rule1",
 				ImportState:       true,
 				ImportStateVerify: true,
 				// Referencing using ID causes import to fail
@@ -64,6 +64,52 @@ func TestAccComputeFirewallPolicyRule_update(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccComputeFirewallPolicyRule_multipleRules(t *testing.T) {
+  t.Parallel()
+
+  context := map[string]interface{}{
+    "random_suffix": acctest.RandString(t, 10),
+    "org_name":      fmt.Sprintf("organizations/%s", envvar.GetTestOrgFromEnv(t)),
+  }
+
+  acctest.VcrTest(t, resource.TestCase{
+    PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+    Steps: []resource.TestStep{
+      {
+        Config: testAccComputeFirewallPolicyRule_multiple(context),
+      },
+      {
+        ResourceName:      "google_compute_firewall_policy_rule.fw_policy_rule1",
+        ImportState:       true,
+        ImportStateVerify: true,
+        // Referencing using ID causes import to fail
+        ImportStateVerifyIgnore: []string{"firewall_policy"},
+      },
+      {
+        ResourceName:      "google_compute_firewall_policy_rule.fw_policy_rule2",
+        ImportState:       true,
+        ImportStateVerify: true,
+        // Referencing using ID causes import to fail
+        ImportStateVerifyIgnore: []string{"firewall_policy"},
+      },
+      {
+        Config: testAccComputeFirewallPolicyRule_multipleAdd(context),
+      },
+      {
+        ResourceName:      "google_compute_firewall_policy_rule.fw_policy_rule3",
+        ImportState:       true,
+        ImportStateVerify: true,
+        // Referencing using ID causes import to fail
+        ImportStateVerifyIgnore: []string{"firewall_policy"},
+      },
+      {
+        Config: testAccComputeFirewallPolicyRule_multipleRemove(context),
+      },
+    },
+  })
 }
 
 func TestAccComputeFirewallPolicyRule_securityProfileGroup_update(t *testing.T) {
@@ -79,20 +125,20 @@ func TestAccComputeFirewallPolicyRule_securityProfileGroup_update(t *testing.T) 
     ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
     Steps: []resource.TestStep{
       {
-        Config: testAccComputeFirewallPolicyRule_securityProfileGroupTls_basic(context),
+        Config: testAccComputeFirewallPolicyRule_securityProfileGroup_basic(context),
       },
       {
-        ResourceName:      "google_compute_firewall_policy_rule.default",
+        ResourceName:      "google_compute_firewall_policy_rule.fw_policy_rule1",
         ImportState:       true,
         ImportStateVerify: true,
         // Referencing using ID causes import to fail
         ImportStateVerifyIgnore: []string{"firewall_policy"},
       },
       {
-        Config: testAccComputeFirewallPolicyRule_securityProfileGroupTls_update(context),
+        Config: testAccComputeFirewallPolicyRule_securityProfileGroup_update(context),
       },
       {
-        ResourceName:      "google_compute_firewall_policy_rule.default",
+        ResourceName:      "google_compute_firewall_policy_rule.fw_policy_rule1",
         ImportState:       true,
         ImportStateVerify: true,
         // Referencing using ID causes import to fail
@@ -104,48 +150,42 @@ func TestAccComputeFirewallPolicyRule_securityProfileGroup_update(t *testing.T) 
 
 func testAccComputeFirewallPolicyRule_securityProfileGroup_basic(context map[string]interface{}) string {
   return acctest.Nprintf(`
-resource "google_compute_network" "network1" {
-  name                    = "tf-test-%{random_suffix}"
-  auto_create_subnetworks = false
-}
-
 resource "google_folder" "folder" {
   display_name = "tf-test-folder-%{random_suffix}"
   parent       = "%{org_name}"
 }
 
 resource "google_network_security_security_profile" "security_profile" {
-    provider    = google-beta
-    name        = "tf-test-my-sp%{random_suffix}"
-    type        = "THREAT_PREVENTION"
-    parent      = "organizations/%{org_name}"
-    location    = "global"
+    name     = "tf-test-my-sp%{random_suffix}"
+    type     = "THREAT_PREVENTION"
+    parent   = "%{org_name}"
+    location = "global"
 }
 
 resource "google_network_security_security_profile_group" "security_profile_group" {
-    provider                  = google-beta
     name                      = "tf-test-my-spg%{random_suffix}"
-    parent                    = "organizations/%{org_name}"
+    parent                    = "%{org_name}"
     location                  = "global"
     description               = "My security profile group."
     threat_prevention_profile = google_network_security_security_profile.security_profile.id
 }
 
-resource "google_compute_firewall_policy" "default" {
+resource "google_compute_firewall_policy" "fw_policy" {
   parent      = google_folder.folder.name
   short_name  = "tf-test-policy-%{random_suffix}"
   description = "Resource created for Terraform acceptance testing"
 }
 
-resource "google_compute_firewall_policy_rule" "default" {
-  firewall_policy        = google_compute_firewall_policy.default.id
+resource "google_compute_firewall_policy_rule" "fw_policy_rule1" {
+  firewall_policy        = google_compute_firewall_policy.fw_policy.id
   description            = "Resource created for Terraform acceptance testing"
   priority               = 9000
   enable_logging         = true
   action                 = "apply_security_profile_group"
-  security_profile_group = google_network_security_security_profile_group.security_profile_group.id
+  security_profile_group = "//networksecurity.googleapis.com/${google_network_security_security_profile_group.security_profile_group.id}"
   direction              = "INGRESS"
   disabled               = false
+
   match {
     layer4_configs {
       ip_protocol = "tcp"
@@ -159,57 +199,50 @@ resource "google_compute_firewall_policy_rule" "default" {
 
 func testAccComputeFirewallPolicyRule_securityProfileGroup_update(context map[string]interface{}) string {
   return acctest.Nprintf(`
-resource "google_compute_network" "network1" {
-  name                    = "tf-test-%{random_suffix}"
-  auto_create_subnetworks = false
-}
-
 resource "google_folder" "folder" {
   display_name = "tf-test-folder-%{random_suffix}"
   parent       = "%{org_name}"
 }
 
 resource "google_network_security_security_profile" "security_profile" {
-    provider    = google-beta
-    name        = "tf-test-my-security-profile%{random_suffix}"
-    type        = "THREAT_PREVENTION"
-    parent      = "organizations/%{org_name}"
-    location    = "global"
+    name     = "tf-test-my-sp%{random_suffix}"
+    type     = "THREAT_PREVENTION"
+    parent   = "%{org_name}"
+    location = "global"
 }
 
 resource "google_network_security_security_profile_group" "security_profile_group" {
-    provider                  = google-beta
-    name                      = "tf-test-my-sp-group%{random_suffix}"
-    parent                    = "organizations/%{org_name}"
+    name                      = "tf-test-my-spg%{random_suffix}"
+    parent                    = "%{org_name}"
     location                  = "global"
     description               = "My security profile group."
     threat_prevention_profile = google_network_security_security_profile.security_profile.id
 }
 
 resource "google_network_security_security_profile_group" "security_profile_group_updated" {
-    provider                  = google-beta
     name                      = "tf-test-my-spg-updated%{random_suffix}"
-    parent                    = "organizations/%{org_name}"
+    parent                    = "%{org_name}"
     location                  = "global"
     description               = "My security profile group."
     threat_prevention_profile = google_network_security_security_profile.security_profile.id
 }
 
-resource "google_compute_firewall_policy" "default" {
+resource "google_compute_firewall_policy" "fw_policy" {
   parent      = google_folder.folder.name
   short_name  = "tf-test-policy-%{random_suffix}"
   description = "Resource created for Terraform acceptance testing"
 }
 
-resource "google_compute_firewall_policy_rule" "default" {
-  firewall_policy        = google_compute_firewall_policy.default.id
+resource "google_compute_firewall_policy_rule" "fw_policy_rule1" {
+  firewall_policy        = google_compute_firewall_policy.fw_policy.id
   description            = "Resource created for Terraform acceptance testing"
   priority               = 9000
   enable_logging         = true
   action                 = "apply_security_profile_group"
-  security_profile_group = google_network_security_security_profile_group.security_profile_group_updated.id
+  security_profile_group = "//networksecurity.googleapis.com/${google_network_security_security_profile_group.security_profile_group_updated.id}"
   direction              = "INGRESS"
   disabled               = false
+
   match {
     layer4_configs {
       ip_protocol = "tcp"
@@ -246,13 +279,13 @@ resource "google_folder" "folder" {
   parent       = "%{org_name}"
 }
 
-resource "google_compute_firewall_policy" "default" {
+resource "google_compute_firewall_policy" "fw_policy" {
   parent      = google_folder.folder.name
   short_name  = "tf-test-policy-%{random_suffix}"
   description = "Resource created for Terraform acceptance testing"
 }
 
-resource "google_network_security_address_group" "basic_global_networksecurity_address_group" {
+resource "google_network_security_address_group" "address_group" {
   name        = "tf-test-policy%{random_suffix}"
   parent      = "%{org_name}"
   description = "Sample global networksecurity_address_group"
@@ -262,14 +295,15 @@ resource "google_network_security_address_group" "basic_global_networksecurity_a
   capacity    = 100
 }
 
-resource "google_compute_firewall_policy_rule" "default" {
-  firewall_policy = google_compute_firewall_policy.default.id
+resource "google_compute_firewall_policy_rule" "fw_policy_rule1" {
+  firewall_policy = google_compute_firewall_policy.fw_policy.id
   description     = "Resource created for Terraform acceptance testing"
   priority        = 9000
   enable_logging  = true
   action          = "allow"
   direction       = "EGRESS"
   disabled        = false
+
   match {
     layer4_configs {
       ip_protocol = "tcp"
@@ -279,7 +313,7 @@ resource "google_compute_firewall_policy_rule" "default" {
     dest_fqdns                = []
     dest_region_codes         = []
     dest_threat_intelligences = []
-    dest_address_groups       = [google_network_security_address_group.basic_global_networksecurity_address_group.id]
+    dest_address_groups       = [google_network_security_address_group.address_group.id]
   }
 }
 `, context)
@@ -310,13 +344,13 @@ resource "google_folder" "folder" {
   parent       = "%{org_name}"
 }
 
-resource "google_compute_firewall_policy" "default" {
+resource "google_compute_firewall_policy" "fw_policy" {
   parent      = google_folder.folder.name
   short_name  = "tf-test-policy-%{random_suffix}"
   description = "Resource created for Terraform acceptance testing"
 }
 
-resource "google_network_security_address_group" "basic_global_networksecurity_address_group" {
+resource "google_network_security_address_group" "address_group" {
   name        = "tf-test-policy%{random_suffix}"
   parent      = "%{org_name}"
   description = "Sample global networksecurity_address_group"
@@ -326,14 +360,20 @@ resource "google_network_security_address_group" "basic_global_networksecurity_a
   capacity    = 100
 }
 
-resource "google_compute_firewall_policy_rule" "default" {
-  firewall_policy = google_compute_firewall_policy.default.id
-  description     = "Resource created for Terraform acceptance testing"
-  priority        = 9000
-  enable_logging  = true
-  action          = "allow"
-  direction       = "EGRESS"
-  disabled        = false
+resource "google_compute_firewall_policy_rule" "fw_policy_rule1" {
+  firewall_policy         = google_compute_firewall_policy.fw_policy.id
+  description             = "Resource created for Terraform acceptance testing"
+  priority                = 9000
+  enable_logging          = true
+  action                  = "allow"
+  direction               = "EGRESS"
+  disabled                = false
+  target_service_accounts = [google_service_account.service_account.email]
+  target_resources        = [
+    google_compute_network.network1.self_link,
+    google_compute_network.network2.self_link
+  ]
+
   match {
     layer4_configs {
       ip_protocol = "tcp"
@@ -348,10 +388,8 @@ resource "google_compute_firewall_policy_rule" "default" {
     dest_region_codes         = ["US"]
     dest_threat_intelligences = ["iplist-known-malicious-ips"]
     src_address_groups        = []
-    dest_address_groups       = [google_network_security_address_group.basic_global_networksecurity_address_group.id]
+    dest_address_groups       = [google_network_security_address_group.address_group.id]
   }
-  target_resources        = [google_compute_network.network1.self_link, google_compute_network.network2.self_link]
-  target_service_accounts = [google_service_account.service_account.email]
 }
 `, context)
 }
@@ -381,13 +419,13 @@ resource "google_folder" "folder" {
   parent       = "%{org_name}"
 }
 
-resource "google_compute_firewall_policy" "default" {
+resource "google_compute_firewall_policy" "fw_policy" {
   parent      = google_folder.folder.id
   short_name  = "tf-test-policy-%{random_suffix}"
   description = "Resource created for Terraform acceptance testing"
 }
 
-resource "google_network_security_address_group" "basic_global_networksecurity_address_group" {
+resource "google_network_security_address_group" "address_group" {
   name        = "tf-test-policy%{random_suffix}"
   parent      = "%{org_name}"
   description = "Sample global networksecurity_address_group"
@@ -397,14 +435,20 @@ resource "google_network_security_address_group" "basic_global_networksecurity_a
   capacity    = 100
 }
 
-resource "google_compute_firewall_policy_rule" "default" {
-  firewall_policy = google_compute_firewall_policy.default.id
-  description     = "Test description"
-  priority        = 9000
-  enable_logging  = false
-  action          = "deny"
-  direction       = "INGRESS"
-  disabled        = true
+resource "google_compute_firewall_policy_rule" "fw_policy_rule1" {
+  firewall_policy         = google_compute_firewall_policy.fw_policy.id
+  description             = "Test description"
+  priority                = 9000
+  enable_logging          = false
+  action                  = "deny"
+  direction               = "INGRESS"
+  disabled                = true
+  target_resources        = [google_compute_network.network1.self_link]
+  target_service_accounts = [
+    google_service_account.service_account.email,
+    google_service_account.service_account2.email
+  ]
+
   match {
     layer4_configs {
       ip_protocol = "udp"
@@ -415,56 +459,8 @@ resource "google_compute_firewall_policy_rule" "default" {
     src_region_codes         = ["US"]
     src_threat_intelligences = ["iplist-known-malicious-ips"]
   }
-  target_resources        = [google_compute_network.network1.self_link]
-  target_service_accounts = [google_service_account.service_account.email, google_service_account.service_account2.email]
 }
 `, context)
-}
-
-func TestAccComputeFirewallPolicyRule_multipleRules(t *testing.T) {
-	t.Parallel()
-
-	context := map[string]interface{}{
-		"random_suffix": acctest.RandString(t, 10),
-		"org_name":      fmt.Sprintf("organizations/%s", envvar.GetTestOrgFromEnv(t)),
-	}
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccComputeFirewallPolicyRule_multiple(context),
-			},
-			{
-				ResourceName:      "google_compute_firewall_policy_rule.rule1",
-				ImportState:       true,
-				ImportStateVerify: true,
-				// Referencing using ID causes import to fail
-				ImportStateVerifyIgnore: []string{"firewall_policy"},
-			},
-			{
-				ResourceName:      "google_compute_firewall_policy_rule.rule2",
-				ImportState:       true,
-				ImportStateVerify: true,
-				// Referencing using ID causes import to fail
-				ImportStateVerifyIgnore: []string{"firewall_policy"},
-			},
-			{
-				Config: testAccComputeFirewallPolicyRule_multipleAdd(context),
-			},
-			{
-				ResourceName:      "google_compute_firewall_policy_rule.rule3",
-				ImportState:       true,
-				ImportStateVerify: true,
-				// Referencing using ID causes import to fail
-				ImportStateVerifyIgnore: []string{"firewall_policy"},
-			},
-			{
-				Config: testAccComputeFirewallPolicyRule_multipleRemove(context),
-			},
-		},
-	})
 }
 
 func testAccComputeFirewallPolicyRule_multiple(context map[string]interface{}) string {
@@ -474,13 +470,13 @@ resource "google_folder" "folder" {
   parent       = "%{org_name}"
 }
 
-resource "google_compute_firewall_policy" "default" {
+resource "google_compute_firewall_policy" "fw_policy" {
   parent      = google_folder.folder.name
   short_name  = "tf-test-policy-%{random_suffix}"
   description = "Resource created for Terraform acceptance testing"
 }
 
-resource "google_network_security_address_group" "basic_global_networksecurity_address_group" {
+resource "google_network_security_address_group" "address_group" {
   name        = "tf-test-policy%{random_suffix}"
   parent      = "%{org_name}"
   description = "Sample global networksecurity_address_group"
@@ -490,14 +486,15 @@ resource "google_network_security_address_group" "basic_global_networksecurity_a
   capacity    = 100
 }
 
-resource "google_compute_firewall_policy_rule" "rule1" {
-  firewall_policy = google_compute_firewall_policy.default.id
+resource "google_compute_firewall_policy_rule" "fw_policy_rule1" {
+  firewall_policy = google_compute_firewall_policy.fw_policy.id
   description     = "Resource created for Terraform acceptance testing"
   priority        = 9000
   enable_logging  = true
   action          = "allow"
   direction       = "EGRESS"
   disabled        = false
+
   match {
     layer4_configs {
       ip_protocol = "tcp"
@@ -507,18 +504,19 @@ resource "google_compute_firewall_policy_rule" "rule1" {
     dest_fqdns                = ["google.com"]
     dest_region_codes         = ["US"]
     dest_threat_intelligences = ["iplist-known-malicious-ips"]
-    dest_address_groups       = [google_network_security_address_group.basic_global_networksecurity_address_group.id]
+    dest_address_groups       = [google_network_security_address_group.address_group.id]
   }
 }
 
-resource "google_compute_firewall_policy_rule" "rule2" {
-  firewall_policy = google_compute_firewall_policy.default.id
+resource "google_compute_firewall_policy_rule" "fw_policy_rule2" {
+  firewall_policy = google_compute_firewall_policy.fw_policy.id
   description     = "Resource created for Terraform acceptance testing"
   priority        = 9001
   enable_logging  = false
   action          = "deny"
   direction       = "INGRESS"
   disabled        = false
+
   match {
     layer4_configs {
       ip_protocol = "tcp"
@@ -531,7 +529,7 @@ resource "google_compute_firewall_policy_rule" "rule2" {
     src_fqdns                = ["google.com"]
     src_region_codes         = ["US"]
     src_threat_intelligences = ["iplist-known-malicious-ips"]
-    src_address_groups       = [google_network_security_address_group.basic_global_networksecurity_address_group.id]
+    src_address_groups       = [google_network_security_address_group.address_group.id]
   }
 }
 `, context)
@@ -544,13 +542,13 @@ resource "google_folder" "folder" {
   parent       = "%{org_name}"
 }
 
-resource "google_compute_firewall_policy" "default" {
+resource "google_compute_firewall_policy" "fw_policy" {
   parent      = google_folder.folder.id
   short_name  = "tf-test-policy-%{random_suffix}"
   description = "Description Update"
 }
 
-resource "google_network_security_address_group" "basic_global_networksecurity_address_group" {
+resource "google_network_security_address_group" "address_group" {
   name        = "tf-test-policy%{random_suffix}"
   parent      = "%{org_name}"
   description = "Sample global networksecurity_address_group"
@@ -560,14 +558,15 @@ resource "google_network_security_address_group" "basic_global_networksecurity_a
   capacity    = 100
 }
 
-resource "google_compute_firewall_policy_rule" "rule1" {
-  firewall_policy = google_compute_firewall_policy.default.id
+resource "google_compute_firewall_policy_rule" "fw_policy_rule1" {
+  firewall_policy = google_compute_firewall_policy.fw_policy.id
   description     = "Resource created for Terraform acceptance testing"
   priority        = 9000
   enable_logging  = true
   action          = "allow"
   direction       = "EGRESS"
   disabled        = false
+
   match {
     layer4_configs {
       ip_protocol = "tcp"
@@ -576,18 +575,19 @@ resource "google_compute_firewall_policy_rule" "rule1" {
     dest_fqdns                = ["google.com"]
     dest_region_codes         = ["US"]
     dest_threat_intelligences = ["iplist-known-malicious-ips"]
-    dest_address_groups       = [google_network_security_address_group.basic_global_networksecurity_address_group.id]
+    dest_address_groups       = [google_network_security_address_group.address_group.id]
   }
 }
 
-resource "google_compute_firewall_policy_rule" "rule2" {
-  firewall_policy = google_compute_firewall_policy.default.id
+resource "google_compute_firewall_policy_rule" "fw_policy_rule2" {
+  firewall_policy = google_compute_firewall_policy.fw_policy.id
   description     = "Resource created for Terraform acceptance testing"
   priority        = 9001
   enable_logging  = false
   action          = "deny"
   direction       = "INGRESS"
   disabled        = false
+
   match {
     layer4_configs {
       ip_protocol = "tcp"
@@ -600,18 +600,19 @@ resource "google_compute_firewall_policy_rule" "rule2" {
     src_fqdns                = ["google.com"]
     src_region_codes         = ["US"]
     src_threat_intelligences = ["iplist-known-malicious-ips"]
-    src_address_groups       = [google_network_security_address_group.basic_global_networksecurity_address_group.id]
+    src_address_groups       = [google_network_security_address_group.address_group.id]
   }
 }
 
-resource "google_compute_firewall_policy_rule" "rule3" {
-  firewall_policy = google_compute_firewall_policy.default.id
+resource "google_compute_firewall_policy_rule" "fw_policy_rule3" {
+  firewall_policy = google_compute_firewall_policy.fw_policy.id
   description     = "Resource created for Terraform acceptance testing"
   priority        = 40
   enable_logging  = true
   action          = "allow"
   direction       = "INGRESS"
   disabled        = true
+
   match {
     layer4_configs {
       ip_protocol = "udp"
@@ -621,7 +622,7 @@ resource "google_compute_firewall_policy_rule" "rule3" {
     src_fqdns                = ["google.com"]
     src_region_codes         = ["US"]
     src_threat_intelligences = ["iplist-known-malicious-ips"]
-    src_address_groups       = [google_network_security_address_group.basic_global_networksecurity_address_group.id]
+    src_address_groups       = [google_network_security_address_group.address_group.id]
   }
 }
 `, context)
@@ -634,13 +635,13 @@ resource "google_folder" "folder" {
   parent       = "%{org_name}"
 }
 
-resource "google_compute_firewall_policy" "default" {
+resource "google_compute_firewall_policy" "fw_policy" {
   parent      = google_folder.folder.name
   short_name  = "tf-test-policy-%{random_suffix}"
   description = "Resource created for Terraform acceptance testing"
 }
 
-resource "google_network_security_address_group" "basic_global_networksecurity_address_group" {
+resource "google_network_security_address_group" "address_group" {
   name        = "tf-test-policy%{random_suffix}"
   parent      = "%{org_name}"
   description = "Sample global networksecurity_address_group"
@@ -650,14 +651,15 @@ resource "google_network_security_address_group" "basic_global_networksecurity_a
   capacity    = 100
 }
 
-resource "google_compute_firewall_policy_rule" "rule1" {
-  firewall_policy = google_compute_firewall_policy.default.id
+resource "google_compute_firewall_policy_rule" "fw_policy_rule1" {
+  firewall_policy = google_compute_firewall_policy.fw_policy.id
   description     = "Resource created for Terraform acceptance testing"
   priority        = 9000
   enable_logging  = true
   action          = "allow"
   direction       = "EGRESS"
   disabled        = false
+
   match {
     layer4_configs {
       ip_protocol = "tcp"
@@ -670,14 +672,15 @@ resource "google_compute_firewall_policy_rule" "rule1" {
   }
 }
 
-resource "google_compute_firewall_policy_rule" "rule3" {
-  firewall_policy = google_compute_firewall_policy.default.id
+resource "google_compute_firewall_policy_rule" "fw_policy_rule3" {
+  firewall_policy = google_compute_firewall_policy.fw_policy.id
   description     = "Resource created for Terraform acceptance testing"
   priority        = 40
   enable_logging  = true
   action          = "allow"
   direction       = "INGRESS"
   disabled        = true
+
   match {
     layer4_configs {
       ip_protocol = "udp"

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_firewall_policy_rule_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_firewall_policy_rule_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
-func TestAccComputeFirewallPolicyRule_update(t *testing.T) {
+func TestAccComputeNetworkFirewallPolicyRule_update(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
@@ -23,40 +23,40 @@ func TestAccComputeFirewallPolicyRule_update(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeFirewallPolicyRule_start(context),
+				Config: testAccComputeNetworkFirewallPolicyRule_start(context),
 			},
 			{
-				ResourceName:      "google_compute_firewall_policy_rule.default",
+				ResourceName:      "google_compute_network_firewall_policy_rule.default",
 				ImportState:       true,
 				ImportStateVerify: true,
 				// Referencing using ID causes import to fail
 				ImportStateVerifyIgnore: []string{"firewall_policy"},
 			},
 			{
-				Config: testAccComputeFirewallPolicyRule_update(context),
+				Config: testAccComputeNetworkFirewallPolicyRule_update(context),
 			},
 			{
-				ResourceName:      "google_compute_firewall_policy_rule.default",
+				ResourceName:      "google_compute_network_firewall_policy_rule.default",
 				ImportState:       true,
 				ImportStateVerify: true,
 				// Referencing using ID causes import to fail
 				ImportStateVerifyIgnore: []string{"firewall_policy", "target_resources"},
 			},
 			{
-				Config: testAccComputeFirewallPolicyRule_removeConfigs(context),
+				Config: testAccComputeNetworkFirewallPolicyRule_removeConfigs(context),
 			},
 			{
-				ResourceName:      "google_compute_firewall_policy_rule.default",
+				ResourceName:      "google_compute_network_firewall_policy_rule.default",
 				ImportState:       true,
 				ImportStateVerify: true,
 				// Referencing using ID causes import to fail
 				ImportStateVerifyIgnore: []string{"firewall_policy", "target_resources"},
 			},
 			{
-				Config: testAccComputeFirewallPolicyRule_start(context),
+				Config: testAccComputeNetworkFirewallPolicyRule_start(context),
 			},
 			{
-				ResourceName:      "google_compute_firewall_policy_rule.default",
+				ResourceName:      "google_compute_network_firewall_policy_rule.default",
 				ImportState:       true,
 				ImportStateVerify: true,
 				// Referencing using ID causes import to fail
@@ -66,7 +66,7 @@ func TestAccComputeFirewallPolicyRule_update(t *testing.T) {
 	})
 }
 
-func TestAccComputeFirewallPolicyRule_securityProfileGroup_update(t *testing.T) {
+func TestAccComputeNetworkFirewallPolicyRule_securityProfileGroupTls_update(t *testing.T) {
   t.Parallel()
 
   context := map[string]interface{}{
@@ -79,20 +79,20 @@ func TestAccComputeFirewallPolicyRule_securityProfileGroup_update(t *testing.T) 
     ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
     Steps: []resource.TestStep{
       {
-        Config: testAccComputeFirewallPolicyRule_securityProfileGroupTls_basic(context),
+        Config: testAccComputeNetworkFirewallPolicyRule_securityProfileGroupTls_basic(context),
       },
       {
-        ResourceName:      "google_compute_firewall_policy_rule.default",
+        ResourceName:      "google_compute_network_firewall_policy_rule.default",
         ImportState:       true,
         ImportStateVerify: true,
         // Referencing using ID causes import to fail
         ImportStateVerifyIgnore: []string{"firewall_policy"},
       },
       {
-        Config: testAccComputeFirewallPolicyRule_securityProfileGroupTls_update(context),
+        Config: testAccComputeNetworkFirewallPolicyRule_securityProfileGroupTls_update(context),
       },
       {
-        ResourceName:      "google_compute_firewall_policy_rule.default",
+        ResourceName:      "google_compute_network_firewall_policy_rule.default",
         ImportState:       true,
         ImportStateVerify: true,
         // Referencing using ID causes import to fail
@@ -102,16 +102,11 @@ func TestAccComputeFirewallPolicyRule_securityProfileGroup_update(t *testing.T) 
   })
 }
 
-func testAccComputeFirewallPolicyRule_securityProfileGroup_basic(context map[string]interface{}) string {
+func testAccComputeNetworkFirewallPolicyRule_securityProfileGroup_basic(context map[string]interface{}) string {
   return acctest.Nprintf(`
 resource "google_compute_network" "network1" {
   name                    = "tf-test-%{random_suffix}"
   auto_create_subnetworks = false
-}
-
-resource "google_folder" "folder" {
-  display_name = "tf-test-folder-%{random_suffix}"
-  parent       = "%{org_name}"
 }
 
 resource "google_network_security_security_profile" "security_profile" {
@@ -131,14 +126,14 @@ resource "google_network_security_security_profile_group" "security_profile_grou
     threat_prevention_profile = google_network_security_security_profile.security_profile.id
 }
 
-resource "google_compute_firewall_policy" "default" {
-  parent      = google_folder.folder.name
+resource "google_compute_network_firewall_policy" "default" {
+  parent      = google_compute_network.network1.id
   short_name  = "tf-test-policy-%{random_suffix}"
   description = "Resource created for Terraform acceptance testing"
 }
 
-resource "google_compute_firewall_policy_rule" "default" {
-  firewall_policy        = google_compute_firewall_policy.default.id
+resource "google_compute_network_firewall_policy_rule" "default" {
+  firewall_policy        = google_compute_network_firewall_policy.default.id
   description            = "Resource created for Terraform acceptance testing"
   priority               = 9000
   enable_logging         = true
@@ -157,16 +152,11 @@ resource "google_compute_firewall_policy_rule" "default" {
 `, context)
 }
 
-func testAccComputeFirewallPolicyRule_securityProfileGroup_update(context map[string]interface{}) string {
+func testAccComputeNetworkFirewallPolicyRule_securityProfileGroup_update(context map[string]interface{}) string {
   return acctest.Nprintf(`
 resource "google_compute_network" "network1" {
   name                    = "tf-test-%{random_suffix}"
   auto_create_subnetworks = false
-}
-
-resource "google_folder" "folder" {
-  display_name = "tf-test-folder-%{random_suffix}"
-  parent       = "%{org_name}"
 }
 
 resource "google_network_security_security_profile" "security_profile" {
@@ -195,14 +185,14 @@ resource "google_network_security_security_profile_group" "security_profile_grou
     threat_prevention_profile = google_network_security_security_profile.security_profile.id
 }
 
-resource "google_compute_firewall_policy" "default" {
-  parent      = google_folder.folder.name
+resource "google_compute_network_firewall_policy" "default" {
+  parent      = google_compute_network.network1.id
   short_name  = "tf-test-policy-%{random_suffix}"
   description = "Resource created for Terraform acceptance testing"
 }
 
-resource "google_compute_firewall_policy_rule" "default" {
-  firewall_policy        = google_compute_firewall_policy.default.id
+resource "google_compute_network_firewall_policy_rule" "default" {
+  firewall_policy        = google_compute_network_firewall_policy.default.id
   description            = "Resource created for Terraform acceptance testing"
   priority               = 9000
   enable_logging         = true
@@ -221,7 +211,7 @@ resource "google_compute_firewall_policy_rule" "default" {
 `, context)
 }
 
-func testAccComputeFirewallPolicyRule_start(context map[string]interface{}) string {
+func testAccComputeNetworkFirewallPolicyRule_start(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_service_account" "service_account" {
   account_id = "tf-test-sa-%{random_suffix}"
@@ -241,13 +231,8 @@ resource "google_compute_network" "network2" {
   auto_create_subnetworks = false
 }
 
-resource "google_folder" "folder" {
-  display_name = "tf-test-folder-%{random_suffix}"
-  parent       = "%{org_name}"
-}
-
-resource "google_compute_firewall_policy" "default" {
-  parent      = google_folder.folder.name
+resource "google_compute_network_firewall_policy" "default" {
+  parent      = google_compute_network.network1.id
   short_name  = "tf-test-policy-%{random_suffix}"
   description = "Resource created for Terraform acceptance testing"
 }
@@ -262,8 +247,8 @@ resource "google_network_security_address_group" "basic_global_networksecurity_a
   capacity    = 100
 }
 
-resource "google_compute_firewall_policy_rule" "default" {
-  firewall_policy = google_compute_firewall_policy.default.id
+resource "google_compute_network_firewall_policy_rule" "default" {
+  firewall_policy = google_compute_network_firewall_policy.default.id
   description     = "Resource created for Terraform acceptance testing"
   priority        = 9000
   enable_logging  = true
@@ -285,7 +270,7 @@ resource "google_compute_firewall_policy_rule" "default" {
 `, context)
 }
 
-func testAccComputeFirewallPolicyRule_update(context map[string]interface{}) string {
+func testAccComputeNetworkFirewallPolicyRule_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_service_account" "service_account" {
   account_id = "tf-test-sa-%{random_suffix}"
@@ -305,13 +290,8 @@ resource "google_compute_network" "network2" {
   auto_create_subnetworks = false
 }
 
-resource "google_folder" "folder" {
-  display_name = "tf-test-folder-%{random_suffix}"
-  parent       = "%{org_name}"
-}
-
-resource "google_compute_firewall_policy" "default" {
-  parent      = google_folder.folder.name
+resource "google_compute_network_firewall_policy" "default" {
+  parent      = google_compute_network.network1.id
   short_name  = "tf-test-policy-%{random_suffix}"
   description = "Resource created for Terraform acceptance testing"
 }
@@ -326,8 +306,8 @@ resource "google_network_security_address_group" "basic_global_networksecurity_a
   capacity    = 100
 }
 
-resource "google_compute_firewall_policy_rule" "default" {
-  firewall_policy = google_compute_firewall_policy.default.id
+resource "google_compute_network_firewall_policy_rule" "default" {
+  firewall_policy = google_compute_network_firewall_policy.default.id
   description     = "Resource created for Terraform acceptance testing"
   priority        = 9000
   enable_logging  = true
@@ -356,7 +336,7 @@ resource "google_compute_firewall_policy_rule" "default" {
 `, context)
 }
 
-func testAccComputeFirewallPolicyRule_removeConfigs(context map[string]interface{}) string {
+func testAccComputeNetworkFirewallPolicyRule_removeConfigs(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_service_account" "service_account" {
   account_id = "tf-test-sa-%{random_suffix}"
@@ -376,13 +356,8 @@ resource "google_compute_network" "network2" {
   auto_create_subnetworks = false
 }
 
-resource "google_folder" "folder" {
-  display_name = "tf-test-folder-%{random_suffix}"
-  parent       = "%{org_name}"
-}
-
-resource "google_compute_firewall_policy" "default" {
-  parent      = google_folder.folder.id
+resource "google_compute_network_firewall_policy" "default" {
+  parent      = google_compute_network.network1.id
   short_name  = "tf-test-policy-%{random_suffix}"
   description = "Resource created for Terraform acceptance testing"
 }
@@ -397,8 +372,8 @@ resource "google_network_security_address_group" "basic_global_networksecurity_a
   capacity    = 100
 }
 
-resource "google_compute_firewall_policy_rule" "default" {
-  firewall_policy = google_compute_firewall_policy.default.id
+resource "google_compute_network_firewall_policy_rule" "default" {
+  firewall_policy = google_compute_network_firewall_policy.default.id
   description     = "Test description"
   priority        = 9000
   enable_logging  = false
@@ -421,7 +396,7 @@ resource "google_compute_firewall_policy_rule" "default" {
 `, context)
 }
 
-func TestAccComputeFirewallPolicyRule_multipleRules(t *testing.T) {
+func TestAccComputeNetworkFirewallPolicyRule_multipleRules(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
@@ -434,48 +409,43 @@ func TestAccComputeFirewallPolicyRule_multipleRules(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeFirewallPolicyRule_multiple(context),
+				Config: testAccComputeNetworkFirewallPolicyRule_multiple(context),
 			},
 			{
-				ResourceName:      "google_compute_firewall_policy_rule.rule1",
+				ResourceName:      "google_compute_network_firewall_policy_rule.rule1",
 				ImportState:       true,
 				ImportStateVerify: true,
 				// Referencing using ID causes import to fail
 				ImportStateVerifyIgnore: []string{"firewall_policy"},
 			},
 			{
-				ResourceName:      "google_compute_firewall_policy_rule.rule2",
+				ResourceName:      "google_compute_network_firewall_policy_rule.rule2",
 				ImportState:       true,
 				ImportStateVerify: true,
 				// Referencing using ID causes import to fail
 				ImportStateVerifyIgnore: []string{"firewall_policy"},
 			},
 			{
-				Config: testAccComputeFirewallPolicyRule_multipleAdd(context),
+				Config: testAccComputeNetworkFirewallPolicyRule_multipleAdd(context),
 			},
 			{
-				ResourceName:      "google_compute_firewall_policy_rule.rule3",
+				ResourceName:      "google_compute_network_firewall_policy_rule.rule3",
 				ImportState:       true,
 				ImportStateVerify: true,
 				// Referencing using ID causes import to fail
 				ImportStateVerifyIgnore: []string{"firewall_policy"},
 			},
 			{
-				Config: testAccComputeFirewallPolicyRule_multipleRemove(context),
+				Config: testAccComputeNetworkFirewallPolicyRule_multipleRemove(context),
 			},
 		},
 	})
 }
 
-func testAccComputeFirewallPolicyRule_multiple(context map[string]interface{}) string {
+func testAccComputeNetworkFirewallPolicyRule_multiple(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_folder" "folder" {
-  display_name = "tf-test-folder-%{random_suffix}"
-  parent       = "%{org_name}"
-}
-
-resource "google_compute_firewall_policy" "default" {
-  parent      = google_folder.folder.name
+resource "google_compute_network_firewall_policy" "default" {
+  parent      = google_compute_network.network1.id
   short_name  = "tf-test-policy-%{random_suffix}"
   description = "Resource created for Terraform acceptance testing"
 }
@@ -490,8 +460,8 @@ resource "google_network_security_address_group" "basic_global_networksecurity_a
   capacity    = 100
 }
 
-resource "google_compute_firewall_policy_rule" "rule1" {
-  firewall_policy = google_compute_firewall_policy.default.id
+resource "google_compute_network_firewall_policy_rule" "rule1" {
+  firewall_policy = google_compute_network_firewall_policy.default.id
   description     = "Resource created for Terraform acceptance testing"
   priority        = 9000
   enable_logging  = true
@@ -511,8 +481,8 @@ resource "google_compute_firewall_policy_rule" "rule1" {
   }
 }
 
-resource "google_compute_firewall_policy_rule" "rule2" {
-  firewall_policy = google_compute_firewall_policy.default.id
+resource "google_compute_network_firewall_policy_rule" "rule2" {
+  firewall_policy = google_compute_network_firewall_policy.default.id
   description     = "Resource created for Terraform acceptance testing"
   priority        = 9001
   enable_logging  = false
@@ -537,15 +507,10 @@ resource "google_compute_firewall_policy_rule" "rule2" {
 `, context)
 }
 
-func testAccComputeFirewallPolicyRule_multipleAdd(context map[string]interface{}) string {
+func testAccComputeNetworkFirewallPolicyRule_multipleAdd(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_folder" "folder" {
-  display_name = "tf-test-folder-%{random_suffix}"
-  parent       = "%{org_name}"
-}
-
-resource "google_compute_firewall_policy" "default" {
-  parent      = google_folder.folder.id
+resource "google_compute_network_firewall_policy" "default" {
+  parent      = google_compute_network.network1.id
   short_name  = "tf-test-policy-%{random_suffix}"
   description = "Description Update"
 }
@@ -560,8 +525,8 @@ resource "google_network_security_address_group" "basic_global_networksecurity_a
   capacity    = 100
 }
 
-resource "google_compute_firewall_policy_rule" "rule1" {
-  firewall_policy = google_compute_firewall_policy.default.id
+resource "google_compute_network_firewall_policy_rule" "rule1" {
+  firewall_policy = google_compute_network_firewall_policy.default.id
   description     = "Resource created for Terraform acceptance testing"
   priority        = 9000
   enable_logging  = true
@@ -580,8 +545,8 @@ resource "google_compute_firewall_policy_rule" "rule1" {
   }
 }
 
-resource "google_compute_firewall_policy_rule" "rule2" {
-  firewall_policy = google_compute_firewall_policy.default.id
+resource "google_compute_network_firewall_policy_rule" "rule2" {
+  firewall_policy = google_compute_network_firewall_policy.default.id
   description     = "Resource created for Terraform acceptance testing"
   priority        = 9001
   enable_logging  = false
@@ -604,8 +569,8 @@ resource "google_compute_firewall_policy_rule" "rule2" {
   }
 }
 
-resource "google_compute_firewall_policy_rule" "rule3" {
-  firewall_policy = google_compute_firewall_policy.default.id
+resource "google_compute_network_firewall_policy_rule" "rule3" {
+  firewall_policy = google_compute_network_firewall_policy.default.id
   description     = "Resource created for Terraform acceptance testing"
   priority        = 40
   enable_logging  = true
@@ -627,15 +592,10 @@ resource "google_compute_firewall_policy_rule" "rule3" {
 `, context)
 }
 
-func testAccComputeFirewallPolicyRule_multipleRemove(context map[string]interface{}) string {
+func testAccComputeNetworkFirewallPolicyRule_multipleRemove(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_folder" "folder" {
-  display_name = "tf-test-folder-%{random_suffix}"
-  parent       = "%{org_name}"
-}
-
-resource "google_compute_firewall_policy" "default" {
-  parent      = google_folder.folder.name
+resource "google_compute_network_firewall_policy" "default" {
+  parent      = google_compute_network.network1.id
   short_name  = "tf-test-policy-%{random_suffix}"
   description = "Resource created for Terraform acceptance testing"
 }
@@ -650,8 +610,8 @@ resource "google_network_security_address_group" "basic_global_networksecurity_a
   capacity    = 100
 }
 
-resource "google_compute_firewall_policy_rule" "rule1" {
-  firewall_policy = google_compute_firewall_policy.default.id
+resource "google_compute_network_firewall_policy_rule" "rule1" {
+  firewall_policy = google_compute_network_firewall_policy.default.id
   description     = "Resource created for Terraform acceptance testing"
   priority        = 9000
   enable_logging  = true
@@ -670,8 +630,8 @@ resource "google_compute_firewall_policy_rule" "rule1" {
   }
 }
 
-resource "google_compute_firewall_policy_rule" "rule3" {
-  firewall_policy = google_compute_firewall_policy.default.id
+resource "google_compute_network_firewall_policy_rule" "rule3" {
+  firewall_policy = google_compute_network_firewall_policy.default.id
   description     = "Resource created for Terraform acceptance testing"
   priority        = 40
   enable_logging  = true

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_firewall_policy_rule_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_firewall_policy_rule_test.go.erb
@@ -26,7 +26,7 @@ func TestAccComputeNetworkFirewallPolicyRule_update(t *testing.T) {
 				Config: testAccComputeNetworkFirewallPolicyRule_start(context),
 			},
 			{
-				ResourceName:      "google_compute_network_firewall_policy_rule.default",
+				ResourceName:      "google_compute_network_firewall_policy_rule.fw_policy_rule1",
 				ImportState:       true,
 				ImportStateVerify: true,
 				// Referencing using ID causes import to fail
@@ -36,27 +36,27 @@ func TestAccComputeNetworkFirewallPolicyRule_update(t *testing.T) {
 				Config: testAccComputeNetworkFirewallPolicyRule_update(context),
 			},
 			{
-				ResourceName:      "google_compute_network_firewall_policy_rule.default",
+				ResourceName:      "google_compute_network_firewall_policy_rule.fw_policy_rule1",
 				ImportState:       true,
 				ImportStateVerify: true,
 				// Referencing using ID causes import to fail
-				ImportStateVerifyIgnore: []string{"firewall_policy", "target_resources"},
+				ImportStateVerifyIgnore: []string{"firewall_policy"},
 			},
 			{
 				Config: testAccComputeNetworkFirewallPolicyRule_removeConfigs(context),
 			},
 			{
-				ResourceName:      "google_compute_network_firewall_policy_rule.default",
+				ResourceName:      "google_compute_network_firewall_policy_rule.fw_policy_rule1",
 				ImportState:       true,
 				ImportStateVerify: true,
 				// Referencing using ID causes import to fail
-				ImportStateVerifyIgnore: []string{"firewall_policy", "target_resources"},
+				ImportStateVerifyIgnore: []string{"firewall_policy"},
 			},
 			{
 				Config: testAccComputeNetworkFirewallPolicyRule_start(context),
 			},
 			{
-				ResourceName:      "google_compute_network_firewall_policy_rule.default",
+				ResourceName:      "google_compute_network_firewall_policy_rule.fw_policy_rule1",
 				ImportState:       true,
 				ImportStateVerify: true,
 				// Referencing using ID causes import to fail
@@ -66,7 +66,7 @@ func TestAccComputeNetworkFirewallPolicyRule_update(t *testing.T) {
 	})
 }
 
-func TestAccComputeNetworkFirewallPolicyRule_securityProfileGroupTls_update(t *testing.T) {
+func TestAccComputeNetworkFirewallPolicyRule_multipleRules(t *testing.T) {
   t.Parallel()
 
   context := map[string]interface{}{
@@ -79,24 +79,70 @@ func TestAccComputeNetworkFirewallPolicyRule_securityProfileGroupTls_update(t *t
     ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
     Steps: []resource.TestStep{
       {
-        Config: testAccComputeNetworkFirewallPolicyRule_securityProfileGroupTls_basic(context),
+        Config: testAccComputeNetworkFirewallPolicyRule_multiple(context),
       },
       {
-        ResourceName:      "google_compute_network_firewall_policy_rule.default",
+        ResourceName:      "google_compute_network_firewall_policy_rule.fw_policy_rule1",
         ImportState:       true,
         ImportStateVerify: true,
         // Referencing using ID causes import to fail
         ImportStateVerifyIgnore: []string{"firewall_policy"},
       },
       {
-        Config: testAccComputeNetworkFirewallPolicyRule_securityProfileGroupTls_update(context),
-      },
-      {
-        ResourceName:      "google_compute_network_firewall_policy_rule.default",
+        ResourceName:      "google_compute_network_firewall_policy_rule.fw_policy_rule2",
         ImportState:       true,
         ImportStateVerify: true,
         // Referencing using ID causes import to fail
-        ImportStateVerifyIgnore: []string{"firewall_policy", "target_resources"},
+        ImportStateVerifyIgnore: []string{"firewall_policy"},
+      },
+      {
+        Config: testAccComputeNetworkFirewallPolicyRule_multipleAdd(context),
+      },
+      {
+        ResourceName:      "google_compute_network_firewall_policy_rule.fw_policy_rule3",
+        ImportState:       true,
+        ImportStateVerify: true,
+        // Referencing using ID causes import to fail
+        ImportStateVerifyIgnore: []string{"firewall_policy"},
+      },
+      {
+        Config: testAccComputeNetworkFirewallPolicyRule_multipleRemove(context),
+      },
+    },
+  })
+}
+
+func TestAccComputeNetworkFirewallPolicyRule_securityProfileGroup_update(t *testing.T) {
+  t.Parallel()
+
+  context := map[string]interface{}{
+    "random_suffix": acctest.RandString(t, 10),
+    "org_name":      fmt.Sprintf("organizations/%s", envvar.GetTestOrgFromEnv(t)),
+  }
+
+  acctest.VcrTest(t, resource.TestCase{
+    PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+    Steps: []resource.TestStep{
+      {
+        Config: testAccComputeNetworkFirewallPolicyRule_securityProfileGroup_basic(context),
+      },
+      {
+        ResourceName:      "google_compute_network_firewall_policy_rule.fw_policy_rule1",
+        ImportState:       true,
+        ImportStateVerify: true,
+        // Referencing using ID causes import to fail
+        ImportStateVerifyIgnore: []string{"firewall_policy"},
+      },
+      {
+        Config: testAccComputeNetworkFirewallPolicyRule_securityProfileGroup_update(context),
+      },
+      {
+        ResourceName:      "google_compute_network_firewall_policy_rule.fw_policy_rule1",
+        ImportState:       true,
+        ImportStateVerify: true,
+        // Referencing using ID causes import to fail
+        ImportStateVerifyIgnore: []string{"firewall_policy"},
       },
     },
   })
@@ -110,35 +156,38 @@ resource "google_compute_network" "network1" {
 }
 
 resource "google_network_security_security_profile" "security_profile" {
-    provider    = google-beta
-    name        = "tf-test-my-sp%{random_suffix}"
-    type        = "THREAT_PREVENTION"
-    parent      = "organizations/%{org_name}"
-    location    = "global"
+    name     = "tf-test-my-sp%{random_suffix}"
+    type     = "THREAT_PREVENTION"
+    parent   = "%{org_name}"
+    location = "global"
 }
 
 resource "google_network_security_security_profile_group" "security_profile_group" {
-    provider                  = google-beta
     name                      = "tf-test-my-spg%{random_suffix}"
-    parent                    = "organizations/%{org_name}"
+    parent                    = "%{org_name}"
     location                  = "global"
     description               = "My security profile group."
     threat_prevention_profile = google_network_security_security_profile.security_profile.id
 }
 
-resource "google_compute_network_firewall_policy" "default" {
-  parent      = google_compute_network.network1.id
-  short_name  = "tf-test-policy-%{random_suffix}"
+resource "google_compute_network_firewall_policy" "fw_policy" {
+  name        = "tf-test-policy-%{random_suffix}"
   description = "Resource created for Terraform acceptance testing"
 }
 
-resource "google_compute_network_firewall_policy_rule" "default" {
-  firewall_policy        = google_compute_network_firewall_policy.default.id
+resource "google_compute_network_firewall_policy_association" "fw_policy_a" {
+  name              = "tf-test-policy-a-%{random_suffix}"
+  attachment_target = google_compute_network.network1.id
+  firewall_policy   = google_compute_network_firewall_policy.fw_policy.id
+}
+
+resource "google_compute_network_firewall_policy_rule" "fw_policy_rule1" {
+  firewall_policy        = google_compute_network_firewall_policy.fw_policy.id
   description            = "Resource created for Terraform acceptance testing"
   priority               = 9000
   enable_logging         = true
   action                 = "apply_security_profile_group"
-  security_profile_group = google_network_security_security_profile_group.security_profile_group.id
+  security_profile_group = "//networksecurity.googleapis.com/${google_network_security_security_profile_group.security_profile_group.id}"
   direction              = "INGRESS"
   disabled               = false
   match {
@@ -160,44 +209,46 @@ resource "google_compute_network" "network1" {
 }
 
 resource "google_network_security_security_profile" "security_profile" {
-    provider    = google-beta
-    name        = "tf-test-my-security-profile%{random_suffix}"
-    type        = "THREAT_PREVENTION"
-    parent      = "organizations/%{org_name}"
-    location    = "global"
+    name     = "tf-test-my-sp%{random_suffix}"
+    type     = "THREAT_PREVENTION"
+    parent   = "%{org_name}"
+    location = "global"
 }
 
 resource "google_network_security_security_profile_group" "security_profile_group" {
-    provider                  = google-beta
-    name                      = "tf-test-my-sp-group%{random_suffix}"
-    parent                    = "organizations/%{org_name}"
+    name                      = "tf-test-my-spg%{random_suffix}"
+    parent                    = "%{org_name}"
     location                  = "global"
     description               = "My security profile group."
     threat_prevention_profile = google_network_security_security_profile.security_profile.id
 }
 
 resource "google_network_security_security_profile_group" "security_profile_group_updated" {
-    provider                  = google-beta
     name                      = "tf-test-my-spg-updated%{random_suffix}"
-    parent                    = "organizations/%{org_name}"
+    parent                    = "%{org_name}"
     location                  = "global"
-    description               = "My security profile group."
+    description               = "My updated security profile group."
     threat_prevention_profile = google_network_security_security_profile.security_profile.id
 }
 
-resource "google_compute_network_firewall_policy" "default" {
-  parent      = google_compute_network.network1.id
-  short_name  = "tf-test-policy-%{random_suffix}"
+resource "google_compute_network_firewall_policy" "fw_policy" {
+  name        = "tf-test-policy-%{random_suffix}"
   description = "Resource created for Terraform acceptance testing"
 }
 
-resource "google_compute_network_firewall_policy_rule" "default" {
-  firewall_policy        = google_compute_network_firewall_policy.default.id
+resource "google_compute_network_firewall_policy_association" "fw_policy_a" {
+  name              = "tf-test-policy-a-%{random_suffix}"
+  attachment_target = google_compute_network.network1.id
+  firewall_policy   = google_compute_network_firewall_policy.fw_policy.id
+}
+
+resource "google_compute_network_firewall_policy_rule" "fw_policy_rule1" {
+  firewall_policy        = google_compute_network_firewall_policy.fw_policy.id
   description            = "Resource created for Terraform acceptance testing"
   priority               = 9000
   enable_logging         = true
   action                 = "apply_security_profile_group"
-  security_profile_group = google_network_security_security_profile_group.security_profile_group_updated.id
+  security_profile_group = "//networksecurity.googleapis.com/${google_network_security_security_profile_group.security_profile_group_updated.id}"
   direction              = "INGRESS"
   disabled               = false
   match {
@@ -213,7 +264,7 @@ resource "google_compute_network_firewall_policy_rule" "default" {
 
 func testAccComputeNetworkFirewallPolicyRule_start(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_service_account" "service_account" {
+resource "google_service_account" "service_account1" {
   account_id = "tf-test-sa-%{random_suffix}"
 }
 
@@ -231,13 +282,12 @@ resource "google_compute_network" "network2" {
   auto_create_subnetworks = false
 }
 
-resource "google_compute_network_firewall_policy" "default" {
-  parent      = google_compute_network.network1.id
-  short_name  = "tf-test-policy-%{random_suffix}"
+resource "google_compute_network_firewall_policy" "fw_policy" {
+  name        = "tf-test-policy-%{random_suffix}"
   description = "Resource created for Terraform acceptance testing"
 }
 
-resource "google_network_security_address_group" "basic_global_networksecurity_address_group" {
+resource "google_network_security_address_group" "address_group" {
   name        = "tf-test-policy%{random_suffix}"
   parent      = "%{org_name}"
   description = "Sample global networksecurity_address_group"
@@ -247,8 +297,8 @@ resource "google_network_security_address_group" "basic_global_networksecurity_a
   capacity    = 100
 }
 
-resource "google_compute_network_firewall_policy_rule" "default" {
-  firewall_policy = google_compute_network_firewall_policy.default.id
+resource "google_compute_network_firewall_policy_rule" "fw_policy_rule1" {
+  firewall_policy = google_compute_network_firewall_policy.fw_policy.id
   description     = "Resource created for Terraform acceptance testing"
   priority        = 9000
   enable_logging  = true
@@ -264,7 +314,7 @@ resource "google_compute_network_firewall_policy_rule" "default" {
     dest_fqdns                = []
     dest_region_codes         = []
     dest_threat_intelligences = []
-    dest_address_groups       = [google_network_security_address_group.basic_global_networksecurity_address_group.id]
+    dest_address_groups       = [google_network_security_address_group.address_group.id]
   }
 }
 `, context)
@@ -272,7 +322,7 @@ resource "google_compute_network_firewall_policy_rule" "default" {
 
 func testAccComputeNetworkFirewallPolicyRule_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_service_account" "service_account" {
+resource "google_service_account" "service_account1" {
   account_id = "tf-test-sa-%{random_suffix}"
 }
 
@@ -290,13 +340,12 @@ resource "google_compute_network" "network2" {
   auto_create_subnetworks = false
 }
 
-resource "google_compute_network_firewall_policy" "default" {
-  parent      = google_compute_network.network1.id
-  short_name  = "tf-test-policy-%{random_suffix}"
+resource "google_compute_network_firewall_policy" "fw_policy" {
+  name        = "tf-test-policy-%{random_suffix}"
   description = "Resource created for Terraform acceptance testing"
 }
 
-resource "google_network_security_address_group" "basic_global_networksecurity_address_group" {
+resource "google_network_security_address_group" "address_group" {
   name        = "tf-test-policy%{random_suffix}"
   parent      = "%{org_name}"
   description = "Sample global networksecurity_address_group"
@@ -306,14 +355,16 @@ resource "google_network_security_address_group" "basic_global_networksecurity_a
   capacity    = 100
 }
 
-resource "google_compute_network_firewall_policy_rule" "default" {
-  firewall_policy = google_compute_network_firewall_policy.default.id
-  description     = "Resource created for Terraform acceptance testing"
-  priority        = 9000
-  enable_logging  = true
-  action          = "allow"
-  direction       = "EGRESS"
-  disabled        = false
+resource "google_compute_network_firewall_policy_rule" "fw_policy_rule1" {
+  firewall_policy         = google_compute_network_firewall_policy.fw_policy.id
+  description             = "Resource created for Terraform acceptance testing"
+  priority                = 9000
+  enable_logging          = true
+  action                  = "allow"
+  direction               = "EGRESS"
+  disabled                = false
+  target_service_accounts = [google_service_account.service_account1.email]
+
   match {
     layer4_configs {
       ip_protocol = "tcp"
@@ -328,17 +379,15 @@ resource "google_compute_network_firewall_policy_rule" "default" {
     dest_region_codes         = ["US"]
     dest_threat_intelligences = ["iplist-known-malicious-ips"]
     src_address_groups        = []
-    dest_address_groups       = [google_network_security_address_group.basic_global_networksecurity_address_group.id]
+    dest_address_groups       = [google_network_security_address_group.address_group.id]
   }
-  target_resources        = [google_compute_network.network1.self_link, google_compute_network.network2.self_link]
-  target_service_accounts = [google_service_account.service_account.email]
 }
 `, context)
 }
 
 func testAccComputeNetworkFirewallPolicyRule_removeConfigs(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_service_account" "service_account" {
+resource "google_service_account" "service_account1" {
   account_id = "tf-test-sa-%{random_suffix}"
 }
 
@@ -356,13 +405,12 @@ resource "google_compute_network" "network2" {
   auto_create_subnetworks = false
 }
 
-resource "google_compute_network_firewall_policy" "default" {
-  parent      = google_compute_network.network1.id
-  short_name  = "tf-test-policy-%{random_suffix}"
+resource "google_compute_network_firewall_policy" "fw_policy" {
+  name        = "tf-test-policy-%{random_suffix}"
   description = "Resource created for Terraform acceptance testing"
 }
 
-resource "google_network_security_address_group" "basic_global_networksecurity_address_group" {
+resource "google_network_security_address_group" "address_group" {
   name        = "tf-test-policy%{random_suffix}"
   parent      = "%{org_name}"
   description = "Sample global networksecurity_address_group"
@@ -372,14 +420,19 @@ resource "google_network_security_address_group" "basic_global_networksecurity_a
   capacity    = 100
 }
 
-resource "google_compute_network_firewall_policy_rule" "default" {
-  firewall_policy = google_compute_network_firewall_policy.default.id
-  description     = "Test description"
-  priority        = 9000
-  enable_logging  = false
-  action          = "deny"
-  direction       = "INGRESS"
-  disabled        = true
+resource "google_compute_network_firewall_policy_rule" "fw_policy_rule1" {
+  firewall_policy         = google_compute_network_firewall_policy.fw_policy.id
+  description             = "Test description"
+  priority                = 9000
+  enable_logging          = false
+  action                  = "deny"
+  direction               = "INGRESS"
+  disabled                = true
+  target_service_accounts = [
+    google_service_account.service_account1.email,
+    google_service_account.service_account2.email
+  ]
+
   match {
     layer4_configs {
       ip_protocol = "udp"
@@ -390,67 +443,29 @@ resource "google_compute_network_firewall_policy_rule" "default" {
     src_region_codes         = ["US"]
     src_threat_intelligences = ["iplist-known-malicious-ips"]
   }
-  target_resources        = [google_compute_network.network1.self_link]
-  target_service_accounts = [google_service_account.service_account.email, google_service_account.service_account2.email]
 }
 `, context)
 }
 
-func TestAccComputeNetworkFirewallPolicyRule_multipleRules(t *testing.T) {
-	t.Parallel()
-
-	context := map[string]interface{}{
-		"random_suffix": acctest.RandString(t, 10),
-		"org_name":      fmt.Sprintf("organizations/%s", envvar.GetTestOrgFromEnv(t)),
-	}
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccComputeNetworkFirewallPolicyRule_multiple(context),
-			},
-			{
-				ResourceName:      "google_compute_network_firewall_policy_rule.rule1",
-				ImportState:       true,
-				ImportStateVerify: true,
-				// Referencing using ID causes import to fail
-				ImportStateVerifyIgnore: []string{"firewall_policy"},
-			},
-			{
-				ResourceName:      "google_compute_network_firewall_policy_rule.rule2",
-				ImportState:       true,
-				ImportStateVerify: true,
-				// Referencing using ID causes import to fail
-				ImportStateVerifyIgnore: []string{"firewall_policy"},
-			},
-			{
-				Config: testAccComputeNetworkFirewallPolicyRule_multipleAdd(context),
-			},
-			{
-				ResourceName:      "google_compute_network_firewall_policy_rule.rule3",
-				ImportState:       true,
-				ImportStateVerify: true,
-				// Referencing using ID causes import to fail
-				ImportStateVerifyIgnore: []string{"firewall_policy"},
-			},
-			{
-				Config: testAccComputeNetworkFirewallPolicyRule_multipleRemove(context),
-			},
-		},
-	})
-}
-
 func testAccComputeNetworkFirewallPolicyRule_multiple(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_compute_network_firewall_policy" "default" {
-  parent      = google_compute_network.network1.id
-  short_name  = "tf-test-policy-%{random_suffix}"
+resource "google_compute_network" "network1" {
+  name                    = "tf-test-%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_network_firewall_policy" "fw_policy" {
+  name        = "tf-test-policy-%{random_suffix}"
   description = "Resource created for Terraform acceptance testing"
 }
 
-resource "google_network_security_address_group" "basic_global_networksecurity_address_group" {
+resource "google_compute_network_firewall_policy_association" "fw_policy_a" {
+  name              = "tf-test-policy-a-%{random_suffix}"
+  attachment_target = google_compute_network.network1.id
+  firewall_policy   = google_compute_network_firewall_policy.fw_policy.id
+}
+
+resource "google_network_security_address_group" "address_group" {
   name        = "tf-test-policy%{random_suffix}"
   parent      = "%{org_name}"
   description = "Sample global networksecurity_address_group"
@@ -460,8 +475,8 @@ resource "google_network_security_address_group" "basic_global_networksecurity_a
   capacity    = 100
 }
 
-resource "google_compute_network_firewall_policy_rule" "rule1" {
-  firewall_policy = google_compute_network_firewall_policy.default.id
+resource "google_compute_network_firewall_policy_rule" "fw_policy_rule1" {
+  firewall_policy = google_compute_network_firewall_policy.fw_policy.id
   description     = "Resource created for Terraform acceptance testing"
   priority        = 9000
   enable_logging  = true
@@ -477,12 +492,12 @@ resource "google_compute_network_firewall_policy_rule" "rule1" {
     dest_fqdns                = ["google.com"]
     dest_region_codes         = ["US"]
     dest_threat_intelligences = ["iplist-known-malicious-ips"]
-    dest_address_groups       = [google_network_security_address_group.basic_global_networksecurity_address_group.id]
+    dest_address_groups       = [google_network_security_address_group.address_group.id]
   }
 }
 
-resource "google_compute_network_firewall_policy_rule" "rule2" {
-  firewall_policy = google_compute_network_firewall_policy.default.id
+resource "google_compute_network_firewall_policy_rule" "fw_policy_rule2" {
+  firewall_policy = google_compute_network_firewall_policy.fw_policy.id
   description     = "Resource created for Terraform acceptance testing"
   priority        = 9001
   enable_logging  = false
@@ -501,7 +516,7 @@ resource "google_compute_network_firewall_policy_rule" "rule2" {
     src_fqdns                = ["google.com"]
     src_region_codes         = ["US"]
     src_threat_intelligences = ["iplist-known-malicious-ips"]
-    src_address_groups       = [google_network_security_address_group.basic_global_networksecurity_address_group.id]
+    src_address_groups       = [google_network_security_address_group.address_group.id]
   }
 }
 `, context)
@@ -509,13 +524,12 @@ resource "google_compute_network_firewall_policy_rule" "rule2" {
 
 func testAccComputeNetworkFirewallPolicyRule_multipleAdd(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_compute_network_firewall_policy" "default" {
-  parent      = google_compute_network.network1.id
-  short_name  = "tf-test-policy-%{random_suffix}"
+resource "google_compute_network_firewall_policy" "fw_policy" {
+  name        = "tf-test-policy-%{random_suffix}"
   description = "Description Update"
 }
 
-resource "google_network_security_address_group" "basic_global_networksecurity_address_group" {
+resource "google_network_security_address_group" "address_group" {
   name        = "tf-test-policy%{random_suffix}"
   parent      = "%{org_name}"
   description = "Sample global networksecurity_address_group"
@@ -525,8 +539,8 @@ resource "google_network_security_address_group" "basic_global_networksecurity_a
   capacity    = 100
 }
 
-resource "google_compute_network_firewall_policy_rule" "rule1" {
-  firewall_policy = google_compute_network_firewall_policy.default.id
+resource "google_compute_network_firewall_policy_rule" "fw_policy_rule1" {
+  firewall_policy = google_compute_network_firewall_policy.fw_policy.id
   description     = "Resource created for Terraform acceptance testing"
   priority        = 9000
   enable_logging  = true
@@ -541,12 +555,12 @@ resource "google_compute_network_firewall_policy_rule" "rule1" {
     dest_fqdns                = ["google.com"]
     dest_region_codes         = ["US"]
     dest_threat_intelligences = ["iplist-known-malicious-ips"]
-    dest_address_groups       = [google_network_security_address_group.basic_global_networksecurity_address_group.id]
+    dest_address_groups       = [google_network_security_address_group.address_group.id]
   }
 }
 
-resource "google_compute_network_firewall_policy_rule" "rule2" {
-  firewall_policy = google_compute_network_firewall_policy.default.id
+resource "google_compute_network_firewall_policy_rule" "fw_policy_rule2" {
+  firewall_policy = google_compute_network_firewall_policy.fw_policy.id
   description     = "Resource created for Terraform acceptance testing"
   priority        = 9001
   enable_logging  = false
@@ -565,12 +579,12 @@ resource "google_compute_network_firewall_policy_rule" "rule2" {
     src_fqdns                = ["google.com"]
     src_region_codes         = ["US"]
     src_threat_intelligences = ["iplist-known-malicious-ips"]
-    src_address_groups       = [google_network_security_address_group.basic_global_networksecurity_address_group.id]
+    src_address_groups       = [google_network_security_address_group.address_group.id]
   }
 }
 
-resource "google_compute_network_firewall_policy_rule" "rule3" {
-  firewall_policy = google_compute_network_firewall_policy.default.id
+resource "google_compute_network_firewall_policy_rule" "fw_policy_rule3" {
+  firewall_policy = google_compute_network_firewall_policy.fw_policy.id
   description     = "Resource created for Terraform acceptance testing"
   priority        = 40
   enable_logging  = true
@@ -586,7 +600,7 @@ resource "google_compute_network_firewall_policy_rule" "rule3" {
     src_fqdns                = ["google.com"]
     src_region_codes         = ["US"]
     src_threat_intelligences = ["iplist-known-malicious-ips"]
-    src_address_groups       = [google_network_security_address_group.basic_global_networksecurity_address_group.id]
+    src_address_groups       = [google_network_security_address_group.address_group.id]
   }
 }
 `, context)
@@ -594,13 +608,12 @@ resource "google_compute_network_firewall_policy_rule" "rule3" {
 
 func testAccComputeNetworkFirewallPolicyRule_multipleRemove(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_compute_network_firewall_policy" "default" {
-  parent      = google_compute_network.network1.id
-  short_name  = "tf-test-policy-%{random_suffix}"
+resource "google_compute_network_firewall_policy" "fw_policy" {
+  name        = "tf-test-policy-%{random_suffix}"
   description = "Resource created for Terraform acceptance testing"
 }
 
-resource "google_network_security_address_group" "basic_global_networksecurity_address_group" {
+resource "google_network_security_address_group" "address_group" {
   name        = "tf-test-policy%{random_suffix}"
   parent      = "%{org_name}"
   description = "Sample global networksecurity_address_group"
@@ -610,8 +623,8 @@ resource "google_network_security_address_group" "basic_global_networksecurity_a
   capacity    = 100
 }
 
-resource "google_compute_network_firewall_policy_rule" "rule1" {
-  firewall_policy = google_compute_network_firewall_policy.default.id
+resource "google_compute_network_firewall_policy_rule" "fw_policy_rule1" {
+  firewall_policy = google_compute_network_firewall_policy.fw_policy.id
   description     = "Resource created for Terraform acceptance testing"
   priority        = 9000
   enable_logging  = true
@@ -630,8 +643,8 @@ resource "google_compute_network_firewall_policy_rule" "rule1" {
   }
 }
 
-resource "google_compute_network_firewall_policy_rule" "rule3" {
-  firewall_policy = google_compute_network_firewall_policy.default.id
+resource "google_compute_network_firewall_policy_rule" "fw_policy_rule3" {
+  firewall_policy = google_compute_network_firewall_policy.fw_policy.id
   description     = "Resource created for Terraform acceptance testing"
   priority        = 40
   enable_logging  = true


### PR DESCRIPTION
**[Please, wait before merging] adding tlsInspect argument tests as well**

* Adds acceptance tests for `google_compute_network_firewall_policy_rule` resource
* Adds acceptance tests for the `securityProfileGroup` argument in `google_compute_firewall_policy_rule` and `google_compute_network_firewall_policy_rule` resources

Fixes [hashicorp/terraform-provider-google/issues/17030](https://github.com/hashicorp/terraform-provider-google/issues/17030).

```release-note:enhancement
compute: Added acceptance tests for `google_compute_network_firewall_policy_rule`
```

```release-note:enhancement
compute: Added acceptance tests for the `securityProfileGroup` argument in `google_compute_firewall_policy_rule` and `google_compute_network_firewall_policy_rule` resources
```