### PR TITLE
fix: Verify `google_cloud_run_v2_{service,job}` 'timeout' field with regex

### DIFF
--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -523,6 +523,8 @@ properties:
 
               A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.5s".
             default_from_api: true
+            validation: !ruby/object:Provider::Terraform::Validation
+              regex: '^[0-9]+(?:\.[0-9]{1,9})?s$'
           - !ruby/object:Api::Type::String
             name: 'serviceAccount'
             description: |-

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -356,6 +356,8 @@ properties:
 
           A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.5s".
         default_from_api: true
+        validation: !ruby/object:Provider::Terraform::Validation
+          regex: '^[0-9]+(?:\.[0-9]{1,9})?s$'
       - !ruby/object:Api::Type::String
         name: 'serviceAccount'
         description: |-


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/18028.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
cloudrunv2: added validation for `timeout` field to `google_cloud_run_v2_job`, `google_cloud_run_v2_service`
```
