### PR TITLE
Removing version guards for fields going GA

### DIFF
--- a/mmv1/products/compute/Router.yaml
+++ b/mmv1/products/compute/Router.yaml
@@ -190,7 +190,6 @@ properties:
       - !ruby/object:Api::Type::String
         name: identifierRange
         default_from_api: true
-        min_version: beta
         description: |
           Explicitly specifies a range of valid BGP Identifiers for this Router.
           It is provided as a link-local IPv4 range (from 169.254.0.0/16), of

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.erb
@@ -207,7 +207,6 @@ func TestAccComputeRouterPeer_Ipv6Basic(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccComputeRouterPeer_Ipv4BasicCreateUpdate(t *testing.T) {
   t.Parallel()
 
@@ -249,7 +248,6 @@ func TestAccComputeRouterPeer_Ipv4BasicCreateUpdate(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func TestAccComputeRouterPeer_UpdateIpv6Address(t *testing.T) {
 	t.Parallel()
@@ -1547,16 +1545,13 @@ resource "google_compute_router_peer" "foobar" {
 `, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, enableIpv6)
 }
 
-<% unless version == 'ga' -%>
 func testAccComputeRouterPeerIpv4(routerName string) string {
 	return fmt.Sprintf(`resource "google_compute_network" "foobar" {
-    provider = google-beta
     name = "%s-net"
     auto_create_subnetworks = false
   }
   
   resource "google_compute_subnetwork" "foobar" {
-    provider = google-beta
     name          = "%s-subnet"
     network       = google_compute_network.foobar.self_link
     ip_cidr_range = "10.0.0.0/16"
@@ -1566,7 +1561,6 @@ func testAccComputeRouterPeerIpv4(routerName string) string {
   }
   
   resource "google_compute_ha_vpn_gateway" "foobar" {
-    provider = google-beta
     name    = "%s-gateway"
     network = google_compute_network.foobar.self_link
     region  = google_compute_subnetwork.foobar.region
@@ -1574,7 +1568,6 @@ func testAccComputeRouterPeerIpv4(routerName string) string {
   }
   
   resource "google_compute_external_vpn_gateway" "external_gateway" {
-    provider = google-beta
     name            = "%s-external-gateway"
     redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
     description     = "An externally managed VPN gateway"
@@ -1585,7 +1578,6 @@ func testAccComputeRouterPeerIpv4(routerName string) string {
   }
   
   resource "google_compute_router" "foobar" {
-    provider = google-beta
     name    = "%s"
     region  = google_compute_subnetwork.foobar.region
     network = google_compute_network.foobar.self_link
@@ -1595,7 +1587,6 @@ func testAccComputeRouterPeerIpv4(routerName string) string {
   }
   
   resource "google_compute_vpn_tunnel" "foobar" {
-    provider = google-beta
     name               = "%s-tunnel"
     region             = google_compute_subnetwork.foobar.region
     vpn_gateway = google_compute_ha_vpn_gateway.foobar.id
@@ -1607,7 +1598,6 @@ func testAccComputeRouterPeerIpv4(routerName string) string {
   }
   
   resource "google_compute_router_interface" "foobar" {
-    provider = google-beta
     name       = "%s-interface"
     router     = google_compute_router.foobar.name
     region     = google_compute_router.foobar.region
@@ -1616,7 +1606,6 @@ func testAccComputeRouterPeerIpv4(routerName string) string {
   }
   
   resource "google_compute_router_peer" "foobar" {
-    provider = google-beta
     name                      = "%s-peer"
     router                    = google_compute_router.foobar.name
     region                    = google_compute_router.foobar.region
@@ -1636,13 +1625,11 @@ func testAccComputeRouterPeerIpv4(routerName string) string {
 
 func testAccComputeRouterPeerUpdateIpv4Address(routerName string) string {
 	return fmt.Sprintf(`resource "google_compute_network" "foobar" {
-    provider = google-beta
     name = "%s-net"
     auto_create_subnetworks = false
   }
   
   resource "google_compute_subnetwork" "foobar" {
-    provider = google-beta
     name          = "%s-subnet"
     network       = google_compute_network.foobar.self_link
     ip_cidr_range = "10.0.0.0/16"
@@ -1652,7 +1639,6 @@ func testAccComputeRouterPeerUpdateIpv4Address(routerName string) string {
   }
   
   resource "google_compute_ha_vpn_gateway" "foobar" {
-    provider = google-beta
     name    = "%s-gateway"
     network = google_compute_network.foobar.self_link
     region  = google_compute_subnetwork.foobar.region
@@ -1660,7 +1646,6 @@ func testAccComputeRouterPeerUpdateIpv4Address(routerName string) string {
   }
   
   resource "google_compute_external_vpn_gateway" "external_gateway" {
-    provider = google-beta
     name            = "%s-external-gateway"
     redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
     description     = "An externally managed VPN gateway"
@@ -1671,7 +1656,6 @@ func testAccComputeRouterPeerUpdateIpv4Address(routerName string) string {
   }
   
   resource "google_compute_router" "foobar" {
-    provider = google-beta
     name    = "%s"
     region  = google_compute_subnetwork.foobar.region
     network = google_compute_network.foobar.self_link
@@ -1681,7 +1665,6 @@ func testAccComputeRouterPeerUpdateIpv4Address(routerName string) string {
   }
   
   resource "google_compute_vpn_tunnel" "foobar" {
-    provider = google-beta
     name               = "%s-tunnel"
     region             = google_compute_subnetwork.foobar.region
     vpn_gateway = google_compute_ha_vpn_gateway.foobar.id
@@ -1693,7 +1676,6 @@ func testAccComputeRouterPeerUpdateIpv4Address(routerName string) string {
   }
   
   resource "google_compute_router_interface" "foobar" {
-    provider = google-beta
     name       = "%s-interface"
     router     = google_compute_router.foobar.name
     region     = google_compute_router.foobar.region
@@ -1702,7 +1684,6 @@ func testAccComputeRouterPeerUpdateIpv4Address(routerName string) string {
   }
   
   resource "google_compute_router_peer" "foobar" {
-    provider = google-beta
     name                      = "%s-peer"
     router                    = google_compute_router.foobar.name
     region                    = google_compute_router.foobar.region
@@ -1719,4 +1700,3 @@ func testAccComputeRouterPeerUpdateIpv4Address(routerName string) string {
   }
   `, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
 }
-<% end -%>

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.erb
@@ -214,7 +214,7 @@ func TestAccComputeRouterPeer_Ipv4BasicCreateUpdate(t *testing.T) {
 	resourceName := "google_compute_router_peer.foobar"
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeRouterPeerDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_interface.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_interface.go.erb
@@ -13,9 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	<% unless version == "ga" -%>
 	"github.com/hashicorp/terraform-provider-google/google/verify"
-	<% end -%>
 	"google.golang.org/api/googleapi"
 
 <% if version == "ga" -%>
@@ -82,8 +80,7 @@ func ResourceComputeRouterInterface() *schema.Resource {
 				Computed:       true,
 				AtLeastOneOf:   []string{"ip_range", "interconnect_attachment", "subnetwork", "vpn_tunnel"},
 				Description:    `The IP address and range of the interface. The IP range must be in the RFC3927 link-local IP space. Changing this forces a new interface to be created.`,
-			},
-			<% unless version == 'ga' -%>
+			},	
 			"ip_version": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -92,7 +89,6 @@ func ResourceComputeRouterInterface() *schema.Resource {
 				ValidateFunc: verify.ValidateEnum([]string{"IPV4", "IPV6"}),
 				Description:  `IP version of this interface.`,
 			},
-			<% end -%>
 			"private_ip_address": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -191,11 +187,9 @@ func resourceComputeRouterInterfaceCreate(d *schema.ResourceData, meta interface
 		iface.IpRange = ipRangeVal.(string)
 	}
 
-	<% unless version == 'ga' -%>
 	if ipVersionVal, ok := d.GetOk("ip_version"); ok {
 		iface.IpVersion = ipVersionVal.(string)
 	}
-	<% end -%>
 
 	if privateIpVal, ok := d.GetOk("private_ip_address"); ok {
 		iface.PrivateIpAddress = privateIpVal.(string)
@@ -288,11 +282,9 @@ func resourceComputeRouterInterfaceRead(d *schema.ResourceData, meta interface{}
 			if err := d.Set("ip_range", iface.IpRange); err != nil {
 				return fmt.Errorf("Error setting ip_range: %s", err)
 			}
-			<% unless version == 'ga' -%>
 			if err := d.Set("ip_version", iface.IpVersion); err != nil {
 				return fmt.Errorf("Error setting ip_version: %s", err)
 			}
-			<% end -%>
 			if err := d.Set("private_ip_address", iface.PrivateIpAddress); err != nil {
 				return fmt.Errorf("Error setting private_ip_address: %s", err)
 			}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_interface_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_interface_test.go.erb
@@ -126,7 +126,7 @@ func TestAccComputeRouterInterface_withIPVersionV4(t *testing.T) {
 	routerName := fmt.Sprintf("tf-test-router-%s", acctest.RandString(t, 10))
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeRouterInterfaceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -149,7 +149,7 @@ func TestAccComputeRouterInterface_withIPVersionV6(t *testing.T) {
 	routerName := fmt.Sprintf("tf-test-router-%s", acctest.RandString(t, 10))
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeRouterInterfaceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_interface_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_interface_test.go.erb
@@ -120,7 +120,6 @@ func TestAccComputeRouterInterface_withPrivateIpAddress(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccComputeRouterInterface_withIPVersionV4(t *testing.T) {
 	t.Parallel()
 
@@ -166,7 +165,6 @@ func TestAccComputeRouterInterface_withIPVersionV6(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func testAccCheckComputeRouterInterfaceDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
@@ -561,23 +559,19 @@ resource "google_compute_router_interface" "foobar" {
 `, routerName, routerName, routerName, routerName, routerName)
 }
 
-<% unless version == 'ga' -%>
 func testAccComputeRouterInterfaceWithIpVersionIPV6(routerName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
-  provider = google-beta
   name = "%s-net"
 }
 
 resource "google_compute_subnetwork" "foobar" {
-  provider = google-beta
   name          = "%s-subnet"
   network       = google_compute_network.foobar.self_link
   ip_cidr_range = "10.0.0.0/16"
 }
 
 resource "google_compute_router" "foobar" {
-  provider = google-beta
   name    = "%s"
   network = google_compute_network.foobar.self_link
   bgp {
@@ -586,7 +580,6 @@ resource "google_compute_router" "foobar" {
 }
 
 resource "google_compute_router_interface" "foobar" {
-  provider = google-beta
   name     = "%s-interface"
   router   = google_compute_router.foobar.name
   region   = google_compute_router.foobar.region
@@ -599,19 +592,16 @@ resource "google_compute_router_interface" "foobar" {
 func testAccComputeRouterInterfaceWithIpVersionIPV4(routerName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
-  provider = google-beta
   name = "%s-net"
 }
 
 resource "google_compute_subnetwork" "foobar" {
-  provider = google-beta
   name          = "%s-subnet"
   network       = google_compute_network.foobar.self_link
   ip_cidr_range = "10.0.0.0/16"
 }
 
 resource "google_compute_router" "foobar" {
-  provider = google-beta
   name    = "%s"
   network = google_compute_network.foobar.self_link
   bgp {
@@ -620,7 +610,6 @@ resource "google_compute_router" "foobar" {
 }
 
 resource "google_compute_router_interface" "foobar" {
-  provider = google-beta
   name     = "%s-interface"
   router   = google_compute_router.foobar.name
   region   = google_compute_router.foobar.region
@@ -629,4 +618,3 @@ resource "google_compute_router_interface" "foobar" {
 }
 `, routerName, routerName, routerName, routerName)
 }
-<% end -%>

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
@@ -207,14 +207,12 @@ The default is true.`,
 				Description: `Enable IPv6 traffic over BGP Peer. If not specified, it is disabled by default.`,
 				Default:     false,
 			},
-<% unless version == 'ga' -%>
 			"enable_ipv4": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: `Enable IPv4 traffic over BGP Peer. It is enabled by default if the peerIpAddress is version 4.`,
 				Computed:    true,
 			},
-<% end -%>
 			"ip_address": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -233,7 +231,6 @@ The address must be in the range 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64.
 If you do not specify the next hop addresses, Google Cloud automatically
 assigns unused addresses from the 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64 range for you.`,
 			},
-<% unless version == 'ga' -%>
 			"ipv4_nexthop_address": {
 				Type:         schema.TypeString,
 				Computed:     true,
@@ -241,7 +238,6 @@ assigns unused addresses from the 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64 range
 				ValidateFunc: verify.ValidateIpAddress,
 				Description:  `IPv4 address of the interface inside Google Cloud Platform.`,
 			},
-<% end -%>
 			"peer_ip_address": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -260,7 +256,6 @@ The address must be in the range 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64.
 If you do not specify the next hop addresses, Google Cloud automatically
 assigns unused addresses from the 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64 range for you.`,
 			},
-<% unless version == 'ga' -%>
 			"peer_ipv4_nexthop_address": {
 				Type:         schema.TypeString,
 				Computed:     true,
@@ -268,7 +263,6 @@ assigns unused addresses from the 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64 range
 				ValidateFunc: verify.ValidateIpAddress,
 				Description:  `IPv4 address of the BGP interface outside Google Cloud Platform.`,
 			},
-<% end -%>
 			"region": {
 				Type:             schema.TypeString,
 				Computed:         true,
@@ -421,7 +415,6 @@ func resourceComputeRouterBgpPeerCreate(d *schema.ResourceData, meta interface{}
 	} else if v, ok := d.GetOkExists("enable_ipv6"); ok || !reflect.DeepEqual(v, enableIpv6Prop) {
 		obj["enableIpv6"] = enableIpv6Prop
 	}
-<% unless version == 'ga' -%>
 	enableIpv4Prop, err := expandNestedComputeRouterBgpPeerEnableIpv4(d.Get("enable_ipv4"), d, config)
 	if err != nil {
 		return err
@@ -440,7 +433,6 @@ func resourceComputeRouterBgpPeerCreate(d *schema.ResourceData, meta interface{}
 	} else if v, ok := d.GetOkExists("peer_ipv6_nexthop_address"); !tpgresource.IsEmptyValue(reflect.ValueOf(peerIpv4NexthopAddressProp)) && (ok || !reflect.DeepEqual(v, peerIpv4NexthopAddressProp)) {
 		obj["peerIpv4NexthopAddress"] = peerIpv4NexthopAddressProp
 	}
-<% end -%>
 	ipv6NexthopAddressProp, err := expandNestedComputeRouterBgpPeerIpv6NexthopAddress(d.Get("ipv6_nexthop_address"), d, config)
 	if err != nil {
 		return err
@@ -632,7 +624,6 @@ func resourceComputeRouterBgpPeerRead(d *schema.ResourceData, meta interface{}) 
 	if err := d.Set("enable_ipv6", flattenNestedComputeRouterBgpPeerEnableIpv6(res["enableIpv6"], d, config)); err != nil {
 		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
 	}
-<% unless version == 'ga' -%>
 	if err := d.Set("enable_ipv4", flattenNestedComputeRouterBgpPeerEnableIpv4(res["enableIpv4"], d, config)); err != nil {
 		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
 	}
@@ -642,7 +633,6 @@ func resourceComputeRouterBgpPeerRead(d *schema.ResourceData, meta interface{}) 
 	if err := d.Set("peer_ipv4_nexthop_address", flattenNestedComputeRouterBgpPeerPeerIpv4NexthopAddress(res["peerIpv4NexthopAddress"], d, config)); err != nil {
 		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
 	}
-<% end -%>
 	if err := d.Set("ipv6_nexthop_address", flattenNestedComputeRouterBgpPeerIpv6NexthopAddress(res["ipv6NexthopAddress"], d, config)); err != nil {
 		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
 	}
@@ -738,7 +728,6 @@ func resourceComputeRouterBgpPeerUpdate(d *schema.ResourceData, meta interface{}
 	} else if v, ok := d.GetOkExists("enable_ipv6"); ok || !reflect.DeepEqual(v, enableIpv6Prop) {
 		obj["enableIpv6"] = enableIpv6Prop
 	}
-<% unless version == 'ga' -%>
 	enableIpv4Prop, err := expandNestedComputeRouterBgpPeerEnableIpv4(d.Get("enable_ipv4"), d, config)
 	if err != nil {
 		return err
@@ -757,7 +746,6 @@ func resourceComputeRouterBgpPeerUpdate(d *schema.ResourceData, meta interface{}
 	} else if v, ok := d.GetOkExists("peer_ipv4_nexthop_address"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, peerIpv4NexthopAddressProp)) {
 		obj["peerIpv4NexthopAddress"] = peerIpv4NexthopAddressProp
 	}
-<% end -%>
 	ipv6NexthopAddressProp, err := expandNestedComputeRouterBgpPeerIpv6NexthopAddress(d.Get("ipv6_nexthop_address"), d, config)
 	if err != nil {
 		return err
@@ -1131,7 +1119,6 @@ func flattenNestedComputeRouterBgpPeerEnableIpv6(v interface{}, d *schema.Resour
 	return v
 }
 
-<% unless version == 'ga' -%>
 func flattenNestedComputeRouterBgpPeerEnableIpv4(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	return v
 }
@@ -1143,7 +1130,6 @@ func flattenNestedComputeRouterBgpPeerIpv4NexthopAddress(v interface{}, d *schem
 func flattenNestedComputeRouterBgpPeerPeerIpv4NexthopAddress(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	return v
 }
-<% end -%>
 
 func flattenNestedComputeRouterBgpPeerIpv6NexthopAddress(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	return v
@@ -1332,7 +1318,6 @@ func expandNestedComputeRouterBgpPeerEnableIpv6(v interface{}, d tpgresource.Ter
 	return v, nil
 }
 
-<% unless version == 'ga' -%>
 func expandNestedComputeRouterBgpPeerEnableIpv4(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
 	return v, nil
 }
@@ -1344,7 +1329,6 @@ func expandNestedComputeRouterBgpPeerIpv4NexthopAddress(v interface{}, d tpgreso
 func expandNestedComputeRouterBgpPeerPeerIpv4NexthopAddress(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
 	return v, nil
 }
-<% end-%>
 
 func expandNestedComputeRouterBgpPeerIpv6NexthopAddress(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
 	return v, nil

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_test.go.erb
@@ -156,7 +156,6 @@ func TestAccComputeRouter_updateAddRemoveBGP(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccComputeRouter_addAndUpdateIdentifierRangeBgp(t *testing.T) {
 	t.Parallel()
 
@@ -189,7 +188,6 @@ func TestAccComputeRouter_addAndUpdateIdentifierRangeBgp(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func testAccComputeRouterBasic(routerName, resourceRegion string) string {
 	return fmt.Sprintf(`
@@ -288,17 +286,14 @@ resource "google_compute_router" "foobar" {
 `, routerName, routerName, resourceRegion, routerName)
 }
 
-<% unless version == 'ga' -%>
 func testAccComputeRouter_addIdentifierRangeBgp(routerName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
-  provider = google-beta
   name                    = "%s-net"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_router" "foobar" {
-  provider = google-beta
   name    = "%s"
   network = google_compute_network.foobar.name
   bgp {
@@ -321,13 +316,11 @@ resource "google_compute_router" "foobar" {
 func testAccComputeRouter_updateIdentifierRangeBgp(routerName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
-  provider = google-beta
   name                    = "%s-net"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_router" "foobar" {
-  provider = google-beta
   name    = "%s"
   network = google_compute_network.foobar.name
   bgp {
@@ -346,4 +339,3 @@ resource "google_compute_router" "foobar" {
 }
 `, routerName, routerName)
 }
-<% end -%>

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_test.go.erb
@@ -163,7 +163,7 @@ func TestAccComputeRouter_addAndUpdateIdentifierRangeBgp(t *testing.T) {
 	routerName := fmt.Sprintf("tf-test-router-%s", testId)
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeRouterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{

--- a/mmv1/third_party/terraform/website/docs/r/compute_router_interface.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_router_interface.html.markdown
@@ -40,7 +40,7 @@ In addition to the above required fields, a router interface must have specified
 * `ip_range` - (Optional) IP address and range of the interface. The IP range must be
     in the RFC3927 link-local IP space. Changing this forces a new interface to be created.
 
-* `ip_version` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+* `ip_version` - (Optional)
     IP version of this interface. Can be either IPV4 or IPV6.
 
 * `vpn_tunnel` - (Optional) The name or resource link to the VPN tunnel this

--- a/mmv1/third_party/terraform/website/docs/r/compute_router_peer.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_router_peer.html.markdown
@@ -302,7 +302,7 @@ The following arguments are supported:
   Enable IPv6 traffic over BGP Peer. If not specified, it is disabled by default.
 
 * `enable_ipv4` -
-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+  (Optional)
   Enable IPv4 traffic over BGP Peer. It is enabled by default if the peerIpAddress is version 4.
 
 * `ipv6_nexthop_address` -
@@ -313,7 +313,7 @@ The following arguments are supported:
   assigns unused addresses from the 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64 range for you.
 
 * `ipv4_nexthop_address` -
-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+  (Optional)
   IPv4 address of the interface inside Google Cloud Platform.
 
 * `peer_ipv6_nexthop_address` -
@@ -324,7 +324,7 @@ The following arguments are supported:
   assigns unused addresses from the 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64 range for you.
 
 * `peer_ipv4_nexthop_address` -
-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+  (Optional)
   IPv4 address of the BGP interface outside Google Cloud Platform.
 
 * `region` -


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Related to b/309454013. Promoting beta fields to GA.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note: enhancement 
compute: promoted `identifier_range` field in `google_compute_router` resource to GA
```

```release-note: enhancement 
compute: promoted `ip_version` field in `google_compute_router_interface` resource to GA
```

```release-note: enhancement 
compute: promoted `enable_ipv4`, `ipv4_nexthop_address` and `peer_ipv4_nexthop_address` fields in `google_compute_router_peer` resource to GA
```
