### PR TITLE
Added "match.expr.expression" field support for compute region security policy rule

### DIFF
--- a/mmv1/products/compute/RegionSecurityPolicyRule.yaml
+++ b/mmv1/products/compute/RegionSecurityPolicyRule.yaml
@@ -113,6 +113,16 @@ properties:
         values:
           - :SRC_IPS_V1
       - !ruby/object:Api::Type::NestedObject
+        name: 'expr'
+        description: |
+          User defined CEVAL expression. A CEVAL expression is used to specify match criteria such as origin.ip, source.region_code and contents in the request header.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'expression'
+            required: true
+            description: |
+              Textual representation of an expression in Common Expression Language syntax. The application context of the containing message determines which well-known feature set of CEL is supported.
+      - !ruby/object:Api::Type::NestedObject
         name: 'config'
         description: |
           The configuration options available when specifying versionedExpr.

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_security_policy_rule_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_security_policy_rule_test.go.erb
@@ -93,6 +93,63 @@ resource "google_compute_region_security_policy_rule" "policy_rule" {
 `, context)
 }
 
+func TestAccComputeRegionSecurityPolicyRule_withRuleExpr(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionSecurityPolicyRuleDestroyProducer(t),
+		Steps: []resource.TestStep{
+      {
+        Config: testAccComputeRegionSecurityPolicyRule_regionSecurityPolicyRulePreUpdate(context),
+      },
+      {
+        ResourceName:      "google_compute_region_security_policy_rule.policy_rule",
+        ImportState:       true,
+        ImportStateVerify: true,
+      },
+      {
+        Config: testAccComputeRegionSecurityPolicyRule_withRuleExpr(context),
+      },
+      {
+        ResourceName:      "google_compute_region_security_policy_rule.policy_rule",
+        ImportState:       true,
+        ImportStateVerify: true,
+      },
+    },
+  })
+}
+
+func testAccComputeRegionSecurityPolicyRule_withRuleExpr(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_region_security_policy" "default" {
+  region      = "us-west2"
+  name        = "tf-test%{random_suffix}"
+  description = "basic region security policy"
+  type        = "CLOUD_ARMOR"
+}
+
+resource "google_compute_region_security_policy_rule" "policy_rule" {
+  region          = "us-west2"
+  security_policy = google_compute_region_security_policy.default.name
+  description     = "basic rule post update withRuleExpr"
+  action          = "allow"
+  priority        = "100"
+  match {
+    expr {
+      expression = "evaluatePreconfiguredExpr('xss-canary')"
+    }
+  }
+  preview = true
+}
+`, context)
+}
+
 func TestAccComputeRegionSecurityPolicyRule_regionSecurityPolicyRuleNetworkMatchUpdate(t *testing.T) {
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds support for "match.expr.expression" field in "google_compute_region_security_policy_rule";

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/17429

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added 'match.expr.expression' field to 'google_compute_region_security_policy_rule' resource
```
