### PR TITLE
Gcf gen2 base image update

### DIFF
--- a/mmv1/products/cloudfunctions2/Function.yaml
+++ b/mmv1/products/cloudfunctions2/Function.yaml
@@ -51,6 +51,8 @@ import_format:
   ['projects/{{project}}/locations/{{location}}/functions/{{name}}']
 taint_resource_on_failed_create: true
 autogen_async: true
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  encoder: 'templates/terraform/encoders/cloudfunctions2_runtime_update_policy.go.erb'
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'cloudfunctions2_basic'
@@ -277,6 +279,48 @@ examples:
       unencoded-ar-repo: 'ar-repo'
       kms_key_name: 'cmek-key'
       project: 'my-project-name'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'cloudfunctions2_abiu'
+    primary_resource_id: 'function'
+    min_version: beta
+    vars:
+      bucket_name: 'gcf-source'
+      service_account: 'gcf-sa'
+      topic: 'functions2-topic'
+      function: 'gcf-function'
+      zip_path: 'function-source.zip'
+    test_env_vars:
+      project: :PROJECT_NAME
+    test_vars_overrides:
+      zip_path: '"./test-fixtures/function-source-pubsub.zip"'
+      primary_resource_id: '"terraform-test"'
+      location:
+        '"europe-west6"'
+        # ignore these fields during import step
+    ignore_read_extra:
+      - 'build_config.0.source.0.storage_source.0.object'
+      - 'build_config.0.source.0.storage_source.0.bucket'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'cloudfunctions2_abiu_on_deploy'
+    primary_resource_id: 'function'
+    min_version: beta
+    vars:
+      bucket_name: 'gcf-source'
+      service_account: 'gcf-sa'
+      topic: 'functions2-topic'
+      function: 'gcf-function'
+      zip_path: 'function-source.zip'
+    test_env_vars:
+      project: :PROJECT_NAME
+    test_vars_overrides:
+      zip_path: '"./test-fixtures/function-source-pubsub.zip"'
+      primary_resource_id: '"terraform-test"'
+      location:
+        '"europe-west6"'
+        # ignore these fields during import step
+    ignore_read_extra:
+      - 'build_config.0.source.0.storage_source.0.object'
+      - 'build_config.0.source.0.storage_source.0.bucket'
 iam_policy: !ruby/object:Api::Resource::IamPolicy
   parent_resource_attribute: 'cloud_function'
   method_name_separator: ':'
@@ -448,6 +492,33 @@ properties:
         name: 'serviceAccount'
         description: 'The fully-qualified name of the service account to be used for building the container.'
         default_from_api: true
+      - !ruby/object:Api::Type::NestedObject
+        name: 'automaticUpdatePolicy'
+        description: |
+          Security patches are applied automatically to the runtime without requiring
+          the function to be redeployed.
+        exactly_one_of:
+          - automatic_update_policy
+          - on_deploy_update_policy
+        send_empty_value: true
+        allow_empty_object: true
+        default_from_api: true
+        properties: []
+      - !ruby/object:Api::Type::NestedObject
+        name: 'onDeployUpdatePolicy'
+        description: |
+          Security patches are only applied when a function is redeployed.
+        exactly_one_of:
+          - automatic_update_policy
+          - on_deploy_update_policy
+        send_empty_value: true
+        allow_empty_object: true
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'runtimeVersion'
+            output: true
+            description: |
+              The runtime version which was used during latest function deployment.
   - !ruby/object:Api::Type::NestedObject
     name: 'serviceConfig'
     description: 'Describes the Service being deployed.'

--- a/mmv1/templates/terraform/encoders/cloudfunctions2_runtime_update_policy.go.erb
+++ b/mmv1/templates/terraform/encoders/cloudfunctions2_runtime_update_policy.go.erb
@@ -1,0 +1,15 @@
+if obj == nil || obj["buildConfig"] == nil {
+  return obj, nil
+}
+
+build_config := obj["buildConfig"].(map[string]interface{})
+
+// Automatic Update policy is the default from API, unset it if the data
+// contains the on-deploy policy.
+if build_config["onDeployUpdatePolicy"] != nil {
+  delete(build_config, "automaticUpdatePolicy")
+}
+
+obj["buildConfig"] = build_config
+
+return obj, nil

--- a/mmv1/templates/terraform/examples/cloudfunctions2_abiu.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudfunctions2_abiu.tf.erb
@@ -1,0 +1,72 @@
+locals {
+  project = "<%= ctx[:test_env_vars]['project'] %>" # Google Cloud Platform Project ID
+}
+
+resource "google_service_account" "account" {
+  provider = google-beta
+  account_id = "<%= ctx[:vars]['service_account'] %>"
+  display_name = "Test Service Account"
+}
+
+resource "google_pubsub_topic" "topic" {
+  provider = google-beta
+  name = "<%= ctx[:vars]['topic'] %>"
+}
+
+resource "google_storage_bucket" "bucket" {
+  provider = google-beta
+  name     = "${local.project}-<%= ctx[:vars]['bucket_name'] %>"  # Every bucket name must be globally unique
+  location = "US"
+  uniform_bucket_level_access = true
+}
+ 
+resource "google_storage_bucket_object" "object" {
+  provider = google-beta
+  name   = "function-source.zip"
+  bucket = google_storage_bucket.bucket.name
+  source = "<%= ctx[:vars]['zip_path'] %>"  # Add path to the zipped function source code
+}
+ 
+resource "google_cloudfunctions2_function" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+  name = "<%= ctx[:vars]['function'] %>"
+  location = "europe-west6"
+  description = "a new function"
+ 
+  build_config {
+    runtime = "nodejs16"
+    entry_point = "helloPubSub"  # Set the entry point 
+    environment_variables = {
+        BUILD_CONFIG_TEST = "build_test"
+    }
+    source {
+      storage_source {
+        bucket = google_storage_bucket.bucket.name
+        object = google_storage_bucket_object.object.name
+      }
+    }
+    automatic_update_policy {}
+  }
+ 
+  service_config {
+    max_instance_count  = 3
+    min_instance_count = 1
+    available_memory    = "4Gi"
+    timeout_seconds     = 60
+    max_instance_request_concurrency = 80
+    available_cpu = "4"
+    environment_variables = {
+        SERVICE_CONFIG_TEST = "config_test"
+    }
+    ingress_settings = "ALLOW_INTERNAL_ONLY"
+    all_traffic_on_latest_revision = true
+    service_account_email = google_service_account.account.email
+  }
+
+  event_trigger {
+    trigger_region = "us-central1"
+    event_type = "google.cloud.pubsub.topic.v1.messagePublished"
+    pubsub_topic = google_pubsub_topic.topic.id
+    retry_policy = "RETRY_POLICY_RETRY"
+  }
+}

--- a/mmv1/templates/terraform/examples/cloudfunctions2_abiu_on_deploy.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudfunctions2_abiu_on_deploy.tf.erb
@@ -1,0 +1,72 @@
+locals {
+  project = "<%= ctx[:test_env_vars]['project'] %>" # Google Cloud Platform Project ID
+}
+
+resource "google_service_account" "account" {
+  provider = google-beta
+  account_id = "<%= ctx[:vars]['service_account'] %>"
+  display_name = "Test Service Account"
+}
+
+resource "google_pubsub_topic" "topic" {
+  provider = google-beta
+  name = "<%= ctx[:vars]['topic'] %>"
+}
+
+resource "google_storage_bucket" "bucket" {
+  provider = google-beta
+  name     = "${local.project}-<%= ctx[:vars]['bucket_name'] %>"  # Every bucket name must be globally unique
+  location = "US"
+  uniform_bucket_level_access = true
+}
+ 
+resource "google_storage_bucket_object" "object" {
+  provider = google-beta
+  name   = "function-source.zip"
+  bucket = google_storage_bucket.bucket.name
+  source = "<%= ctx[:vars]['zip_path'] %>"  # Add path to the zipped function source code
+}
+ 
+resource "google_cloudfunctions2_function" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+  name = "<%= ctx[:vars]['function'] %>"
+  location = "europe-west6"
+  description = "a new function"
+ 
+  build_config {
+    runtime = "nodejs16"
+    entry_point = "helloPubSub"  # Set the entry point 
+    environment_variables = {
+        BUILD_CONFIG_TEST = "build_test"
+    }
+    source {
+      storage_source {
+        bucket = google_storage_bucket.bucket.name
+        object = google_storage_bucket_object.object.name
+      }
+    }
+    on_deploy_update_policy {}
+  }
+ 
+  service_config {
+    max_instance_count  = 3
+    min_instance_count = 1
+    available_memory    = "4Gi"
+    timeout_seconds     = 60
+    max_instance_request_concurrency = 80
+    available_cpu = "4"
+    environment_variables = {
+        SERVICE_CONFIG_TEST = "config_test"
+    }
+    ingress_settings = "ALLOW_INTERNAL_ONLY"
+    all_traffic_on_latest_revision = true
+    service_account_email = google_service_account.account.email
+  }
+
+  event_trigger {
+    trigger_region = "us-central1"
+    event_type = "google.cloud.pubsub.topic.v1.messagePublished"
+    pubsub_topic = google_pubsub_topic.topic.id
+    retry_policy = "RETRY_POLICY_RETRY"
+  }
+}

--- a/mmv1/third_party/terraform/services/cloudfunctions2/resource_cloudfunctions2_function_test.go
+++ b/mmv1/third_party/terraform/services/cloudfunctions2/resource_cloudfunctions2_function_test.go
@@ -125,6 +125,7 @@ resource "google_cloudfunctions2_function" "terraform-test2" {
         object = google_storage_bucket_object.object.name
       }
     }
+    on_deploy_update_policy {}
   }
 
   service_config {
@@ -318,4 +319,172 @@ resource "google_cloudfunctions2_function" "function" {
     }
   }
 }`, context)
+}
+
+func TestAccCloudFunctions2Function_updateAbiuFull(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"zip_path":      "./test-fixtures/function-source.zip",
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckCloudfunctions2functionDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudfunctions2function_abiuBasic(context),
+			},
+			{
+				ResourceName:            "google_cloudfunctions2_function.terraform-test2",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "build_config.0.source.0.storage_source.0.object", "build_config.0.source.0.storage_source.0.bucket", "labels", "terraform_labels"},
+			},
+			{
+				Config: testAccCloudFunctions2Function_test_abiuUpdate(context),
+			},
+			{
+				ResourceName:            "google_cloudfunctions2_function.terraform-test2",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "build_config.0.source.0.storage_source.0.object", "build_config.0.source.0.storage_source.0.bucket", "labels", "terraform_labels"},
+			},
+			{
+				Config: testAccCloudFunctions2Function_test_abiuUpdate2(context),
+			},
+			{
+				ResourceName:            "google_cloudfunctions2_function.terraform-test2",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "build_config.0.source.0.storage_source.0.object", "build_config.0.source.0.storage_source.0.bucket", "labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccCloudfunctions2function_abiuBasic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_storage_bucket" "bucket" {
+  name     = "tf-test-cloudfunctions2-function-bucket%{random_suffix}"
+  location = "US"
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket_object" "object" {
+  name   = "function-source.zip"
+  bucket = google_storage_bucket.bucket.name
+  source = "%{zip_path}"
+}
+
+resource "google_cloudfunctions2_function" "terraform-test2" {
+  name = "tf-test-test-function%{random_suffix}"
+  location = "us-central1"
+  description = "a new function"
+  labels = {
+    env = "test"
+  }
+
+  build_config {
+    runtime = "nodejs12"
+    entry_point = "helloHttp"
+    source {
+      storage_source {
+        bucket = google_storage_bucket.bucket.name
+        object = google_storage_bucket_object.object.name
+      }
+    }
+    automatic_update_policy {}
+  }
+
+  service_config {
+    max_instance_count  = 1
+    available_memory    = "1536Mi"
+    timeout_seconds     = 30
+  }
+}
+`, context)
+}
+
+func testAccCloudFunctions2Function_test_abiuUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_storage_bucket" "bucket" {
+  name     = "tf-test-cloudfunctions2-function-bucket%{random_suffix}"
+  location = "US"
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket_object" "object" {
+  name   = "function-source.zip"
+  bucket = google_storage_bucket.bucket.name
+  source = "%{zip_path}"
+}
+
+resource "google_cloudfunctions2_function" "terraform-test2" {
+  name = "tf-test-test-function%{random_suffix}"
+  location = "us-central1"
+  description = "an updated function with automatic runtime update specified"
+  labels = {
+    env = "test-update"
+  }
+
+  build_config {
+    runtime = "nodejs12"
+    entry_point = "helloHttp"
+    source {
+      storage_source {
+        bucket = google_storage_bucket.bucket.name
+        object = google_storage_bucket_object.object.name
+      }
+    }
+    on_deploy_update_policy {}
+  }
+
+  service_config {
+    min_instance_count = 1
+  }
+}
+`, context)
+}
+
+func testAccCloudFunctions2Function_test_abiuUpdate2(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_storage_bucket" "bucket" {
+  name     = "tf-test-cloudfunctions2-function-bucket%{random_suffix}"
+  location = "US"
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket_object" "object" {
+  name   = "function-source.zip"
+  bucket = google_storage_bucket.bucket.name
+  source = "%{zip_path}"
+}
+
+resource "google_cloudfunctions2_function" "terraform-test2" {
+  name = "tf-test-test-function%{random_suffix}"
+  location = "us-central1"
+  description = "an updated function with no runtime update specified"
+  labels = {
+    env = "test-update"
+  }
+  
+  build_config {
+    runtime = "nodejs12"
+    entry_point = "helloHttp"
+    source {
+      storage_source {
+        bucket = google_storage_bucket.bucket.name
+        object = google_storage_bucket_object.object.name
+      }
+    }
+  }
+
+  service_config {
+    min_instance_count = 1
+  }
+}
+`, context)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add new fields to the cloudfunctions2 resource to support automatic base image updates. (b/330553378)

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudfunctions2: added `build_config.automatic_update_policy` and `build_config.on_deploy_update_policy` to `google_cloudfunctions2_function` resource
```
