### PR TITLE
Remove min_master_version from stack type tests

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -2682,7 +2682,7 @@ func TestAccContainerCluster_stackType_withDualStack(t *testing.T) {
 				ResourceName:		 resourceName,
 				ImportState:		 true,
 				ImportStateVerify:	 true,
-				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
 	})
@@ -2710,7 +2710,7 @@ func TestAccContainerCluster_stackType_withSingleStack(t *testing.T) {
 				ResourceName:		 resourceName,
 				ImportState:		 true,
 				ImportStateVerify:	 true,
-				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
 	})
@@ -7921,7 +7921,6 @@ resource "google_container_cluster" "with_stack_type" {
     network    = google_compute_network.container_network.name
     subnetwork = google_compute_subnetwork.container_subnetwork.name
 
-    min_master_version = "1.25"
     initial_node_count = 1
     datapath_provider = "ADVANCED_DATAPATH"
     enable_l4_ilb_subsetting = true
@@ -7957,7 +7956,6 @@ resource "google_container_cluster" "with_stack_type" {
     network    = google_compute_network.container_network.name
     subnetwork = google_compute_subnetwork.container_subnetwork.name
 
-    min_master_version = "1.25"
     initial_node_count = 1
     enable_l4_ilb_subsetting = true
 


### PR DESCRIPTION
"Stack type" supported minimum master version of 1.25. Now that the minimum master versions no longer include 1.25, we do not need to specify the version for stack type tests. All current versions are supported.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/17982

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
