### PR TITLE
Introduce endpoint global access field in endpoint attachment resource

### DIFF
--- a/mmv1/products/integrationconnectors/EndpointAttachment.yaml
+++ b/mmv1/products/integrationconnectors/EndpointAttachment.yaml
@@ -105,3 +105,7 @@ properties:
     description: |
       The Private Service Connect connection endpoint ip.
     output: true
+  - !ruby/object:Api::Type::boolean
+    name: "endpointGlobalAccess"
+    description: |
+      Enable global access for endpoint attachment.

--- a/mmv1/products/integrationconnectors/EndpointAttachment.yaml
+++ b/mmv1/products/integrationconnectors/EndpointAttachment.yaml
@@ -105,7 +105,7 @@ properties:
     description: |
       The Private Service Connect connection endpoint ip.
     output: true
-  - !ruby/object:Api::Type::boolean
+  - !ruby/object:Api::Type::Boolean
     name: "endpointGlobalAccess"
     description: |
       Enable global access for endpoint attachment.

--- a/mmv1/templates/terraform/examples/integration_connectors_endpoint_attachment.tf.erb
+++ b/mmv1/templates/terraform/examples/integration_connectors_endpoint_attachment.tf.erb
@@ -6,4 +6,5 @@ resource "google_integration_connectors_endpoint_attachment" "<%= ctx[:primary_r
   labels = {
     foo = "bar"
   }
+  endpoint_global_access = false
 }

--- a/mmv1/templates/terraform/examples/integration_connectors_endpoint_attachment.tf.erb
+++ b/mmv1/templates/terraform/examples/integration_connectors_endpoint_attachment.tf.erb
@@ -6,5 +6,4 @@ resource "google_integration_connectors_endpoint_attachment" "<%= ctx[:primary_r
   labels = {
     foo = "bar"
   }
-  endpoint_global_access = false
 }

--- a/mmv1/third_party/terraform/services/integrationconnectors/resource_integration_connectors_endpoint_attachment_test.go
+++ b/mmv1/third_party/terraform/services/integrationconnectors/resource_integration_connectors_endpoint_attachment_test.go
@@ -56,6 +56,7 @@ resource "google_integration_connectors_endpoint_attachment" "sampleendpointatta
   labels = {
     foo = "bar"
   }
+  endpoint_global_access = false
 }
 `, context)
 }
@@ -74,6 +75,7 @@ resource "google_integration_connectors_endpoint_attachment" "sampleendpointatta
   labels = {
     bar = "foo"
   }
+  endpoint_global_access = false
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/integrationconnectors/resource_integration_connectors_endpoint_attachment_test.go
+++ b/mmv1/third_party/terraform/services/integrationconnectors/resource_integration_connectors_endpoint_attachment_test.go
@@ -75,7 +75,7 @@ resource "google_integration_connectors_endpoint_attachment" "sampleendpointatta
   labels = {
     bar = "foo"
   }
-  endpoint_global_access = false
+  endpoint_global_access = true
 }
 `, context)
 }


### PR DESCRIPTION
Adding support for endpoint global access field Endpoint Attachment resource of Integration connectors.

Release Note Template for Downstream PRs (will be copied)

`google_integration_connectors_endpoint_attachment`

```release-note:enhancement
integrationconnectors: added `endpoint_global_access` field to `google_integration_connectors_endpoint_attachment` resource
```
Fixes hashicorp/terraform-provider-google#18030