### PR TITLE
fix issue 18002

### DIFF
--- a/mmv1/products/compute/RegionSecurityPolicyRule.yaml
+++ b/mmv1/products/compute/RegionSecurityPolicyRule.yaml
@@ -213,3 +213,22 @@ properties:
         description: |
           BGP Autonomous System Number associated with the source IP address.
         item_type: Api::Type::Integer
+  - !ruby/object:Api::Type::NestedObject
+    name: 'rateLimitOptions'
+    description: |
+      Must be specified if the action is "rate_based_ban" or "throttle".
+      Cannot be specified for any other actions.
+    properties:
+     - !ruby/object:Api::Type::NestedObject
+      name: 'rateLimitThreshold'
+      description: |
+        Threshold at which to begin ratelimiting.
+      properties:
+       - !ruby/object:Api::Type::Integer
+        name: 'count'
+        description: |
+          Number of HTTP(S) requests for calculating the threshold.
+       - !ruby/object:Api::Type::Integer
+        name: 'intervalSec'
+        description: |
+          Interval over which the threshold is computed.

--- a/mmv1/products/compute/SecurityPolicyRule.yaml
+++ b/mmv1/products/compute/SecurityPolicyRule.yaml
@@ -287,3 +287,22 @@ properties:
     name: 'preview'
     description: |
       If set to true, the specified action is not enforced.
+  - !ruby/object:Api::Type::NestedObject
+    name: 'rateLimitOptions'
+    description: |
+      Must be specified if the action is "rate_based_ban" or "throttle".
+      Cannot be specified for any other actions.
+    properties:
+     - !ruby/object:Api::Type::NestedObject
+      name: 'rateLimitThreshold'
+      description: |
+        Threshold at which to begin ratelimiting.
+      properties:
+       - !ruby/object:Api::Type::Integer
+        name: 'count'
+        description: |
+          Number of HTTP(S) requests for calculating the threshold.
+       - !ruby/object:Api::Type::Integer
+        name: 'intervalSec'
+        description: |
+          Interval over which the threshold is computed.


### PR DESCRIPTION
Adding rate_limit_options to google_compute_security_policy_rule as a supported field 

Fixing issue https://github.com/hashicorp/terraform-provider-google/issues/18033

```
release-note:enhancement
release-note:bug
Compute Security policy rule : added `rate_limit_options`  `google_compute_security_policy_rule` resource
```
