### PR TITLE
Add external_providers to replace pull_external in example object

### DIFF
--- a/mmv1/api/resource/examples.go
+++ b/mmv1/api/resource/examples.go
@@ -153,15 +153,20 @@ type Examples struct {
 	// Or a config with two fine grained resources that have a race condition during create
 	SkipVcr bool `yaml:"skip_vcr"`
 
+	// (DEPRECATED) Use ExternalProviders instead
 	// Set for false by default. Set to true if you need to pull external provider for your
 	// testcase. Think before adding as there is latency and adds an external dependency to
 	// your test so avoid if you can.
 	PullExternal bool `yaml:"pull_external"`
 
+	// Specify which external providers are needed
+	ExternalProviders []string `yaml:"external_providers"`
+
 	DocumentationHCLText string
 	TestHCLText          string
 }
 
+// Set default value for fields
 func (e *Examples) UnmarshalYAML(n *yaml.Node) error {
 	type exampleAlias Examples
 	aliasObj := (*exampleAlias)(e)

--- a/mmv1/products/apphub/Service.yaml
+++ b/mmv1/products/apphub/Service.yaml
@@ -25,7 +25,7 @@ autogen_async: true
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: "apphub_service_basic"
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: "example"
     vars:
       application_id: "example-application-1"
@@ -40,7 +40,7 @@ examples:
       billing_account: :BILLING_ACCT
   - !ruby/object:Provider::Terraform::Examples
     name: "apphub_service_full"
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: "example"
     vars:
       application_id: "example-application-1"

--- a/mmv1/products/apphub/ServiceProjectAttachment.yaml
+++ b/mmv1/products/apphub/ServiceProjectAttachment.yaml
@@ -29,7 +29,7 @@ custom_code: !ruby/object:Provider::Terraform::CustomCode
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: "service_project_attachment_basic"
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: "example"
     config_path: "templates/terraform/examples/apphub_service_project_attachment_basic.tf.erb"
     vars:
@@ -39,7 +39,7 @@ examples:
       host_project: :PROJECT_NAME
   - !ruby/object:Provider::Terraform::Examples
     name: "service_project_attachment_full"
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: "example2"
     config_path: "templates/terraform/examples/apphub_service_project_attachment_full.tf.erb"
     vars:

--- a/mmv1/products/apphub/Workload.yaml
+++ b/mmv1/products/apphub/Workload.yaml
@@ -25,7 +25,7 @@ autogen_async: true
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: "apphub_workload_basic"
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: "example"
     vars:
       application_id: "example-application-1"
@@ -39,7 +39,7 @@ examples:
       billing_account: :BILLING_ACCT
   - !ruby/object:Provider::Terraform::Examples
     name: "apphub_workload_full"
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: "example"
     vars:
       application_id: "example-application-1"

--- a/mmv1/products/bigqueryconnection/Connection.yaml
+++ b/mmv1/products/bigqueryconnection/Connection.yaml
@@ -46,7 +46,7 @@ custom_code: !ruby/object:Provider::Terraform::CustomCode
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'bigquery_connection_cloud_resource'
-    pull_external: true
+    external_providers: ["random", "time"]
     region_override: 'US'
     primary_resource_id: 'connection'
     primary_resource_name: "fmt.Sprintf(\"tf-test-my-connection%s\",
@@ -56,7 +56,7 @@ examples:
       connection_id: 'my-connection'
   - !ruby/object:Provider::Terraform::Examples
     name: 'bigquery_connection_basic'
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id:
       'connection'
       # Random provider
@@ -73,7 +73,7 @@ examples:
       - 'cloud_sql.0.credential'  # password removed
   - !ruby/object:Provider::Terraform::Examples
     name: 'bigquery_connection_full'
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id:
       'connection'
       # Random provider
@@ -91,14 +91,14 @@ examples:
       - 'cloud_sql.0.credential'  # password removed
   - !ruby/object:Provider::Terraform::Examples
     name: 'bigquery_connection_aws'
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: 'connection'
     vars:
       connection_id: 'my-connection'
       iam_role_id: 'arn:aws:iam::999999999999:role/omnirole'
   - !ruby/object:Provider::Terraform::Examples
     name: 'bigquery_connection_azure'
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: 'connection'
     vars:
       connection_id: 'my-connection'
@@ -106,7 +106,7 @@ examples:
       federated_application_client_id: 'b43eeeee-eeee-eeee-eeee-a480155501ce'
   - !ruby/object:Provider::Terraform::Examples
     name: 'bigquery_connection_cloudspanner'
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: 'connection'
     vars:
       connection_id: 'my-connection'
@@ -114,7 +114,7 @@ examples:
       database_role: 'database_role'
   - !ruby/object:Provider::Terraform::Examples
     name: 'bigquery_connection_cloudspanner_databoost'
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: 'connection'
     vars:
       connection_id: 'my-connection'

--- a/mmv1/products/bigqueryreservation/BiReservation.yaml
+++ b/mmv1/products/bigqueryreservation/BiReservation.yaml
@@ -35,11 +35,11 @@ custom_code: !ruby/object:Provider::Terraform::CustomCode
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'bigquery_reservation_bi_reservation_basic'
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: 'reservation'
   - !ruby/object:Provider::Terraform::Examples
     name: 'bigquery_reservation_bi_reservation_full'
-    pull_external: true
+    external_providers: ["random", "time"]
     skip_docs: true
     primary_resource_id: 'reservation'
     test_env_vars:

--- a/mmv1/products/bigqueryreservation/CapacityCommitment.yaml
+++ b/mmv1/products/bigqueryreservation/CapacityCommitment.yaml
@@ -37,12 +37,12 @@ custom_code: !ruby/object:Provider::Terraform::CustomCode
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'bigquery_reservation_capacity_commitment_basic'
-    pull_external: true
+    external_providers: ["random", "time"]
     skip_docs: true
     primary_resource_id: 'commitment'
   - !ruby/object:Provider::Terraform::Examples
     name: 'bigquery_reservation_capacity_commitment_no_id'
-    pull_external: true
+    external_providers: ["random", "time"]
     skip_docs: true
     primary_resource_id: 'commitment'
   - !ruby/object:Provider::Terraform::Examples

--- a/mmv1/products/cloudfunctions2/Function.yaml
+++ b/mmv1/products/cloudfunctions2/Function.yaml
@@ -177,7 +177,7 @@ examples:
     ignore_read_extra:
       - 'build_config.0.source.0.storage_source.0.object'
       - 'build_config.0.source.0.storage_source.0.bucket'
-    pull_external: true
+    external_providers: ["random", "time"]
   - !ruby/object:Provider::Terraform::Examples
     name: 'cloudfunctions2_secret_env'
     primary_resource_id: 'function'

--- a/mmv1/products/compute/BackendBucketSignedUrlKey.yaml
+++ b/mmv1/products/compute/BackendBucketSignedUrlKey.yaml
@@ -58,7 +58,7 @@ mutex: signedUrlKey/{{project}}/backendBuckets/{{backend_bucket}}/
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'backend_bucket_signed_url_key'
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: 'backend_key'
     vars:
       key_name: 'test-key'

--- a/mmv1/products/compute/BackendServiceSignedUrlKey.yaml
+++ b/mmv1/products/compute/BackendServiceSignedUrlKey.yaml
@@ -58,7 +58,7 @@ mutex: signedUrlKey/{{project}}/backendServices/{{backend_service}}/
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'backend_service_signed_url_key'
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: 'backend_key'
     vars:
       key_name: 'test-key'

--- a/mmv1/products/compute/ManagedSslCertificate.yaml
+++ b/mmv1/products/compute/ManagedSslCertificate.yaml
@@ -89,8 +89,7 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'managed_ssl_certificate_recreation'
     primary_resource_id: 'cert'
-    pull_external:
-      true
+    external_providers: ["random", "time"]
       # Random provider
     skip_vcr: true
 properties:

--- a/mmv1/products/compute/RegionSslCertificate.yaml
+++ b/mmv1/products/compute/RegionSslCertificate.yaml
@@ -59,7 +59,7 @@ examples:
       - 'name_prefix'
   - !ruby/object:Provider::Terraform::Examples
     name: 'region_ssl_certificate_random_provider'
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id:
       'default'
       # Uses resource.UniqueId

--- a/mmv1/products/compute/SslCertificate.yaml
+++ b/mmv1/products/compute/SslCertificate.yaml
@@ -59,7 +59,7 @@ examples:
       - 'name_prefix'
   - !ruby/object:Provider::Terraform::Examples
     name: 'ssl_certificate_random_provider'
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id:
       'default'
       # Uses resource.UniqueId

--- a/mmv1/products/datafusion/go_instance.yaml
+++ b/mmv1/products/datafusion/go_instance.yaml
@@ -59,6 +59,7 @@ examples:
       prober_test_run: ''
     test_vars_overrides:
       'prober_test_run': '`options = { prober_test_run = "true" }`'
+    external_providers: ["random", "time"]
   - name: 'data_fusion_instance_full'
     primary_resource_id: 'extended_instance'
     primary_resource_name: 'extended_instance'

--- a/mmv1/products/datastream/ConnectionProfile.yaml
+++ b/mmv1/products/datastream/ConnectionProfile.yaml
@@ -37,7 +37,7 @@ examples:
       connection_profile_id: 'my-profile'
   - !ruby/object:Provider::Terraform::Examples
     name: 'datastream_connection_profile_postgresql_private_connection'
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: 'default'
     # Random provider
     skip_vcr: true

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -50,7 +50,7 @@ custom_diff: [
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'datastream_stream_basic'
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: 'default'
     skip_docs:
       true
@@ -71,7 +71,7 @@ examples:
       deletion_protection: 'false'
   - !ruby/object:Provider::Terraform::Examples
     name: 'datastream_stream_full'
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id:
       'default'
       # Random provider
@@ -117,12 +117,12 @@ examples:
       instance_name: 'instance-name'
       sql_user_name: 'my-user'
       source_connection_profile_id: 'source-profile'
-    pull_external: true
+    external_providers: ["random", "time"]
     # Random provider
     skip_vcr: true
   - !ruby/object:Provider::Terraform::Examples
     name: 'datastream_stream_bigquery'
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id:
       'default'
       # Random provider

--- a/mmv1/products/dns/ManagedZone.yaml
+++ b/mmv1/products/dns/ManagedZone.yaml
@@ -61,8 +61,7 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'dns_managed_zone_basic'
     primary_resource_id: 'example-zone'
-    pull_external:
-      true
+    external_providers: ["random", "time"]
       # Randomness from random provider
     skip_vcr: true
   - !ruby/object:Provider::Terraform::Examples

--- a/mmv1/products/firebaseappcheck/AppAttestConfig.yaml
+++ b/mmv1/products/firebaseappcheck/AppAttestConfig.yaml
@@ -39,7 +39,7 @@ examples:
     name: "firebase_app_check_app_attest_config_minimal"
     min_version: 'beta'
     # Need the time_sleep resource
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: "default"
     vars:
       team_id: "9987654321"
@@ -53,7 +53,7 @@ examples:
     name: "firebase_app_check_app_attest_config_full"
     min_version: 'beta'
     # Need the time_sleep resource
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: "default"
     vars:
       team_id: "9987654321"

--- a/mmv1/products/firebaseappcheck/DebugToken.yaml
+++ b/mmv1/products/firebaseappcheck/DebugToken.yaml
@@ -40,7 +40,7 @@ examples:
     name: "firebase_app_check_debug_token_basic"
     min_version: 'beta'
     # Need the time_sleep resource
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: "default"
     vars:
       display_name: "Debug Token"

--- a/mmv1/products/firebaseappcheck/DeviceCheckConfig.yaml
+++ b/mmv1/products/firebaseappcheck/DeviceCheckConfig.yaml
@@ -39,7 +39,7 @@ examples:
     name: "firebase_app_check_device_check_config_full"
     min_version: 'beta'
     # Need the time_sleep resource
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: "default"
     vars:
       bundle_id: "bundle.id.devicecheck"

--- a/mmv1/products/firebaseappcheck/PlayIntegrityConfig.yaml
+++ b/mmv1/products/firebaseappcheck/PlayIntegrityConfig.yaml
@@ -39,7 +39,7 @@ examples:
     name: "firebase_app_check_play_integrity_config_minimal"
     min_version: 'beta'
     # Need the time_sleep resource
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: "default"
     vars:
       package_name: "package.name.playintegrity"
@@ -49,7 +49,7 @@ examples:
     name: "firebase_app_check_play_integrity_config_full"
     min_version: 'beta'
     # Need the time_sleep resource
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: "default"
     vars:
       package_name: "package.name.playintegrity"

--- a/mmv1/products/firebaseappcheck/RecaptchaEnterpriseConfig.yaml
+++ b/mmv1/products/firebaseappcheck/RecaptchaEnterpriseConfig.yaml
@@ -38,7 +38,7 @@ examples:
     name: "firebase_app_check_recaptcha_enterprise_config_basic"
     min_version: 'beta'
     # Need the time_sleep resource
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: "default"
     vars:
       token_ttl: "7200s"

--- a/mmv1/products/firebaseappcheck/RecaptchaV3Config.yaml
+++ b/mmv1/products/firebaseappcheck/RecaptchaV3Config.yaml
@@ -38,7 +38,7 @@ examples:
     name: "firebase_app_check_recaptcha_v3_config_basic"
     min_version: 'beta'
     # Need the time_sleep resource
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: "default"
     vars:
       token_ttl: "7200s"

--- a/mmv1/products/firestore/Document.yaml
+++ b/mmv1/products/firestore/Document.yaml
@@ -45,7 +45,7 @@ examples:
     vars:
       document_id: 'my-doc-id'
       project_id: 'project-id'
-    pull_external: true
+    external_providers: ["random", "time"]
   - !ruby/object:Provider::Terraform::Examples
     name: 'firestore_document_nested_document'
     primary_resource_id: 'mydoc'
@@ -54,7 +54,7 @@ examples:
     vars:
       document_id: 'my-doc-id'
       project_id: 'project-id'
-    pull_external: true
+    external_providers: ["random", "time"]
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/firestore_document.go.erb
   decoder: templates/terraform/decoders/firestore_document.go.erb

--- a/mmv1/products/firestore/Index.yaml
+++ b/mmv1/products/firestore/Index.yaml
@@ -63,7 +63,7 @@ examples:
       database_id: "database-id"
     test_env_vars:
       project_id: :PROJECT_NAME
-    pull_external: true
+    external_providers: ["random", "time"]
   - !ruby/object:Provider::Terraform::Examples
     name: 'firestore_index_datastore_mode'
     primary_resource_id:

--- a/mmv1/products/iap/Tunnel.yaml
+++ b/mmv1/products/iap/Tunnel.yaml
@@ -32,7 +32,7 @@ import_format: ['projects/{{project}}/iap_tunnel']
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'iap_project'
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: 'project_service'
     primary_resource_name: 'fmt.Sprintf("tf-test%s", context["random_suffix"])'
     test_env_vars:

--- a/mmv1/products/iap/TunnelDestGroup.yaml
+++ b/mmv1/products/iap/TunnelDestGroup.yaml
@@ -43,7 +43,7 @@ iam_policy: !ruby/object:Api::Resource::IamPolicy
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'iap_destgroup'
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: 'dest_group'
     primary_resource_name: 'fmt.Sprintf("tf-test%s", context["random_suffix"])'
 parameters:

--- a/mmv1/products/iap/Web.yaml
+++ b/mmv1/products/iap/Web.yaml
@@ -32,7 +32,7 @@ iam_policy: !ruby/object:Api::Resource::IamPolicy
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'iap_project'
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: 'project_service'
     primary_resource_name: 'fmt.Sprintf("tf-test%s", context["random_suffix"])'
     test_env_vars:

--- a/mmv1/products/iap/WebTypeAppEngine.yaml
+++ b/mmv1/products/iap/WebTypeAppEngine.yaml
@@ -35,7 +35,7 @@ import_format: ['projects/{{project}}/iap_web/appengine-{{appId}}']
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'iap_appengine'
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: 'app'
     primary_resource_name: 'context["project_id"]'
     test_env_vars:

--- a/mmv1/products/iap/WebTypeCompute.yaml
+++ b/mmv1/products/iap/WebTypeCompute.yaml
@@ -33,7 +33,7 @@ import_format: ['projects/{{project}}/iap_web/compute']
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'iap_project'
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: 'project_service'
     primary_resource_name: 'fmt.Sprintf("tf-test%s", context["random_suffix"])'
     test_env_vars:

--- a/mmv1/products/securesourcemanager/Instance.yaml
+++ b/mmv1/products/securesourcemanager/Instance.yaml
@@ -76,7 +76,7 @@ examples:
       key_name: 'my-key'
   - !ruby/object:Provider::Terraform::Examples
     name: 'secure_source_manager_instance_private'
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: 'default'
     primary_resource_name: "fmt.Sprintf(\"tf-test-my-instance%s\",
       context[\"random_suffix\"\

--- a/mmv1/products/securitycenter/FolderCustomModule.yaml
+++ b/mmv1/products/securitycenter/FolderCustomModule.yaml
@@ -32,7 +32,7 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: "scc_folder_custom_module_basic"
     primary_resource_id: "example"
-    pull_external: true
+    external_providers: ["random", "time"]
     skip_test: true
     vars:
       folder_display_name: "folder-name"
@@ -45,7 +45,7 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: "scc_folder_custom_module_full"
     primary_resource_id: "example"
-    pull_external: true
+    external_providers: ["random", "time"]
     skip_test: true
     vars:
       folder_display_name: "folder-name"

--- a/mmv1/products/tpuv2/Vm.yaml
+++ b/mmv1/products/tpuv2/Vm.yaml
@@ -59,7 +59,7 @@ examples:
     name: 'tpu_v2_vm_full'
     min_version: 'beta'
     primary_resource_id: 'tpu'
-    pull_external: true
+    external_providers: ["random", "time"]
     vars:
       vm_name: 'test-tpu'
       network_name: 'tpu-net'

--- a/mmv1/products/vmwareengine/Network.yaml
+++ b/mmv1/products/vmwareengine/Network.yaml
@@ -49,7 +49,7 @@ examples:
     primary_resource_id: "vmw-engine-network"
   - !ruby/object:Provider::Terraform::Examples
     name: "vmware_engine_network_legacy"
-    pull_external: true
+    external_providers: ["random", "time"]
     primary_resource_id: "vmw-engine-network"
     skip_test: true   # update tests will take care of create and update. Legacy network needs to be created on an isolated project.
     vars:

--- a/mmv1/provider/terraform/examples.rb
+++ b/mmv1/provider/terraform/examples.rb
@@ -143,10 +143,21 @@ module Provider
       # Or a config with two fine grained resources that have a race condition during create
       attr_reader :skip_vcr
 
+      # (DEPRECATED) Use external_providers instead
       # Set for false by default. Set to true if you need to pull external provider for your
       # testcase. Think before adding as there is latency and adds an external dependency to
       # your test so avoid if you can.
       attr_reader :pull_external
+
+      # Specify which external providers are needed
+      attr_reader :external_providers
+
+      # Official providers supported by HashiCorp
+      # https://registry.terraform.io/search/providers?namespace=hashicorp&tier=official
+      HASHICORP_PROVIDERS = %w[aws random null template azurerm kubernetes local external time vault
+                               archive tls helm azuread http cloudinit tfe dns consul vsphere
+                               nomad awscc googleworkspace hcp boundary ad azurestack opc oraclepaas
+                               hcs salesforce].freeze
 
       def config_documentation(pwd)
         docs_defaults = {
@@ -311,6 +322,8 @@ module Provider
         check :config_path, type: String, default: "templates/terraform/examples/#{name}.tf.erb"
         check :skip_vcr, type: TrueClass
         check :pull_external, type: :boolean, default: false
+
+        validate_external_providers
       end
 
       def merge(other)
@@ -329,6 +342,22 @@ module Provider
         end
 
         result
+      end
+
+      def validate_external_providers
+        check :external_providers, type: Array, item_type: String
+
+        return if external_providers.nil?
+
+        unallowed_providers = []
+        @external_providers.each do |p|
+          unallowed_providers.append(p) unless HASHICORP_PROVIDERS.include?(p)
+        end
+
+        return if unallowed_providers.empty?
+
+        raise "Providers #{unallowed_providers} are not allowed." \
+              'Only providers published by HashiCorp are allowed.'
       end
     end
   end

--- a/mmv1/templates/terraform/examples/base_configs/iam_test_file.go.erb
+++ b/mmv1/templates/terraform/examples/base_configs/iam_test_file.go.erb
@@ -76,7 +76,13 @@ func TestAcc<%= resource_name -%>IamBindingGenerated(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 <% else -%>
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		<% if example.pull_external -%>
+		<% if !example.external_providers.nil? && !example.external_providers.empty? -%>
+		ExternalProviders: map[string]resource.ExternalProvider{
+		<% example.external_providers.each do |provider| -%>
+			"<%= provider %>": {},
+		<% end -%>
+		},
+		<% elsif example.pull_external -%>
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"random": {},
 			"time": {},
@@ -123,7 +129,13 @@ func TestAcc<%= resource_name -%>IamMemberGenerated(t *testing.T) {
 <% else -%>
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 <% end -%>
-		<% if example.pull_external -%>
+		<% if !example.external_providers.nil? && !example.external_providers.empty? -%>
+		ExternalProviders: map[string]resource.ExternalProvider{
+		<% example.external_providers.each do |provider| -%>
+			"<%= provider %>": {},
+		<% end -%>
+		},
+		<% elsif example.pull_external -%>
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"random": {},
 			"time": {},
@@ -165,7 +177,13 @@ func TestAcc<%= resource_name -%>IamPolicyGenerated(t *testing.T) {
 <% else -%>
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 <% end -%>
-		<% if example.pull_external -%>
+		<% if !example.external_providers.nil? && !example.external_providers.empty? -%>
+		ExternalProviders: map[string]resource.ExternalProvider{
+		<% example.external_providers.each do |provider| -%>
+			"<%= provider %>": {},
+		<% end -%>
+		},
+		<% elsif example.pull_external -%>
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"random": {},
 			"time": {},
@@ -212,7 +230,13 @@ func TestAcc<%= resource_name -%>IamBindingGenerated_withCondition(t *testing.T)
 <% else -%>
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 <% end -%>
-		<% if example.pull_external -%>
+		<% if !example.external_providers.nil? && !example.external_providers.empty? -%>
+		ExternalProviders: map[string]resource.ExternalProvider{
+		<% example.external_providers.each do |provider| -%>
+			"<%= provider %>": {},
+		<% end -%>
+		},
+		<% elsif example.pull_external -%>
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"random": {},
 			"time": {},
@@ -248,7 +272,13 @@ func TestAcc<%= resource_name -%>IamBindingGenerated_withAndWithoutCondition(t *
 <% else -%>
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 <% end -%>
-		<% if example.pull_external -%>
+		<% if !example.external_providers.nil? && !example.external_providers.empty? -%>
+		ExternalProviders: map[string]resource.ExternalProvider{
+		<% example.external_providers.each do |provider| -%>
+			"<%= provider %>": {},
+		<% end -%>
+		},
+		<% elsif example.pull_external -%>
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"random": {},
 			"time": {},
@@ -294,7 +324,13 @@ func TestAcc<%= resource_name -%>IamMemberGenerated_withCondition(t *testing.T) 
 <% else -%>
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 <% end -%>
-		<% if example.pull_external -%>
+		<% if !example.external_providers.nil? && !example.external_providers.empty? -%>
+		ExternalProviders: map[string]resource.ExternalProvider{
+		<% example.external_providers.each do |provider| -%>
+			"<%= provider %>": {},
+		<% end -%>
+		},
+		<% elsif example.pull_external -%>
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"random": {},
 			"time": {},
@@ -330,7 +366,13 @@ func TestAcc<%= resource_name -%>IamMemberGenerated_withAndWithoutCondition(t *t
 <% else -%>
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 <% end -%>
-		<% if example.pull_external -%>
+		<% if !example.external_providers.nil? && !example.external_providers.empty? -%>
+		ExternalProviders: map[string]resource.ExternalProvider{
+		<% example.external_providers.each do |provider| -%>
+			"<%= provider %>": {},
+		<% end -%>
+		},
+		<% elsif example.pull_external -%>
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"random": {},
 			"time": {},
@@ -392,7 +434,13 @@ func TestAcc<%= resource_name -%>IamPolicyGenerated_withCondition(t *testing.T) 
 <% else -%>
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 <% end -%>
-		<% if example.pull_external -%>
+		<% if !example.external_providers.nil? && !example.external_providers.empty? -%>
+		ExternalProviders: map[string]resource.ExternalProvider{
+		<% example.external_providers.each do |provider| -%>
+			"<%= provider %>": {},
+		<% end -%>
+		},
+		<% elsif example.pull_external -%>
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"random": {},
 			"time": {},

--- a/mmv1/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/mmv1/templates/terraform/examples/base_configs/test_file.go.erb
@@ -81,7 +81,13 @@ func TestAcc<%= test_slug -%>(t *testing.T) {
 		<% else -%>
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 		<% end -%>
-		<% if example.pull_external -%>
+		<% if !example.external_providers.nil? && !example.external_providers.empty? -%>
+		ExternalProviders: map[string]resource.ExternalProvider{
+		<% example.external_providers.each do |provider| -%>
+			"<%= provider %>": {},
+		<% end -%>
+		},
+		<% elsif example.pull_external -%>
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"random": {},
 			"time": {},

--- a/mmv1/templates/terraform/examples/base_configs/test_file.go.tmpl
+++ b/mmv1/templates/terraform/examples/base_configs/test_file.go.tmpl
@@ -90,7 +90,13 @@ func TestAcc{{ $e.TestSlug $.Res.ProductMetadata.Name $.Res.Name }}(t *testing.T
 	{{- else }}
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 	{{- end }}
-	{{- if $e.PullExternal }}
+	{{- if $e.ExternalProviders }}
+		ExternalProviders: map[string]resource.ExternalProvider{
+		{{- range $provider := $e.ExternalProviders }}
+			"{{$provider}}": {},
+		{{- end }}
+		},
+	{{- else if $e.PullExternal }}
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"random": {},
 			"time": {},

--- a/mmv1/templates/terraform/yaml_conversion.erb
+++ b/mmv1/templates/terraform/yaml_conversion.erb
@@ -498,6 +498,9 @@ examples:
 <%      unless !example.pull_external -%>
     pull_external: <%= example.pull_external %>
 <%      end -%>
+<%      unless example.external_providers.nil? -%>
+    external_providers: <%= example.external_providers %>
+<%      end -%>
 <%      unless example.skip_test.nil? -%>
     skip_test: <%= example.skip_test %>
 <%      end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
fixes https://github.com/hashicorp/terraform-provider-google/issues/15312

1. Add field `external_providers` to example object, so the specific external providers will be added to the generated tests. Only official Hashicorp providers are allowed to put into external_providers.
2. Iterate `external_providers` in test templates
3. Replace `pull_external` with `external_providers` in YAML files
4. `pull_external` will be cleaned up in a couple weeks.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
