### PR TITLE
Update compute snapshots doc for regex filters.

### DIFF
--- a/mmv1/third_party/terraform/website/docs/d/compute_snapshot.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_snapshot.html.markdown
@@ -36,6 +36,7 @@ The following arguments are supported:
 * `filter` - (Optional) A filter to retrieve the compute snapshot.
     See [gcloud topic filters](https://cloud.google.com/sdk/gcloud/reference/topic/filters) for reference.
     If multiple compute snapshot match, either adjust the filter or specify `most_recent`. One of `name` or `filter` must be provided.
+    If you want to use a regular expression, use the `eq` (equal) or `ne` (not equal) operator against a single un-parenthesized expression with or without quotes or against multiple parenthesized expressions. Example `sourceDisk eq '.*(.*/data-disk$).*'`. More details for golang Snapshots list call filters [here](https://pkg.go.dev/google.golang.org/api/compute/v1#SnapshotsListCall.Filter).
 
 * `most_recent` - (Optional) If `filter` is provided, ensures the most recent snapshot is returned when multiple compute snapshot match. 
 


### PR DESCRIPTION
Update compute snapshots doc for regex filters.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/16254

```release-note:none
docs: added the guide to use regular expression for the field `filter` in data source `google_compute_snapshot` 
```
