### PR TITLE
Adding support for FLEX service level in netapp volumes

### DIFF
--- a/mmv1/products/netapp/storagePool.yaml
+++ b/mmv1/products/netapp/storagePool.yaml
@@ -74,6 +74,7 @@ properties:
       - :PREMIUM
       - :EXTREME
       - :STANDARD
+      - :FLEX
     required: true
     immutable: true
   - !ruby/object:Api::Type::String

--- a/mmv1/products/netapp/volume.yaml
+++ b/mmv1/products/netapp/volume.yaml
@@ -109,15 +109,10 @@ properties:
     description: |
       VPC network name with format: `projects/{{project}}/global/networks/{{network}}`. Inherited from storage pool.
     output: true
-  - !ruby/object:Api::Type::Enum
+  - !ruby/object:Api::Type::String
     name: 'serviceLevel'
     description: |
-      Service level of the volume. Inherited from storage pool.
-    values:
-      - :SERVICE_LEVEL_UNSPECIFIED
-      - :PREMIUM
-      - :EXTREME
-      - :STANDARD
+      Service level of the volume. Inherited from storage pool. Supported values are : PREMIUM, EXTERME, STANDARD, FLEX.
     output: true
   - !ruby/object:Api::Type::String
     name: 'capacityGib'


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adding support for FLEX service level in netapp volumes.
This is a new service level currently being added to the netapp volumes GCP service.
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
netapp: added `FLEX` value to field `service_level` in `google_netapp_storage_pool` resource
```
