### PR TITLE
chore(ci): uncomment the remove cassettes since the copy is working

### DIFF
--- a/.ci/magician/cmd/vcr_merge.go
+++ b/.ci/magician/cmd/vcr_merge.go
@@ -83,7 +83,7 @@ func mergeCassettes(basePath, baseBranch, prPath string, runner source.Runner) {
 		runner,
 	)
 
-	// rmCassettes(fmt.Sprintf("%s/%s/", basePath, prPath), runner)
+	rmCassettes(fmt.Sprintf("%s/%s/", basePath, prPath), runner)
 }
 
 func listCassettes(path string, runner source.Runner) error {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Proceed with removing the cassettes since the copy seems working. 

One example: https://pantheon.corp.google.com/cloud-build/builds/16a8295b-81fe-4344-ab20-659606fb789c;step=16?e=13803378&mods=monitoring_api_prod&project=graphite-docker-images

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
