### PR TITLE
Update suppress func for compute_disk.type and compute_instance.machineType.

### DIFF
--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -393,6 +393,7 @@ properties:
     name: 'type'
     resource: 'DiskType'
     imports: 'selfLink'
+    diff_suppress_func: 'tpgresource.CompareResourceNames'
     description: |
       URL of the disk type resource describing which disk type to use to
       create the disk. Provide this when creating the disk.

--- a/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.erb
@@ -336,13 +336,14 @@ func TestAccComputeDisk_update(t *testing.T) {
 	t.Parallel()
 
 	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	diskType := "pd-ssd"
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeDisk_basic(diskName),
+				Config: testAccComputeDisk_basic(diskName, diskType),
 			},
 			{
 				ResourceName:      "google_compute_disk.foobar",
@@ -351,7 +352,7 @@ func TestAccComputeDisk_update(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			{
-				Config: testAccComputeDisk_updated(diskName),
+				Config: testAccComputeDisk_updated(diskName, diskType),
 			},
 			{
 				ResourceName:      "google_compute_disk.foobar",
@@ -362,6 +363,30 @@ func TestAccComputeDisk_update(t *testing.T) {
 		},
 	})
 }
+
+func TestAccComputeDisk_fromTypeUrl(t *testing.T) {
+	t.Parallel()
+
+	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	diskType := fmt.Sprintf("projects/%s/zones/us-central1-a/diskTypes/pd-ssd", envvar.GetTestProjectFromEnv())
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeDisk_basic(diskName, diskType),
+			},
+			{
+				ResourceName:      "google_compute_disk.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
 func TestAccComputeDisk_pdHyperDiskProvisionedIopsLifeCycle(t *testing.T) {
 	t.Parallel()
 
@@ -866,7 +891,7 @@ func TestAccComputeDisk_featuresUpdated(t *testing.T) {
 }
 
 
-func testAccComputeDisk_basic(diskName string) string {
+func testAccComputeDisk_basic(diskName string, diskType string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
   family  = "debian-11"
@@ -877,16 +902,16 @@ resource "google_compute_disk" "foobar" {
   name  = "%s"
   image = data.google_compute_image.my_image.self_link
   size  = 50
-  type  = "pd-ssd"
+  type  = "%s"
   zone  = "us-central1-a"
   labels = {
     my-label = "my-label-value"
   }
 }
-`, diskName)
+`, diskName, diskType)
 }
 
-func testAccComputeDisk_updated(diskName string) string {
+func testAccComputeDisk_updated(diskName string, diskType string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
   family  = "debian-11"
@@ -897,14 +922,14 @@ resource "google_compute_disk" "foobar" {
   name  = "%s"
   image = data.google_compute_image.my_image.self_link
   size  = 100
-  type  = "pd-ssd"
+  type  = "%s"
   zone  = "us-central1-a"
   labels = {
     my-label    = "my-updated-label-value"
     a-new-label = "a-new-label-value"
   }
 }
-`, diskName)
+`, diskName, diskType)
 }
 
 func testAccComputeDisk_fromSnapshot(projectName, firstDiskName, snapshotName, diskName, ref_selector string) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
@@ -302,6 +302,7 @@ func ResourceComputeInstance() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: `The machine type to create.`,
+				DiffSuppressFunc: tpgresource.CompareResourceNames,
 			},
 
 			"name": {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -276,6 +276,30 @@ func TestAccComputeInstance_resourceManagerTags(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstance_machineTypeUrl(t *testing.T) {
+	t.Parallel()
+
+	var instance compute.Instance
+	var instanceName = fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	var machineTypeUrl = "zones/us-central1-a/machineTypes/e2-medium"
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_machineType(instanceName, machineTypeUrl),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "description", "old_desc"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccComputeInstance_descriptionUpdate(t *testing.T) {
 	t.Parallel()
 
@@ -4261,6 +4285,32 @@ resource "google_compute_instance" "foobar" {
   }
 }
 `, instance)
+}
+
+func testAccComputeInstance_machineType(instance string, machineType string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%s"
+  machine_type = "%s"
+  zone         = "us-central1-a"
+  description  = "old_desc"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+`, instance, machineType)
 }
 
 func testAccComputeInstance_description(instance string) string {


### PR DESCRIPTION
Update supress func for compute_disk.type and compute_instance.machineType to account for type URLs. These URLs were treated differently due to terraform import and plan which caused forced destroy and creation of new resources. This pull request updates the suppress func so only resource names are used for terraform import and plan.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/10428

```release-note:bug
compute: update supress func for compute_disk.type and compute_instance.machineType to account for type URLs.
```
