### PR TITLE
Check if property type has prefix KeyValue in Go templates

### DIFF
--- a/mmv1/products/datafusion/go_instance.yaml
+++ b/mmv1/products/datafusion/go_instance.yaml
@@ -143,7 +143,8 @@ pipelines at low cost."
   - name: 'labels'
     type: KeyValueLabels
     description: "The resource labels for instance to use to annotate any related underlying resources,
-such as Compute Engine VMs."
+such as Compute Engine VMs.
+"
     immutable: false
   - name: 'options'
     type: KeyValuePairs

--- a/mmv1/products/pubsub/go_Subscription.yaml
+++ b/mmv1/products/pubsub/go_Subscription.yaml
@@ -116,10 +116,7 @@ the topic is in the same project as the subscription."
   - name: 'labels'
     type: KeyValueLabels
     description: "A set of key/value label pairs to assign to this Subscription.
-
-
-**Note**: This field is non-authoritative, and will only manage the labels present in your configuration.
-Please refer to the field `effective_labels` for all of the labels present on the resource."
+"
     immutable: false
   - name: 'bigqueryConfig'
     type: NestedObject

--- a/mmv1/products/pubsub/go_Topic.yaml
+++ b/mmv1/products/pubsub/go_Topic.yaml
@@ -95,10 +95,7 @@ The expected format is `projects/*/locations/*/keyRings/*/cryptoKeys/*`"
   - name: 'labels'
     type: KeyValueLabels
     description: "A set of key/value label pairs to assign to this Topic.
-
-
-**Note**: This field is non-authoritative, and will only manage the labels present in your configuration.
-Please refer to the field `effective_labels` for all of the labels present on the resource."
+"
     immutable: false
   - name: 'messageStoragePolicy'
     type: NestedObject

--- a/mmv1/provider/template_data.go
+++ b/mmv1/provider/template_data.go
@@ -77,6 +77,7 @@ var TemplateFunctions = template.FuncMap{
 	"dict":            wrapMultipleParams,
 	"format2regex":    google.Format2Regex,
 	"orderProperties": api.OrderProperties,
+	"hasPrefix":       strings.HasPrefix,
 }
 
 var GA_VERSION = "ga"

--- a/mmv1/templates/terraform/expand_property_method.go.tmpl
+++ b/mmv1/templates/terraform/expand_property_method.go.tmpl
@@ -50,7 +50,7 @@ func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.T
   }
   return m, nil
 }
-    {{ else if or ($.IsA "KeyValuePairs") ($.IsA "KeyValueEffectiveLabels") }}{{/* if $.IsA "Map" */}}
+    {{ else if hasPrefix $.Type "KeyValue" }}{{/* KeyValueLabels, KeyValueTerraformLabels, KeyValueEffectiveLabels, KeyValueAnnotations are types similar to KeyValuePairs*/}}
 func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (map[string]string, error) {
   if v == nil {
     return map[string]string{}, nil
@@ -65,7 +65,7 @@ func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.T
 func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
   transformed := make(map[string]interface{})
       {{- range $prop := $.NestedProperties }}
-        {{- if not (and ($prop.IsA "KeyValuePairs") $prop.IgnoreWrite) }}
+        {{- if not (and (hasPrefix $.prop.Type "KeyValue") $prop.IgnoreWrite) }}
   transformed{{$prop.TitlelizeProperty}}, err := expand{{$.GetPrefix}}{{$.TitlelizeProperty}}{{$prop.TitlelizeProperty}}({{ if $prop.FlattenObject }}nil{{ else }}d.Get("{{ underscore $prop.Name }}"), d, config)
   if err != nil {
     return nil, err
@@ -116,7 +116,7 @@ func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.T
         {{- end }}{{/* if $.IsA "Array */}}
     transformed := make(map[string]interface{})
         {{ range $prop := $.NestedProperties }}
-          {{- if not (and ($prop.IsA "KeyValuePairs") $prop.IgnoreWrite) }}
+          {{- if not (and (hasPrefix $prop.Type "KeyValue") $prop.IgnoreWrite) }}
       transformed{{$prop.TitlelizeProperty}}, err := expand{{$.GetPrefix}}{{$.TitlelizeProperty}}{{$prop.TitlelizeProperty}}(original["{{ underscore $prop.Name }}"], d, config)
       if err != nil {
         return nil, err
@@ -157,7 +157,7 @@ func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.T
     {{- end }}{{/* if $.IsA "Map" */}}
     {{ if $.NestedProperties }}
       {{- range $prop := $.NestedProperties }}
-        {{- if not (and ($prop.IsA "KeyValuePairs") $prop.IgnoreWrite) }}
+        {{- if not (and (hasPrefix $prop.Type "KeyValue") $prop.IgnoreWrite) }}
           {{- template "expandPropertyMethod" $prop -}}
         {{- end }}
       {{- end }}

--- a/mmv1/templates/terraform/schema_property.go.tmpl
+++ b/mmv1/templates/terraform/schema_property.go.tmpl
@@ -129,7 +129,7 @@ Default value: {{.DefaultValue -}}
     // Default schema.HashSchema is used.
     {{ end -}}
   {{ end -}}
-{{ else if eq .Type "KeyValuePairs" -}}
+{{ else if hasPrefix .Type "KeyValue" -}}{{- /* KeyValueLabels, KeyValueTerraformLabels, KeyValueEffectiveLabels, KeyValueAnnotations are types similar to KeyValuePairs*/ -}}
   Elem: &schema.Schema{Type: schema.TypeString},
 {{ else if eq .Type "Map" -}}
 	Elem: &schema.Resource{

--- a/mmv1/templates/terraform/yaml_conversion_field.erb
+++ b/mmv1/templates/terraform/yaml_conversion_field.erb
@@ -3,7 +3,13 @@
   - name: '<%= property.name -%>'
     type: <%= property.class.to_s.gsub("Api::Type::", "") %>
 <%  unless property.description.nil? -%>
-    description: "<%= property.description.strip.gsub('"', '\'') -%>"
+<%    des = property.description.strip.gsub('"', '\'') -%>
+<%    if property.is_a?(Api::Type::KeyValueLabels) || property.is_a?(Api::Type::KeyValueAnnotations) -%>
+<%      index = des.index("\n\n**Note**: This field is non-authoritative") -%>
+    description: "<%= des[0, index] -%>"
+<%    else -%>
+    description: "<%= des -%>"
+<%    end -%>
 <%  end -%>
 <%  unless !property.unordered_list -%>
     unordered_list: <%= property.unordered_list %>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
1. Check the property types if they starts with `KeyValue` to add element (`Elem: &schema.Schema{Type: schema.TypeString},`) to the map.  In Ruby code, `KeyValuePairs` are the parent class of other `KeyValue` classes. In Go code, the inheritance relationship is lost as the property type changes to string from an object in Ruby. Go doesn't support the same inheritance as Ruby. 
2. Trim the note added to labels/annotations fields by the system (not the user) when converting Ruby YAML files to Go YAML files.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
