### PR TITLE
Add uniform bucket level access to fix local testing

### DIFF
--- a/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function_test.go.erb
@@ -647,6 +647,7 @@ func testAccCloudFunctionsFunction_basic(functionName string, bucketName string,
 resource "google_storage_bucket" "bucket" {
   name     = "%s"
   location = "US"
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_object" "archive" {
@@ -687,6 +688,7 @@ func testAccCloudFunctionsFunction_updated(functionName string, bucketName strin
 resource "google_storage_bucket" "bucket" {
   name     = "%s"
   location = "US"
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_object" "archive" {
@@ -740,6 +742,7 @@ func testAccCloudFunctionsFunction_buildworkerpool(functionName string, bucketNa
 resource "google_storage_bucket" "bucket" {
   name     = "%s"
   location = "US"
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_object" "archive" {
@@ -779,6 +782,7 @@ func testAccCloudFunctionsFunction_pubsub(functionName string, bucketName string
 resource "google_storage_bucket" "bucket" {
   name     = "%s"
   location = "US"
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_object" "archive" {
@@ -819,6 +823,7 @@ data "google_client_config" "current" {
 resource "google_storage_bucket" "bucket" {
   name     = "%s"
   location = "US"
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_object" "archive" {
@@ -852,6 +857,7 @@ func testAccCloudFunctionsFunction_bucketNoRetry(functionName string, bucketName
 resource "google_storage_bucket" "bucket" {
   name     = "%s"
   location = "US"
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_object" "archive" {
@@ -882,6 +888,7 @@ func testAccCloudFunctionsFunction_firestore(functionName string, bucketName str
 resource "google_storage_bucket" "bucket" {
   name     = "%s"
   location = "US"
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_object" "archive" {
@@ -931,6 +938,7 @@ func testAccCloudFunctionsFunction_serviceAccountEmail(functionName, bucketName,
 resource "google_storage_bucket" "bucket" {
   name     = "%s"
   location = "US"
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_object" "archive" {
@@ -982,6 +990,7 @@ resource "google_vpc_access_connector" "%s" {
 resource "google_storage_bucket" "bucket" {
   name     = "%s"
   location = "US"
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_object" "archive" {
@@ -1041,6 +1050,7 @@ resource "google_artifact_registry_repository_iam_binding" "binding" {
 resource "google_storage_bucket" "bucket" {
   name     = "%s"
   location = "US"
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_object" "archive" {
@@ -1123,6 +1133,7 @@ resource "google_artifact_registry_repository" "encoded-ar-repo" {
 resource "google_storage_bucket" "bucket" {
   name     = "%s"
   location = "US"
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_object" "archive" {


### PR DESCRIPTION
Tests fail without the addition of uniform bucket level access, add it to all google_storage_bucket resources.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Local testing fails for the `cloudfunctions` resource due to this missing field. Add it to correct test failures.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
cloudfunctions: fixed local test failures due to missing uniform bucket access in `google_storage_bucket` resources.
```
