### PR TITLE
Make downstream builder no-op when commit already built

### DIFF
--- a/.ci/gcb-push-downstream.yml
+++ b/.ci/gcb-push-downstream.yml
@@ -35,7 +35,7 @@ steps:
       id: tpg-sync
       waitFor: ["build-magician-binary"]
       args:
-          - wait-for-commit
+          - 'wait-for-commit'
           - 'tpg-sync'
           - $BRANCH_NAME
           - $COMMIT_SHA
@@ -46,7 +46,7 @@ steps:
       id: tpgb-sync
       waitFor: ["build-magician-binary"]
       args:
-          - wait-for-commit
+          - 'wait-for-commit'
           - 'tpgb-sync'
           - $BRANCH_NAME
           - $COMMIT_SHA
@@ -57,7 +57,7 @@ steps:
       id: tgc-sync
       waitFor: ["build-magician-binary"]
       args:
-          - wait-for-commit
+          - 'wait-for-commit'
           - 'tgc-sync'
           - $BRANCH_NAME
           - $COMMIT_SHA
@@ -68,7 +68,7 @@ steps:
       id: tf-oics-sync
       waitFor: ["build-magician-binary"]
       args:
-          - wait-for-commit
+          - 'wait-for-commit'
           - 'tf-oics-sync'
           - $BRANCH_NAME
           - $COMMIT_SHA

--- a/.ci/magician/cmd/generate_downstream.go
+++ b/.ci/magician/cmd/generate_downstream.go
@@ -98,6 +98,24 @@ func execGenerateDownstream(baseBranch, command, repo, version, ref string, gh G
 		baseBranch = "main"
 	}
 
+	var syncBranchPrefix string
+	if repo == "terraform" {
+		if version == "beta" {
+			syncBranchPrefix = "tpgb-sync"
+		} else if version == "ga" {
+			syncBranchPrefix = "tpg-sync"
+		}
+	} else if repo == "terraform-google-conversion" {
+		syncBranchPrefix = "tgc-sync"
+	} else if repo == "tf-oics" {
+		syncBranchPrefix = "tf-oics-sync"
+	}
+	syncBranch := getSyncBranch(syncBranchPrefix, baseBranch)
+	if syncBranchHasCommit(ref, syncBranch, rnr) {
+		fmt.Printf("Sync branch %s already has commit %s, skipping generation\n", syncBranch, ref)
+		os.Exit(0)
+	}
+
 	mmLocalPath := filepath.Join(rnr.GetCWD(), "..", "..")
 	mmCopyPath := filepath.Join(mmLocalPath, "..", fmt.Sprintf("mm-%s-%s-%s", repo, version, command))
 	if _, err := rnr.Run("cp", []string{"-rp", mmLocalPath, mmCopyPath}, nil); err != nil {

--- a/.ci/magician/cmd/sync_branch.go
+++ b/.ci/magician/cmd/sync_branch.go
@@ -58,6 +58,11 @@ func execSyncBranchCmd(syncBranchPrefix, baseBranch, sha, githubToken string, ru
 	syncBranch := getSyncBranch(syncBranchPrefix, baseBranch)
 	fmt.Println("SYNC_BRANCH: ", syncBranch)
 
+	if syncBranchHasCommit(sha, syncBranch, runner) {
+		fmt.Printf("Commit %s already in sync branch %s, skipping sync\n", sha, syncBranch)
+		return nil
+	}
+
 	_, err := runner.Run("git", []string{"push", fmt.Sprintf("https://modular-magician:%s@github.com/GoogleCloudPlatform/magic-modules", githubToken), fmt.Sprintf("%s:%s", sha, syncBranch)}, nil)
 	return err
 }

--- a/.ci/magician/cmd/wait_for_commit.go
+++ b/.ci/magician/cmd/wait_for_commit.go
@@ -48,7 +48,8 @@ func execWaitForCommit(syncBranchPrefix, baseBranch, sha string, runner source.R
 	fmt.Println("SYNC_BRANCH: ", syncBranch)
 
 	if syncBranchHasCommit(sha, syncBranch, runner) {
-		return fmt.Errorf("found %s in history of %s - dying to avoid double-generating that commit", sha, syncBranch)
+		fmt.Printf("found %s in history of %s - skipping wait\n", sha, syncBranch)
+		return nil
 	}
 
 	for {
@@ -68,7 +69,7 @@ func execWaitForCommit(syncBranchPrefix, baseBranch, sha string, runner source.R
 		}
 		fmt.Println("sync branch is at: ", syncHead)
 		fmt.Println("current commit is: ", sha)
-		
+
 		if _, err := runner.Run("git", []string{"fetch", "origin", syncBranch}, nil); err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fixes https://github.com/hashicorp/terraform-provider-google/issues/12360

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
