### PR TITLE
Sort ImportStateVerifyIgnore arrays in generated tests

### DIFF
--- a/mmv1/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/mmv1/templates/terraform/examples/base_configs/test_file.go.erb
@@ -47,6 +47,7 @@ object.examples
       .map { |p| p.name.underscore }
       .concat(example.ignore_read_extra)
       .concat(object.ignore_read_labels_fields(object.properties_with_excluded))
+	  .sort()
 
     # Use explicit version for the example if given.
     # Otherwise, use object version.

--- a/mmv1/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/mmv1/templates/terraform/examples/base_configs/test_file.go.erb
@@ -47,7 +47,7 @@ object.examples
       .map { |p| p.name.underscore }
       .concat(example.ignore_read_extra)
       .concat(object.ignore_read_labels_fields(object.properties_with_excluded))
-	  .sort()
+      .sort()
 
     # Use explicit version for the example if given.
     # Otherwise, use object version.


### PR DESCRIPTION
Ensures that `ImportStateVerifyIgnore` arrays are ordered as a prelude to https://github.com/GoogleCloudPlatform/magic-modules/pull/10639

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
