### PR TITLE
Adding self_link output to google_network_security profile group

### DIFF
--- a/mmv1/products/networksecurity/SecurityProfileGroup.yaml
+++ b/mmv1/products/networksecurity/SecurityProfileGroup.yaml
@@ -68,6 +68,7 @@ properties:
     name: 'selfLink'
     description: |
       Server-defined URL of this resource.
+    output: true
   - !ruby/object:Api::Type::Time
     name: 'createTime'
     description: Time the security profile group was created in UTC.

--- a/mmv1/products/networksecurity/SecurityProfileGroup.yaml
+++ b/mmv1/products/networksecurity/SecurityProfileGroup.yaml
@@ -64,6 +64,10 @@ parameters:
     immutable: true
     url_param_only: true
 properties:
+  - !ruby/object:Api::Type::String
+    name: 'selfLink'
+    description: |
+      Server-defined URL of this resource.
   - !ruby/object:Api::Type::Time
     name: 'createTime'
     description: Time the security profile group was created in UTC.


### PR DESCRIPTION
Adds self_link output to google_network_security profile group.
This is needed to use it in firewall policies.

```release-note:enhancement
networksecurity: added `self_link` attribute to `google_network_security_profile_group`
```
