### PR TITLE
Remove slashes in titles in resource docs

### DIFF
--- a/mmv1/templates/terraform/datasource_iam.html.markdown.erb
+++ b/mmv1/templates/terraform/datasource_iam.html.markdown.erb
@@ -65,7 +65,6 @@ Retrieves the current IAM policy data for <%= object.name.downcase -%>
 See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
 <% end -%>
 
-<% markdown_escaped_name = resource_ns_iam.gsub("_", "\\_") %>
 <% params = extract_identifiers(object.iam_policy.self_link || object.self_link_url) -%>
 <%
 url_properties = object.all_user_properties.select do

--- a/mmv1/templates/terraform/resource.html.markdown.erb
+++ b/mmv1/templates/terraform/resource.html.markdown.erb
@@ -53,7 +53,7 @@ description: |-
 <%= indent(object.description.first_sentence, 2) %>
 ---
 
-# <%= terraform_name.gsub("_", "\\_") %>
+# <%= terraform_name %>
 <% if object.deprecation_message -%>
 ~> **Warning:** <%= object.deprecation_message %>
 <% end -%>

--- a/mmv1/templates/terraform/resource_iam.html.markdown.erb
+++ b/mmv1/templates/terraform/resource_iam.html.markdown.erb
@@ -80,14 +80,13 @@ A data source can be used to retrieve policy data in advent you do not need crea
 See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
 <% end -%>
 
-<% markdown_escaped_name = resource_ns_iam.gsub("_", "\\_") %>
 <% params = extract_identifiers(object.iam_policy.self_link || object.self_link_url) -%>
 <%
 url_properties = object.all_user_properties.select do
   |param| params.include?(param.name)
 end
 -%>
-## <%= markdown_escaped_name -%>\_policy
+## <%= resource_ns_iam -%>_policy
 
 ```hcl
 data "google_iam_policy" "admin" {
@@ -142,7 +141,7 @@ resource "<%= resource_ns_iam -%>_policy" "policy" {
 }
 ```
 <% end -%>
-## <%= markdown_escaped_name -%>\_binding
+## <%= resource_ns_iam -%>_binding
 
 ```hcl
 resource "<%= resource_ns_iam -%>_binding" "binding" {
@@ -179,7 +178,7 @@ resource "<%= resource_ns_iam -%>_binding" "binding" {
 }
 ```
 <% end -%>
-## <%= markdown_escaped_name -%>\_member
+## <%= resource_ns_iam -%>_member
 
 ```hcl
 resource "<%= resource_ns_iam -%>_member" "member" {

--- a/mmv1/third_party/terraform/website/docs/d/access_approval_folder_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/access_approval_folder_service_account.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get the email address of a folder's Access Approval service account.
 ---
 
-# google\_access\_approval\_folder\_service\_account
+# google_access_approval_folder_service_account
 
 Get the email address of a folder's Access Approval service account.
 

--- a/mmv1/third_party/terraform/website/docs/d/access_approval_organization_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/access_approval_organization_service_account.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get the email address of an organization's Access Approval service account.
 ---
 
-# google\_access\_approval\_organization\_service\_account
+# google_access_approval_organization_service_account
 
 Get the email address of an organization's Access Approval service account.
 

--- a/mmv1/third_party/terraform/website/docs/d/access_approval_project_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/access_approval_project_service_account.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get the email address of a project's Access Approval service account.
 ---
 
-# google\_access\_approval\_project\_service\_account
+# google_access_approval_project_service_account
 
 Get the email address of a project's Access Approval service account.
 

--- a/mmv1/third_party/terraform/website/docs/d/active_folder.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/active_folder.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a folder within GCP.
 ---
 
-# google\_active\_folder
+# google_active_folder
 
 Get an active folder within GCP by `display_name` and `parent`.
 

--- a/mmv1/third_party/terraform/website/docs/d/alloydb_locations.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/alloydb_locations.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Fetches the details of available locations.
 ---
 
-# google\_alloydb\_locations
+# google_alloydb_locations
 
 Use this data source to get information about the available locations. For more details refer the [API docs](https://cloud.google.com/alloydb/docs/reference/rest/v1/projects.locations).
 

--- a/mmv1/third_party/terraform/website/docs/d/alloydb_supported_database_flags.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/alloydb_supported_database_flags.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Fetches the list of supported alloydb database flags in a location.
 ---
 
-# google\_alloydb\_supported\_database\_flags
+# google_alloydb_supported_database_flags
 
 Use this data source to get information about the supported alloydb database flags in a location.
 

--- a/mmv1/third_party/terraform/website/docs/d/app_engine_default_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/app_engine_default_service_account.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Retrieve the default App Engine service account used in this project
 ---
 
-# google\_app_engine\_default\_service\_account
+# google_app_engine_default_service_account
 
 Use this data source to retrieve the default App Engine service account for the specified project.
 

--- a/mmv1/third_party/terraform/website/docs/d/apphub_application.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/apphub_application.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Application is a functional grouping of Services and Workloads that helps achieve a desired end-to-end business functionality.
 ---
 
-# google\_apphub\_application
+# google_apphub_application
 
 Application is a functional grouping of Services and Workloads that helps achieve a desired end-to-end business functionality. Services and Workloads are owned by the Application.
 

--- a/mmv1/third_party/terraform/website/docs/d/apphub_discovered_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/apphub_discovered_service.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a discovered service.
 ---
 
-# google\_apphub\_discovered_service
+# google_apphub_discovered_service
 
 Get information about a discovered service from its uri.
 

--- a/mmv1/third_party/terraform/website/docs/d/apphub_discovered_workload.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/apphub_discovered_workload.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a discovered workload.
 ---
 
-# google\_apphub\_discovered_workload
+# google_apphub_discovered_workload
 
 Get information about a discovered workload from its uri.
 

--- a/mmv1/third_party/terraform/website/docs/d/artifact_registry_repository.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/artifact_registry_repository.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google Artifact Registry Repository.
 ---
 
-# google\_artifact\_registry\_repository
+# google_artifact_registry_repository
 
 Get information about a Google Artifact Registry Repository. For more information see
 the [official documentation](https://cloud.google.com/artifact-registry/docs/)

--- a/mmv1/third_party/terraform/website/docs/d/backup_dr_management_server.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/backup_dr_management_server.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Backupdr Management server.
 ---
 
-# google\_backup\_dr\_management\_server
+# google_backup_dr_management_server
 
 Get information about a Google Backup DR Management server.
 

--- a/mmv1/third_party/terraform/website/docs/d/beyondcorp_app_connection.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/beyondcorp_app_connection.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google BeyondCorp App Connection.
 ---
 
-# google\_beyondcorp\_app\_connection
+# google_beyondcorp_app_connection
 
 Get information about a Google BeyondCorp App Connection.
 

--- a/mmv1/third_party/terraform/website/docs/d/beyondcorp_app_connector.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/beyondcorp_app_connector.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google BeyondCorp App Connector.
 ---
 
-# google\_beyondcorp\_app\_connector
+# google_beyondcorp_app_connector
 
 Get information about a Google BeyondCorp App Connector.
 

--- a/mmv1/third_party/terraform/website/docs/d/beyondcorp_app_gateway.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/beyondcorp_app_gateway.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google BeyondCorp App Gateway.
 ---
 
-# google\_beyondcorp\_app\_gateway
+# google_beyondcorp_app_gateway
 
 Get information about a Google BeyondCorp App Gateway.
 

--- a/mmv1/third_party/terraform/website/docs/d/bigquery_default_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/bigquery_default_service_account.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get the email address of the project's BigQuery service account
 ---
 
-# google\_bigquery\_default\_service\_account
+# google_bigquery_default_service_account
 
 Get the email address of a project's unique BigQuery service account.
 

--- a/mmv1/third_party/terraform/website/docs/d/billing_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/billing_account.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google Billing Account.
 ---
 
-# google\_billing\_account
+# google_billing_account
 
 Use this data source to get information about a Google Billing Account.
 

--- a/mmv1/third_party/terraform/website/docs/d/client_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/client_config.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about the configuration of the Google Cloud provider.
 ---
 
-# google\_client\_config
+# google_client_config
 
 Use this data source to access the configuration of the Google Cloud provider.
 

--- a/mmv1/third_party/terraform/website/docs/d/client_openid_userinfo.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/client_openid_userinfo.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get OpenID userinfo about the credentials used with the Google provider, specifically the email.
 ---
 
-# google\_client\_openid\_userinfo
+# google_client_openid_userinfo
 
 Get OpenID userinfo about the credentials used with the Google provider,
 specifically the email.

--- a/mmv1/third_party/terraform/website/docs/d/cloud_asset_resources_search_all.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/cloud_asset_resources_search_all.markdown
@@ -4,7 +4,7 @@ description: |-
   Retrieve all the resources within a given accessible CRM scope (project/folder/organization).
 ---
 
-# google\_cloud\_asset\_resources\_search\_all
+# google_cloud_asset_resources_search_all
 
 Retrieve all the resources within a given accessible CRM scope (project/folder/organization). See the
 [REST API](https://cloud.google.com/asset-inventory/docs/reference/rest/v1p1beta1/resources/searchAll)

--- a/mmv1/third_party/terraform/website/docs/d/cloud_quotas_quota_info.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/cloud_quotas_quota_info.html.markdown
@@ -2,7 +2,7 @@
 subcategory: "Cloud Quotas"
 ---
 
-# google\_cloud\_quotas\_quota\_info
+# google_cloud_quotas_quota_info
 
 Provides information about a particular quota for a given project, folder or organization.
 

--- a/mmv1/third_party/terraform/website/docs/d/cloud_quotas_quota_infos.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/cloud_quotas_quota_infos.html.markdown
@@ -2,7 +2,7 @@
 subcategory: "Cloud Quotas"
 ---
 
-# google\_cloud\_quotas\_quota\_infos
+# google_cloud_quotas_quota_infos
 
 Provides information about all quotas for a given project, folder or organization.
 

--- a/mmv1/third_party/terraform/website/docs/d/cloud_run_locations.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/cloud_run_locations.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get Cloud Run locations available for a project.
 ---
 
-# google\_cloud\_run\_locations
+# google_cloud_run_locations
 
 Get Cloud Run locations available for a project. 
 

--- a/mmv1/third_party/terraform/website/docs/d/cloud_run_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/cloud_run_service.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google Cloud Run Service.
 ---
 
-# google\_cloud\_run\_service
+# google_cloud_run_service
 
 Get information about a Google Cloud Run Service. For more information see
 the [official documentation](https://cloud.google.com/run/docs/)

--- a/mmv1/third_party/terraform/website/docs/d/cloud_run_v2_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/cloud_run_v2_job.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google Cloud Run v2 Job.
 ---
 
-# google\_cloud\_run\_v2\_job
+# google_cloud_run_v2_job
 
 Get information about a Google Cloud Run v2 Job. For more information see
 the [official documentation](https://cloud.google.com/run/docs/)

--- a/mmv1/third_party/terraform/website/docs/d/cloud_run_v2_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/cloud_run_v2_service.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google Cloud Run v2 Service.
 ---
 
-# google\_cloud\_run\_v2\_service
+# google_cloud_run_v2_service
 
 Get information about a Google Cloud Run v2 Service. For more information see
 the [official documentation](https://cloud.google.com/run/docs/)

--- a/mmv1/third_party/terraform/website/docs/d/cloudbuild_trigger.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/cloudbuild_trigger.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google CloudBuild Trigger.
 ---
 
-# google\_cloudbuild\_trigger
+# google_cloudbuild_trigger
 
 To get more information about Cloudbuild Trigger, see:
 

--- a/mmv1/third_party/terraform/website/docs/d/cloudfunctions2_function.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/cloudfunctions2_function.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google Cloud Function (2nd gen).
 ---
 
-# google\_cloudfunctions2\_function
+# google_cloudfunctions2_function
 
 Get information about a Google Cloud Function (2nd gen). For more information see:
 

--- a/mmv1/third_party/terraform/website/docs/d/cloudfunctions_function.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/cloudfunctions_function.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google Cloud Function.
 ---
 
-# google\_cloudfunctions\_function
+# google_cloudfunctions_function
 
 Get information about a Google Cloud Function. For more information see
 the [official documentation](https://cloud.google.com/functions/docs/)

--- a/mmv1/third_party/terraform/website/docs/d/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/composer_environment.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Provides Cloud Composer environment configuration data.
 ---
 
-# google\_composer\_environment
+# google_composer_environment
 
 Provides access to Cloud Composer environment configuration in a region for a given project.
 

--- a/mmv1/third_party/terraform/website/docs/d/composer_image_versions.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/composer_image_versions.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Provides available Cloud Composer versions.
 ---
 
-# google\_composer\_image\_versions
+# google_composer_image_versions
 
 Provides access to available Cloud Composer versions in a region for a given project.
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_address.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_address.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get the IP address from a static address.
 ---
 
-# google\_compute\_address
+# google_compute_address
 
 Get the IP address from a static address. For more information see
 the official [API](https://cloud.google.com/compute/docs/reference/latest/addresses/get) documentation.

--- a/mmv1/third_party/terraform/website/docs/d/compute_addresses.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_addresses.html.markdown
@@ -4,7 +4,7 @@ description: |-
   List google compute addresses.
 ---
 
-# google\_compute\_addresses
+# google_compute_addresses
 
 List IP addresses in a project. For more information see
 the official API [list](https://cloud.google.com/compute/docs/reference/latest/addresses/list) and 

--- a/mmv1/third_party/terraform/website/docs/d/compute_backend_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_backend_bucket.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a BackendBucket.
 ---
 
-# google\_compute\_backend\_bucket
+# google_compute_backend_bucket
 
 Get information about a BackendBucket.
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_backend_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_backend_service.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Backend Service.
 ---
 
-# google\_compute\_backend\_service
+# google_compute_backend_service
 
 Provide access to a Backend Service's attribute. For more information
 see [the official documentation](https://cloud.google.com/compute/docs/load-balancing/http/backend-service)

--- a/mmv1/third_party/terraform/website/docs/d/compute_default_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_default_service_account.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Retrieve default service account used by VMs running in this project
 ---
 
-# google\_compute\_default\_service\_account
+# google_compute_default_service_account
 
 Use this data source to retrieve default service account for this project
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_disk.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_disk.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google Compute Persistent disks.
 ---
 
-# google\_compute\_disk
+# google_compute_disk
 
 Get information about a Google Compute Persistent disks.
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_forwarding_rule.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_forwarding_rule.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a regional forwarding rule within GCE.
 ---
 
-# google\_compute\_forwarding\_rule
+# google_compute_forwarding_rule
 
 Get a forwarding rule within GCE from its name.
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_forwarding_rules.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_forwarding_rules.html.markdown
@@ -4,7 +4,7 @@ description: |-
   List forwarding rules in a region of a Google Cloud project.
 ---
 
-# google\_compute\_forwarding\_rules
+# google_compute_forwarding_rules
 
 List all networks in a specified Google Cloud project.
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_global_address.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_global_address.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get the IP address from a static address reserved for a Global Forwarding Rule.
 ---
 
-# google\_compute\_global\_address
+# google_compute_global_address
 
 Get the IP address from a static address reserved for a Global Forwarding Rule which are only used for HTTP load balancing. For more information see
 the official [API](https://cloud.google.com/compute/docs/reference/latest/globalAddresses) documentation.

--- a/mmv1/third_party/terraform/website/docs/d/compute_global_forwarding_rule.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_global_forwarding_rule.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a global forwarding rule within GCE.
 ---
 
-# google\_compute\_global_\forwarding\_rule
+# google_compute_global_\forwarding_rule
 
 Get a global forwarding rule within GCE from its name.
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_ha_vpn_gateway.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_ha_vpn_gateway.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a HA VPN Gateway within GCE.
 ---
 
-# google\_compute\_forwarding\_rule
+# google_compute_forwarding_rule
 
 Get a HA VPN Gateway within GCE from its name.
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_health_check.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_health_check.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a HealthCheck.
 ---
 
-# google\_compute\_health\_check
+# google_compute_health_check
 
 Get information about a HealthCheck.
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_image.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_image.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google Compute Image.
 ---
 
-# google\_compute\_image
+# google_compute_image
 
 Get information about a Google Compute Image. Check that your service account has the `compute.imageUser` role if you want to share [custom images](https://cloud.google.com/compute/docs/images/sharing-images-across-projects) from another project. If you want to use [public images][pubimg], do not forget to specify the dedicated project. For more information see
 [the official documentation](https://cloud.google.com/compute/docs/images) and its [API](https://cloud.google.com/compute/docs/reference/latest/images).

--- a/mmv1/third_party/terraform/website/docs/d/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a VM instance within GCE.
 ---
 
-# google\_compute\_instance
+# google_compute_instance
 
 Get information about a VM instance resource within GCE. For more information see
 [the official documentation](https://cloud.google.com/compute/docs/instances)

--- a/mmv1/third_party/terraform/website/docs/d/compute_instance_group.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance_group.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a Compute Instance Group within GCE.
 ---
 
-# google\_compute\_instance\_group
+# google_compute_instance_group
 
 Get a Compute Instance Group within GCE.
 For more information, see [the official documentation](https://cloud.google.com/compute/docs/instance-groups/#unmanaged_instance_groups)

--- a/mmv1/third_party/terraform/website/docs/d/compute_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance_group_manager.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a Compute Instance Group within GCE.
 ---
 
-# google\_compute\_instance\_group\_manager
+# google_compute_instance_group_manager
 
 Get a Compute Instance Group Manager within GCE.
 For more information, see [the official documentation](https://cloud.google.com/compute/docs/instance-groups#managed_instance_groups)

--- a/mmv1/third_party/terraform/website/docs/d/compute_instance_serial_port.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance_serial_port.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get the serial port output from a Compute Instance.
 ---
 
-# google\_compute\_instance\_serial\_port
+# google_compute_instance_serial_port
 
 Get the serial port output from a Compute Instance. For more information see
 the official [API](https://cloud.google.com/compute/docs/instances/viewing-serial-port-output) documentation.

--- a/mmv1/third_party/terraform/website/docs/d/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance_template.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a VM instance template within GCE.
 ---
 
-# google\_compute\_instance\_template
+# google_compute_instance_template
 
 -> **Note**: Global instance templates can be used in any region. To lower the impact of outages outside your region and gain data residency within your region, use [google_compute_region_instance_template](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_instance_template).
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_machine_types.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_machine_types.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Provides a list of available Google Compute machine types
 ---
 
-# google\_compute\_machine\_types
+# google_compute_machine_types
 
 Provides access to available Google Compute machine types in a zone for a given project.
 See more about [machine type availability](https://cloud.google.com/compute/docs/regions-zones#available) in the upstream docs.

--- a/mmv1/third_party/terraform/website/docs/d/compute_network.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_network.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a network within GCE.
 ---
 
-# google\_compute\_network
+# google_compute_network
 
 Get a network within GCE from its name.
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_network_endpoint_group.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_network_endpoint_group.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Retrieve Network Endpoint Group's details.
 ---
 
-# google\_compute\_network\_endpoint\_group
+# google_compute_network_endpoint_group
 
 Use this data source to access a Network Endpoint Group's attributes.
 
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 * `zone` - (Optional) The Network Endpoint Group availability zone.
 
-* `self_link` - (Optional) The Network Endpoint Group self\_link.
+* `self_link` - (Optional) The Network Endpoint Group self_link.
 
 ## Attributes Reference
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_network_peering.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_network_peering.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information of a specified compute network peering.
 ---
 
-# google\_compute\_network\_peering
+# google_compute_network_peering
 
 Get information of a specified compute network peering. For more information see
 [the official documentation](https://cloud.google.com/compute/docs/vpc/vpc-peering)

--- a/mmv1/third_party/terraform/website/docs/d/compute_networks.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_networks.html.markdown
@@ -4,7 +4,7 @@ description: |-
   List networks in a Google Cloud project.
 ---
 
-# google\_compute\_networks
+# google_compute_networks
 
 List all networks in a specified Google Cloud project.
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_node_types.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_node_types.html.markdown
@@ -5,7 +5,7 @@ description: |-
   sole-tenant nodes.
 ---
 
-# google\_compute\_node\_types
+# google_compute_node_types
 
 Provides available node types for Compute Engine sole-tenant nodes in a zone
 for a given project. For more information, see [the official documentation](https://cloud.google.com/compute/docs/nodes/#types) and [API](https://cloud.google.com/compute/docs/reference/rest/v1/nodeTypes).

--- a/mmv1/third_party/terraform/website/docs/d/compute_region_disk.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_region_disk.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google Compute Regional Persistent disks.
 ---
 
-# google\_compute\_region\_disk
+# google_compute_region_disk
 
 Get information about a Google Compute Regional Persistent disks.
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_region_instance_group.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_region_instance_group.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get the instances inside a Compute Region Instance Group within GCE.
 ---
 
-# google\_compute\_region\_instance\_group
+# google_compute_region_instance_group
 
 Get a Compute Region Instance Group within GCE.
 For more information, see [the official documentation](https://cloud.google.com/compute/docs/instance-groups/distributing-instances-with-regional-instance-groups) and [API](https://cloud.google.com/compute/docs/reference/latest/regionInstanceGroups).

--- a/mmv1/third_party/terraform/website/docs/d/compute_region_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_region_instance_template.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a VM instance template within GCE.
 ---
 
-# google\_compute\_region\_instance\_template
+# google_compute_region_instance_template
 
 Get information about a VM instance template resource within GCE. For more information see
 [the official documentation](https://cloud.google.com/compute/docs/instance-templates)

--- a/mmv1/third_party/terraform/website/docs/d/compute_region_network_endpoint_group.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_region_network_endpoint_group.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Retrieve Region Network Endpoint Group's details.
 ---
 
-# google\_compute\_region\_network\_endpoint\_group
+# google_compute_region_network_endpoint_group
 
 Use this data source to access a Region Network Endpoint Group's attributes.
 
@@ -33,7 +33,7 @@ The following arguments are supported:
 
 * `region` - (Optional) A reference to the region where the Serverless REGs Reside. Provide either this or a `self_link`.
 
-* `self_link` - (Optional) The Network Endpoint Group self\_link.
+* `self_link` - (Optional) The Network Endpoint Group self_link.
 
 ## Attributes Reference
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_region_ssl_certificate.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_region_ssl_certificate.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get info about a Regional Google Compute SSL Certificate.
 ---
 
-# google\_compute\_region\_ssl\_certificate
+# google_compute_region_ssl_certificate
 
 Get info about a Region Google Compute SSL Certificate from its name.
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_regions.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_regions.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Provides a list of available Google Compute regions
 ---
 
-# google\_compute\_regions
+# google_compute_regions
 
 Provides access to available Google Compute regions for a given project.
 See more about [regions and zones](https://cloud.google.com/compute/docs/regions-zones/) in the upstream docs.

--- a/mmv1/third_party/terraform/website/docs/d/compute_reservation.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_reservation.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Provide access to a Reservation's attributes
 ---
 
-# google\_compute\_reservation
+# google_compute_reservation
 
 Provides access to available Google Compute Reservation Resources for a given project.
 See more about [Reservations of Compute Engine resources](https://cloud.google.com/compute/docs/instances/reservations-overview) in the upstream docs.

--- a/mmv1/third_party/terraform/website/docs/d/compute_resource_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_resource_policy.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Provide access to a Resource Policy's attributes
 ---
 
-# google\_compute\_resource\_policy
+# google_compute_resource_policy
 
 Provide access to a Resource Policy's attributes. For more information see [the official documentation](https://cloud.google.com/compute/docs/disks/scheduled-snapshots) or the [API](https://cloud.google.com/compute/docs/reference/rest/beta/resourcePolicies).
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_router.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_router.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a Cloud Router within GCE.
 ---
 
-# google\_compute\_router
+# google_compute_router
 
 Get a router within GCE from its name and VPC.
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_router_nat.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_router_nat.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google Compute Router NAT.
 ---
 
-# google\_compute\_router\_nat
+# google_compute_router_nat
 
 To get more information about Snapshot, see:
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_router_status.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_router_status.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a Cloud Router's Status.
 ---
 
-# google\_compute\_router\_status
+# google_compute_router_status
 
 Get a Cloud Router's status within GCE from its name and region. This data source exposes the
 routes learned by a Cloud Router via BGP peers.

--- a/mmv1/third_party/terraform/website/docs/d/compute_snapshot.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_snapshot.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google Compute Snapshot.
 ---
 
-# google\_compute\_snapshot
+# google_compute_snapshot
 
 To get more information about Snapshot, see:
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_ssl_certificate.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_ssl_certificate.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get info about a Google Compute SSL Certificate.
 ---
 
-# google\_compute\_ssl\_certificate
+# google_compute_ssl_certificate
 
 Get info about a Google Compute SSL Certificate from its name.
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_ssl_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_ssl_policy.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Gets an SSL Policy within GCE, for use with Target HTTPS and Target SSL Proxies.
 ---
 
-# google\_compute\_ssl\_policy
+# google_compute_ssl_policy
 
 Gets an SSL Policy within GCE from its name, for use with Target HTTPS and Target SSL Proxies.
     For more information see [the official documentation](https://cloud.google.com/compute/docs/load-balancing/ssl-policies).

--- a/mmv1/third_party/terraform/website/docs/d/compute_subnetwork.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_subnetwork.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a subnetwork within GCE.
 ---
 
-# google\_compute\_subnetwork
+# google_compute_subnetwork
 
 Get a subnetwork within GCE from its name and region.
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_vpn_gateway.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_vpn_gateway.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a VPN gateway within GCE.
 ---
 
-# google\_compute\_vpn\_gateway
+# google_compute_vpn_gateway
 
 Get a VPN gateway within GCE from its name.
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_zones.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_zones.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Provides a list of available Google Compute zones
 ---
 
-# google\_compute\_zones
+# google_compute_zones
 
 Provides access to available Google Compute zones in a region for a given project.
 See more about [regions and zones](https://cloud.google.com/compute/docs/regions-zones/regions-zones) in the upstream docs.

--- a/mmv1/third_party/terraform/website/docs/d/container_attached_install_manifest.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/container_attached_install_manifest.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Generates a YAML manifest for boot-strapping an Attached cluster registration.
 ---
 
-# google\_container\_attached\_install_manifest
+# google_container_attached_install_manifest
 
 Provides access to available platform versions in a location for a given project.
 

--- a/mmv1/third_party/terraform/website/docs/d/container_attached_versions.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/container_attached_versions.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Provides lists of available platform versions for the Container Attached resources.
 ---
 
-# google\_container\_attached\_versions
+# google_container_attached_versions
 
 Provides access to available platform versions in a location for a given project.
 

--- a/mmv1/third_party/terraform/website/docs/d/container_aws_versions.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/container_aws_versions.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Provides lists of available Kubernetes versions for the Container AWS resources.
 ---
 
-# google\_container\_aws\_versions
+# google_container_aws_versions
 
 Provides access to available Kubernetes versions in a location for a given project.
 

--- a/mmv1/third_party/terraform/website/docs/d/container_azure_versions.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/container_azure_versions.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Provides lists of available Kubernetes versions for the Container Azure resources.
 ---
 
-# google\_container\_azure\_versions
+# google_container_azure_versions
 
 Provides access to available Kubernetes versions in a location for a given project.
 

--- a/mmv1/third_party/terraform/website/docs/d/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/container_cluster.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get info about a Google Kubernetes Engine cluster.
 ---
 
-# google\_container\_cluster
+# google_container_cluster
 
 Get info about a GKE cluster from its name and location.
 

--- a/mmv1/third_party/terraform/website/docs/d/container_engine_versions.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/container_engine_versions.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Provides lists of available Google Kubernetes Engine versions for masters and nodes.
 ---
 
-# google\_container\_engine\_versions
+# google_container_engine_versions
 
 Provides access to available Google Kubernetes Engine versions in a zone or region for a given project.
 

--- a/mmv1/third_party/terraform/website/docs/d/container_registry_image.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/container_registry_image.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get URLs for a given project's container registry image.
 ---
 
-# google\_container\_registry\_image
+# google_container_registry_image
 
 This data source fetches the project name, and provides the appropriate URLs to use for container registry for this project.
 

--- a/mmv1/third_party/terraform/website/docs/d/container_registry_repository.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/container_registry_repository.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get URLs for a given project's container registry repository.
 ---
 
-# google\_container\_registry\_repository
+# google_container_registry_repository
 
 This data source fetches the project name, and provides the appropriate URLs to use for container registry for this project.
 

--- a/mmv1/third_party/terraform/website/docs/d/dataproc_metastore_service.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/dataproc_metastore_service.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a Dataproc Metastore Service from Google Cloud
 ---
 
-# google\_dataproc\_metastore\_service
+# google_dataproc_metastore_service
 
 Get a Dataproc Metastore service from Google Cloud by its id and location.
 

--- a/mmv1/third_party/terraform/website/docs/d/datastream_static_ips.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/datastream_static_ips.markdown
@@ -4,7 +4,7 @@ description: |-
   Returns the list of IP addresses that Datastream connects from.
 ---
 
-# google\_datastream\_static\_ips
+# google_datastream_static_ips
 
 Returns the list of IP addresses that Datastream connects from. For more information see
 the [official documentation](https://cloud.google.com/datastream/docs/ip-allowlists-and-regions).

--- a/mmv1/third_party/terraform/website/docs/d/dns_keys.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/dns_keys.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get DNSKEY and DS records of DNSSEC-signed managed zones.
 ---
 
-# google\_dns\_keys
+# google_dns_keys
 
 Get the DNSKEY and DS records of DNSSEC-signed managed zones.
 

--- a/mmv1/third_party/terraform/website/docs/d/dns_managed_zone.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/dns_managed_zone.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Provides access to the attributes of a zone within Google Cloud DNS
 ---
 
-# google\_dns\_managed\_zone
+# google_dns_managed_zone
 
 Provides access to a zone's attributes within Google Cloud DNS.
 For more information see

--- a/mmv1/third_party/terraform/website/docs/d/dns_managed_zones.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/dns_managed_zones.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Provides access to a list of zones within Google Cloud DNS
 ---
 
-# google\_dns\_managed\_zones
+# google_dns_managed_zones
 
 Provides access to a list of zones within Google Cloud DNS.
 For more information see

--- a/mmv1/third_party/terraform/website/docs/d/dns_record_set.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/dns_record_set.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a DNS record set within Google Cloud DNS
 ---
 
-# google\_dns\_record\_set
+# google_dns_record_set
 
 Get a DNS record set within Google Cloud DNS
 For more information see

--- a/mmv1/third_party/terraform/website/docs/d/filestore_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/filestore_instance.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google Cloud Filestore instance.
 ---
 
-# google\_filestore\_instance
+# google_filestore_instance
 
 Get info about a Google Cloud Filestore instance.
 

--- a/mmv1/third_party/terraform/website/docs/d/firebase_android_app.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/firebase_android_app.html.markdown
@@ -4,7 +4,7 @@ description: |-
   A Google Cloud Firebase Android application instance
 ---
 
-# google\_firebase\_android\_app
+# google_firebase_android_app
 
 A Google Cloud Firebase Android application instance
 

--- a/mmv1/third_party/terraform/website/docs/d/firebase_android_app_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/firebase_android_app_config.html.markdown
@@ -4,7 +4,7 @@ description: |-
   A Google Cloud Firebase Android application configuration
 ---
 
-# google\_firebase\_android\_app\_config
+# google_firebase_android_app_config
 
 A Google Cloud Firebase Android application configuration
 

--- a/mmv1/third_party/terraform/website/docs/d/firebase_apple_app.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/firebase_apple_app.html.markdown
@@ -4,7 +4,7 @@ description: |-
   A Google Cloud Firebase Apple application instance
 ---
 
-# google\_firebase\_apple\_app
+# google_firebase_apple_app
 
 A Google Cloud Firebase Apple application instance
 

--- a/mmv1/third_party/terraform/website/docs/d/firebase_apple_app_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/firebase_apple_app_config.html.markdown
@@ -4,7 +4,7 @@ description: |-
   A Google Cloud Firebase Apple application configuration
 ---
 
-# google\_firebase\_apple\_app\_config
+# google_firebase_apple_app_config
 
 A Google Cloud Firebase Apple application configuration
 

--- a/mmv1/third_party/terraform/website/docs/d/firebase_hosting_channel.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/firebase_hosting_channel.html.markdown
@@ -5,7 +5,7 @@ description: |-
   A Google Cloud Firebase Hosting Channel instance
 ---
 
-# google\_firebase\_hosting\_channel
+# google_firebase_hosting_channel
 
 A Google Cloud Firebase Hosting Channel instance
 

--- a/mmv1/third_party/terraform/website/docs/d/firebase_web_app.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/firebase_web_app.html.markdown
@@ -4,7 +4,7 @@ description: |-
   A Google Cloud Firebase web application instance
 ---
 
-# google\_firebase\_web\_app
+# google_firebase_web_app
 
 A Google Cloud Firebase web application instance
 

--- a/mmv1/third_party/terraform/website/docs/d/firebase_web_app_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/firebase_web_app_config.html.markdown
@@ -4,7 +4,7 @@ description: |-
   A Google Cloud Firebase web application configuration
 ---
 
-# google\_firebase\_web\_app\_config
+# google_firebase_web_app_config
 
 A Google Cloud Firebase web application configuration
 

--- a/mmv1/third_party/terraform/website/docs/d/folder.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/folder.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google Cloud Folder.
 ---
 
-# google\_folder
+# google_folder
 
 Use this data source to get information about a Google Cloud Folder.
 

--- a/mmv1/third_party/terraform/website/docs/d/folder_organization_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/folder_organization_policy.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Retrieve Organization policies for a Google Folder
 ---
 
-# google\_folder\_organization\_policy
+# google_folder_organization_policy
 
 Allows management of Organization policies for a Google Folder. For more information see
 [the official

--- a/mmv1/third_party/terraform/website/docs/d/folders.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/folders.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Retrieve a set of folders based on a parent ID.
 ---
 
-# google\_folders
+# google_folders
 
 Retrieve information about a set of folders based on a parent ID. See the
 [REST API](https://cloud.google.com/resource-manager/reference/rest/v3/folders/list)

--- a/mmv1/third_party/terraform/website/docs/d/google_project_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/google_project_service.html.markdown
@@ -4,7 +4,7 @@ description: |-
  Verify the API service for the Google Cloud Platform project to see if it is enabled or not.
 ---
 
-# google\_project\_service
+# google_project_service
 
 Verify the API service for the Google Cloud Platform project to see if it is enabled or not.
 

--- a/mmv1/third_party/terraform/website/docs/d/google_vertex_ai_index.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/google_vertex_ai_index.html.markdown
@@ -4,7 +4,7 @@ description: |-
   A representation of a collection of database items organized in a way that allows for approximate nearest neighbor (a.k.a ANN) algorithms search.
 ---
 
-# google\_vertex\_ai\_index
+# google_vertex_ai_index
 
 A representation of a collection of database items organized in a way that allows for approximate nearest neighbor (a.k.a ANN) algorithms search.
 

--- a/mmv1/third_party/terraform/website/docs/d/iam_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/iam_policy.html.markdown
@@ -5,7 +5,7 @@ description: |-
   the policy to them.
 ---
 
-# google\_iam\_policy
+# google_iam_policy
 
 Generates an IAM policy document that may be referenced by and applied to
 other Google Cloud Platform IAM resources, such as the `google_project_iam_policy` resource.

--- a/mmv1/third_party/terraform/website/docs/d/iam_role.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/iam_role.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google IAM Role.
 ---
 
-# google\_iam\_role
+# google_iam_role
 
 Use this data source to get information about a Google IAM Role.
 

--- a/mmv1/third_party/terraform/website/docs/d/iam_testable_permissions.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/iam_testable_permissions.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Retrieve a list of testable permissions for a resource. Testable permissions mean the permissions that user can add or remove in a role at a given resource. The resource can be referenced either via the full resource name or via a URI.
 ---
 
-# google\_iam\_testable\_permissions
+# google_iam_testable_permissions
 
 Retrieve a list of testable permissions for a resource. Testable permissions mean the permissions that user can add or remove in a role at a given resource. The resource can be referenced either via the full resource name or via a URI.
 

--- a/mmv1/third_party/terraform/website/docs/d/iam_workload_identity_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/iam_workload_identity_pool.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a IAM workload identity pool from Google Cloud
 ---
 
-# google\_iam\_workload\_identity\_pool
+# google_iam_workload_identity_pool
 
 Get a IAM workload identity pool from Google Cloud by its id.
 

--- a/mmv1/third_party/terraform/website/docs/d/iam_workload_identity_pool_provider.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/iam_workload_identity_pool_provider.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a IAM workload identity pool provider from Google Cloud
 ---
 
-# google\_iam\_workload\_identity\_pool\_provider
+# google_iam_workload_identity_pool_provider
 
 Get a IAM workload identity provider from Google Cloud by its id.
 

--- a/mmv1/third_party/terraform/website/docs/d/kms_crypto_key.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/kms_crypto_key.html.markdown
@@ -4,7 +4,7 @@ description: |-
  Provides access to KMS key data with Google Cloud KMS.
 ---
 
-# google\_kms\_crypto\_key
+# google_kms_crypto_key
 
 Provides access to a Google Cloud Platform KMS CryptoKey. For more information see
 [the official documentation](https://cloud.google.com/kms/docs/object-hierarchy#key)

--- a/mmv1/third_party/terraform/website/docs/d/kms_crypto_key_version.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/kms_crypto_key_version.html.markdown
@@ -4,7 +4,7 @@ description: |-
  Provides access to KMS key version data with Google Cloud KMS.
 ---
 
-# google\_kms\_crypto\_key\_version
+# google_kms_crypto_key_version
 
 Provides access to a Google Cloud Platform KMS CryptoKeyVersion. For more information see
 [the official documentation](https://cloud.google.com/kms/docs/object-hierarchy#key_version)

--- a/mmv1/third_party/terraform/website/docs/d/kms_key_ring.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/kms_key_ring.html.markdown
@@ -4,7 +4,7 @@ description: |-
  Provides access to KMS key ring data with Google Cloud KMS.
 ---
 
-# google\_kms\_key\_ring
+# google_kms_key_ring
 
 Provides access to Google Cloud Platform KMS KeyRing. For more information see
 [the official documentation](https://cloud.google.com/kms/docs/object-hierarchy#key_ring)

--- a/mmv1/third_party/terraform/website/docs/d/kms_secret.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/kms_secret.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Provides access to secret data encrypted with Google Cloud KMS
 ---
 
-# google\_kms\_secret
+# google_kms_secret
 
 This data source allows you to use data encrypted with Google Cloud KMS
 within your resource definitions.

--- a/mmv1/third_party/terraform/website/docs/d/kms_secret_asymmetric.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/kms_secret_asymmetric.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Provides access to secret data encrypted with Google Cloud KMS asymmetric key
 ---
 
-# google\_kms\_secret\_asymmetric
+# google_kms_secret_asymmetric
 
 This data source allows you to use data encrypted with a Google Cloud KMS asymmetric key
 within your resource definitions.

--- a/mmv1/third_party/terraform/website/docs/d/kms_secret_ciphertext.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/kms_secret_ciphertext.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Encrypts secret data with Google Cloud KMS and provides access to the ciphertext
 ---
 
-# google\_kms\_secret\_ciphertext
+# google_kms_secret_ciphertext
 
 !> **Warning:** This data source is deprecated. Use the [`google_kms_secret_ciphertext`](../r/kms_secret_ciphertext.html) **resource** instead.
 

--- a/mmv1/third_party/terraform/website/docs/d/logging_folder_settings.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/logging_folder_settings.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Describes the settings associated with a folder.
 ---
 
-# google\_logging\_folder\_settings
+# google_logging_folder_settings
 
 Describes the settings associated with a folder.
 

--- a/mmv1/third_party/terraform/website/docs/d/logging_organization_settings.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/logging_organization_settings.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Describes the settings associated with a organization.
 ---
 
-# google\_logging\_organization\_settings
+# google_logging_organization_settings
 
 Describes the settings associated with a organization.
 

--- a/mmv1/third_party/terraform/website/docs/d/logging_project_cmek_settings.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/logging_project_cmek_settings.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Describes the customer-managed encryption key (CMEK) settings associated with a project.
 ---
 
-# google\_logging\_project\_cmek\_settings
+# google_logging_project_cmek_settings
 
 Describes the customer-managed encryption key (CMEK) settings associated with a project.
 

--- a/mmv1/third_party/terraform/website/docs/d/logging_project_settings.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/logging_project_settings.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Describes the settings associated with a project.
 ---
 
-# google\_logging\_project\_settings
+# google_logging_project_settings
 
 Describes the settings associated with a project.
 

--- a/mmv1/third_party/terraform/website/docs/d/logging_sink.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/logging_sink.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google Cloud Logging Sink.
 ---
 
-# google\_logging\_sink
+# google_logging_sink
 
 Use this data source to get a project, folder, organization or billing account logging sink details.
 To get more information about Service, see:

--- a/mmv1/third_party/terraform/website/docs/d/monitoring_app_engine_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/monitoring_app_engine_service.html.markdown
@@ -5,7 +5,7 @@ description: |-
   App Engine service.
 ---
 
-# google\_monitoring\_app\_engine\_service
+# google_monitoring_app_engine_service
 
 A Monitoring Service is the root resource under which operational aspects of a
 generic service are accessible. A service is some discrete, autonomous, and

--- a/mmv1/third_party/terraform/website/docs/d/monitoring_cluster_istio_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/monitoring_cluster_istio_service.html.markdown
@@ -5,7 +5,7 @@ description: |-
   Cluster Istio service.
 ---
 
-# google\_monitoring\_cluster\_istio\_service
+# google_monitoring_cluster_istio_service
 
 A Monitoring Service is the root resource under which operational aspects of a
 generic service are accessible. A service is some discrete, autonomous, and

--- a/mmv1/third_party/terraform/website/docs/d/monitoring_istio_canonical_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/monitoring_istio_canonical_service.html.markdown
@@ -5,7 +5,7 @@ description: |-
   Istio Canonical service.
 ---
 
-# google\_monitoring\_istio\_canonical\_service
+# google_monitoring_istio_canonical_service
 
 A Monitoring Service is the root resource under which operational aspects of a
 generic service are accessible. A service is some discrete, autonomous, and

--- a/mmv1/third_party/terraform/website/docs/d/monitoring_mesh_istio_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/monitoring_mesh_istio_service.html.markdown
@@ -5,7 +5,7 @@ description: |-
   Mesh Istio service.
 ---
 
-# google\_monitoring\_mesh\_istio\_service
+# google_monitoring_mesh_istio_service
 
 A Monitoring Service is the root resource under which operational aspects of a
 generic service are accessible. A service is some discrete, autonomous, and

--- a/mmv1/third_party/terraform/website/docs/d/monitoring_notification_channel.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/monitoring_notification_channel.html.markdown
@@ -5,7 +5,7 @@ description: |-
   when a policy violation is detected.
 ---
 
-# google\_monitoring\_notification\_channel
+# google_monitoring_notification_channel
 
 A NotificationChannel is a medium through which an alert is delivered
 when a policy violation is detected. Examples of channels include email, SMS,

--- a/mmv1/third_party/terraform/website/docs/d/monitoring_uptime_check_ips.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/monitoring_uptime_check_ips.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Returns the list of IP addresses Stackdriver Monitoring uses for uptime checking.
 ---
 
-# google\_monitoring\_uptime\_check\_ips
+# google_monitoring_uptime_check_ips
 
 Returns the list of IP addresses that checkers run from. For more information see
 the [official documentation](https://cloud.google.com/monitoring/uptime-checks#get-ips).

--- a/mmv1/third_party/terraform/website/docs/d/organization.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/organization.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google Cloud Organization.
 ---
 
-# google\_organization
+# google_organization
 
 Get information about a Google Cloud Organization. Note that you must have the `roles/resourcemanager.organizationViewer` role (or equivalent permissions) at the organization level to use this datasource.
 

--- a/mmv1/third_party/terraform/website/docs/d/project.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/project.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Retrieve project details
 ---
 
-# google\_project
+# google_project
 
 Use this data source to get project details.
 For more information see

--- a/mmv1/third_party/terraform/website/docs/d/project_organization_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/project_organization_policy.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Retrieve Organization policies for a Google Project.
 ---
 
-# google\_project\_organization\_policy
+# google_project_organization_policy
 
 Allows management of Organization policies for a Google Project. For more information see
 [the official

--- a/mmv1/third_party/terraform/website/docs/d/projects.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/projects.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Retrieve a set of projects based on a filter.
 ---
 
-# google\_projects
+# google_projects
 
 Retrieve information about a set of projects based on a filter. See the
 [REST API](https://cloud.google.com/resource-manager/reference/rest/v1/projects/list)

--- a/mmv1/third_party/terraform/website/docs/d/pubsub_subscription.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/pubsub_subscription.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google Cloud Pub/Sub Subscription.
 ---
 
-# google\_pubsub\_subscription
+# google_pubsub_subscription
 
 Get information about a Google Cloud Pub/Sub Subscription. For more information see
 the [official documentation](https://cloud.google.com/pubsub/docs/)

--- a/mmv1/third_party/terraform/website/docs/d/pubsub_topic.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/pubsub_topic.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google Cloud Pub/Sub Topic.
 ---
 
-# google\_pubsub\_topic
+# google_pubsub_topic
 
 Get information about a Google Cloud Pub/Sub Topic. For more information see
 the [official documentation](https://cloud.google.com/pubsub/docs/)

--- a/mmv1/third_party/terraform/website/docs/d/redis_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/redis_instance.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google Cloud Redis instance.
 ---
 
-# google\_redis\_instance
+# google_redis_instance
 
 Get info about a Google Cloud Redis instance.
 

--- a/mmv1/third_party/terraform/website/docs/d/runtimeconfig_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/runtimeconfig_config.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google Cloud RuntimeConfig.
 ---
 
-# google\_runtimeconfig\_config
+# google_runtimeconfig_config
 
 To get more information about RuntimeConfigs, see:
 

--- a/mmv1/third_party/terraform/website/docs/d/runtimeconfig_variable.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/runtimeconfig_variable.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google Cloud RuntimeConfig variable.
 ---
 
-# google\_runtimeconfig\_variable
+# google_runtimeconfig_variable
 
 To get more information about RuntimeConfigs, see:
 

--- a/mmv1/third_party/terraform/website/docs/d/secret_manager_secret.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/secret_manager_secret.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Secret Manager Secret
 ---
 
-# google\_secret\_manager\_secret
+# google_secret_manager_secret
 
 Use this data source to get information about a Secret Manager Secret
 

--- a/mmv1/third_party/terraform/website/docs/d/secret_manager_secret_version.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/secret_manager_secret_version.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a Secret Manager secret's version.
 ---
 
-# google\_secret\_manager\_secret\_version
+# google_secret_manager_secret_version
 
 Get the value and metadata from a Secret Manager secret version. For more information see the [official documentation](https://cloud.google.com/secret-manager/docs/) and [API](https://cloud.google.com/secret-manager/docs/reference/rest/v1/projects.secrets.versions). If you don't need the metadata (i.e., if you want to use a more limited role to access the secret version only), see also the [google_secret_manager_secret_version_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/secret_manager_secret_version_access) datasource.
 

--- a/mmv1/third_party/terraform/website/docs/d/secret_manager_secret_version_access.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/secret_manager_secret_version_access.html.markdown
@@ -5,7 +5,7 @@ description: |-
   Get a payload of Secret Manager secret's version.
 ---
 
-# google\_secret\_manager\_secret\_version\_access
+# google_secret_manager_secret_version_access
 
 Get the value from a Secret Manager secret version. This is similar to the [google_secret_manager_secret_version](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/secret_manager_secret_version) datasource, but it only requires the [Secret Manager Secret Accessor](https://cloud.google.com/secret-manager/docs/access-control#secretmanager.secretAccessor) role. For more information see the [official documentation](https://cloud.google.com/secret-manager/docs/) and [API](https://cloud.google.com/secret-manager/docs/reference/rest/v1/projects.secrets.versions/access).
 

--- a/mmv1/third_party/terraform/website/docs/d/secret_manager_secrets.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/secret_manager_secrets.html.markdown
@@ -4,7 +4,7 @@ description: |-
   List the Secret Manager Secrets.
 ---
 
-# google\_secret\_manager\_secrets
+# google_secret_manager_secrets
 
 Use this data source to list the Secret Manager Secrets
 

--- a/mmv1/third_party/terraform/website/docs/d/service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/service_account.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get the service account from a project.
 ---
 
-# google\_service\_account
+# google_service_account
 
 Get the service account from a project. For more information see
 the official [API](https://cloud.google.com/compute/docs/access/service-accounts) documentation.

--- a/mmv1/third_party/terraform/website/docs/d/service_account_access_token.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/service_account_access_token.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Produces access_token for impersonated service accounts
 ---
 
-# google\_service\_account\_access\_token
+# google_service_account_access_token
 
 This data source provides a google `oauth2` `access_token` for a different service account than the one initially running the script.
 

--- a/mmv1/third_party/terraform/website/docs/d/service_account_id_token.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/service_account_id_token.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Produces OpenID Connect token for service accounts
 ---
 
-# google\_service\_account\_id\_token
+# google_service_account_id_token
 
 This data source provides a Google OpenID Connect (`oidc`) `id_token`.  Tokens issued from this data source are typically used to call external services that accept OIDC tokens for authentication (e.g. [Google Cloud Run](https://cloud.google.com/run/docs/authenticating/service-to-service)).
 

--- a/mmv1/third_party/terraform/website/docs/d/service_account_jwt.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/service_account_jwt.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Produces an arbitrary self-signed JWT for service accounts
 ---
 
-# google\_service\_account\_jwt
+# google_service_account_jwt
 
 This data source provides a [self-signed JWT](https://cloud.google.com/iam/docs/create-short-lived-credentials-direct#sa-credentials-jwt).  Tokens issued from this data source are typically used to call external services that accept JWTs for authentication.
 

--- a/mmv1/third_party/terraform/website/docs/d/sourcerepo_repository.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/sourcerepo_repository.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google Cloud Source Repository.
 ---
 
-# google\_sourcerepo\_repository
+# google_sourcerepo_repository
 
 Get infomation about an existing Google Cloud Source Repository.
 For more information see [the official documentation](https://cloud.google.com/source-repositories)

--- a/mmv1/third_party/terraform/website/docs/d/spanner_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/spanner_instance.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a spanner instance from Google Cloud
 ---
 
-# google\_spanner\_instance
+# google_spanner_instance
 
 Get a spanner instance from Google Cloud by its name.
 

--- a/mmv1/third_party/terraform/website/docs/d/sql_backup_run.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/sql_backup_run.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a  SQL backup run in Google Cloud SQL.
 ---
 
-# google\_sql\_backup\_run
+# google_sql_backup_run
 
 Use this data source to get information about a Cloud SQL instance backup run.
 

--- a/mmv1/third_party/terraform/website/docs/d/sql_ca_certs.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/sql_ca_certs.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get all of the trusted Certificate Authorities (CAs) for the specified SQL database instance.
 ---
 
-# google\_sql\_ca\_certs
+# google_sql_ca_certs
 
 Get all of the trusted Certificate Authorities (CAs) for the specified SQL database instance. For more information see the
 [official documentation](https://cloud.google.com/sql/)

--- a/mmv1/third_party/terraform/website/docs/d/sql_database.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/sql_database.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a database in a Cloud SQL database instance.
 ---
 
-# google\_sql\_database
+# google_sql_database
 
 Use this data source to get information about a database in a Cloud SQL instance.
 

--- a/mmv1/third_party/terraform/website/docs/d/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/sql_database_instance.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a SQL database instance in Google Cloud SQL.
 ---
 
-# google\_sql\_database\_instance
+# google_sql_database_instance
 
 Use this data source to get information about a Cloud SQL instance.
 

--- a/mmv1/third_party/terraform/website/docs/d/sql_database_instance_latest_recovery_time.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/sql_database_instance_latest_recovery_time.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get Latest Recovery Time for a given instance.
 ---
 
-# google\_sql\_database\_instance\_latest\_recovery\_time
+# google_sql_database_instance_latest_recovery_time
 
 Get Latest Recovery Time for a given instance. For more information see the
 [official documentation](https://cloud.google.com/sql/)

--- a/mmv1/third_party/terraform/website/docs/d/sql_database_instances.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/sql_database_instances.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a list of SQL database instances in a project in Google Cloud SQL.
 ---
 
-# google\_sql\_database\_instances
+# google_sql_database_instances
 
 Use this data source to get information about a list of Cloud SQL instances in a project. You can also apply some filters over this list to get a more filtered list of Cloud SQL instances.
 

--- a/mmv1/third_party/terraform/website/docs/d/sql_databases.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/sql_databases.html.markdown
@@ -5,7 +5,7 @@ description: |-
   Get a list of databases in a Cloud SQL database instance.
 ---
 
-# google\_sql\_databases
+# google_sql_databases
 
 Use this data source to get information about a list of databases in a Cloud SQL instance.
 ## Example Usage

--- a/mmv1/third_party/terraform/website/docs/d/sql_tiers.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/sql_tiers.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get all available Cloud SQL tiers for the given project.
 ---
 
-# google\_sql\_tiers
+# google_sql_tiers
 
 Get all available machine types (tiers) for a project, for example, db-custom-1-3840. For more information see the
 [official documentation](https://cloud.google.com/sql/)

--- a/mmv1/third_party/terraform/website/docs/d/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/storage_bucket.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a Google Cloud Storage bucket.
 ---
 
-# google\_storage\_bucket
+# google_storage_bucket
 
 Gets an existing bucket in Google Cloud Storage service (GCS).
 See [the official documentation](https://cloud.google.com/storage/docs/key-terms#buckets)

--- a/mmv1/third_party/terraform/website/docs/d/storage_bucket_object.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/storage_bucket_object.html.markdown
@@ -5,7 +5,7 @@ description: |-
 ---
 
 
-# google\_storage\_bucket\_object
+# google_storage_bucket_object
 
 Gets an existing object inside an existing bucket in Google Cloud Storage service (GCS).
 See [the official documentation](https://cloud.google.com/storage/docs/key-terms#objects)

--- a/mmv1/third_party/terraform/website/docs/d/storage_bucket_object_content.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/storage_bucket_object_content.html.markdown
@@ -5,7 +5,7 @@ description: |-
 ---
 
 
-# google\_storage\_bucket\_object\_content
+# google_storage_bucket_object_content
 
 Gets an existing object content inside an existing bucket in Google Cloud Storage service (GCS).
 See [the official documentation](https://cloud.google.com/storage/docs/key-terms#objects)

--- a/mmv1/third_party/terraform/website/docs/d/storage_bucket_objects.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/storage_bucket_objects.html.markdown
@@ -5,7 +5,7 @@ description: |-
 ---
 
 
-# google\_storage\_bucket\_objects
+# google_storage_bucket_objects
 
 Gets existing objects inside an existing bucket in Google Cloud Storage service (GCS).
 See [the official documentation](https://cloud.google.com/storage/docs/key-terms#objects)

--- a/mmv1/third_party/terraform/website/docs/d/storage_buckets.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/storage_buckets.html.markdown
@@ -5,7 +5,7 @@ description: |-
 ---
 
 
-# google\_storage\_buckets
+# google_storage_buckets
 
 Gets a list of existing GCS buckets.
 See [the official documentation](https://cloud.google.com/storage/docs/introduction)

--- a/mmv1/third_party/terraform/website/docs/d/storage_object_signed_url.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/storage_object_signed_url.html.markdown
@@ -4,7 +4,7 @@ description: |-
     Provides signed URL to Google Cloud Storage object.
 ---
 
-# google\_storage\_object\_signed_url
+# google_storage_object_signed_url
 
 The Google Cloud storage signed URL data source generates a signed URL for a given storage object. Signed URLs provide a way to give time-limited read or write access to anyone in possession of the URL, regardless of whether they have a Google account.
 

--- a/mmv1/third_party/terraform/website/docs/d/storage_project_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/storage_project_service_account.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get the email address of the project's Google Cloud Storage service account
 ---
 
-# google\_storage\_project\_service\_account
+# google_storage_project_service_account
 
 Get the email address of a project's unique [automatic Google Cloud Storage service account](https://cloud.google.com/storage/docs/projects#service-accounts).
 

--- a/mmv1/third_party/terraform/website/docs/d/storage_transfer_project_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/storage_transfer_project_service_account.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Retrieve default service account used by Storage Transfer Jobs running in this project
 ---
 
-# google\_storage\_transfer\_project\_service\_account
+# google_storage_transfer_project_service_account
 
 Use this data source to retrieve Storage Transfer service account for this project
 

--- a/mmv1/third_party/terraform/website/docs/d/tags_tag_key.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/tags_tag_key.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a tag key within a GCP organization or project.
 ---
 
-# google\_tags\_tag\_key
+# google_tags_tag_key
 
 Get a tag key by org or project `parent` and `short_name`.
 

--- a/mmv1/third_party/terraform/website/docs/d/tags_tag_keys.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/tags_tag_keys.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get tag keys within a GCP organization or project.
 ---
 
-# google\_tags\_tag\_keys
+# google_tags_tag_keys
 
 Get tag keys by org or project `parent`.
 

--- a/mmv1/third_party/terraform/website/docs/d/tags_tag_value.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/tags_tag_value.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a tag value from the parent key and short_name.
 ---
 
-# google\_tags\_tag\_value
+# google_tags_tag_value
 
 Get a tag value by `parent` key and `short_name`.
 

--- a/mmv1/third_party/terraform/website/docs/d/tags_tag_values.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/tags_tag_values.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get tag values from the parent key.
 ---
 
-# google\_tags\_tag\_values
+# google_tags_tag_values
 
 Get tag values from a `parent` key.
 

--- a/mmv1/third_party/terraform/website/docs/d/tpu_tensorflow_versions.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/tpu_tensorflow_versions.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get available TensorFlow versions.
 ---
 
-# google\_tpu\_tensorflow\_versions
+# google_tpu_tensorflow_versions
 
 Get TensorFlow versions available for a project. For more information see the [official documentation](https://cloud.google.com/tpu/docs/) and [API](https://cloud.google.com/tpu/docs/reference/rest/v1/projects.locations.tensorflowVersions).
 

--- a/mmv1/third_party/terraform/website/docs/d/tpu_v2_accelerator_types.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/tpu_v2_accelerator_types.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get available accelerator types.
 ---
 
-# google\_tpu\_v2\_accelerator\_types
+# google_tpu_v2_accelerator_types
 
 Get accelerator types available for a project. For more information see the [official documentation](https://cloud.google.com/tpu/docs/) and [API](https://cloud.google.com/tpu/docs/reference/rest/v2/projects.locations.acceleratorTypes).
 

--- a/mmv1/third_party/terraform/website/docs/d/tpu_v2_runtime_versions.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/tpu_v2_runtime_versions.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get available runtime versions.
 ---
 
-# google\_tpu\_v2\_runtime\_versions
+# google_tpu_v2_runtime_versions
 
 Get runtime versions available for a project. For more information see the [official documentation](https://cloud.google.com/tpu/docs/) and [API](https://cloud.google.com/tpu/docs/reference/rest/v2/projects.locations.runtimeVersions).
 

--- a/mmv1/third_party/terraform/website/docs/d/vmwareengine_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/vmwareengine_cluster.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get info about a private cloud cluster.
 ---
 
-# google\_vmwareengine\_cluster
+# google_vmwareengine_cluster
 
 Use this data source to get details about a cluster resource.
 

--- a/mmv1/third_party/terraform/website/docs/d/vmwareengine_external_access_rule.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/vmwareengine_external_access_rule.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a external access rule.
 ---
 
-# google\_vmwareengine\_external_access_rule
+# google_vmwareengine_external_access_rule
 
 Use this data source to get details about a external access rule resource.
 

--- a/mmv1/third_party/terraform/website/docs/d/vmwareengine_external_address.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/vmwareengine_external_address.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a external address.
 ---
 
-# google\_vmwareengine\_external_address
+# google_vmwareengine_external_address
 
 Use this data source to get details about a external address resource.
 

--- a/mmv1/third_party/terraform/website/docs/d/vmwareengine_network.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/vmwareengine_network.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a VMwareEngine network.
 ---
 
-# google\_vmwareengine\_network
+# google_vmwareengine_network
 
 Use this data source to get details about a VMwareEngine network resource.
 

--- a/mmv1/third_party/terraform/website/docs/d/vmwareengine_network_peering.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/vmwareengine_network_peering.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a network peering.
 ---
 
-# google\_vmwareengine\_network_peering
+# google_vmwareengine_network_peering
 
 Use this data source to get details about a network peering resource.
 

--- a/mmv1/third_party/terraform/website/docs/d/vmwareengine_network_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/vmwareengine_network_policy.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a network policy.
 ---
 
-# google\_vmwareengine\_network_policy
+# google_vmwareengine_network_policy
 
 Use this data source to get details about a network policy resource.
 

--- a/mmv1/third_party/terraform/website/docs/d/vmwareengine_nsx_credentials.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/vmwareengine_nsx_credentials.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get NSX Credentials of a Private Cloud.
 ---
 
-# google\_vmwareengine\_nsx_credentials
+# google_vmwareengine_nsx_credentials
 
 Use this data source to get NSX credentials for a Private Cloud.
 

--- a/mmv1/third_party/terraform/website/docs/d/vmwareengine_private_cloud.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/vmwareengine_private_cloud.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get information about a private cloud.
 ---
 
-# google\_vmwareengine\_private_cloud
+# google_vmwareengine_private_cloud
 
 Use this data source to get details about a private cloud resource.
 

--- a/mmv1/third_party/terraform/website/docs/d/vmwareengine_subnet.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/vmwareengine_subnet.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get info about a private cloud subnet.
 ---
 
-# google\_vmwareengine\_subnet
+# google_vmwareengine_subnet
 
 Use this data source to get details about a subnet. Management subnets support only read operations and should be configured through this data source. User defined subnets can be configured using the resource as well as the datasource.
 

--- a/mmv1/third_party/terraform/website/docs/d/vmwareengine_vcenter_credentials.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/vmwareengine_vcenter_credentials.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get Vcenter Credentials of a Private Cloud.
 ---
 
-# google\_vmwareengine\_vcenter_credentials
+# google_vmwareengine_vcenter_credentials
 
 Use this data source to get Vcenter credentials for a Private Cloud.
 

--- a/mmv1/third_party/terraform/website/docs/d/vpc_access_connector.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/vpc_access_connector.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Get a Serverless VPC Access connector.
 ---
 
-# google\_vpc\_access\_connector
+# google_vpc_access_connector
 
 Get a Serverless VPC Access connector.
 

--- a/mmv1/third_party/terraform/website/docs/r/apigee_flowhook.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/apigee_flowhook.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Represents a sharedflow attachment to a flowhook point.
 ---
 
-# google\_apigee\_flowhook
+# google_apigee_flowhook
 
 Represents a sharedflow attachment to a flowhook point.
 

--- a/mmv1/third_party/terraform/website/docs/r/apigee_keystores_aliases_key_cert_file.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/apigee_keystores_aliases_key_cert_file.html.markdown
@@ -4,7 +4,7 @@ description: |-
   An alias from a key/certificate pair.
 ---
 
-# google\_apigee\_keystores\_aliases\_key\_cert\_file
+# google_apigee_keystores_aliases_key_cert_file
 
 An alias from a key/certificate pair.
 

--- a/mmv1/third_party/terraform/website/docs/r/apigee_keystores_aliases_pkcs12.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/apigee_keystores_aliases_pkcs12.html.markdown
@@ -4,7 +4,7 @@ description: |-
   An alias from a pkcs12 file.
 ---
 
-# google\_apigee\_keystores\_aliases\_pkcs12
+# google_apigee_keystores_aliases_pkcs12
 
 An alias from a pkcs12 file.
 

--- a/mmv1/third_party/terraform/website/docs/r/apigee_sharedflow.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/apigee_sharedflow.html.markdown
@@ -5,7 +5,7 @@ description: |-
   You can combine policies and resources into a shared flow that you can consume from multiple API proxies, and even from other shared flows.
 ---
 
-# google\_apigee\_shared\_flow
+# google_apigee_shared_flow
 
 You can combine policies and resources into a shared flow that you can consume from multiple API proxies, and even from other shared flows. Although it's like a proxy, a shared flow has no endpoint. It can be used only from an API proxy or shared flow that's in the same organization as the shared flow itself.
 

--- a/mmv1/third_party/terraform/website/docs/r/apigee_sharedflow_deployment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/apigee_sharedflow_deployment.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Deploys a revision of a sharedflow.
 ---
 
-# google\_apigee\_sharedflow\_deployment
+# google_apigee_sharedflow_deployment
 
 Deploys a revision of a sharedflow.
 

--- a/mmv1/third_party/terraform/website/docs/r/bigquery_dataset_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigquery_dataset_iam.html.markdown
@@ -24,7 +24,7 @@ These resources are intended to convert the permissions system for BigQuery data
 
 ~> **Note:** `google_bigquery_dataset_iam_binding` resources **can be** used in conjunction with `google_bigquery_dataset_iam_member` resources **only if** they do not grant privilege to the same role.
 
-## google\_bigquery\_dataset\_iam\_policy
+## google_bigquery_dataset_iam_policy
 
 ```hcl
 data "google_iam_policy" "owner" {
@@ -47,7 +47,7 @@ resource "google_bigquery_dataset" "dataset" {
 }
 ```
 
-## google\_bigquery\_dataset\_iam\_binding
+## google_bigquery_dataset_iam_binding
 
 ```hcl
 resource "google_bigquery_dataset_iam_binding" "reader" {
@@ -64,7 +64,7 @@ resource "google_bigquery_dataset" "dataset" {
 }
 ```
 
-## google\_bigquery\_dataset\_iam\_member
+## google_bigquery_dataset_iam_member
 
 ```hcl
 resource "google_bigquery_dataset_iam_member" "editor" {

--- a/mmv1/third_party/terraform/website/docs/r/bigtable_instance_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_instance_iam.html.markdown
@@ -16,7 +16,7 @@ Three different resources help you manage IAM policies on bigtable instances. Ea
 
 ~> **Note:** `google_bigtable_instance_iam_binding` resources **can be** used in conjunction with `google_bigtable_instance_iam_member` resources **only if** they do not grant privilege to the same role.
 
-## google\_bigtable\_instance\_iam\_policy
+## google_bigtable_instance_iam_policy
 
 ```hcl
 data "google_iam_policy" "admin" {
@@ -35,7 +35,7 @@ resource "google_bigtable_instance_iam_policy" "editor" {
 }
 ```
 
-## google\_bigtable\_instance\_iam\_binding
+## google_bigtable_instance_iam_binding
 
 ```hcl
 resource "google_bigtable_instance_iam_binding" "editor" {
@@ -47,7 +47,7 @@ resource "google_bigtable_instance_iam_binding" "editor" {
 }
 ```
 
-## google\_bigtable\_instance\_iam\_member
+## google_bigtable_instance_iam_member
 
 ```hcl
 resource "google_bigtable_instance_iam_member" "editor" {

--- a/mmv1/third_party/terraform/website/docs/r/bigtable_table_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_table_iam.html.markdown
@@ -16,7 +16,7 @@ Three different resources help you manage IAM policies on bigtable tables. Each 
 
 ~> **Note:** `google_bigtable_table_iam_binding` resources **can be** used in conjunction with `google_bigtable_table_iam_member` resources **only if** they do not grant privilege to the same role.
 
-## google\_bigtable\_table\_iam\_policy
+## google_bigtable_table_iam_policy
 
 ```hcl
 data "google_iam_policy" "admin" {
@@ -36,7 +36,7 @@ resource "google_bigtable_table_iam_policy" "editor" {
 }
 ```
 
-## google\_bigtable\_table\_iam\_binding
+## google_bigtable_table_iam_binding
 
 ```hcl
 resource "google_bigtable_table_iam_binding" "editor" {
@@ -49,7 +49,7 @@ resource "google_bigtable_table_iam_binding" "editor" {
 }
 ```
 
-## google\_bigtable\_table\_iam\_member
+## google_bigtable_table_iam_member
 
 ```hcl
 resource "google_bigtable_table_iam_member" "editor" {

--- a/mmv1/third_party/terraform/website/docs/r/billing_account_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/billing_account_iam.html.markdown
@@ -16,7 +16,7 @@ Three different resources help you manage IAM policies on billing accounts. Each
 
 ~> **Note:** `google_billing_account_iam_binding` resources **can be** used in conjunction with `google_billing_account_iam_member` resources **only if** they do not grant privilege to the same role.
 
-## google\_billing\_account\_iam\_policy
+## google_billing_account_iam_policy
 
 ```hcl
 data "google_iam_policy" "admin" {
@@ -34,7 +34,7 @@ resource "google_billing_account_iam_policy" "editor" {
 }
 ```
 
-## google\_billing\_account\_iam\_binding
+## google_billing_account_iam_binding
 
 ```hcl
 resource "google_billing_account_iam_binding" "editor" {
@@ -46,7 +46,7 @@ resource "google_billing_account_iam_binding" "editor" {
 }
 ```
 
-## google\_billing\_account\_iam\_member
+## google_billing_account_iam_member
 
 ```hcl
 resource "google_billing_account_iam_member" "editor" {

--- a/mmv1/third_party/terraform/website/docs/r/cloudbuild_worker_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/cloudbuild_worker_pool.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Configuration for custom WorkerPool to run builds
 ---
 
-# google\_cloudbuild\_worker\_pool
+# google_cloudbuild_worker_pool
 
 Definition of custom Cloud Build WorkerPools for running jobs with custom configuration and custom networking.
 

--- a/mmv1/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Creates a new Cloud Function.
 ---
 
-# google\_cloudfunctions\_function
+# google_cloudfunctions_function
 
 Creates a new Cloud Function. For more information see:
 

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -4,7 +4,7 @@ description: |-
   An environment for running orchestration tasks.
 ---
 
-# google\_composer\_environment
+# google_composer_environment
 
 An environment for running orchestration tasks.
 

--- a/mmv1/third_party/terraform/website/docs/r/composer_user_workloads_secret.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_user_workloads_secret.html.markdown
@@ -4,7 +4,7 @@ description: |-
   User workloads Secret used by Airflow tasks that run with Kubernetes Executor or KubernetesPodOperator.
 ---
 
-# google\_composer\_user\_workloads\_secret
+# google_composer_user_workloads_secret
 
 ~> **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
 See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.

--- a/mmv1/third_party/terraform/website/docs/r/compute_attached_disk.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_attached_disk.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Resource that allows attaching existing persistent disks to compute instances.
 ---
 
-# google\_compute\_attached\_disk
+# google_compute_attached_disk
 
 Persistent disks can be attached to a compute instance using [the `attached_disk`
 section within the compute instance configuration](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance#attached_disk).

--- a/mmv1/third_party/terraform/website/docs/r/compute_disk_async_replication.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_disk_async_replication.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manage asynchronous Persistent Disk replication.
 ---
 
-# google\_compute\_disk\_async\_replication
+# google_compute_disk_async_replication
 
 Starts and stops asynchronous persistent disk replication. For more information
 see [the official documentation](https://cloud.google.com/compute/docs/disks/async-pd/about)

--- a/mmv1/third_party/terraform/website/docs/r/compute_firewall_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_firewall_policy.html.markdown
@@ -18,7 +18,7 @@ description: |-
   Creates a hierarchical firewall policy
 ---
 
-# google\_compute\_firewall\_policy
+# google_compute_firewall_policy
 
 Hierarchical firewall policy rules let you create and enforce a consistent firewall policy across your organization. Rules can explicitly allow or deny connections or delegate evaluation to lower level policies. Policies can be created within organizations or folders.
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_firewall_policy_association.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_firewall_policy_association.html.markdown
@@ -18,7 +18,7 @@ description: |-
   Applies a hierarchical firewall policy to a target resource
 ---
 
-# google\_compute\_firewall\_policy\_association
+# google_compute_firewall_policy_association
 
 Allows associating hierarchical firewall policies with the target where they are applied. This allows creating policies and rules in a different location than they are applied.
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a VM instance resource within GCE.
 ---
 
-# google\_compute\_instance
+# google_compute_instance
 
 Manages a VM instance resource within GCE. For more information see
 [the official documentation](https://cloud.google.com/compute/docs/instances)

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_from_machine_image.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_from_machine_image.html.markdown
@@ -7,7 +7,7 @@ description: |-
 ~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
 See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
 
-# google\_compute\_instance\_from\_machine\_image
+# google_compute_instance_from_machine_image
 
 Manages a VM instance resource within GCE. For more information see
 [the official documentation](https://cloud.google.com/compute/docs/instances)

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_from_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_from_template.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a VM instance resource within GCE.
 ---
 
-# google\_compute\_instance\_from\_template
+# google_compute_instance_from_template
 
 Manages a VM instance resource within GCE. For more information see
 [the official documentation](https://cloud.google.com/compute/docs/instances)

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_group.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_group.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages an Instance Group within GCE.
 ---
 
-# google\_compute\_instance\_group
+# google_compute_instance_group
 
 Creates a group of dissimilar Compute Engine virtual machine instances.
 For more information, see [the official documentation](https://cloud.google.com/compute/docs/instance-groups/#unmanaged_instance_groups)

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages an Instance Group within GCE.
 ---
 
-# google\_compute\_instance\_group\_manager
+# google_compute_instance_group_manager
 
 The Google Compute Engine Instance Group Manager API creates and manages pools
 of homogeneous Compute Engine virtual machine instances from a common instance

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a VM instance template resource within GCE.
 ---
 
-# google\_compute\_instance\_template
+# google_compute_instance_template
 
 -> **Note**: Global instance templates can be used in any region. To lower the impact of outages outside your region and gain data residency within your region, use [google_compute_region_instance_template](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_instance_template).
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_network_peering.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_network_peering.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a network peering within GCE.
 ---
 
-# google\_compute\_network\_peering
+# google_compute_network_peering
 
 Manages a network peering within GCE. For more information see
 [the official documentation](https://cloud.google.com/compute/docs/vpc/vpc-peering)

--- a/mmv1/third_party/terraform/website/docs/r/compute_project_default_network_tier.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_project_default_network_tier.html.markdown
@@ -4,7 +4,7 @@ description: |-
  Configures the default network tier for a project.
 ---
 
-# google\_compute\_project\_default\_network\_tier
+# google_compute_project_default_network_tier
 
 Configures the Google Compute Engine
 [Default Network Tier](https://cloud.google.com/network-tiers/docs/using-network-service-tiers#setting_the_tier_for_all_resources_in_a_project)

--- a/mmv1/third_party/terraform/website/docs/r/compute_project_metadata.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_project_metadata.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages common instance metadata
 ---
 
-# google\_compute\_project\_metadata
+# google_compute_project_metadata
 
 Authoritatively manages metadata common to all instances for a project in GCE. For more information see
 [the official documentation](https://cloud.google.com/compute/docs/storing-retrieving-metadata)

--- a/mmv1/third_party/terraform/website/docs/r/compute_project_metadata_item.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_project_metadata_item.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a single key/value pair on common instance metadata
 ---
 
-# google\_compute\_project\_metadata\_item
+# google_compute_project_metadata_item
 
 Manages a single key/value pair on metadata common to all instances for
 a project in GCE. Using `google_compute_project_metadata_item` lets you

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages an Regional Instance Group within GCE.
 ---
 
-# google\_compute\_region\_instance\_group\_manager
+# google_compute_region_instance_group_manager
 
 The Google Compute Engine Regional Instance Group Manager API creates and manages pools
 of homogeneous Compute Engine virtual machine instances from a common instance

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a VM instance template resource within GCE.
 ---
 
-# google\_compute\_region\_instance\_template
+# google_compute_region_instance_template
 
 Manages a VM instance template resource within GCE. For more information see
 [the official documentation](https://cloud.google.com/compute/docs/instance-templates)

--- a/mmv1/third_party/terraform/website/docs/r/compute_router_interface.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_router_interface.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a Cloud Router interface.
 ---
 
-# google\_compute\_router_interface
+# google_compute_router_interface
 
 Manages a Cloud Router interface. For more information see
 [the official documentation](https://cloud.google.com/compute/docs/cloudrouter)

--- a/mmv1/third_party/terraform/website/docs/r/compute_router_peer.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_router_peer.html.markdown
@@ -5,7 +5,7 @@ description: |-
   establish BGP peering.
 ---
 
-# google\_compute\_router\_peer
+# google_compute_router_peer
 
 BGP information that must be configured into the routing stack to
 establish BGP peering. This information must specify the peer ASN

--- a/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Creates a Security Policy resource for Google Compute Engine.
 ---
 
-# google\_compute\_security\_policy
+# google_compute_security_policy
 
 A Security Policy defines an IP blacklist or whitelist that protects load balanced Google Cloud services by denying or permitting traffic from specified IP ranges. For more information
 see the [official documentation](https://cloud.google.com/armor/docs/configure-security-policies)

--- a/mmv1/third_party/terraform/website/docs/r/compute_target_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_target_pool.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a Target Pool within GCE.
 ---
 
-# google\_compute\_target\_pool
+# google_compute_target_pool
 
 Manages a Target Pool within GCE. This is a collection of instances used as
 target of a network load balancer (Forwarding Rule). For more information see
@@ -47,7 +47,7 @@ The following arguments are supported:
 - - -
 
 * `backup_pool` - (Optional) URL to the backup target pool. Must also set
-    failover\_ratio.
+    failover_ratio.
 
 * `description` - (Optional) Textual description field.
 
@@ -70,8 +70,8 @@ The following arguments are supported:
     region.
 
 * `session_affinity` - (Optional) How to distribute load. Options are "NONE" (no
-    affinity). "CLIENT\_IP" (hash of the source/dest addresses / ports), and
-    "CLIENT\_IP\_PROTO" also includes the protocol (default "NONE").
+    affinity). "CLIENT_IP" (hash of the source/dest addresses / ports), and
+    "CLIENT_IP_PROTO" also includes the protocol (default "NONE").
 
 * `security_policy` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) The resource URL for the security policy associated with this target pool.
 

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Creates a Google Kubernetes Engine (GKE) cluster.
 ---
 
-# google\_container\_cluster
+# google_container_cluster
 
 Manages a Google Kubernetes Engine (GKE) cluster.
 

--- a/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a GKE NodePool resource.
 ---
 
-# google\_container\_node\_pool
+# google_container_node_pool
 
 -> See the [Using GKE with Terraform](/docs/providers/google/guides/using_gke_with_terraform.html)
 guide for more information about using GKE with Terraform.

--- a/mmv1/third_party/terraform/website/docs/r/dataflow_flex_template_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataflow_flex_template_job.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Creates a job in Dataflow based on a Flex Template.
 ---
 
-# google\_dataflow\_flex\_template\_job
+# google_dataflow_flex_template_job
 
 Creates a [Flex Template](https://cloud.google.com/dataflow/docs/guides/templates/using-flex-templates)
 job on Dataflow, which is an implementation of Apache Beam running on Google

--- a/mmv1/third_party/terraform/website/docs/r/dataflow_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataflow_job.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Creates a job in Dataflow according to a provided config file.
 ---
 
-# google\_dataflow\_job
+# google_dataflow_job
 
 Creates a job on Dataflow, which is an implementation of Apache Beam running on Google Compute Engine. For more information see
 the official documentation for

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a Cloud Dataproc cluster resource.
 ---
 
-# google\_dataproc\_cluster
+# google_dataproc_cluster
 
 Manages a Cloud Dataproc cluster resource within GCP.
 

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_cluster_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_cluster_iam.html.markdown
@@ -16,7 +16,7 @@ Three different resources help you manage IAM policies on dataproc clusters. Eac
 
 ~> **Note:** `google_dataproc_cluster_iam_binding` resources **can be** used in conjunction with `google_dataproc_cluster_iam_member` resources **only if** they do not grant privilege to the same role.
 
-## google\_dataproc\_cluster\_iam\_policy
+## google_dataproc_cluster_iam_policy
 
 ```hcl
 data "google_iam_policy" "admin" {
@@ -36,7 +36,7 @@ resource "google_dataproc_cluster_iam_policy" "editor" {
 }
 ```
 
-## google\_dataproc\_cluster\_iam\_binding
+## google_dataproc_cluster_iam_binding
 
 ```hcl
 resource "google_dataproc_cluster_iam_binding" "editor" {
@@ -48,7 +48,7 @@ resource "google_dataproc_cluster_iam_binding" "editor" {
 }
 ```
 
-## google\_dataproc\_cluster\_iam\_member
+## google_dataproc_cluster_iam_member
 
 ```hcl
 resource "google_dataproc_cluster_iam_member" "editor" {

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_job.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a job resource within a Dataproc cluster.
 ---
 
-# google\_dataproc\_job
+# google_dataproc_job
 
 Manages a job resource within a Dataproc cluster within GCE. For more information see
 [the official dataproc documentation](https://cloud.google.com/dataproc/).

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_job_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_job_iam.html.markdown
@@ -16,7 +16,7 @@ Three different resources help you manage IAM policies on dataproc jobs. Each of
 
 ~> **Note:** `google_dataproc_job_iam_binding` resources **can be** used in conjunction with `google_dataproc_job_iam_member` resources **only if** they do not grant privilege to the same role.
 
-## google\_dataproc\_job\_iam\_policy
+## google_dataproc_job_iam_policy
 
 ```hcl
 data "google_iam_policy" "admin" {
@@ -36,7 +36,7 @@ resource "google_dataproc_job_iam_policy" "editor" {
 }
 ```
 
-## google\_dataproc\_job\_iam\_binding
+## google_dataproc_job_iam_binding
 
 ```hcl
 resource "google_dataproc_job_iam_binding" "editor" {
@@ -48,7 +48,7 @@ resource "google_dataproc_job_iam_binding" "editor" {
 }
 ```
 
-## google\_dataproc\_job\_iam\_member
+## google_dataproc_job_iam_member
 
 ```hcl
 resource "google_dataproc_job_iam_member" "editor" {

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_workflow_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_workflow_template.html.markdown
@@ -4,7 +4,7 @@ description: |-
   A Workflow Template is a reusable workflow configuration.
 ---
 
-# google\_dataproc\_workflow\_template
+# google_dataproc_workflow_template
 
 A Workflow Template is a reusable workflow configuration. It defines a graph of jobs with information on where to run those jobs.
 

--- a/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a set of DNS records within Google Cloud DNS.
 ---
 
-# google\_dns\_record\_set
+# google_dns_record_set
 
 Manages a set of DNS records within Google Cloud DNS. For more information see [the official documentation](https://cloud.google.com/dns/records/) and
 [API](https://cloud.google.com/dns/api/v1/resourceRecordSets).

--- a/mmv1/third_party/terraform/website/docs/r/gke_hub_feature_membership.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/gke_hub_feature_membership.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Contains information about a GKEHub Feature Memberships.
 ---
 
-# google\_gkehub\_feature\_membership
+# google_gkehub_feature_membership
 
 Contains information about a GKEHub Feature Memberships. Feature Memberships configure GKEHub Features that apply to specific memberships rather than the project as a whole. The google_gke_hub is the Fleet API.
 

--- a/mmv1/third_party/terraform/website/docs/r/google_billing_subaccount.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_billing_subaccount.html.markdown
@@ -4,7 +4,7 @@ description: |-
  Allows management of a Google Cloud Billing Subaccount.
 ---
 
-# google\_billing\_subaccount
+# google_billing_subaccount
 
 Allows creation and management of a Google Cloud Billing Subaccount.
 

--- a/mmv1/third_party/terraform/website/docs/r/google_folder.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_folder.html.markdown
@@ -4,7 +4,7 @@ description: |-
  Allows management of a Google Cloud Platform folder.
 ---
 
-# google\_folder
+# google_folder
 
 Allows management of a Google Cloud Platform folder. For more information see 
 [the official documentation](https://cloud.google.com/resource-manager/docs/creating-managing-folders)

--- a/mmv1/third_party/terraform/website/docs/r/google_folder_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_folder_iam.html.markdown
@@ -21,7 +21,7 @@ Four different resources help you manage your IAM policy for a folder. Each of t
 ~> **Note:** The underlying API method `projects.setIamPolicy` has constraints which are documented [here](https://cloud.google.com/resource-manager/reference/rest/v1/projects/setIamPolicy). In addition to these constraints, 
    IAM Conditions cannot be used with Basic Roles such as Owner. Violating these constraints will result in the API returning a 400 error code so please review these if you encounter errors with this resource.
 
-## google\_folder\_iam\_policy
+## google_folder_iam_policy
 
 !> **Be careful!** You can accidentally lock yourself out of your folder
    using this resource. Deleting a `google_folder_iam_policy` removes access
@@ -73,7 +73,7 @@ data "google_iam_policy" "admin" {
 }
 ```
 
-## google\_folder\_iam\_binding
+## google_folder_iam_binding
 
 ```hcl
 resource "google_folder_iam_binding" "folder" {
@@ -105,7 +105,7 @@ resource "google_folder_iam_binding" "folder" {
 }
 ```
 
-## google\_folder\_iam\_member
+## google_folder_iam_member
 
 ```hcl
 resource "google_folder_iam_member" "folder" {
@@ -131,7 +131,7 @@ resource "google_folder_iam_member" "folder" {
 }
 ```
 
-## google\_folder\_iam\_audit\_config
+## google_folder_iam_audit_config
 
 ```hcl
 resource "google_folder_iam_audit_config" "folder" {
@@ -153,14 +153,14 @@ resource "google_folder_iam_audit_config" "folder" {
 
 The following arguments are supported:
 
-* `member/members` - (Required except for google\_folder\_iam\_audit\_config) Identities that will be granted the privilege in `role`.
+* `member/members` - (Required except for google_folder_iam_audit_config) Identities that will be granted the privilege in `role`.
   Each entry can have one of the following values:
   * **user:{emailid}**: An email address that represents a specific Google account. For example, alice@gmail.com or joe@example.com.
   * **serviceAccount:{emailid}**: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.
   * **group:{emailid}**: An email address that represents a Google group. For example, admins@example.com.
   * **domain:{domain}**: A G Suite domain (primary, instead of alias) name that represents all the users of that domain. For example, google.com or example.com.
 
-* `role` - (Required except for google\_folder\_iam\_audit\_config) The role that should be applied. Only one
+* `role` - (Required except for google_folder_iam_audit_config) The role that should be applied. Only one
     `google_folder_iam_binding` can be used per role. Note that custom roles must be of the format
     `organizations/{{org_id}}/roles/{{role_id}}`.
 
@@ -175,9 +175,9 @@ The following arguments are supported:
 
 * `folder` - (Required) The resource name of the folder the policy is attached to. Its format is folders/{folder_id}.
 
-* `service` - (Required only by google\_folder\_iam\_audit\_config) Service which will be enabled for audit logging.  The special value `allServices` covers all services.  Note that if there are google\_folder\_iam\_audit\_config resources covering both `allServices` and a specific service then the union of the two AuditConfigs is used for that service: the `log_types` specified in each `audit_log_config` are enabled, and the `exempted_members` in each `audit_log_config` are exempted.
+* `service` - (Required only by google_folder_iam_audit_config) Service which will be enabled for audit logging.  The special value `allServices` covers all services.  Note that if there are google_folder_iam_audit_config resources covering both `allServices` and a specific service then the union of the two AuditConfigs is used for that service: the `log_types` specified in each `audit_log_config` are enabled, and the `exempted_members` in each `audit_log_config` are exempted.
 
-* `audit_log_config` - (Required only by google\_folder\_iam\_audit\_config) The configuration for logging of each type of permission.  This can be specified multiple times.  Structure is [documented below](#nested_audit_log_config).
+* `audit_log_config` - (Required only by google_folder_iam_audit_config) The configuration for logging of each type of permission.  This can be specified multiple times.  Structure is [documented below](#nested_audit_log_config).
 
 * `condition` - (Optional) An [IAM Condition](https://cloud.google.com/iam/docs/conditions-overview) for a given binding.
   Structure is [documented below](#nested_condition).

--- a/mmv1/third_party/terraform/website/docs/r/google_folder_organization_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_folder_organization_policy.html.markdown
@@ -4,7 +4,7 @@ description: |-
  Allows management of Organization policies for a Google Folder.
 ---
 
-# google\_folder\_organization\_policy
+# google_folder_organization_policy
 
 Allows management of Organization Policies for a Google Cloud Folder. 
 

--- a/mmv1/third_party/terraform/website/docs/r/google_kms_crypto_key_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_kms_crypto_key_iam.html.markdown
@@ -16,7 +16,7 @@ Three different resources help you manage your IAM policy for KMS crypto key. Ea
 
 ~> **Note:** `google_kms_crypto_key_iam_binding` resources **can be** used in conjunction with `google_kms_crypto_key_iam_member` resources **only if** they do not grant privilege to the same role.
 
-# google\_kms\_crypto\_key\_iam\_policy
+# google_kms_crypto_key_iam_policy
 
 ```hcl
 resource "google_kms_key_ring" "keyring" {
@@ -68,7 +68,7 @@ data "google_iam_policy" "admin" {
 }
 ```
 
-# google\_kms\_crypto\_key\_iam\_binding
+# google_kms_crypto_key_iam_binding
 
 ```hcl
 resource "google_kms_crypto_key_iam_binding" "crypto_key" {
@@ -100,7 +100,7 @@ resource "google_kms_crypto_key_iam_binding" "crypto_key" {
 }
 ```
 
-# google\_kms\_crypto\_key\_iam\_member
+# google_kms_crypto_key_iam_member
 
 ```hcl
 resource "google_kms_crypto_key_iam_member" "crypto_key" {

--- a/mmv1/third_party/terraform/website/docs/r/google_kms_key_ring_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_kms_key_ring_iam.html.markdown
@@ -16,7 +16,7 @@ Three different resources help you manage your IAM policy for KMS key ring. Each
 
 ~> **Note:** `google_kms_key_ring_iam_binding` resources **can be** used in conjunction with `google_kms_key_ring_iam_member` resources **only if** they do not grant privilege to the same role.
 
-## google\_kms\_key\_ring\_iam\_policy
+## google_kms_key_ring_iam_policy
 
 ```hcl
 resource "google_kms_key_ring" "keyring" {
@@ -70,7 +70,7 @@ resource "google_kms_key_ring_iam_policy" "key_ring" {
 }
 ```
 
-## google\_kms\_key\_ring\_iam\_binding
+## google_kms_key_ring_iam_binding
 
 ```hcl
 resource "google_kms_key_ring_iam_binding" "key_ring" {
@@ -102,7 +102,7 @@ resource "google_kms_key_ring_iam_binding" "key_ring" {
 }
 ```
 
-## google\_kms\_key\_ring\_iam\_member
+## google_kms_key_ring_iam_member
 
 ```hcl
 resource "google_kms_key_ring_iam_member" "key_ring" {

--- a/mmv1/third_party/terraform/website/docs/r/google_organization_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_organization_iam.html.markdown
@@ -18,7 +18,7 @@ Four different resources help you manage your IAM policy for a organization. Eac
 
 ~> **Note:** `google_organization_iam_binding` resources **can be** used in conjunction with `google_organization_iam_member` resources **only if** they do not grant privilege to the same role.
 
-## google\_organization\_iam\_policy
+## google_organization_iam_policy
 
 !> **Warning:** New organizations have several default policies which will,
    without extreme caution, be **overwritten** by use of this resource.
@@ -74,7 +74,7 @@ data "google_iam_policy" "admin" {
 }
 ```
 
-## google\_organization\_iam\_binding
+## google_organization_iam_binding
 
 ~> **Note:** If `role` is set to `roles/owner` and you don't specify a user or service account you have access to in `members`, you can lock yourself out of your organization.
 
@@ -108,7 +108,7 @@ resource "google_organization_iam_binding" "organization" {
 }
 ```
 
-## google\_organization\_iam\_member
+## google_organization_iam_member
 
 ```hcl
 resource "google_organization_iam_member" "organization" {
@@ -134,7 +134,7 @@ resource "google_organization_iam_member" "organization" {
 }
 ```
 
-## google\_organization\_iam\_audit\_config
+## google_organization_iam_audit_config
 
 ```hcl
 resource "google_organization_iam_audit_config" "organization" {
@@ -156,14 +156,14 @@ resource "google_organization_iam_audit_config" "organization" {
 
 The following arguments are supported:
 
-* `member/members` - (Required except for google\_organization\_iam\_audit\_config) Identities that will be granted the privilege in `role`.
+* `member/members` - (Required except for google_organization_iam_audit_config) Identities that will be granted the privilege in `role`.
   Each entry can have one of the following values:
   * **user:{emailid}**: An email address that represents a specific Google account. For example, alice@gmail.com or joe@example.com.
   * **serviceAccount:{emailid}**: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.
   * **group:{emailid}**: An email address that represents a Google group. For example, admins@example.com.
   * **domain:{domain}**: A G Suite domain (primary, instead of alias) name that represents all the users of that domain. For example, google.com or example.com.
 
-* `role` - (Required except for google\_organization\_iam\_audit\_config) The role that should be applied. Only one
+* `role` - (Required except for google_organization_iam_audit_config) The role that should be applied. Only one
     `google_organization_iam_binding` can be used per role. Note that custom roles must be of the format
     `organizations/{{org_id}}/roles/{{role_id}}`.
 
@@ -178,9 +178,9 @@ The following arguments are supported:
 
 * `org_id` - (Required) The organization id of the target organization.
 
-* `service` - (Required only by google\_organization\_iam\_audit\_config) Service which will be enabled for audit logging.  The special value `allServices` covers all services.  Note that if there are google\_organization\_iam\_audit\_config resources covering both `allServices` and a specific service then the union of the two AuditConfigs is used for that service: the `log_types` specified in each `audit_log_config` are enabled, and the `exempted_members` in each `audit_log_config` are exempted.
+* `service` - (Required only by google_organization_iam_audit_config) Service which will be enabled for audit logging.  The special value `allServices` covers all services.  Note that if there are google_organization_iam_audit_config resources covering both `allServices` and a specific service then the union of the two AuditConfigs is used for that service: the `log_types` specified in each `audit_log_config` are enabled, and the `exempted_members` in each `audit_log_config` are exempted.
 
-* `audit_log_config` - (Required only by google\_organization\_iam\_audit\_config) The configuration for logging of each type of permission.  This can be specified multiple times.  Structure is [documented below](#nested_audit_log_config).
+* `audit_log_config` - (Required only by google_organization_iam_audit_config) The configuration for logging of each type of permission.  This can be specified multiple times.  Structure is [documented below](#nested_audit_log_config).
 
 * `condition` - (Optional) An [IAM Condition](https://cloud.google.com/iam/docs/conditions-overview) for a given binding.
   Structure is [documented below](#nested_condition).

--- a/mmv1/third_party/terraform/website/docs/r/google_organization_iam_custom_role.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_organization_iam_custom_role.html.markdown
@@ -4,7 +4,7 @@ description: |-
  Allows management of a customized Cloud IAM organization role.
 ---
 
-# google\_organization\_iam\_custom\_role
+# google_organization_iam_custom_role
 
 Allows management of a customized Cloud IAM organization role. For more information see
 [the official documentation](https://cloud.google.com/iam/docs/understanding-custom-roles)

--- a/mmv1/third_party/terraform/website/docs/r/google_organization_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_organization_policy.html.markdown
@@ -4,7 +4,7 @@ description: |-
  Allows management of Organization policies for a Google Organization.
 ---
 
-# google\_organization\_policy
+# google_organization_policy
 
 Allows management of Organization Policies for a Google Cloud Organization. 
 

--- a/mmv1/third_party/terraform/website/docs/r/google_project.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project.html.markdown
@@ -4,7 +4,7 @@ description: |-
  Allows management of a Google Cloud Platform project.
 ---
 
-# google\_project
+# google_project
 
 Allows creation and management of a Google Cloud Platform project.
 

--- a/mmv1/third_party/terraform/website/docs/r/google_project_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project_iam.html.markdown
@@ -20,7 +20,7 @@ Four different resources help you manage your IAM policy for a project. Each of 
 ~> **Note:** The underlying API method `projects.setIamPolicy` has a lot of constraints which are documented [here](https://cloud.google.com/resource-manager/reference/rest/v1/projects/setIamPolicy). In addition to these constraints, 
    IAM Conditions cannot be used with Basic Roles such as Owner. Violating these constraints will result in the API returning 400 error code so please review these if you encounter errors with this resource.
 
-## google\_project\_iam\_policy
+## google_project_iam_policy
 
 !> **Be careful!** You can accidentally lock yourself out of your project
    using this resource. Deleting a `google_project_iam_policy` removes access
@@ -72,7 +72,7 @@ data "google_iam_policy" "admin" {
 }
 ```
 
-## google\_project\_iam\_binding
+## google_project_iam_binding
 
 ```hcl
 resource "google_project_iam_binding" "project" {
@@ -104,7 +104,7 @@ resource "google_project_iam_binding" "project" {
 }
 ```
 
-## google\_project\_iam\_member
+## google_project_iam_member
 
 ```hcl
 resource "google_project_iam_member" "project" {
@@ -130,7 +130,7 @@ resource "google_project_iam_member" "project" {
 }
 ```
 
-## google\_project\_iam\_audit\_config
+## google_project_iam_audit_config
 
 ```hcl
 resource "google_project_iam_audit_config" "project" {
@@ -152,14 +152,14 @@ resource "google_project_iam_audit_config" "project" {
 
 The following arguments are supported:
 
-* `member/members` - (Required except for google\_project\_iam\_audit\_config) Identities that will be granted the privilege in `role`. google\_project\_iam\_binding expects `members` field while google\_project\_iam\_member expects `member` field.
+* `member/members` - (Required except for google_project_iam_audit_config) Identities that will be granted the privilege in `role`. google_project_iam_binding expects `members` field while google_project_iam_member expects `member` field.
   Each entry can have one of the following values:
   * **user:{emailid}**: An email address that represents a specific Google account. For example, alice@gmail.com or joe@example.com.
   * **serviceAccount:{emailid}**: An email address that represents a service account. For example, my-other-app@appspot.gserviceaccount.com.
   * **group:{emailid}**: An email address that represents a Google group. For example, admins@example.com.
   * **domain:{domain}**: A G Suite domain (primary, instead of alias) name that represents all the users of that domain. For example, google.com or example.com.
 
-* `role` - (Required except for google\_project\_iam\_audit\_config) The role that should be applied. Only one
+* `role` - (Required except for google_project_iam_audit_config) The role that should be applied. Only one
     `google_project_iam_binding` can be used per role. Note that custom roles must be of the format
     `[projects|organizations]/{parent-name}/roles/{role-name}`.
 
@@ -175,9 +175,9 @@ The following arguments are supported:
 * `project` - (Required) The project id of the target project. This is not
 inferred from the provider.
 
-* `service` - (Required only by google\_project\_iam\_audit\_config) Service which will be enabled for audit logging.  The special value `allServices` covers all services.  Note that if there are google\_project\_iam\_audit\_config resources covering both `allServices` and a specific service then the union of the two AuditConfigs is used for that service: the `log_types` specified in each `audit_log_config` are enabled, and the `exempted_members` in each `audit_log_config` are exempted.
+* `service` - (Required only by google_project_iam_audit_config) Service which will be enabled for audit logging.  The special value `allServices` covers all services.  Note that if there are google_project_iam_audit_config resources covering both `allServices` and a specific service then the union of the two AuditConfigs is used for that service: the `log_types` specified in each `audit_log_config` are enabled, and the `exempted_members` in each `audit_log_config` are exempted.
 
-* `audit_log_config` - (Required only by google\_project\_iam\_audit\_config) The configuration for logging of each type of permission.  This can be specified multiple times.  Structure is [documented below](#nested_audit_log_config).
+* `audit_log_config` - (Required only by google_project_iam_audit_config) The configuration for logging of each type of permission.  This can be specified multiple times.  Structure is [documented below](#nested_audit_log_config).
 
 * `condition` - (Optional) An [IAM Condition](https://cloud.google.com/iam/docs/conditions-overview) for a given binding.
   Structure is [documented below](#nested_condition).

--- a/mmv1/third_party/terraform/website/docs/r/google_project_iam_custom_role.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project_iam_custom_role.html.markdown
@@ -4,7 +4,7 @@ description: |-
  Allows management of a customized Cloud IAM project role.
 ---
 
-# google\_project\_iam\_custom\_role
+# google_project_iam_custom_role
 
 Allows management of a customized Cloud IAM project role. For more information see
 [the official documentation](https://cloud.google.com/iam/docs/understanding-custom-roles)

--- a/mmv1/third_party/terraform/website/docs/r/google_project_iam_member_remove.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project_iam_member_remove.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Ensures that a member:role pairing does not exist in a project's IAM policy.
 ---
 
-# google\_project\_iam\member\_remove
+# google_project_iam\member_remove
 
 Ensures that a member:role pairing does not exist in a project's IAM policy. 
 

--- a/mmv1/third_party/terraform/website/docs/r/google_project_organization_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project_organization_policy.html.markdown
@@ -4,7 +4,7 @@ description: |-
  Allows management of Organization policies for a Google Project.
 ---
 
-# google\_project\_organization\_policy
+# google_project_organization_policy
 
 Allows management of Organization Policies for a Google Cloud Project.
 

--- a/mmv1/third_party/terraform/website/docs/r/google_project_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project_service.html.markdown
@@ -4,7 +4,7 @@ description: |-
  Allows management of a single API service for a Google Cloud project.
 ---
 
-# google\_project\_service
+# google_project_service
 
 Allows management of a single API service for a Google Cloud project. 
 

--- a/mmv1/third_party/terraform/website/docs/r/google_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_service_account.html.markdown
@@ -4,7 +4,7 @@ description: |-
  Allows management of a Google Cloud Platform service account.
 ---
 
-# google\_service\_account
+# google_service_account
 
 Allows management of a Google Cloud service account.
 

--- a/mmv1/third_party/terraform/website/docs/r/google_service_account_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_service_account_iam.html.markdown
@@ -18,7 +18,7 @@ Three different resources help you manage your IAM policy for a service account.
 
 ~> **Note:** `google_service_account_iam_binding` resources **can be** used in conjunction with `google_service_account_iam_member` resources **only if** they do not grant privilege to the same role.
 
-## google\_service\_account\_iam\_policy
+## google_service_account_iam_policy
 
 ```hcl
 data "google_iam_policy" "admin" {
@@ -42,7 +42,7 @@ resource "google_service_account_iam_policy" "admin-account-iam" {
 }
 ```
 
-## google\_service\_account\_iam\_binding
+## google_service_account_iam_binding
 
 ```hcl
 resource "google_service_account" "sa" {
@@ -84,7 +84,7 @@ resource "google_service_account_iam_binding" "admin-account-iam" {
 }
 ```
 
-## google\_service\_account\_iam\_member
+## google_service_account_iam_member
 
 ```hcl
 data "google_compute_default_service_account" "default" {

--- a/mmv1/third_party/terraform/website/docs/r/google_service_networking_peered_dns_domain.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_service_networking_peered_dns_domain.html.markdown
@@ -4,7 +4,7 @@ description: |-
  Allows management of a single peered DNS domain on a project.
 ---
 
-# google\_project\_service\_peered\_dns\_domain
+# google_project_service_peered_dns_domain
 
 Allows management of a single peered DNS domain for an existing Google Cloud Platform project.
 

--- a/mmv1/third_party/terraform/website/docs/r/google_tags_location_tag_binding.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_tags_location_tag_binding.html.markdown
@@ -4,7 +4,7 @@ description: |-
   A LocationTagBinding represents a connection between a TagValue and a non-global cloud resource.
 ---
 
-# google\_tags\_location\_tag\_binding
+# google_tags_location_tag_binding
 
 A LocationTagBinding represents a connection between a TagValue and a non-global target such as a Cloud Run Service or Compute Instance. Once a LocationTagBinding is created, the TagValue is applied to all the descendants of the cloud resource.
 

--- a/mmv1/third_party/terraform/website/docs/r/healthcare_dataset_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/healthcare_dataset_iam.html.markdown
@@ -19,7 +19,7 @@ Three different resources help you manage your IAM policy for Healthcare dataset
 
 ~> **Note:** `google_healthcare_dataset_iam_binding` resources **can be** used in conjunction with `google_healthcare_dataset_iam_member` resources **only if** they do not grant privilege to the same role.
 
-## google\_healthcare\_dataset\_iam\_policy
+## google_healthcare_dataset_iam_policy
 
 ```hcl
 data "google_iam_policy" "admin" {
@@ -38,7 +38,7 @@ resource "google_healthcare_dataset_iam_policy" "dataset" {
 }
 ```
 
-## google\_healthcare\_dataset\_iam\_binding
+## google_healthcare_dataset_iam_binding
 
 ```hcl
 resource "google_healthcare_dataset_iam_binding" "dataset" {
@@ -51,7 +51,7 @@ resource "google_healthcare_dataset_iam_binding" "dataset" {
 }
 ```
 
-## google\_healthcare\_dataset\_iam\_member
+## google_healthcare_dataset_iam_member
 
 ```hcl
 resource "google_healthcare_dataset_iam_member" "dataset" {

--- a/mmv1/third_party/terraform/website/docs/r/healthcare_dicom_store_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/healthcare_dicom_store_iam.html.markdown
@@ -19,7 +19,7 @@ Three different resources help you manage your IAM policy for Healthcare DICOM s
 
 ~> **Note:** `google_healthcare_dicom_store_iam_binding` resources **can be** used in conjunction with `google_healthcare_dicom_store_iam_member` resources **only if** they do not grant privilege to the same role.
 
-## google\_healthcare\_dicom\_store\_iam\_policy
+## google_healthcare_dicom_store_iam_policy
 
 ```hcl
 data "google_iam_policy" "admin" {
@@ -38,7 +38,7 @@ resource "google_healthcare_dicom_store_iam_policy" "dicom_store" {
 }
 ```
 
-## google\_healthcare\_dicom\_store\_iam\_binding
+## google_healthcare_dicom_store_iam_binding
 
 ```hcl
 resource "google_healthcare_dicom_store_iam_binding" "dicom_store" {
@@ -51,7 +51,7 @@ resource "google_healthcare_dicom_store_iam_binding" "dicom_store" {
 }
 ```
 
-## google\_healthcare\_dicom\_store\_iam\_member
+## google_healthcare_dicom_store_iam_member
 
 ```hcl
 resource "google_healthcare_dicom_store_iam_member" "dicom_store" {

--- a/mmv1/third_party/terraform/website/docs/r/healthcare_fhir_store_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/healthcare_fhir_store_iam.html.markdown
@@ -19,7 +19,7 @@ Three different resources help you manage your IAM policy for Healthcare FHIR st
 
 ~> **Note:** `google_healthcare_fhir_store_iam_binding` resources **can be** used in conjunction with `google_healthcare_fhir_store_iam_member` resources **only if** they do not grant privilege to the same role.
 
-## google\_healthcare\_fhir\_store\_iam\_policy
+## google_healthcare_fhir_store_iam_policy
 
 ```hcl
 data "google_iam_policy" "admin" {
@@ -38,7 +38,7 @@ resource "google_healthcare_fhir_store_iam_policy" "fhir_store" {
 }
 ```
 
-## google\_healthcare\_fhir\_store\_iam\_binding
+## google_healthcare_fhir_store_iam_binding
 
 ```hcl
 resource "google_healthcare_fhir_store_iam_binding" "fhir_store" {
@@ -51,7 +51,7 @@ resource "google_healthcare_fhir_store_iam_binding" "fhir_store" {
 }
 ```
 
-## google\_healthcare\_fhir\_store\_iam\_member
+## google_healthcare_fhir_store_iam_member
 
 ```hcl
 resource "google_healthcare_fhir_store_iam_member" "fhir_store" {

--- a/mmv1/third_party/terraform/website/docs/r/healthcare_hl7_v2_store_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/healthcare_hl7_v2_store_iam.html.markdown
@@ -19,7 +19,7 @@ Three different resources help you manage your IAM policy for Healthcare HL7v2 s
 
 ~> **Note:** `google_healthcare_hl7_v2_store_iam_binding` resources **can be** used in conjunction with `google_healthcare_hl7_v2_store_iam_member` resources **only if** they do not grant privilege to the same role.
 
-## google\_healthcare\_hl7\_v2\_store\_iam\_policy
+## google_healthcare_hl7_v2_store_iam_policy
 
 ```hcl
 data "google_iam_policy" "admin" {
@@ -38,7 +38,7 @@ resource "google_healthcare_hl7_v2_store_iam_policy" "hl7_v2_store" {
 }
 ```
 
-## google\_healthcare\_hl7\_v2\_store\_iam\_binding
+## google_healthcare_hl7_v2_store_iam_binding
 
 ```hcl
 resource "google_healthcare_hl7_v2_store_iam_binding" "hl7_v2_store" {
@@ -52,7 +52,7 @@ resource "google_healthcare_hl7_v2_store_iam_binding" "hl7_v2_store" {
 
 ```
 
-## google\_healthcare\_hl7\_v2\_store\_iam\_member
+## google_healthcare_hl7_v2_store_iam_member
 
 ```hcl
 resource "google_healthcare_hl7_v2_store_iam_member" "hl7_v2_store" {

--- a/mmv1/third_party/terraform/website/docs/r/logging_billing_account_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_billing_account_bucket_config.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a billing account level logging bucket config.
 ---
 
-# google\_logging\_billing_account\_bucket\_config
+# google_logging_billing_account_bucket_config
 
 Manages a billing account level logging bucket config. For more information see
 [the official logging documentation](https://cloud.google.com/logging/docs/) and

--- a/mmv1/third_party/terraform/website/docs/r/logging_billing_account_exclusion.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_billing_account_exclusion.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a billing_account-level logging exclusion.
 ---
 
-# google\_logging\_billing\_account\_exclusion
+# google_logging_billing_account_exclusion
 
 Manages a billing account logging exclusion. For more information see:
 

--- a/mmv1/third_party/terraform/website/docs/r/logging_billing_account_sink.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_billing_account_sink.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a billing account logging sink.
 ---
 
-# google\_logging\_billing\_account\_sink
+# google_logging_billing_account_sink
 
 * [API documentation](https://cloud.google.com/logging/docs/reference/v2/rest/v2/billingAccounts.sinks)
 * How-to Guides

--- a/mmv1/third_party/terraform/website/docs/r/logging_folder_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_folder_bucket_config.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a folder-level logging bucket config.
 ---
 
-# google\_logging\_folder\_bucket\_config
+# google_logging_folder_bucket_config
 
 Manages a folder-level logging bucket config. For more information see
 [the official logging documentation](https://cloud.google.com/logging/docs/) and

--- a/mmv1/third_party/terraform/website/docs/r/logging_folder_exclusion.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_folder_exclusion.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a folder-level logging exclusion.
 ---
 
-# google\_logging\_folder\_exclusion
+# google_logging_folder_exclusion
 
 Manages a folder-level logging exclusion. For more information see:
 

--- a/mmv1/third_party/terraform/website/docs/r/logging_folder_sink.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_folder_sink.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a folder-level logging sink.
 ---
 
-# google\_logging\_folder\_sink
+# google_logging_folder_sink
 
 Manages a folder-level logging sink. For more information see:
 * [API documentation](https://cloud.google.com/logging/docs/reference/v2/rest/v2/folders.sinks)

--- a/mmv1/third_party/terraform/website/docs/r/logging_organization_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_organization_bucket_config.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a organization-level logging bucket config.
 ---
 
-# google\_logging\_organization\_bucket\_config
+# google_logging_organization_bucket_config
 
 Manages a organization-level logging bucket config. For more information see
 [the official logging documentation](https://cloud.google.com/logging/docs/) and

--- a/mmv1/third_party/terraform/website/docs/r/logging_organization_exclusion.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_organization_exclusion.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a organization-level logging exclusion.
 ---
 
-# google\_logging\_organization\_exclusion
+# google_logging_organization_exclusion
 
 Manages an organization-level logging exclusion. For more information see:
 

--- a/mmv1/third_party/terraform/website/docs/r/logging_organization_sink.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_organization_sink.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a organization-level logging sink.
 ---
 
-# google\_logging\_organization\_sink
+# google_logging_organization_sink
 
 Manages a organization-level logging sink. For more information see:
 * [API documentation](https://cloud.google.com/logging/docs/reference/v2/rest/v2/organizations.sinks)

--- a/mmv1/third_party/terraform/website/docs/r/logging_project_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_project_bucket_config.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a project-level logging bucket config.
 ---
 
-# google\_logging\_project\_bucket\_config
+# google_logging_project_bucket_config
 
 Manages a project-level logging bucket config. For more information see
 [the official logging documentation](https://cloud.google.com/logging/docs/) and

--- a/mmv1/third_party/terraform/website/docs/r/logging_project_exclusion.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_project_exclusion.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a project-level logging exclusion.
 ---
 
-# google\_logging\_project\_exclusion
+# google_logging_project_exclusion
 
 Manages a project-level logging exclusion. For more information see:
 

--- a/mmv1/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a project-level logging sink.
 ---
 
-# google\_logging\_project\_sink
+# google_logging_project_sink
 
 Manages a project-level logging sink. For more information see:
 

--- a/mmv1/third_party/terraform/website/docs/r/monitoring_dashboard.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/monitoring_dashboard.html.markdown
@@ -4,7 +4,7 @@ description: |-
   A Google Stackdriver dashboard.
 ---
 
-# google\_monitoring\_dashboard
+# google_monitoring_dashboard
 
 A Google Stackdriver dashboard. Dashboards define the content and layout of pages in the Stackdriver web application.
 

--- a/mmv1/third_party/terraform/website/docs/r/project_service_identity.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/project_service_identity.html.markdown
@@ -4,7 +4,7 @@ description: |-
  Generate service identity for a service.
 ---
 
-# google\_project\_service\_identity
+# google_project_service_identity
 
 ~> **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
 See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.

--- a/mmv1/third_party/terraform/website/docs/r/pubsub_subscription_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/pubsub_subscription_iam.html.markdown
@@ -16,7 +16,7 @@ Three different resources help you manage your IAM policy for pubsub subscriptio
 
 ~> **Note:** `google_pubsub_subscription_iam_binding` resources **can be** used in conjunction with `google_pubsub_subscription_iam_member` resources **only if** they do not grant privilege to the same role.
 
-## google\_pubsub\_subscription\_iam\_policy
+## google_pubsub_subscription_iam_policy
 
 ```hcl
 data "google_iam_policy" "admin" {
@@ -34,7 +34,7 @@ resource "google_pubsub_subscription_iam_policy" "editor" {
 }
 ```
 
-## google\_pubsub\_subscription\_iam\_binding
+## google_pubsub_subscription_iam_binding
 
 ```hcl
 resource "google_pubsub_subscription_iam_binding" "editor" {
@@ -46,7 +46,7 @@ resource "google_pubsub_subscription_iam_binding" "editor" {
 }
 ```
 
-## google\_pubsub\_subscription\_iam\_member
+## google_pubsub_subscription_iam_member
 
 ```hcl
 resource "google_pubsub_subscription_iam_member" "editor" {

--- a/mmv1/third_party/terraform/website/docs/r/runtimeconfig_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/runtimeconfig_config.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a RuntimeConfig resource in Google Cloud.
 ---
 
-# google\_runtimeconfig\_config
+# google_runtimeconfig_config
 
 Manages a RuntimeConfig resource in Google Cloud.
 

--- a/mmv1/third_party/terraform/website/docs/r/runtimeconfig_variable.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/runtimeconfig_variable.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages a RuntimeConfig variable in Google Cloud.
 ---
 
-# google\_runtimeconfig\_variable
+# google_runtimeconfig_variable
 
 Manages a RuntimeConfig variable in Google Cloud. For more information, see the
 [official documentation](https://cloud.google.com/deployment-manager/runtime-configurator/),

--- a/mmv1/third_party/terraform/website/docs/r/service_networking_connection.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/service_networking_connection.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Manages creating a private VPC connection to a service provider.
 ---
 
-# google\_service\_networking\_connection
+# google_service_networking_connection
 
 Manages a private VPC connection with a GCP service provider. For more information see
 [the official documentation](https://cloud.google.com/vpc/docs/configure-private-services-access#creating-connection)

--- a/mmv1/third_party/terraform/website/docs/r/spanner_database_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/spanner_database_iam.html.markdown
@@ -19,7 +19,7 @@ Three different resources help you manage your IAM policy for a Spanner database
 
 ~> **Note:** `google_spanner_database_iam_binding` resources **can be** used in conjunction with `google_spanner_database_iam_member` resources **only if** they do not grant privilege to the same role.
 
-## google\_spanner\_database\_iam\_policy
+## google_spanner_database_iam_policy
 
 ```hcl
 data "google_iam_policy" "admin" {
@@ -65,7 +65,7 @@ resource "google_spanner_database_iam_policy" "database" {
 }
 ```
 
-## google\_spanner\_database\_iam\_binding
+## google_spanner_database_iam_binding
 
 ```hcl
 resource "google_spanner_database_iam_binding" "database" {
@@ -99,7 +99,7 @@ resource "google_spanner_database_iam_binding" "database" {
 }
 ```
 
-## google\_spanner\_database\_iam\_member
+## google_spanner_database_iam_member
 
 ```hcl
 resource "google_spanner_database_iam_member" "database" {

--- a/mmv1/third_party/terraform/website/docs/r/spanner_instance_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/spanner_instance_iam.html.markdown
@@ -19,7 +19,7 @@ Three different resources help you manage your IAM policy for a Spanner instance
 
 ~> **Note:** `google_spanner_instance_iam_binding` resources **can be** used in conjunction with `google_spanner_instance_iam_member` resources **only if** they do not grant privilege to the same role.
 
-## google\_spanner\_instance\_iam\_policy
+## google_spanner_instance_iam_policy
 
 ```hcl
 data "google_iam_policy" "admin" {
@@ -38,7 +38,7 @@ resource "google_spanner_instance_iam_policy" "instance" {
 }
 ```
 
-## google\_spanner\_instance\_iam\_binding
+## google_spanner_instance_iam_binding
 
 ```hcl
 resource "google_spanner_instance_iam_binding" "instance" {
@@ -51,7 +51,7 @@ resource "google_spanner_instance_iam_binding" "instance" {
 }
 ```
 
-## google\_spanner\_instance\_iam\_member
+## google_spanner_instance_iam_member
 
 ```hcl
 resource "google_spanner_instance_iam_member" "instance" {

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Creates a new SQL database instance in Google Cloud SQL.
 ---
 
-# google\_sql\_database\_instance
+# google_sql_database_instance
 
 Creates a new Google SQL Database Instance. For more information, see the [official documentation](https://cloud.google.com/sql/),
 or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/instances).

--- a/mmv1/third_party/terraform/website/docs/r/sql_ssl_cert.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_ssl_cert.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Creates a new SQL Ssl Cert in Google Cloud SQL.
 ---
 
-# google\_sql\_ssl\_cert
+# google_sql_ssl_cert
 
 Creates a new Google SQL SSL Cert on a Google SQL Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/sslCerts).
 

--- a/mmv1/third_party/terraform/website/docs/r/sql_user.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_user.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Creates a new SQL user in Google Cloud SQL.
 ---
 
-# google\_sql\_user
+# google_sql_user
 
 Creates a new Google SQL User on a Google SQL User Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/users).
 

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Creates a new bucket in Google Cloud Storage.
 ---
 
-# google\_storage\_bucket
+# google_storage_bucket
 
 Creates a new bucket in Google cloud storage service (GCS).
 Once a bucket has been created, its location can't be changed.

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket_acl.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket_acl.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Creates a new bucket ACL in Google Cloud Storage.
 ---
 
-# google\_storage\_bucket\_acl
+# google_storage_bucket_acl
 
 Authoritatively manages a bucket's ACLs in Google cloud storage service (GCS). For more information see
 [the official documentation](https://cloud.google.com/storage/docs/access-control/lists)

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Creates a new object inside a specified bucket
 ---
 
-# google\_storage\_bucket\_object
+# google_storage_bucket_object
 
 Creates a new object inside an existing bucket in Google cloud storage service (GCS). 
 [ACLs](https://cloud.google.com/storage/docs/access-control/lists) can be applied using the `google_storage_object_acl` resource.

--- a/mmv1/third_party/terraform/website/docs/r/storage_default_object_acl.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_default_object_acl.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Authoritatively manages the default object ACLs for a Google Cloud Storage bucket
 ---
 
-# google\_storage\_default\_object\_acl
+# google_storage_default_object_acl
 
 Authoritatively manages the default object ACLs for a Google Cloud Storage bucket
 without managing the bucket itself.

--- a/mmv1/third_party/terraform/website/docs/r/storage_notification.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_notification.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Creates a new notification configuration on a specified bucket.
 ---
 
-# google\_storage\_notification
+# google_storage_notification
 
 Creates a new notification configuration on a specified bucket, establishing a flow of event notifications from GCS to a Cloud Pub/Sub topic.
  For more information see

--- a/mmv1/third_party/terraform/website/docs/r/storage_object_acl.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_object_acl.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Creates a new object ACL in Google Cloud Storage.
 ---
 
-# google\_storage\_object\_acl
+# google_storage_object_acl
 
 Authoritatively manages the access control list (ACL) for an object in a Google
 Cloud Storage (GCS) bucket. Removing a `google_storage_object_acl` sets the

--- a/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
@@ -4,7 +4,7 @@ description: |-
   Creates a new Transfer Job in Google Cloud Storage Transfer.
 ---
 
-# google\_storage\_transfer\_job
+# google_storage_transfer_job
 
 Creates a new Transfer Job in Google Cloud Storage Transfer.
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The slashes in resource titles in docs were used to avoid italic formatting in Terraform Registry and not needed now.

The resource titles without slashes render well in Terraform Registry.
Example:
https://github.com/hashicorp/terraform-provider-google/blob/main/website/docs/r/apikeys_key.html.markdown?plain=1#L21

https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/apikeys_key


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
