### PR TITLE
[CloudSQL] Handle CLOUD_IAM_GROUP username edgecases

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_user.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user.go
@@ -3,6 +3,7 @@ package sql
 import (
 	"fmt"
 	"log"
+	"slices"
 	"strings"
 	"time"
 
@@ -17,12 +18,25 @@ import (
 )
 
 func diffSuppressIamUserName(_, old, new string, d *schema.ResourceData) bool {
-	strippedName := strings.Split(new, "@")[0]
+	// IAM users of type `CLOUD_IAM_USER` and `CLOUD_IAM_SERVICE_ACCOUNT` are created based on
+	// email addresses, but do not include the domain in the generated user. So we need
+	// to strip the domain in order to compare incoming values with old values.
+	// Group users of type `CLOUD_IAM_GROUP`, however, retain their domains as a part of their username,
+	// so we need to compare these directly
+	truncated_iam_types := []string{"CLOUD_IAM_USER", "CLOUD_IAM_SERVICE_ACCOUNT"}
+	untruncated_iam_types := []string{"CLOUD_IAM_GROUP"}
 
 	userType := d.Get("type").(string)
 
-	if old == strippedName && strings.Contains(userType, "IAM") {
-		return true
+	if slices.Contains(untruncated_iam_types, userType) {
+		// We compare old and new directly for untruncated entries
+		return old == new
+	}
+
+	if slices.Contains(truncated_iam_types, userType) {
+		// For truncated types, We strip the domain from the new value and use it for comparison
+		strippedName := strings.Split(new, "@")[0]
+		return old == strippedName
 	}
 
 	return false
@@ -349,6 +363,8 @@ func resourceSqlUserRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	for _, currentUser := range users.Items {
+		// `CLOUD_IAM_GROUP` users are created with the domain name in the username, unlike
+		// the other `CLOUD_IAM_*` user types.
 		if !(strings.Contains(databaseInstance.DatabaseVersion, "POSTGRES") || currentUser.Type == "CLOUD_IAM_GROUP") {
 			name = strings.Split(name, "@")[0]
 		}


### PR DESCRIPTION
Although some of the issues surrounding the use of CLOUD_IAM_GROUP users with cloudsql I believe are google's own problems, in this case, I think this PR will address some of the problems with TF not being able to locate CLOUD_IAM_GROUP type resources, as discussed in https://github.com/hashicorp/terraform-provider-google/issues/17040.

The issue, I believe, is that group users retain the domain as a part of their username while standard users and service accounts have the domain stripped. You can see on L369 of the PR that this fact is already accounted for in part, but the same exception wasn't included in the diffSuppress function (L21ff.).

I've also included comments to make some of this explicit, since it's a bit counterintuitive.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
sql: fix `diffSuppressIamUserName` function to handle `CLOUD_IAM_GROUP` correctly
```
