### PR TITLE
Revert "Use magician for downstream builder sync jobs"

### DIFF
--- a/.ci/gcb-push-downstream.yml
+++ b/.ci/gcb-push-downstream.yml
@@ -30,45 +30,41 @@ steps:
       waitFor: ["checkout"]
 
     # TPG
-    - name: 'gcr.io/graphite-docker-images/go-plus'
-      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+    - name: 'gcr.io/graphite-docker-images/bash-plus'
+      entrypoint: '/workspace/.ci/scripts/bash-plus/downstream-waiter/wait_for_commit.sh'
       id: tpg-sync
       waitFor: ["checkout"]
       args:
-          - 'wait-for-commit'
           - 'tpg-sync'
           - $BRANCH_NAME
           - $COMMIT_SHA
 
     # TPGB
-    - name: 'gcr.io/graphite-docker-images/go-plus'
-      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+    - name: 'gcr.io/graphite-docker-images/bash-plus'
+      entrypoint: '/workspace/.ci/scripts/bash-plus/downstream-waiter/wait_for_commit.sh'
       id: tpgb-sync
       waitFor: ["checkout"]
       args:
-          - 'wait-for-commit'
           - 'tpgb-sync'
           - $BRANCH_NAME
           - $COMMIT_SHA
 
     # TGC
-    - name: 'gcr.io/graphite-docker-images/go-plus'
-      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+    - name: 'gcr.io/graphite-docker-images/bash-plus'
+      entrypoint: '/workspace/.ci/scripts/bash-plus/downstream-waiter/wait_for_commit.sh'
       id: tgc-sync
       waitFor: ["checkout"]
       args:
-          - 'wait-for-commit'
           - 'tgc-sync'
           - $BRANCH_NAME
           - $COMMIT_SHA
 
     # TF-OICS
-    - name: 'gcr.io/graphite-docker-images/go-plus'
-      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+    - name: 'gcr.io/graphite-docker-images/bash-plus'
+      entrypoint: '/workspace/.ci/scripts/bash-plus/downstream-waiter/wait_for_commit.sh'
       id: tf-oics-sync
       waitFor: ["checkout"]
       args:
-          - 'wait-for-commit'
           - 'tf-oics-sync'
           - $BRANCH_NAME
           - $COMMIT_SHA


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#10658

This change appears to have caused an issue in the build process. We should revert the change and correct our pipeline, and then figure out a fix (ideally with some sort of test).