### PR TITLE
chore(ci): use wait for commit go version in downstream ci

### DIFF
--- a/.ci/gcb-push-downstream.yml
+++ b/.ci/gcb-push-downstream.yml
@@ -30,10 +30,10 @@ steps:
       waitFor: ["checkout"]
 
     # TPG
-    - name: 'gcr.io/graphite-docker-images/bash-plus'
+    - name: 'gcr.io/graphite-docker-images/go-plus'
       entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
       id: tpg-sync
-      waitFor: ["checkout"]
+      waitFor: ["build-magician-binary", "checkout"]
       args:
           - wait-for-commit
           - 'tpg-sync'
@@ -41,10 +41,10 @@ steps:
           - $COMMIT_SHA
 
     # TPGB
-    - name: 'gcr.io/graphite-docker-images/bash-plus'
+    - name: 'gcr.io/graphite-docker-images/go-plus'
       entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
       id: tpgb-sync
-      waitFor: ["checkout"]
+      waitFor: ["build-magician-binary", "checkout"]
       args:
           - wait-for-commit
           - 'tpgb-sync'
@@ -52,10 +52,10 @@ steps:
           - $COMMIT_SHA
 
     # TGC
-    - name: 'gcr.io/graphite-docker-images/bash-plus'
+    - name: 'gcr.io/graphite-docker-images/go-plus'
       entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
       id: tgc-sync
-      waitFor: ["checkout"]
+      waitFor: ["build-magician-binary", "checkout"]
       args:
           - wait-for-commit
           - 'tgc-sync'
@@ -63,10 +63,10 @@ steps:
           - $COMMIT_SHA
 
     # TF-OICS
-    - name: 'gcr.io/graphite-docker-images/bash-plus'
+    - name: 'gcr.io/graphite-docker-images/go-plus'
       entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
       id: tf-oics-sync
-      waitFor: ["checkout"]
+      waitFor: ["build-magician-binary", "checkout"]
       args:
           - wait-for-commit
           - 'tf-oics-sync'

--- a/.ci/gcb-push-downstream.yml
+++ b/.ci/gcb-push-downstream.yml
@@ -31,40 +31,44 @@ steps:
 
     # TPG
     - name: 'gcr.io/graphite-docker-images/bash-plus'
-      entrypoint: '/workspace/.ci/scripts/bash-plus/downstream-waiter/wait_for_commit.sh'
+      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
       id: tpg-sync
       waitFor: ["checkout"]
       args:
+          - wait-for-commit
           - 'tpg-sync'
           - $BRANCH_NAME
           - $COMMIT_SHA
 
     # TPGB
     - name: 'gcr.io/graphite-docker-images/bash-plus'
-      entrypoint: '/workspace/.ci/scripts/bash-plus/downstream-waiter/wait_for_commit.sh'
+      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
       id: tpgb-sync
       waitFor: ["checkout"]
       args:
+          - wait-for-commit
           - 'tpgb-sync'
           - $BRANCH_NAME
           - $COMMIT_SHA
 
     # TGC
     - name: 'gcr.io/graphite-docker-images/bash-plus'
-      entrypoint: '/workspace/.ci/scripts/bash-plus/downstream-waiter/wait_for_commit.sh'
+      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
       id: tgc-sync
       waitFor: ["checkout"]
       args:
+          - wait-for-commit
           - 'tgc-sync'
           - $BRANCH_NAME
           - $COMMIT_SHA
 
     # TF-OICS
     - name: 'gcr.io/graphite-docker-images/bash-plus'
-      entrypoint: '/workspace/.ci/scripts/bash-plus/downstream-waiter/wait_for_commit.sh'
+      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
       id: tf-oics-sync
       waitFor: ["checkout"]
       args:
+          - wait-for-commit
           - 'tf-oics-sync'
           - $BRANCH_NAME
           - $COMMIT_SHA

--- a/.ci/gcb-push-downstream.yml
+++ b/.ci/gcb-push-downstream.yml
@@ -33,7 +33,7 @@ steps:
     - name: 'gcr.io/graphite-docker-images/go-plus'
       entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
       id: tpg-sync
-      waitFor: ["build-magician-binary", "checkout"]
+      waitFor: ["build-magician-binary"]
       args:
           - wait-for-commit
           - 'tpg-sync'
@@ -44,7 +44,7 @@ steps:
     - name: 'gcr.io/graphite-docker-images/go-plus'
       entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
       id: tpgb-sync
-      waitFor: ["build-magician-binary", "checkout"]
+      waitFor: ["build-magician-binary"]
       args:
           - wait-for-commit
           - 'tpgb-sync'
@@ -55,7 +55,7 @@ steps:
     - name: 'gcr.io/graphite-docker-images/go-plus'
       entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
       id: tgc-sync
-      waitFor: ["build-magician-binary", "checkout"]
+      waitFor: ["build-magician-binary"]
       args:
           - wait-for-commit
           - 'tgc-sync'
@@ -66,7 +66,7 @@ steps:
     - name: 'gcr.io/graphite-docker-images/go-plus'
       entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
       id: tf-oics-sync
-      waitFor: ["build-magician-binary", "checkout"]
+      waitFor: ["build-magician-binary"]
       args:
           - wait-for-commit
           - 'tf-oics-sync'
@@ -78,7 +78,7 @@ steps:
       entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
       secretEnv: ["GITHUB_TOKEN_CLASSIC"]
       id: tpg-push
-      waitFor: ["tpg-sync", "tpgb-sync", "tgc-sync", "tf-oics-sync", "build-magician-binary"]
+      waitFor: ["tpg-sync", "tpgb-sync", "tgc-sync", "tf-oics-sync"]
       env:
         - BASE_BRANCH=$BRANCH_NAME
       args:
@@ -106,7 +106,7 @@ steps:
       entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
       secretEnv: ["GITHUB_TOKEN_CLASSIC"]
       id: tpgb-push
-      waitFor: ["tpg-sync", "tpgb-sync", "tgc-sync", "tf-oics-sync", "build-magician-binary"]
+      waitFor: ["tpg-sync", "tpgb-sync", "tgc-sync", "tf-oics-sync"]
       env:
         - BASE_BRANCH=$BRANCH_NAME
       args:
@@ -162,7 +162,7 @@ steps:
       entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
       secretEnv: ["GITHUB_TOKEN_CLASSIC"]
       id: tf-oics-push
-      waitFor: ["tpg-sync", "tpgb-sync", "tgc-sync", "tf-oics-sync", "build-magician-binary"]
+      waitFor: ["tpg-sync", "tpgb-sync", "tgc-sync", "tf-oics-sync"]
       env:
         - BASE_BRANCH=$BRANCH_NAME
       args:


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

use wait for commit go version in downstream ci

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
