### PR TITLE
Remove schema_config_mode_attr from secondary_ip_ranges

### DIFF
--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -223,7 +223,6 @@ properties:
     api_name: secondaryIpRanges
     unordered_list: true
     default_from_api: true
-    schema_config_mode_attr: true
     send_empty_value: true
     description: |
       An array of configurations for secondary IP ranges for VM instances


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed an issue where `secondary_ip_range.reserved_internal_range` in `google_compute_subnetwork` was incorrectly behaving as required
```
