### PR TITLE
Remove self_link from network security resources that don't expose it

### DIFF
--- a/mmv1/products/networksecurity/FirewallEndpoint.yaml
+++ b/mmv1/products/networksecurity/FirewallEndpoint.yaml
@@ -85,11 +85,6 @@ properties:
     name: 'labels'
     description: |
       A map of key/value label pairs to assign to the resource.
-  - !ruby/object:Api::Type::String
-    name: 'selfLink'
-    description: |
-      Server-defined URL of this resource.
-    output: true
   - !ruby/object:Api::Type::Time
     name: 'createTime'
     description: Time the firewall endpoint was created in UTC.

--- a/mmv1/products/networksecurity/FirewallEndpointAssociation.yaml
+++ b/mmv1/products/networksecurity/FirewallEndpointAssociation.yaml
@@ -99,11 +99,6 @@ properties:
 
       ~> **Note:** The API will reject the request if this value is set to true when creating the resource,
       otherwise on an update the association can be disabled.
-  - !ruby/object:Api::Type::String
-    name: 'selfLink'
-    description: |
-      Server-defined URL of this resource.
-    output: true
   - !ruby/object:Api::Type::Time
     name: 'createTime'
     description: Time the firewall endpoint was created in UTC.

--- a/mmv1/products/networksecurity/SecurityProfile.yaml
+++ b/mmv1/products/networksecurity/SecurityProfile.yaml
@@ -69,11 +69,6 @@ parameters:
     immutable: true
     url_param_only: true
 properties:
-  - !ruby/object:Api::Type::String
-    name: 'selfLink'
-    description: |
-      Server-defined URL of this resource.
-    output: true
   - !ruby/object:Api::Type::Time
     name: 'createTime'
     description: Time the security profile was created in UTC.

--- a/mmv1/products/networksecurity/SecurityProfileGroup.yaml
+++ b/mmv1/products/networksecurity/SecurityProfileGroup.yaml
@@ -64,11 +64,6 @@ parameters:
     immutable: true
     url_param_only: true
 properties:
-  - !ruby/object:Api::Type::String
-    name: 'selfLink'
-    description: |
-      Server-defined URL of this resource.
-    output: true
   - !ruby/object:Api::Type::Time
     name: 'createTime'
     description: Time the security profile group was created in UTC.


### PR DESCRIPTION
Removes self_link output parameters from network security resources that don't expose it through REST APIs.

This PR removes the `self_link` I added by mistake, even if it wasn't exported by REST APIs of the following resources:

- `google_network_security_security_profile`
- `google_network_security_security_profile_group`
- `google_network_security_endpoint`
- `google_network_security_endpoint_association`

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
networksecurity: removed self_link output parameter from `google_network_security_security_profile`, `google_network_security_security_profile_group`, `google_network_security_endpoint`, `google_network_security_endpoint_association`
```
