### PR TITLE
Switched to using channel-based versions for TestAccContainerCluster_updateVersion

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -6135,7 +6135,8 @@ data "google_container_engine_versions" "central1a" {
 resource "google_container_cluster" "with_version" {
   name               = "%s"
   location           = "us-central1-a"
-  min_master_version = data.google_container_engine_versions.central1a.valid_master_versions[3]
+  min_master_version = data.google_container_engine_versions.central1a.release_channel_default_version["STABLE"]
+  node_version       = data.google_container_engine_versions.central1a.release_channel_default_version["STABLE"]
   initial_node_count = 1
   deletion_protection = false
   network    = "%s"
@@ -6171,8 +6172,8 @@ data "google_container_engine_versions" "central1a" {
 resource "google_container_cluster" "with_version" {
   name               = "%s"
   location           = "us-central1-a"
-  min_master_version = data.google_container_engine_versions.central1a.latest_master_version
-  node_version       = data.google_container_engine_versions.central1a.valid_node_versions[1]
+  min_master_version = data.google_container_engine_versions.central1a.release_channel_latest_version["STABLE"]
+  node_version       = data.google_container_engine_versions.central1a.release_channel_latest_version["STABLE"]
   initial_node_count = 1
   deletion_protection = false
   network    = "%s"


### PR DESCRIPTION
Fixed https://github.com/hashicorp/terraform-provider-google/issues/15084

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
