### PR TITLE
Prevent permadiff on monitoring_uptime_check_config

### DIFF
--- a/mmv1/products/monitoring/UptimeCheckConfig.yaml
+++ b/mmv1/products/monitoring/UptimeCheckConfig.yaml
@@ -462,7 +462,6 @@ properties:
         name: 'labels'
         immutable: true
         required: true
-        default_from_api: true
         diff_suppress_func: resourceMonitoringUptimeCheckConfigMonitoredResourceLabelsDiffSuppress
         description:
           Values for all of the labels listed in the associated monitored

--- a/mmv1/products/monitoring/UptimeCheckConfig.yaml
+++ b/mmv1/products/monitoring/UptimeCheckConfig.yaml
@@ -462,6 +462,7 @@ properties:
         name: 'labels'
         immutable: true
         required: true
+        default_from_api: true
         description:
           Values for all of the labels listed in the associated monitored
           resource descriptor. For example, Compute Engine VM instances use the

--- a/mmv1/products/monitoring/UptimeCheckConfig.yaml
+++ b/mmv1/products/monitoring/UptimeCheckConfig.yaml
@@ -463,6 +463,7 @@ properties:
         immutable: true
         required: true
         default_from_api: true
+        diff_suppress_func: resourceMonitoringUptimeCheckConfigMonitoredResourceLabelsDiffSuppress
         description:
           Values for all of the labels listed in the associated monitored
           resource descriptor. For example, Compute Engine VM instances use the

--- a/mmv1/templates/terraform/constants/monitoring_uptime_check_config.go.erb
+++ b/mmv1/templates/terraform/constants/monitoring_uptime_check_config.go.erb
@@ -1,3 +1,12 @@
 func resourceMonitoringUptimeCheckConfigHttpCheckPathDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	return old == "/"+new
 }
+
+func resourceMonitoringUptimeCheckConfigMonitoredResourceLabelsDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	// GCP adds the project_id to the labels if unset.
+	// We want to suppress the diff if not set in the config.
+	if strings.HasSuffix(k, "project_id") && new == "" && old != "" {
+		return true
+	}
+	return false
+}

--- a/mmv1/third_party/terraform/services/monitoring/resource_monitoring_uptime_check_config_test.go
+++ b/mmv1/third_party/terraform/services/monitoring/resource_monitoring_uptime_check_config_test.go
@@ -41,6 +41,34 @@ func TestAccMonitoringUptimeCheckConfig_update(t *testing.T) {
 	})
 }
 
+func TestAccMonitoringUptimeCheckConfig_noProjectId(t *testing.T) {
+	t.Parallel()
+	host := "192.168.1.1"
+	suffix := acctest.RandString(t, 4)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckMonitoringUptimeCheckConfigDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMonitoringUptimeCheckConfig_noProjectId(suffix, host),
+			},
+			{
+				ResourceName:            "google_monitoring_uptime_check_config.http",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"http_check.0.auth_info.0.password"},
+			},
+			{
+				Config:       testAccMonitoringUptimeCheckConfig_noProjectId(suffix, host),
+				PlanOnly:     true,
+				ResourceName: "google_monitoring_uptime_check_config.http",
+			},
+		},
+	})
+}
+
 // The second update should force a recreation of the uptime check because 'monitored_resource' isn't
 // updatable in place
 func TestAccMonitoringUptimeCheckConfig_changeNonUpdatableFields(t *testing.T) {
@@ -178,5 +206,38 @@ resource "google_monitoring_uptime_check_config" "http" {
   }
 }
 `, suffix, project, host, content, json_path, json_path_matcher,
+	)
+}
+
+func testAccMonitoringUptimeCheckConfig_noProjectId(suffix, host string) string {
+	return fmt.Sprintf(`
+resource "google_monitoring_uptime_check_config" "http" {
+  display_name = "http-uptime-check-%s"
+  timeout      = "60s"
+  period       = "60s"
+
+  http_check {
+    path = "/mypath"
+    port = "8010"
+    request_method = "GET"
+    auth_info {
+      username = "name"
+      password = "mypassword"
+    }
+  }
+
+  monitored_resource {
+    type = "uptime_url"
+    labels = {
+      host       = "%s"
+    }
+  }
+
+  content_matchers {
+    content = "example"
+    matcher = "CONTAINS_STRING"
+  }
+}
+`, suffix, host,
 	)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes a permadiff on uptime check config which causes it to be recreated every time.

The labels property in the monitored_resource property should ignore changes to the project_id label if not set by the user. GCP sets the project_id and that causes the resource to exhibit a diff and get recreated every time.

fixes https://github.com/hashicorp/terraform-provider-google/issues/18038


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
monitoring: fixed a permadiff with `monitored_resource.labels` property in the `google_monitoring_uptime_check_config` resource
```
