### PR TITLE
Added new resource "Project Cloud Armor Tier"

### DIFF
--- a/mmv1/products/compute/ProjectCloudArmorTier.yaml
+++ b/mmv1/products/compute/ProjectCloudArmorTier.yaml
@@ -1,0 +1,59 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'ProjectCloudArmorTier'
+base_url: 'projects/{{project}}'
+create_url: 'projects/{{project}}/setCloudArmorTier'
+update_url: 'projects/{{project}}/setCloudArmorTier'
+read_query_params: '?fields=cloudArmorTier'
+create_verb: :POST
+update_verb: :POST
+description: |
+  Sets the Cloud Armor tier of the project.
+references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+    'Subscribing to Cloud Armor Enterprise': 'https://cloud.google.com/armor/docs/managed-protection-overview#subscribing_to_plus'
+  api:
+    'https://cloud.google.com/compute/docs/reference/rest/v1/projects/setCloudArmorTier'
+id_format: 'projects/{{project}}'
+import_format: ['projects/{{project}}']
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
+    kind: 'compute#operation'
+    path: 'name'
+    base_url: 'projects/{{project}}/global/operations/{{op_id}}'
+    wait_ms: 1000
+  result: !ruby/object:Api::OpAsync::Result
+    path: 'targetLink'
+  status: !ruby/object:Api::OpAsync::Status
+    path: 'status'
+    complete: 'DONE'
+    allowed:
+      - 'PENDING'
+      - 'RUNNING'
+      - 'DONE'
+  error: !ruby/object:Api::OpAsync::Error
+    path: 'error/errors'
+    message: 'message'
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  custom_delete: templates/terraform/custom_delete/only_remove_from_state.go.erb
+properties:
+  - !ruby/object:Api::Type::Enum
+    name: 'cloudArmorTier'
+    required: true
+    description: |
+      Managed protection tier to be set.
+    values:
+      - :CA_STANDARD
+      - :CA_ENTERPRISE_PAYGO

--- a/mmv1/products/compute/ProjectCloudArmorTier.yaml
+++ b/mmv1/products/compute/ProjectCloudArmorTier.yaml
@@ -28,6 +28,18 @@ references: !ruby/object:Api::Resource::ReferenceLinks
     'https://cloud.google.com/compute/docs/reference/rest/v1/projects/setCloudArmorTier'
 id_format: 'projects/{{project}}'
 import_format: ['projects/{{project}}']
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'compute_project_cloud_armor_tier_basic'
+    primary_resource_id: 'cloud_armor_tier_config'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'compute_project_cloud_armor_tier_project_set'
+    primary_resource_id: 'cloud_armor_tier_config'
+    vars:
+      project_id: 'your_project_id'
+    test_env_vars:
+      org_id: :ORG_ID
+      billing_account: :BILLING_ACCT
 async: !ruby/object:Api::OpAsync
   operation: !ruby/object:Api::OpAsync::Operation
     kind: 'compute#operation'

--- a/mmv1/products/compute/ProjectCloudArmorTier.yaml
+++ b/mmv1/products/compute/ProjectCloudArmorTier.yaml
@@ -31,9 +31,11 @@ import_format: ['projects/{{project}}']
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'compute_project_cloud_armor_tier_basic'
+    skip_test: true
     primary_resource_id: 'cloud_armor_tier_config'
   - !ruby/object:Provider::Terraform::Examples
     name: 'compute_project_cloud_armor_tier_project_set'
+    skip_test: true
     primary_resource_id: 'cloud_armor_tier_config'
     vars:
       project_id: 'your_project_id'

--- a/mmv1/templates/terraform/custom_delete/only_remove_from_state.go.erb
+++ b/mmv1/templates/terraform/custom_delete/only_remove_from_state.go.erb
@@ -1,0 +1,3 @@
+log.Printf("[WARNING] Resource [%s] will be only removed from Terraform state, but will be left intact on GCP. %s", d.Id(), userAgent)
+
+return schema.RemoveFromState(d, meta)

--- a/mmv1/templates/terraform/examples/compute_project_cloud_armor_tier_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/compute_project_cloud_armor_tier_basic.tf.erb
@@ -1,0 +1,3 @@
+resource "google_compute_project_cloud_armor_tier" "<%= ctx[:primary_resource_id] %>" {
+  cloud_armor_tier  = "CA_STANDARD"
+}

--- a/mmv1/templates/terraform/examples/compute_project_cloud_armor_tier_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/compute_project_cloud_armor_tier_basic.tf.erb
@@ -1,3 +1,3 @@
 resource "google_compute_project_cloud_armor_tier" "<%= ctx[:primary_resource_id] %>" {
-  cloud_armor_tier  = "CA_ENTERPRISE_PAYGO"
+  cloud_armor_tier  = "CA_STANDARD"
 }

--- a/mmv1/templates/terraform/examples/compute_project_cloud_armor_tier_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/compute_project_cloud_armor_tier_basic.tf.erb
@@ -1,3 +1,3 @@
 resource "google_compute_project_cloud_armor_tier" "<%= ctx[:primary_resource_id] %>" {
-  cloud_armor_tier  = "CA_STANDARD"
+  cloud_armor_tier  = "CA_ENTERPRISE_PAYGO"
 }

--- a/mmv1/templates/terraform/examples/compute_project_cloud_armor_tier_project_set.tf.erb
+++ b/mmv1/templates/terraform/examples/compute_project_cloud_armor_tier_project_set.tf.erb
@@ -1,0 +1,17 @@
+resource "google_project" "project" {
+  project_id      = "<%= ctx[:vars]['project_id'] %>"
+  name            = "<%= ctx[:vars]['project_id'] %>"
+  org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
+  billing_account = "<%= ctx[:test_env_vars]['billing_account'] %>"
+}
+
+resource "google_project_service" "compute" {
+  project = google_project.project.project_id
+  service = "compute.googleapis.com"
+}
+
+resource "google_compute_project_cloud_armor_tier" "<%= ctx[:primary_resource_id] %>" {
+  project          = google_project.project.project_id  
+  cloud_armor_tier = "CA_STANDARD"
+  depends_on       = [google_project_service.compute]
+}

--- a/mmv1/templates/terraform/examples/compute_project_cloud_armor_tier_project_set.tf.erb
+++ b/mmv1/templates/terraform/examples/compute_project_cloud_armor_tier_project_set.tf.erb
@@ -12,6 +12,6 @@ resource "google_project_service" "compute" {
 
 resource "google_compute_project_cloud_armor_tier" "<%= ctx[:primary_resource_id] %>" {
   project          = google_project.project.project_id  
-  cloud_armor_tier = "CA_ENTERPRISE_PAYGO"
+  cloud_armor_tier = "CA_STANDARD"
   depends_on       = [google_project_service.compute]
 }

--- a/mmv1/templates/terraform/examples/compute_project_cloud_armor_tier_project_set.tf.erb
+++ b/mmv1/templates/terraform/examples/compute_project_cloud_armor_tier_project_set.tf.erb
@@ -12,6 +12,6 @@ resource "google_project_service" "compute" {
 
 resource "google_compute_project_cloud_armor_tier" "<%= ctx[:primary_resource_id] %>" {
   project          = google_project.project.project_id  
-  cloud_armor_tier = "CA_STANDARD"
+  cloud_armor_tier = "CA_ENTERPRISE_PAYGO"
   depends_on       = [google_project_service.compute]
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_project_cloud_armor_tier_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_project_cloud_armor_tier_test.go
@@ -1,0 +1,163 @@
+package compute_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccComputeProjectCloudArmorTier_basic(t *testing.T) {
+	t.Parallel()
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeProject_cloudArmorTier_standard(),
+			},
+			{
+				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeProjectCloudArmorTier_modify(t *testing.T) {
+	t.Parallel()
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeProject_cloudArmorTier_standard(),
+			},
+			{
+				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeProject_cloudArmorTier_enterprise_paygo(),
+			},
+			{
+				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeProject_cloudArmorTier_standard(),
+			},
+			{
+				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeProjectCloudArmorTier_withProjectSet(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org":       envvar.GetTestOrgFromEnv(t),
+		"billingId": envvar.GetTestBillingAccountFromEnv(t),
+		"projectID": fmt.Sprintf("tf-test-%d", acctest.RandInt(t)),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeProject_cloudArmorTier_withProjectSet_standard(context),
+			},
+			{
+				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeProject_cloudArmorTier_withProjectSet_enterprise_paygo(context),
+			},
+			{
+				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeProject_cloudArmorTier_withProjectSet_standard(context),
+			},
+			{
+				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccComputeProject_cloudArmorTier_enterprise_paygo() string {
+	return fmt.Sprintln(`
+resource "google_compute_project_cloud_armor_tier" "cloud_armor_tier" {
+  cloud_armor_tier = "CA_ENTERPRISE_PAYGO"
+}`)
+}
+
+func testAccComputeProject_cloudArmorTier_standard() string {
+	return fmt.Sprintln(`
+resource "google_compute_project_cloud_armor_tier" "cloud_armor_tier" {
+	cloud_armor_tier = "CA_STANDARD"
+}`)
+}
+
+func testAccComputeProject_cloudArmorTier_withProjectSet_enterprise_paygo(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_project" "project" {
+  project_id      = "%{projectID}"
+  name            = "%{projectID}"
+  org_id          = "%{org}"
+  billing_account = "%{billingId}"
+}
+
+resource "google_project_service" "compute" {
+  project = google_project.project.project_id
+  service = "compute.googleapis.com"
+}
+
+resource "google_compute_project_cloud_armor_tier" "cloud_armor_tier" {
+  project      = google_project.project.project_id
+  cloud_armor_tier = "CA_ENTERPRISE_PAYGO"
+  depends_on   = [google_project_service.compute]
+}
+`, context)
+}
+
+func testAccComputeProject_cloudArmorTier_withProjectSet_standard(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_project" "project" {
+  project_id      = "%{projectID}"
+  name            = "%{projectID}"
+  org_id          = "%{org}"
+  billing_account = "%{billingId}"
+}
+
+resource "google_project_service" "compute" {
+  project = google_project.project.project_id
+  service = "compute.googleapis.com"
+}
+
+resource "google_compute_project_cloud_armor_tier" "cloud_armor_tier" {
+  project      = google_project.project.project_id
+  cloud_armor_tier = "CA_STANDARD"
+  depends_on   = [google_project_service.compute]
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_project_cloud_armor_tier_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_project_cloud_armor_tier_test.go
@@ -17,7 +17,7 @@ func TestAccComputeProjectCloudArmorTier_basic(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeProject_cloudArmorTier_standard(),
+				Config: testAccComputeProject_cloudArmorTier_enterprise_paygo(),
 			},
 			{
 				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier_config",
@@ -29,6 +29,7 @@ func TestAccComputeProjectCloudArmorTier_basic(t *testing.T) {
 }
 
 func TestAccComputeProjectCloudArmorTier_modify(t *testing.T) {
+	acctest.SkipIfVcr(t)
 	t.Parallel()
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_project_cloud_armor_tier_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_project_cloud_armor_tier_test.go
@@ -20,7 +20,7 @@ func TestAccComputeProjectCloudArmorTier_basic(t *testing.T) {
 				Config: testAccComputeProject_cloudArmorTier_standard(),
 			},
 			{
-				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier",
+				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier_config",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -39,7 +39,7 @@ func TestAccComputeProjectCloudArmorTier_modify(t *testing.T) {
 				Config: testAccComputeProject_cloudArmorTier_standard(),
 			},
 			{
-				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier",
+				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier_config",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -47,7 +47,7 @@ func TestAccComputeProjectCloudArmorTier_modify(t *testing.T) {
 				Config: testAccComputeProject_cloudArmorTier_enterprise_paygo(),
 			},
 			{
-				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier",
+				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier_config",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -55,7 +55,7 @@ func TestAccComputeProjectCloudArmorTier_modify(t *testing.T) {
 				Config: testAccComputeProject_cloudArmorTier_standard(),
 			},
 			{
-				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier",
+				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier_config",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -80,7 +80,7 @@ func TestAccComputeProjectCloudArmorTier_withProjectSet(t *testing.T) {
 				Config: testAccComputeProject_cloudArmorTier_withProjectSet_standard(context),
 			},
 			{
-				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier",
+				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier_config",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -88,7 +88,7 @@ func TestAccComputeProjectCloudArmorTier_withProjectSet(t *testing.T) {
 				Config: testAccComputeProject_cloudArmorTier_withProjectSet_enterprise_paygo(context),
 			},
 			{
-				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier",
+				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier_config",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -96,7 +96,7 @@ func TestAccComputeProjectCloudArmorTier_withProjectSet(t *testing.T) {
 				Config: testAccComputeProject_cloudArmorTier_withProjectSet_standard(context),
 			},
 			{
-				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier",
+				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier_config",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -106,14 +106,14 @@ func TestAccComputeProjectCloudArmorTier_withProjectSet(t *testing.T) {
 
 func testAccComputeProject_cloudArmorTier_enterprise_paygo() string {
 	return fmt.Sprintln(`
-resource "google_compute_project_cloud_armor_tier" "cloud_armor_tier" {
+resource "google_compute_project_cloud_armor_tier" "cloud_armor_tier_config" {
   cloud_armor_tier = "CA_ENTERPRISE_PAYGO"
 }`)
 }
 
 func testAccComputeProject_cloudArmorTier_standard() string {
 	return fmt.Sprintln(`
-resource "google_compute_project_cloud_armor_tier" "cloud_armor_tier" {
+resource "google_compute_project_cloud_armor_tier" "cloud_armor_tier_config" {
 	cloud_armor_tier = "CA_STANDARD"
 }`)
 }
@@ -132,7 +132,7 @@ resource "google_project_service" "compute" {
   service = "compute.googleapis.com"
 }
 
-resource "google_compute_project_cloud_armor_tier" "cloud_armor_tier" {
+resource "google_compute_project_cloud_armor_tier" "cloud_armor_tier_config" {
   project      = google_project.project.project_id
   cloud_armor_tier = "CA_ENTERPRISE_PAYGO"
   depends_on   = [google_project_service.compute]
@@ -154,7 +154,7 @@ resource "google_project_service" "compute" {
   service = "compute.googleapis.com"
 }
 
-resource "google_compute_project_cloud_armor_tier" "cloud_armor_tier" {
+resource "google_compute_project_cloud_armor_tier" "cloud_armor_tier_config" {
   project      = google_project.project.project_id
   cloud_armor_tier = "CA_STANDARD"
   depends_on   = [google_project_service.compute]

--- a/mmv1/third_party/terraform/services/compute/resource_compute_project_cloud_armor_tier_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_project_cloud_armor_tier_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccComputeProjectCloudArmorTier_basic(t *testing.T) {
+	acctest.SkipIfVcr(t)
 	t.Parallel()
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -17,7 +18,7 @@ func TestAccComputeProjectCloudArmorTier_basic(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeProject_cloudArmorTier_enterprise_paygo(),
+				Config: testAccComputeProject_cloudArmorTier_standard(),
 			},
 			{
 				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier_config",


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds a new resource "google_compute_project_cloud_armor_tier" allowing the management Cloud Armor Tier configuration in a similar function as the "google_compute_project_default_network_tier" resource

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/17658

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_compute_project_cloud_armor_tier`
```
