### PR TITLE
Docs: Add STANDARD_WITH_GRAPHQL option for json_parsing to google_compute_security_policy documentation

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
@@ -196,6 +196,7 @@ The following arguments are supported:
 * `json_parsing` - Whether or not to JSON parse the payload body. Defaults to `DISABLED`.
   * `DISABLED` - Don't parse JSON payloads in POST bodies.
   * `STANDARD` - Parse JSON payloads in POST bodies.
+  * `STANDARD_WITH_GRAPHQL` - Parse JSON and GraphQL payloads in POST bodies.
 
 * `json_custom_config` - Custom configuration to apply the JSON parsing. Only applicable when
     `json_parsing` is set to `STANDARD`. Structure is [documented below](#nested_json_custom_config).


### PR DESCRIPTION
The STANDARD_WITH_GRAPQL option for json_parsing is supported for the google_compute_security_policy resource, however, the documentation did not reflect this. This change adds this option to the documentation.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
