### PR TITLE
Fix references to non-existent TF meta-argument `update_triggered_by` in docs

### DIFF
--- a/mmv1/products/compute/InstanceGroup.yaml
+++ b/mmv1/products/compute/InstanceGroup.yaml
@@ -62,7 +62,7 @@ parameters:
       !> **WARNING** If a user will be recreating instances under the same name
       (eg. via `terraform taint`), please consider adding instances to an instance
       group via the `instance_group_membership` resource, along side the
-      `update_triggered_by` lifecycle method with an instance's ID.
+      `replace_triggered_by` lifecycle method with an instance's ID.
     exclude: true
     item_type: !ruby/object:Api::Type::ResourceRef
       name: 'instance'

--- a/mmv1/products/compute/InstanceGroupMembership.yaml
+++ b/mmv1/products/compute/InstanceGroupMembership.yaml
@@ -25,7 +25,7 @@ description: |
   -> **NOTE** This resource has been added to avoid a situation, where after
   Instance is recreated, it's removed from Instance Group and it's needed to
   perform `apply` twice. To avoid situations like this, please use this resource
-  with the lifecycle `update_triggered_by` method, with the passed Instance's ID.
+  with the lifecycle `replace_triggered_by` method, with the passed Instance's ID.
 immutable: true
 create_verb: :POST
 create_url: projects/{{project}}/zones/{{zone}}/instanceGroups/{{instance_group}}/addInstances

--- a/mmv1/products/compute/NetworkEndpoint.yaml
+++ b/mmv1/products/compute/NetworkEndpoint.yaml
@@ -21,7 +21,7 @@ description: |
   collections of these endpoints for GCP resources within a
   single subnet. **NOTE**: Network endpoints cannot be created outside of a
   network endpoint group.
-  
+
   -> **NOTE** In case the Endpoint's Instance is recreated, it's needed to
   perform `apply` twice. To avoid situations like this, please use this resource
   with the lifecycle `replace_triggered_by` method, with the passed Instance's ID.

--- a/mmv1/products/compute/NetworkEndpoint.yaml
+++ b/mmv1/products/compute/NetworkEndpoint.yaml
@@ -24,7 +24,7 @@ description: |
   
   -> **NOTE** In case the Endpoint's Instance is recreated, it's needed to
   perform `apply` twice. To avoid situations like this, please use this resource
-  with the lifecycle `update_triggered_by` method, with the passed Instance's ID.
+  with the lifecycle `replace_triggered_by` method, with the passed Instance's ID.
 immutable: true
 create_verb: :POST
 create_url: projects/{{project}}/zones/{{zone}}/networkEndpointGroups/{{network_endpoint_group}}/attachNetworkEndpoints

--- a/mmv1/products/compute/NetworkEndpoints.yaml
+++ b/mmv1/products/compute/NetworkEndpoints.yaml
@@ -27,7 +27,7 @@ description: |
   
   -> **NOTE** In case the Endpoint's Instance is recreated, it's needed to
   perform `apply` twice. To avoid situations like this, please use this resource
-  with the lifecycle `update_triggered_by` method, with the passed Instance's ID.
+  with the lifecycle `replace_triggered_by` method, with the passed Instance's ID.
 create_verb: :POST
 create_url: projects/{{project}}/zones/{{zone}}/networkEndpointGroups/{{network_endpoint_group}}/attachNetworkEndpoints
 update_verb: :POST

--- a/mmv1/products/compute/NetworkEndpoints.yaml
+++ b/mmv1/products/compute/NetworkEndpoints.yaml
@@ -24,7 +24,7 @@ description: |
 
   This resource is authoritative for a single NEG. Any endpoints not specified
   by this resource will be deleted when the resource configuration is applied.
-  
+
   -> **NOTE** In case the Endpoint's Instance is recreated, it's needed to
   perform `apply` twice. To avoid situations like this, please use this resource
   with the lifecycle `replace_triggered_by` method, with the passed Instance's ID.


### PR DESCRIPTION
The documentation for the following four resources refers to terraform lifecycle meta-argument `update_triggered_by` which doesn't exist. The correct name is [`replace_triggered_by`](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#replace_triggered_by).

- [google_compute_network_endpoint](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network_endpoint)
- [google_compute_network_endpoints](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network_endpoints)
- [google_compute_instance_group_membership](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_group_membership)
- [google_compute_instance_group](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_group)
  - For this one resource the linked web docs don't mention the `update_triggered_by`, but it is referenced in the docs source code.

PR fixes this issue in documentation and doesn't modify any functionality.

This issue has not been reported in the public issue tracker.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
