### PR TITLE
Add definition of table_replication_info to public documentation and bigquery/Table.yaml

### DIFF
--- a/mmv1/products/bigquery/Table.yaml
+++ b/mmv1/products/bigquery/Table.yaml
@@ -508,6 +508,30 @@ properties:
                     - :INTEGER
                     - :FLOAT
                     - :BOOLEAN
+  - !ruby/object:Api::Type::NestedObject
+    name: 'tableReplicationInfo'
+    description: |
+      Replication info of a table created using "AS REPLICA" DDL like:
+      `CREATE MATERIALIZED VIEW mv1 AS REPLICA OF src_mv`.
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'sourceProjectId'
+        description: The ID of the source project.
+        required: true
+      - !ruby/object:Api::Type::String
+        name: 'sourceDatasetId'
+        description: The ID of the source dataset.
+        required: true
+      - !ruby/object:Api::Type::String
+        name: 'sourceTableId'
+        description: The ID of the source materialized view.
+        required: true
+      - !ruby/object:Api::Type::Integer
+        name: 'replicationIntervalMs'
+        description: |
+          The interval at which the source materialized view is polled for updates. The default is
+          300000.
+        default_value: 300000
   - !ruby/object:Api::Type::KeyValuePairs
     name: 'resourceTags'
     min_version: beta

--- a/mmv1/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -167,6 +167,11 @@ in Terraform state, a `terraform destroy` or `terraform apply` that would delete
 * `table_constraints` - (Optional) Defines the primary key and foreign keys. 
     Structure is [documented below](#nested_table_constraints).
 
+* `table_replication_info` - (Optional) Replication info of a table created
+    using "AS REPLICA" DDL like:
+    `CREATE MATERIALIZED VIEW mv1 AS REPLICA OF src_mv`.
+    Structure is [documented below](#nested_table_replication_info).
+
 * `resource_tags` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
     This field is in beta. The tags attached to this table. Tag keys are
     globally unique. Tag key is expected to be in the namespaced format, for
@@ -443,6 +448,17 @@ in Terraform state, a `terraform destroy` or `terraform apply` that would delete
 
 * `referenced_column`: (Required) The column in the primary key that are
     referenced by the referencingColumn
+
+<a name="nested_table_replication_info"></a>The `table_replication_info` block supports:
+
+* `source_project_id` (Required) - The ID of the source project.
+
+* `source_dataset_id` (Required) - The ID of the source dataset.
+
+* `source_table_id` (Required) - The ID of the source materialized view.
+
+* `replication_interval_ms` (Optional) - The interval at which the source
+    materialized view is polled for updates. The default is 300000.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add definition of table_replication_info to public documentation and bigquery/Table.yaml.

The argument was added to the resource in https://github.com/GoogleCloudPlatform/magic-modules/pull/9909.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
