### PR TITLE
Add resource_tags argument definitions to resource_bigquery_table documentation

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -167,6 +167,17 @@ in Terraform state, a `terraform destroy` or `terraform apply` that would delete
 * `table_constraints` - (Optional) Defines the primary key and foreign keys. 
     Structure is [documented below](#nested_table_constraints).
 
+* `resource_tags` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+    This field is in beta. The tags attached to this table. Tag keys are
+    globally unique. Tag key is expected to be in the namespaced format, for
+    example "123456789012/environment" where 123456789012 is the ID of the
+    parent organization or project resource for this tag key. Tag value is
+    expected to be the short name, for example "Production".
+
+* `allow_resource_tags_on_deletion` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+    This field is in beta. Whether or not to allow table deletion when there are
+    still resource tags attached. The default value is false.
+
 <a name="nested_external_data_configuration"></a>The `external_data_configuration` block supports:
 
 * `autodetect` - (Required) - Let BigQuery try to autodetect the schema


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add resource_tags argument definitions to resource_bigquery_table documentation

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:note
bigquery: add resource_tags argument definitions to resource_bigquery_table documentation
```
