### PR TITLE
Add support for setting Pub/Sub subscription filename_datetime_format

### DIFF
--- a/mmv1/products/pubsub/Subscription.yaml
+++ b/mmv1/products/pubsub/Subscription.yaml
@@ -174,6 +174,10 @@ properties:
         description: |
           User-provided suffix for Cloud Storage filename. Must not end in "/".
       - !ruby/object:Api::Type::String
+        name: 'filenameDatetimeFormat'
+        description: |
+          User-provided format string specifying how to represent datetimes in Cloud Storage filenames.
+      - !ruby/object:Api::Type::String
         name: 'maxDuration'
         description: |
           The maximum duration that can elapse before a new Cloud Storage file is created. Min 1 minute, max 10 minutes, default 5 minutes.

--- a/mmv1/templates/terraform/examples/pubsub_subscription_push_cloudstorage.tf.erb
+++ b/mmv1/templates/terraform/examples/pubsub_subscription_push_cloudstorage.tf.erb
@@ -17,11 +17,12 @@ resource "google_pubsub_subscription" "<%= ctx[:primary_resource_id] %>" {
 
     filename_prefix = "pre-"
     filename_suffix = "-%{random_suffix}"
-  
+    filename_datetime_format = "YYYY-MM-DD/hh_mm_ssZ"
+
     max_bytes = 1000
     max_duration = "300s"
   }
-  depends_on = [ 
+  depends_on = [
     google_storage_bucket.<%= ctx[:primary_resource_id] %>,
     google_storage_bucket_iam_member.admin,
   ]

--- a/mmv1/templates/terraform/examples/pubsub_subscription_push_cloudstorage_avro.tf.erb
+++ b/mmv1/templates/terraform/examples/pubsub_subscription_push_cloudstorage_avro.tf.erb
@@ -17,15 +17,16 @@ resource "google_pubsub_subscription" "<%= ctx[:primary_resource_id] %>" {
 
     filename_prefix = "pre-"
     filename_suffix = "-%{random_suffix}"
-  
+    filename_datetime_format = "YYYY-MM-DD/hh_mm_ssZ"
+
     max_bytes = 1000
     max_duration = "300s"
-  
+
     avro_config {
       write_metadata = true
     }
   }
-  depends_on = [ 
+  depends_on = [
     google_storage_bucket.<%= ctx[:primary_resource_id] %>,
     google_storage_bucket_iam_member.admin,
   ]

--- a/mmv1/third_party/terraform/services/pubsub/resource_pubsub_subscription_test.go
+++ b/mmv1/third_party/terraform/services/pubsub/resource_pubsub_subscription_test.go
@@ -206,6 +206,40 @@ func TestAccPubsubSubscriptionBigQuery_update(t *testing.T) {
 	})
 }
 
+func TestAccPubsubSubscriptionCloudStorage_update(t *testing.T) {
+	t.Parallel()
+
+	bucket := fmt.Sprintf("tf-test-bucket-%s", acctest.RandString(t, 10))
+	topic := fmt.Sprintf("tf-test-topic-%s", acctest.RandString(t, 10))
+	subscriptionShort := fmt.Sprintf("tf-test-sub-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckPubsubSubscriptionDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPubsubSubscriptionCloudStorage_basic(bucket, topic, subscriptionShort, ""),
+			},
+			{
+				ResourceName:      "google_pubsub_subscription.foo",
+				ImportStateId:     subscriptionShort,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccPubsubSubscriptionCloudStorage_basic(bucket, topic, subscriptionShort, "YYYY-MM-DD/hh_mm_ssZ"),
+			},
+			{
+				ResourceName:      "google_pubsub_subscription.foo",
+				ImportStateId:     subscriptionShort,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 // Context: hashicorp/terraform-provider-google#4993
 // This test makes a call to GET an subscription before it is actually created.
 // The PubSub API negative-caches responses so this tests we are
@@ -457,6 +491,37 @@ resource "google_pubsub_subscription" "foo" {
   ]
 }
 `, dataset, table, topic, subscription, useTableSchema)
+}
+
+func testAccPubsubSubscriptionCloudStorage_basic(bucket, topic, subscription, filenameDatetimeFormat string) string {
+	filenameDatetimeString := ""
+	if filenameDatetimeFormat != "" {
+		filenameDatetimeString = fmt.Sprintf(`filename_datetime_format = "%s"`, filenameDatetimeFormat)
+	}
+	return fmt.Sprintf(`
+data "google_project" "project" { }
+resource "google_project_iam_member" "admin" {
+  project = data.google_project.project.project_id
+  role   = "roles/storage.admin"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+}
+resource "google_storage_bucket" "test" {
+  name = "%s"
+  location = "US"
+}
+resource "google_pubsub_topic" "foo" {
+  name = "%s"
+}
+resource "google_pubsub_subscription" "foo" {
+  name   = "%s"
+  topic  = google_pubsub_topic.foo.id
+
+  cloud_storage_config {
+    bucket = "${google_storage_bucket.test.name}"
+    %s
+  }
+}
+`, bucket, topic, subscription, filenameDatetimeString)
 }
 
 func testAccPubsubSubscription_topicOnly(topic string) string {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/17911.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
pubsub: added `cloud_storage_config.filename_datetime_format` field to `google_pubsub_subscription` resource
```