### PR TITLE
Fixes LifecycleRules Conditions not being set issue.

### DIFF
--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
@@ -262,6 +262,21 @@ func ResourceStorageBucket() *schema.Resource {
 										Elem:        &schema.Schema{Type: schema.TypeString},
 										Description: `One or more matching name suffixes to satisfy this condition.`,
 									},
+									"send_days_since_noncurrent_time_if_zero": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Description: `While set true, days_since_noncurrent_time value will be sent in the request even for zero value of the field. This field is only useful for setting 0 value to the days_since_noncurrent_time field. It can be used alone or together with days_since_noncurrent_time.`,
+									},
+									"send_days_since_custom_time_if_zero": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Description: `While set true, days_since_custom_time value will be sent in the request even for zero value of the field. This field is only useful for setting 0 value to the days_since_custom_time field. It can be used alone or together with days_since_custom_time.`,
+									},
+									"send_num_newer_versions_if_zero": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Description: `While set true, num_newer_versions value will be sent in the request even for zero value of the field. This field is only useful for setting 0 value to the num_newer_versions field. It can be used alone or together with num_newer_versions.`,
+									},
 								},
 							},
 							Description: `The Lifecycle Rule's condition configuration.`,
@@ -1363,6 +1378,9 @@ func flattenBucketLifecycleRuleCondition(index int, d *schema.ResourceData, cond
 	if v, ok := d.GetOk(fmt.Sprintf("lifecycle_rule.%d.condition",index)); ok{
 		state_condition := v.(*schema.Set).List()[0].(map[string]interface{})
 		ruleCondition["no_age"] = state_condition["no_age"].(bool)
+		ruleCondition["send_days_since_noncurrent_time_if_zero"] = state_condition["send_days_since_noncurrent_time_if_zero"].(bool)
+		ruleCondition["send_days_since_custom_time_if_zero"] = state_condition["send_days_since_custom_time_if_zero"].(bool)
+		ruleCondition["send_num_newer_versions_if_zero"] = state_condition["send_num_newer_versions_if_zero"].(bool)
 	}
 
 	return ruleCondition
@@ -1555,6 +1573,9 @@ func expandStorageBucketLifecycleRuleCondition(v interface{}) (*storage.BucketLi
 
 	if v, ok := condition["num_newer_versions"]; ok {
 		transformed.NumNewerVersions = int64(v.(int))
+		if u, ok := condition["send_num_newer_versions_if_zero"]; ok && u.(bool) {
+			transformed.ForceSendFields = append(transformed.ForceSendFields, "NumNewerVersions")
+		}
 	}
 
 	if v, ok := condition["custom_time_before"]; ok {
@@ -1563,10 +1584,16 @@ func expandStorageBucketLifecycleRuleCondition(v interface{}) (*storage.BucketLi
 
 	if v, ok := condition["days_since_custom_time"]; ok {
 		transformed.DaysSinceCustomTime = int64(v.(int))
+		if u, ok := condition["send_days_since_custom_time_if_zero"]; ok && u.(bool) {
+			transformed.ForceSendFields = append(transformed.ForceSendFields, "DaysSinceCustomTime")
+		}
 	}
 
 	if v, ok := condition["days_since_noncurrent_time"]; ok {
 		transformed.DaysSinceNoncurrentTime = int64(v.(int))
+		if u, ok := condition["send_days_since_noncurrent_time_if_zero"]; ok && u.(bool) {
+			transformed.ForceSendFields = append(transformed.ForceSendFields, "DaysSinceNoncurrentTime")
+		}
 	}
 
 	if v, ok := condition["noncurrent_time_before"]; ok {
@@ -1667,6 +1694,18 @@ func resourceGCSBucketLifecycleRuleConditionHash(v interface{}) int {
 
 	if v, ok := m["num_newer_versions"]; ok {
 		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
+	}
+
+	if v, ok := m["send_days_since_noncurrent_time_if_zero"]; ok {
+		buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
+	}
+
+	if v, ok := m["send_days_since_custom_time_if_zero"]; ok {
+		buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
+	}
+
+	if v, ok := m["send_num_newer_versions_if_zero"]; ok {
+		buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
 	}
 
 	if v, ok := m["matches_prefix"]; ok {

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
@@ -477,7 +477,7 @@ func TestAccStorageBucket_lifecycleRuleStateAny(t *testing.T) {
 	})
 }
 
-func TestAccStorageBucket_lifecycleRulesNoAge(t *testing.T) {
+func TestAccStorageBucket_lifecycleRulesVirtualFields(t *testing.T) {
 	t.Parallel()
 	var bucket storage.Bucket
 	bucketName := acctest.TestBucketName(t)
@@ -501,7 +501,7 @@ func TestAccStorageBucket_lifecycleRulesNoAge(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
-				Config: testAccStorageBucket_customAttributes_withLifecycleNoAge(bucketName),
+				Config: testAccStorageBucket_customAttributes_withLifecycleVirtualFieldsUpdate1(bucketName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStorageBucketExists(
 						t, "google_storage_bucket.bucket", bucketName, &bucket),
@@ -512,10 +512,10 @@ func TestAccStorageBucket_lifecycleRulesNoAge(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.1.condition.0.no_age"},
+				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.1.condition.0.no_age","lifecycle_rule.1.condition.0.send_days_since_noncurrent_time_if_zero","lifecycle_rule.2.condition.0.send_days_since_noncurrent_time_if_zero","lifecycle_rule.1.condition.0.send_days_since_custom_time_if_zero","lifecycle_rule.2.condition.0.send_days_since_custom_time_if_zero","lifecycle_rule.1.condition.0.send_num_newer_versions_if_zero","lifecycle_rule.2.condition.0.send_num_newer_versions_if_zero"},
 			},
 			{
-				Config: testAccStorageBucket_customAttributes_withLifecycleNoAgeAndAge(bucketName),
+				Config: testAccStorageBucket_customAttributes_withLifecycleVirtualFieldsUpdate2(bucketName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStorageBucketExists(
 						t, "google_storage_bucket.bucket", bucketName, &bucket),
@@ -526,7 +526,7 @@ func TestAccStorageBucket_lifecycleRulesNoAge(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.1.condition.0.no_age"},
+				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.1.condition.0.no_age","lifecycle_rule.0.condition.0.send_days_since_noncurrent_time_if_zero","lifecycle_rule.0.condition.0.send_days_since_custom_time_if_zero","lifecycle_rule.0.condition.0.send_num_newer_versions_if_zero"},
 			},
 			{
 				Config: testAccStorageBucket_customAttributes_withLifecycle1(bucketName),
@@ -1746,7 +1746,7 @@ resource "google_storage_bucket" "bucket" {
 `, bucketName)
 }
 
-func testAccStorageBucket_customAttributes_withLifecycleNoAge(bucketName string) string {
+func testAccStorageBucket_customAttributes_withLifecycleVirtualFieldsUpdate1(bucketName string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
   name          = "%s"
@@ -1754,11 +1754,17 @@ resource "google_storage_bucket" "bucket" {
   force_destroy = "true"
   lifecycle_rule {
      action {
-       type = "Delete"
+      type = "Delete"
      }
      condition {
-        age = 10
-        no_age = false
+      age = 10
+      no_age = false
+      days_since_noncurrent_time = 0
+      send_days_since_noncurrent_time_if_zero = false
+      days_since_custom_time = 0
+      send_days_since_custom_time_if_zero = false
+      num_newer_versions = 0
+      send_num_newer_versions_if_zero = false
      }
   }
   lifecycle_rule {
@@ -1766,15 +1772,30 @@ resource "google_storage_bucket" "bucket" {
       type = "Delete"
     }
     condition {
-      num_newer_versions = 2
       no_age = true
+      days_since_noncurrent_time = 0
+      send_days_since_noncurrent_time_if_zero = true
+      days_since_custom_time = 0
+      send_days_since_custom_time_if_zero = true
+      num_newer_versions = 0
+      send_num_newer_versions_if_zero = true
+    }
+  }
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+    condition {
+      send_days_since_noncurrent_time_if_zero = true
+      send_days_since_custom_time_if_zero = true
+      send_num_newer_versions_if_zero = true
     }
   }
 }
 `, bucketName)
 }
 
-func testAccStorageBucket_customAttributes_withLifecycleNoAgeAndAge(bucketName string) string {
+func testAccStorageBucket_customAttributes_withLifecycleVirtualFieldsUpdate2(bucketName string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
   name          = "%s"
@@ -1782,11 +1803,17 @@ resource "google_storage_bucket" "bucket" {
   force_destroy = "true"
   lifecycle_rule {
      action {
-       type = "Delete"
+      type = "Delete"
      }
      condition {
-       age = 10
-       no_age = false
+      age = 10
+      no_age = false
+      days_since_noncurrent_time = 0
+      send_days_since_noncurrent_time_if_zero = true
+      days_since_custom_time = 0
+      send_days_since_custom_time_if_zero = true
+      num_newer_versions = 0
+      send_num_newer_versions_if_zero = true
      }
   }
   lifecycle_rule {
@@ -1794,9 +1821,26 @@ resource "google_storage_bucket" "bucket" {
       type = "Delete"
     }
     condition {
-      num_newer_versions = 2
       age = 10
       no_age = true
+      custom_time_before = "2022-09-01"
+      days_since_noncurrent_time = 0
+      send_days_since_noncurrent_time_if_zero = false
+      days_since_custom_time = 0
+      send_days_since_custom_time_if_zero = false
+      num_newer_versions = 0
+      send_num_newer_versions_if_zero = false
+    }
+  }
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+    condition {
+      custom_time_before = "2022-09-01"
+      send_days_since_noncurrent_time_if_zero = false
+      send_days_since_custom_time_if_zero = false
+      send_num_newer_versions_if_zero = false
     }
   }
 }

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -171,7 +171,7 @@ The following arguments are supported:
 
 <a name="nested_condition"></a>The `condition` block supports the following elements, and requires at least one to be defined. If you specify multiple conditions in a rule, an object has to match all of the conditions for the action to be taken:
 
-* `age` - (Optional) Minimum age of an object in days to satisfy this condition. If not supplied alongside another condition and without setting `no_age` to `true`, a default `age` of 0 will be set. 
+* `age` - (Optional) Minimum age of an object in days to satisfy this condition. If not supplied alongside another condition and without setting `no_age` to `true`, a default `age` of 0 will be set.
 
 * `no_age` - (Optional) While set `true`, `age` value will be omitted from requests. This prevents a default age of `0` from being applied, and if you do not have an `age` value set, setting this to `true` is strongly recommended. When unset and other conditions are set to zero values, this can result in a rule that applies your action to all files in the bucket.
 
@@ -187,11 +187,17 @@ The following arguments are supported:
 
 * `num_newer_versions` - (Optional) Relevant only for versioned objects. The number of newer versions of an object to satisfy this condition. Due to a current bug you are unable to set this value to `0` within Terraform. When set to `0` it will be ignored and your state will treat it as though you supplied no `num_newer_versions` condition.
 
+* `send_num_newer_versions_if_zero` - (Optional) While set true, `num_newer_versions` value will be sent in the request even for zero value of the field. This field is only useful for setting 0 value to the `num_newer_versions` field. It can be used alone or together with `num_newer_versions`.
+
 * `custom_time_before` - (Optional) A date in the RFC 3339 format YYYY-MM-DD. This condition is satisfied when the customTime metadata for the object is set to an earlier date than the date used in this lifecycle condition.
 
-* `days_since_custom_time` - (Optional)	Days since the date set in the `customTime` metadata for the object. This condition is satisfied when the current date and time is at least the specified number of days after the `customTime`. Due to a current bug you are unable to set this value to `0` within Terraform. When set to `0` it will be ignored, and your state will treat it as though you supplied no `days_since_custom_time` condition. 
+* `days_since_custom_time` - (Optional)	Days since the date set in the `customTime` metadata for the object. This condition is satisfied when the current date and time is at least the specified number of days after the `customTime`. Due to a current bug you are unable to set this value to `0` within Terraform. When set to `0` it will be ignored, and your state will treat it as though you supplied no `days_since_custom_time` condition.
+
+* `send_days_since_custom_time_if_zero` - (Optional) While set true, `days_since_custom_time` value will be sent in the request even for zero value of the field. This field is only useful for setting 0 value to the `days_since_custom_time` field. It can be used alone or together with `days_since_custom_time`.
 
 * `days_since_noncurrent_time` - (Optional) Relevant only for versioned objects. Number of days elapsed since the noncurrent timestamp of an object. Due to a current bug you are unable to set this value to `0` within Terraform. When set to `0` it will be ignored, and your state will treat it as though you supplied no `days_since_noncurrent_time` condition.
+
+* `send_days_since_noncurrent_time_if_zero` - (Optional) While set true, `days_since_noncurrent_time` value will be sent in the request even for zero value of the field. This field is only useful for setting 0 value to the `days_since_noncurrent_time` field. It can be used alone or together with `days_since_noncurrent_time`.
 
 * `noncurrent_time_before` - (Optional) Relevant only for versioned objects. The date in RFC 3339 (e.g. `2017-06-13`) when the object became nonconcurrent. Due to a current bug you are unable to set this value to `0` within Terraform. When set to `0` it will be ignored, and your state will treat it as though you supplied no `noncurrent_time_before` condition.
 
@@ -259,7 +265,7 @@ The following arguments are supported:
 
 <a name="nested_soft_delete_policy"></a>The `soft_delete_policy` block supports:
 
-* `retention_duration_seconds` - (Optional, Default: 604800) The duration in seconds that soft-deleted objects in the bucket will be retained and cannot be permanently deleted. Default value is 604800. The value must be in between 604800(7 days) and 7776000(90 days). **Note**: To disable the soft delete policy on a bucket, This field must be set to 0. 
+* `retention_duration_seconds` - (Optional, Default: 604800) The duration in seconds that soft-deleted objects in the bucket will be retained and cannot be permanently deleted. Default value is 604800. The value must be in between 604800(7 days) and 7776000(90 days). **Note**: To disable the soft delete policy on a bucket, This field must be set to 0.
 
 * `effective_time` - (Computed) Server-determined value that indicates the time from which the policy, or one with a greater retention, was effective. This value is in RFC 3339 format.
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/17990


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
storage: fixed a bug where `google_storage_bucket.lifecycle_rule.condition` block fields  `days_since_noncurrent_time` and `days_since_custom_time`  and `num_newer_versions` were not working for 0 value. You can now send these by including a corresponding field such as `send_days_since_noncurrent_time_if_zero` in your configuration that is set to true.
```
