### PR TITLE
Address acc tests failures with higher TF versions by removing unused output block from acctest configs

### DIFF
--- a/mmv1/templates/terraform/examples/cloudfunctions2_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudfunctions2_basic.tf.erb
@@ -36,7 +36,3 @@ resource "google_cloudfunctions2_function" "<%= ctx[:primary_resource_id] %>" {
     timeout_seconds     = 60
   }
 }
-
-output "function_uri" { 
-  value = google_cloudfunctions2_function.function.service_config[0].uri
-}

--- a/mmv1/templates/terraform/examples/cloudfunctions2_basic_builder.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudfunctions2_basic_builder.tf.erb
@@ -73,7 +73,3 @@ resource "google_cloudfunctions2_function" "<%= ctx[:primary_resource_id] %>" {
 
   depends_on = [time_sleep.wait_60s]
 }
-
-output "function_uri" { 
-  value = google_cloudfunctions2_function.function.service_config[0].uri
-}

--- a/mmv1/templates/terraform/examples/go/cloudfunctions2_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/cloudfunctions2_basic.tf.tmpl
@@ -37,6 +37,3 @@ resource "google_cloudfunctions2_function" "{{$.PrimaryResourceId}}" {
   }
 }
 
-output "function_uri" { 
-  value = google_cloudfunctions2_function.function.service_config[0].uri
-}

--- a/mmv1/templates/terraform/examples/go/cloudfunctions2_basic_builder.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/cloudfunctions2_basic_builder.tf.tmpl
@@ -73,7 +73,3 @@ resource "google_cloudfunctions2_function" "{{$.PrimaryResourceId}}" {
 
   depends_on = [time_sleep.wait_60s]
 }
-
-output "function_uri" { 
-  value = google_cloudfunctions2_function.function.service_config[0].uri
-}


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/18109

In the context of the IAM tests that are generated from this example config, this output block triggers a bug present in Terraform 1.4.0 up to 1.8.3 (latest release).

I've raised that bug internally, but this edit to the test will enable it to pass again. The output isn't being used by any tests, so removing it seems ok to me.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
