### PR TITLE
docs: Correction for google_sql_database_instance database_flags

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/sql_user.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_user.html.markdown
@@ -53,7 +53,7 @@ resource "google_sql_database_instance" "main" {
     tier = "db-f1-micro"
 
     database_flags {
-      name  = "cloudsql.iam_authentication"
+      name  = "cloudsql_iam_authentication"
       value = "on"
     }
   }
@@ -89,7 +89,7 @@ resource "google_sql_database_instance" "main" {
     tier = "db-f1-micro"
 
     database_flags {
-      name  = "cloudsql.iam_authentication"
+      name  = "cloudsql_iam_authentication"
       value = "on"
     }
   }
@@ -124,7 +124,7 @@ The following arguments are supported:
 * `deletion_policy` - (Optional) The deletion policy for the user.
     Setting `ABANDON` allows the resource to be abandoned rather than deleted. This is useful
     for Postgres, where users cannot be deleted from the API if they have been granted SQL roles.
-    
+
     Possible values are: `ABANDON`.
 
 - - -


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Currently the [Terraform documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_user) for `google_sql_database_instance` `database_flags` is incorrect. It's showing `cloudsql.iam_authentication` instead of `cloudsql_iam_authentication` like it's showed in the official [GCloud  documentation](https://cloud.google.com/sql/docs/mysql/create-edit-iam-instances#terraform) and also [here](https://cloud.google.com/sql/docs/mysql/flags#terraform)

A ticket referencing this issue can be found here https://github.com/hashicorp/terraform-provider-google/issues/16941

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
