### PR TITLE
Fix TestAccSqlUser_postgresIAM by using a real IAM user

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_user_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user_test.go
@@ -422,14 +422,14 @@ resource "google_sql_database_instance" "instance" {
 }
 
 # TODO: Remove with resolution of https://github.com/hashicorp/terraform-provider-google/issues/14233
-resource "time_sleep" "wait_30_seconds" {
+resource "time_sleep" "wait_60_seconds" {
   depends_on = [google_sql_database_instance.instance]
 
-  create_duration = "30s"
+  create_duration = "60s"
 }
 
 resource "google_sql_user" "user" {
-  depends_on = [time_sleep.wait_30_seconds]
+  depends_on = [time_sleep.wait_60_seconds]
   name     = "%s"
   instance = google_sql_database_instance.instance.name
   type     = "CLOUD_IAM_USER"


### PR DESCRIPTION
This PR aims to fix TestAccSqlUser_postgresIAM. The backend checks that the passed in IAM_USER actually exists, so we need to use a valid user in the test.

Fixes hashicorp/terraform-provider-google#16704

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
