### PR TITLE
Go Rewrite - Fix a some description diffs

### DIFF
--- a/mmv1/api/type.go
+++ b/mmv1/api/type.go
@@ -21,6 +21,7 @@ import (
 	"github.com/GoogleCloudPlatform/magic-modules/mmv1/api/product"
 	"github.com/GoogleCloudPlatform/magic-modules/mmv1/api/resource"
 	"github.com/GoogleCloudPlatform/magic-modules/mmv1/google"
+	"golang.org/x/exp/slices"
 )
 
 // Represents a property type
@@ -411,11 +412,15 @@ func (t Type) TerraformLineage() string {
 	return fmt.Sprintf("%s.0.%s", t.ParentMetadata.TerraformLineage(), google.Underscore(t.Name))
 }
 
-func (t Type) EnumValuesToString(quoteSeperator string) string {
+func (t Type) EnumValuesToString(quoteSeperator string, addEmpty bool) string {
 	var values []string
 
 	for _, val := range t.EnumValues {
 		values = append(values, fmt.Sprintf("%s%s%s", quoteSeperator, val, quoteSeperator))
+	}
+
+	if addEmpty && !slices.Contains(values, "\"\"") && !t.Required {
+		values = append(values, "\"\"")
 	}
 
 	return strings.Join(values, ", ")
@@ -685,6 +690,10 @@ func (t Type) Removed() bool {
 // def deprecated?
 func (t Type) Deprecated() bool {
 	return t.DeprecationMessage != ""
+}
+
+func (t *Type) GetDescription() string {
+	return strings.TrimRight(t.Description, "\n")
 }
 
 // // private

--- a/mmv1/products/datafusion/go_instance.yaml
+++ b/mmv1/products/datafusion/go_instance.yaml
@@ -115,16 +115,17 @@ properties:
     immutable: true
   - name: 'type'
     type: Enum
-    description: "Represents the type of Data Fusion instance. Each type is configured with
-the default settings for processing and memory.
-- BASIC: Basic Data Fusion instance. In Basic type, the user will be able to create data pipelines
-using point and click UI. However, there are certain limitations, such as fewer number
-of concurrent pipelines, no support for streaming pipelines, etc.
-- ENTERPRISE: Enterprise Data Fusion instance. In Enterprise type, the user will have more features
-available, such as support for streaming pipelines, higher number of concurrent pipelines, etc.
-- DEVELOPER: Developer Data Fusion instance. In Developer type, the user will have all features available but
-with restrictive capabilities. This is to help enterprises design and develop their data ingestion and integration
-pipelines at low cost."
+    description: |
+      Represents the type of Data Fusion instance. Each type is configured with
+      the default settings for processing and memory.
+      - BASIC: Basic Data Fusion instance. In Basic type, the user will be able to create data pipelines
+      using point and click UI. However, there are certain limitations, such as fewer number
+      of concurrent pipelines, no support for streaming pipelines, etc.
+      - ENTERPRISE: Enterprise Data Fusion instance. In Enterprise type, the user will have more features
+      available, such as support for streaming pipelines, higher number of concurrent pipelines, etc.
+      - DEVELOPER: Developer Data Fusion instance. In Developer type, the user will have all features available but
+      with restrictive capabilities. This is to help enterprises design and develop their data ingestion and integration
+      pipelines at low cost.
     required: true
     immutable: true
     enum_values:
@@ -142,9 +143,9 @@ pipelines at low cost."
     description: "Option to enable granular role-based access control."
   - name: 'labels'
     type: KeyValueLabels
-    description: "The resource labels for instance to use to annotate any related underlying resources,
-such as Compute Engine VMs.
-"
+    description: |
+      The resource labels for instance to use to annotate any related underlying resources,
+      such as Compute Engine VMs.
     immutable: false
   - name: 'options'
     type: KeyValuePairs
@@ -154,21 +155,24 @@ such as Compute Engine VMs.
     diff_suppress_func: 'instanceOptionsDiffSuppress'
   - name: 'createTime'
     type: String
-    description: "The time the instance was created in RFC3339 UTC 'Zulu' format, accurate to nanoseconds."
+    description: |
+      The time the instance was created in RFC3339 UTC "Zulu" format, accurate to nanoseconds.
     output: true
   - name: 'updateTime'
     type: String
-    description: "The time the instance was last updated in RFC3339 UTC 'Zulu' format, accurate to nanoseconds."
+    description: |
+      The time the instance was last updated in RFC3339 UTC "Zulu" format, accurate to nanoseconds.
     output: true
   - name: 'state'
     type: Enum
-    description: "The current state of this Data Fusion instance.
-- CREATING: Instance is being created
-- RUNNING: Instance is running and ready for requests
-- FAILED: Instance creation failed
-- DELETING: Instance is being deleted
-- UPGRADING: Instance is being upgraded
-- RESTARTING: Instance is being restarted"
+    description: |
+      The current state of this Data Fusion instance.
+      - CREATING: Instance is being created
+      - RUNNING: Instance is running and ready for requests
+      - FAILED: Instance creation failed
+      - DELETING: Instance is being deleted
+      - UPGRADING: Instance is being upgraded
+      - RESTARTING: Instance is being restarted
     output: true
     enum_values:
       - 'CREATING'
@@ -197,9 +201,10 @@ such as Compute Engine VMs.
     deprecation_message: '`service_account` is deprecated and will be removed in a future major release. Instead, use `tenant_project_id` to extract the tenant project ID.'
   - name: 'privateInstance'
     type: Boolean
-    description: "Specifies whether the Data Fusion instance should be private. If set to
-true, all Data Fusion nodes will have private IP addresses and will not be
-able to access the public internet."
+    description: |
+      Specifies whether the Data Fusion instance should be private. If set to
+      true, all Data Fusion nodes will have private IP addresses and will not be
+      able to access the public internet.
     immutable: true
   - name: 'dataprocServiceAccount'
     type: String
@@ -220,15 +225,17 @@ able to access the public internet."
     properties:
       - name: 'ipAllocation'
         type: String
-        description: "The IP range in CIDR notation to use for the managed Data Fusion instance
-    nodes. This range must not overlap with any other ranges used in the Data Fusion instance network."
+        description: |
+          The IP range in CIDR notation to use for the managed Data Fusion instance
+          nodes. This range must not overlap with any other ranges used in the Data Fusion instance network.
         required: true
         immutable: true
       - name: 'network'
         type: String
-        description: "Name of the network in the project with which the tenant project
-    will be peered for executing pipelines. In case of shared VPC where the network resides in another host
-    project the network should specified in the form of projects/{host-project-id}/global/networks/{network}"
+        description: |
+          Name of the network in the project with which the tenant project
+          will be peered for executing pipelines. In case of shared VPC where the network resides in another host
+          project the network should specified in the form of projects/{host-project-id}/global/networks/{network}
         required: true
         immutable: true
   - name: 'zone'
@@ -275,8 +282,9 @@ able to access the public internet."
     type: Array
     description: |
       List of accelerators enabled for this CDF instance.
-        If accelerators are enabled it is possible a permadiff will be created with the Options field.
-        Users will need to either manually update their state file to include these diffed options, or include the field in a [lifecycle ignore changes block](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes).
+
+      If accelerators are enabled it is possible a permadiff will be created with the Options field.
+      Users will need to either manually update their state file to include these diffed options, or include the field in a [lifecycle ignore changes block](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes).
     item_type:
       properties:
         - name: 'acceleratorType'
@@ -289,7 +297,8 @@ able to access the public internet."
             - 'CCAI_INSIGHTS'
         - name: 'state'
           type: Enum
-          description: "The type of an accelator for a CDF instance."
+          description: |
+            The type of an accelator for a CDF instance.
           required: true
           enum_values:
             - 'ENABLED'

--- a/mmv1/products/pubsub/go_Schema.yaml
+++ b/mmv1/products/pubsub/go_Schema.yaml
@@ -74,13 +74,13 @@ properties:
       - 'TYPE_UNSPECIFIED'
       - 'PROTOCOL_BUFFER'
       - 'AVRO'
-      - ''
   - name: 'definition'
     type: String
-    description: "The definition of the schema.
-This should contain a string representing the full definition of the schema
-that is a valid schema definition of the type specified in type. Changes
-to the definition commit new [schema revisions](https://cloud.google.com/pubsub/docs/commit-schema-revision).
-A schema can only have up to 20 revisions, so updates that fail with an
-error indicating that the limit has been reached require manually
-[deleting old revisions](https://cloud.google.com/pubsub/docs/delete-schema-revision)."
+    description: |
+      The definition of the schema.
+      This should contain a string representing the full definition of the schema
+      that is a valid schema definition of the type specified in type. Changes
+      to the definition commit new [schema revisions](https://cloud.google.com/pubsub/docs/commit-schema-revision).
+      A schema can only have up to 20 revisions, so updates that fail with an
+      error indicating that the limit has been reached require manually
+      [deleting old revisions](https://cloud.google.com/pubsub/docs/delete-schema-revision).

--- a/mmv1/products/pubsub/go_Subscription.yaml
+++ b/mmv1/products/pubsub/go_Subscription.yaml
@@ -103,9 +103,10 @@ properties:
     custom_expand: 'templates/terraform/custom_expand/go/shortname_to_url.go.tmpl'
   - name: 'topic'
     type: ResourceRef
-    description: "A reference to a Topic resource, of the form projects/{project}/topics/{{name}}
-(as in the id property of a google_pubsub_topic), or just a topic name if
-the topic is in the same project as the subscription."
+    description: |
+      A reference to a Topic resource, of the form projects/{project}/topics/{{name}}
+      (as in the id property of a google_pubsub_topic), or just a topic name if
+      the topic is in the same project as the subscription.
     required: true
     immutable: true
     diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
@@ -271,24 +272,25 @@ pull and ack messages using API methods."
             send_empty_value: true
   - name: 'ackDeadlineSeconds'
     type: Integer
-    description: "This value is the maximum time after a subscriber receives a message
-before the subscriber should acknowledge the message. After message
-delivery but before the ack deadline expires and before the message is
-acknowledged, it is an outstanding message and will not be delivered
-again during that time (on a best-effort basis).
+    description: |
+      This value is the maximum time after a subscriber receives a message
+      before the subscriber should acknowledge the message. After message
+      delivery but before the ack deadline expires and before the message is
+      acknowledged, it is an outstanding message and will not be delivered
+      again during that time (on a best-effort basis).
 
-For pull subscriptions, this value is used as the initial value for
-the ack deadline. To override this value for a given message, call
-subscriptions.modifyAckDeadline with the corresponding ackId if using
-pull. The minimum custom deadline you can specify is 10 seconds. The
-maximum custom deadline you can specify is 600 seconds (10 minutes).
-If this parameter is 0, a default value of 10 seconds is used.
+      For pull subscriptions, this value is used as the initial value for
+      the ack deadline. To override this value for a given message, call
+      subscriptions.modifyAckDeadline with the corresponding ackId if using
+      pull. The minimum custom deadline you can specify is 10 seconds. The
+      maximum custom deadline you can specify is 600 seconds (10 minutes).
+      If this parameter is 0, a default value of 10 seconds is used.
 
-For push delivery, this value is also used to set the request timeout
-for the call to the push endpoint.
+      For push delivery, this value is also used to set the request timeout
+      for the call to the push endpoint.
 
-If the subscriber never acknowledges the message, the Pub/Sub system
-will eventually redeliver the message."
+      If the subscriber never acknowledges the message, the Pub/Sub system
+      will eventually redeliver the message.
     default_from_api: true
   - name: 'messageRetentionDuration'
     type: String

--- a/mmv1/templates/terraform/expand_property_method.go.tmpl
+++ b/mmv1/templates/terraform/expand_property_method.go.tmpl
@@ -14,7 +14,7 @@
   limitations under the License. */ -}}
 {{- define "expandPropertyMethod" }}
   {{- if $.CustomExpand }}
-    {{- $.CustomTemplate $.CustomExpand -}}
+    {{ $.CustomTemplate $.CustomExpand -}}
   {{- else }}{{/* if $.CustomExpand */}}
     {{- if $.IsA "Map" }}
 func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (map[string]interface{}, error) {

--- a/mmv1/templates/terraform/property_documentation.html.markdown.tmpl
+++ b/mmv1/templates/terraform/property_documentation.html.markdown.tmpl
@@ -26,12 +26,12 @@
     {{- if not (or $.ItemType.DefaultValue (eq $.ItemType.DefaultValue "")) }}
     Default value is [`{{ $.ItemType.DefaultValue }}`].
     {{- end }}
-    Each value may be one of: {{ $.ItemType.EnumValuesToString "`" }}.
+    Each value may be one of: {{ $.ItemType.EnumValuesToString "`" false }}.
   {{- else if and ($.IsA "Enum") (and (not $.Output) (not (and $.ItemType $.ItemType.SkipDocsValues)))}}
     {{- if not (or $.DefaultValue (eq $.DefaultValue "")) }}
     Default value is [`{{ $.DefaultValue }}`].
     {{- end }}
-    Possible values are: {{ $.EnumValuesToString "`" }}.
+    Possible values are: {{ $.EnumValuesToString "`" false }}.
   {{- end }}
   {{- if $.Sensitive }}
     **Note**: This property is sensitive and will not be displayed in the plan.

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -1182,18 +1182,19 @@ func resource{{ $.ResourceName -}}Encoder(d *schema.ResourceData, meta interface
 }
 {{- end }}
 {{- if $.CustomCode.UpdateEncoder }}
+
 func resource{{ $.ResourceName -}}UpdateEncoder(d *schema.ResourceData, meta interface{}, obj map[string]interface{}) (map[string]interface{}, error) {
     {{- $.CustomTemplate $.CustomCode.UpdateEncoder -}}
 }
 {{- end }}
 {{- if $.CustomCode.Decoder }}
 func resource{{ $.ResourceName -}}Decoder(d *schema.ResourceData, meta interface{}, obj map[string]interface{}) (map[string]interface{}, error) {
-    {{- $.CustomTemplate $.CustomCode.Decoder -}}
+    {{ $.CustomTemplate $.CustomCode.Decoder -}}
 }
 {{- end }}
 {{- if $.CustomCode.PostCreateFailure }}
 func resource{{ $.ResourceName -}}PostCreateFailure(d *schema.ResourceData, meta interface{}, obj map[string]interface{}) (map[string]interface{}, error) {
-    {{- $.CustomTemplate $.CustomCode.PostCreateFailure -}}
+    {{ $.CustomTemplate $.CustomCode.PostCreateFailure -}}
 }
 {{- end }}
 {{/* TODO nested query */}}

--- a/mmv1/templates/terraform/schema_property.go.tmpl
+++ b/mmv1/templates/terraform/schema_property.go.tmpl
@@ -51,7 +51,7 @@
 	{{ end  -}}
 {{ end -}}
 {{ if and (eq .Type "Enum") (not .Output) -}}
-	ValidateFunc: verify.ValidateEnum([]string{ {{- .EnumValuesToString "\"" -}} }),
+	ValidateFunc: verify.ValidateEnum([]string{ {{- .EnumValuesToString "\"" true -}} }),
 {{ end -}}
 {{ if .DiffSuppressFunc -}}
   DiffSuppressFunc: {{ .DiffSuppressFunc }},
@@ -61,18 +61,18 @@
 {{ if .StateFunc -}}
 	StateFunc: {{ .StateFunc }},
 {{ end -}}
-  Description: `{{ replace .Description "`" "'" -1 -}}
-{{ if and (eq .Type "Array") (eq .ItemType.Type "Enum") (not .Output) (not .ItemType.SkipDocsValues) -}}
-{{ if .ItemType.DefaultValue -}}
+  Description: `{{ replace .GetDescription "`" "'" -1 -}}
+{{- if and (eq .Type "Array") (eq .ItemType.Type "Enum") (not .Output) (not .ItemType.SkipDocsValues) -}}
+  {{- if .ItemType.DefaultValue -}}
 Default value: {{ .ItemType.DefaultValue -}}
-{{ end -}}
-Possible values: [{{- .EnumValuesToString "\"" -}}]
-{{ else if and (eq .Type "Enum") (not .Output) -}}
-{{ if .DefaultValue -}}
-Default value: {{.DefaultValue -}}
-{{ end -}}
-{{" "}}Possible values: [{{- .EnumValuesToString "\"" -}}]
-{{- end -}}`,
+  {{- end -}}
+Possible values: [{{- .EnumValuesToString "\"" false -}}]
+  {{- else if and (eq .Type "Enum") (not .Output) -}}
+    {{- if .DefaultValue -}}
+      {{- " "}}Default value: "{{ .DefaultValue -}}"
+    {{- end -}}
+    {{- " "}}Possible values: [{{- .EnumValuesToString "\"" false -}}]
+  {{- end -}}`,
 {{ if eq .Type "NestedObject" -}}
   {{ if not .Output -}}
   MaxItems: 1,
@@ -110,7 +110,7 @@ Default value: {{.DefaultValue -}}
   {{ else if eq .ItemType.Type "Enum" -}}
       Elem: &schema.Schema{
         Type: schema.Type{{ .ItemTypeClass -}},
-        ValidateFunc: verify.ValidateEnum([]string{ {{- .ItemType.EnumValuesToString "\"" -}} }),
+        ValidateFunc: verify.ValidateEnum([]string{ {{- .ItemType.EnumValuesToString "\"" true -}} }),
       },
   {{ else -}}
       Elem: &schema.Schema{


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Turns out the diffs are mostly from the go YAML themselves not keeping the block indicator `|` and the exact same indentation. I looked at the current conversion script and could not figure out a way to preserve indentation and the indicator with Ruby YAML, so we may need a secondary script to just copy/paste the descriptions after the first runs.

In the meantime, here are some fixes.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
