### PR TITLE
use new compute network to fix dbms private connection test

### DIFF
--- a/mmv1/products/databasemigrationservice/PrivateConnection.yaml
+++ b/mmv1/products/databasemigrationservice/PrivateConnection.yaml
@@ -43,9 +43,7 @@ examples:
     primary_resource_id: 'default'
     vars:
       private_connection_id: 'my-connection'
-      network_name: 'my-network'
-    test_vars_overrides:
-      network_name: 'acctest.BootstrapSharedTestNetwork(t, "dbms-privateconnection")'
+      network_name: 'my-private-connection-network'
 parameters:
   - !ruby/object:Api::Type::String
     name: privateConnectionId

--- a/mmv1/templates/terraform/examples/database_migration_service_private_connection.tf.erb
+++ b/mmv1/templates/terraform/examples/database_migration_service_private_connection.tf.erb
@@ -8,11 +8,14 @@ resource "google_database_migration_service_private_connection" "<%= ctx[:primar
 	}
 
 	vpc_peering_config {
-		vpc_name = data.google_compute_network.default.id
-		subnet = "10.0.0.0/29"
+		vpc_name = data.google_compute_network.private_connection.id
+		subnet = "10.128.0.0/9"
 	}
+
+	depends_on = [google_compute_network.private_connection]
 }
 
-data "google_compute_network" "default" {
+resource "google_compute_network" "private_connection" {
   name = "<%= ctx[:vars]['network_name'] %>"
+  auto_create_subnetworks = true
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes #17384

Since the test itself relies on a default network it attempts to use an ip address that has already been reserved resulting in an operation timeout. Solution Reference: https://github.com/hashicorp/terraform-provider-google/issues/17384#issuecomment-1964796123

The chosen subnet ip comes from the docs themselves since we're using `auto_create_subnetworks`: https://cloud.google.com/vpc/docs/vpc#ip-ranges


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
