### PR TITLE
update `launch_stage` test value: Fixes TestAccCloudRunV2Service_cloudrunv2ServiceWithDirectVPCUpdate

### DIFF
--- a/mmv1/templates/terraform/examples/go/cloudrunv2_service_directvpc.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/cloudrunv2_service_directvpc.tf.tmpl
@@ -1,7 +1,7 @@
 resource "google_cloud_run_v2_service" "{{$.PrimaryResourceId}}" {
   name     = "{{index $.Vars "cloud_run_service_name"}}"
   location = "us-central1"
-  launch_stage = "BETA"
+  launch_stage = "GA"
   template {
     containers {
       image = "us-docker.pkg.dev/cloudrun/container/hello"

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.erb
@@ -733,7 +733,7 @@ func testAccCloudRunV2Service_cloudRunServiceWithDirectVPC(context map[string]in
 resource "google_cloud_run_v2_service" "default" {
   name     = "%{service_name}"
   location = "us-central1"
-  launch_stage = "BETA"
+  launch_stage = "GA"
   template {
     containers {
       image = "us-docker.pkg.dev/cloudrun/container/hello"
@@ -753,7 +753,7 @@ func testAccCloudRunV2Service_cloudRunServiceWithDirectVPCUpdate(context map[str
 resource "google_cloud_run_v2_service" "default" {
   name     = "%{service_name}"
   location = "us-central1"
-  launch_stage = "BETA"
+  launch_stage = "GA"
   template {
     containers {
       image = "us-docker.pkg.dev/cloudrun/container/hello"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes [#17983](https://github.com/hashicorp/terraform-provider-google/issues/17983)

The default value from the api for `launch_stage` used to `BETA`, but a recent change to `GA` for the default value has caused test failures. This PR updates the test to match the behavior of the api.

Tests were ran locally with passing test
```
└─(00:44:06 on fix-dbms-test-privateconnection ✹)──> envchain GCLOUD make testacc TEST=./google/services/cloudrunv2 TESTARGS='-run=TestAccCloudRunV2Service_cloudrunv2ServiceWithDirectVPCUpdate'
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/cloudrunv2 -v -run=TestAccCloudRunV2Service_cloudrunv2ServiceWithDirectVPCUpdate -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccCloudRunV2Service_cloudrunv2ServiceWithDirectVPCUpdate
=== PAUSE TestAccCloudRunV2Service_cloudrunv2ServiceWithDirectVPCUpdate
=== CONT  TestAccCloudRunV2Service_cloudrunv2ServiceWithDirectVPCUpdate
--- PASS: TestAccCloudRunV2Service_cloudrunv2ServiceWithDirectVPCUpdate (59.80s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/cloudrunv2       61.004s
```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
