### PR TITLE
Made pr review reminders only run on magic-modules

### DIFF
--- a/.github/workflows/scheduled-pr-reminders.yml
+++ b/.github/workflows/scheduled-pr-reminders.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   send-pr-reminders:
+    if: github.repository == 'GoogleCloudPlatform/magic-modules'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Resolved https://github.com/hashicorp/terraform-provider-google/issues/18193

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
