### PR TITLE
Add new resource "StoragePool".

### DIFF
--- a/mmv1/products/compute/StoragePool.yaml
+++ b/mmv1/products/compute/StoragePool.yaml
@@ -1,0 +1,242 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'StoragePool'
+kind: 'compute#storagePool'
+immutable: true
+base_url: projects/{{project}}/zones/{{zone}}/storagePools
+collection_url_key: 'items'
+has_self_link: true
+description: |
+  Storage pools improve performance for volumes of the CVS service type. A storage pool
+  acts as a container for up to 50 volumes; all volumes in the pool share the capacity
+  and performance of that pool.
+
+  Each volume of the CVS-Performance service type exists individually. The performance
+  of a volume of the CVS-Performance service type is determined by its size and its
+  service level, which can impose a performance limitation for very small volumes.
+  To improve performance for small volume performance, the CVS service type manages
+  volumes with storage pools.
+
+  A storage pool aggregates capacity and performance. Volumes are created within the
+  storage pool and can use the capacity and performance of that pool. All volumes in
+  the same storage pool share the performance capability of the pool. A volume can use
+  the full performance capacity of its pool. If volumes need performance isolation from
+  each other, they must be created in different pools.
+
+  Storage pools support two levels of availability: zonal and zone-redundant.
+  Redundancy is set when you create a storage pool and can either be zonal (high
+  availability within a single zone) or zone-redundant (high availability across two
+  zones). For zone-redundant volumes, all volumes are run in a primary zone and fail
+  over to the secondary zone in the case of zone failure or because of a user-initiated
+  cross-zone move. Primary and secondary zones are chosen at the time of pool creation.
+references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+    'Create a storage pool': 'https://cloud.google.com/compute/docs/disks/create-storage-pools'
+  api: 'https://cloud.google.com/compute/docs/reference/rest/v1/storagePools'
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
+    kind: 'compute#operation'
+    path: 'name'
+    base_url: 'projects/{{project}}/zones/{{zone}}/operations/{{op_id}}'
+    wait_ms: 1000
+  result: !ruby/object:Api::OpAsync::Result
+    path: 'targetLink'
+  status: !ruby/object:Api::OpAsync::Status
+    path: 'status'
+    complete: 'DONE'
+    allowed:
+      - 'PENDING'
+      - 'RUNNING'
+      - 'DONE'
+  error: !ruby/object:Api::OpAsync::Error
+    path: 'error/errors'
+    message: 'message'
+examples:
+  # The creation tests are covered in the update test and fromStoragePoolTypeUrl test.
+  # Skip these since generated creation tests and IAM tests will exceed the storage pool
+  # hourly creation limit.
+  - !ruby/object:Provider::Terraform::Examples
+    skip_test: true
+    name: 'compute_storage_pool_basic'
+    primary_resource_id: 'default'
+    primary_resource_name: "fmt.Sprintf(\"tf-test-test-storage-pool%s\",
+      context[\"random_suffix\"\
+      ])"
+    vars:
+      storage_pool_name: 'test-storage-pool'
+  - !ruby/object:Provider::Terraform::Examples
+    skip_test: true
+    name: 'compute_storage_pool_hyperdisk_balanced'
+    primary_resource_id: 'default'
+    primary_resource_name: "fmt.Sprintf(\"tf-test-test-storage-pool-hyperdisk-balanced%s\",
+      context[\"random_suffix\"\
+      ])"
+    vars:
+      storage_pool_name: 'test-storage-pool-hyperdisk-balanced'
+iam_policy: !ruby/object:Api::Resource::IamPolicy
+  method_name_separator: '/'
+  fetch_iam_policy_verb: :GET
+  parent_resource_attribute: 'name'
+  import_format:
+    ['projects/{{project}}/zones/{{zone}}/storagePools/{{name}}', '{{name}}']
+  base_url: projects/{{project}}/zones/{{zone}}/storagePools/{{name}}
+parameters:
+  - !ruby/object:Api::Type::ResourceRef
+    name: 'zone'
+    resource: 'Zone'
+    imports: 'name'
+    description: |
+      A reference to the zone where the storage pool resides.
+    required: false
+    default_from_api: true
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.erb'
+properties:
+  - !ruby/object:Api::Type::String
+    name: 'StoragePoolId'
+    description: |
+      The unique identifier for the resource. This identifier is defined by the server.
+    output: true
+    api_name: id
+  - !ruby/object:Api::Type::Time
+    name: 'creationTimestamp'
+    description: 'Creation timestamp in RFC3339 text format.'
+    output: true
+  - !ruby/object:Api::Type::String
+    name: 'name'
+    description: |
+      Name of the resource. Provided by the client when the resource is
+      created. The name must be 1-63 characters long, and comply with
+      RFC1035. Specifically, the name must be 1-63 characters long and match
+      the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the
+      first character must be a lowercase letter, and all following
+      characters must be a dash, lowercase letter, or digit, except the last
+      character, which cannot be a dash.
+    immutable: true
+    required: true
+  - !ruby/object:Api::Type::String
+    name: 'description'
+    description: |
+      An optional description of this resource. Provide this property when
+      you create the resource.
+  - !ruby/object:Api::Type::Integer
+    name: 'poolProvisionedCapacityGb'
+    description: |
+      Size, in GiB, of the storage pool. Choose between 10,240 and 1,048,576 GiB.
+    required: true
+    update_verb: :PATCH
+    update_url: 'projects/{{project}}/zones/{{zone}}/storagePools/{{name}}?updateMask=poolProvisionedCapacityGb'
+  - !ruby/object:Api::Type::Integer
+    name: 'poolProvisionedIops'
+    description: |
+      Provisioned IOPS of the storage pool. Only relevant if the storage pool type is
+      hyperdisk-balanced. Provision between 0 and 40,000, must be a multiple of 10,000.
+    default_from_api: true
+    update_verb: :PATCH
+    update_url: 'projects/{{project}}/zones/{{zone}}/storagePools/{{name}}?updateMask=poolProvisionedIops'
+  - !ruby/object:Api::Type::Integer
+    name: 'poolProvisionedThroughput'
+    description: |
+      Provisioned throughput of the storage pool. For hyperdisk-balanced storage pool type,
+      provision between 0 and 10,240, must be a multiple of 1,024 MB/s. For hyperdisk-throughput
+      storage pool type, provision between 100 and 180, must be a multiple of 10 MB/s.
+    required: true
+    update_verb: :PATCH
+    update_url: 'projects/{{project}}/zones/{{zone}}/storagePools/{{name}}?updateMask=poolProvisionedThroughput'
+  - !ruby/object:Api::Type::Time
+    name: 'lastResizeTimestamp'
+    description: 'Timestamp of the last successful resize in RFC3339 text format.'
+    output: true
+  - !ruby/object:Api::Type::Integer
+    name: 'diskCount'
+    description: |
+      Number of disks used.
+    output: true
+  - !ruby/object:Api::Type::Integer
+    name: 'poolUsedCapacityBytes'
+    description: |
+      Space used by data stored in disks within the storage pool (in bytes).
+      This will reflect the total number of bytes written to the disks in the pool,
+      in contrast to the capacity of those disks.
+    output: true
+  - !ruby/object:Api::Type::Integer
+    name: 'poolUserWrittenBytes'
+    description: |
+      Amount of data written into the pool, before it is compacted.
+    output: true
+  - !ruby/object:Api::Type::Integer
+    name: 'totalProvisionedDiskCapacityGb'
+    description: |
+      Sum of all the capacity provisioned in disks in this storage pool.
+      A disk's provisioned capacity is the same as its total capacity.
+    output: true
+  - !ruby/object:Api::Type::Integer
+    name: 'maxTotalProvisionedDiskCapacityGb'
+    description: |
+      Maximum allowed aggregate disk size in gigabytes.
+    output: true
+  - !ruby/object:Api::Type::Integer
+    name: 'poolUsedIops'
+    description: |
+      Sum of all the disks' provisioned IOPS, minus some amount that is allowed
+      per disk that is not counted towards pool's IOPS capacity.
+    output: true
+  - !ruby/object:Api::Type::Integer
+    name: 'totalProvisionedDiskIops'
+    description: |
+      Sum of all the disks' provisioned IOPS.
+    output: true
+  - !ruby/object:Api::Type::Integer
+    name: 'poolUsedThroughput'
+    description: |
+      Sum of all the disks' provisioned throughput in MB/s.
+    output: true
+  - !ruby/object:Api::Type::Integer
+    name: 'totalProvisionedDiskThroughput'
+    description: |
+      Sum of all the disks' provisioned throughput in MB/s, minus
+      some amount that is allowed per disk that is not counted
+      toward pool's throughput capacity.
+    output: true
+  - !ruby/object:Api::Type::ResourceRef
+    name: 'storagePoolType'
+    resource: 'StoragePoolType'
+    imports: 'selfLink'
+    description: |
+      URL of the storage pool type resource describing which storage pool type to use to
+      create the storage pool. Provide this when creating the storage pool.
+    diff_suppress_func: 'tpgresource.CompareResourceNames'
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.erb'
+    required: true
+  - !ruby/object:Api::Type::Enum
+    name: 'capacityProvisioningType'
+    description: |
+      Provisioning type of the byte capacity of the pool.
+    immutable: true
+    default_from_api: true
+    values:
+      - :ADVANCED
+      - :STANDARD
+  - !ruby/object:Api::Type::Enum
+    name: 'performanceProvisioningType'
+    description: |
+      Provisioning type of the performance-related parameters of the pool,
+      such as throughput and IOPS.
+    immutable: true
+    default_from_api: true
+    values:
+      - :ADVANCED
+      - :STANDARD

--- a/mmv1/products/compute/StoragePool.yaml
+++ b/mmv1/products/compute/StoragePool.yaml
@@ -65,8 +65,8 @@ async: !ruby/object:Api::OpAsync
     message: 'message'
 examples:
   # The creation tests are covered in the update test and fromStoragePoolTypeUrl test.
-  # Skip these since generated creation tests and IAM tests will exceed the storage pool
-  # hourly creation limit.
+  # Skip these since generated creation tests will cause the total number of creation of
+  # all storage-pool-related tests exceeds the storage pool hourly creation limit.
   - !ruby/object:Provider::Terraform::Examples
     skip_test: true
     name: 'compute_storage_pool_basic'

--- a/mmv1/products/compute/StoragePoolType.yaml
+++ b/mmv1/products/compute/StoragePoolType.yaml
@@ -1,0 +1,134 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'StoragePoolType'
+kind: 'compute#storagePoolType'
+base_url: projects/{{project}}/zones/{{zone}}/storagePoolTypes
+collection_url_key: 'items'
+description: |
+  Represents a StoragePoolType resource. A StoragePoolType resource represents the type
+  of storage pool to use, such as hyperdisk-balanced or hyperdisk-throughput. To reference
+  a storage pool type, use the storage pool type's full or partial URL.
+# Make StoragePoolType virtual so no tests gets triggered for create.
+readonly: true
+has_self_link: true
+exclude: true
+parameters:
+  - !ruby/object:Api::Type::ResourceRef
+    name: 'zone'
+    resource: 'Zone'
+    imports: 'name'
+    description: 'A reference to the zone where the storage pool type resides.'
+    required: true
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.erb'
+properties:
+  - !ruby/object:Api::Type::Integer
+    name: 'id'
+    description: |
+      The unique identifier for the resource. This identifier is defined by the server.
+    output: true
+  - !ruby/object:Api::Type::Time
+    name: 'creationTimestamp'
+    description: 'Creation timestamp in RFC3339 text format.'
+    output: true
+  - !ruby/object:Api::Type::String
+    name: 'name'
+    description: 'Name of the resource.'
+    output: true
+  - !ruby/object:Api::Type::String
+    name: 'description'
+    description: 'An optional description of this resource.'
+    output: true
+  - !ruby/object:Api::Type::NestedObject
+    name: 'deprecated'
+    description: 'The deprecation status associated with this disk type.'
+    output: true
+    properties:
+      - !ruby/object:Api::Type::Time
+        name: 'deleted'
+        description: |
+          An optional RFC3339 timestamp on or after which the state of this
+          resource is intended to change to DELETED. This is only informational
+          and the status will not change unless the client explicitly changes it.
+        output: true
+      - !ruby/object:Api::Type::Time
+        name: 'deprecated'
+        description: |
+          An optional RFC3339 timestamp on or after which the state of this
+          resource is intended to change to DEPRECATED. This is only informational
+          and the status will not change unless the client explicitly changes it.
+        output: true
+      - !ruby/object:Api::Type::Time
+        name: 'obsolete'
+        description: |
+          An optional RFC3339 timestamp on or after which the state of this
+          resource is intended to change to OBSOLETE. This is only informational
+          and the status will not change unless the client explicitly changes it.
+        output: true
+      - !ruby/object:Api::Type::String
+        name: 'replacement'
+        description: |
+          The URL of the suggested replacement for a deprecated resource. The
+          suggested replacement resource must be the same kind of resource as
+          the deprecated resource.
+        output: true
+      - !ruby/object:Api::Type::Enum
+        name: 'state'
+        description: |
+          The deprecation state of this resource. This can be ACTIVE, DEPRECATED,
+          OBSOLETE, or DELETED. Operations which communicate the end of life date
+          for an image, can use ACTIVE. Operations which create a new resource using
+          a DEPRECATED resource will return successfully, but with a warning indicating
+          the deprecated resource and recommending its replacement. Operations which
+          use OBSOLETE or DELETED resources will be rejected and result in an error.
+        values:
+          - :ACTIVE
+          - :DEPRECATED
+          - :OBSOLETE
+          - :DELETED
+        output: true
+  - !ruby/object:Api::Type::Integer
+    name: 'minPoolProvisionedCapacityGb'
+    description: 'Minimum storage pool size in GB.'
+    output: true
+  - !ruby/object:Api::Type::Integer
+    name: 'maxPoolProvisionedCapacityGb'
+    description: 'Maximum storage pool size in GB.'
+    output: true
+  - !ruby/object:Api::Type::Integer
+    name: 'minPoolProvisionedIops'
+    description: 'Minimum provisioned IOPS.'
+    output: true
+  - !ruby/object:Api::Type::Integer
+    name: 'maxPoolProvisionedIops'
+    description: 'Maximum provisioned IOPS.'
+    output: true
+  - !ruby/object:Api::Type::Integer
+    name: 'minPoolProvisionedThroughput'
+    description: 'Minimum provisioned throughput.'
+    output: true
+  - !ruby/object:Api::Type::Integer
+    name: 'maxPoolProvisionedThroughput'
+    description: 'Maximum provisioned throughput.'
+    output: true
+  - !ruby/object:Api::Type::Array
+    name: 'supportedDiskTypes'
+    description: 'The list of disk types supported in this storage pool type.'
+    output: true
+    item_type: !ruby/object:Api::Type::ResourceRef
+      name: 'supportedDiskType'
+      resource: 'DiskType'
+      imports: 'selfLink'
+      description: 'A reference to a supported disk type of this storage pool'
+    custom_expand: 'templates/terraform/custom_expand/array_resourceref_with_validation.go.erb'

--- a/mmv1/templates/terraform/examples/compute_storage_pool_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/compute_storage_pool_basic.tf.erb
@@ -1,0 +1,7 @@
+resource "google_compute_storage_pool" "default" {
+  name  = "<%= ctx[:vars]['storage_pool_name'] %>"
+  zone  = "us-central1-a"
+  storage_pool_type = "hyperdisk-throughput"
+  pool_provisioned_capacity_gb = 10240
+  pool_provisioned_throughput = 100
+}

--- a/mmv1/templates/terraform/examples/compute_storage_pool_hyperdisk_balanced.tf.erb
+++ b/mmv1/templates/terraform/examples/compute_storage_pool_hyperdisk_balanced.tf.erb
@@ -1,0 +1,9 @@
+resource "google_compute_storage_pool" "default" {
+  name  = "<%= ctx[:vars]['storage_pool_name'] %>"
+  zone  = "us-central1-a"
+  storage_pool_type = "hyperdisk-balanced"
+  capacity_provisioning_type = "ADVANCED"
+  pool_provisioned_capacity_gb = 10240
+  pool_provisioned_iops = 10000
+  pool_provisioned_throughput = 1024
+}

--- a/mmv1/third_party/terraform/services/compute/iam_compute_storage_pool_test.go
+++ b/mmv1/third_party/terraform/services/compute/iam_compute_storage_pool_test.go
@@ -1,0 +1,193 @@
+package compute_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccComputeStoragePoolIam(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"role":          "roles/viewer",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				// Test Iam Policy
+				Config: testAccComputeStoragePoolIamPolicy_basic(context),
+				Check:  resource.TestCheckResourceAttrSet("data.google_compute_storage_pool_iam_policy.foo", "policy_data"),
+			},
+			{
+				ResourceName:      "google_compute_storage_pool_iam_policy.foo",
+				ImportStateId:     fmt.Sprintf("projects/%s/zones/%s/storagePools/%s", envvar.GetTestProjectFromEnv(), envvar.GetTestZoneFromEnv(), fmt.Sprintf("tf-test-test-storage-pool%s", context["random_suffix"])),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeStoragePoolIamPolicy_emptyBinding(context),
+			},
+			{
+				ResourceName:      "google_compute_storage_pool_iam_policy.foo",
+				ImportStateId:     fmt.Sprintf("projects/%s/zones/%s/storagePools/%s", envvar.GetTestProjectFromEnv(), envvar.GetTestZoneFromEnv(), fmt.Sprintf("tf-test-test-storage-pool%s", context["random_suffix"])),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// Test Iam Binding
+				Config: testAccComputeStoragePoolIamBinding_basic(context),
+			},
+			{
+				ResourceName:      "google_compute_storage_pool_iam_binding.foo",
+				ImportStateId:     fmt.Sprintf("projects/%s/zones/%s/storagePools/%s roles/viewer", envvar.GetTestProjectFromEnv(), envvar.GetTestZoneFromEnv(), fmt.Sprintf("tf-test-test-storage-pool%s", context["random_suffix"])),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// Test Iam Binding update
+				Config: testAccComputeStoragePoolIamBinding_update(context),
+			},
+			{
+				ResourceName:      "google_compute_storage_pool_iam_binding.foo",
+				ImportStateId:     fmt.Sprintf("projects/%s/zones/%s/storagePools/%s roles/viewer", envvar.GetTestProjectFromEnv(), envvar.GetTestZoneFromEnv(), fmt.Sprintf("tf-test-test-storage-pool%s", context["random_suffix"])),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// Test Iam Member creation (no update for member, no need to test)
+				Config: testAccComputeStoragePoolIamMember_basic(context),
+			},
+			{
+				ResourceName:      "google_compute_storage_pool_iam_member.foo",
+				ImportStateId:     fmt.Sprintf("projects/%s/zones/%s/storagePools/%s roles/viewer user:admin@hashicorptest.com", envvar.GetTestProjectFromEnv(), envvar.GetTestZoneFromEnv(), fmt.Sprintf("tf-test-test-storage-pool%s", context["random_suffix"])),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccComputeStoragePoolIamMember_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_storage_pool" "default" {
+  name  = "tf-test-test-storage-pool%{random_suffix}"
+  zone  = "us-central1-a"
+  storage_pool_type = "hyperdisk-throughput"
+  pool_provisioned_capacity_gb = 10240
+  pool_provisioned_throughput = 100
+}
+
+resource "google_compute_storage_pool_iam_member" "foo" {
+  project = google_compute_storage_pool.default.project
+  zone = google_compute_storage_pool.default.zone
+  name = google_compute_storage_pool.default.name
+  role = "%{role}"
+  member = "user:admin@hashicorptest.com"
+}
+`, context)
+}
+
+func testAccComputeStoragePoolIamPolicy_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_storage_pool" "default" {
+  name  = "tf-test-test-storage-pool%{random_suffix}"
+  zone  = "us-central1-a"
+  storage_pool_type = "hyperdisk-throughput"
+  pool_provisioned_capacity_gb = 10240
+  pool_provisioned_throughput = 100
+}
+
+data "google_iam_policy" "foo" {
+  binding {
+    role = "%{role}"
+    members = ["user:admin@hashicorptest.com"]
+  }
+}
+
+resource "google_compute_storage_pool_iam_policy" "foo" {
+  project = google_compute_storage_pool.default.project
+  zone = google_compute_storage_pool.default.zone
+  name = google_compute_storage_pool.default.name
+  policy_data = data.google_iam_policy.foo.policy_data
+}
+
+data "google_compute_storage_pool_iam_policy" "foo" {
+  project = google_compute_storage_pool.default.project
+  zone = google_compute_storage_pool.default.zone
+  name = google_compute_storage_pool.default.name
+  depends_on = [
+    google_compute_storage_pool_iam_policy.foo
+  ]
+}
+`, context)
+}
+
+func testAccComputeStoragePoolIamPolicy_emptyBinding(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_storage_pool" "default" {
+  name  = "tf-test-test-storage-pool%{random_suffix}"
+  zone  = "us-central1-a"
+  storage_pool_type = "hyperdisk-throughput"
+  pool_provisioned_capacity_gb = 10240
+  pool_provisioned_throughput = 100
+}
+
+data "google_iam_policy" "foo" {
+}
+
+resource "google_compute_storage_pool_iam_policy" "foo" {
+  project = google_compute_storage_pool.default.project
+  zone = google_compute_storage_pool.default.zone
+  name = google_compute_storage_pool.default.name
+  policy_data = data.google_iam_policy.foo.policy_data
+}
+`, context)
+}
+
+func testAccComputeStoragePoolIamBinding_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_storage_pool" "default" {
+  name  = "tf-test-test-storage-pool%{random_suffix}"
+  zone  = "us-central1-a"
+  storage_pool_type = "hyperdisk-throughput"
+  pool_provisioned_capacity_gb = 10240
+  pool_provisioned_throughput = 100
+}
+
+resource "google_compute_storage_pool_iam_binding" "foo" {
+  project = google_compute_storage_pool.default.project
+  zone = google_compute_storage_pool.default.zone
+  name = google_compute_storage_pool.default.name
+  role = "%{role}"
+  members = ["user:admin@hashicorptest.com"]
+}
+`, context)
+}
+
+func testAccComputeStoragePoolIamBinding_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_storage_pool" "default" {
+  name  = "tf-test-test-storage-pool%{random_suffix}"
+  zone  = "us-central1-a"
+  storage_pool_type = "hyperdisk-throughput"
+  pool_provisioned_capacity_gb = 10240
+  pool_provisioned_throughput = 100
+}
+
+resource "google_compute_storage_pool_iam_binding" "foo" {
+  project = google_compute_storage_pool.default.project
+  zone = google_compute_storage_pool.default.zone
+  name = google_compute_storage_pool.default.name
+  role = "%{role}"
+  members = ["user:admin@hashicorptest.com", "user:gterraformtest1@gmail.com"]
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_storage_pool_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_storage_pool_test.go
@@ -75,8 +75,10 @@ func testAccComputeStoragePool_basic(context map[string]interface{}) string {
 resource "google_compute_storage_pool" "foobar" {
   name  = "%{storage_pool_name}"
   zone  = "us-central1-a"
+  description = "testing storage pool basic"
   storage_pool_type = "%{storage_pool_type}"
   capacity_provisioning_type = "ADVANCED"
+  performance_provisioning_type = "STANDARD"
   pool_provisioned_capacity_gb = 10240
   pool_provisioned_throughput = 140
 }
@@ -88,8 +90,10 @@ func testAccComputeStoragePool_update(context map[string]interface{}) string {
 resource "google_compute_storage_pool" "foobar" {
   name  = "%{storage_pool_name}"
   zone  = "us-central1-a"
+  description = "testing storage pool update"
   storage_pool_type = "%{storage_pool_type}"
   capacity_provisioning_type = "ADVANCED"
+  performance_provisioning_type = "STANDARD"
   pool_provisioned_capacity_gb = 11264
   pool_provisioned_throughput = 120
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_storage_pool_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_storage_pool_test.go
@@ -1,0 +1,111 @@
+package compute_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccComputeStoragePool_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"storage_pool_name": fmt.Sprintf("tf-test-storage-pool-%s", acctest.RandString(t, 10)),
+		"storage_pool_type": fmt.Sprintf("hyperdisk-throughput"),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeStoragePool_basic(context),
+			},
+			{
+				ResourceName:            "google_compute_storage_pool.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"storage_pool_type", "zone"},
+			},
+			{
+				Config: testAccComputeStoragePool_update(context),
+			},
+			{
+				ResourceName:            "google_compute_storage_pool.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"storage_pool_type", "zone"},
+				Destroy:                 true,
+			},
+		},
+	})
+}
+
+func TestAccComputeStoragePool_fromStoragePoolTypeUrl(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"storage_pool_name": fmt.Sprintf("tf-test-storage-pool-%s", acctest.RandString(t, 10)),
+		"storage_pool_type": fmt.Sprintf("projects/%s/zones/us-central1-a/storagePoolTypes/hyperdisk-balanced", envvar.GetTestProjectFromEnv()),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeStoragePool_hyperdiskBalanced(context),
+			},
+			{
+				ResourceName:            "google_compute_storage_pool.hdb",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"storage_pool_type", "zone"},
+				Destroy:                 true,
+			},
+		},
+	})
+}
+
+func testAccComputeStoragePool_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_storage_pool" "foobar" {
+  name  = "%{storage_pool_name}"
+  zone  = "us-central1-a"
+  storage_pool_type = "%{storage_pool_type}"
+  capacity_provisioning_type = "ADVANCED"
+  pool_provisioned_capacity_gb = 10240
+  pool_provisioned_throughput = 140
+}
+`, context)
+}
+
+func testAccComputeStoragePool_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_storage_pool" "foobar" {
+  name  = "%{storage_pool_name}"
+  zone  = "us-central1-a"
+  storage_pool_type = "%{storage_pool_type}"
+  capacity_provisioning_type = "ADVANCED"
+  pool_provisioned_capacity_gb = 11264
+  pool_provisioned_throughput = 120
+}
+`, context)
+}
+
+func testAccComputeStoragePool_hyperdiskBalanced(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_storage_pool" "hdb" {
+  name  = "%{storage_pool_name}"
+  zone  = "us-central1-a"
+  storage_pool_type = "%{storage_pool_type}"
+  capacity_provisioning_type = "ADVANCED"
+  pool_provisioned_capacity_gb = 10240
+  pool_provisioned_iops = 10000
+  pool_provisioned_throughput = 1024
+}
+`, context)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adding a new resource `StoragePool` which references a new virtual resource `StoragePoolType`. Putting them in a PR, since they are dependent and are necessary to stay together to run tests.
`StoragePoolType` is a virtual resource, so there is no creation/update test for it, and it will be tested by being referenced in `StoragePool`.
There are update/creatFromUrl tests for `StoragePool`. Skipping generated creation test because it is already covered by the update/creatFromUrl tests, and more importantly, the generated creation tests plus generated IAM tests will use up storage pool hourly creation limit resulting in some of the tests cannot be run. However, I can confirm that the generated creation tests and IAM tests all passed by locally running them in separate hours.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
```release-note:new-resource
`google_compute_storage_pool_type`
```
```release-note:new-resource
`google_compute_storage_pool`
```
