### PR TITLE
adding support for Dataplex Aspect Type resource.

### DIFF
--- a/mmv1/products/dataplex/AspectType.yaml
+++ b/mmv1/products/dataplex/AspectType.yaml
@@ -1,0 +1,142 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'AspectType'
+base_url: 'projects/{{project}}/locations/{{location}}/aspectTypes/{{aspect_type_id}}'
+self_link: 'projects/{{project}}/locations/{{location}}/aspectTypes/{{aspect_type_id}}'
+create_url: 'projects/{{project}}/locations/{{location}}/aspectTypes?aspectTypeId={{aspect_type_id}}'
+update_verb: :PATCH
+update_mask: true
+description: |
+ An Aspect Type is a template for creating Aspects.
+import_format: ['projects/{{project}}/locations/{{location}}/aspectTypes/{{aspect_type_id}}']
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
+    path: 'name'
+    base_url: '{{op_id}}'
+    wait_ms: 1000
+    timeouts: !ruby/object:Api::Timeouts
+      insert_minutes: 5
+      update_minutes: 5
+      delete_minutes: 5
+  result: !ruby/object:Api::OpAsync::Result
+    path: 'response'
+  status: !ruby/object:Api::OpAsync::Status
+    path: 'done'
+    complete: true
+    allowed:
+      - true
+      - false
+  error: !ruby/object:Api::OpAsync::Error
+    path: 'error'
+    message: 'message'
+autogen_async: true
+iam_policy: !ruby/object:Api::Resource::IamPolicy
+  skip_import_test: true
+  method_name_separator: ':'
+  fetch_iam_policy_verb: :GET
+  parent_resource_attribute: 'aspect_type_id'
+  import_format:
+    [
+      'projects/{{project}}/locations/{{location}}/aspectTypes/{{aspect_type_id}}',
+      '{{aspect_type_id}}',
+    ]
+parameters:
+  - !ruby/object:Api::Type::String
+    name: 'location'
+    url_param_only: true
+    immutable: true
+    description: |
+      The location where aspect type will be created in.
+  - !ruby/object:Api::Type::String
+    name: 'aspectTypeId'
+    url_param_only: true
+    immutable: true
+    description: |
+      The aspect type id of the aspect type.
+properties:
+  - !ruby/object:Api::Type::String
+    name: name
+    description: |
+      The relative resource name of the AspectType, of the form: projects/{project_number}/locations/{location_id}/aspectTypes/{aspect_type_id}
+    output: true
+  - !ruby/object:Api::Type::String
+    name: 'uid'
+    output: true
+    description: |
+      System generated globally unique ID for the AspectType. This ID will be different if the AspectType is deleted and re-created with the same name.
+  - !ruby/object:Api::Type::Time
+    name: 'createTime'
+    output: true
+    description: |
+      The time when the AspectType was created.
+  - !ruby/object:Api::Type::Time
+    name: 'updateTime'
+    output: true
+    description: |
+      The time when the AspectType was last updated.
+  - !ruby/object:Api::Type::String
+    name: 'description'
+    description: |
+      Description of the AspectType.
+  - !ruby/object:Api::Type::String
+    name: 'displayName'
+    description: |
+      User friendly display name.
+  - !ruby/object:Api::Type::KeyValueLabels
+    name: 'labels'
+    description: |
+      User-defined labels for the AspectType.
+  - !ruby/object:Api::Type::String
+    name: 'metadataTemplate'
+    description: |
+      MetadataTemplate of the Aspect.
+    custom_expand: 'templates/terraform/custom_expand/json_schema.erb'
+    custom_flatten: 'templates/terraform/custom_flatten/json_schema.erb'
+    state_func:
+      'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+      return s }'
+    validation: !ruby/object:Provider::Terraform::Validation
+      function: 'validation.StringIsJSON'
+  - !ruby/object:Api::Type::Enum
+    name: 'transferStatus'
+    output: true
+    description: |
+      Denotes the transfer status of the Aspect Type. It is unspecified
+      for Aspect Type created from Dataplex API.
+    values:
+      - :TRANSFER_STATUS_UNSPECIFIED
+      - :TRANSFER_STATUS_MIGRATED
+      - :TRANSFER_STATUS_TRANSFERRED
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'dataplex_aspect_type_basic'
+    primary_resource_id: 'test_aspect_type_basic'
+    primary_resource_name: "fmt.Sprintf(\"tf-test-aspect-type%s\",
+      context[\"random_suffix\"\
+      ])"
+    test_env_vars:
+      project_name: :PROJECT_NAME
+    vars:
+      aspect_type_name: aspect-type-basic
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'dataplex_aspect_type_full'
+    primary_resource_id: 'test_aspect_type_full'
+    primary_resource_name: "fmt.Sprintf(\"tf-test-aspect-type%s\",
+      context[\"random_suffix\"\
+      ])"
+    test_env_vars:
+      project_name: :PROJECT_NAME
+    vars:
+      aspect_type_name: aspect-type-full

--- a/mmv1/templates/terraform/examples/dataplex_aspect_type_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_aspect_type_basic.tf.erb
@@ -1,0 +1,32 @@
+resource "google_dataplex_aspect_type" "<%= ctx[:primary_resource_id] %>" {
+  aspect_type_id = "<%= ctx[:vars]['aspect_type_name'] %>"
+  project = "<%= ctx[:test_env_vars]['project_name'] %>"
+  location = "us-central1"
+
+  metadata_template = <<EOF
+{
+  "name": "tf-test-template",
+  "type": "record",
+  "recordFields": [
+    {
+      "name": "type",
+      "type": "enum",
+      "annotations": {
+        "displayName": "Type",
+        "description": "Specifies the type of view represented by the entry."
+      },
+      "index": 1,
+      "constraints": {
+        "required": true
+      },
+      "enumValues": [
+        {
+          "name": "VIEW",
+          "index": 1
+        }
+      ]
+    }
+  ]
+}
+EOF
+}

--- a/mmv1/templates/terraform/examples/dataplex_aspect_type_full.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_aspect_type_full.tf.erb
@@ -1,0 +1,139 @@
+resource "google_dataplex_aspect_type" "<%= ctx[:primary_resource_id] %>" {
+  aspect_type_id = "<%= ctx[:vars]['aspect_type_name'] %>"
+  project = "<%= ctx[:test_env_vars]['project_name'] %>"
+  location = "us-central1"
+
+  labels = { "tag": "test-tf" }
+  display_name = "terraform aspect type"
+  description = "aspect type created by Terraform"
+  metadata_template = <<EOF
+{
+  "type": "record",
+  "name": "Schema",
+  "recordFields": [
+    {
+      "name": "fields",
+      "type": "array",
+      "index": 1,
+      "arrayItems": {
+        "name": "field",
+        "type": "record",
+        "typeId": "field",
+        "recordFields": [
+          {
+            "name": "name",
+            "type": "string",
+            "index": 1,
+            "constraints": {
+              "required": true
+            }
+          },
+          {
+            "name": "description",
+            "type": "string",
+            "index": 2
+          },
+          {
+            "name": "dataType",
+            "type": "string",
+            "index": 3,
+            "constraints": {
+              "required": true
+            }
+          },
+          {
+            "name": "metadataType",
+            "type": "enum",
+            "index": 4,
+            "constraints": {
+              "required": true
+            },
+            "enumValues": [
+              {
+                "name": "BOOLEAN",
+                "index": 1
+              },
+              {
+                "name": "NUMBER",
+                "index": 2
+              },
+              {
+                "name": "STRING",
+                "index": 3
+              },
+              {
+                "name": "BYTES",
+                "index": 4
+              },
+              {
+                "name": "DATETIME",
+                "index": 5
+              },
+              {
+                "name": "TIMESTAMP",
+                "index": 6
+              },
+              {
+                "name": "GEOSPATIAL",
+                "index": 7
+              },
+              {
+                "name": "STRUCT",
+                "index": 8
+              },
+              {
+                "name": "OTHER",
+                "index": 100
+              }
+            ]
+          },
+          {
+            "name": "mode",
+            "type": "enum",
+            "index": 5,
+            "enumValues": [
+              {
+                "name": "NULLABLE",
+                "index": 1
+              },
+              {
+                "name": "REPEATED",
+                "index": 2
+              },
+              {
+                "name": "REQUIRED",
+                "index": 3
+              }
+            ]
+          },
+          {
+            "name": "defaultValue",
+            "type": "string",
+            "index": 6
+          },
+          {
+            "name": "annotations",
+            "type": "map",
+            "index": 7,
+            "mapItems": {
+              "name": "label",
+              "type": "string"
+            }
+          },
+          {
+            "name": "fields",
+            "type": "array",
+            "index": 20,
+            "arrayItems": {
+              "name": "field",
+              "type": "record",
+              "typeRef": "field"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+EOF
+}

--- a/mmv1/third_party/terraform/services/dataplex/resource_dataplex_aspect_type_test.go
+++ b/mmv1/third_party/terraform/services/dataplex/resource_dataplex_aspect_type_test.go
@@ -97,11 +97,11 @@ resource "google_dataplex_aspect_type" "test_aspect_type" {
   "type": "record",
   "recordFields": [
     {
-      "name": "type",
+      "name": "updatedType",
       "type": "enum",
       "annotations": {
         "displayName": "Type",
-        "description": "Specifies the type of view represented by the entry."
+        "description": "Specifies the type of view represented by the entry. This is updated."
       },
       "index": 1,
       "constraints": {

--- a/mmv1/third_party/terraform/services/dataplex/resource_dataplex_aspect_type_test.go
+++ b/mmv1/third_party/terraform/services/dataplex/resource_dataplex_aspect_type_test.go
@@ -53,28 +53,28 @@ resource "google_dataplex_aspect_type" "test_aspect_type" {
 
   metadata_template = <<EOF
 {
-	"name": "tf-test-template",
-	"type": "record",
-	"recordFields": [
-		{
-			"name": "type",
-			"type": "enum",
-			"annotations": {
-				"displayName": "Type",
-				"description": "Specifies the type of view represented by the entry."
-			},
-			"index": 1,
-			"constraints": {
-				"required": true
-			},
-			"enumValues": [
-				{
-					"name": "VIEW",
-					"index": 1
-				}
-			]
-		}
-	]
+  "name": "tf-test-template",
+  "type": "record",
+  "recordFields": [
+    {
+      "name": "type",
+      "type": "enum",
+      "annotations": {
+        "displayName": "Type",
+        "description": "Specifies the type of view represented by the entry."
+      },
+      "index": 1,
+      "constraints": {
+        "required": true
+      },
+      "enumValues": [
+        {
+          "name": "VIEW",
+          "index": 1
+        }
+      ]
+    }
+  ]
 }
 EOF
 }

--- a/mmv1/third_party/terraform/services/dataplex/resource_dataplex_aspect_type_test.go
+++ b/mmv1/third_party/terraform/services/dataplex/resource_dataplex_aspect_type_test.go
@@ -1,0 +1,122 @@
+package dataplex_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccDataplexAspectType_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project_name":  envvar.GetTestProjectFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataplexAspectTypeDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataplexAspectType_full(context),
+			},
+			{
+				ResourceName:            "google_dataplex_aspect_type.test_aspect_type",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"aspect_type_id", "labels", "location", "terraform_labels"},
+			},
+			{
+				Config: testAccDataplexAspectType_update(context),
+			},
+			{
+				ResourceName:            "google_dataplex_aspect_type.test_aspect_type",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"aspect_type_id", "labels", "location", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccDataplexAspectType_full(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_dataplex_aspect_type" "test_aspect_type" {
+  aspect_type_id = "tf-test-aspect-type%{random_suffix}"
+  project = "%{project_name}"
+  location = "us-central1"
+
+  metadata_template = <<EOF
+{
+	"name": "tf-test-template",
+	"type": "record",
+	"recordFields": [
+		{
+			"name": "type",
+			"type": "enum",
+			"annotations": {
+				"displayName": "Type",
+				"description": "Specifies the type of view represented by the entry."
+			},
+			"index": 1,
+			"constraints": {
+				"required": true
+			},
+			"enumValues": [
+				{
+					"name": "VIEW",
+					"index": 1
+				}
+			]
+		}
+	]
+}
+EOF
+}
+`, context)
+}
+
+func testAccDataplexAspectType_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_dataplex_aspect_type" "test_aspect_type" {
+  aspect_type_id = "tf-test-aspect-type%{random_suffix}"
+  project = "%{project_name}"
+  location = "us-central1"
+
+  labels = { "tag": "test-tf" }
+  display_name = "terraform aspect type"
+  description = "aspect type created by Terraform"
+  metadata_template = <<EOF
+{
+  "name": "tf-test-template",
+  "type": "record",
+  "recordFields": [
+    {
+      "name": "type",
+      "type": "enum",
+      "annotations": {
+        "displayName": "Type",
+        "description": "Specifies the type of view represented by the entry."
+      },
+      "index": 1,
+      "constraints": {
+        "required": true
+      },
+      "enumValues": [
+        {
+          "name": "VIEW",
+          "index": 1
+        }
+      ]
+    }
+  ]
+}
+EOF
+}
+`, context)
+}


### PR DESCRIPTION
Adding Terraform support for a Dataplex Aspect Type resource.
Tracking issue: https://github.com/hashicorp/terraform-provider-google/issues/18147



```release-note:new-resource
`google_dataplex_aspect_type`
```