### PR TITLE
added required label to load balancing scheme for traffic extensions

### DIFF
--- a/mmv1/products/networkservices/LbTrafficExtension.yaml
+++ b/mmv1/products/networkservices/LbTrafficExtension.yaml
@@ -174,6 +174,7 @@ properties:
                 item_type: Api::Type::String
   - !ruby/object:Api::Type::Enum
     name: 'loadBalancingScheme'
+    required: true
     immutable: true
     description: |
       All backend services and forwarding rules referenced by this extension must share the same load balancing scheme.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/18196

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
networkservices: made field `load_balancing_scheme` required in resource `google_network_services_lb_traffic_extension`, as resource creation is always failing
```

**References**
* https://cloud.google.com/service-extensions/docs/reference/rest/v1beta1/projects.locations.lbTrafficExtensions#resource:-lbtrafficextension