### PR TITLE
adding support for Cloud Dataplex Entry Type resource.

### DIFF
--- a/mmv1/products/dataplex/EntryType.yaml
+++ b/mmv1/products/dataplex/EntryType.yaml
@@ -116,11 +116,11 @@ properties:
     description: |
       AspectInfo for the entry type.
     item_type: !ruby/object:Api::Type::NestedObject
-    properties:
-      - !ruby/object:Api::Type::String
-        name: 'type'
-        description: |
-          Required aspect type for the entry type.
+      properties:
+        - !ruby/object:Api::Type::String
+          name: 'type'
+          description: |
+            Required aspect type for the entry type.
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'dataplex_entry_type_basic'

--- a/mmv1/products/dataplex/EntryType.yaml
+++ b/mmv1/products/dataplex/EntryType.yaml
@@ -1,0 +1,144 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'EntryType'
+base_url: 'projects/{{project}}/locations/{{location}}/entryTypes/{{entry_type_id}}'
+self_link: 'projects/{{project}}/locations/{{location}}/entryTypes/{{entry_type_id}}'
+create_url: 'projects/{{project}}/locations/{{location}}/entryTypes?entryTypeId={{entry_type_id}}'
+update_verb: :PATCH
+update_mask: true
+description: |
+ An Entry Type is a template for creating Entries.
+import_format: ['projects/{{project}}/locations/{{location}}/entryTypes/{{entry_type_id}}']
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
+    path: 'name'
+    base_url: '{{op_id}}'
+    wait_ms: 1000
+    timeouts: !ruby/object:Api::Timeouts
+      insert_minutes: 5
+      update_minutes: 5
+      delete_minutes: 5
+  result: !ruby/object:Api::OpAsync::Result
+    path: 'response'
+  status: !ruby/object:Api::OpAsync::Status
+    path: 'done'
+    complete: true
+    allowed:
+      - true
+      - false
+  error: !ruby/object:Api::OpAsync::Error
+    path: 'error'
+    message: 'message'
+autogen_async: true
+iam_policy: !ruby/object:Api::Resource::IamPolicy
+  skip_import_test: true
+  method_name_separator: ':'
+  fetch_iam_policy_verb: :GET
+  parent_resource_attribute: 'entry_type_id'
+  import_format:
+    [
+      'projects/{{project}}/locations/{{location}}/entryTypes/{{entry_type_id}}',
+      '{{entry_type_id}}',
+    ]
+parameters:
+  - !ruby/object:Api::Type::String
+    name: 'location'
+    url_param_only: true
+    immutable: true
+    description: |
+      The location where entry type will be created in.
+  - !ruby/object:Api::Type::String
+    name: 'entryTypeId'
+    url_param_only: true
+    immutable: true
+    description: |
+      The entry type id of the entry type.
+properties:
+  - !ruby/object:Api::Type::String
+    name: name
+    description: |
+      The relative resource name of the EntryType, of the form: projects/{project_number}/locations/{location_id}/entryTypes/{entry_type_id}
+    output: true
+  - !ruby/object:Api::Type::String
+    name: 'uid'
+    output: true
+    description: |
+      System generated globally unique ID for the EntryType. This ID will be different if the EntryType is deleted and re-created with the same name.
+  - !ruby/object:Api::Type::Time
+    name: 'createTime'
+    output: true
+    description: |
+      The time when the EntryType was created.
+  - !ruby/object:Api::Type::Time
+    name: 'updateTime'
+    output: true
+    description: |
+      The time when the EntryType was last updated.
+  - !ruby/object:Api::Type::String
+    name: 'description'
+    description: |
+      Description of the EntryType.
+  - !ruby/object:Api::Type::String
+    name: 'displayName'
+    description: |
+      User friendly display name.
+  - !ruby/object:Api::Type::KeyValueLabels
+    name: 'labels'
+    description: |
+      User-defined labels for the EntryType.
+  - !ruby/object:Api::Type::Array
+    name: 'typeAliases'
+    description: |
+      Indicates the class this Entry Type belongs to, for example, TABLE, DATABASE, MODEL.
+    item_type: Api::Type::String
+  - !ruby/object:Api::Type::String
+    name: 'platform'
+    description: |
+      The platform that Entries of this type belongs to.
+  - !ruby/object:Api::Type::String
+    name: 'system'
+    description: |
+      The system that Entries of this type belongs to.
+  - !ruby/object:Api::Type::Array
+    name: 'requiredAspects'
+    description: |
+      AspectInfo for the entry type.
+    item_type: !ruby/object:Api::Type::NestedObject
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'type'
+        description: |
+          Required aspect type for the entry type.
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'dataplex_entry_type_basic'
+    primary_resource_id: 'test_entry_type_basic'
+    primary_resource_name: "fmt.Sprintf(\"tf-test-entry-type%s\",
+      context[\"random_suffix\"\
+      ])"
+    test_env_vars:
+      project_name: :PROJECT_NAME
+    vars:
+      entry_type_name: entry-type-basic
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'dataplex_entry_type_full'
+    primary_resource_id: 'test_entry_type_full'
+    primary_resource_name: "fmt.Sprintf(\"tf-test-entry-type%s\",
+      context[\"random_suffix\"\
+      ])"
+    test_env_vars:
+      project_name: :PROJECT_NAME
+    vars:
+      entry_type_name: entry-type-full

--- a/mmv1/templates/terraform/examples/dataplex_entry_type_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_entry_type_basic.tf.erb
@@ -1,0 +1,5 @@
+resource "google_dataplex_entry_type" "<%= ctx[:primary_resource_id] %>" {
+  entry_type_id = "<%= ctx[:vars]['entry_type_name'] %>"
+  project = "<%= ctx[:test_env_vars]['project_name'] %>"
+  location = "us-central1"
+}

--- a/mmv1/templates/terraform/examples/dataplex_entry_type_full.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_entry_type_full.tf.erb
@@ -5,9 +5,28 @@ resource "google_dataplex_aspect_type" "<%= ctx[:primary_resource_id] %>" {
 
   metadata_template = <<EOF
 {
-  "name": "CloudSQLDatabase",
+  "name": "tf-test-template",
   "type": "record",
-  "recordFields": []
+  "recordFields": [
+    {
+      "name": "type",
+      "type": "enum",
+      "annotations": {
+        "displayName": "Type",
+        "description": "Specifies the type of view represented by the entry."
+      },
+      "index": 1,
+      "constraints": {
+        "required": true
+      },
+      "enumValues": [
+        {
+          "name": "VIEW",
+          "index": 1
+        }
+      ]
+    }
+  ]
 }
 EOF
 }

--- a/mmv1/templates/terraform/examples/dataplex_entry_type_full.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_entry_type_full.tf.erb
@@ -1,3 +1,9 @@
+resource "google_dataplex_aspect_type" "<%= ctx[:primary_resource_id] %>" {
+  name         = "tf-test-aspect-type%{random_suffix}"
+  location     = "us-central1"
+  project = "<%= ctx[:test_env_vars]['project_name'] %>"
+}
+
 resource "google_dataplex_entry_type" "<%= ctx[:primary_resource_id] %>" {
   entry_type_id = "<%= ctx[:vars]['entry_type_name'] %>"
   project = "<%= ctx[:test_env_vars]['project_name'] %>"
@@ -6,4 +12,8 @@ resource "google_dataplex_entry_type" "<%= ctx[:primary_resource_id] %>" {
   labels = { "tag": "test-tf" }
   display_name = "terraform entry type"
   description = "entry type created by Terraform"
+
+  type_aliases = ["TABLE", "DATABASE"]
+  platform = "GCS"
+  system = "MariaDB"
 }

--- a/mmv1/templates/terraform/examples/dataplex_entry_type_full.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_entry_type_full.tf.erb
@@ -1,7 +1,15 @@
 resource "google_dataplex_aspect_type" "<%= ctx[:primary_resource_id] %>" {
-  name         = "tf-test-aspect-type%{random_suffix}"
+  aspect_type_id         = "tf-test-aspect-type%{random_suffix}"
   location     = "us-central1"
-  project = "<%= ctx[:test_env_vars]['project_name'] %>"
+  project      = "<%= ctx[:test_env_vars]['project_name'] %>"
+
+  metadata_template = <<EOF
+{
+  "name": "CloudSQLDatabase",
+  "type": "record",
+  "recordFields": []
+}
+EOF
 }
 
 resource "google_dataplex_entry_type" "<%= ctx[:primary_resource_id] %>" {
@@ -15,5 +23,9 @@ resource "google_dataplex_entry_type" "<%= ctx[:primary_resource_id] %>" {
 
   type_aliases = ["TABLE", "DATABASE"]
   platform = "GCS"
-  system = "MariaDB"
+  system = "CloudSQL"
+  
+  required_aspects {
+    type = google_dataplex_aspect_type.<%= ctx[:primary_resource_id] %>.name
+  }
 }

--- a/mmv1/templates/terraform/examples/dataplex_entry_type_full.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_entry_type_full.tf.erb
@@ -1,0 +1,9 @@
+resource "google_dataplex_entry_type" "<%= ctx[:primary_resource_id] %>" {
+  entry_type_id = "<%= ctx[:vars]['entry_type_name'] %>"
+  project = "<%= ctx[:test_env_vars]['project_name'] %>"
+  location = "us-central1"
+
+  labels = { "tag": "test-tf" }
+  display_name = "terraform entry type"
+  description = "entry type created by Terraform"
+}

--- a/mmv1/third_party/terraform/services/dataplex/resource_dataplex_entry_type_test.go
+++ b/mmv1/third_party/terraform/services/dataplex/resource_dataplex_entry_type_test.go
@@ -32,7 +32,7 @@ func TestAccDataplexEntryType_update(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"entry_type_id", "labels", "location", "terraform_labels"},
 			},
 			{
-				Config: TestAccDataplexEntryType_update(context),
+				Config: testAccDataplexEntryType_update(context),
 			},
 			{
 				ResourceName:            "google_dataplex_entry_type.test_entry_type",

--- a/mmv1/third_party/terraform/services/dataplex/resource_dataplex_entry_type_test.go
+++ b/mmv1/third_party/terraform/services/dataplex/resource_dataplex_entry_type_test.go
@@ -63,28 +63,28 @@ resource "google_dataplex_aspect_type" "test_entry_type" {
 
   metadata_template = <<EOF
 {
-	"name": "tf-test-template",
-	"type": "record",
-	"recordFields": [
-		{
-			"name": "type",
-			"type": "enum",
-			"annotations": {
-				"displayName": "Type",
-				"description": "Specifies the type of view represented by the entry."
-			},
-			"index": 1,
-			"constraints": {
-				"required": true
-			},
-			"enumValues": [
-				{
-					"name": "VIEW",
-					"index": 1
-				}
-			]
-		}
-	]
+  "name": "tf-test-template",
+  "type": "record",
+  "recordFields": [
+    {
+      "name": "type",
+      "type": "enum",
+      "annotations": {
+        "displayName": "Type",
+        "description": "Specifies the type of view represented by the entry."
+      },
+      "index": 1,
+      "constraints": {
+        "required": true
+      },
+      "enumValues": [
+        {
+          "name": "VIEW",
+          "index": 1
+        }
+      ]
+    }
+  ]
 }
 EOF
 }

--- a/mmv1/third_party/terraform/services/dataplex/resource_dataplex_entry_type_test.go
+++ b/mmv1/third_party/terraform/services/dataplex/resource_dataplex_entry_type_test.go
@@ -1,0 +1,110 @@
+package dataplex_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccDataplexEntryType_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project_name":  envvar.GetTestProjectFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataplexEntryTypeDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataplexEntryType_full(context),
+			},
+			{
+				ResourceName:            "google_dataplex_entry_type.test_entry_type",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"entry_type_id", "labels", "location", "terraform_labels"},
+			},
+			{
+				Config: TestAccDataplexEntryType_update(context),
+			},
+			{
+				ResourceName:            "google_dataplex_entry_type.test_entry_type",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"entry_type_id", "labels", "location", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccDataplexEntryType_full(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_dataplex_entry_type" "test_entry_type" {
+  entry_type_id = "tf-test-entry-type%{random_suffix}"
+  project = "%{project_name}"
+  location = "us-central1"
+}
+`, context)
+}
+
+func testAccDataplexEntryType_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_dataplex_aspect_type" "test_entry_type" {
+  aspect_type_id         = "tf-test-aspect-type%{random_suffix}"
+  location     = "us-central1"
+  project      = "%{project_name}"
+
+  metadata_template = <<EOF
+{
+	"name": "tf-test-template",
+	"type": "record",
+	"recordFields": [
+		{
+			"name": "type",
+			"type": "enum",
+			"annotations": {
+				"displayName": "Type",
+				"description": "Specifies the type of view represented by the entry."
+			},
+			"index": 1,
+			"constraints": {
+				"required": true
+			},
+			"enumValues": [
+				{
+					"name": "VIEW",
+					"index": 1
+				}
+			]
+		}
+	]
+}
+EOF
+}
+
+resource "google_dataplex_entry_type" "test_entry_type" {
+  entry_type_id = "tf-test-entry-type-%{random_suffix}"
+  project = "%{project_name}"
+  location = "us-central1"
+
+  labels = { "tag": "test-tf" }
+  display_name = "terraform entry type"
+  description = "entry type created by Terraform"
+
+  type_aliases = ["TABLE", "DATABASE"]
+  platform = "GCS"
+  system = "CloudSQL"
+  
+  required_aspects {
+    type = google_dataplex_aspect_type.test_entry_type.name
+  }
+}
+`, context)
+}


### PR DESCRIPTION
Adding Terraform support for a Dataplex Entry Type resource.
Tracking issue: https://github.com/hashicorp/terraform-provider-google/issues/18146



```release-note:new-resource
`google_dataplex_entry_type`
```