### PR TITLE
Revert "Add guard against trying to upload non-existant artifacts to GCS"

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
@@ -140,12 +140,6 @@ fun BuildSteps.saveArtifactsToGCS() {
             #!/bin/bash
             echo "Post-test step - storge artifacts(debug logs) to GCS"
 
-            export TEST_COUNT=${'$'}(./test-binary -test.list="%TEST_PREFIX%" | wc -l)
-            if test ${'$'}TEST_COUNT -le "0"; then
-                echo "Skipping upload to GCS; no tests were run, so no artifacts were generated"
-                exit 0
-            fi
-
             # Authenticate gcloud CLI
             echo "${'$'}{GOOGLE_CREDENTIALS_GCS}" > google-account.json
             chmod 600 google-account.json


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#10677

I just realized that artifacts copy stopped working after this change's merged. Let's revert this for now before I look into why it's failing closely. 

```release-note:none

```