### PR TITLE
Added "ActionTokenSiteKeys" and "SessionTokenSiteKeys" to "compute_security_policy" and "compute_security_policy_rule"

### DIFF
--- a/mmv1/products/compute/SecurityPolicyRule.yaml
+++ b/mmv1/products/compute/SecurityPolicyRule.yaml
@@ -124,6 +124,26 @@ properties:
           #   description: |
           #     Optional. String indicating the location of the expression for error reporting, e.g. a file name and a position in the file.
       - !ruby/object:Api::Type::NestedObject
+        name: 'exprOptions'
+        description: |
+          The configuration options available when specifying a user defined CEVAL expression (i.e., 'expr').
+        properties:
+          - !ruby/object:Api::Type::NestedObject
+            name: 'recaptchaOptions'
+            description: |
+              reCAPTCHA configuration options to be applied for the rule. If the rule does not evaluate reCAPTCHA tokens, this field has no effect.
+            properties:
+              - !ruby/object:Api::Type::Array
+                  name: 'actionTokenSiteKeys'
+                  description: |
+                    A list of site keys to be used during the validation of reCAPTCHA action-tokens. The provided site keys need to be created from reCAPTCHA API under the same project where the security policy is created.
+                  item_type: Api::Type::String
+              - !ruby/object:Api::Type::Array
+                  name: 'sessionTokenSiteKeys'
+                  description: |
+                    A list of site keys to be used during the validation of reCAPTCHA session-tokens. The provided site keys need to be created from reCAPTCHA API under the same project where the security policy is created.
+                  item_type: Api::Type::String
+      - !ruby/object:Api::Type::NestedObject
         name: 'config'
         description: |
           The configuration options available when specifying versionedExpr.

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.erb
@@ -155,6 +155,45 @@ func ResourceComputeSecurityPolicy() *schema.Resource {
 										},
 										Description: `User defined CEVAL expression. A CEVAL expression is used to specify match criteria such as origin.ip, source.region_code and contents in the request header.`,
 									},
+
+                  "expr_options": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+                    Description: `The configuration options available when specifying a user defined CEVAL expression (i.e., 'expr').`,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+                        "recaptcha_options": {
+                          Type:     schema.TypeList,
+                          Optional: true,
+                          MaxItems: 1,
+                          Description: `reCAPTCHA configuration options to be applied for the rule. If the rule does not evaluate reCAPTCHA tokens, this field has no effect.`,
+                          Elem: &schema.Resource{
+                            Schema: map[string]*schema.Schema{
+                              "action_token_site_keys": {
+                                Type:     schema.TypeList,
+                                Optional: true,
+                                Description: `A list of site keys to be used during the validation of reCAPTCHA action-tokens. The provided site keys need to be created from reCAPTCHA API under the same project where the security policy is created`,
+                                MinItems: 1,
+                                Elem: &schema.Schema{
+                                  Type: schema.TypeString,
+                                },
+                              },
+                              "session_token_site_keys": {
+                                Type:     schema.TypeList,
+                                Optional: true,
+                                Description: `A list of site keys to be used during the validation of reCAPTCHA session-tokens. The provided site keys need to be created from reCAPTCHA API under the same project where the security policy is created.`,
+                                MinItems: 1,
+                                Elem: &schema.Schema{
+                                  Type: schema.TypeString,
+                                },
+                              },
+                            },
+                          },
+                        },
+											},
+										},
+									},
 								},
 							},
 							Description: `A match condition that incoming traffic is evaluated against. If it evaluates to true, the corresponding action is enforced.`,
@@ -1024,6 +1063,7 @@ func expandSecurityPolicyMatch(configured []interface{}) *compute.SecurityPolicy
 		VersionedExpr: data["versioned_expr"].(string),
 		Config:        expandSecurityPolicyMatchConfig(data["config"].([]interface{})),
 		Expr:          expandSecurityPolicyMatchExpr(data["expr"].([]interface{})),
+    ExprOptions:   expandSecurityPolicyMatchExprOptions(data["expr_options"].([]interface{})),
 	}
 }
 
@@ -1050,6 +1090,42 @@ func expandSecurityPolicyMatchExpr(expr []interface{}) *compute.Expr {
 		// Title:       data["title"].(string),
 		// Description: data["description"].(string),
 		// Location:    data["location"].(string),
+	}
+}
+
+func expandSecurityPolicyMatchExprOptions(exprOptions []interface{}) *compute.SecurityPolicyRuleMatcherExprOptions {
+	if len(exprOptions) == 0 || exprOptions[0] == nil {
+		return nil
+	}
+
+	data := exprOptions[0].(map[string]interface{})
+	return &compute.SecurityPolicyRuleMatcherExprOptions{
+		RecaptchaOptions: expandSecurityPolicyMatchExprOptionsRecaptchaOptions(data["recaptcha_options"].([]interface{})),
+	}
+}
+
+func expandSecurityPolicyMatchExprOptionsRecaptchaOptions(RecaptchaOptions []interface{}) *compute.SecurityPolicyRuleMatcherExprOptionsRecaptchaOptions {
+	if len(RecaptchaOptions) == 0 || RecaptchaOptions[0] == nil {
+		return nil
+	}
+
+	data := RecaptchaOptions[0].(map[string]interface{})
+
+  actionTokenKeysInterface := data["action_token_site_keys"].([]interface{})
+	actionTokenKeysString := make([]string, len(actionTokenKeysInterface))
+	for i, v := range actionTokenKeysInterface {
+		actionTokenKeysString[i] = v.(string)
+	}
+
+	sessionTokenKeysInterface := data["session_token_site_keys"].([]interface{})
+	sessionTokenKeysString := make([]string, len(sessionTokenKeysInterface))
+	for i, v := range sessionTokenKeysInterface {
+		sessionTokenKeysString[i] = v.(string)
+	}
+
+	return &compute.SecurityPolicyRuleMatcherExprOptionsRecaptchaOptions{
+		ActionTokenSiteKeys:  actionTokenKeysString,
+		SessionTokenSiteKeys: sessionTokenKeysString,
 	}
 }
 
@@ -1132,6 +1208,7 @@ func flattenMatch(match *compute.SecurityPolicyRuleMatcher) []map[string]interfa
 		"versioned_expr": match.VersionedExpr,
 		"config":         flattenMatchConfig(match.Config),
 		"expr":           flattenMatchExpr(match),
+    "expr_options":   flattenMatchExprOptions(match.ExprOptions),
 	}
 
 	return []map[string]interface{}{data}
@@ -1144,6 +1221,31 @@ func flattenMatchConfig(conf *compute.SecurityPolicyRuleMatcherConfig) []map[str
 
 	data := map[string]interface{}{
 		"src_ip_ranges": schema.NewSet(schema.HashString, tpgresource.ConvertStringArrToInterface(conf.SrcIpRanges)),
+	}
+
+	return []map[string]interface{}{data}
+}
+
+func flattenMatchExprOptions(exprOptions *compute.SecurityPolicyRuleMatcherExprOptions) []map[string]interface{} {
+	if exprOptions == nil {
+		return nil
+	}
+
+	data := map[string]interface{}{
+		"recaptcha_options": flattenMatchExprOptionsRecaptchaOptions(exprOptions.RecaptchaOptions),
+	}
+
+	return []map[string]interface{}{data}
+}
+
+func flattenMatchExprOptionsRecaptchaOptions(recaptchaOptions *compute.SecurityPolicyRuleMatcherExprOptionsRecaptchaOptions) []map[string]interface{} {
+	if recaptchaOptions == nil {
+		return nil
+	}
+
+	data := map[string]interface{}{
+		"action_token_site_keys":  recaptchaOptions.ActionTokenSiteKeys,
+		"session_token_site_keys": recaptchaOptions.SessionTokenSiteKeys,
 	}
 
 	return []map[string]interface{}{data}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_rule_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_rule_test.go.erb
@@ -297,6 +297,28 @@ func TestAccComputeSecurityPolicyRule_EnforceOnKeyUpdates(t *testing.T) {
 	})
 }
 
+func TestAccComputeSecurityPolicyRule_withExprOptions(t *testing.T) {
+	t.Parallel()
+
+	spName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeSecurityPolicyRuleDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSecurityPolicyRule_withExprOptions(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy_rule.policy_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccComputeSecurityPolicyRule_preBasicUpdate(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_security_policy" "default" {
@@ -914,6 +936,38 @@ resource "google_compute_security_policy_rule" "policy_rule" {
     rate_limit_threshold {
       count = 10
       interval_sec = 60
+    }
+  }
+}
+`, spName)
+}
+
+func testAccComputeSecurityPolicyRule_withExprOptions(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+	name = "%s"
+}
+
+resource "google_compute_security_policy_rule" "policy_rule" {
+  security_policy = google_compute_security_policy.policy.name
+  description     = "reCAPTCHA rule"
+  action          = "deny(403)"
+  priority        = "2000"
+  match {
+    expr {
+      expression = "request.path.endsWith('RegisterWithEmail') && token.recaptcha_action.score >= 0.8 && (token.recaptcha_action.valid)"
+    }
+    expr_options {
+      recaptcha_options {
+        action_token_site_keys = [
+          "placeholder-recaptcha-action-site-key-01",
+          "placeholder-recaptcha-action-site-key-02"
+        ]
+        session_token_site_keys = [
+          "placeholder-recaptcha-session-site-key-1",
+          "placeholder-recaptcha-session-site-key-2"
+        ]
+      }
     }
   }
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
@@ -557,6 +557,29 @@ func TestAccComputeSecurityPolicy_withHeadAction(t *testing.T) {
 		},
 	})
 }
+
+func TestAccComputeSecurityPolicy_withExprOptions(t *testing.T) {
+	t.Parallel()
+
+	spName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeSecurityPolicyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSecurityPolicy_withExprOptions(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccComputeSecurityPolicy_withRecaptchaOptionsConfig(project, spName string) string {
 	return fmt.Sprintf(`
 resource "google_recaptcha_enterprise_key" "primary" {
@@ -1699,6 +1722,49 @@ resource "google_compute_security_policy" "policy" {
 		redirect_options {
 			type = "EXTERNAL_302"
 			target = "https://example.com"
+		}
+	}
+}
+`, spName)
+}
+
+func testAccComputeSecurityPolicy_withExprOptions(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+	name = "%s"
+
+	rule {
+		action   = "allow"
+		priority = "2147483647"
+    description = "default rule"
+		match {
+			versioned_expr = "SRC_IPS_V1"
+			config {
+				src_ip_ranges = ["*"]
+			}
+		}
+	}
+
+	rule {
+		action   = "deny(403)"
+		priority = "2000"
+    description = "reCAPTCHA rule"
+		match {
+			expr {
+				expression = "request.path.endsWith('RegisterWithEmail') && token.recaptcha_action.score >= 0.8 && (token.recaptcha_action.valid)"
+			}
+      expr_options {
+        recaptcha_options {
+          action_token_site_keys = [
+            "placeholder-recaptcha-action-site-key-01",
+            "placeholder-recaptcha-action-site-key-02"
+          ]
+          session_token_site_keys = [
+            "placeholder-recaptcha-session-site-key-1",
+            "placeholder-recaptcha-session-site-key-2"
+          ]
+        }
+      }
 		}
 	}
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds "action_token_site_keys" and "session_token_site_keys" as "exprOptions>recaptchaOptions" to "resource_compute_security_policy" and "resource_compute_security_policy_rule", as well as related tests;

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/15850

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**


```release-note:enhancement
compute: Added 'action_token_site_keys' and 'session_token_site_keys' fields to 'google_compute_security_policy' resource;
```
```release-note:enhancement
compute: Added 'action_token_site_keys' and 'session_token_site_keys' fields to 'google_compute_security_policy_rule' resource;
```
