### PR TITLE
[discoveryengine] Add documentProcessingConfig field to DataStore resource

### DIFF
--- a/mmv1/products/discoveryengine/DataStore.yaml
+++ b/mmv1/products/discoveryengine/DataStore.yaml
@@ -55,10 +55,18 @@ async: !ruby/object:Api::OpAsync
     path: "error"
     message: "message"
 
+# Custom titles for examples?
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: "discoveryengine_datastore_basic"
     primary_resource_id: 'basic'
+    primary_resource_name:
+      'fmt.Sprintf("tf_test_data_store%s", context["random_suffix"])'
+    vars:
+      data_store_id: "data-store-id"
+  - !ruby/object:Provider::Terraform::Examples
+    name: "discoveryengine_datastore_document_processing_config"
+    primary_resource_id: 'document_processing_config'
     primary_resource_name:
       'fmt.Sprintf("tf_test_data_store%s", context["random_suffix"])'
     vars:
@@ -142,16 +150,25 @@ properties:
     required: true
   - !ruby/object:Api::Type::NestedObject
     name: 'documentProcessingConfig'
+    immutable: true   # Not documented in REST Reference, but the field is immutable (evidence: PATCH request returns
+                      # Field \"updateMask\" contains an immutable path \"document_processing_config\".)
     description: |
-      Configuration for Document understanding and enrichment.
+      Configuration for Document understanding and enrichment. Only one among 
     required: false
     properties:
+      # explain
       - !ruby/object:Api::Type::String
         name: 'name'
         description: |
           The full resource name of the Document Processing Config. Format:
           `projects/{project}/locations/{location}/collections/{collection_id}/dataStores/{data_store_id}/documentProcessingConfig`.
-        output: true
+        
+        # not marked as "output only" in the docs. However, this seems to have no effect.
+        # i.e. referencing an existing "documentProcessingConfig.name" when creating a datastore
+        # will produce a datastore with different (default) documentProcessingConfig params,
+        # while the original conf in the existing datastore is left unchanged
+        # output: true
+        required: false
 
       - !ruby/object:Api::Type::NestedObject
           name: 'defaultParsingConfig'
@@ -170,6 +187,7 @@ properties:
                 - default_parsing_config.0.ocr_parsing_config
               description: |
                 Configurations applied to digital parser.
+              required: false
               properties: []
             - !ruby/object:Api::Type::NestedObject
               name: 'ocrParsingConfig'
@@ -185,6 +203,50 @@ properties:
                   required: false
                   description: |
                     If true, will use native text instead of OCR text on pages containing native text.
+
+      - !ruby/object:Api::Type::Map
+        name: 'parsingConfigOverrides'
+        description: |
+          Map from file type to override the default parsing configuration based on the file type.
+        key_name: KEY_NAME
+
+        # The description mentions some constraints that cannot be modeled in a map. Should this be converted to a NestedObject
+        # The description mentions Layout parsing, which is only available in alpha
+        key_description: |
+          Supported keys:
+            * pdf: Override parsing config for PDF files, either digital parsing, ocr parsing or layout parsing is supported.
+            * html: Override parsing config for HTML files, only digital parsing and or layout parsing are supported.
+            * docx: Override parsing config for DOCX files, only digital parsing and or layout parsing are supported.
+
+        # This is a duplication of "defaultParsingConfig". I couldn't find a way to reuse existing models
+        value_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::NestedObject
+              name: 'digitalParsingConfig'
+              allow_empty_object: true
+              send_empty_value: true
+              exactly_one_of:
+                - default_parsing_config.0.digital_parsing_config
+                - default_parsing_config.0.ocr_parsing_config
+              description: |
+                Configurations applied to digital parser.
+              required: false
+              properties: []
+            - !ruby/object:Api::Type::NestedObject
+              name: 'ocrParsingConfig'
+              exactly_one_of:
+                - default_parsing_config.0.digital_parsing_config
+                - default_parsing_config.0.ocr_parsing_config
+              description: |
+                Configurations applied to OCR parser. Currently it only applies to PDFs.
+              required: false
+              properties:
+                - !ruby/object:Api::Type::Boolean
+                  name: 'useNativeText'
+                  required: false
+                  description: |
+                    If true, will use native text instead of OCR text on pages containing native text.
+
   - !ruby/object:Api::Type::Time
     name: "createTime"
     description: |

--- a/mmv1/products/discoveryengine/DataStore.yaml
+++ b/mmv1/products/discoveryengine/DataStore.yaml
@@ -140,6 +140,51 @@ properties:
       - :PUBLIC_WEBSITE
     immutable: true
     required: true
+  - !ruby/object:Api::Type::NestedObject
+    name: 'documentProcessingConfig'
+    description: |
+      Configuration for Document understanding and enrichment.
+    required: false
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          The full resource name of the Document Processing Config. Format:
+          `projects/{project}/locations/{location}/collections/{collection_id}/dataStores/{data_store_id}/documentProcessingConfig`.
+        output: true
+
+      - !ruby/object:Api::Type::NestedObject
+          name: 'defaultParsingConfig'
+          description: |
+            Configurations for default Document parser. If not specified, we will
+            configure it as default DigitalParsingConfig, and the default parsing
+            config will be applied to all file types for Document parsing.
+          required: false
+          properties:
+            - !ruby/object:Api::Type::NestedObject
+              name: 'digitalParsingConfig'
+              allow_empty_object: true
+              send_empty_value: true
+              exactly_one_of:
+                - default_parsing_config.0.digital_parsing_config
+                - default_parsing_config.0.ocr_parsing_config
+              description: |
+                Configurations applied to digital parser.
+              properties: []
+            - !ruby/object:Api::Type::NestedObject
+              name: 'ocrParsingConfig'
+              exactly_one_of:
+                - default_parsing_config.0.digital_parsing_config
+                - default_parsing_config.0.ocr_parsing_config
+              description: |
+                Configurations applied to OCR parser. Currently it only applies to PDFs.
+              required: false
+              properties:
+                - !ruby/object:Api::Type::Boolean
+                  name: 'useNativeText'
+                  required: false
+                  description: |
+                    If true, will use native text instead of OCR text on pages containing native text.
   - !ruby/object:Api::Type::Time
     name: "createTime"
     description: |

--- a/mmv1/products/discoveryengine/DataStore.yaml
+++ b/mmv1/products/discoveryengine/DataStore.yaml
@@ -55,7 +55,6 @@ async: !ruby/object:Api::OpAsync
     path: "error"
     message: "message"
 
-# Custom titles for examples?
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: "discoveryengine_datastore_basic"
@@ -150,75 +149,62 @@ properties:
     required: true
   - !ruby/object:Api::Type::NestedObject
     name: 'documentProcessingConfig'
-    immutable: true   # Not documented in REST Reference, but the field is immutable (evidence: PATCH request returns
-                      # Field \"updateMask\" contains an immutable path \"document_processing_config\".)
+    immutable: true
     description: |
-      Configuration for Document understanding and enrichment. Only one among 
+      Configuration for Document understanding and enrichment.
     required: false
     properties:
-      # explain
       - !ruby/object:Api::Type::String
         name: 'name'
         description: |
           The full resource name of the Document Processing Config. Format:
           `projects/{project}/locations/{location}/collections/{collection_id}/dataStores/{data_store_id}/documentProcessingConfig`.
-        
-        # not marked as "output only" in the docs. However, this seems to have no effect.
-        # i.e. referencing an existing "documentProcessingConfig.name" when creating a datastore
-        # will produce a datastore with different (default) documentProcessingConfig params,
-        # while the original conf in the existing datastore is left unchanged
-        # output: true
+        output: true
         required: false
 
       - !ruby/object:Api::Type::NestedObject
-          name: 'defaultParsingConfig'
-          description: |
-            Configurations for default Document parser. If not specified, we will
-            configure it as default DigitalParsingConfig, and the default parsing
-            config will be applied to all file types for Document parsing.
-          required: false
-          properties:
-            - !ruby/object:Api::Type::NestedObject
-              name: 'digitalParsingConfig'
-              allow_empty_object: true
-              send_empty_value: true
-              exactly_one_of:
-                - default_parsing_config.0.digital_parsing_config
-                - default_parsing_config.0.ocr_parsing_config
-              description: |
-                Configurations applied to digital parser.
-              required: false
-              properties: []
-            - !ruby/object:Api::Type::NestedObject
-              name: 'ocrParsingConfig'
-              exactly_one_of:
-                - default_parsing_config.0.digital_parsing_config
-                - default_parsing_config.0.ocr_parsing_config
-              description: |
-                Configurations applied to OCR parser. Currently it only applies to PDFs.
-              required: false
-              properties:
-                - !ruby/object:Api::Type::Boolean
-                  name: 'useNativeText'
-                  required: false
-                  description: |
-                    If true, will use native text instead of OCR text on pages containing native text.
+        name: 'defaultParsingConfig'
+        description: |
+          Configurations for default Document parser. If not specified, we will
+          configure it as default DigitalParsingConfig, and the default parsing
+          config will be applied to all file types for Document parsing.
+        required: false
+        properties:
+          - !ruby/object:Api::Type::NestedObject
+            name: 'digitalParsingConfig'
+            allow_empty_object: true
+            send_empty_value: true
+            exactly_one_of:
+              - default_parsing_config.0.digital_parsing_config
+              - default_parsing_config.0.ocr_parsing_config
+            description: |
+              Configurations applied to digital parser.
+            required: false
+            properties: []
+          - !ruby/object:Api::Type::NestedObject
+            name: 'ocrParsingConfig'
+            exactly_one_of:
+              - default_parsing_config.0.digital_parsing_config
+              - default_parsing_config.0.ocr_parsing_config
+            description: |
+              Configurations applied to OCR parser. Currently it only applies to PDFs.
+            required: false
+            properties:
+              - !ruby/object:Api::Type::Boolean
+                name: 'useNativeText'
+                required: false
+                description: |
+                  If true, will use native text instead of OCR text on pages containing native text.
 
       - !ruby/object:Api::Type::Map
         name: 'parsingConfigOverrides'
         description: |
-          Map from file type to override the default parsing configuration based on the file type.
-        key_name: KEY_NAME
+          Map from file type to override the default parsing configuration based on the file type. Supported keys:
+            * `pdf`: Override parsing config for PDF files, either digital parsing, ocr parsing or layout parsing is supported.
+            * `html`: Override parsing config for HTML files, only digital parsing and or layout parsing are supported.
+            * `docx`: Override parsing config for DOCX files, only digital parsing and or layout parsing are supported.
+        key_name: file_type
 
-        # The description mentions some constraints that cannot be modeled in a map. Should this be converted to a NestedObject
-        # The description mentions Layout parsing, which is only available in alpha
-        key_description: |
-          Supported keys:
-            * pdf: Override parsing config for PDF files, either digital parsing, ocr parsing or layout parsing is supported.
-            * html: Override parsing config for HTML files, only digital parsing and or layout parsing are supported.
-            * docx: Override parsing config for DOCX files, only digital parsing and or layout parsing are supported.
-
-        # This is a duplication of "defaultParsingConfig". I couldn't find a way to reuse existing models
         value_type: !ruby/object:Api::Type::NestedObject
           properties:
             - !ruby/object:Api::Type::NestedObject

--- a/mmv1/products/discoveryengine/DataStore.yaml
+++ b/mmv1/products/discoveryengine/DataStore.yaml
@@ -70,6 +70,14 @@ examples:
       'fmt.Sprintf("tf_test_data_store%s", context["random_suffix"])'
     vars:
       data_store_id: "data-store-id"
+  - !ruby/object:Provider::Terraform::Examples
+    name: "discoveryengine_datastore_document_processing_config_ocr"
+    skip_docs: true
+    primary_resource_id: 'document_processing_config_ocr'
+    primary_resource_name:
+      'fmt.Sprintf("tf_test_data_store%s", context["random_suffix"])'
+    vars:
+      data_store_id: "data-store-id"
 parameters:
   - !ruby/object:Api::Type::String
     name: 'location'
@@ -161,12 +169,11 @@ properties:
           `projects/{project}/locations/{location}/collections/{collection_id}/dataStores/{data_store_id}/documentProcessingConfig`.
         output: true
         required: false
-
       - !ruby/object:Api::Type::NestedObject
         name: 'defaultParsingConfig'
         description: |
-          Configurations for default Document parser. If not specified, we will
-          configure it as default DigitalParsingConfig, and the default parsing
+          Configurations for default Document parser. If not specified, this resource
+          will be configured to use a default DigitalParsingConfig, and the default parsing
           config will be applied to all file types for Document parsing.
         required: false
         properties:

--- a/mmv1/templates/terraform/examples/discoveryengine_datastore_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/discoveryengine_datastore_basic.tf.erb
@@ -6,4 +6,9 @@ resource "google_discovery_engine_data_store" "basic" {
   content_config              = "NO_CONTENT"
   solution_types              = ["SOLUTION_TYPE_SEARCH"]
   create_advanced_site_search = false
+  document_processing_config {
+    default_parsing_config  {
+      digital_parsing_config {}
+    } 
+  }        
 }

--- a/mmv1/templates/terraform/examples/discoveryengine_datastore_document_processing_config.tf.erb
+++ b/mmv1/templates/terraform/examples/discoveryengine_datastore_document_processing_config.tf.erb
@@ -10,11 +10,10 @@ resource "google_discovery_engine_data_store" "document_processing_config" {
     default_parsing_config  {
       digital_parsing_config {}
     }
-    parsingConfigOverrides {
-      pdf = {
-        ocrParsingConfig {
-          useNativeText = true
-        }
+    parsing_config_overrides {
+      file_type = "pdf"
+      ocr_parsing_config {
+        use_native_text = true
       }
     }
   }        

--- a/mmv1/templates/terraform/examples/discoveryengine_datastore_document_processing_config.tf.erb
+++ b/mmv1/templates/terraform/examples/discoveryengine_datastore_document_processing_config.tf.erb
@@ -1,4 +1,4 @@
-resource "google_discovery_engine_data_store" "basic" {
+resource "google_discovery_engine_data_store" "document_processing_config" {
   location                    = "global"
   data_store_id               = "<%= ctx[:vars]['data_store_id'] %>"
   display_name                = "tf-test-structured-datastore"
@@ -6,4 +6,16 @@ resource "google_discovery_engine_data_store" "basic" {
   content_config              = "NO_CONTENT"
   solution_types              = ["SOLUTION_TYPE_SEARCH"]
   create_advanced_site_search = false
+  document_processing_config {
+    default_parsing_config  {
+      digital_parsing_config {}
+    }
+    parsingConfigOverrides {
+      pdf = {
+        ocrParsingConfig {
+          useNativeText = true
+        }
+      }
+    }
+  }        
 }

--- a/mmv1/templates/terraform/examples/discoveryengine_datastore_document_processing_config_ocr.tf.erb
+++ b/mmv1/templates/terraform/examples/discoveryengine_datastore_document_processing_config_ocr.tf.erb
@@ -1,0 +1,16 @@
+resource "google_discovery_engine_data_store" "document_processing_config_ocr" {
+  location                    = "global"
+  data_store_id               = "<%= ctx[:vars]['data_store_id'] %>"
+  display_name                = "tf-test-structured-datastore"
+  industry_vertical           = "GENERIC"
+  content_config              = "NO_CONTENT"
+  solution_types              = ["SOLUTION_TYPE_SEARCH"]
+  create_advanced_site_search = false
+  document_processing_config {
+    default_parsing_config {
+      ocr_parsing_config {
+        use_native_text = true
+      }
+    }
+  }      
+}


### PR DESCRIPTION
Add `documentProcessingConfig` parameter to discoveryengine/DataStore model. 

Resolves part of https://github.com/hashicorp/terraform-provider-google/issues/17554. The remaining items (Layout Parser, chunking options) are still in *alpha*, a separate issue will be opened for those. 

**NOTE**: It's my first PR on `magic-modules`, I'll comment some of the assumptions I made throughout the code

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
discoveryengine: added `document_processing_config` field to `google_discovery_engine_data_store` resource
```
