### PR TITLE
Adding a breaking change for adding subfields to SchemaConfigModeAttr

### DIFF
--- a/docs/content/develop/breaking-changes/breaking-changes.md
+++ b/docs/content/develop/breaking-changes/breaking-changes.md
@@ -82,6 +82,12 @@ For more information, see
 * <a name="field-removing-diff-suppress"></a> Removing diff suppression from a field.
   * For MMv1 resources, removing `diff_suppress_func` from a field.
   * For handwritten resources, removing `DiffSuppressFunc` from a field.
+* <a name="field-adding-subfield-to-config-mode-attr"></a> Adding a subfield to
+  a SchemaConfigModeAttr field.
+  * For MMv1 resources, adding a subfield to a field that has
+    SchemaConfigModeAttr.
+  * For handwritten resources, adding a subfield to a field that has
+    SchemaConfigModeAttr.
 * Removing update support from a field.
 
 ### Making validation more strict

--- a/tools/diff-processor/rules/rules_field_test.go
+++ b/tools/diff-processor/rules/rules_field_test.go
@@ -560,6 +560,81 @@ var fieldRule_ShrinkingMaxTestCases = []fieldTestCase{
 	},
 }
 
+func TestFieldRule_AddingSubfieldToConfigModeAttr(t *testing.T) {
+	for _, tc := range fieldRule_AddingSubfieldToConfigModeAttrTestCases {
+		tc.check(fieldRule_AddingSubfieldToConfigModeAttr, t)
+	}
+}
+
+var fieldRule_AddingSubfieldToConfigModeAttrTestCases = []fieldTestCase{
+	{
+		name: "no new subfields",
+		oldField: &schema.Schema{
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Description: "beep",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"field_one": {},
+				},
+			},
+		},
+		newField: &schema.Schema{
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Description: "beep",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"field_one": {},
+				},
+			},
+		},
+		expectedViolation: false,
+	},
+	{
+		name: "adding a subfield with no SchemaConfigModeAttr",
+		oldField: &schema.Schema{
+			Description: "beep",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"field_one": {},
+				},
+			},
+		},
+		newField: &schema.Schema{
+			Description: "beep",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"field_one": {},
+					"field_two": {},
+				},
+			},
+		},
+		expectedViolation: false,
+	},
+	{
+		name: "adding a field with SchemaConfigModeAttr",
+		oldField: &schema.Schema{
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Description: "beep",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"field_one": {},
+				},
+			},
+		},
+		newField: &schema.Schema{
+			ConfigMode:  schema.SchemaConfigModeAttr,
+			Description: "beep",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"field_one": {},
+					"field_two": {},
+				},
+			},
+		},
+		expectedViolation: true,
+	},
+}
+
 func (tc *fieldTestCase) check(rule FieldRule, t *testing.T) {
 	breakage := rule.isRuleBreak(tc.oldField, tc.newField, MessageContext{})
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
