### PR TITLE
Remove most calls to 'GetServiceAccount' in the create path

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account.go
@@ -139,47 +139,14 @@ func resourceGoogleServiceAccountCreate(d *schema.ResourceData, meta interface{}
 	if err := d.Set("unique_id", sa.UniqueId); err != nil {
 		return fmt.Errorf("Error setting unique_id: %s", err)
 	}
-	if err := d.Set("account_id", aid); err != nil {
-		return fmt.Errorf("Error setting account_id: %s", err)
-	}
 	if err := d.Set("name", sa.Name); err != nil {
 		return fmt.Errorf("Error setting name: %s", err)
-	}
-	if err := d.Set("display_name", displayName); err != nil {
-		return fmt.Errorf("Error setting display_name: %s", err)
-	}
-	if err := d.Set("description", description); err != nil {
-		return fmt.Errorf("Error setting description: %s", err)
 	}
 	if err := d.Set("member", "serviceAccount:"+email); err != nil {
 		return fmt.Errorf("Error setting member: %s", err)
 	}
 
-	if d.Get("disabled") == nil {
-		if err := d.Set("disabled", false); err != nil {
-			return fmt.Errorf("Error setting disabled: %s", err)
-		}
-	}
-
 	return nil
-}
-
-func resourceServiceAccountPollRead(d *schema.ResourceData, meta interface{}) transport_tpg.PollReadFunc {
-	return func() (map[string]interface{}, error) {
-		config := meta.(*transport_tpg.Config)
-		userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
-		if err != nil {
-			return nil, err
-		}
-
-		// Confirm the service account exists
-		_, err = config.NewIamClient(userAgent).Projects.ServiceAccounts.Get(d.Id()).Do()
-
-		if err != nil {
-			return nil, err
-		}
-		return nil, nil
-	}
 }
 
 func resourceGoogleServiceAccountRead(d *schema.ResourceData, meta interface{}) error {

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account_test.go
@@ -101,12 +101,14 @@ func TestAccServiceAccount_createIgnoreAlreadyExists(t *testing.T) {
 	project := envvar.GetTestProjectFromEnv()
 	expectedEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", accountId, project)
 
-	// Create a service account before prior to applying the terraform config
-	config := acctest.GoogleProviderConfig(t)
-	testAccCreateServiceAccount(project, accountId, desc, displayName, config)
-
 	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		PreCheck: func() {
+			acctest.AccTestPreCheck(t)
+
+			// Create a service account before prior to applying the terraform config
+			config := acctest.GoogleProviderConfig(t)
+			testAccCreateServiceAccount(project, accountId, desc, displayName, config)
+		},
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			// Create a new resource that duplicates with the existing service account.
@@ -202,7 +204,6 @@ func TestAccServiceAccount_Disabled(t *testing.T) {
 						"google_service_account.acceptance", "project", project),
 					testAccStoreServiceAccountUniqueId(&uniqueId),
 				),
-				RefreshState: false, // Eventual consistency makes an immediate refresh flaky
 			},
 			{
 				ResourceName:      "google_service_account.acceptance",


### PR DESCRIPTION
Removes calls to GetServiceAccount in all cases except when `create_ignore_already_exists=true` and the Service Account already exists. This should eliminate most cases of the "Provider produced inconsistent result after apply" that occurs when creating new Service Accounts.

This bug occurs when a Service Account is created successfully but GetServiceAccount returns a 404 due to eventual consistency. We have all the information we need from the input config and the CreateServiceAccount response, so there's no need to make requests to GetServiceAccount at all.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
iam: Fix most instances of the "Provider produced inconsistent result after apply" bug for `google_service_account` resources.
```
