### PR TITLE
Add Managed Kafka Topic resource and tests.

### DIFF
--- a/mmv1/products/managedkafka/Cluster.yaml
+++ b/mmv1/products/managedkafka/Cluster.yaml
@@ -19,7 +19,7 @@ id_format: projects/{{project}}/locations/{{location}}/clusters/{{cluster_id}}
 import_format:
   - projects/{{project}}/locations/{{location}}/clusters/{{cluster_id}}
 name: Cluster
-description: An Apache Kafka for BigQuery cluster.
+description: An Apache Kafka for BigQuery cluster. Apache Kafka:tm: is a trademark owned by the Apache Software Foundation.
 min_version: beta
 update_verb: :PATCH
 update_mask: true

--- a/mmv1/products/managedkafka/Cluster.yaml
+++ b/mmv1/products/managedkafka/Cluster.yaml
@@ -19,7 +19,7 @@ id_format: projects/{{project}}/locations/{{location}}/clusters/{{cluster_id}}
 import_format:
   - projects/{{project}}/locations/{{location}}/clusters/{{cluster_id}}
 name: Cluster
-description: An Apache Kafka for BigQuery cluster. Apache Kafka:tm: is a trademark owned by the Apache Software Foundation.
+description: An Apache Kafka for BigQuery cluster. Apache Kafka is a trademark owned by the Apache Software Foundation.
 min_version: beta
 update_verb: :PATCH
 update_mask: true

--- a/mmv1/products/managedkafka/Topic.yaml
+++ b/mmv1/products/managedkafka/Topic.yaml
@@ -1,3 +1,16 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 --- !ruby/object:Api::Resource
 base_url: projects/{{project}}/locations/{{location}}/clusters/{{cluster}}/topics
 create_url: projects/{{project}}/locations/{{location}}/clusters/{{cluster}}/topics?topicId={{topic_id}}

--- a/mmv1/products/managedkafka/Topic.yaml
+++ b/mmv1/products/managedkafka/Topic.yaml
@@ -1,0 +1,64 @@
+--- !ruby/object:Api::Resource
+base_url: projects/{{project}}/locations/{{location}}/clusters/{{cluster}}/topics
+create_url: projects/{{project}}/locations/{{location}}/clusters/{{cluster}}/topics?topicId={{topic_id}}
+self_link: projects/{{project}}/locations/{{location}}/clusters/{{cluster}}/topics/{{topic_id}}
+id_format: projects/{{project}}/locations/{{location}}/clusters/{{cluster}}/topics/{{topic_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/clusters/{{cluster}}/topics/{{topic_id}}
+name: Topic
+description: An Apache Kafka for BigQuery topic.
+min_version: beta
+update_verb: :PATCH
+update_mask: true
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: "managedkafka_topic_basic"
+    primary_resource_id: "example"
+    min_version: beta
+    vars:
+      cluster_id: "my-cluster"
+      topic_id: "my-topic"
+properties:
+  - !ruby/object:Api::Type::String
+    name: name
+    description: "The name of the topic. The `topic` segment is used when
+      connecting directly to the cluster. Must be in the format `projects/PROJECT_ID/locations/LOCATION/clusters/CLUSTER_ID/topics/TOPIC_ID`."
+    output: true
+  - !ruby/object:Api::Type::Integer
+    name: partitionCount
+    description: "The number of partitions in a topic. You can increase the partition
+      count for a topic, but you cannot decrease it. Increasing partitions
+      for a topic that uses a key might change how messages are distributed."
+  - !ruby/object:Api::Type::Integer
+    name: replicationFactor
+    description: "The number of replicas of each partition. A replication factor of 3 is
+      recommended for high availability."
+    required: true
+    immutable: true
+  - !ruby/object:Api::Type::KeyValuePairs
+    name: configs
+    description: "Configuration for the topic that are overridden from the cluster
+      defaults. The key of the map is a Kafka topic property name, for
+      example: `cleanup.policy=compact`, `compression.type=producer`."
+parameters:
+  - !ruby/object:Api::Type::String
+    name: location
+    description: "ID of the location of the Apache Kafka for BigQuery resource. See
+      https://cloud.google.com/managed-kafka/docs/locations for a list of
+      supported locations."
+    url_param_only: true
+    required: true
+    immutable: true
+  - !ruby/object:Api::Type::String
+    name: cluster
+    description: "The cluster name."
+    url_param_only: true
+    required: true
+    immutable: true
+  - !ruby/object:Api::Type::String
+    name: topicId
+    description: "The ID to use for the topic, which will become the final
+      component of the topic's name. This value is structured like: `my-topic-name`."
+    url_param_only: true
+    required: true
+    immutable: true

--- a/mmv1/products/managedkafka/Topic.yaml
+++ b/mmv1/products/managedkafka/Topic.yaml
@@ -19,7 +19,7 @@ id_format: projects/{{project}}/locations/{{location}}/clusters/{{cluster}}/topi
 import_format:
   - projects/{{project}}/locations/{{location}}/clusters/{{cluster}}/topics/{{topic_id}}
 name: Topic
-description: An Apache Kafka for BigQuery topic.
+description: An Apache Kafka for BigQuery topic. Apache Kafka is a trademark owned by the Apache Software Foundation.
 min_version: beta
 update_verb: :PATCH
 update_mask: true

--- a/mmv1/templates/terraform/examples/managedkafka_topic_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/managedkafka_topic_basic.tf.erb
@@ -1,0 +1,34 @@
+resource "google_managed_kafka_cluster" "<%= ctx[:primary_resource_id] %>" {
+  cluster_id = "<%= ctx[:vars]['cluster_id'] %>"
+  location = "us-central1"
+  capacity_config {
+    vcpu_count = 3
+    memory_bytes = 3221225472
+  }
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/${data.google_project.project.number}/regions/us-central1/subnetworks/default"
+      }
+    }
+  }
+
+  provider = google-beta
+}
+
+resource "google_managed_kafka_topic" "<%= ctx[:primary_resource_id] %>" {
+  topic_id = "<%= ctx[:vars]['topic_id'] %>"
+  cluster = google_managed_kafka_cluster.<%= ctx[:primary_resource_id] %>.cluster_id
+  location = "us-central1"
+  partition_count = 2
+  replication_factor = 3
+  configs = {
+  "cleanup.policy" = "compact"
+  }
+
+  provider = google-beta
+}
+
+data "google_project" "project" {
+  provider = google-beta
+}

--- a/mmv1/templates/terraform/examples/managedkafka_topic_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/managedkafka_topic_basic.tf.erb
@@ -1,4 +1,4 @@
-resource "google_managed_kafka_cluster" "<%= ctx[:primary_resource_id] %>" {
+resource "google_managed_kafka_cluster" "cluster" {
   cluster_id = "<%= ctx[:vars]['cluster_id'] %>"
   location = "us-central1"
   capacity_config {
@@ -18,12 +18,12 @@ resource "google_managed_kafka_cluster" "<%= ctx[:primary_resource_id] %>" {
 
 resource "google_managed_kafka_topic" "<%= ctx[:primary_resource_id] %>" {
   topic_id = "<%= ctx[:vars]['topic_id'] %>"
-  cluster = google_managed_kafka_cluster.<%= ctx[:primary_resource_id] %>.cluster_id
+  cluster = google_managed_kafka_cluster.cluster.cluster_id
   location = "us-central1"
   partition_count = 2
   replication_factor = 3
   configs = {
-  "cleanup.policy" = "compact"
+    "cleanup.policy" = "compact"
   }
 
   provider = google-beta

--- a/mmv1/third_party/terraform/services/managedkafka/resource_managed_kafka_topic_test.go.erb
+++ b/mmv1/third_party/terraform/services/managedkafka/resource_managed_kafka_topic_test.go.erb
@@ -1,0 +1,125 @@
+<% autogen_exception -%>
+package managedkafka_test
+<% unless version == 'ga' -%>
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccManagedKafkaTopic_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckManagedKafkaTopicDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccManagedKafkaTopic_basic(context),
+			},
+			{
+				ResourceName:            "google_managed_kafka_topic.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"cluster", "location", "topic_id"},
+			},
+			{
+				Config: testAccManagedKafkaTopic_update(context),
+			},
+			{
+				ResourceName:            "google_managed_kafka_topic.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"cluster", "location", "topic_id"},
+			},
+		},
+	})
+}
+
+func testAccManagedKafkaTopic_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_managed_kafka_cluster" "example" {
+  cluster_id = "tf-test-my-cluster%{random_suffix}"
+  location = "us-central1"
+  capacity_config {
+    vcpu_count = 3
+    memory_bytes = 3221225472
+  }
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/${data.google_project.project.number}/regions/us-central1/subnetworks/default"
+      }
+    }
+  }
+
+  provider = google-beta
+}
+
+resource "google_managed_kafka_topic" "example" {
+  cluster = google_managed_kafka_cluster.example.cluster_id
+  topic_id = "tf-test-my-topic%{random_suffix}"
+  location = "us-central1"
+  partition_count = 2
+  replication_factor = 3
+  configs = {
+  "cleanup.policy" = "compact"
+  }
+
+  provider = google-beta
+}
+
+data "google_project" "project" {
+  provider = google-beta
+}
+`, context)
+}
+
+func testAccManagedKafkaTopic_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_managed_kafka_cluster" "example" {
+  cluster_id = "tf-test-my-cluster%{random_suffix}"
+  location = "us-central1"
+  capacity_config {
+    vcpu_count = 3
+    memory_bytes = 3221225472
+  }
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/${data.google_project.project.number}/regions/us-central1/subnetworks/default"
+      }
+    }
+  }
+
+  provider = google-beta
+}
+
+resource "google_managed_kafka_topic" "example" {
+  cluster = google_managed_kafka_cluster.example.cluster_id
+  topic_id = "tf-test-my-topic%{random_suffix}"
+  location = "us-central1"
+  partition_count = 3
+  replication_factor = 3
+  configs = {
+  "cleanup.policy" = "compact"
+  }
+
+  provider = google-beta
+}
+
+data "google_project" "project" {
+  provider = google-beta
+}
+`, context)
+}
+<% else %>
+// Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
+<% end -%>

--- a/mmv1/third_party/terraform/services/managedkafka/resource_managed_kafka_topic_test.go.erb
+++ b/mmv1/third_party/terraform/services/managedkafka/resource_managed_kafka_topic_test.go.erb
@@ -70,7 +70,7 @@ resource "google_managed_kafka_topic" "example" {
   partition_count = 2
   replication_factor = 3
   configs = {
-  "cleanup.policy" = "compact"
+    "cleanup.policy" = "compact"
   }
 
   provider = google-beta
@@ -109,7 +109,7 @@ resource "google_managed_kafka_topic" "example" {
   partition_count = 3
   replication_factor = 3
   configs = {
-  "cleanup.policy" = "compact"
+    "cleanup.policy" = "compact"
   }
 
   provider = google-beta


### PR DESCRIPTION
Description: Adding a new Managed Kafka Topic terraform resource to terraform-provider-google-beta. Includes a basic create and update test.

Issue: https://b.corp.google.com/issues/322841720

```release-note:new-resource
`google_managed_kafka_topic` (beta)
```