### PR TITLE
`google_compute_instance` - add validation for `name`

### DIFF
--- a/mmv1/products/compute/Instance.yaml
+++ b/mmv1/products/compute/Instance.yaml
@@ -378,6 +378,8 @@ properties:
       lowercase letter, and all following characters must be a dash,
       lowercase letter, or digit, except the last character, which cannot
       be a dash.
+    validation: !ruby/object:Provider::Terraform::Validation
+      regex: '^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$'
   - !ruby/object:Api::Type::Array
     name: 'networkInterfaces'
     description: |


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

To fail during the plan phase if the name violates the following rules:
https://cloud.google.com/compute/docs/naming-resources#resource-name-format.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `regex` validation for the `name` field of the `google_compute_instance` resource
```
