### PR TITLE
Update Instance.yaml to fix name regex

### DIFF
--- a/mmv1/products/looker/Instance.yaml
+++ b/mmv1/products/looker/Instance.yaml
@@ -339,7 +339,7 @@ properties:
     immutable: true
     url_param_only: true
     validation: !ruby/object:Provider::Terraform::Validation
-      regex: '^[a-z][a-z0-9-]{0,39}[a-z0-9]$'
+      regex: '^[a-z][a-z0-9-]{0,61}[a-z0-9]$'
   # Oauth Object
   - !ruby/object:Api::Type::NestedObject
     name: oauthConfig


### PR DESCRIPTION
Fixing where name only allows for < 42 characters when our API allows for < 64 characters

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
looker: increased validation length of `name` to `google_looker_instance` resource
```
