### PR TITLE
Add beta support for custom error response policies for URL maps

### DIFF
--- a/mmv1/products/compute/UrlMap.yaml
+++ b/mmv1/products/compute/UrlMap.yaml
@@ -338,7 +338,6 @@ properties:
               description: |
                 Specifies rules for returning error responses.
                 In a given policy, if you specify rules for both a range of error codes as well as rules for specific error codes then rules with specific error codes have a higher priority.
-                
                 For example, assume that you configure a rule for 401 (Un-authorized) code, and another for all 4 series error codes (4XX).
                 If the backend service returns a 401, then the rule for 401 will be applied. However if the backend service returns a 403, the rule for 4xx takes effect.
               item_type: !ruby/object:Api::Type::NestedObject
@@ -350,7 +349,6 @@ properties:
                       - A number between 400 and 599: For example 401 or 503, in which case the load balancer applies the policy if the error code exactly matches this value.
                       - 5xx: Load Balancer will apply the policy if the backend service responds with any response code in the range of 500 to 599.
                       - 4xx: Load Balancer will apply the policy if the backend service responds with any response code in the range of 400 to 499.
-                      
                       Values must be unique within matchResponseCodes and across all errorResponseRules of CustomErrorResponsePolicy.
                     item_type: Api::Type::String
                   - !ruby/object:Api::Type::String
@@ -481,11 +479,9 @@ properties:
                 description: |
                   customErrorResponsePolicy specifies how the Load Balancer returns error responses when BackendServiceor BackendBucket responds with an error.
                   If a policy for an error code is not configured for the PathRule, a policy for the error code configured in pathMatcher.defaultCustomErrorResponsePolicy is applied. If one is not specified in pathMatcher.defaultCustomErrorResponsePolicy, the policy configured in UrlMap.defaultCustomErrorResponsePolicy takes effect.
-                  
                   For example, consider a UrlMap with the following configuration:
                   UrlMap.defaultCustomErrorResponsePolicy are configured with policies for 5xx and 4xx errors
                   A PathRule for /coming_soon/ is configured for the error code 404.
-                  
                   If the request is for www.myotherdomain.com and a 404 is encountered, the policy under UrlMap.defaultCustomErrorResponsePolicy takes effect. If a 404 response is encountered for the request www.example.com/current_events/, the pathMatcher's policy takes effect. If however, the request for www.example.com/coming_soon/ encounters a 404, the policy in PathRule.customErrorResponsePolicy takes effect. If any of the requests in this example encounter a 500 error code, the policy at UrlMap.defaultCustomErrorResponsePolicy takes effect.
                   customErrorResponsePolicy is supported only for global external Application Load Balancers.
                 properties:

--- a/mmv1/products/compute/UrlMap.yaml
+++ b/mmv1/products/compute/UrlMap.yaml
@@ -486,7 +486,7 @@ properties:
                   customErrorResponsePolicy is supported only for global external Application Load Balancers.
                 properties:
                   - !ruby/object:Api::Type::Array
-                    name: 'error_response_rule'
+                    name: 'errorResponseRule'
                     api_name: errorResponseRules
                     description: |
                       Specifies rules for returning error responses.

--- a/mmv1/products/compute/UrlMap.yaml
+++ b/mmv1/products/compute/UrlMap.yaml
@@ -333,7 +333,7 @@ properties:
             defaultCustomErrorResponsePolicy is supported only for global external Application Load Balancers.
           properties:
             - !ruby/object:Api::Type::Array
-              name: 'error_response_rule'
+              name: 'errorResponseRule'
               api_name: errorResponseRules
               description: |
                 Specifies rules for returning error responses.

--- a/mmv1/products/compute/UrlMap.yaml
+++ b/mmv1/products/compute/UrlMap.yaml
@@ -2094,7 +2094,7 @@ properties:
             - !ruby/object:Api::Type::Integer
               name: 'overrideResponseCode'
               description: |
-                The HTTP status code returned with the response containing the custom error content. 
+                The HTTP status code returned with the response containing the custom error content.
                 If overrideResponseCode is not supplied, the same response code returned by the original backend bucket or backend service is returned to the client.
       - !ruby/object:Api::Type::ResourceRef
         name: "errorService"

--- a/mmv1/products/compute/UrlMap.yaml
+++ b/mmv1/products/compute/UrlMap.yaml
@@ -337,8 +337,8 @@ properties:
               api_name: errorResponseRules
               description: |
                 Specifies rules for returning error responses.
-                In a given policy, if you specify rules for both a range of error codes as well as rules for specific error codes then rules with specific error codes have a higher priority. 
-                For example, assume that you configure a rule for 401 (Un-authorized) code, and another for all 4 series error codes (4XX). 
+                In a given policy, if you specify rules for both a range of error codes as well as rules for specific error codes then rules with specific error codes have a higher priority.
+                For example, assume that you configure a rule for 401 (Un-authorized) code, and another for all 4 series error codes (4XX).
                 If the backend service returns a 401, then the rule for 401 will be applied. However if the backend service returns a 403, the rule for 4xx takes effect.
               item_type: !ruby/object:Api::Type::NestedObject
                 properties:
@@ -363,7 +363,7 @@ properties:
                   - !ruby/object:Api::Type::Integer
                     name: 'overrideResponseCode'
                     description: |
-                      The HTTP status code returned with the response containing the custom error content. 
+                      The HTTP status code returned with the response containing the custom error content.
                       If overrideResponseCode is not supplied, the same response code returned by the original backend bucket or backend service is returned to the client.
             - !ruby/object:Api::Type::ResourceRef
               name: 'errorService'
@@ -482,7 +482,7 @@ properties:
                 min_version: beta
                 description: |
                   customErrorResponsePolicy specifies how the Load Balancer returns error responses when BackendServiceor BackendBucket responds with an error.
-                  If a policy for an error code is not configured for the PathRule, a policy for the error code configured in pathMatcher.defaultCustomErrorResponsePolicy is applied. If one is not specified in pathMatcher.defaultCustomErrorResponsePolicy, the policy configured in UrlMap.defaultCustomErrorResponsePolicy takes effect.      
+                  If a policy for an error code is not configured for the PathRule, a policy for the error code configured in pathMatcher.defaultCustomErrorResponsePolicy is applied. If one is not specified in pathMatcher.defaultCustomErrorResponsePolicy, the policy configured in UrlMap.defaultCustomErrorResponsePolicy takes effect.    
                   For example, consider a UrlMap with the following configuration:
                     
                   UrlMap.defaultCustomErrorResponsePolicy are configured with policies for 5xx and 4xx errors
@@ -496,8 +496,8 @@ properties:
                     api_name: errorResponseRules
                     description: |
                       Specifies rules for returning error responses.
-                      In a given policy, if you specify rules for both a range of error codes as well as rules for specific error codes then rules with specific error codes have a higher priority. 
-                      For example, assume that you configure a rule for 401 (Un-authorized) code, and another for all 4 series error codes (4XX). 
+                      In a given policy, if you specify rules for both a range of error codes as well as rules for specific error codes then rules with specific error codes have a higher priority.
+                      For example, assume that you configure a rule for 401 (Un-authorized) code, and another for all 4 series error codes (4XX).
                       If the backend service returns a 401, then the rule for 401 will be applied. However if the backend service returns a 403, the rule for 4xx takes effect.
                     item_type: !ruby/object:Api::Type::NestedObject
                       properties:
@@ -522,7 +522,7 @@ properties:
                         - !ruby/object:Api::Type::Integer
                           name: 'overrideResponseCode'
                           description: |
-                            The HTTP status code returned with the response containing the custom error content. 
+                            The HTTP status code returned with the response containing the custom error content.
                             If overrideResponseCode is not supplied, the same response code returned by the original backend bucket or backend service is returned to the client.
                   - !ruby/object:Api::Type::ResourceRef
                     name: "errorService"

--- a/mmv1/products/compute/UrlMap.yaml
+++ b/mmv1/products/compute/UrlMap.yaml
@@ -346,11 +346,9 @@ properties:
                     name: 'matchResponseCodes'
                     description: |
                       Valid values include:
-
                       - A number between 400 and 599: For example 401 or 503, in which case the load balancer applies the policy if the error code exactly matches this value.
                       - 5xx: Load Balancer will apply the policy if the backend service responds with any response code in the range of 500 to 599.
                       - 4xx: Load Balancer will apply the policy if the backend service responds with any response code in the range of 400 to 499.
-                      
                       Values must be unique within matchResponseCodes and across all errorResponseRules of CustomErrorResponsePolicy.
                     item_type: Api::Type::String
                   - !ruby/object:Api::Type::String
@@ -371,11 +369,9 @@ properties:
               imports: 'selfLink'
               description: |
                 The full or partial URL to the BackendBucket resource that contains the custom error content. Examples are:
-
                 https://www.googleapis.com/compute/v1/projects/project/global/backendBuckets/myBackendBucket
                 compute/v1/projects/project/global/backendBuckets/myBackendBucket
                 global/backendBuckets/myBackendBucket
-                
                 If errorService is not specified at lower levels like pathMatcher, pathRule and routeRule, an errorService specified at a higher level in the UrlMap will be used. If UrlMap.defaultCustomErrorResponsePolicy contains one or more errorResponseRules[], it must specify errorService.
                 If load balancer cannot reach the backendBucket, a simple Not Found Error will be returned, with the original response code (or overrideResponseCode if configured).
         - !ruby/object:Api::Type::NestedObject
@@ -484,11 +480,9 @@ properties:
                   customErrorResponsePolicy specifies how the Load Balancer returns error responses when BackendServiceor BackendBucket responds with an error.
                   If a policy for an error code is not configured for the PathRule, a policy for the error code configured in pathMatcher.defaultCustomErrorResponsePolicy is applied. If one is not specified in pathMatcher.defaultCustomErrorResponsePolicy, the policy configured in UrlMap.defaultCustomErrorResponsePolicy takes effect.    
                   For example, consider a UrlMap with the following configuration:
-                    
                   UrlMap.defaultCustomErrorResponsePolicy are configured with policies for 5xx and 4xx errors
                   A PathRule for /coming_soon/ is configured for the error code 404.
-                  If the request is for www.myotherdomain.com and a 404 is encountered, the policy under UrlMap.defaultCustomErrorResponsePolicy takes effect. If a 404 response is encountered for the request www.example.com/current_events/, the pathMatcher's policy takes effect. If however, the request for www.example.com/coming_soon/ encounters a 404, the policy in PathRule.customErrorResponsePolicy takes effect. If any of the requests in this example encounter a 500 error code, the policy at UrlMap.defaultCustomErrorResponsePolicy takes effect.
-                  
+                  If the request is for www.myotherdomain.com and a 404 is encountered, the policy under UrlMap.defaultCustomErrorResponsePolicy takes effect. If a 404 response is encountered for the request www.example.com/current_events/, the pathMatcher's policy takes effect. If however, the request for www.example.com/coming_soon/ encounters a 404, the policy in PathRule.customErrorResponsePolicy takes effect. If any of the requests in this example encounter a 500 error code, the policy at UrlMap.defaultCustomErrorResponsePolicy takes effect.                  
                   customErrorResponsePolicy is supported only for global external Application Load Balancers.
                 properties:
                   - !ruby/object:Api::Type::Array
@@ -2072,8 +2066,8 @@ properties:
         api_name: errorResponseRules
         description: |
           Specifies rules for returning error responses.
-          In a given policy, if you specify rules for both a range of error codes as well as rules for specific error codes then rules with specific error codes have a higher priority. 
-          For example, assume that you configure a rule for 401 (Un-authorized) code, and another for all 4 series error codes (4XX). 
+          In a given policy, if you specify rules for both a range of error codes as well as rules for specific error codes then rules with specific error codes have a higher priority.
+          For example, assume that you configure a rule for 401 (Un-authorized) code, and another for all 4 series error codes (4XX).
           If the backend service returns a 401, then the rule for 401 will be applied. However if the backend service returns a 403, the rule for 4xx takes effect.
         item_type: !ruby/object:Api::Type::NestedObject
           properties:
@@ -2081,11 +2075,9 @@ properties:
               name: 'matchResponseCodes'
               description: |
                 Valid values include:
-
                 - A number between 400 and 599: For example 401 or 503, in which case the load balancer applies the policy if the error code exactly matches this value.
                 - 5xx: Load Balancer will apply the policy if the backend service responds with any response code in the range of 500 to 599.
                 - 4xx: Load Balancer will apply the policy if the backend service responds with any response code in the range of 400 to 499.
-
                 Values must be unique within matchResponseCodes and across all errorResponseRules of CustomErrorResponsePolicy.
               item_type: Api::Type::String
             - !ruby/object:Api::Type::String

--- a/mmv1/products/compute/UrlMap.yaml
+++ b/mmv1/products/compute/UrlMap.yaml
@@ -338,6 +338,7 @@ properties:
               description: |
                 Specifies rules for returning error responses.
                 In a given policy, if you specify rules for both a range of error codes as well as rules for specific error codes then rules with specific error codes have a higher priority.
+                
                 For example, assume that you configure a rule for 401 (Un-authorized) code, and another for all 4 series error codes (4XX).
                 If the backend service returns a 401, then the rule for 401 will be applied. However if the backend service returns a 403, the rule for 4xx takes effect.
               item_type: !ruby/object:Api::Type::NestedObject
@@ -349,6 +350,7 @@ properties:
                       - A number between 400 and 599: For example 401 or 503, in which case the load balancer applies the policy if the error code exactly matches this value.
                       - 5xx: Load Balancer will apply the policy if the backend service responds with any response code in the range of 500 to 599.
                       - 4xx: Load Balancer will apply the policy if the backend service responds with any response code in the range of 400 to 499.
+                      
                       Values must be unique within matchResponseCodes and across all errorResponseRules of CustomErrorResponsePolicy.
                     item_type: Api::Type::String
                   - !ruby/object:Api::Type::String
@@ -478,11 +480,13 @@ properties:
                 min_version: beta
                 description: |
                   customErrorResponsePolicy specifies how the Load Balancer returns error responses when BackendServiceor BackendBucket responds with an error.
-                  If a policy for an error code is not configured for the PathRule, a policy for the error code configured in pathMatcher.defaultCustomErrorResponsePolicy is applied. If one is not specified in pathMatcher.defaultCustomErrorResponsePolicy, the policy configured in UrlMap.defaultCustomErrorResponsePolicy takes effect.    
+                  If a policy for an error code is not configured for the PathRule, a policy for the error code configured in pathMatcher.defaultCustomErrorResponsePolicy is applied. If one is not specified in pathMatcher.defaultCustomErrorResponsePolicy, the policy configured in UrlMap.defaultCustomErrorResponsePolicy takes effect.
+                  
                   For example, consider a UrlMap with the following configuration:
                   UrlMap.defaultCustomErrorResponsePolicy are configured with policies for 5xx and 4xx errors
                   A PathRule for /coming_soon/ is configured for the error code 404.
-                  If the request is for www.myotherdomain.com and a 404 is encountered, the policy under UrlMap.defaultCustomErrorResponsePolicy takes effect. If a 404 response is encountered for the request www.example.com/current_events/, the pathMatcher's policy takes effect. If however, the request for www.example.com/coming_soon/ encounters a 404, the policy in PathRule.customErrorResponsePolicy takes effect. If any of the requests in this example encounter a 500 error code, the policy at UrlMap.defaultCustomErrorResponsePolicy takes effect.                  
+                  
+                  If the request is for www.myotherdomain.com and a 404 is encountered, the policy under UrlMap.defaultCustomErrorResponsePolicy takes effect. If a 404 response is encountered for the request www.example.com/current_events/, the pathMatcher's policy takes effect. If however, the request for www.example.com/coming_soon/ encounters a 404, the policy in PathRule.customErrorResponsePolicy takes effect. If any of the requests in this example encounter a 500 error code, the policy at UrlMap.defaultCustomErrorResponsePolicy takes effect.
                   customErrorResponsePolicy is supported only for global external Application Load Balancers.
                 properties:
                   - !ruby/object:Api::Type::Array
@@ -2083,10 +2087,10 @@ properties:
             - !ruby/object:Api::Type::String
               name: 'path'
               description: |
-                The full path to a file within backendBucket . For example: /errors/defaultError.html
+                The full path to a file within backendBucket. For example: /errors/defaultError.html
                 path must start with a leading slash. path cannot have trailing slashes.
                 If the file is not available in backendBucket or the load balancer cannot reach the BackendBucket, a simple Not Found Error is returned to the client.
-                The value must be from 1 to 1024 characters
+                The value must be from 1 to 1024 characters.
             - !ruby/object:Api::Type::Integer
               name: 'overrideResponseCode'
               description: |

--- a/mmv1/products/compute/UrlMap.yaml
+++ b/mmv1/products/compute/UrlMap.yaml
@@ -2062,7 +2062,7 @@ properties:
       defaultCustomErrorResponsePolicy is supported only for global external Application Load Balancers.
     properties:
       - !ruby/object:Api::Type::Array
-        name: 'error_response_rule'
+        name: 'errorResponseRule'
         api_name: errorResponseRules
         description: |
           Specifies rules for returning error responses.

--- a/mmv1/products/compute/UrlMap.yaml
+++ b/mmv1/products/compute/UrlMap.yaml
@@ -124,6 +124,16 @@ examples:
       http_health_check_name: "health-check"
       backend_bucket_name: "static-asset-backend-bucket"
       storage_bucket_name: "static-asset-bucket"
+  - !ruby/object:Provider::Terraform::Examples
+    name: "url_map_custom_error_response_policy"
+    primary_resource_id: "urlmap"
+    min_version: beta
+    vars:
+      url_map_name: "urlmap"
+      backend_service_name: "login"
+      http_health_check_name: "health-check"
+      storage_bucket_name: "static-asset-bucket"
+      error_backend_bucket_name: "error-backend-bucket"
 properties:
   - !ruby/object:Api::Type::Time
     name: 'creationTimestamp'
@@ -305,6 +315,70 @@ properties:
             An optional description of this resource. Provide this property when you create
             the resource.
         - !ruby/object:Api::Type::NestedObject
+          name: 'defaultCustomErrorResponsePolicy'
+          min_version: beta
+          description: |
+            defaultCustomErrorResponsePolicy specifies how the Load Balancer returns error responses when BackendServiceor BackendBucket responds with an error.
+
+            This policy takes effect at the PathMatcher level and applies only when no policy has been defined for the error code at lower levels like RouteRule and PathRule within this PathMatcher. If an error code does not have a policy defined in defaultCustomErrorResponsePolicy, then a policy defined for the error code in UrlMap.defaultCustomErrorResponsePolicy takes effect.
+
+            For example, consider a UrlMap with the following configuration:
+
+            UrlMap.defaultCustomErrorResponsePolicy is configured with policies for 5xx and 4xx errors
+            A RouteRule for /coming_soon/ is configured for the error code 404.
+            If the request is for www.myotherdomain.com and a 404 is encountered, the policy under UrlMap.defaultCustomErrorResponsePolicy takes effect. If a 404 response is encountered for the request www.example.com/current_events/, the pathMatcher's policy takes effect. If however, the request for www.example.com/coming_soon/ encounters a 404, the policy in RouteRule.customErrorResponsePolicy takes effect. If any of the requests in this example encounter a 500 error code, the policy at UrlMap.defaultCustomErrorResponsePolicy takes effect.
+
+            When used in conjunction with pathMatcher.defaultRouteAction.retryPolicy, retries take precedence. Only once all retries are exhausted, the defaultCustomErrorResponsePolicy is applied. While attempting a retry, if load balancer is successful in reaching the service, the defaultCustomErrorResponsePolicy is ignored and the response from the service is returned to the client.
+
+            defaultCustomErrorResponsePolicy is supported only for global external Application Load Balancers.
+          properties:
+            - !ruby/object:Api::Type::Array
+              name: 'error_response_rule'
+              api_name: errorResponseRules
+              description: |
+                Specifies rules for returning error responses.
+                In a given policy, if you specify rules for both a range of error codes as well as rules for specific error codes then rules with specific error codes have a higher priority. 
+                For example, assume that you configure a rule for 401 (Un-authorized) code, and another for all 4 series error codes (4XX). 
+                If the backend service returns a 401, then the rule for 401 will be applied. However if the backend service returns a 403, the rule for 4xx takes effect.
+              item_type: !ruby/object:Api::Type::NestedObject
+                properties:
+                  - !ruby/object:Api::Type::Array
+                    name: 'matchResponseCodes'
+                    description: |
+                      Valid values include:
+
+                      - A number between 400 and 599: For example 401 or 503, in which case the load balancer applies the policy if the error code exactly matches this value.
+                      - 5xx: Load Balancer will apply the policy if the backend service responds with any response code in the range of 500 to 599.
+                      - 4xx: Load Balancer will apply the policy if the backend service responds with any response code in the range of 400 to 499.
+                      
+                      Values must be unique within matchResponseCodes and across all errorResponseRules of CustomErrorResponsePolicy.
+                    item_type: Api::Type::String
+                  - !ruby/object:Api::Type::String
+                    name: 'path'
+                    description: |
+                      The full path to a file within backendBucket . For example: /errors/defaultError.html
+                      path must start with a leading slash. path cannot have trailing slashes.
+                      If the file is not available in backendBucket or the load balancer cannot reach the BackendBucket, a simple Not Found Error is returned to the client.
+                      The value must be from 1 to 1024 characters
+                  - !ruby/object:Api::Type::Integer
+                    name: 'overrideResponseCode'
+                    description: |
+                      The HTTP status code returned with the response containing the custom error content. 
+                      If overrideResponseCode is not supplied, the same response code returned by the original backend bucket or backend service is returned to the client.
+            - !ruby/object:Api::Type::ResourceRef
+              name: 'errorService'
+              resource: 'BackendBucket'
+              imports: 'selfLink'
+              description: |
+                The full or partial URL to the BackendBucket resource that contains the custom error content. Examples are:
+
+                https://www.googleapis.com/compute/v1/projects/project/global/backendBuckets/myBackendBucket
+                compute/v1/projects/project/global/backendBuckets/myBackendBucket
+                global/backendBuckets/myBackendBucket
+                
+                If errorService is not specified at lower levels like pathMatcher, pathRule and routeRule, an errorService specified at a higher level in the UrlMap will be used. If UrlMap.defaultCustomErrorResponsePolicy contains one or more errorResponseRules[], it must specify errorService.
+                If load balancer cannot reach the backendBucket, a simple Not Found Error will be returned, with the original response code (or overrideResponseCode if configured).
+        - !ruby/object:Api::Type::NestedObject
           name: 'headerAction'
           description: |
             Specifies changes to request and response headers that need to take effect for
@@ -403,6 +477,66 @@ properties:
                   \* is allowed is at the end following a /. The string fed to the path matcher
                   does not include any text after the first ? or #, and those chars are not
                   allowed here.
+              - !ruby/object:Api::Type::NestedObject
+                name: 'customErrorResponsePolicy'
+                min_version: beta
+                description: |
+                  customErrorResponsePolicy specifies how the Load Balancer returns error responses when BackendServiceor BackendBucket responds with an error.
+                  If a policy for an error code is not configured for the PathRule, a policy for the error code configured in pathMatcher.defaultCustomErrorResponsePolicy is applied. If one is not specified in pathMatcher.defaultCustomErrorResponsePolicy, the policy configured in UrlMap.defaultCustomErrorResponsePolicy takes effect.      
+                  For example, consider a UrlMap with the following configuration:
+                    
+                  UrlMap.defaultCustomErrorResponsePolicy are configured with policies for 5xx and 4xx errors
+                  A PathRule for /coming_soon/ is configured for the error code 404.
+                  If the request is for www.myotherdomain.com and a 404 is encountered, the policy under UrlMap.defaultCustomErrorResponsePolicy takes effect. If a 404 response is encountered for the request www.example.com/current_events/, the pathMatcher's policy takes effect. If however, the request for www.example.com/coming_soon/ encounters a 404, the policy in PathRule.customErrorResponsePolicy takes effect. If any of the requests in this example encounter a 500 error code, the policy at UrlMap.defaultCustomErrorResponsePolicy takes effect.
+                  
+                  customErrorResponsePolicy is supported only for global external Application Load Balancers.
+                properties:
+                  - !ruby/object:Api::Type::Array
+                    name: 'error_response_rule'
+                    api_name: errorResponseRules
+                    description: |
+                      Specifies rules for returning error responses.
+                      In a given policy, if you specify rules for both a range of error codes as well as rules for specific error codes then rules with specific error codes have a higher priority. 
+                      For example, assume that you configure a rule for 401 (Un-authorized) code, and another for all 4 series error codes (4XX). 
+                      If the backend service returns a 401, then the rule for 401 will be applied. However if the backend service returns a 403, the rule for 4xx takes effect.
+                    item_type: !ruby/object:Api::Type::NestedObject
+                      properties:
+                        - !ruby/object:Api::Type::Array
+                          name: 'matchResponseCodes'
+                          description: |
+                            Valid values include:
+
+                            - A number between 400 and 599: For example 401 or 503, in which case the load balancer applies the policy if the error code exactly matches this value.
+                            - 5xx: Load Balancer will apply the policy if the backend service responds with any response code in the range of 500 to 599.
+                            - 4xx: Load Balancer will apply the policy if the backend service responds with any response code in the range of 400 to 499.
+
+                            Values must be unique within matchResponseCodes and across all errorResponseRules of CustomErrorResponsePolicy.
+                          item_type: Api::Type::String
+                        - !ruby/object:Api::Type::String
+                          name: 'path'
+                          description: |
+                            The full path to a file within backendBucket . For example: /errors/defaultError.html
+                            path must start with a leading slash. path cannot have trailing slashes.
+                            If the file is not available in backendBucket or the load balancer cannot reach the BackendBucket, a simple Not Found Error is returned to the client.
+                            The value must be from 1 to 1024 characters
+                        - !ruby/object:Api::Type::Integer
+                          name: 'overrideResponseCode'
+                          description: |
+                            The HTTP status code returned with the response containing the custom error content. 
+                            If overrideResponseCode is not supplied, the same response code returned by the original backend bucket or backend service is returned to the client.
+                  - !ruby/object:Api::Type::ResourceRef
+                    name: "errorService"
+                    resource: "BackendBucket"
+                    imports: 'selfLink'
+                    description: |
+                      The full or partial URL to the BackendBucket resource that contains the custom error content. Examples are:
+
+                      https://www.googleapis.com/compute/v1/projects/project/global/backendBuckets/myBackendBucket
+                      compute/v1/projects/project/global/backendBuckets/myBackendBucket
+                      global/backendBuckets/myBackendBucket
+
+                      If errorService is not specified at lower levels like pathMatcher, pathRule and routeRule, an errorService specified at a higher level in the UrlMap will be used. If UrlMap.defaultCustomErrorResponsePolicy contains one or more errorResponseRules[], it must specify errorService.
+                      If load balancer cannot reach the backendBucket, a simple Not Found Error will be returned, with the original response code (or overrideResponseCode if configured).
               - !ruby/object:Api::Type::NestedObject
                 name: 'routeAction'
                 description: |
@@ -1915,6 +2049,70 @@ properties:
                         The value must be between 0.0 and 100.0 inclusive.
                       validation: !ruby/object:Provider::Terraform::Validation
                         function: 'validation.FloatBetween(0, 100)'
+  - !ruby/object:Api::Type::NestedObject
+    name: 'defaultCustomErrorResponsePolicy'
+    min_version: beta
+    description: |
+      defaultCustomErrorResponsePolicy specifies how the Load Balancer returns error responses when BackendServiceor BackendBucket responds with an error.
+
+      This policy takes effect at the PathMatcher level and applies only when no policy has been defined for the error code at lower levels like RouteRule and PathRule within this PathMatcher. If an error code does not have a policy defined in defaultCustomErrorResponsePolicy, then a policy defined for the error code in UrlMap.defaultCustomErrorResponsePolicy takes effect.
+
+      For example, consider a UrlMap with the following configuration:
+
+      UrlMap.defaultCustomErrorResponsePolicy is configured with policies for 5xx and 4xx errors
+      A RouteRule for /coming_soon/ is configured for the error code 404.
+      If the request is for www.myotherdomain.com and a 404 is encountered, the policy under UrlMap.defaultCustomErrorResponsePolicy takes effect. If a 404 response is encountered for the request www.example.com/current_events/, the pathMatcher's policy takes effect. If however, the request for www.example.com/coming_soon/ encounters a 404, the policy in RouteRule.customErrorResponsePolicy takes effect. If any of the requests in this example encounter a 500 error code, the policy at UrlMap.defaultCustomErrorResponsePolicy takes effect.
+
+      When used in conjunction with pathMatcher.defaultRouteAction.retryPolicy, retries take precedence. Only once all retries are exhausted, the defaultCustomErrorResponsePolicy is applied. While attempting a retry, if load balancer is successful in reaching the service, the defaultCustomErrorResponsePolicy is ignored and the response from the service is returned to the client.
+
+      defaultCustomErrorResponsePolicy is supported only for global external Application Load Balancers.
+    properties:
+      - !ruby/object:Api::Type::Array
+        name: 'error_response_rule'
+        api_name: errorResponseRules
+        description: |
+          Specifies rules for returning error responses.
+          In a given policy, if you specify rules for both a range of error codes as well as rules for specific error codes then rules with specific error codes have a higher priority. 
+          For example, assume that you configure a rule for 401 (Un-authorized) code, and another for all 4 series error codes (4XX). 
+          If the backend service returns a 401, then the rule for 401 will be applied. However if the backend service returns a 403, the rule for 4xx takes effect.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::Array
+              name: 'matchResponseCodes'
+              description: |
+                Valid values include:
+
+                - A number between 400 and 599: For example 401 or 503, in which case the load balancer applies the policy if the error code exactly matches this value.
+                - 5xx: Load Balancer will apply the policy if the backend service responds with any response code in the range of 500 to 599.
+                - 4xx: Load Balancer will apply the policy if the backend service responds with any response code in the range of 400 to 499.
+
+                Values must be unique within matchResponseCodes and across all errorResponseRules of CustomErrorResponsePolicy.
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::String
+              name: 'path'
+              description: |
+                The full path to a file within backendBucket . For example: /errors/defaultError.html
+                path must start with a leading slash. path cannot have trailing slashes.
+                If the file is not available in backendBucket or the load balancer cannot reach the BackendBucket, a simple Not Found Error is returned to the client.
+                The value must be from 1 to 1024 characters
+            - !ruby/object:Api::Type::Integer
+              name: 'overrideResponseCode'
+              description: |
+                The HTTP status code returned with the response containing the custom error content. 
+                If overrideResponseCode is not supplied, the same response code returned by the original backend bucket or backend service is returned to the client.
+      - !ruby/object:Api::Type::ResourceRef
+        name: "errorService"
+        resource: "BackendBucket"
+        imports: 'selfLink'
+        description: |
+          The full or partial URL to the BackendBucket resource that contains the custom error content. Examples are:
+
+          https://www.googleapis.com/compute/v1/projects/project/global/backendBuckets/myBackendBucket
+          compute/v1/projects/project/global/backendBuckets/myBackendBucket
+          global/backendBuckets/myBackendBucket
+
+          If errorService is not specified at lower levels like pathMatcher, pathRule and routeRule, an errorService specified at a higher level in the UrlMap will be used. If UrlMap.defaultCustomErrorResponsePolicy contains one or more errorResponseRules[], it must specify errorService.
+          If load balancer cannot reach the backendBucket, a simple Not Found Error will be returned, with the original response code (or overrideResponseCode if configured).
   - !ruby/object:Api::Type::Array
     name: "test"
     api_name: tests

--- a/mmv1/templates/terraform/examples/url_map_custom_error_response_policy.tf.erb
+++ b/mmv1/templates/terraform/examples/url_map_custom_error_response_policy.tf.erb
@@ -1,0 +1,86 @@
+resource "google_compute_url_map" "<%= ctx[:primary_resource_id] %>" {
+  provider    = google-beta
+  name        = "<%= ctx[:vars]['url_map_name'] %>"
+  description = "a description"
+
+  default_service = google_compute_backend_service.example.id
+
+  default_custom_error_response_policy {
+    error_response_rule {
+      match_response_codes = ["5xx"] # All 5xx responses will be catched
+      path = "/*"
+      override_response_code = 502
+    }
+    error_service = google_compute_backend_bucket.error.id
+  }
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "mysite"
+  }
+
+  path_matcher {
+    name            = "mysite"
+    default_service = google_compute_backend_service.example.id
+
+    default_custom_error_response_policy {
+      error_response_rule {
+        match_response_codes = ["4xx", "5xx"] # All 4xx and 5xx responses will be catched on path login
+        path = "/login"
+        override_response_code = 404
+      }
+      error_response_rule {
+        match_response_codes = ["503"] # Only a 503 response will be catched on path example
+        path = "/example"
+        override_response_code = 502
+      }
+      error_service = google_compute_backend_bucket.error.id
+    }
+
+    path_rule {
+      paths   = ["/*"]
+      service = google_compute_backend_service.example.id
+
+      custom_error_response_policy {
+        error_response_rule {
+          match_response_codes = ["4xx"]
+          path = "/register"
+          override_response_code = 401
+        }
+        error_service = google_compute_backend_bucket.error.id
+      }
+    }
+  }
+}
+
+resource "google_compute_backend_service" "example" {
+  provider    = google-beta
+  name        = "<%= ctx[:vars]['backend_service_name'] %>"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+
+  health_checks = [google_compute_http_health_check.default.id]
+}
+
+resource "google_compute_http_health_check" "default" {
+  provider           = google-beta
+  name               = "<%= ctx[:vars]['http_health_check_name'] %>"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+resource "google_compute_backend_bucket" "error" {
+  provider    = google-beta
+  name        = "<%= ctx[:vars]['error_backend_bucket_name'] %>"
+  bucket_name = google_storage_bucket.error.name
+  enable_cdn  = true
+}
+
+resource "google_storage_bucket" "error" {
+  provider    = google-beta
+  name        = "<%= ctx[:vars]['storage_bucket_name'] %>"
+  location    = "US"
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_url_map_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_url_map_test.go.erb
@@ -362,6 +362,7 @@ func TestAccComputeUrlMap_defaultUrlRedirect(t *testing.T) {
 	})
 }
 
+<% unless version == 'ga' -%>
 func TestAccComputeUrlMap_urlMapCustomErrorResponsePolicyUpdate(t *testing.T) {
 	t.Parallel()
 
@@ -395,6 +396,7 @@ func TestAccComputeUrlMap_urlMapCustomErrorResponsePolicyUpdate(t *testing.T) {
 		},
 	})
 }
+<% end -%>
 
 func testAccComputeUrlMap_basic1(bsName, hcName, umName string) string {
 	return fmt.Sprintf(`
@@ -1720,6 +1722,7 @@ resource "google_compute_url_map" "foobar" {
 `, randomSuffix)
 }
 
+<% unless version == 'ga' -%>
 func testAccComputeUrlMap_urlMapCustomErrorResponsePolicy(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_url_map" "urlmap" {
@@ -1810,7 +1813,9 @@ resource "google_storage_bucket" "error" {
 }
 `, context)
 }
+<% end -%>
 
+<% unless version == 'ga' -%>
 func testAccComputeUrlMap_urlMapCustomErrorResponsePolicyUpdate(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_url_map" "urlmap" {
@@ -1905,3 +1910,4 @@ resource "google_storage_bucket" "error" {
 }
 `, context)
 }
+<% end -%>

--- a/mmv1/third_party/terraform/services/compute/resource_compute_url_map_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_url_map_test.go.erb
@@ -349,7 +349,6 @@ func TestAccComputeUrlMap_defaultUrlRedirect(t *testing.T) {
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckComputeUrlMapDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccComputeUrlMap_defaultUrlRedirectConfig(randomSuffix),
@@ -358,6 +357,40 @@ func TestAccComputeUrlMap_defaultUrlRedirect(t *testing.T) {
 				ResourceName:      "google_compute_url_map.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeUrlMap_urlMapCustomErrorResponsePolicyUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckComputeUrlMapDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeUrlMap_urlMapCustomErrorResponsePolicy(context),
+			},
+			{
+				ResourceName:            "google_compute_url_map.urlmap",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"default_service"},
+			},
+			{
+				Config: testAccComputeUrlMap_urlMapCustomErrorResponsePolicyUpdate(context),
+			},
+			{
+				ResourceName:            "google_compute_url_map.urlmap",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"default_service"},
 			},
 		},
 	})
@@ -1685,4 +1718,190 @@ resource "google_compute_url_map" "foobar" {
   }
 }
 `, randomSuffix)
+}
+
+func testAccComputeUrlMap_urlMapCustomErrorResponsePolicy(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_url_map" "urlmap" {
+  provider    = google-beta
+  name        = "urlmap%{random_suffix}"
+  description = "a description"
+
+  default_service = google_compute_backend_service.example.id
+
+  default_custom_error_response_policy {
+    error_response_rule {
+      match_response_codes = ["5xx"] # All 5xx responses will be catched
+      path = "/*"
+      override_response_code = 502
+    }
+    error_service = google_compute_backend_bucket.error.id
+  }
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "mysite"
+  }
+
+  path_matcher {
+    name            = "mysite"
+    default_service = google_compute_backend_service.example.id
+
+    default_custom_error_response_policy {
+      error_response_rule {
+        match_response_codes = ["4xx", "5xx"] # All 4xx and 5xx responses will be catched on path login
+        path = "/login"
+        override_response_code = 404
+      }
+      error_response_rule {
+        match_response_codes = ["503"] # Only a 503 response will be catched on path example
+        path = "/example"
+        override_response_code = 502
+      }
+      error_service = google_compute_backend_bucket.error.id
+    }
+
+    path_rule {
+      paths   = ["/*"]
+      service = google_compute_backend_service.example.id
+
+      custom_error_response_policy {
+        error_response_rule {
+          match_response_codes = ["4xx"]
+          path = "/register"
+          override_response_code = 401
+        }
+        error_service = google_compute_backend_bucket.error.id
+      }
+    }
+  }
+}
+
+resource "google_compute_backend_service" "example" {
+  provider    = google-beta
+  name        = "login%{random_suffix}"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+
+  health_checks = [google_compute_http_health_check.default.id]
+}
+
+resource "google_compute_http_health_check" "default" {
+  provider           = google-beta
+  name               = "tf-test-health-check%{random_suffix}"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+resource "google_compute_backend_bucket" "error" {
+  provider    = google-beta
+  name        = "tf-test-error-backend-bucket%{random_suffix}"
+  bucket_name = google_storage_bucket.error.name
+  enable_cdn  = true
+}
+
+resource "google_storage_bucket" "error" {
+  provider    = google-beta
+  name        = "tf-test-static-asset-bucket%{random_suffix}"
+  location    = "US"
+}
+`, context)
+}
+
+func testAccComputeUrlMap_urlMapCustomErrorResponsePolicyUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_url_map" "urlmap" {
+  provider    = google-beta
+  name        = "urlmap%{random_suffix}"
+  description = "a description"
+
+  default_service = google_compute_backend_service.example.id
+
+  default_custom_error_response_policy {
+    error_response_rule {
+      match_response_codes = ["5xx", "4xx"] # All 5xx responses will be catched
+      path = "/test/*"
+      override_response_code = 503
+    }
+    error_service = google_compute_backend_bucket.error.id
+  }
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "mysite"
+  }
+
+  path_matcher {
+    name            = "mysite"
+    default_service = google_compute_backend_service.example.id
+
+    default_custom_error_response_policy {
+      error_response_rule {
+        match_response_codes = ["5xx"] # All 4xx and 5xx responses will be catched on path login
+        path = "/*"
+        override_response_code = 502
+      }
+      error_response_rule {
+        match_response_codes = ["4xx"] # Only a 503 response will be catched on path example
+        path = "/example/test"
+        override_response_code = 400
+      }
+      error_service = google_compute_backend_bucket.error.id
+    }
+
+    path_rule {
+      paths   = ["/*"]
+      service = google_compute_backend_service.example.id
+
+      custom_error_response_policy {
+        error_response_rule {
+          match_response_codes = ["5xx"]
+          path = "/register/example/*"
+          override_response_code = 403
+        }
+        error_service = google_compute_backend_bucket.error.id
+      }
+    }
+  }
+}
+
+resource "google_compute_backend_service" "example" {
+  provider    = google-beta
+  name        = "login%{random_suffix}"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+
+  health_checks = [google_compute_http_health_check.default.id]
+}
+
+resource "google_compute_http_health_check" "default" {
+  provider           = google-beta
+  name               = "tf-test-health-check%{random_suffix}"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+resource "google_compute_backend_bucket" "error" {
+  provider    = google-beta
+  name        = "tf-test-error-backend-bucket-2%{random_suffix}"
+  bucket_name = google_storage_bucket.error.name
+  enable_cdn  = true
+
+	lifecycle {
+		create_before_destroy = true
+	}
+}
+
+resource "google_storage_bucket" "error" {
+  provider    = google-beta
+  name        = "tf-test-static-asset-bucket-2%{random_suffix}"
+  location    = "US"
+}
+`, context)
 }


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/18200

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added fields `customErrorResponsePolicy` and `defaultErrorResponsePolicy` to the `google_compute_url_map` resource
```
