### PR TITLE
Bitbucket support for cloudbuild repos

### DIFF
--- a/mmv1/products/cloudbuildv2/Connection.yaml
+++ b/mmv1/products/cloudbuildv2/Connection.yaml
@@ -26,7 +26,7 @@ async: !ruby/object:Api::OpAsync
     base_url: '{{op_id}}'
 update_verb: :PATCH
 description: |
-  A connection to a SCM like GitHub, GitHub Enterprise, Bitbucket Data Center or GitLab.
+  A connection to a SCM like GitHub, GitHub Enterprise, Bitbucket Data Center/Cloud or GitLab.
 exclude_tgc: true
 legacy_long_form_project: true
 iam_policy: !ruby/object:Api::Resource::IamPolicy
@@ -84,6 +84,8 @@ properties:
     conflicts:
       - 'github_enterprise_config'
       - 'gitlab_config'
+      - 'bitbucket_cloud_config'
+      - 'bitbucket_data_center_config'
     properties:
       - !ruby/object:Api::Type::NestedObject
         name: authorizerCredential
@@ -105,6 +107,8 @@ properties:
     conflicts:
       - 'github_config'
       - 'gitlab_config'
+      - 'bitbucket_cloud_config'
+      - 'bitbucket_data_center_config'
     description: Configuration for connections to an instance of GitHub Enterprise.
     properties:
       - !ruby/object:Api::Type::String
@@ -145,6 +149,8 @@ properties:
     conflicts:
       - 'github_config'
       - 'github_enterprise_config'
+      - 'bitbucket_cloud_config'
+      - 'bitbucket_data_center_config'
     description: Configuration for connections to gitlab.com or an instance of GitLab Enterprise.
     properties:
       - !ruby/object:Api::Type::String
@@ -201,6 +207,116 @@ properties:
         name: serverVersion
         description: Output only. Version of the GitLab Enterprise server running on the `host_uri`.
         output: true
+  - !ruby/object:Api::Type::NestedObject
+    name: bitbucketDataCenterConfig
+    conflicts:
+      - 'github_config'
+      - 'github_enterprise_config'
+      - 'bitbucket_cloud_config'
+      - 'gitlab_config'
+    description: Configuration for connections to Bitbucket Data Center.
+    properties:
+      - !ruby/object:Api::Type::String
+        name: hostUri
+        description: The URI of the Bitbucket Data Center host this connection is for.
+        required: true
+      - !ruby/object:Api::Type::String
+        name: webhookSecretSecretVersion
+        description: Required. Immutable. SecretManager resource containing the webhook secret used to verify webhook events, formatted as `projects/*/secrets/*/versions/*`.
+        required: true
+        immutable: true
+        diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+      - !ruby/object:Api::Type::NestedObject
+        name: readAuthorizerCredential
+        description: Required. A http access token with the `REPO_READ` access.
+        required: true
+        properties:
+          - !ruby/object:Api::Type::String
+            name: userTokenSecretVersion
+            description: 'Required. A SecretManager resource containing the user token that authorizes the Cloud Build connection. Format: `projects/*/secrets/*/versions/*`.'
+            required: true
+            diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+          - !ruby/object:Api::Type::String
+            name: username
+            description: Output only. The username associated to this token.
+            output: true
+      - !ruby/object:Api::Type::NestedObject
+        name: authorizerCredential
+        description: Required. A http access token with the `REPO_ADMIN` scope access.
+        required: true
+        properties:
+          - !ruby/object:Api::Type::String
+            name: userTokenSecretVersion
+            description: 'Required. A SecretManager resource containing the user token that authorizes the Cloud Build connection. Format: `projects/*/secrets/*/versions/*`.'
+            required: true
+            diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+          - !ruby/object:Api::Type::String
+            name: username
+            description: Output only. The username associated to this token.
+            output: true
+      - !ruby/object:Api::Type::NestedObject
+        name: serviceDirectoryConfig
+        description: Configuration for using Service Directory to privately connect to a Bitbucket Data Center. This should only be set if the Bitbucket Data Center is hosted on-premises and not reachable by public internet. If this field is left empty, calls to the Bitbucket Data Center will be made over the public internet.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: service
+            description: 'Required. The Service Directory service name. Format: projects/{project}/locations/{location}/namespaces/{namespace}/services/{service}.'
+            required: true
+            diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+      - !ruby/object:Api::Type::String
+        name: sslCa
+        description: SSL certificate to use for requests to the Bitbucket Data Center.
+      - !ruby/object:Api::Type::String
+        name: serverVersion
+        description: Output only. Version of the Bitbucket Data Center running on the `host_uri`.
+        output: true
+  - !ruby/object:Api::Type::NestedObject
+    name: bitbucketCloudConfig
+    conflicts:
+      - 'github_config'
+      - 'github_enterprise_config'
+      - 'gitlab_config'
+      - 'bitbucket_data_center_config'
+    description: Configuration for connections to Bitbucket Cloud.
+    properties:
+      - !ruby/object:Api::Type::String
+        name: workspace
+        description: The Bitbucket Cloud Workspace ID to be connected to Google Cloud Platform.
+        required: true
+      - !ruby/object:Api::Type::String
+        name: webhookSecretSecretVersion
+        description: Required. Immutable. SecretManager resource containing the webhook secret used to verify webhook events, formatted as `projects/*/secrets/*/versions/*`.
+        required: true
+        immutable: true
+        diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+      - !ruby/object:Api::Type::NestedObject
+        name: readAuthorizerCredential
+        description: Required. An access token with the `repository` access. It can be either a workspace, project or repository access token. It's recommended to use a system account to generate the credentials.
+        required: true
+        properties:
+          - !ruby/object:Api::Type::String
+            name: userTokenSecretVersion
+            description: 'Required. A SecretManager resource containing the user token that authorizes the Cloud Build connection. Format: `projects/*/secrets/*/versions/*`.'
+            required: true
+            diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+          - !ruby/object:Api::Type::String
+            name: username
+            description: Output only. The username associated to this token.
+            output: true
+      - !ruby/object:Api::Type::NestedObject
+        name: authorizerCredential
+        description: Required. An access token with the `webhook`, `repository`, `repository:admin` and `pullrequest` scope access. It can be either a workspace, project or repository access token. It's recommended to use a system account to generate these credentials.
+        required: true
+        properties:
+          - !ruby/object:Api::Type::String
+            name: userTokenSecretVersion
+            description: 'Required. A SecretManager resource containing the user token that authorizes the Cloud Build connection. Format: `projects/*/secrets/*/versions/*`.'
+            required: true
+            diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+          - !ruby/object:Api::Type::String
+            name: username
+            description: Output only. The username associated to this token.
+            output: true
   - !ruby/object:Api::Type::NestedObject
     name: installationState
     description: Output only. Installation state of the Connection.

--- a/mmv1/third_party/terraform/services/cloudbuildv2/resource_cloudbuildv2_connection_test.go
+++ b/mmv1/third_party/terraform/services/cloudbuildv2/resource_cloudbuildv2_connection_test.go
@@ -825,7 +825,6 @@ resource "google_cloudbuildv2_connection" "primary" {
 `, context)
 }
 
-
 func testAccCloudbuildv2Connection_BbcConnection(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_cloudbuildv2_connection" "primary" {

--- a/mmv1/third_party/terraform/services/cloudbuildv2/resource_cloudbuildv2_connection_test.go
+++ b/mmv1/third_party/terraform/services/cloudbuildv2/resource_cloudbuildv2_connection_test.go
@@ -327,6 +327,93 @@ func TestAccCloudbuildv2Connection_GlePrivUpdateConnection(t *testing.T) {
 	})
 }
 
+func TestAccCloudbuildv2Connection_BbdcPrivConnection(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project_name":  envvar.GetTestProjectFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckCloudbuildv2ConnectionDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudbuildv2Connection_BbdcPrivConnection(context),
+			},
+			{
+				ResourceName:            "google_cloudbuildv2_connection.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations"},
+			},
+		},
+	})
+}
+
+func TestAccCloudbuildv2Connection_BbdcPrivUpdateConnection(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project_name":  envvar.GetTestProjectFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckCloudbuildv2ConnectionDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudbuildv2Connection_BbdcConnection(context),
+			},
+			{
+				ResourceName:            "google_cloudbuildv2_connection.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations"},
+			},
+			{
+				Config: testAccCloudbuildv2Connection_BbdcPrivConnection(context),
+			},
+			{
+				ResourceName:            "google_cloudbuildv2_connection.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations"},
+			},
+		},
+	})
+}
+
+func TestAccCloudbuildv2Connection_BbcConnection(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project_name":  envvar.GetTestProjectFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckCloudbuildv2ConnectionDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudbuildv2Connection_BbcConnection(context),
+			},
+			{
+				ResourceName:            "google_cloudbuildv2_connection.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations"},
+			},
+		},
+	})
+}
+
 func testAccCloudbuildv2Connection_GheCompleteConnection(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_cloudbuildv2_connection" "primary" {
@@ -668,6 +755,94 @@ resource "google_cloudbuildv2_connection" "primary" {
     }
 
     ssl_ca = "-----BEGIN CERTIFICATE-----\nMIIDcTCCAlmgAwIBAgIUbxJ3jxaRf5IPcUiQWRPRqpLL4s4wDQYJKoZIhvcNAQEL\nBQAwTjELMAkGA1UEBhMCVVMxGzAZBgNVBAoMEkdvb2dsZSBDbG91ZCBCdWlsZDEi\nMCAGA1UEAwwZZ2xlLXVzLmdsZS11cy1wcml2YXRlLmNvbTAeFw0yMzEwMjAxNjQ3\nNDJaFw0yNDEwMTkxNjQ3NDJaME4xCzAJBgNVBAYTAlVTMRswGQYDVQQKDBJHb29n\nbGUgQ2xvdWQgQnVpbGQxIjAgBgNVBAMMGWdsZS11cy5nbGUtdXMtcHJpdmF0ZS5j\nb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDRE84wKcuzc+beQ323\nIsNVVOF1+WZ975LvXpIt8Mw1bcYeYUcvgBXSXAByHGMtef8OBb9BUvLOVZdT3Xow\nCUbhCiK3zQy29pCn0rsneIvzGUXQgQRXK/Zap1N/hif4E7CIgjuvCN0Mn6BfDV/H\nXFm6EV3YUJrRPBr1rZik7doaYYwaJshCSTBtZxXZdvsG/OBuAXbJ9GB0B62EiTBz\n5g6yRdATut+PbgfzaWlPsgL3TTH+HPNCMO+ULnFupfZwRCtV+dJng76QYGs8fmFo\ntiWeElcsU8W7aqmjOkKRWcFsHpxPNXp8GG+jsZrVAnMOR3QeRLvowysSQD99IrGH\nAhwlAgMBAAGjRzBFMCQGA1UdEQQdMBuCGWdsZS11cy5nbGUtdXMtcHJpdmF0ZS5j\nb20wHQYDVR0OBBYEFKCIp5BruT4fpeDFQ2bKgdUvpfbWMA0GCSqGSIb3DQEBCwUA\nA4IBAQAQ4pUQmmd7eNIu9MQGna9lHYRFL0/G3mrK6Dcfm2As9qdcRw3dph8/iute\nxKDdBsnt6jDHrsjN0Na7Eq0040oBJrxG/NtqGX0zHNdpAT61bQ6j9reAT+KOrHys\nDJXH2lPuFW183AU7mmvcbXTEwkKex1i+DNoEdGYUbBfnWWeuhGzFog+/f9mtjoHL\nplcmx0VWHBQ5KO9Aq4OR/86DSg5QRPk76W9k3cM2ShXMm3TmTBZ+taJFfjZo5jP+\n7PLt2z9grSvFSXh2jnMyAs2yP4c+WezOXZLijqROr378AGBaksQK0CP+CYjZRpn1\nvndr1njLbvSjIypwKgZROb4P6XVa\n-----END CERTIFICATE-----\n"
+  }
+
+  project     = "%{project_name}"
+  annotations = {}
+}
+
+
+`, context)
+}
+
+func testAccCloudbuildv2Connection_BbdcConnection(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_cloudbuildv2_connection" "primary" {
+  location = "us-west1"
+  name     = "tf-test-connection%{random_suffix}"
+
+  bitbucket_data_center_config {
+    authorizer_credential {
+      user_token_secret_version = "projects/407304063574/secrets/bbdc-api-token/versions/latest"
+    }
+
+    read_authorizer_credential {
+      user_token_secret_version = "projects/407304063574/secrets/bbdc-read-token/versions/latest"
+    }
+
+    webhook_secret_secret_version = "projects/407304063574/secrets/bbdc-webhook-secret/versions/latest"
+    host_uri                      = "https://bitbucket-us-central.gcb-test.com"
+  }
+
+  project     = "%{project_name}"
+  annotations = {}
+}
+
+
+`, context)
+}
+
+func testAccCloudbuildv2Connection_BbdcPrivConnection(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_cloudbuildv2_connection" "primary" {
+  location = "us-west1"
+  name     = "tf-test-connection%{random_suffix}"
+
+  bitbucket_data_center_config {
+    authorizer_credential {
+      user_token_secret_version = "projects/407304063574/secrets/private-bbdc-api-token/versions/1"
+    }
+
+    read_authorizer_credential {
+      user_token_secret_version = "projects/407304063574/secrets/private-bbdc-read-token/versions/1"
+    }
+
+    webhook_secret_secret_version = "projects/407304063574/secrets/bbdc-webhook-secret/versions/latest"
+    host_uri                      = "https://private-bitbucket.proctor-test.com"
+
+	service_directory_config {
+	  service = "projects/407304063574/locations/us-west1/namespaces/private-conn/services/private-bitbucket"
+	}
+
+	ssl_ca = "-----BEGIN CERTIFICATE-----\nMIIDjDCCAnSgAwIBAgIUBh5+3oeT1vmUSS5rSNaFfy6igSAwDQYJKoZIhvcNAQEL\nBQAwVzELMAkGA1UEBhMCVVMxGzAZBgNVBAoMEkdvb2dsZSBDbG91ZCBCdWlsZDEr\nMCkGA1UEAwwicHJpdmF0ZS1iaXRidWNrZXQucHJvY3Rvci10ZXN0LmNvbTAeFw0y\nMzEyMTIyMzI5NTlaFw0yNDEyMTEyMzI5NTlaMFcxCzAJBgNVBAYTAlVTMRswGQYD\nVQQKDBJHb29nbGUgQ2xvdWQgQnVpbGQxKzApBgNVBAMMInByaXZhdGUtYml0YnVj\na2V0LnByb2N0b3ItdGVzdC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK\nAoIBAQCNfMx4ImGD4imZR64RbmRtpUNmypDokx2/S9kgobmyNvBWeSgRVhOGHGbU\nUgyvENcEg803K8unwF2jF6sdGrocRnIdPpr2tUoViOM2Ss6ds+TD8a2kqBA6+hmQ\nOMJiEIirpGT3Mw1pYTpuLisfIeeuuYssoS5k18kFLZ+Mk6MUSAHCgC8EowUZLGBZ\nagh9OhrjpMSXyidv+2d7FKTh/k3BWffVkDXehjvWjcr47hSvQwqW5m773ewCq0uD\nwxUgO6MAAAxLJz15cjhfvk4ishgSqcp49IZrx+xsNCLbHjPVyGkrL2OhgFaGsQS/\nq6GkXYfJ1sJYrf5Xm1EXbZlQZzJPAgMBAAGjUDBOMC0GA1UdEQQmMCSCInByaXZh\ndGUtYml0YnVja2V0LnByb2N0b3ItdGVzdC5jb20wHQYDVR0OBBYEFISmuuTpHKMB\n+m1h62gEqg1ovC86MA0GCSqGSIb3DQEBCwUAA4IBAQAwIwR6pIum9EZyLtC438Q1\nEgH3SKqbdyMFCkFSBvr4WfFU6ja1pn5ZxzJWt5TRFlI9GMy7BupQrxJGebOiFuUC\noNJpc4QDt9a0/GKh48DGF7uKo9XK33p0v1ahq3ewNT/CUnHewQNX7aXXP1/rL+br\nZPA20XWURUTviMik7DdhaXKQv76K9coI3H74heeBUp+OHKgUkqA3D1QIGNRGOKos\n4z6MyBWVpMUIeJQGtIQBd9CY1hBN231iG1+hdOlOMwgyNVK2GS738r+HbngFo9v4\nh2I1HMUHVcHiPQLqwZ2/OTmTmF1aWCUbhnAvoisu20rHVcGnVIOqMrHYFzdGr3ZQ\n-----END CERTIFICATE-----\n"  
+  }
+
+  project     = "%{project_name}"
+  annotations = {}
+}
+
+
+`, context)
+}
+
+
+func testAccCloudbuildv2Connection_BbcConnection(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_cloudbuildv2_connection" "primary" {
+  location = "us-west1"
+  name     = "tf-test-connection%{random_suffix}"
+
+  bitbucket_cloud_config {
+	workspace                   = "proctor-test"
+    authorizer_credential {
+      user_token_secret_version = "projects/407304063574/secrets/bbc-api-token/versions/latest"
+    }
+
+    read_authorizer_credential {
+      user_token_secret_version = "projects/407304063574/secrets/bbc-read-token/versions/latest"
+    }
+
+    webhook_secret_secret_version = "projects/407304063574/secrets/bbdc-webhook-secret/versions/latest"
   }
 
   project     = "%{project_name}"

--- a/mmv1/third_party/terraform/services/cloudbuildv2/resource_cloudbuildv2_connection_test.go
+++ b/mmv1/third_party/terraform/services/cloudbuildv2/resource_cloudbuildv2_connection_test.go
@@ -810,9 +810,9 @@ resource "google_cloudbuildv2_connection" "primary" {
     webhook_secret_secret_version = "projects/407304063574/secrets/bbdc-webhook-secret/versions/latest"
     host_uri                      = "https://private-bitbucket.proctor-test.com"
 
-	service_directory_config {
-	  service = "projects/407304063574/locations/us-west1/namespaces/private-conn/services/private-bitbucket"
-	}
+  service_directory_config {
+    service = "projects/407304063574/locations/us-west1/namespaces/private-conn/services/private-bitbucket"
+  }
 
 	ssl_ca = "-----BEGIN CERTIFICATE-----\nMIIDjDCCAnSgAwIBAgIUBh5+3oeT1vmUSS5rSNaFfy6igSAwDQYJKoZIhvcNAQEL\nBQAwVzELMAkGA1UEBhMCVVMxGzAZBgNVBAoMEkdvb2dsZSBDbG91ZCBCdWlsZDEr\nMCkGA1UEAwwicHJpdmF0ZS1iaXRidWNrZXQucHJvY3Rvci10ZXN0LmNvbTAeFw0y\nMzEyMTIyMzI5NTlaFw0yNDEyMTEyMzI5NTlaMFcxCzAJBgNVBAYTAlVTMRswGQYD\nVQQKDBJHb29nbGUgQ2xvdWQgQnVpbGQxKzApBgNVBAMMInByaXZhdGUtYml0YnVj\na2V0LnByb2N0b3ItdGVzdC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK\nAoIBAQCNfMx4ImGD4imZR64RbmRtpUNmypDokx2/S9kgobmyNvBWeSgRVhOGHGbU\nUgyvENcEg803K8unwF2jF6sdGrocRnIdPpr2tUoViOM2Ss6ds+TD8a2kqBA6+hmQ\nOMJiEIirpGT3Mw1pYTpuLisfIeeuuYssoS5k18kFLZ+Mk6MUSAHCgC8EowUZLGBZ\nagh9OhrjpMSXyidv+2d7FKTh/k3BWffVkDXehjvWjcr47hSvQwqW5m773ewCq0uD\nwxUgO6MAAAxLJz15cjhfvk4ishgSqcp49IZrx+xsNCLbHjPVyGkrL2OhgFaGsQS/\nq6GkXYfJ1sJYrf5Xm1EXbZlQZzJPAgMBAAGjUDBOMC0GA1UdEQQmMCSCInByaXZh\ndGUtYml0YnVja2V0LnByb2N0b3ItdGVzdC5jb20wHQYDVR0OBBYEFISmuuTpHKMB\n+m1h62gEqg1ovC86MA0GCSqGSIb3DQEBCwUAA4IBAQAwIwR6pIum9EZyLtC438Q1\nEgH3SKqbdyMFCkFSBvr4WfFU6ja1pn5ZxzJWt5TRFlI9GMy7BupQrxJGebOiFuUC\noNJpc4QDt9a0/GKh48DGF7uKo9XK33p0v1ahq3ewNT/CUnHewQNX7aXXP1/rL+br\nZPA20XWURUTviMik7DdhaXKQv76K9coI3H74heeBUp+OHKgUkqA3D1QIGNRGOKos\n4z6MyBWVpMUIeJQGtIQBd9CY1hBN231iG1+hdOlOMwgyNVK2GS738r+HbngFo9v4\nh2I1HMUHVcHiPQLqwZ2/OTmTmF1aWCUbhnAvoisu20rHVcGnVIOqMrHYFzdGr3ZQ\n-----END CERTIFICATE-----\n"  
   }
@@ -832,7 +832,7 @@ resource "google_cloudbuildv2_connection" "primary" {
   name     = "tf-test-connection%{random_suffix}"
 
   bitbucket_cloud_config {
-	workspace                   = "proctor-test"
+  workspace = "proctor-test"
     authorizer_credential {
       user_token_secret_version = "projects/407304063574/secrets/bbc-api-token/versions/latest"
     }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adding CloudBuild Repos TF Support for Bitbucket Cloud and Bitbucket Data Center 

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:note
cloudbuildv2: added support for connecting to Bitbucket Data Center and Bitbucket Cloud with the `bitbucket_data_center_config` and `bitbucket_cloud_config` fields in `google_cloudbuildv2_connection`
```
