### PR TITLE
Update go-plus to use Terraform 1.8.3

### DIFF
--- a/.ci/containers/go-plus/Dockerfile
+++ b/.ci/containers/go-plus/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN wget https://releases.hashicorp.com/terraform/1.2.5/terraform_1.2.5_linux_amd64.zip \
-    && unzip terraform_1.2.5_linux_amd64.zip \
-    && rm terraform_1.2.5_linux_amd64.zip \
+RUN wget https://releases.hashicorp.com/terraform/1.8.3/terraform_1.8.3_linux_amd64.zip \
+    && unzip terraform_1.8.3_linux_amd64.zip \
+    && rm terraform_1.8.3_linux_amd64.zip \
     && mv ./terraform /bin/terraform


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Followup to https://github.com/GoogleCloudPlatform/magic-modules/pull/10293

I thought that https://github.com/GoogleCloudPlatform/magic-modules/pull/10293 would cause VCR tests to run in the new version of Terraform, but it wasn't the correct Dockerfile.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
