### PR TITLE
Add field `default_uri_disabled` to `google_cloud_run_v2_job` resource

### DIFF
--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -266,6 +266,11 @@ properties:
         name: 'minInstanceCount'
         description: |
           Minimum number of instances for the service, to be divided among all revisions receiving traffic.
+  - !ruby/object:Api::Type::Boolean
+    name: 'defaultUriDisabled'
+    min_version: beta
+    description: |-
+      Disables public resolution of the default URI of this service.
   - !ruby/object:Api::Type::NestedObject
     name: 'template'
     required: true

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.erb
@@ -895,107 +895,6 @@ func TestAccCloudRunV2Service_cloudrunv2ServiceAttributionLabel(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
-func TestAccCloudRunV2Service_cloudrunv2ServiceWithServiceMinInstances(t *testing.T) {
-  t.Parallel()
-  context := map[string]interface{} {
-    "random_suffix" : acctest.RandString(t, 10),
-  }
-  acctest.VcrTest(t, resource.TestCase {
-    PreCheck: func() { acctest.AccTestPreCheck(t)},
-    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-    CheckDestroy: testAccCheckCloudRunV2ServiceDestroyProducer(t),
-    Steps: []resource.TestStep{
-       {
-        Config: testAccCloudRunV2Service_cloudrunv2ServiceWithMinInstances(context),
-      },
-      {
-        ResourceName: "google_cloud_run_v2_service.default",
-        ImportState: true,
-        ImportStateVerify: true,
-        ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "launch_stage"},
-      },
-      {
-        Config: testAccCloudRunV2Service_cloudrunv2ServiceWithNoMinInstances(context),
-      },
-      {
-        ResourceName: "google_cloud_run_v2_service.default",
-        ImportState: true,
-        ImportStateVerify: true,
-        ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "launch_stage"},
-      },
-
-    }, 
-  })
-}
-
-func testAccCloudRunV2Service_cloudrunv2ServiceWithNoMinInstances(context map[string]interface{}) string {
-	return acctest.Nprintf(`
-resource "google_cloud_run_v2_service" "default" {
-  name     = "tf-test-cloudrun-service%{random_suffix}"
-  description = "description creating"
-  location = "us-central1"
-  launch_stage = "BETA"
-  annotations = {
-    generated-by = "magic-modules"
-  }
-  ingress = "INGRESS_TRAFFIC_ALL"
-  labels = {
-    label-1 = "value-1"
-  }
-  client = "client-1"
-  client_version = "client-version-1"
-  template {
-    containers {
-      name = "container-1"
-      image = "us-docker.pkg.dev/cloudrun/container/hello"
-      }
-    }
-  lifecycle {
-    ignore_changes = [
-      launch_stage,
-    ]
-  }
-}
-
-`, context)
-}
-func testAccCloudRunV2Service_cloudrunv2ServiceWithMinInstances(context map[string]interface{}) string {
-	return acctest.Nprintf(`
-resource "google_cloud_run_v2_service" "default" {
-  name     = "tf-test-cloudrun-service%{random_suffix}"
-  description = "description creating"
-  location = "us-central1"
-  launch_stage = "BETA"
-  annotations = {
-    generated-by = "magic-modules"
-  }
-  ingress = "INGRESS_TRAFFIC_ALL"
-  labels = {
-    label-1 = "value-1"
-  }
-  client = "client-1"
-  client_version = "client-version-1"
-  scaling {
-    min_instance_count = 1
-  }
-  template {
-    containers {
-      name = "container-1"
-      image = "us-docker.pkg.dev/cloudrun/container/hello"
-    }
-  }
-  lifecycle {
-    ignore_changes = [
-      launch_stage,
-    ]
-  }
-}
-
-`, context)
-}
-<% end -%>
-
 func testAccCloudRunV2Service_cloudrunv2ServiceWithAttributionLabel(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 provider "google" {
@@ -1049,3 +948,105 @@ resource "google_cloud_run_v2_service" "default" {
 }
 `, context)
 }
+
+<% unless version == 'ga' -%>
+func TestAccCloudRunV2Service_cloudrunv2ServiceWithServiceMinInstances(t *testing.T) {
+  t.Parallel()
+  context := map[string]interface{} {
+    "random_suffix" : acctest.RandString(t, 10),
+  }
+  acctest.VcrTest(t, resource.TestCase {
+    PreCheck: func() { acctest.AccTestPreCheck(t)},
+    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+    CheckDestroy: testAccCheckCloudRunV2ServiceDestroyProducer(t),
+    Steps: []resource.TestStep{
+       {
+        Config: testAccCloudRunV2Service_cloudrunv2ServiceWithMinInstancesAndDefaultUriDisabled(context),
+      },
+      {
+        ResourceName: "google_cloud_run_v2_service.default",
+        ImportState: true,
+        ImportStateVerify: true,
+        ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "launch_stage"},
+      },
+      {
+        Config: testAccCloudRunV2Service_cloudrunv2ServiceWithNoMinInstances(context),
+      },
+      {
+        ResourceName: "google_cloud_run_v2_service.default",
+        ImportState: true,
+        ImportStateVerify: true,
+        ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "launch_stage"},
+      },
+
+    }, 
+  })
+}
+
+func testAccCloudRunV2Service_cloudrunv2ServiceWithNoMinInstances(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_cloud_run_v2_service" "default" {
+  name     = "tf-test-cloudrun-service%{random_suffix}"
+  description = "description creating"
+  location = "us-central1"
+  launch_stage = "BETA"
+  annotations = {
+    generated-by = "magic-modules"
+  }
+  ingress = "INGRESS_TRAFFIC_ALL"
+  labels = {
+    label-1 = "value-1"
+  }
+  client = "client-1"
+  client_version = "client-version-1"
+  template {
+    containers {
+      name = "container-1"
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+      }
+    }
+  lifecycle {
+    ignore_changes = [
+      launch_stage,
+    ]
+  }
+}
+
+`, context)
+}
+func testAccCloudRunV2Service_cloudrunv2ServiceWithMinInstancesAndDefaultUriDisabled(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_cloud_run_v2_service" "default" {
+  name     = "tf-test-cloudrun-service%{random_suffix}"
+  description = "description creating"
+  location = "us-central1"
+  launch_stage = "BETA"
+  annotations = {
+    generated-by = "magic-modules"
+  }
+  ingress = "INGRESS_TRAFFIC_ALL"
+  labels = {
+    label-1 = "value-1"
+  }
+  client = "client-1"
+  client_version = "client-version-1"
+  scaling {
+    min_instance_count = 1
+  }
+  default_uri_disabled = true
+  template {
+    containers {
+      name = "container-1"
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+  }
+  lifecycle {
+    ignore_changes = [
+      launch_stage,
+    ]
+  }
+}
+
+`, context)
+}
+<% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add a new field `default_uri_disabled` to `google_cloud_run_v2_job` resource for `terraform-provider-google-beta`.

Also relocate one test so that all tests for GA provider are located together.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudrunv2: added field `default_uri_disabled` to resource `google_cloud_run_v2_service` to allow disabling the default service URI.
```
