### PR TITLE
Add beta support for keyAccessJustificationsPolicy to KMS module

### DIFF
--- a/mmv1/products/kms/CryptoKey.yaml
+++ b/mmv1/products/kms/CryptoKey.yaml
@@ -163,3 +163,26 @@ properties:
       The resource name of the backend environment associated with all CryptoKeyVersions within this CryptoKey.
       The resource name is in the format "projects/*/locations/*/ekmConnections/*" and only applies to "EXTERNAL_VPC" keys.
     default_from_api: true
+  - !ruby/object:Api::Type::NestedObject
+    name: 'keyAccessJustificationsPolicy'
+    min_version: beta
+    description: |
+      The policy used for Key Access Justifications Policy Enforcement. If this
+      field is present and this key is enrolled in Key Access Justifications
+      Policy Enforcement, the policy will be evaluated in Encrypt, Decrypt, and
+      Sign operations, and the operation will fail if rejected by the policy. The
+      policy is defined by specifying zero or more allowed justification codes.
+      https://cloud.google.com/assured-workloads/key-access-justifications/docs/justification-codes
+      By default, this field is absent, and all justification codes are allowed.
+      This field is currently in beta and is subject to change.
+    default_from_api: true
+    update_mask_fields:
+      - 'keyAccessJustificationsPolicy'
+    properties:
+      - !ruby/object:Api::Type::Array
+        item_type: Api::Type::String
+        name: 'allowedAccessReasons'
+        description: |
+          The list of allowed reasons for access to this CryptoKey. Zero allowed
+          access reasons means all Encrypt, Decrypt, and Sign requests for this
+          CryptoKey will fail.

--- a/mmv1/products/kms/CryptoKey.yaml
+++ b/mmv1/products/kms/CryptoKey.yaml
@@ -169,8 +169,8 @@ properties:
     description: |
       The policy used for Key Access Justifications Policy Enforcement. If this
       field is present and this key is enrolled in Key Access Justifications
-      Policy Enforcement, the policy will be evaluated in Encrypt, Decrypt, and
-      Sign operations, and the operation will fail if rejected by the policy. The
+      Policy Enforcement, the policy will be evaluated in encrypt, decrypt, and
+      sign operations, and the operation will fail if rejected by the policy. The
       policy is defined by specifying zero or more allowed justification codes.
       https://cloud.google.com/assured-workloads/key-access-justifications/docs/justification-codes
       By default, this field is absent, and all justification codes are allowed.
@@ -184,5 +184,5 @@ properties:
         name: 'allowedAccessReasons'
         description: |
           The list of allowed reasons for access to this CryptoKey. Zero allowed
-          access reasons means all Encrypt, Decrypt, and Sign requests for this
-          CryptoKey will fail.
+          access reasons means all encrypt, decrypt, and sign operations for
+          this CryptoKey will fail.

--- a/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go
@@ -317,6 +317,53 @@ func TestAccKmsCryptoKey_destroyDuration(t *testing.T) {
 	})
 }
 
+func TestAccKmsCryptoKey_keyAccessJustificationsPolicy(t *testing.T) {
+	t.Parallel()
+
+	projectId := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+	projectOrg := envvar.GetTestOrgFromEnv(t)
+	location := envvar.GetTestRegionFromEnv()
+	projectBillingAccount := envvar.GetTestBillingAccountFromEnv(t)
+	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	cryptoKeyName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	allowedAccessReason := "CUSTOMER_INITIATED_SUPPORT"
+	updatedAllowedAccessReason := "GOOGLE_INITIATED_SERVICE"
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleKmsCryptoKey_keyAccessJustificationsPolicy(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, allowedAccessReason),
+			},
+			{
+				ResourceName:            "google_kms_crypto_key.crypto_key",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testGoogleKmsCryptoKey_keyAccessJustificationsPolicy(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, updatedAllowedAccessReason),
+			},
+			{
+				ResourceName:            "google_kms_crypto_key.crypto_key",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			// Use a separate TestStep rather than a CheckDestroy because we need the project to still exist.
+			{
+				Config: testGoogleKmsCryptoKey_removed(projectId, projectOrg, projectBillingAccount, keyRingName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleKmsCryptoKeyWasRemovedFromState("google_kms_crypto_key.crypto_key"),
+					testAccCheckGoogleKmsCryptoKeyVersionsDestroyed(t, projectId, location, keyRingName, cryptoKeyName),
+					testAccCheckGoogleKmsCryptoKeyRotationDisabled(t, projectId, location, keyRingName, cryptoKeyName),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKmsCryptoKey_importOnly(t *testing.T) {
 	t.Parallel()
 
@@ -787,6 +834,39 @@ resource "google_kms_crypto_key" "crypto_key" {
   destroy_scheduled_duration = "129600s"
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
+}
+
+func testGoogleKmsCryptoKey_keyAccessJustificationsPolicy(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, allowed_access_reason string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+  name            = "%s"
+  project_id      = "%s"
+  org_id          = "%s"
+  billing_account = "%s"
+}
+
+resource "google_project_service" "acceptance" {
+  project = google_project.acceptance.project_id
+  service = "cloudkms.googleapis.com"
+}
+
+resource "google_kms_key_ring" "key_ring" {
+  project  = google_project_service.acceptance.project
+  name     = "%s"
+  location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "crypto_key" {
+  name     = "%s"
+  key_ring = google_kms_key_ring.key_ring.id
+  labels = {
+    key = "value"
+  }
+  key_access_justifications_policy {
+    allowed_access_reasons = ["%s"]
+  }
+}
+`, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, allowed_access_reason)
 }
 
 func testGoogleKmsCryptoKey_importOnly(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName string) string {

--- a/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go
@@ -321,9 +321,7 @@ func TestAccKmsCryptoKey_keyAccessJustificationsPolicy(t *testing.T) {
 	t.Parallel()
 
 	projectId := envvar.GetTestProjectFromEnv()
-	projectOrg := envvar.GetTestOrgFromEnv(t)
 	location := envvar.GetTestRegionFromEnv()
-	projectBillingAccount := envvar.GetTestBillingAccountFromEnv(t)
 	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	cryptoKeyName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	allowedAccessReason := "CUSTOMER_INITIATED_SUPPORT"
@@ -353,7 +351,7 @@ func TestAccKmsCryptoKey_keyAccessJustificationsPolicy(t *testing.T) {
 			},
 			// Use a separate TestStep rather than a CheckDestroy because we need the project to still exist.
 			{
-				Config: testGoogleKmsCryptoKey_removed(projectId, projectOrg, projectBillingAccount, keyRingName),
+				Config: testGoogleKmsCryptoKey_removedProjectOverride(projectId, keyRingName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleKmsCryptoKeyWasRemovedFromState("google_kms_crypto_key.crypto_key"),
 					testAccCheckGoogleKmsCryptoKeyVersionsDestroyed(t, projectId, location, keyRingName, cryptoKeyName),
@@ -805,6 +803,16 @@ resource "google_kms_key_ring" "key_ring" {
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName)
 }
 
+func testGoogleKmsCryptoKey_removedProjectOverride(projectId, keyRingName string) string {
+	return fmt.Sprintf(`
+resource "google_kms_key_ring" "key_ring" {
+  project  = "%s"
+  name     = "%s"
+  location = "us-central1"
+}
+`, projectId, keyRingName)
+}
+
 func testGoogleKmsCryptoKey_destroyDuration(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
@@ -838,6 +846,11 @@ resource "google_kms_crypto_key" "crypto_key" {
 
 func testGoogleKmsCryptoKey_keyAccessJustificationsPolicy(projectId, keyRingName, cryptoKeyName, allowed_access_reason string) string {
 	return fmt.Sprintf(`
+provider "google" {
+  user_project_override = true
+  project = "%s"
+}
+
 data "google_project" "project" {
   project_id = "%s"
 }
@@ -858,7 +871,7 @@ resource "google_kms_crypto_key" "crypto_key" {
     allowed_access_reasons = ["%s"]
   }
 }
-`, projectId, keyRingName, cryptoKeyName, allowed_access_reason)
+`, projectId, projectId, keyRingName, cryptoKeyName, allowed_access_reason)
 }
 
 func testGoogleKmsCryptoKey_importOnly(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName string) string {


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/18247

keyAccessJustificationsPolicy is a new field on the CryptoKey resource currently in private beta. Terraform support
is added now ahead of full public release.

```release-note:enhancement
cloudkms: added `key_access_justifications_policy` field to `google_kms_crypto_key` resource (beta)
```