### PR TITLE
Add support for specifying storage pool when creating a disk.

### DIFF
--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -513,3 +513,14 @@ properties:
       resource: 'License'
       imports: 'selfLink'
     custom_expand: 'templates/terraform/custom_expand/array_resourceref_with_validation.go.erb'
+  - !ruby/object:Api::Type::String
+    name: 'storagePool'
+    required: false
+    immutable: true
+    description: |
+      The URL of the storage pool in which the new disk is created.
+      For example:
+      * https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/storagePools/{storagePool}
+      * /projects/{project}/zones/{zone}/storagePools/{storagePool}
+    diff_suppress_func: 'tpgresource.CompareResourceNames'
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.erb
@@ -3,14 +3,17 @@ package compute_test
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 <% if version == "ga" -%>
 	"google.golang.org/api/compute/v1"
@@ -1516,3 +1519,109 @@ resource "google_compute_disk" "foobar" {
 `, add, strategy, diskName)
 }
 
+func TestAccComputeDisk_storagePoolSpecified(t *testing.T) {
+	t.Parallel()
+
+	storagePoolName := fmt.Sprintf("tf-test-storage-pool-%s", acctest.RandString(t, 10))
+	storagePoolUrl := fmt.Sprintf("/projects/%s/zones/%s/storagePools/%s", envvar.GetTestProjectFromEnv(), envvar.GetTestZoneFromEnv(), storagePoolName)
+	diskName := fmt.Sprintf("tf-test-disk-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				PreConfig: setupTestingStoragePool(t, storagePoolName),
+				Config:    testAccComputeDisk_storagePoolSpecified(diskName, storagePoolUrl),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_compute_disk.foobar", "storage_pool", storagePoolName),
+				),
+			},
+			{
+				ResourceName:      "google_compute_disk.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+
+	cleanupTestingStoragePool(t, storagePoolName)
+}
+
+func setupTestingStoragePool(t *testing.T, storagePoolName string) func() {
+	return func() {
+		config := acctest.GoogleProviderConfig(t)
+		headers := make(http.Header)
+		project := envvar.GetTestProjectFromEnv()
+		zone := envvar.GetTestZoneFromEnv()
+		url := fmt.Sprintf("%sprojects/%s/zones/%s/storagePools", config.ComputeBasePath, project, zone)
+		storagePoolTypeUrl := fmt.Sprintf("/projects/%s/zones/%s/storagePoolTypes/hyperdisk-throughput", project, zone)
+		defaultTimeout := 20 * time.Minute
+		obj := make(map[string]interface{})
+		obj["name"] = storagePoolName
+		obj["poolProvisionedCapacityGb"] = 10240
+		obj["poolProvisionedThroughput"] = 180
+		obj["storagePoolType"] = storagePoolTypeUrl
+		obj["capacityProvisioningType"] = "ADVANCED"
+
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: config.UserAgent,
+			Body:      obj,
+			Timeout:   defaultTimeout,
+			Headers:   headers,
+		})
+		if err != nil {
+			t.Errorf("Error creating StoragePool: %s", err)
+		}
+
+		err = tpgcompute.ComputeOperationWaitTime(config, res, project, "Creating StoragePool", config.UserAgent, defaultTimeout)
+		if err != nil {
+			t.Errorf("Error waiting to create StoragePool: %s", err)
+		}
+	}
+}
+
+func cleanupTestingStoragePool(t *testing.T, storagePoolName string) {
+	config := acctest.GoogleProviderConfig(t)
+	headers := make(http.Header)
+	project := envvar.GetTestProjectFromEnv()
+	zone := envvar.GetTestZoneFromEnv()
+	url := fmt.Sprintf("%sprojects/%s/zones/%s/storagePools/%s", config.ComputeBasePath, project, zone, storagePoolName)
+	defaultTimeout := 20 * time.Minute
+	var obj map[string]interface{}
+
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "DELETE",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: config.UserAgent,
+		Body:      obj,
+		Timeout:   defaultTimeout,
+		Headers:   headers,
+	})
+	if err != nil {
+		t.Errorf("Error deleting StoragePool: %s", err)
+	}
+
+	err = tpgcompute.ComputeOperationWaitTime(config, res, project, "Deleting StoragePool", config.UserAgent, defaultTimeout)
+	if err != nil {
+		t.Errorf("Error waiting to delete StoragePool: %s", err)
+	}
+}
+
+func testAccComputeDisk_storagePoolSpecified(diskName, storagePoolUrl string) string {
+	return fmt.Sprintf(`
+resource "google_compute_disk" "foobar" {
+  name = "%s"
+  type = "hyperdisk-throughput"
+  size = 2048
+  provisioned_throughput = 140
+  storage_pool = "%s"
+}
+`, diskName, storagePoolUrl)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add field `storage_pool` to `google_compute_disk` resource to support creating disk with the storage pool in which it will reside.
Instead of adding a resource for storage pool and using resourceRef to let disk reference it, we add the field as a string which will contain the URL for a storage pool. The main reason for this decision is that if we add storage pool as a resource, and in the scenario that users want to destroy a storage pool, Terraform will plan to delete all disks first and then delete the storage pool, which we definitely want to prevent from happening.
Therefore, we eventually decided to not support creating storage pool via Terraform, and only support adding the field for disks to specify existing storage pool. The management of storage pool itself will remain through GCP APIs.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

```release-note:enhancement
compute: added `storage_pool` field to `google_compute_disk` resource
```
