### PR TITLE
chore(ci): exit 1 on generate commit if run into other errors

### DIFF
--- a/.ci/magician/cmd/generate_downstream.go
+++ b/.ci/magician/cmd/generate_downstream.go
@@ -153,6 +153,9 @@ func execGenerateDownstream(baseBranch, command, repo, version, ref string, gh G
 	scratchCommitSha, commitErr := createCommit(scratchRepo, commitMessage, rnr)
 	if commitErr != nil {
 		fmt.Println("Error creating commit: ", commitErr)
+		if !strings.Contains(commitErr.Error(), "nothing to commit") {
+			os.Exit(1)
+		}
 	}
 
 	if _, err := rnr.Run("git", []string{"push", ctlr.URL(scratchRepo), scratchRepo.Branch, "-f"}, nil); err != nil {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

https://github.com/hashicorp/terraform-provider-google/issues/17702
createCommit() function returns error if there is nothing to commit, in that case, it should proceed, one example error message in that case: https://pantheon.corp.google.com/cloud-build/builds/a44b5665-a33b-43e9-a888-16348ce5574e;step=8?e=-13802955&mods=logs_tg_staging&project=graphite-docker-images

In other case like what is specified in the issue, it should exit. Hence checking the error message to see whether it contains "nothing to commit" to exit or not. 

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
