### PR TITLE
Add secrets_discovery_target field in google_data_loss_prevention_discovery_config, as well as fields to support single-resource mode for big_query_target and cloud_sql_target

### DIFF
--- a/mmv1/products/dlp/DiscoveryConfig.yaml
+++ b/mmv1/products/dlp/DiscoveryConfig.yaml
@@ -32,17 +32,20 @@ id_format: '{{parent}}/discoveryConfigs/{{name}}'
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'dlp_discovery_config_basic'
+    skip_test: true
     primary_resource_id: 'basic'
     test_env_vars:
       project: :PROJECT_NAME
       location: :REGION
   - !ruby/object:Provider::Terraform::Examples
     name: 'dlp_discovery_config_actions'
+    skip_test: true
     primary_resource_id: 'actions'
     test_env_vars:
       project: :PROJECT_NAME
   - !ruby/object:Provider::Terraform::Examples
     name: 'dlp_discovery_config_org_running'
+    skip_test: true
     primary_resource_id: 'org_running'
     test_env_vars:
       project: :PROJECT_NAME
@@ -55,16 +58,19 @@ examples:
       organization: :ORG_ID
   - !ruby/object:Provider::Terraform::Examples
     name: 'dlp_discovery_config_conditions_cadence'
+    skip_test: true
     primary_resource_id: 'conditions_cadence'
     test_env_vars:
       project: :PROJECT_NAME
   - !ruby/object:Provider::Terraform::Examples
     name: 'dlp_discovery_config_filter_regexes_and_conditions'
+    skip_test: true
     primary_resource_id: 'filter_regexes_and_conditions'
     test_env_vars:
       project: :PROJECT_NAME
   - !ruby/object:Provider::Terraform::Examples
     name: 'dlp_discovery_config_cloud_sql'
+    skip_test: true
     primary_resource_id: 'cloud_sql'
     test_env_vars:
       project: :PROJECT_NAME
@@ -237,6 +243,18 @@ properties:
                     # The fields below are necessary to include the "otherTables" filter in the payload
                   send_empty_value: true
                   allow_empty_object: true
+                - !ruby/object:Api::Type::NestedObject
+                  name: tableReference
+                  description: The table to scan. Discovery configurations including this can only include one DiscoveryTarget (the DiscoveryTarget with this TableReference).
+                  properties:
+                    - !ruby/object:Api::Type::String
+                      name: datasetId
+                      description: Dataset ID of the table.
+                      required: true
+                    - !ruby/object:Api::Type::String
+                      name: tableId
+                      description: Name of the table.
+                      required: true
             - !ruby/object:Api::Type::NestedObject
               name: conditions
               description: In addition to matching the filter, these conditions must be true before a profile is generated
@@ -371,6 +389,26 @@ properties:
                     []  # Meant to be an empty object with no properties. The fields below are necessary to include the "others" filter in the payload
                   send_empty_value: true
                   allow_empty_object: true
+                - !ruby/object:Api::Type::NestedObject
+                  name: databaseResourceReference
+                  description: The database resource to scan. Targets including this can only include one target (the target with this database resource reference).
+                  properties:
+                    - !ruby/object:Api::Type::String
+                      name: projectId
+                      description: Required. If within a project-level config, then this must match the config's project ID.
+                      required: true
+                    - !ruby/object:Api::Type::String
+                      name: instance
+                      description: 'Required. The instance where this resource is located. For example: Cloud SQL instance ID.'
+                      required: true
+                    - !ruby/object:Api::Type::String
+                      name: database
+                      description: Required. Name of a database within the instance.
+                      required: true
+                    - !ruby/object:Api::Type::String
+                      name: databaseResource
+                      description: Required. Name of a database resource, for example, a table within the database.
+                      required: true
             - !ruby/object:Api::Type::NestedObject
               name: conditions
               description: 'In addition to matching the filter, these conditions must be true before a profile is generated.'
@@ -439,6 +477,14 @@ properties:
                 # The fields below are necessary to include the "disabled" filter in the payload
               send_empty_value: true
               allow_empty_object: true
+        - !ruby/object:Api::Type::NestedObject
+          name: secretsTarget
+          description: Discovery target that looks for credentials and secrets stored in cloud resource metadata and reports them as vulnerabilities to Security Command Center. Only one target of this type is allowed.
+          properties:
+            []  # Meant to be an empty object with no properties - see here : https://cloud.google.com/sensitive-data-protection/docs/reference/rest/v2/organizations.locations.discoveryConfigs#DiscoveryConfig.SecretsDiscoveryTarget
+            # The fields below are necessary to include the "secretsDiscoveryTarget" target in the payload
+          send_empty_value: true
+          allow_empty_object: true
   - !ruby/object:Api::Type::Array
     name: 'errors'
     description: Output only. A stream of errors encountered when the config was activated. Repeated errors may result in the config automatically being paused. Output only field. Will return the last 100 errors. Whenever the config is modified this list will be cleared.

--- a/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_discovery_config_test.go
+++ b/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_discovery_config_test.go
@@ -16,6 +16,9 @@ func TestAccDataLossPreventionDiscoveryConfig_Update(t *testing.T) {
 		"conditions": testAccDataLossPreventionDiscoveryConfig_ConditionsCadenceUpdate,
 		"filter":     testAccDataLossPreventionDiscoveryConfig_FilterUpdate,
 		"cloud_sql":  testAccDataLossPreventionDiscoveryConfig_CloudSqlUpdate,
+		"bq_single":  testAccDataLossPreventionDiscoveryConfig_BqSingleTable,
+		"sql_single": testAccDataLossPreventionDiscoveryConfig_SqlSingleTable,
+		"secrets":    testAccDataLossPreventionDiscoveryConfig_SecretsUpdate,
 	}
 	for name, tc := range testCases {
 		// shadow the tc variable into scope so that when
@@ -238,6 +241,111 @@ func testAccDataLossPreventionDiscoveryConfig_CloudSqlUpdate(t *testing.T) {
 			},
 			{
 				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigUpdateCloudSql(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time"},
+			},
+		},
+	})
+}
+
+func testAccDataLossPreventionDiscoveryConfig_BqSingleTable(t *testing.T) {
+
+	context := map[string]interface{}{
+		"project":       envvar.GetTestProjectFromEnv(),
+		"location":      envvar.GetTestRegionFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataLossPreventionDiscoveryConfigDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigStart(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time"},
+			},
+			{
+				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigBqSingleUpdate(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time"},
+			},
+		},
+	})
+}
+
+func testAccDataLossPreventionDiscoveryConfig_SqlSingleTable(t *testing.T) {
+
+	context := map[string]interface{}{
+		"project":       envvar.GetTestProjectFromEnv(),
+		"location":      envvar.GetTestRegionFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataLossPreventionDiscoveryConfigDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigStartCloudSql(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time"},
+			},
+			{
+				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigCloudSqlSingleUpdate(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time"},
+			},
+		},
+	})
+}
+
+func testAccDataLossPreventionDiscoveryConfig_SecretsUpdate(t *testing.T) {
+
+	context := map[string]interface{}{
+		"project":       envvar.GetTestProjectFromEnv(),
+		"location":      envvar.GetTestRegionFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataLossPreventionDiscoveryConfigDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigSecretsStart(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time"},
+			},
+			{
+				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigSecretsUpdate(context),
 			},
 			{
 				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
@@ -735,6 +843,170 @@ resource "google_data_loss_prevention_discovery_config" "basic" {
         }
     }
     inspect_templates = ["projects/%{project}/inspectTemplates/${google_data_loss_prevention_inspect_template.basic.name}"]
+}
+`, context)
+}
+
+func testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigBqSingleUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_data_loss_prevention_inspect_template" "basic" {
+	parent = "projects/%{project}"
+	description = "Description"
+	display_name = "Display"
+
+	inspect_config {
+		info_types {
+			name = "EMAIL_ADDRESS"
+		}
+	}
+}
+resource "google_bigquery_dataset" "default" {
+    dataset_id                  = "tf_test_%{random_suffix}"
+    friendly_name               = "terraform-test"
+    description                 = "Description for the dataset created by terraform"
+    location                    = "US"
+    default_table_expiration_ms = 3600000
+
+    labels = {
+        env = "default"
+    }
+}
+resource "google_bigquery_table" "default" {
+    dataset_id          = google_bigquery_dataset.default.dataset_id
+    table_id            = "tf_test_%{random_suffix}"
+    deletion_protection = false
+
+    labels = {
+        env = "default"
+    }
+
+    schema = <<EOF
+        [
+        {
+            "name": "quantity",
+            "type": "NUMERIC",
+            "mode": "NULLABLE",
+            "description": "The quantity"
+        },
+        {
+            "name": "name",
+            "type": "STRING",
+            "mode": "NULLABLE",
+            "description": "Name of the object"
+        }
+        ]
+    EOF
+}
+
+resource "google_data_loss_prevention_discovery_config" "basic" {
+    parent = "projects/%{project}/locations/%{location}"
+    location = "%{location}"
+    display_name = "display name"
+    status = "RUNNING"
+
+    targets {
+        big_query_target {
+            filter {
+                table_reference {
+                    dataset_id = google_bigquery_dataset.default.dataset_id
+                    table_id = google_bigquery_table.default.table_id
+				}
+            }
+        }
+    }
+    inspect_templates = ["projects/%{project}/inspectTemplates/${google_data_loss_prevention_inspect_template.basic.name}"]
+}
+`, context)
+}
+
+func testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigCloudSqlSingleUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_data_loss_prevention_inspect_template" "basic" {
+    parent = "projects/%{project}"
+    description = "Description"
+    display_name = "Display"
+    inspect_config {
+        info_types {
+            name = "EMAIL_ADDRESS"  
+        }
+    }
+}
+resource "google_sql_database_instance" "instance" {
+    name             = "tf-test-instance-%{random_suffix}"
+    database_version = "POSTGRES_14"
+    region           = "%{location}"
+
+    settings {
+        tier = "db-f1-micro"
+    }
+  
+    deletion_protection = false
+}
+resource "google_sql_database" "db" {
+    instance = google_sql_database_instance.instance.name
+    name     = "database"
+}
+data "google_project" "project" {
+}
+resource "google_project_iam_member" "dlp_role" {
+    project = "%{project}"
+    role    = "roles/dlp.projectdriver"
+    member = "serviceAccount:service-${data.google_project.project.number}@dlp-api.iam.gserviceaccount.com"
+}
+resource "google_data_loss_prevention_discovery_config" "basic" {
+    parent = "projects/%{project}/locations/%{location}"
+    location = "%{location}"
+    status = "RUNNING"
+    targets {
+        cloud_sql_target {
+            filter {
+                database_resource_reference {
+                    project_id = "%{project}"
+                    instance = google_sql_database_instance.instance.name
+                    database = "database"
+                    database_resource = "resource"
+                }
+            }
+            conditions {
+                database_engines = ["ALL_SUPPORTED_DATABASE_ENGINES"]
+                types = ["DATABASE_RESOURCE_TYPE_TABLE"]
+            }
+            generation_cadence {
+                schema_modified_cadence {
+                    types = ["NEW_COLUMNS", "REMOVED_COLUMNS"]
+                    frequency = "UPDATE_FREQUENCY_DAILY"
+                }
+                refresh_frequency = "UPDATE_FREQUENCY_MONTHLY"
+            }
+        }
+    }
+    inspect_templates = ["projects/%{project}/inspectTemplates/${google_data_loss_prevention_inspect_template.basic.name}"]
+}
+`, context)
+}
+
+func testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigSecretsStart(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_data_loss_prevention_discovery_config" "basic" {
+    parent = "projects/%{project}/locations/%{location}"
+    location = "%{location}"
+    status = "RUNNING"
+    targets {
+       secrets_target {}
+    }
+}
+`, context)
+}
+
+func testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigSecretsUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_data_loss_prevention_discovery_config" "basic" {
+    parent = "projects/%{project}/locations/%{location}"
+    location = "%{location}"
+    status = "PAUSED"
+    targets {
+       secrets_target {}
+    }
 }
 `, context)
 }


### PR DESCRIPTION
```release-note:enhancement
dlp: added `secrets_discovery_target` field to `google_data_loss_prevention_discovery_config` resource
```

```release-note:enhancement
dlp: added `cloud_sql_target.filter.database_resource_reference` and `big_query_target.filter.table_reference` fields to `google_data_loss_prevention_discovery_config` resource to support single-resource mode
```
Also disable some example tests, since DiscoveryConfigs are limited to 1-per-region-per-storage-type at the project level, and the parallelism applied to example tests causes flakiness and interferes with update tests.
