### PR TITLE
Add force_destroy field to google_bigtable_instance resource

### DIFF
--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
@@ -10,12 +10,30 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"google.golang.org/api/iterator"
 
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 	"cloud.google.com/go/bigtable"
 )
+
+// resourceBigtableInstanceVirtualUpdate identifies if an update to the resource includes only virtual field updates
+func resourceBigtableInstanceVirtualUpdate(d *schema.ResourceData, resourceSchema map[string]*schema.Schema) bool {
+	// force_destroy is the only virtual field
+	if d.HasChange("force_destroy") {
+		for field := range resourceSchema {
+			if field == "force_destroy" {
+				continue
+			}
+			if d.HasChange(field) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
 
 func ResourceBigtableInstance() *schema.Resource {
 	return &schema.Resource{
@@ -151,6 +169,13 @@ func ResourceBigtableInstance() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"DEVELOPMENT", "PRODUCTION"}, false),
 				Description:  `The instance type to create. One of "DEVELOPMENT" or "PRODUCTION". Defaults to "PRODUCTION".`,
 				Deprecated:   `It is recommended to leave this field unspecified since the distinction between "DEVELOPMENT" and "PRODUCTION" instances is going away, and all instances will become "PRODUCTION" instances. This means that new and existing "DEVELOPMENT" instances will be converted to "PRODUCTION" instances. It is recommended for users to use "PRODUCTION" instances in any case, since a 1-node "PRODUCTION" instance is functionally identical to a "DEVELOPMENT" instance, but without the accompanying restrictions.`,
+			},
+
+			"force_destroy": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: `When deleting a BigTable instance, this boolean option will delete all backups within the instance.`,
 			},
 
 			"deletion_protection": {
@@ -341,6 +366,13 @@ func resourceBigtableInstanceRead(d *schema.ResourceData, meta interface{}) erro
 	// Don't set instance_type: we don't want to detect drift on it because it can
 	// change under-the-hood.
 
+	// Explicitly set virtual fields to default values if unset
+	if _, ok := d.GetOkExists("force_destroy"); !ok {
+		if err := d.Set("force_destroy", false); err != nil {
+			return fmt.Errorf("Error setting force_destroy: %s", err)
+		}
+	}
+
 	return nil
 }
 
@@ -389,6 +421,18 @@ func resourceBigtableInstanceUpdate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
+	log.Printf("[DEBUG] Updating BigTable instance %q: %#v", d.Id(), conf)
+
+	// Handle scenario where the update includes only updating force_destroy
+	if resourceBigtableInstanceVirtualUpdate(d, ResourceBigtableInstance().Schema) {
+		if d.Get("force_destroy") != nil {
+			if err := d.Set("force_destroy", d.Get("force_destroy")); err != nil {
+				return fmt.Errorf("error reading Instance: %s", err)
+			}
+		}
+		return nil
+	}
+
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, d.Timeout(schema.TimeoutUpdate))
 	defer cancel()
 	if _, err := bigtable.UpdateInstanceAndSyncClusters(ctxWithTimeout, c, conf); err != nil {
@@ -399,6 +443,7 @@ func resourceBigtableInstanceUpdate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceBigtableInstanceDestroy(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Deleting BigTable instance %q", d.Id())
 	if d.Get("deletion_protection").(bool) {
 		return fmt.Errorf("cannot destroy instance without setting deletion_protection=false and running `terraform apply`")
 	}
@@ -423,6 +468,40 @@ func resourceBigtableInstanceDestroy(d *schema.ResourceData, meta interface{}) e
 	defer c.Close()
 
 	name := d.Get("name").(string)
+
+	// If force_destroy is set, delete all backups and unblock deletion of the instance
+	if d.Get("force_destroy").(bool) {
+		adminClient, err := config.BigTableClientFactory(userAgent).NewAdminClient(project, name)
+		if err != nil {
+			return fmt.Errorf("error starting admin client. %s", err)
+		}
+
+		// Iterate over clusters to get all backups
+		//    Need to get backup data per cluster because when you delete a backup the name must be provided.
+		//    If we get all backups in an instance at once the information about the cluster a backup belongs to isn't present.
+		clusters, err := c.Clusters(ctx, name)
+		if err != nil {
+			return fmt.Errorf("error retrieving cluster data for instance %s: %s", name, err)
+		}
+		for _, cluster := range clusters {
+			it := adminClient.Backups(ctx, cluster.Name)
+			for {
+				backup, err := it.Next()
+				if err == iterator.Done {
+					break
+				}
+				if err != nil {
+					return fmt.Errorf("error iterating over backups in cluster %s: %s", cluster.Name, err)
+				}
+				log.Printf("[DEBUG] Deleting backup %s from cluster %s", backup.Name, cluster.Name)
+				err = adminClient.DeleteBackup(ctx, cluster.Name, backup.Name)
+				if err != nil {
+					return fmt.Errorf("error backup %s from cluster %s: %s", backup.Name, cluster.Name, err)
+				}
+			}
+		}
+	}
+
 	err = c.DeleteInstance(ctx, name)
 	if err != nil {
 		return fmt.Errorf("Error deleting instance. %s", err)
@@ -732,6 +811,11 @@ func resourceBigtableInstanceImport(d *schema.ResourceData, meta interface{}) ([
 		return nil, fmt.Errorf("Error constructing id: %s", err)
 	}
 	d.SetId(id)
+
+	// Explicitly set virtual fields to default values on import
+	if err := d.Set("force_destroy", false); err != nil {
+		return nil, fmt.Errorf("error setting force_destroy: %s", err)
+	}
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_test.go
@@ -485,7 +485,7 @@ func TestAccBigtableInstance_forceDestroyBackups(t *testing.T) {
 			},
 			{
 				// Try to delete the instance after force_destroy = true was set before
-				Config: testAccBigtableInstance_forceDestroy_deleteInstance(), // Empty config; trying to delete the instance with force_destroy = true previously
+				Config: testAccBigtableInstance_forceDestroy_deleteInstance(),
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
@@ -97,7 +97,7 @@ to default to the backend value. See [structure below](#nested_cluster).
 
 * `display_name` - (Optional) The human-readable display name of the Bigtable instance. Defaults to the instance `name`.
 
-* `force_destroy` - (Optional) deleting a BigTable instance can be blocked if any backups are present in the instance. When `force_destroy` is set to true, Terraform will delete all backups found in the BigTable instance before attempting to delete the instance itself. Defaults to false.
+* `force_destroy` - (Optional) Deleting a BigTable instance can be blocked if any backups are present in the instance. When `force_destroy` is set to true, Terraform will delete all backups found in the BigTable instance before attempting to delete the instance itself. Defaults to false.
 
 * `deletion_protection` - (Optional) Whether or not to allow Terraform to destroy the instance. Unless this field is set to false
 in Terraform state, a `terraform destroy` or `terraform apply` that would delete the instance will fail. Defaults to true.

--- a/mmv1/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
@@ -97,8 +97,10 @@ to default to the backend value. See [structure below](#nested_cluster).
 
 * `display_name` - (Optional) The human-readable display name of the Bigtable instance. Defaults to the instance `name`.
 
+* `force_destroy` - (Optional) deleting a BigTable instance can be blocked if any backups are present in the instance. When `force_destroy` is set to true, Terraform will delete all backups found in the BigTable instance before attempting to delete the instance itself. Defaults to false.
+
 * `deletion_protection` - (Optional) Whether or not to allow Terraform to destroy the instance. Unless this field is set to false
-in Terraform state, a `terraform destroy` or `terraform apply` that would delete the instance will fail.
+in Terraform state, a `terraform destroy` or `terraform apply` that would delete the instance will fail. Defaults to true.
 
 * `labels` - (Optional) A set of key/value label pairs to assign to the resource. Label keys must follow the requirements at https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements.
 


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/18194

**Background**

If a user tries to delete a bigtable instance that contains backups they will experience an API error saying deletion cannot happen due to backups.

There currently isn't a way to address this through Terraform; bigtable backups are not supported by the provider, so users will need to manually delete backups to unblock Terraform.

This PR adds a force_destroy field that will delete all backups when the instance is being deleted. This behaviour is opt-in, so there's no risk of unintentional deletion of backups. It copies some existing code from [the force_destroy field on google_spanner_instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/spanner_instance.html#force_destroy).

**Testing**

The acceptance test in this PR uses the http provider to make a backup by directly interacting with the API.

If/when backups are supported by the provider the test should be refactored.


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigtable: added force_destroy field to `google_bigtable_instance` resource. This will force delete any backups present in the instance and allow the instance to be deleted.
```
O