### PR TITLE
TeamCity : Define execution mode of post VCR step

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/builds/vcr_build_steps.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/vcr_build_steps.kt
@@ -140,7 +140,7 @@ fun BuildSteps.runVcrTestRecordingSetup() {
 fun BuildSteps.runVcrTestRecordingSaveCassettes() {
     step(ScriptBuildStep {
         name = "Tasks after running VCR tests: if in RECORDING mode, push new cassettes to GCS"
-        executionMode = "RUN_ON_FAILURE"
+        executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
         scriptContent = """
             #!/bin/bash
             echo "VCR Testing: Post-test steps"

--- a/mmv1/third_party/terraform/.teamcity/components/builds/vcr_build_steps.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/vcr_build_steps.kt
@@ -140,6 +140,7 @@ fun BuildSteps.runVcrTestRecordingSetup() {
 fun BuildSteps.runVcrTestRecordingSaveCassettes() {
     step(ScriptBuildStep {
         name = "Tasks after running VCR tests: if in RECORDING mode, push new cassettes to GCS"
+        executionMode = "RUN_ON_FAILURE"
         scriptContent = """
             #!/bin/bash
             echo "VCR Testing: Post-test steps"

--- a/mmv1/third_party/terraform/.teamcity/components/builds/vcr_build_steps.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/vcr_build_steps.kt
@@ -7,6 +7,7 @@
 
 package builds
 
+import jetbrains.buildServer.configs.kotlin.BuildStep
 import jetbrains.buildServer.configs.kotlin.BuildSteps
 import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
 


### PR DESCRIPTION
Currently is a test fails (specifically in the VCR recording builds) all subsequent build steps are skipped.

This PR makes teamcity VCR recording builds push cassettes to GCS even if a test fails.

See the docs here for the effect of execution mode: https://www.jetbrains.com/help/teamcity/kotlin-dsl-documentation/root/build-step/execution-mode/

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
