### PR TITLE
Add terraform support for maintenance exclusion windows for edgeconta…

### DIFF
--- a/mmv1/products/edgecontainer/Cluster.yaml
+++ b/mmv1/products/edgecontainer/Cluster.yaml
@@ -74,6 +74,11 @@ examples:
     primary_resource_id: "default"
     vars:
       edgecontainer_cluster_name: "cluster-with-maintenance"
+  - !ruby/object:Provider::Terraform::Examples
+    name: "edgecontainer_cluster_with_maintenance_exclusion_windows"
+    primary_resource_id: "default"
+    vars:
+      edgecontainer_cluster_name: "cluster-with-maintenance-exclusions"
   # Skip the local control plane cluster test as we only have limited machine resources.
   # Instead the local control plane cluster test will be tested in the node pool test.
   - !ruby/object:Provider::Terraform::Examples
@@ -256,6 +261,37 @@ properties:
                   An RRULE (https://tools.ietf.org/html/rfc5545#section-3.8.5.3) for how
                   this window recurs. They go on for the span of time between the start and
                   end time.
+      - !ruby/object:Api::Type::Array
+        name: "maintenance_exclusions"
+        required: false
+        description: |
+          Exclusions to automatic maintenance. Non-emergency maintenance should not occur
+          in these windows. Each exclusion has a unique name and may be active or expired.
+          The max number of maintenance exclusions allowed at a given time is 3.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::NestedObject
+              name: "window"
+              default_from_api: true
+              description: |
+                Represents an arbitrary window of time.
+              properties:
+                - !ruby/object:Api::Type::Time
+                  name: "startTime"
+                  description: |
+                    The time that the window first starts.
+                  default_from_api: true
+                - !ruby/object:Api::Type::Time
+                  name: "endTime"
+                  description: |
+                    The time that the window ends. The end time must take place after the
+                    start time.
+                  default_from_api: true
+            - !ruby/object:Api::Type::String
+              name: "id"
+              default_from_api: true
+              description: |
+                A unique (per cluster) id for the window.
   - !ruby/object:Api::Type::String
     name: "controlPlaneVersion"
     description: |

--- a/mmv1/templates/terraform/examples/edgecontainer_cluster_with_maintenance_exclusion_windows.tf.erb
+++ b/mmv1/templates/terraform/examples/edgecontainer_cluster_with_maintenance_exclusion_windows.tf.erb
@@ -1,0 +1,47 @@
+resource "google_edgecontainer_cluster" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['edgecontainer_cluster_name'] %>"
+  location = "us-central1"
+
+  authorization {
+    admin_users {
+      username = "admin@hashicorptest.com"
+    }
+  }
+
+  networking {
+    cluster_ipv4_cidr_blocks = ["10.0.0.0/16"]
+    services_ipv4_cidr_blocks = ["10.1.0.0/16"]
+  }
+
+  fleet {
+    project = "projects/${data.google_project.project.number}"
+  }
+
+  maintenance_policy {
+    window {
+      recurring_window {
+        window {
+          start_time = "2023-01-01T08:00:00Z"
+          end_time = "2023-01-01T17:00:00Z"
+        }
+        recurrence = "FREQ=WEEKLY;BYDAY=SA"
+      }
+    }
+    maintenance_exclusions {
+      window {
+        start_time = "2023-01-01T08:00:00Z"
+        end_time = "2023-01-01T20:00:00Z"
+      }
+      id = "short-exclusion"
+    }
+    maintenance_exclusions {
+      window {
+        start_time = "2023-01-02T08:00:00Z"
+        end_time = "2023-01-13T08:00:00Z"
+      }
+      id = "long-exclusion"
+    }
+  }
+}
+
+data "google_project" "project" {}

--- a/mmv1/third_party/terraform/services/edgecontainer/resource_edgecontainer_cluster_test.go
+++ b/mmv1/third_party/terraform/services/edgecontainer/resource_edgecontainer_cluster_test.go
@@ -1,0 +1,134 @@
+package edgecontainer_test
+
+import (
+        "testing"
+
+        "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+        "github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccEdgecontainerCluster_update(t *testing.T) {
+        t.Parallel()
+
+        context := map[string]interface{}{
+                "random_suffix": acctest.RandString(t, 10),
+        }
+
+        acctest.VcrTest(t, resource.TestCase{
+                PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+                ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+                CheckDestroy:             testAccCheckEdgecontainerClusterDestroyProducer(t),
+                Steps: []resource.TestStep{
+                        {
+                                Config: testAccEdgecontainerCluster_full(context),
+                        },
+                        {
+                                ResourceName:            "google_edgecontainer_cluster.default",
+                                ImportState:             true,
+                                ImportStateVerify:       true,
+                                ImportStateVerifyIgnore: []string{"labels", "location", "name", "terraform_labels"},
+                        },
+                        {
+                                Config: testAccEdgecontainerCluster_addedExclusionWindows(context),
+                        },
+                        {
+                                ResourceName:            "google_edgecontainer_cluster.default",
+                                ImportState:             true,
+                                ImportStateVerify:       true,
+                                ImportStateVerifyIgnore: []string{"labels", "location", "name", "terraform_labels"},
+                        },
+                },
+        })
+}
+
+func testAccEdgecontainerCluster_full(context map[string]interface{}) string {
+        return acctest.Nprintf(`
+resource "google_edgecontainer_cluster" "default" {
+  name = "tf-test-cluster-with-maintenance-exclusions%{random_suffix}"
+  location = "us-central1"
+
+  authorization {
+    admin_users {
+      username = "admin@hashicorptest.com"
+    }
+  }
+
+  networking {
+    cluster_ipv4_cidr_blocks = ["10.0.0.0/16"]
+    services_ipv4_cidr_blocks = ["10.1.0.0/16"]
+  }
+
+  fleet {
+    project = "projects/${data.google_project.project.number}"
+  }
+
+  maintenance_policy {
+    window {
+      recurring_window {
+        window {
+          start_time = "2023-01-01T08:00:00Z"
+          end_time = "2023-01-01T17:00:00Z"
+        }
+        recurrence = "FREQ=WEEKLY;BYDAY=SA"
+      }
+    }
+  }
+}
+
+data "google_project" "project" {}
+`, context)
+}
+
+func testAccEdgecontainerCluster_addedExclusionWindows(context map[string]interface{}) string {
+        return acctest.Nprintf(`
+resource "google_edgecontainer_cluster" "default" {
+  name = "tf-test-cluster-with-maintenance-exclusions%{random_suffix}"
+  location = "us-central1"
+
+  authorization {
+    admin_users {
+      username = "admin@hashicorptest.com"
+    }
+  }
+
+  networking {
+    cluster_ipv4_cidr_blocks = ["10.0.0.0/16"]
+    services_ipv4_cidr_blocks = ["10.1.0.0/16"]
+  }
+
+  fleet {
+    project = "projects/${data.google_project.project.number}"
+  }
+
+  maintenance_policy {
+    window {
+      recurring_window {
+        window {
+          start_time = "2023-01-01T08:00:00Z"
+          end_time = "2023-01-01T17:00:00Z"
+        }
+        recurrence = "FREQ=WEEKLY;BYDAY=SA"
+      }
+    }
+    maintenance_exclusions {
+      window {
+        start_time = "2023-01-01T08:00:00Z"
+        end_time = "2023-01-01T20:00:00Z"
+      }
+      id = "short-exclusion"
+    }
+    maintenance_exclusions {
+      window {
+        start_time = "2023-01-02T08:00:00Z"
+        end_time = "2023-01-13T08:00:00Z"
+      }
+      id = "long-exclusion"
+    }
+  }
+}
+
+data "google_project" "project" {}
+`, context)
+}
+


### PR DESCRIPTION
…iner product.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
edgecontainer cluster API has a new field maintenance exclusions that needs to be supported by terraform for cluster configuration. This change adds the relevant magic modules changes with tests to ensure integration safety.


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
edgecontainer: added 'maintenance_exclusions' field to 'edgecontainer_Cluster' resource.
```

No github issue exists for this new enhancement feature.