### PR TITLE
Docs - Changed documentation for VPC SC perimeter ingress policy sources

### DIFF
--- a/mmv1/products/accesscontextmanager/ServicePerimeter.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeter.yaml
@@ -269,10 +269,10 @@ properties:
                         description: |
                           A Google Cloud resource that is allowed to ingress the perimeter.
                           Requests from these resources will be allowed to access perimeter data.
-                          Currently only projects are allowed. Format `projects/{project_number}`
-                          The project may be in any Google Cloud organization, not just the
-                          organization that the perimeter is defined in. `*` is not allowed, the case
-                          of allowing all Google Cloud resources only is not supported.
+                          Currently only projects and VPCs are allowed.
+                          Project format: projects/{projectNumber} VPC network format: //compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NAME}.
+                          The project may be in any Google Cloud organization, not just the organization that the perimeter is defined in.
+                          * is not allowed, the case of allowing all Google Cloud resources only is not supported.
             - !ruby/object:Api::Type::NestedObject
               name: 'ingressTo'
               description: |

--- a/mmv1/products/accesscontextmanager/ServicePerimeterIngressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterIngressPolicy.yaml
@@ -111,10 +111,10 @@ properties:
               description: |
                 A Google Cloud resource that is allowed to ingress the perimeter.
                 Requests from these resources will be allowed to access perimeter data.
-                Currently only projects are allowed. Format `projects/{project_number}`
-                The project may be in any Google Cloud organization, not just the
-                organization that the perimeter is defined in. `*` is not allowed, the case
-                of allowing all Google Cloud resources only is not supported.
+                Currently only projects and VPCs are allowed.
+                Project format: projects/{projectNumber} VPC network format: //compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NAME}.T
+                he project may be in any Google Cloud organization, not just the organization that the perimeter is defined in.
+                * is not allowed, the case of allowing all Google Cloud resources only is not supported.
   - !ruby/object:Api::Type::NestedObject
     name: 'ingressTo'
     description: |


### PR DESCRIPTION
Added documentation about the support of VPC sources for `IngressPolicy[].from.resource` fields

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
accesscontextmanager: Added docs for `google_access_context_manager_service_perimeter` and `google_access_context_manager_service_perimeter_ingress_policy` which reflects VPC network support for the `from.resource` field
```
