### PR TITLE
Add support for preventDrift field in ConfigManagement Fleet-level default config

### DIFF
--- a/mmv1/products/gkehub2/Feature.yaml
+++ b/mmv1/products/gkehub2/Feature.yaml
@@ -285,6 +285,9 @@ properties:
               - !ruby/object:Api::Type::String
                 name: sourceFormat
                 description: 'Specifies whether the Config Sync Repo is in hierarchical or unstructured mode'
+              - !ruby/object:Api::Type::Boolean
+                name: preventDrift
+                description: 'Set to true to enable the Config Sync admission webhook to prevent drifts. If set to `false`, disables the Config Sync admission webhook and does not prevent drifts.'
               - !ruby/object:Api::Type::NestedObject
                 name: git
                 description: 'Git repo configuration for the cluster'

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go.erb
@@ -488,6 +488,7 @@ resource "google_gke_hub_feature" "feature" {
   fleet_default_member_config {
     configmanagement {
       version = "1.16.1"
+      prevent_drift = true
       config_sync {
         source_format = "unstructured"
         oci {

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go.erb
@@ -488,8 +488,8 @@ resource "google_gke_hub_feature" "feature" {
   fleet_default_member_config {
     configmanagement {
       version = "1.16.1"
-      prevent_drift = true
-      config_sync {
+     config_sync {
+       prevent_drift = true
         source_format = "unstructured"
         oci {
           sync_repo = "us-central1-docker.pkg.dev/corp-gke-build-artifacts/acm/configs:latest"


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
gkehub: added `prevent_drift` field to ConfigManagement `fleet_default_member_config`
```