### PR TITLE
Removed required tag on maxFindingsPerInfoType.infoType

### DIFF
--- a/mmv1/products/dlp/InspectTemplate.yaml
+++ b/mmv1/products/dlp/InspectTemplate.yaml
@@ -55,6 +55,11 @@ examples:
     test_env_vars:
       project: :PROJECT_NAME
     skip_docs: true
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'dlp_inspect_template_max_infotype_per_finding_default'
+    primary_resource_id: 'max_infotype_per_finding_default'
+    test_env_vars:
+      project: :PROJECT_NAME
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   decoder: templates/terraform/decoders/dlp_template_id.go.erb
   encoder: templates/terraform/encoders/wrap_object_with_template_id.go.erb

--- a/mmv1/products/dlp/InspectTemplate.yaml
+++ b/mmv1/products/dlp/InspectTemplate.yaml
@@ -144,7 +144,6 @@ properties:
               properties:
                 - !ruby/object:Api::Type::NestedObject
                   name: 'infoType'
-                  required: true
                   description: |
                     Type of information the findings limit applies to. Only one limit per infoType should be provided. If InfoTypeLimit does
                     not have an infoType, the DLP API applies the limit against all infoTypes that are found but not

--- a/mmv1/templates/terraform/examples/dlp_inspect_template_max_infotype_per_finding_default.tf.erb
+++ b/mmv1/templates/terraform/examples/dlp_inspect_template_max_infotype_per_finding_default.tf.erb
@@ -1,0 +1,22 @@
+resource "google_data_loss_prevention_inspect_template" "<%= ctx[:primary_resource_id] %>" {
+  parent = "projects/<%= ctx[:test_env_vars]['project'] %>"
+
+  inspect_config {
+    info_types {
+      name = "EMAIL_ADDRESS"
+    }
+    info_types {
+      name = "PERSON_NAME"
+    }
+
+    min_likelihood = "UNLIKELY"
+    limits {
+        max_findings_per_request = 333
+        max_findings_per_item = 222
+        max_findings_per_info_type {
+          # Entry with no info_type specifies the default value used by all info_types that don't specify their own limit
+          max_findings = 111
+        }
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/18149
```release-note:bug
dlp: removed required on  `google_data_loss_prevention_inspect_template` to allow use of default `per_info_type` limit by not setting the `info_type` field
```