### PR TITLE
Add missing closing backtick for `gae_app` in monitoring uptime check resource

### DIFF
--- a/mmv1/products/monitoring/UptimeCheckConfig.yaml
+++ b/mmv1/products/monitoring/UptimeCheckConfig.yaml
@@ -438,7 +438,7 @@ properties:
       uptime checks:
       * `aws_ec2_instance`
       * `aws_elb_load_balancer`
-      * `gae_app
+      * `gae_app`
       * `gce_instance`
       * `k8s_service`
       * `servicedirectory_service`


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add the missing closing backtick in the document [`google_monitoring_uptime_check_config`](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/monitoring_uptime_check_config):

![Screenshot-2024-05-29 at 08 53 23@2x](https://github.com/GoogleCloudPlatform/magic-modules/assets/23056537/43fdde44-624a-489e-8d27-6b97ed02a821)

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
