### PR TITLE
Adding support for backup_config in netapp volumes volume resource

### DIFF
--- a/mmv1/products/netapp/volume.yaml
+++ b/mmv1/products/netapp/volume.yaml
@@ -452,6 +452,29 @@ properties:
             description: |-
               Set the day or days of the month to make a snapshot (1-31). Accepts a comma separated number of days. Defaults to '1'.
             default_value: '1'
+  - !ruby/object:Api::Type::NestedObject
+    name: 'backupConfig'
+    description: |-
+      Backup configuration for the volume.
+    update_mask_fields:
+      - 'backup_config.backup_policies'
+      - 'backup_config.backup_vault'
+      - 'backup_config.scheduled_backup_enabled'
+    properties:
+      - !ruby/object:Api::Type::Array
+        name: 'backupPolicies'
+        description: |-
+          Specify a single backup policy ID for scheduled backups. Format: `projects/{{projectId}}/locations/{{location}}/backupPolicies/{{backupPolicyName}}`
+        item_type: Api::Type::String
+      - !ruby/object:Api::Type::String
+        name: 'backupVault'
+        description: |-
+          ID of the backup vault to use. A backup vault is reqired to create manual or scheduled backups.
+          Format: `projects/{{projectId}}/locations/{{location}}/backupVaults/{{backupVaultName}}`
+      - !ruby/object:Api::Type::Boolean
+        name: 'scheduledBackupEnabled'
+        description: |-
+          When set to true, scheduled backup is enabled on the volume. Omit if no backup_policy is specified.
 virtual_fields:
   - !ruby/object:Api::Type::Enum
     name: 'deletion_policy'

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_test.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_test.go
@@ -4,16 +4,21 @@
 package netapp_test
 
 import (
+	"fmt"
+	"sort"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-google/google/services/netapp"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 func TestAccNetappVolume_netappVolumeBasicExample_update(t *testing.T) {
-	t.Parallel()
-
 	context := map[string]interface{}{
 		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "gcnv-network-config-1", acctest.ServiceNetworkWithParentService("netapp.servicenetworking.goog")),
 		"random_suffix": acctest.RandString(t, 10),
@@ -23,6 +28,9 @@ func TestAccNetappVolume_netappVolumeBasicExample_update(t *testing.T) {
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckNetappVolumeDestroyProducer(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNetappVolume_volumeBasicExample_basic(context),
@@ -64,6 +72,34 @@ func TestAccNetappVolume_netappVolumeBasicExample_update(t *testing.T) {
 			},
 			{
 				ResourceName:            "google_netapp_volume.test_volume_clone",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"restore_parameters", "location", "name", "deletion_policy", "labels", "terraform_labels"},
+			},
+			{
+				Config: testAccNetappVolume_volumeBasicExample_createBackupConfig(context),
+			},
+			{
+				ResourceName:            "google_netapp_volume.test_volume",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"restore_parameters", "location", "name", "deletion_policy", "labels", "terraform_labels"},
+			},
+			{
+				Config: testAccNetappVolume_volumeBasicExample_updateBackupConfigRemoveBackupPolicy(context),
+				Check:  testAccNetappVolume_volumeBasicExample_cleanupScheduledBackup(t, "google_netapp_backup_vault.backup-vault"),
+			},
+			{
+				ResourceName:            "google_netapp_volume.test_volume",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"restore_parameters", "location", "name", "deletion_policy", "labels", "terraform_labels"},
+			},
+			{
+				Config: testAccNetappVolume_volumeBasicExample_updateBackupConfigRemoveBackupVault(context),
+			},
+			{
+				ResourceName:            "google_netapp_volume.test_volume",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"restore_parameters", "location", "name", "deletion_policy", "labels", "terraform_labels"},
@@ -394,4 +430,232 @@ data "google_compute_network" "default" {
     name = "%{network_name}"
 }
 	`, context)
+}
+
+// Tests creating a volume with backup config
+func testAccNetappVolume_volumeBasicExample_createBackupConfig(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_netapp_storage_pool" "default2" {
+    name = "tf-test-pool%{random_suffix}"
+    location = "us-west2"
+    service_level = "EXTREME"
+    capacity_gib = "2048"
+    network = data.google_compute_network.default.id
+}
+
+resource "google_netapp_volume" "test_volume" {
+    location = "us-west2"
+    name = "tf-test-test-volume%{random_suffix}"
+    capacity_gib = "200"
+    share_name = "tf-test-test-volume%{random_suffix}"
+    storage_pool = google_netapp_storage_pool.default2.name
+    protocols = ["NFSV3"]
+    security_style = "UNIX"
+    # Delete protection only gets active after an NFS client mounts.
+    # Setting it here is save, volume can still be deleted.
+    restricted_actions = ["DELETE"]
+    deletion_policy = "FORCE"
+    backup_config {
+        backup_policies = [
+            google_netapp_backup_policy.backup-policy.id
+        ]
+        backup_vault = google_netapp_backup_vault.backup-vault.id
+        scheduled_backup_enabled = true
+    }
+}
+
+resource "time_sleep" "wait_30_minutes" {
+    depends_on = [google_netapp_volume.test_volume]
+    create_duration = "30m"
+}
+
+resource "google_netapp_backup_vault" "backup-vault" {
+    location = "us-west2"
+    name = "tf-test-vault%{random_suffix}"
+}
+
+resource "google_netapp_backup_policy" "backup-policy" {
+    name          		 = "tf-test-backup-policy%{random_suffix}"
+    location 			 = "us-west2"
+    daily_backup_limit   = 2
+    weekly_backup_limit  = 0
+    monthly_backup_limit = 0
+    enabled = true
+}
+
+data "google_compute_network" "default" {
+    name = "%{network_name}"
+}
+	`, context)
+}
+
+// Tests updating the volume backup config
+func testAccNetappVolume_volumeBasicExample_updateBackupConfigRemoveBackupPolicy(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_netapp_storage_pool" "default2" {
+    name = "tf-test-pool%{random_suffix}"
+    location = "us-west2"
+    service_level = "EXTREME"
+    capacity_gib = "2048"
+    network = data.google_compute_network.default.id
+}
+
+resource "google_netapp_volume" "test_volume" {
+    location = "us-west2"
+    name = "tf-test-test-volume%{random_suffix}"
+    capacity_gib = "200"
+    share_name = "tf-test-test-volume%{random_suffix}"
+    storage_pool = google_netapp_storage_pool.default2.name
+    protocols = ["NFSV3"]
+    security_style = "UNIX"
+    # Delete protection only gets active after an NFS client mounts.
+    # Setting it here is save, volume can still be deleted.
+    restricted_actions = ["DELETE"]
+    deletion_policy = "FORCE"
+    backup_config {
+        backup_vault = google_netapp_backup_vault.backup-vault.id
+    }
+}
+
+resource "time_sleep" "wait_30_minutes" {
+    depends_on = [google_netapp_volume.test_volume]
+    create_duration = "30m"
+}
+
+resource "google_netapp_backup_vault" "backup-vault" {
+    location = "us-west2"
+    name = "tf-test-vault%{random_suffix}"
+}
+
+resource "google_netapp_backup_policy" "backup-policy" {
+    name          		 = "tf-test-backup-policy%{random_suffix}"
+    location 			 = "us-west2"
+    daily_backup_limit   = 2
+    weekly_backup_limit  = 0
+    monthly_backup_limit = 0
+    enabled = true
+}
+
+data "google_compute_network" "default" {
+    name = "%{network_name}"
+}
+	`, context)
+}
+
+// Tests updating the volume to no backup config
+func testAccNetappVolume_volumeBasicExample_updateBackupConfigRemoveBackupVault(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_netapp_storage_pool" "default2" {
+    name = "tf-test-pool%{random_suffix}"
+    location = "us-west2"
+    service_level = "EXTREME"
+    capacity_gib = "2048"
+    network = data.google_compute_network.default.id
+}
+
+resource "google_netapp_volume" "test_volume" {
+    location = "us-west2"
+    name = "tf-test-test-volume%{random_suffix}"
+    capacity_gib = "200"
+    share_name = "tf-test-test-volume%{random_suffix}"
+    storage_pool = google_netapp_storage_pool.default2.name
+    protocols = ["NFSV3"]
+    security_style = "UNIX"
+    # Delete protection only gets active after an NFS client mounts.
+    # Setting it here is save, volume can still be deleted.
+    restricted_actions = ["DELETE"]
+    deletion_policy = "FORCE"
+}
+
+resource "time_sleep" "wait_30_minutes" {
+    depends_on = [google_netapp_volume.test_volume]
+    create_duration = "30m"
+}
+
+resource "google_netapp_backup_vault" "backup-vault" {
+    location = "us-west2"
+    name = "tf-test-vault%{random_suffix}"
+}
+
+resource "google_netapp_backup_policy" "backup-policy" {
+    name          		 = "tf-test-backup-policy%{random_suffix}"
+    location 			 = "us-west2"
+    daily_backup_limit   = 2
+    weekly_backup_limit  = 0
+    monthly_backup_limit = 0
+    enabled = true
+}
+
+data "google_compute_network" "default" {
+    name = "%{network_name}"
+}
+	`, context)
+}
+
+// Cleanup the created backup of the test
+func testAccNetappVolume_volumeBasicExample_cleanupScheduledBackup(t *testing.T, vault string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := acctest.GoogleProviderConfig(t)
+		rs, ok := s.RootModule().Resources[vault]
+		if !ok {
+			return fmt.Errorf("Not found: %v", vault)
+		}
+		url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{NetappBasePath}}projects/{{project}}/locations/{{location}}/backupVaults/{{name}}/backups")
+		if err != nil {
+			return fmt.Errorf("Error : %v", err)
+		}
+		response, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			RawURL:    url,
+			UserAgent: config.UserAgent,
+		})
+		backups := response["backups"].([]interface{})
+		if len(backups) == 0 {
+			return nil
+		}
+		type BackupData struct {
+			name       string
+			createTime time.Time
+		}
+		var backupDataList []BackupData
+		for i, _ := range backups {
+			backup := backups[i].(map[string]interface{})
+			backupName := backup["name"].(string)
+			backupCreateTimeStr := backup["createTime"].(string)
+			backupCreateTime, err := time.Parse(time.RFC3339, backupCreateTimeStr)
+			if err != nil {
+				fmt.Errorf("Failed to parse backup create time : %v", err)
+			}
+			backupData := BackupData{
+				name:       backupName,
+				createTime: backupCreateTime,
+			}
+			backupDataList = append(backupDataList, backupData)
+		}
+		sort.Slice(backupDataList, func(i, j int) bool {
+			return backupDataList[i].createTime.After(backupDataList[j].createTime)
+		})
+		for i, _ := range backupDataList {
+			baseUrl, err := tpgresource.ReplaceVarsForTest(config, rs, "{{NetappBasePath}}")
+			if err != nil {
+				return fmt.Errorf("Error : %v", err)
+			}
+			backupUrl := baseUrl + backupDataList[i].name
+			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "DELETE",
+				RawURL:    backupUrl,
+				UserAgent: config.UserAgent,
+			})
+			if err != nil {
+				return fmt.Errorf("Delete Request Error : %v", err)
+			}
+			err = netapp.NetappOperationWaitTime(config, res, config.Project, "Deleting Backup", config.UserAgent, 10*time.Minute)
+			if err != nil {
+				return fmt.Errorf("Delete LRO Error : %v", err)
+			}
+		}
+		return nil
+	}
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adding support for backup_config in netapp volumes volume resource

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
netapp: added `backup_config` field to `google_netapp_volume` resource
```
