### PR TITLE
Make `google_compute_security_policy`'s `rule_visibility` optional + computed and remove default value

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.erb
@@ -496,7 +496,7 @@ func ResourceComputeSecurityPolicy() *schema.Resource {
 									"rule_visibility": {
 										Type: schema.TypeString,
 										Optional: true,
-										Default: "STANDARD",
+										Computed: true,
 										ValidateFunc: validation.StringInSlice([]string{"STANDARD", "PREMIUM"}, false),
 										Description: `Rule visibility. Supported values include: "STANDARD", "PREMIUM".`,
 									},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
@@ -239,7 +239,7 @@ func TestAccComputeSecurityPolicy_withAdaptiveProtection(t *testing.T) {
 		CheckDestroy:             testAccCheckComputeSecurityPolicyDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeSecurityPolicy_withAdaptiveProtection(spName),
+				Config: testAccComputeSecurityPolicy_withAdaptiveProtection_enabled(spName),
 			},
 			{
 				ResourceName:      "google_compute_security_policy.policy",
@@ -247,7 +247,7 @@ func TestAccComputeSecurityPolicy_withAdaptiveProtection(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeSecurityPolicy_withAdaptiveProtectionUpdate(spName),
+				Config: testAccComputeSecurityPolicy_withAdaptiveProtection_update(spName),
 			},
 			{
 				ResourceName:      "google_compute_security_policy.policy",
@@ -1192,7 +1192,31 @@ resource "google_compute_security_policy" "policy" {
 `, spName)
 }
 
-func testAccComputeSecurityPolicy_withAdaptiveProtection(spName string) string {
+func testAccComputeSecurityPolicy_withoutAdaptiveProtection(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+  name        = "%s"
+  description = "updated description"
+}
+`, spName)
+}
+
+func testAccComputeSecurityPolicy_withAdaptiveProtection_disabled(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+  name        = "%s"
+  description = "updated description"
+
+  adaptive_protection_config {
+    layer_7_ddos_defense_config {
+      enable = false
+    }
+  }
+}
+`, spName)
+}
+
+func testAccComputeSecurityPolicy_withAdaptiveProtection_enabled(spName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_security_policy" "policy" {
   name        = "%s"
@@ -1208,7 +1232,7 @@ resource "google_compute_security_policy" "policy" {
 `, spName)
 }
 
-func testAccComputeSecurityPolicy_withAdaptiveProtectionUpdate(spName string) string {
+func testAccComputeSecurityPolicy_withAdaptiveProtection_update(spName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_security_policy" "policy" {
   name        = "%s"
@@ -1658,6 +1682,68 @@ func TestAccComputeSecurityPolicy_withRedirectOptionsExternal(t *testing.T) {
 	})
 }
 
+// See https://github.com/hashicorp/terraform-provider-google/issues/12743
+func TestAccComputeSecurityPolicy_issue_12743(t *testing.T) {
+	t.Parallel()
+
+	randomString := acctest.RandString(t, 10)
+	context := map[string]interface{}{
+		"security_policy_name": fmt.Sprintf("tf-test-%s", randomString),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeSecurityPolicyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				// Config from https://github.com/hashicorp/terraform-provider-google/issues/12743
+				Config: testAccComputeSecurityPolicy_issue_12743(context),
+			},
+			{
+				ResourceName:      "google_compute_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeSecurityPolicy_withoutAdaptiveProtection(t *testing.T) {
+	t.Parallel()
+
+	spName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeSecurityPolicyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				// Can create with layer 7 protection disabled
+				Config: testAccComputeSecurityPolicy_withAdaptiveProtection_disabled(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// Can update to layer 7 protection enabled
+				Config: testAccComputeSecurityPolicy_withAdaptiveProtection_enabled(spName),
+			},
+			{
+				// Can update to layer 7 protection disabled again
+				Config: testAccComputeSecurityPolicy_withAdaptiveProtection_disabled(spName),
+			},
+			{
+				// Can remove adaptive protection block
+				Config: testAccComputeSecurityPolicy_withoutAdaptiveProtection(spName),
+			},
+		},
+	})
+}
+
 func testAccComputeSecurityPolicy_withRedirectOptionsRecaptcha(spName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_security_policy" "policy" {
@@ -1704,3 +1790,66 @@ resource "google_compute_security_policy" "policy" {
 }
 `, spName)
 }
+
+func testAccComputeSecurityPolicy_issue_12743(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+locals {
+  ip_allow_list = [
+    "192.168.1.0/24",
+    "192.168.2.0/24",
+    "192.168.3.0/24",
+    "192.168.4.0/24",
+    "192.168.0.1/32",
+  ]
+}
+
+resource "google_compute_security_policy" "policy" {
+  name        = "%{security_policy_name}"
+  description = "Limit incoming traffic to only IP ranges specified here"
+
+  dynamic "rule" {
+    for_each = chunklist(local.ip_allow_list, 10)
+
+    content {
+      description = "Allow traffic from client network ranges"
+      preview     = true
+      action      = "allow"
+      priority    = rule.key + 10
+
+      match {
+        versioned_expr = "SRC_IPS_V1"
+
+        config {
+          src_ip_ranges = rule.value
+        }
+      }
+    }
+  }
+  rule {
+    preview  = true
+    action   = "deny(403)"
+    priority = "10000"
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = ["*"]
+      }
+    }
+    description = "Deny all other traffic"
+  }
+  rule {
+    action   = "allow"
+    priority = "2147483647"
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = ["*"]
+      }
+    }
+    description = "Default rule, higher priority overrides it"
+  }
+}
+`, context)
+}
+
+//foo

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
@@ -1709,41 +1709,6 @@ func TestAccComputeSecurityPolicy_issue_12743(t *testing.T) {
 	})
 }
 
-func TestAccComputeSecurityPolicy_withoutAdaptiveProtection(t *testing.T) {
-	t.Parallel()
-
-	spName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckComputeSecurityPolicyDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				// Can create with layer 7 protection disabled
-				Config: testAccComputeSecurityPolicy_withAdaptiveProtection_disabled(spName),
-			},
-			{
-				ResourceName:      "google_compute_security_policy.policy",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				// Can update to layer 7 protection enabled
-				Config: testAccComputeSecurityPolicy_withAdaptiveProtection_enabled(spName),
-			},
-			{
-				// Can update to layer 7 protection disabled again
-				Config: testAccComputeSecurityPolicy_withAdaptiveProtection_disabled(spName),
-			},
-			{
-				// Can remove adaptive protection block
-				Config: testAccComputeSecurityPolicy_withoutAdaptiveProtection(spName),
-			},
-		},
-	})
-}
-
 func testAccComputeSecurityPolicy_withRedirectOptionsRecaptcha(spName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_security_policy" "policy" {
@@ -1851,5 +1816,3 @@ resource "google_compute_security_policy" "policy" {
 }
 `, context)
 }
-
-//foo

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
@@ -258,6 +258,37 @@ func TestAccComputeSecurityPolicy_withAdaptiveProtection(t *testing.T) {
 	})
 }
 
+func TestAccComputeSecurityPolicy_withoutAdaptiveProtection(t *testing.T) {
+	t.Parallel()
+
+	spName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeSecurityPolicyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				// Can create with layer 7 protection disabled
+				Config: testAccComputeSecurityPolicy_withAdaptiveProtection_disabled(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// Can update to layer 7 protection enabled
+				Config: testAccComputeSecurityPolicy_withAdaptiveProtection_enabled(spName),
+			},
+			{
+				// Can update to layer 7 protection disabled again
+				Config: testAccComputeSecurityPolicy_withAdaptiveProtection_disabled(spName),
+			},
+		},
+	})
+}
+
 <% unless version == 'ga' -%>
 func TestAccComputeSecurityPolicy_withAdaptiveProtectionAutoDeployConfig(t *testing.T) {
 	t.Parallel()

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.erb
@@ -1682,33 +1682,6 @@ func TestAccComputeSecurityPolicy_withRedirectOptionsExternal(t *testing.T) {
 	})
 }
 
-// See https://github.com/hashicorp/terraform-provider-google/issues/12743
-func TestAccComputeSecurityPolicy_issue_12743(t *testing.T) {
-	t.Parallel()
-
-	randomString := acctest.RandString(t, 10)
-	context := map[string]interface{}{
-		"security_policy_name": fmt.Sprintf("tf-test-%s", randomString),
-	}
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckComputeSecurityPolicyDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				// Config from https://github.com/hashicorp/terraform-provider-google/issues/12743
-				Config: testAccComputeSecurityPolicy_issue_12743(context),
-			},
-			{
-				ResourceName:      "google_compute_security_policy.policy",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func testAccComputeSecurityPolicy_withRedirectOptionsRecaptcha(spName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_security_policy" "policy" {
@@ -1754,65 +1727,4 @@ resource "google_compute_security_policy" "policy" {
 	}
 }
 `, spName)
-}
-
-func testAccComputeSecurityPolicy_issue_12743(context map[string]interface{}) string {
-	return acctest.Nprintf(`
-locals {
-  ip_allow_list = [
-    "192.168.1.0/24",
-    "192.168.2.0/24",
-    "192.168.3.0/24",
-    "192.168.4.0/24",
-    "192.168.0.1/32",
-  ]
-}
-
-resource "google_compute_security_policy" "policy" {
-  name        = "%{security_policy_name}"
-  description = "Limit incoming traffic to only IP ranges specified here"
-
-  dynamic "rule" {
-    for_each = chunklist(local.ip_allow_list, 10)
-
-    content {
-      description = "Allow traffic from client network ranges"
-      preview     = true
-      action      = "allow"
-      priority    = rule.key + 10
-
-      match {
-        versioned_expr = "SRC_IPS_V1"
-
-        config {
-          src_ip_ranges = rule.value
-        }
-      }
-    }
-  }
-  rule {
-    preview  = true
-    action   = "deny(403)"
-    priority = "10000"
-    match {
-      versioned_expr = "SRC_IPS_V1"
-      config {
-        src_ip_ranges = ["*"]
-      }
-    }
-    description = "Deny all other traffic"
-  }
-  rule {
-    action   = "allow"
-    priority = "2147483647"
-    match {
-      versioned_expr = "SRC_IPS_V1"
-      config {
-        src_ip_ranges = ["*"]
-      }
-    }
-    description = "Default rule, higher priority overrides it"
-  }
-}
-`, context)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Supersedes https://github.com/GoogleCloudPlatform/magic-modules/pull/8060
Might fix https://github.com/hashicorp/terraform-provider-google/issues/12743 ?

I find that issue above confusing as it includes 2 issues:
1. Being unable to create a google_compute_security_policy resource when this is in the config:
```
adaptive_protection_config {
      layer_7_ddos_defense_config {
          enable = false
      }
}
```
2. Issues/expected behaviour when the adaptive_protection_config block is removed:
```diff
- adaptive_protection_config {
-      layer_7_ddos_defense_config {
-          enable = false
-      }
-}
```


This PR addresses issue 1.
[I explored issue 2](https://github.com/GoogleCloudPlatform/magic-modules/pull/10823#issuecomment-2142542094) but [decided that it'd be best to address that separately to 1.](https://github.com/GoogleCloudPlatform/magic-modules/pull/10823#issuecomment-2142696373)

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed issue where users could not create `google_compute_security_policy` resources with `layer_7_ddos_defense_config` explicitly disabled
```
