### PR TITLE
Add 6.0.0 upgrade guide for the deprecated `require_ssl` field.

### DIFF
--- a/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
@@ -107,3 +107,9 @@ Description of the change and how users should adjust their configuration (if ne
 ### Resource-level change example header
 
 Description of the change and how users should adjust their configuration (if needed).
+
+## Resource: `google_sql_database_instance`
+
+### `settings.ip_configuration.require_ssl` is now removed
+
+Removed in favor of field `settings.ip_configuration.ssl_mode`.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Following the deprecation [guide](https://googlecloudplatform.github.io/magic-modules/develop/breaking-changes/make-a-breaking-change/#add-upgrade-guide-entries-to-the-main-branch-of-magic-modules) to add the upgrade entry for the deprecated `require_ssl` which will be removed in 6.0.0.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:note
Add upgrade guide for the deprecated `require_ssl` field which will be removed in 6.0.0.
```
