### PR TITLE
[#11127] Fixes ability to add secret manager secrets IAM bindings with conditions

### DIFF
--- a/mmv1/products/secretmanager/Secret.yaml
+++ b/mmv1/products/secretmanager/Secret.yaml
@@ -22,6 +22,7 @@ iam_policy: !ruby/object:Api::Resource::IamPolicy
   parent_resource_attribute: secret_id
   method_name_separator: ':'
   allowed_iam_role: roles/secretmanager.secretAccessor
+  iam_conditions_request_type: :QUERY_PARAM_NESTED
 references: !ruby/object:Api::Resource::ReferenceLinks
   api: 'https://cloud.google.com/secret-manager/docs/reference/rest/v1/projects.secrets'
 description: |

--- a/mmv1/third_party/terraform/services/secretmanager/iam_secret_manager_secret_test.go.erb
+++ b/mmv1/third_party/terraform/services/secretmanager/iam_secret_manager_secret_test.go.erb
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
-func TestAccSecretManagerSecretIam_iamMemberCondition(t *testing.T) {
+func TestAccSecretManagerSecretIam_iamMemberConditionUpdate(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
@@ -25,7 +25,7 @@ func TestAccSecretManagerSecretIam_iamMemberCondition(t *testing.T) {
 		CheckDestroy:             testAccCheckSecretManagerSecretDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecretManagerSecretIam_iamMemberCondition(context),
+				Config: testAccSecretManagerSecretIam_iamMemberCondition_basic(context),
 			},
 			{
 				ResourceName:      "google_secret_manager_secret_iam_member.default",
@@ -33,11 +33,20 @@ func TestAccSecretManagerSecretIam_iamMemberCondition(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccSecretManagerSecretIam_iamMemberCondition_update(context),
+			},
+			{
+				ResourceName:      "google_secret_manager_secret_iam_member.default",
+				ImportStateId:     fmt.Sprintf("projects/%s/secrets/%s %s serviceAccount:%s %s", envvar.GetTestProjectFromEnv(), fmt.Sprintf("tf-test-secret-%s", context["random_suffix"]), context["role"], fmt.Sprintf("tf-test-sa-%s@%s.iam.gserviceaccount.com", context["random_suffix"], envvar.GetTestProjectFromEnv()), fmt.Sprintf("tf-test-condition-new-%s", context["random_suffix"])),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
 
-func testAccSecretManagerSecretIam_iamMemberCondition(context map[string]interface{}) string {
+func testAccSecretManagerSecretIam_iamMemberCondition_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_service_account" "default" {
   account_id   = "tf-test-sa-%{random_suffix}"
@@ -68,6 +77,42 @@ resource "google_secret_manager_secret_iam_member" "default" {
     title       = "tf-test-condition-%{random_suffix}"
     description = "test condition"
     expression  = "request.time < timestamp(\"2022-03-01T00:00:00Z\")"
+  }
+}
+`, context)
+}
+
+func testAccSecretManagerSecretIam_iamMemberCondition_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_service_account" "default" {
+  account_id   = "tf-test-sa-%{random_suffix}"
+  display_name = "Secret manager IAM testing account"
+}
+
+resource "google_secret_manager_secret" "default" {
+  secret_id = "tf-test-secret-%{random_suffix}"
+  ttl       = "3600s"
+
+  replication {
+    user_managed {
+      replicas {
+        location = "us-central1"
+      }
+      replicas {
+        location = "us-east1"
+      }
+    }
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "default" {
+  secret_id = google_secret_manager_secret.default.id
+  role      = "%{role}"
+  member    = "serviceAccount:${google_service_account.default.email}"
+  condition {
+    title       = "tf-test-condition-new-%{random_suffix}"
+    description = "test new condition"
+    expression  = "request.time < timestamp(\"2024-03-01T00:00:00Z\")"
   }
 }
 `, context)

--- a/mmv1/third_party/terraform/services/secretmanager/iam_secret_manager_secret_test.go.erb
+++ b/mmv1/third_party/terraform/services/secretmanager/iam_secret_manager_secret_test.go.erb
@@ -1,0 +1,74 @@
+<% autogen_exception -%>
+package secretmanager_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccSecretManagerSecretIam_iamMemberCondition(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"role": "roles/secretmanager.secretAccessor",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerSecretDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretManagerSecretIam_iamMemberCondition(context),
+			},
+			{
+				ResourceName:      "google_secret_manager_secret_iam_member.default",
+				ImportStateId:     fmt.Sprintf("projects/%s/secrets/%s %s serviceAccount:%s %s", envvar.GetTestProjectFromEnv(), fmt.Sprintf("tf-test-secret-%s", context["random_suffix"]), context["role"], fmt.Sprintf("tf-test-sa-%s@%s.iam.gserviceaccount.com", context["random_suffix"], envvar.GetTestProjectFromEnv()), fmt.Sprintf("tf-test-condition-%s", context["random_suffix"])),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccSecretManagerSecretIam_iamMemberCondition(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_service_account" "default" {
+  account_id   = "tf-test-sa-%{random_suffix}"
+  display_name = "Secret manager IAM testing account"
+}
+
+resource "google_secret_manager_secret" "default" {
+  secret_id = "tf-test-secret-%{random_suffix}"
+  ttl       = "3600s"
+
+  replication {
+    user_managed {
+      replicas {
+        location = "us-central1"
+      }
+      replicas {
+        location = "us-east1"
+      }
+    }
+  }
+}
+
+resource "google_secret_manager_secret_iam_member" "default" {
+  secret_id = google_secret_manager_secret.default.id
+  role      = "%{role}"
+  member    = "serviceAccount:${google_service_account.default.email}"
+  condition {
+    title       = "tf-test-condition-%{random_suffix}"
+    description = "test condition"
+    expression  = "request.time < timestamp(\"2022-03-01T00:00:00Z\")"
+  }
+}
+`, context)
+}


### PR DESCRIPTION
- Fixes ability to add secret manager secrets IAM bindings with conditions.
- Adds additional tests to verify that IAM bindings with conditions on secret manager secrets are created correctly

Fixes [hashicorp/terraform-provider-google/issues/11127](https://github.com/hashicorp/terraform-provider-google/issues/11127)

```release-note:bug
secretmanager: fixed ability to add `google_secret_manager_secret_iam_*` bindings and members with conditions
```
