### PR TITLE
feat(google_container_node_pool): Handle nil mode in secondary boot disk.

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -896,17 +896,23 @@ func expandNodeConfig(v interface{}) *container.NodeConfig {
 	}
 
 	if v, ok := nodeConfig["secondary_boot_disks"]; ok && len(v.([]interface{})) > 0 {
-		conf := v.([]interface{})[0].(map[string]interface{})
-		modeValue, modeOK := conf["mode"]
-		diskImage := conf["disk_image"]
-    	if modeOK && modeValue.(string) == "CONTAINER_IMAGE_CACHE" {
-			nc.SecondaryBootDisks = append(nc.SecondaryBootDisks, &container.SecondaryBootDisk{
-				DiskImage: diskImage.(string),
-				Mode:      modeValue.(string),
-			})
+		conf, confOK := v.([]interface{})[0].(map[string]interface{})
+		if confOK {
+			modeValue, modeOK := conf["mode"]
+			diskImage := conf["disk_image"].(string)
+			if modeOK && modeValue.(string) == "CONTAINER_IMAGE_CACHE" {
+				nc.SecondaryBootDisks = append(nc.SecondaryBootDisks, &container.SecondaryBootDisk{
+					DiskImage: diskImage,
+					Mode:      modeValue.(string),
+				})
+			} else {
+				nc.SecondaryBootDisks = append(nc.SecondaryBootDisks, &container.SecondaryBootDisk{
+					DiskImage: diskImage,
+				})
+			}
 		} else {
 			nc.SecondaryBootDisks = append(nc.SecondaryBootDisks, &container.SecondaryBootDisk{
-				DiskImage: diskImage.(string),
+				DiskImage: "",
 			})
 		}
 	}
@@ -1535,7 +1541,9 @@ func flattenSecondaryBootDisks(c []*container.SecondaryBootDisk) []map[string]in
 		for _, disk := range c {
 			secondaryBootDisk := map[string]interface{}{
 				"disk_image": disk.DiskImage,
-				"mode": disk.Mode,
+			}
+			if disk.Mode == "CONTAINER_IMAGE_CACHE" {
+				secondaryBootDisk["mode"] = disk.Mode
 			}
 			result = append(result, secondaryBootDisk)
 		}

--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -900,7 +900,7 @@ func expandNodeConfig(v interface{}) *container.NodeConfig {
 		if confOK {
 			modeValue, modeOK := conf["mode"]
 			diskImage := conf["disk_image"].(string)
-			if modeOK && modeValue.(string) == "CONTAINER_IMAGE_CACHE" {
+			if modeOK {
 				nc.SecondaryBootDisks = append(nc.SecondaryBootDisks, &container.SecondaryBootDisk{
 					DiskImage: diskImage,
 					Mode:      modeValue.(string),
@@ -1541,9 +1541,7 @@ func flattenSecondaryBootDisks(c []*container.SecondaryBootDisk) []map[string]in
 		for _, disk := range c {
 			secondaryBootDisk := map[string]interface{}{
 				"disk_image": disk.DiskImage,
-			}
-			if disk.Mode == "CONTAINER_IMAGE_CACHE" {
-				secondaryBootDisk["mode"] = disk.Mode
+				"mode": disk.Mode,
 			}
 			result = append(result, secondaryBootDisk)
 		}

--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -898,7 +898,7 @@ func expandNodeConfig(v interface{}) *container.NodeConfig {
 	if v, ok := nodeConfig["secondary_boot_disks"]; ok && len(v.([]interface{})) > 0 {
 		conf := v.([]interface{})[0].(map[string]interface{})
 		modeValue, modeOK := conf["mode"]
-		diskImage, diskImageOK := conf["disk_image"]
+		diskImage := conf["disk_image"]
     	if modeOK && modeValue.(string) == "CONTAINER_IMAGE_CACHE" {
 			nc.SecondaryBootDisks = append(nc.SecondaryBootDisks, &container.SecondaryBootDisk{
 				DiskImage: diskImage.(string),

--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -897,17 +897,16 @@ func expandNodeConfig(v interface{}) *container.NodeConfig {
 
 	if v, ok := nodeConfig["secondary_boot_disks"]; ok && len(v.([]interface{})) > 0 {
 		conf := v.([]interface{})[0].(map[string]interface{})
-		diskImage, diskImageOK := conf["disk_image"].(string)
-    	mode, modeOK := conf["mode"].(string)
-
-    	if diskImageOK && modeOK && mode == "CONTAINER_IMAGE_CACHE" {
+		modeValue, modeOK := conf["mode"]
+		diskImage, diskImageOK := conf["disk_image"]
+    	if modeOK && modeValue.(string) == "CONTAINER_IMAGE_CACHE" {
 			nc.SecondaryBootDisks = append(nc.SecondaryBootDisks, &container.SecondaryBootDisk{
-				DiskImage: diskImage,
-				Mode:      mode,
+				DiskImage: diskImage.(string),
+				Mode:      modeValue.(string),
 			})
 		} else {
 			nc.SecondaryBootDisks = append(nc.SecondaryBootDisks, &container.SecondaryBootDisk{
-				DiskImage: diskImage,
+				DiskImage: diskImage.(string),
 			})
 		}
 	}

--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -897,10 +897,19 @@ func expandNodeConfig(v interface{}) *container.NodeConfig {
 
 	if v, ok := nodeConfig["secondary_boot_disks"]; ok && len(v.([]interface{})) > 0 {
 		conf := v.([]interface{})[0].(map[string]interface{})
-		nc.SecondaryBootDisks = append(nc.SecondaryBootDisks, &container.SecondaryBootDisk{
-			DiskImage: conf["disk_image"].(string),
-			Mode:      conf["mode"].(string),
-		})
+		diskImage, diskImageOK := conf["disk_image"].(string)
+    	mode, modeOK := conf["mode"].(string)
+
+    	if diskImageOK && modeOK {
+			nc.SecondaryBootDisks = append(nc.SecondaryBootDisks, &container.SecondaryBootDisk{
+				DiskImage: diskImage,
+				Mode:      mode,
+			})
+		} else {
+			nc.SecondaryBootDisks = append(nc.SecondaryBootDisks, &container.SecondaryBootDisk{
+				DiskImage: diskImage,
+			})
+		}
 	}
 
 	if v, ok := nodeConfig["gcfs_config"]; ok && len(v.([]interface{})) > 0 {

--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -900,7 +900,7 @@ func expandNodeConfig(v interface{}) *container.NodeConfig {
 		diskImage, diskImageOK := conf["disk_image"].(string)
     	mode, modeOK := conf["mode"].(string)
 
-    	if diskImageOK && modeOK {
+    	if diskImageOK && modeOK && mode == "CONTAINER_IMAGE_CACHE" {
 			nc.SecondaryBootDisks = append(nc.SecondaryBootDisks, &container.SecondaryBootDisk{
 				DiskImage: diskImage,
 				Mode:      mode,

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -1665,6 +1665,11 @@ func TestAccContainerNodePool_secondaryBootDisks(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 			},
+			resource.TestStep{
+				ResourceName:            "google_container_node_pool.np-no-mode",
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
 		},
 	})
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -1699,7 +1699,25 @@ resource "google_container_node_pool" "np" {
     }
   }
 }
-`, cluster, networkName, subnetworkName, np)
+
+resource "google_container_node_pool" "np" {
+  name               = "%s-no-mode"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  initial_node_count = 1
+
+  node_config {
+    machine_type = "n1-standard-8"
+    image_type = "COS_CONTAINERD"
+	gcfs_config {
+  		enabled = true
+	}
+    secondary_boot_disks {
+      disk_image = ""
+    }
+  }
+}
+`, cluster, networkName, subnetworkName, np, np)
 }
 
 func TestAccContainerNodePool_gcfsConfig(t *testing.T) {

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -1700,7 +1700,7 @@ resource "google_container_node_pool" "np" {
   }
 }
 
-resource "google_container_node_pool" "np" {
+resource "google_container_node_pool" "np-no-mode" {
   name               = "%s-no-mode"
   location           = "us-central1-a"
   cluster            = google_container_cluster.cluster.name


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/17655

This PR is a follow up to https://github.com/GoogleCloudPlatform/magic-modules/pull/10511, which added Terraform support for secondary boot disks in GKE. I discovered a bug when trying to create a node pool with "mode" not specified. Terraform throws a "panic: interface conversion: interface {} is nil, not map[string]interface {}" during the expandNodeConfig function. I pinpointed the error to the function's type assertion of the mode argument. This PR adds logic to bypass the type assertion when mode is nil.


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**
```release-note:bug
container: modify `node_config.secondary_boot_disks` logic in `google_container_node_pool` to handle nil mode
```