### PR TITLE
Allow guest OS validation to be handled by GCE APIs

### DIFF
--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -484,7 +484,7 @@ properties:
     is_set: true
     item_type: !ruby/object:Api::Type::NestedObject
       properties:
-        - !ruby/object:Api::Type::Enum
+        - !ruby/object:Api::Type::String
           name: 'type'
           required: true
           description: |

--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -489,19 +489,6 @@ properties:
           required: true
           description: |
             The type of supported feature. Read [Enabling guest operating system features](https://cloud.google.com/compute/docs/images/create-delete-deprecate-private-images#guest-os-features) to see a list of available options.
-          values:
-            - :MULTI_IP_SUBNET
-            - :SECURE_BOOT
-            - :SEV_CAPABLE
-            - :UEFI_COMPATIBLE
-            - :VIRTIO_SCSI_MULTIQUEUE
-            - :WINDOWS
-            - :GVNIC
-            - :SEV_LIVE_MIGRATABLE
-            - :SEV_SNP_CAPABLE
-            - :SUSPEND_RESUME_COMPATIBLE
-            - :TDX_CAPABLE
-            - :SEV_LIVE_MIGRATABLE_V2
   - !ruby/object:Api::Type::Array
     name: 'licenses'
     description: Any applicable license URI.


### PR DESCRIPTION
Remove validation for guest OS feature types and allow validation to be handled by the GCE APIs.
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: removed enum validation on `guest_os_features.type` in `google_compute_disk` to allow for new features to be used without provider update
```
