### PR TITLE
add nested virtualization, boot disk size, and pool size to boost

### DIFF
--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -342,6 +342,21 @@ properties:
                   name: 'machineType'
                   description: |
                     The type of machine that boosted VM instances will use—for example, e2-standard-4. For more information about machine types that Cloud Workstations supports, see the list of available machine types https://cloud.google.com/workstations/docs/available-machine-types. Defaults to e2-standard-4.
+                - !ruby/object:Api::Type::Integer
+                  name: 'bootDiskSizeGb'
+                  immutable: true
+                  description: |-
+                    Size of the boot disk in GB. The minimum boot disk size is `30` GB. Defaults to `50` GB.
+                - !ruby/object:Api::Type::Boolean
+                  name: 'enableNestedVirtualization'
+                  description: |
+                    Whether to enable nested virtualization on the Compute Engine VMs backing boosted Workstations.
+
+                    See https://cloud.google.com/workstations/docs/reference/rest/v1beta/projects.locations.workstationClusters.workstationConfigs#GceInstance.FIELDS.enable_nested_virtualization
+                - !ruby/object:Api::Type::Integer
+                  name: 'poolSize'
+                  description: |-
+                    Number of instances to pool for faster workstation boosting.
                 - !ruby/object:Api::Type::Array
                   name: 'accelerators'
                   description: |

--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -347,16 +347,19 @@ properties:
                   immutable: true
                   description: |-
                     Size of the boot disk in GB. The minimum boot disk size is `30` GB. Defaults to `50` GB.
+                  default_from_api: true
                 - !ruby/object:Api::Type::Boolean
                   name: 'enableNestedVirtualization'
                   description: |
                     Whether to enable nested virtualization on the Compute Engine VMs backing boosted Workstations.
 
                     See https://cloud.google.com/workstations/docs/reference/rest/v1beta/projects.locations.workstationClusters.workstationConfigs#GceInstance.FIELDS.enable_nested_virtualization
+                  default_from_api: true
                 - !ruby/object:Api::Type::Integer
                   name: 'poolSize'
                   description: |-
                     Number of instances to pool for faster workstation boosting.
+                  default_from_api: true
                 - !ruby/object:Api::Type::Array
                   name: 'accelerators'
                   description: |

--- a/mmv1/templates/terraform/examples/workstation_config_boost.tf.erb
+++ b/mmv1/templates/terraform/examples/workstation_config_boost.tf.erb
@@ -48,8 +48,11 @@ resource "google_workstations_workstation_config" "<%= ctx[:primary_resource_id]
         }
       }
       boost_configs {
-        id           = "boost-1"
-        machine_type = "e2-standard-2"
+        id                           = "boost-2"
+        machine_type                 = "n1-standard-2"
+        pool_size                    = 2
+        boot_disk_size_gb            = 30
+        enable_nested_virtualization = true
       }
     }
   }

--- a/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
+++ b/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
@@ -541,8 +541,11 @@ func testAccWorkstationsWorkstationConfig_boost(context map[string]interface{}) 
           }
         }
         boost_configs {
-          id           = "boost-1"
-          machine_type = "e2-standard-2"
+          id                           = "boost-2"
+          machine_type                 = "n1-standard-2"
+          pool_size                    = 2
+          boot_disk_size_gb            = 30
+          enable_nested_virtualization = true
         }
       }
     }


### PR DESCRIPTION
fixes: b/325077244), b/325077245

This change updates  `google_workstations_workstation_config`'s `host.gceInstance.boostConfig` field with `bootDiskSizeGb`, `enableNestedVirtualization`, and `poolSize` that are supported by the cloud workstations api and can be set when creating and updating workstation configs to augment the boost configuration object.

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [make test and make lint](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.


**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
workstations: added `bootDiskSizeGb`, `enableNestedVirtualization`, and `poolSize`  to `host.gceInstance.boostConfig` in `google_workstations_workstation_config` resource
```
