### PR TITLE
Adding mmv1 generated Resource: google_composer_user_workloads_config_map

### DIFF
--- a/mmv1/products/composer/UserWorkloadsConfigMap.yaml
+++ b/mmv1/products/composer/UserWorkloadsConfigMap.yaml
@@ -1,0 +1,147 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+# API resource name
+name: 'UserWorkloadsConfigMap'
+# Resource description for the provider documentation.
+description: |
+  User workloads Secret used by Airflow tasks that run with Kubernetes Executor or KubernetesPodOperator. 
+  Intended for Composer 3 Environments.
+references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+   # Link to quickstart in the API's Guides section. For example:
+   # 'Create and connect to a database': 'https://cloud.google.com/alloydb/docs/quickstart/create-and-connect'
+    'QUICKSTART_TITLE': 'QUICKSTART_URL'
+  # Link to the REST API reference for the resource. For example,
+  # https://cloud.google.com/alloydb/docs/reference/rest/v1/projects.locations.backups
+  api: 'API_REFERENCE_URL'
+# Marks the resource as beta-only. Ensure a beta version block is present in
+# provider.yaml.
+min_version: beta
+
+# Inserts styled markdown into the header of the resource's page in the
+# provider documentation.
+# docs: !ruby/object:Provider::Terraform::Docs
+#   warning: |
+#     MULTILINE_WARNING_MARKDOWN
+#   note: |
+#     MULTILINE_NOTE_MARKDOWN
+
+# URL for the resource's standard List method. https://google.aip.dev/132
+# Terraform field names enclosed in double curly braces are replaced with
+# the field values from the resource at runtime.
+base_url: 'projects/{{project}}/locations/{{location}}/environments/{{environment}}/UserWorkloadsConfigMaps'
+# URL for the resource's standard Get method. https://google.aip.dev/131
+# Terraform field names enclosed in double curly braces are replaced with
+# the field values from the resource at runtime.
+self_link: 'projects/{{project}}/locations/{{location}}/environments/{{environment}}/UserWorkloadsConfigMaps/{{name}}'
+
+# If true, the resource and all its fields are considered immutable - that is,
+# only creatable, not updatable. Individual fields can override this if they
+# have a custom update method in the API.
+# immutable: true
+
+# Overrides one or more timeouts, in minutes. All timeouts default to 20.
+timeouts: !ruby/object:Api::Timeouts
+  insert_minutes: 1
+  update_minutes: 1
+  delete_minutes: 1
+
+# URL for the resource's standard Create method, including query parameters.
+# https://google.aip.dev/133
+# Terraform field names enclosed in double curly braces are replaced with
+# the field values from the resource at runtime.
+create_url: 'projects/{{project}}/locations/{{location}}/environments/{{environment}}/UserWorkloadsConfigMaps'
+# Overrides the HTTP verb used to create a new resource.
+# Allowed values: :POST, :PUT, :PATCH. Default: :POST
+# create_verb: :POST
+
+# Overrides the URL for the resource's standard Update method. (If unset, the
+# self_link URL is used by default.) https://google.aip.dev/134
+# Terraform field names enclosed in double curly braces are replaced with
+# the field values from the resource at runtime.
+# update_url: 'projects/{{project}}/locations/{{location}}/resourcenames/{{name}}'
+# The HTTP verb used to update a resource. Allowed values: :POST, :PUT, :PATCH. Default: :PUT.
+update_verb: :PUT
+# If true, the resource sets an `updateMask` query parameter listing modified
+# fields when updating the resource. If false, it does not.
+# update_mask: true
+
+# Overrides the URL for the resource's standard Delete method. (If unset, the
+# self_link URL is used by default.) https://google.aip.dev/135
+# Terraform field names enclosed in double curly braces are replaced with
+# the field values from the resource at runtime.
+# delete_url: 'projects/{{project}}/locations/{{location}}/resourcenames/{{name}}'
+# Overrides the HTTP verb used to delete a resource.
+# Allowed values: :POST, :PUT, :PATCH, :DELETE. Default: :DELETE
+# delete_verb: :DELETE
+
+# If true, code for handling long-running operations is generated along with
+# the resource. If false, that code is not generated.
+# autogen_async: true
+# Sets parameters for handling operations returned by the API.
+#async: !ruby/object:Api::OpAsync
+  # Overrides which API calls return operations. Default: ['create',
+  # 'update', 'delete']
+  # actions: ['create', 'update', 'delete']
+#  operation: !ruby/object:Api::OpAsync::Operation
+#    base_url: '{{op_id}}'
+
+  # If true, the provider sets the resource's Terraform ID after the resource is created,
+  # taking into account values that are set by the API at create time. This is only possible
+  # when the completed operation's JSON includes the created resource in the "response" field.
+  # If false (or unset), the provider sets the resource's Terraform ID before the resource is
+  # created, based only on the resource configuration.
+  # result: !ruby/object:Api::OpAsync::Result
+  #   resource_inside_response: true
+
+# All resources (of all kinds) that share a mutex value block rather than
+# executing concurrent API requests.
+# Terraform field names enclosed in double curly braces are replaced with
+# the field values from the resource at runtime.
+# mutex: RESOURCE_NAME/{{name}}
+
+parameters:
+  - !ruby/object:Api::Type::String
+    name: 'region'
+    required: false
+    immutable: true
+    default_from_api: true
+    description: |
+      The location or Compute Engine region for the environment.
+  - !ruby/object:Api::Type::String
+    name: 'environment'
+    required: true
+    immutable: true
+    validation: !ruby/object:Provider::Terraform::Validation
+      function: 'verify.ValidateGCEName'
+    description: |
+      Name of the environment.
+  - !ruby/object:Api::Type::String
+    name: 'name'
+    required: true
+    immutable: true
+    validation: !ruby/object:Provider::Terraform::Validation
+      function: 'verify.ValidateGCEName'
+    description: |
+      Name of the secret.
+  - !ruby/object:Api::Type::KeyValuePairs
+    name: 'data'
+    required: false
+    immutable: false
+    description: |
+      A map of the secret data. 
+
+properties:
+  # Fields go here

--- a/mmv1/products/composer/product.yaml
+++ b/mmv1/products/composer/product.yaml
@@ -1,0 +1,25 @@
+# Copyright 2022 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Product
+name: Composer
+display_name: Cloud Composer
+scopes:
+  - https://www.googleapis.com/auth/cloud-platform
+versions:
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: google.golang.org/api/composer/v1/
+  - !ruby/object:Api::Product::Version
+    name: beta
+    base_url: google.golang.org/api/composer/v1beta1


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_composer_user_workloads_config_map` (beta)
```
