### PR TITLE
Fix inaccurate documentation for TargetHttpsProxy resource

### DIFF
--- a/mmv1/products/compute/RegionTargetHttpsProxy.yaml
+++ b/mmv1/products/compute/RegionTargetHttpsProxy.yaml
@@ -140,7 +140,7 @@ properties:
     name: 'certificateManagerCertificates'
     description: |
       URLs to certificate manager certificate resources that are used to authenticate connections between users and the load balancer.
-      sslCertificates and certificateManagerCertificates can not be defined together.
+      sslCertificates and certificateManagerCertificates can't be defined together.
       Accepted format is `//certificatemanager.googleapis.com/projects/{project}/locations/{location}/certificates/{resourceName}` or just the self_link `projects/{project}/locations/{location}/certificates/{resourceName}`
     update_verb: :POST
     update_url: 'projects/{{project}}/regions/{{region}}/targetHttpsProxies/{{name}}/setSslCertificates'

--- a/mmv1/products/compute/RegionTargetHttpsProxy.yaml
+++ b/mmv1/products/compute/RegionTargetHttpsProxy.yaml
@@ -140,8 +140,7 @@ properties:
     name: 'certificateManagerCertificates'
     description: |
       URLs to certificate manager certificate resources that are used to authenticate connections between users and the load balancer.
-      Currently, you may specify up to 15 certificates. Certificate manager certificates do not apply when the load balancing scheme is set to INTERNAL_SELF_MANAGED.
-      sslCertificates and certificateManagerCertificates fields can not be defined together.
+      sslCertificates and certificateManagerCertificates can not be defined together.
       Accepted format is `//certificatemanager.googleapis.com/projects/{project}/locations/{location}/certificates/{resourceName}` or just the self_link `projects/{project}/locations/{location}/certificates/{resourceName}`
     update_verb: :POST
     update_url: 'projects/{{project}}/regions/{{region}}/targetHttpsProxies/{{name}}/setSslCertificates'

--- a/mmv1/products/compute/TargetHttpsProxy.yaml
+++ b/mmv1/products/compute/TargetHttpsProxy.yaml
@@ -134,7 +134,8 @@ properties:
     name: 'certificateManagerCertificates'
     description: |
       URLs to certificate manager certificate resources that are used to authenticate connections between users and the load balancer.
-      Currently, you may specify up to 15 certificates. Certificate manager certificates do not apply when the load balancing scheme is set to INTERNAL_SELF_MANAGED.
+      Certificate manager certificates only apply when the load balancing scheme is set to INTERNAL_MANAGED.
+      For EXTERNAL and EXTERNAL_MANAGED please use certificate_map instead.
       sslCertificates and certificateManagerCertificates fields can not be defined together.
       Accepted format is `//certificatemanager.googleapis.com/projects/{project}/locations/{location}/certificates/{resourceName}` or just the self_link `projects/{project}/locations/{location}/certificates/{resourceName}`
     update_verb: :POST
@@ -164,7 +165,8 @@ properties:
     name: 'certificateMap'
     description: |
       A reference to the CertificateMap resource uri that identifies a certificate map
-      associated with the given target proxy. This field can only be set for global target proxies.
+      associated with the given target proxy. This field is only supported for EXTERNAL and EXTERNAL_MANAGED load balancing schemes.
+      For INTERNAL_MANAGED, please use certificate_manager_certificates instead.
       Accepted format is `//certificatemanager.googleapis.com/projects/{project}/locations/{location}/certificateMaps/{resourceName}`.
     update_verb: :POST
     update_url: 'projects/{{project}}/global/targetHttpsProxies/{{name}}/setCertificateMap'

--- a/mmv1/products/compute/TargetHttpsProxy.yaml
+++ b/mmv1/products/compute/TargetHttpsProxy.yaml
@@ -135,7 +135,7 @@ properties:
     description: |
       URLs to certificate manager certificate resources that are used to authenticate connections between users and the load balancer.
       Certificate manager certificates only apply when the load balancing scheme is set to INTERNAL_MANAGED.
-      For EXTERNAL and EXTERNAL_MANAGED please use certificate_map instead.
+      For EXTERNAL and EXTERNAL_MANAGED, use certificate_map instead.
       sslCertificates and certificateManagerCertificates fields can not be defined together.
       Accepted format is `//certificatemanager.googleapis.com/projects/{project}/locations/{location}/certificates/{resourceName}` or just the self_link `projects/{project}/locations/{location}/certificates/{resourceName}`
     update_verb: :POST
@@ -166,7 +166,7 @@ properties:
     description: |
       A reference to the CertificateMap resource uri that identifies a certificate map
       associated with the given target proxy. This field is only supported for EXTERNAL and EXTERNAL_MANAGED load balancing schemes.
-      For INTERNAL_MANAGED, please use certificate_manager_certificates instead.
+      For INTERNAL_MANAGED, use certificate_manager_certificates instead.
       Accepted format is `//certificatemanager.googleapis.com/projects/{project}/locations/{location}/certificateMaps/{resourceName}`.
     update_verb: :POST
     update_url: 'projects/{{project}}/global/targetHttpsProxies/{{name}}/setCertificateMap'


### PR DESCRIPTION
This PR 
- Fixes inaccurate documentation for certificateManagerCertificates and certificateMap fields in TargetHttpsProxy 
- Fixes inaccurate documentation for certificateManagerCertificates field in RegionTargetHttpsProxy
- Addresses documentation issue referenced in https://github.com/hashicorp/terraform-provider-google/issues/17176
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: updated documentation of google_compute_target_https_proxy and google_compute_region_target_https_proxy
```
