### PR TITLE
Added update support to sslPolicy field in region_target_https_proxy

### DIFF
--- a/mmv1/products/compute/RegionTargetHttpsProxy.yaml
+++ b/mmv1/products/compute/RegionTargetHttpsProxy.yaml
@@ -174,11 +174,11 @@ properties:
       A reference to the Region SslPolicy resource that will be associated with
       the TargetHttpsProxy resource. If not set, the TargetHttpsProxy
       resource will not have any SSL policy configured.
-  # 2022 May 28 - setSslPolicy method not yet listed
-  # https://cloud.google.com/compute/docs/reference/rest/beta/regionTargetHttpsProxies
-  #  update_verb: :POST
-  #  update_url:
-  #    'projects/{{project}}/regions/{{region}}/targetHttpsProxies/{{name}}/setSslPolicy'
+    update_id: 'sslPolicy'
+    fingerprint_name: 'fingerprint'
+    update_verb: :PATCH
+    update_url:
+      'projects/{{project}}/regions/{{region}}/targetHttpsProxies/{{name}}'
     custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.erb'
   - !ruby/object:Api::Type::ResourceRef
     name: 'urlMap'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_target_https_proxy_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_target_https_proxy_test.go.erb
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
-  "github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -398,7 +398,7 @@ resource "google_compute_forwarding_rule" "default-https" {
   ip_protocol           = "TCP"
   port_range            = "443"
   allow_global_access   = "true"
-	depends_on            = [google_compute_subnetwork.ilb_subnet2]
+  depends_on            = [google_compute_subnetwork.ilb_subnet2]
 }
 
 resource "google_compute_region_backend_service" "default" {
@@ -520,7 +520,7 @@ resource "google_compute_forwarding_rule" "default-https" {
   ip_protocol           = "TCP"
   port_range            = "443"
   allow_global_access   = "true"
-	depends_on            = [google_compute_subnetwork.ilb_subnet2]
+  depends_on            = [google_compute_subnetwork.ilb_subnet2]
 }
 
 resource "google_compute_region_backend_service" "default" {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_target_https_proxy_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_target_https_proxy_test.go.erb
@@ -456,10 +456,6 @@ resource "google_compute_region_target_https_proxy" "default-https" {
   name             = "https-proxy-%{resource_suffix}"
   url_map          = google_compute_region_url_map.default-https.self_link
   ssl_certificates = [google_compute_region_ssl_certificate.foobar0.self_link]
-
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 resource "google_compute_region_url_map" "default-https" {
@@ -579,10 +575,6 @@ resource "google_compute_region_target_https_proxy" "default-https" {
   url_map          = google_compute_region_url_map.default-https.self_link
   ssl_certificates = [google_compute_region_ssl_certificate.foobar0.self_link]
   ssl_policy       = google_compute_region_ssl_policy.default.id
-
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 resource "google_compute_region_url_map" "default-https" {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_target_https_proxy_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_target_https_proxy_test.go.erb
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+  "github.com/hashicorp/terraform-provider-google/google/envvar"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -348,4 +349,291 @@ resource "google_compute_region_ssl_certificate" "foobar2" {
   certificate = file("test-fixtures/test.crt")
 }
 `, id, id, id, id, id, id, id, id, id, id)
+}
+
+func TestAccComputeRegionTargetHttpsProxy_addSslPolicy_withForwardingRule(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"resource_suffix": acctest.RandString(t, 10),
+		"project_id":      envvar.GetTestProjectFromEnv(),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeTargetHttpsProxyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionTargetHttpsProxy_withForwardingRule(context),
+			},
+			{
+				ResourceName:      "google_compute_region_target_https_proxy.default-https",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRegionTargetHttpsProxy_withForwardingRule_withSslPolicy(context),
+			},
+			{
+				ResourceName:      "google_compute_region_target_https_proxy.default-https",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccComputeRegionTargetHttpsProxy_withForwardingRule(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_forwarding_rule" "default-https" {
+  project               = "%{project_id}"
+  region                = "us-central1"
+  name                  = "https-frwd-rule-%{resource_suffix}"
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  target                = google_compute_region_target_https_proxy.default-https.self_link
+  network               = google_compute_network.ilb_network.name
+  subnetwork            = google_compute_subnetwork.ilb_subnet.name
+  ip_address            = google_compute_address.consumer_address.id
+  ip_protocol           = "TCP"
+  port_range            = "443"
+  allow_global_access   = "true"
+	depends_on            = [google_compute_subnetwork.ilb_subnet2]
+}
+
+resource "google_compute_region_backend_service" "default" {
+  project               = "%{project_id}"
+  region                = "us-central1"
+  name                  = "backend-service-%{resource_suffix}"
+  protocol              = "HTTPS"
+  port_name             = "https-server"
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  session_affinity      = "HTTP_COOKIE"
+  health_checks         = [google_compute_region_health_check.default.self_link]
+  locality_lb_policy    = "RING_HASH"
+
+  # webscoket handling: https://stackoverflow.com/questions/63822612/websocket-connection-being-closed-on-google-compute-engine
+  timeout_sec = 600
+
+  consistent_hash {
+    http_cookie {
+      ttl {
+        # 24hr cookie ttl
+        seconds = 86400
+        nanos   = null
+      }
+      name = "X-CLIENT-SESSION"
+      path = null
+    }
+    http_header_name  = null
+    minimum_ring_size = 1024
+  }
+
+  log_config {
+    enable      = true
+    sample_rate = 1.0
+  }
+}
+
+resource "google_compute_region_health_check" "default" {
+  project             = "%{project_id}"
+  region              = "us-central1"
+  name                = "hc-%{resource_suffix}"
+  timeout_sec         = 5
+  check_interval_sec  = 30
+  healthy_threshold   = 3
+  unhealthy_threshold = 3
+
+  https_health_check {
+    port         = 443
+    request_path = "/health"
+  }
+}
+
+resource "google_compute_region_target_https_proxy" "default-https" {
+  project          = "%{project_id}"
+  region           = "us-central1"
+  name             = "https-proxy-%{resource_suffix}"
+  url_map          = google_compute_region_url_map.default-https.self_link
+  ssl_certificates = [google_compute_region_ssl_certificate.foobar0.self_link]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "google_compute_region_url_map" "default-https" {
+  project         = "%{project_id}"
+  region          = "us-central1"
+  name            = "lb-%{resource_suffix}"
+  default_service = google_compute_region_backend_service.default.id
+}
+
+resource "google_compute_region_ssl_certificate" "foobar0" {
+  name        = "httpsproxy-test-cert0-%{resource_suffix}"
+  description = "very descriptive"
+  private_key = file("test-fixtures/test.key")
+  certificate = file("test-fixtures/test.crt")
+}
+
+resource "google_compute_network" "ilb_network" {
+  name                    = "tf-test-l4-ilb-network-%{resource_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "ilb_subnet" {
+  name          = "tf-test-l4-ilb-subnet-%{resource_suffix}"
+  ip_cidr_range = "10.0.1.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.ilb_network.id
+}
+
+resource "google_compute_subnetwork" "ilb_subnet2" {
+  name          = "tf-test-l4-ilb-subnet2-%{resource_suffix}"
+	ip_cidr_range = "10.142.0.0/20"
+  region        = "us-central1"
+  purpose       = "REGIONAL_MANAGED_PROXY"
+  role          = "ACTIVE"
+  network       = google_compute_network.ilb_network.id
+}
+
+resource "google_compute_address" "consumer_address" {
+  name         = "tf-test-website-ip-%{resource_suffix}-1"
+  region       = "us-central1"
+  subnetwork   = google_compute_subnetwork.ilb_subnet.id
+  address_type = "INTERNAL"
+}
+`, context)
+}
+
+func testAccComputeRegionTargetHttpsProxy_withForwardingRule_withSslPolicy(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_forwarding_rule" "default-https" {
+  project               = "%{project_id}"
+  region                = "us-central1"
+  name                  = "https-frwd-rule-%{resource_suffix}"
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  target                = google_compute_region_target_https_proxy.default-https.self_link
+  network               = google_compute_network.ilb_network.name
+  subnetwork            = google_compute_subnetwork.ilb_subnet.name
+  ip_address            = google_compute_address.consumer_address.id
+  ip_protocol           = "TCP"
+  port_range            = "443"
+  allow_global_access   = "true"
+	depends_on            = [google_compute_subnetwork.ilb_subnet2]
+}
+
+resource "google_compute_region_backend_service" "default" {
+  project               = "%{project_id}"
+  region                = "us-central1"
+  name                  = "backend-service-%{resource_suffix}"
+  protocol              = "HTTPS"
+  port_name             = "https-server"
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  session_affinity      = "HTTP_COOKIE"
+  health_checks         = [google_compute_region_health_check.default.self_link]
+  locality_lb_policy    = "RING_HASH"
+
+  # webscoket handling: https://stackoverflow.com/questions/63822612/websocket-connection-being-closed-on-google-compute-engine
+  timeout_sec = 600
+
+  consistent_hash {
+    http_cookie {
+      ttl {
+        # 24hr cookie ttl
+        seconds = 86400
+        nanos   = null
+      }
+      name = "X-CLIENT-SESSION"
+      path = null
+    }
+    http_header_name  = null
+    minimum_ring_size = 1024
+  }
+
+  log_config {
+    enable      = true
+    sample_rate = 1.0
+  }
+}
+
+resource "google_compute_region_health_check" "default" {
+  project             = "%{project_id}"
+  region              = "us-central1"
+  name                = "hc-%{resource_suffix}"
+  timeout_sec         = 5
+  check_interval_sec  = 30
+  healthy_threshold   = 3
+  unhealthy_threshold = 3
+
+  https_health_check {
+    port         = 443
+    request_path = "/health"
+  }
+}
+
+resource "google_compute_region_target_https_proxy" "default-https" {
+  project          = "%{project_id}"
+  region           = "us-central1"
+  name             = "https-proxy-%{resource_suffix}"
+  url_map          = google_compute_region_url_map.default-https.self_link
+  ssl_certificates = [google_compute_region_ssl_certificate.foobar0.self_link]
+  ssl_policy       = google_compute_region_ssl_policy.default.id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "google_compute_region_url_map" "default-https" {
+  project         = "%{project_id}"
+  region          = "us-central1"
+  name            = "lb-%{resource_suffix}"
+  default_service = google_compute_region_backend_service.default.id
+}
+
+resource "google_compute_region_ssl_policy" "default" {
+  project = "%{project_id}"
+  region  = "us-central1"
+  name    = "ssl-policy-%{resource_suffix}"
+
+  profile         = "RESTRICTED"
+  min_tls_version = "TLS_1_2"
+}
+
+resource "google_compute_region_ssl_certificate" "foobar0" {
+  name        = "httpsproxy-test-cert0-%{resource_suffix}"
+  description = "very descriptive"
+  private_key = file("test-fixtures/test.key")
+  certificate = file("test-fixtures/test.crt")
+}
+
+resource "google_compute_network" "ilb_network" {
+  name                    = "tf-test-l4-ilb-network-%{resource_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "ilb_subnet" {
+  name          = "tf-test-l4-ilb-subnet-%{resource_suffix}"
+  ip_cidr_range = "10.0.1.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.ilb_network.id
+}
+
+resource "google_compute_subnetwork" "ilb_subnet2" {
+  name          = "tf-test-l4-ilb-subnet2-%{resource_suffix}"
+	ip_cidr_range = "10.142.0.0/20"
+  region        = "us-central1"
+  purpose       = "REGIONAL_MANAGED_PROXY"
+  role          = "ACTIVE"
+  network       = google_compute_network.ilb_network.id
+}
+
+resource "google_compute_address" "consumer_address" {
+  name         = "tf-test-website-ip-%{resource_suffix}-1"
+  region       = "us-central1"
+  subnetwork   = google_compute_subnetwork.ilb_subnet.id
+  address_type = "INTERNAL"
+}
+`, context)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds support to update "ssl_policy" field in "compute_region_target_https_proxy" via the [PATCH](https://cloud.google.com/compute/docs/reference/rest/v1/regionTargetHttpsProxies/patch) endpoint, removing its ForceNew flag, as well as related tests;

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/16963

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added update support to 'ssl_policy' field in 'compute_region_target_https_proxy' resource
```