### PR TITLE
chore(ci): refactor vcr comment into go template

### DIFF
--- a/.ci/magician/cmd/test_terraform_vcr.go
+++ b/.ci/magician/cmd/test_terraform_vcr.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"text/template"
 
 	"github.com/spf13/cobra"
 
@@ -15,6 +16,21 @@ import (
 	"magician/provider"
 	"magician/source"
 	"magician/vcr"
+
+	_ "embed"
+)
+
+var (
+	//go:embed test_terraform_vcr_test_analytics.tmpl
+	testsAnalyticsTmplText string
+	//go:embed test_terraform_vcr_non_exercised_tests.tmpl
+	nonExercisedTestsTmplText string
+	//go:embed test_terraform_vcr_with_replay_failed_tests.tmpl
+	withReplayFailedTestsTmplText string
+	//go:embed test_terraform_vcr_without_replay_failed_tests.tmpl
+	withoutReplayFailedTestsTmplText string
+	//go:embed test_terraform_vcr_record_replay.tmpl
+	recordReplayTmplText string
 )
 
 var ttvEnvironmentVariables = [...]string{
@@ -38,6 +54,37 @@ var ttvEnvironmentVariables = [...]string{
 	"PATH",
 	"SA_KEY",
 	"USER",
+}
+
+type analytics struct {
+	ReplayingResult  *vcr.Result
+	RunFullVCR       bool
+	AffectedServices []string
+}
+
+type nonExercisedTests struct {
+	NotRunBetaTests []string
+	NotRunGATests   []string
+}
+
+type withReplayFailedTests struct {
+	ReplayingResult *vcr.Result
+}
+
+type withoutReplayFailedTests struct {
+	ReplayingErr error
+	PRNumber     string
+	BuildID      string
+}
+
+type recordReplay struct {
+	RecordingResult               *vcr.Result
+	ReplayingAfterRecordingResult *vcr.Result
+	HasTerminatedTests            bool
+	RecordingErr                  error
+	AllRecordingPassed            bool
+	PRNumber                      string
+	BuildID                       string
 }
 
 var testTerraformVCRCmd = &cobra.Command{
@@ -143,7 +190,7 @@ func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, 
 		return fmt.Errorf("error posting pending status: %w", err)
 	}
 
-	replayingResult, affectedServicesComment, testDirs, replayingErr := runReplaying(runFullVCR, services, vt)
+	replayingResult, testDirs, replayingErr := runReplaying(runFullVCR, services, vt)
 	testState := "success"
 	if replayingErr != nil {
 		testState = "failure"
@@ -159,55 +206,44 @@ func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, 
 		return nil
 	}
 
-	failedTestsPattern := strings.Join(replayingResult.FailedTests, "|")
-
-	comment := `#### Tests analytics
-Total tests: ` + fmt.Sprintf("`%d`", len(replayingResult.PassedTests)+len(replayingResult.SkippedTests)+len(replayingResult.FailedTests)) + `
-Passed tests: ` + fmt.Sprintf("`%d`", len(replayingResult.PassedTests)) + `
-Skipped tests: ` + fmt.Sprintf("`%d`", len(replayingResult.SkippedTests)) + `
-Affected tests: ` + fmt.Sprintf("`%d`", len(replayingResult.FailedTests)) + `
-
-<details><summary>Click here to see the affected service packages</summary><blockquote>` + affectedServicesComment + `</blockquote></details>`
+	var servicesArr []string
+	for s := range services {
+		servicesArr = append(servicesArr, s)
+	}
+	analyticsData := analytics{
+		ReplayingResult:  replayingResult,
+		RunFullVCR:       runFullVCR,
+		AffectedServices: sort.StringSlice(servicesArr),
+	}
+	testsAnalyticsComment, err := formatTestsAnalytics(analyticsData)
+	if err != nil {
+		fmt.Println("Error formatting test_analytics comment: ", err)
+		os.Exit(1)
+	}
 
 	notRunBeta, notRunGa := notRunTests(tpgRepo.UnifiedZeroDiff, tpgbRepo.UnifiedZeroDiff, replayingResult)
-	if len(notRunBeta) > 0 || len(notRunGa) > 0 {
-		comment += `
 
-
-#### Non-exercised tests`
-
-		if len(notRunBeta) > 0 {
-			comment += `
-
-Tests were added that are skipped in VCR:
-`
-			for _, t := range notRunBeta {
-				comment += `
-- ` + t
-			}
-		}
-
-		if len(notRunGa) > 0 {
-			comment += `
-
-Tests were added that are GA-only additions and require manual runs:
-`
-			for _, t := range notRunGa {
-				comment += `
-- ` + t
-			}
-		}
+	nonExercisedTestsData := nonExercisedTests{
+		NotRunBetaTests: notRunBeta,
+		NotRunGATests:   notRunGa,
+	}
+	nonExercisedTestsComment, err := formatNonExercisedTests(nonExercisedTestsData)
+	if err != nil {
+		fmt.Println("Error formatting non exercised tests comment: ", err)
+		os.Exit(1)
 	}
 
 	if len(replayingResult.FailedTests) > 0 {
-		comment += fmt.Sprintf(`
+		withReplayFailedTestsData := withReplayFailedTests{
+			ReplayingResult: replayingResult,
+		}
+		withReplayFailedTestsComment, err := formatWithReplayFailedTests(withReplayFailedTestsData)
+		if err != nil {
+			fmt.Println("Error formatting action taken comment: ", err)
+			os.Exit(1)
+		}
 
-
-#### Action taken
-<details> <summary>Found %d affected test(s) by replaying old test recordings. Starting RECORDING based on the most recent commit. Click here to see the affected tests</summary><blockquote>%s </blockquote></details>
-
-[Get to know how VCR tests work](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/contributing/#general-contributing-steps)`, len(replayingResult.FailedTests), failedTestsPattern)
-
+		comment := strings.Join([]string{testsAnalyticsComment, nonExercisedTestsComment, withReplayFailedTestsComment}, "\n")
 		if err := gh.PostComment(prNumber, comment); err != nil {
 			return fmt.Errorf("error posting comment: %w", err)
 		}
@@ -233,15 +269,10 @@ Tests were added that are GA-only additions and require manual runs:
 			return nil
 		}
 
-		comment = ""
+		var replayingAfterRecordingResult *vcr.Result
+		var replayingAfterRecordingErr error
 		if len(recordingResult.PassedTests) > 0 {
-			comment += "$\\textcolor{green}{\\textsf{Tests passed during RECORDING mode:}}$\n"
-			for _, passedTest := range recordingResult.PassedTests {
-				comment += fmt.Sprintf("`%s`[[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-%s/artifacts/%s/recording/%s.log)]\n", passedTest, prNumber, buildID, passedTest)
-			}
-			comment += "\n\n"
-
-			replayingAfterRecordingResult, replayingAfterRecordingErr := vt.RunParallel(vcr.Replaying, provider.Beta, testDirs, recordingResult.PassedTests)
+			replayingAfterRecordingResult, replayingAfterRecordingErr = vt.RunParallel(vcr.Replaying, provider.Beta, testDirs, recordingResult.PassedTests)
 			if replayingAfterRecordingErr != nil {
 				testState = "failure"
 			}
@@ -249,61 +280,47 @@ Tests were added that are GA-only additions and require manual runs:
 			if err := vt.UploadLogs("ci-vcr-logs", prNumber, buildID, true, true, vcr.Replaying, provider.Beta); err != nil {
 				return fmt.Errorf("error uploading recording logs: %w", err)
 			}
-
-			if len(replayingAfterRecordingResult.FailedTests) > 0 {
-				comment += "$\\textcolor{red}{\\textsf{Tests failed when rerunning REPLAYING mode:}}$\n"
-				for _, failedTest := range replayingAfterRecordingResult.FailedTests {
-					comment += fmt.Sprintf("`%s`[[Error message](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-%s/artifacts/%s/build-log/replaying_build_after_recording/%s_replaying_test.log)] [[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-%s/artifacts/%s/replaying_after_recording/%s.log)]\n", failedTest, prNumber, buildID, failedTest, prNumber, buildID, failedTest)
-				}
-				comment += "\n\n"
-				comment += `Tests failed due to non-determinism or randomness when the VCR replayed the response after the HTTP request was made.
-
-Please fix these to complete your PR. If you believe these test failures to be incorrect or unrelated to your change, or if you have any questions, please raise the concern with your reviewer.
-`
-			} else {
-				comment += "$\\textcolor{green}{\\textsf{No issues found for passed tests after REPLAYING rerun.}}$\n"
-			}
-			comment += "\n---\n"
-
 		}
 
-		if len(recordingResult.FailedTests) > 0 {
-			comment += "$\\textcolor{red}{\\textsf{Tests failed during RECORDING mode:}}$\n"
-			for _, failedTest := range recordingResult.FailedTests {
-				comment += fmt.Sprintf("`%s`[[Error message](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-%s/artifacts/%s/build-log/recording_build/%s_recording_test.log)] [[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-%s/artifacts/%s/recording/%s.log)]\n", failedTest, prNumber, buildID, failedTest, prNumber, buildID, failedTest)
-			}
-			comment += "\n\n"
-			if len(recordingResult.PassedTests)+len(recordingResult.FailedTests) < len(replayingResult.FailedTests) {
-				comment += "$\\textcolor{red}{\\textsf{Several tests got terminated during RECORDING mode.}}$\n"
-			}
-			comment += "$\\textcolor{red}{\\textsf{Please fix these to complete your PR.}}$\n"
-		} else {
-			if len(recordingResult.PassedTests)+len(recordingResult.FailedTests) < len(replayingResult.FailedTests) {
-				comment += "$\\textcolor{red}{\\textsf{Several tests got terminated during RECORDING mode.}}$\n"
-			} else if recordingErr != nil {
-				// Check for any uncaught errors in RECORDING mode.
-				comment += "$\\textcolor{red}{\\textsf{Errors occurred during RECORDING mode. Please fix them to complete your PR.}}$\n"
-			} else {
-				comment += "$\\textcolor{green}{\\textsf{All tests passed!}}$\n"
-			}
+		hasTerminatedTests := (len(recordingResult.PassedTests) + len(recordingResult.FailedTests)) < len(replayingResult.FailedTests)
+		allRecordingPassed := len(recordingResult.FailedTests) == 0 && !hasTerminatedTests && recordingErr == nil
+
+		recordReplayData := recordReplay{
+			RecordingResult:               recordingResult,
+			ReplayingAfterRecordingResult: replayingAfterRecordingResult,
+			RecordingErr:                  recordingErr,
+			HasTerminatedTests:            hasTerminatedTests,
+			AllRecordingPassed:            allRecordingPassed,
+			PRNumber:                      prNumber,
+			BuildID:                       buildID,
+		}
+		recordReplayComment, err := formatRecordReplay(recordReplayData)
+		if err != nil {
+			fmt.Println("Error formatting record replay comment: ", err)
+			os.Exit(1)
+		}
+		if err := gh.PostComment(prNumber, recordReplayComment); err != nil {
+			fmt.Println("Error posting comment: ", err)
+			os.Exit(1)
 		}
 
-		comment += fmt.Sprintf("View the [build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-%s/artifacts/%s/build-log/recording_test.log) or the [debug log](https://console.cloud.google.com/storage/browser/ci-vcr-logs/beta/refs/heads/auto-pr-%s/artifacts/%s/recording) for each test", prNumber, buildID, prNumber, buildID)
-	} else {
-		// Add newlines so that the color formatting will work properly.
-		comment += `
-
-`
-		if replayingErr != nil {
-			// Check for any uncaught errors in REPLAYING mode.
-			comment += "$\\textcolor{red}{\\textsf{Errors occurred during REPLAYING mode. Please fix them to complete your PR.}}$\n"
-		} else {
-			comment += "$\\textcolor{green}{\\textsf{All tests passed!}}$\n"
+	} else { //  len(replayingResult.FailedTests) == 0
+		withoutReplayFailedTestsData := withoutReplayFailedTests{
+			ReplayingErr: replayingErr,
+			PRNumber:     prNumber,
+			BuildID:      buildID,
 		}
-		comment += fmt.Sprintf("View the [build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-%s/artifacts/%s/build-log/replaying_test.log)", prNumber, buildID)
-	}
-	if err := gh.PostComment(prNumber, comment); err != nil {
-		return fmt.Errorf("error posting comment: %w", err)
+		withoutReplayFailedTestsComment, err := formatWithoutReplayFailedTests(withoutReplayFailedTestsData)
+		if err != nil {
+			fmt.Println("Error formatting action taken comment: ", err)
+			os.Exit(1)
+		}
+
+		comment := strings.Join([]string{testsAnalyticsComment, nonExercisedTestsComment, withoutReplayFailedTestsComment}, "\n")
+		if err := gh.PostComment(prNumber, comment); err != nil {
+			fmt.Println("Error posting comment: ", err)
+			os.Exit(1)
+		}
 	}
 
 	if err := gh.PostBuildStatus(prNumber, "VCR-test", testState, buildStatusTargetURL, mmCommitSha); err != nil {
@@ -379,17 +396,14 @@ func modifiedPackages(changedFiles []string) (map[string]struct{}, bool) {
 	return services, runFullVCR
 }
 
-func runReplaying(runFullVCR bool, services map[string]struct{}, vt *vcr.Tester) (*vcr.Result, string, []string, error) {
+func runReplaying(runFullVCR bool, services map[string]struct{}, vt *vcr.Tester) (*vcr.Result, []string, error) {
 	var result *vcr.Result
-	affectedServicesComment := "None"
 	var testDirs []string
 	var replayingErr error
 	if runFullVCR {
 		fmt.Println("run full VCR tests")
-		affectedServicesComment = "all service packages are affected"
 		result, replayingErr = vt.Run(vcr.Replaying, provider.Beta, nil)
 	} else if len(services) > 0 {
-		affectedServicesComment = "<ul>"
 		result = &vcr.Result{}
 		for service := range services {
 			servicePath := "./" + filepath.Join("google-beta", "services", service)
@@ -403,12 +417,10 @@ func runReplaying(runFullVCR bool, services map[string]struct{}, vt *vcr.Tester)
 			result.SkippedTests = append(result.SkippedTests, serviceResult.SkippedTests...)
 			result.FailedTests = append(result.FailedTests, serviceResult.FailedTests...)
 			result.Panics = append(result.Panics, serviceResult.Panics...)
-			affectedServicesComment += fmt.Sprintf("<li>%s</li>", service)
 		}
-		affectedServicesComment += "</ul>"
 	}
 
-	return result, affectedServicesComment, testDirs, replayingErr
+	return result, testDirs, replayingErr
 }
 
 func handlePanics(prNumber, buildID, buildStatusTargetURL, mmCommitSha string, result *vcr.Result, mode vcr.Mode, gh GithubClient) (bool, error) {
@@ -429,4 +441,41 @@ View the [build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/head
 
 func init() {
 	rootCmd.AddCommand(testTerraformVCRCmd)
+}
+
+func formatComment(fileName string, tmplText string, data any) (string, error) {
+	funcs := template.FuncMap{
+		"join": strings.Join,
+		"add":  func(i, j int) int { return i + j },
+	}
+	tmpl, err := template.New(fileName).Funcs(funcs).Parse(tmplText)
+	if err != nil {
+		panic(fmt.Sprintf("Unable to parse %s: %s", fileName, err))
+	}
+	sb := new(strings.Builder)
+	err = tmpl.Execute(sb, data)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(sb.String()), nil
+}
+
+func formatTestsAnalytics(data analytics) (string, error) {
+	return formatComment("test_terraform_vcr_test_analytics.tmpl", testsAnalyticsTmplText, data)
+}
+
+func formatNonExercisedTests(data nonExercisedTests) (string, error) {
+	return formatComment("test_terraform_vcr_recording_mode_results.tmpl", nonExercisedTestsTmplText, data)
+}
+
+func formatWithReplayFailedTests(data withReplayFailedTests) (string, error) {
+	return formatComment("test_terraform_vcr_with_replay_failed_tests.tmpl", withReplayFailedTestsTmplText, data)
+}
+
+func formatWithoutReplayFailedTests(data withoutReplayFailedTests) (string, error) {
+	return formatComment("test_terraform_vcr_without_replay_failed_tests.tmpl", withoutReplayFailedTestsTmplText, data)
+}
+
+func formatRecordReplay(data recordReplay) (string, error) {
+	return formatComment("test_terraform_vcr_record_replay.tmpl", recordReplayTmplText, data)
 }

--- a/.ci/magician/cmd/test_terraform_vcr.go
+++ b/.ci/magician/cmd/test_terraform_vcr.go
@@ -217,8 +217,7 @@ func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, 
 	}
 	testsAnalyticsComment, err := formatTestsAnalytics(analyticsData)
 	if err != nil {
-		fmt.Println("Error formatting test_analytics comment: ", err)
-		os.Exit(1)
+		return fmt.Errorf("error formatting test_analytics comment: %w", err)
 	}
 
 	notRunBeta, notRunGa := notRunTests(tpgRepo.UnifiedZeroDiff, tpgbRepo.UnifiedZeroDiff, replayingResult)
@@ -229,8 +228,7 @@ func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, 
 	}
 	nonExercisedTestsComment, err := formatNonExercisedTests(nonExercisedTestsData)
 	if err != nil {
-		fmt.Println("Error formatting non exercised tests comment: ", err)
-		os.Exit(1)
+		return fmt.Errorf("error formatting non exercised tests comment: %w", err)
 	}
 
 	if len(replayingResult.FailedTests) > 0 {
@@ -239,8 +237,7 @@ func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, 
 		}
 		withReplayFailedTestsComment, err := formatWithReplayFailedTests(withReplayFailedTestsData)
 		if err != nil {
-			fmt.Println("Error formatting action taken comment: ", err)
-			os.Exit(1)
+			return fmt.Errorf("error formatting action taken comment: %w", err)
 		}
 
 		comment := strings.Join([]string{testsAnalyticsComment, nonExercisedTestsComment, withReplayFailedTestsComment}, "\n")
@@ -296,12 +293,10 @@ func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, 
 		}
 		recordReplayComment, err := formatRecordReplay(recordReplayData)
 		if err != nil {
-			fmt.Println("Error formatting record replay comment: ", err)
-			os.Exit(1)
+			return fmt.Errorf("error formatting record replay comment: %w", err)
 		}
 		if err := gh.PostComment(prNumber, recordReplayComment); err != nil {
-			fmt.Println("Error posting comment: ", err)
-			os.Exit(1)
+			return fmt.Errorf("error posting comment: %w", err)
 		}
 
 	} else { //  len(replayingResult.FailedTests) == 0
@@ -312,14 +307,12 @@ func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, 
 		}
 		withoutReplayFailedTestsComment, err := formatWithoutReplayFailedTests(withoutReplayFailedTestsData)
 		if err != nil {
-			fmt.Println("Error formatting action taken comment: ", err)
-			os.Exit(1)
+			return fmt.Errorf("error formatting action taken comment: %w", err)
 		}
 
 		comment := strings.Join([]string{testsAnalyticsComment, nonExercisedTestsComment, withoutReplayFailedTestsComment}, "\n")
 		if err := gh.PostComment(prNumber, comment); err != nil {
-			fmt.Println("Error posting comment: ", err)
-			os.Exit(1)
+			return fmt.Errorf("error posting comment: %w", err)
 		}
 	}
 

--- a/.ci/magician/cmd/test_terraform_vcr_non_exercised_tests.tmpl
+++ b/.ci/magician/cmd/test_terraform_vcr_non_exercised_tests.tmpl
@@ -1,0 +1,13 @@
+{{- if or (gt (len .NotRunBetaTests) 0) (gt (len .NotRunGATests) 0) -}}
+#### Non-exercised tests
+
+{{if gt (len .NotRunBetaTests) 0 -}}
+Tests were added that are skipped in VCR:
+{{range .NotRunBetaTests}}{{. | printf "- %s\n"}}{{end}}
+{{end}}
+
+{{if gt (len .NotRunGATests) 0 -}}
+Tests were added that are GA-only additions and require manual runs:
+{{range .NotRunGATests}}{{. | printf "- %s\n"}}{{end}}
+{{end}}
+{{end}}

--- a/.ci/magician/cmd/test_terraform_vcr_record_replay.tmpl
+++ b/.ci/magician/cmd/test_terraform_vcr_record_replay.tmpl
@@ -1,0 +1,31 @@
+{{- if gt (len .RecordingResult.PassedTests) 0 -}}
+$\textcolor{green}{\textsf{Tests passed during RECORDING mode:}}$
+{{range .RecordingResult.PassedTests}}`{{.}}`[[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-{{$.PRNumber}}/artifacts/{{$.BuildID}}/recording/{{.}}.log)]
+{{end}}
+
+{{- if gt (len .ReplayingAfterRecordingResult.FailedTests ) 0 -}}
+$\textcolor{red}{\textsf{Tests failed when rerunning REPLAYING mode:}}$
+{{range .ReplayingAfterRecordingResult.FailedTests}}`{{.}}`[[Error message](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-{{$.PRNumber}}/artifacts/{{$.BuildID}}/build-log/replaying_build_after_recording/{{.}}_replaying_test.log)] [[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-{{$.PRNumber}}/artifacts/{{$.BuildID}}/replaying_after_recording/{{.}}.log)]
+{{end}}
+
+Tests failed due to non-determinism or randomness when the VCR replayed the response after the HTTP request was made.
+
+Please fix these to complete your PR. If you believe these test failures to be incorrect or unrelated to your change, or if you have any questions, please raise the concern with your reviewer.
+
+{{else}}
+$\textcolor{green}{\textsf{No issues found for passed tests after REPLAYING rerun.}}$
+{{end}}{{/* end of if gt (len .ReplayingAfterRecordingResult.FailedTests ) 0 */}}
+---
+{{end}}{{/* end of if gt (len .RecordingResult.PassedTests) 0 */}}
+
+{{if gt (len .RecordingResult.FailedTests) 0 -}}
+$\textcolor{red}{\textsf{Tests failed during RECORDING mode:}}$
+{{range .RecordingResult.FailedTests}}`{{.}}`[[Error message](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-{{$.PRNumber}}/artifacts/{{$.BuildID}}/build-log/recording_build/{{.}}_recording_test.log)] [[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-{{$.PRNumber}}/artifacts/{{$.BuildID}}/recording/{{.}}.log)]
+{{end}}
+{{end}} {{- /* end of if gt (len .RecordingResult.FailedTests) 0 */ -}}
+
+{{if .HasTerminatedTests}}$\textcolor{red}{\textsf{Several tests got terminated during RECORDING mode.}}${{end}}
+{{if .RecordingErr}}$\textcolor{red}{\textsf{Errors occurred during RECORDING mode. Please fix them to complete your PR.}}${{end}}
+{{if .AllRecordingPassed}}$\textcolor{green}{\textsf{All tests passed!}}${{end}}
+
+View the [build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-{{.PRNumber}}/artifacts/{{.BuildID}}/build-log/recording_test.log) or the [debug log](https://console.cloud.google.com/storage/browser/ci-vcr-logs/beta/refs/heads/auto-pr-{{.PRNumber}}/artifacts/{{.BuildID}}/recording) for each test

--- a/.ci/magician/cmd/test_terraform_vcr_test.go
+++ b/.ci/magician/cmd/test_terraform_vcr_test.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 
 	"magician/vcr"
@@ -210,6 +213,405 @@ func TestNotRunTests(t *testing.T) {
 			notRunBeta, notRunGa := notRunTests(tc.gaDiff, tc.betaDiff, tc.result)
 			assert.Equal(t, tc.wantNotRunBeta, notRunBeta)
 			assert.Equal(t, tc.wantNotRunGa, notRunGa)
+		})
+	}
+}
+
+func TestAnalyticsComment(t *testing.T) {
+	tests := []struct {
+		name string
+		data analytics
+		want string
+	}{
+		{
+			name: "run full vcr is false and no affected services",
+			data: analytics{
+				ReplayingResult: &vcr.Result{
+					PassedTests:  []string{"a", "b", "c"},
+					SkippedTests: []string{"d", "e"},
+					FailedTests:  []string{"f"},
+				},
+				RunFullVCR:       false,
+				AffectedServices: []string{},
+			},
+			want: strings.Join(
+				[]string{
+					"#### Tests analytics",
+					"Total tests: 7",
+					"Passed tests: 3",
+					"Skipped tests: 2",
+					"Affected tests: 1",
+					"",
+					"<details>",
+					"<summary>Click here to see the affected service packages</summary>",
+					"<blockquote>",
+					"",
+					"None",
+					"",
+					"</blockquote>",
+					"</details>",
+				},
+				"\n",
+			),
+		},
+		{
+			name: "run full vcr is false and has affected services",
+			data: analytics{
+				ReplayingResult: &vcr.Result{
+					PassedTests:  []string{"a", "b", "c"},
+					SkippedTests: []string{"d", "e"},
+					FailedTests:  []string{"f"},
+				},
+				RunFullVCR:       false,
+				AffectedServices: []string{"svc-a", "svc-b"},
+			},
+			want: strings.Join(
+				[]string{
+					"#### Tests analytics",
+					"Total tests: 7",
+					"Passed tests: 3",
+					"Skipped tests: 2",
+					"Affected tests: 1",
+					"",
+					"<details>",
+					"<summary>Click here to see the affected service packages</summary>",
+					"<blockquote>",
+					"",
+					"<ul>",
+					"<li>svc-a</li>",
+					"<li>svc-b</li>",
+					"",
+					"</ul>",
+					"",
+					"</blockquote>",
+					"</details>",
+				},
+				"\n",
+			),
+		},
+		{
+			name: "run full vcr is true",
+			data: analytics{
+				ReplayingResult: &vcr.Result{
+					PassedTests:  []string{"a", "b", "c"},
+					SkippedTests: []string{"d", "e"},
+					FailedTests:  []string{"f"},
+				},
+				RunFullVCR:       true,
+				AffectedServices: []string{},
+			},
+			want: strings.Join([]string{
+				"#### Tests analytics",
+				"Total tests: 7",
+				"Passed tests: 3",
+				"Skipped tests: 2",
+				"Affected tests: 1",
+				"",
+				"<details>",
+				"<summary>Click here to see the affected service packages</summary>",
+				"<blockquote>",
+				"",
+				"All service packages are affected",
+				"",
+				"</blockquote>",
+				"</details>",
+			},
+				"\n",
+			),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := formatTestsAnalytics(tc.data)
+			if err != nil {
+				t.Fatalf("Failed to format comment: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("formatTestsAnalytics() returned unexpected difference (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNonExercisedTestsComment(t *testing.T) {
+	tests := []struct {
+		name string
+		data nonExercisedTests
+		want string
+	}{
+		{
+			name: "without non exercised tests",
+			data: nonExercisedTests{},
+			want: strings.Join(
+				[]string{},
+				"\n",
+			),
+		},
+		{
+			name: "with not run beta tests",
+			data: nonExercisedTests{
+				NotRunBetaTests: []string{"beta-1", "beta-2"},
+			},
+			want: strings.Join(
+				[]string{
+					"#### Non-exercised tests",
+					"",
+					"Tests were added that are skipped in VCR:",
+					"- beta-1",
+					"- beta-2",
+				},
+				"\n",
+			),
+		},
+		{
+			name: "with not run ga tests",
+			data: nonExercisedTests{
+				NotRunGATests: []string{"ga-1", "ga-2"},
+			},
+			want: strings.Join(
+				[]string{
+					"#### Non-exercised tests",
+					"",
+					"",
+					"",
+					"Tests were added that are GA-only additions and require manual runs:",
+					"- ga-1",
+					"- ga-2",
+				},
+				"\n",
+			),
+		},
+		{
+			name: "with not run ga tests and not run beta tests",
+			data: nonExercisedTests{
+				NotRunGATests:   []string{"ga-1", "ga-2"},
+				NotRunBetaTests: []string{"beta-1", "beta-2"},
+			},
+			want: strings.Join(
+				[]string{
+					"#### Non-exercised tests",
+					"",
+					"Tests were added that are skipped in VCR:",
+					"- beta-1",
+					"- beta-2",
+					"",
+					"",
+					"",
+					"Tests were added that are GA-only additions and require manual runs:",
+					"- ga-1",
+					"- ga-2",
+				},
+				"\n",
+			),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := formatNonExercisedTests(tc.data)
+			if err != nil {
+				t.Fatalf("Failed to format comment: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("formatNonExercisedTests() returned unexpected difference (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestWithReplayFailedTests(t *testing.T) {
+	tests := []struct {
+		name string
+		data withReplayFailedTests
+		want string
+	}{
+		{
+			name: "with failed tests",
+			data: withReplayFailedTests{
+				ReplayingResult: &vcr.Result{
+					FailedTests: []string{"a", "b"},
+				},
+			},
+			want: strings.Join(
+				[]string{
+					"#### Action taken",
+					"<details>",
+					"<summary>Found 2 affected test(s) by replaying old test recordings. Starting RECORDING based on the most recent commit. Click here to see the affected tests",
+					"</summary>",
+					"<blockquote>",
+					"<ul>",
+					"<li>a</li>",
+					"<li>b</li>",
+					"", // Empty line
+					"</ul>",
+					"</blockquote>",
+					"</details>",
+					"",
+					"[Get to know how VCR tests work](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/contributing/#general-contributing-steps)",
+				},
+				"\n",
+			),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := formatWithReplayFailedTests(tc.data)
+			if err != nil {
+				t.Fatalf("Failed to format comment: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("formatWithReplayFailedTests() returned unexpected difference (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestWithoutReplayFailedTests(t *testing.T) {
+	tests := []struct {
+		name string
+		data withoutReplayFailedTests
+		want string
+	}{
+		{
+			name: "with replay error",
+			data: withoutReplayFailedTests{
+				ReplayingErr: fmt.Errorf("some error"),
+				BuildID:      "build-123",
+				PRNumber:     "pr-123",
+			},
+			want: strings.Join(
+				[]string{
+					"$\\textcolor{red}{\\textsf{Errors occurred during REPLAYING mode. Please fix them to complete your PR.}}$",
+					"",
+					"View the [build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-pr-123/artifacts/build-123/build-log/replaying_test.log)",
+				},
+				"\n",
+			),
+		},
+		{
+			name: "without replay error",
+			data: withoutReplayFailedTests{
+				BuildID:  "build-123",
+				PRNumber: "pr-123",
+			},
+			want: strings.Join(
+				[]string{
+					"$\\textcolor{green}{\\textsf{All tests passed!}}$",
+					"",
+					"View the [build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-pr-123/artifacts/build-123/build-log/replaying_test.log)",
+				},
+				"\n",
+			),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := formatWithoutReplayFailedTests(tc.data)
+			if err != nil {
+				t.Fatalf("Failed to format comment: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("formatWithoutReplayFailedTests() returned unexpected difference (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRecordReplay(t *testing.T) {
+	tests := []struct {
+		name string
+		data recordReplay
+		want string
+	}{
+		{
+			name: "ReplayingAfterRecordingResult has failed tests",
+			data: recordReplay{
+				RecordingResult: &vcr.Result{
+					PassedTests: []string{"a", "b", "c"},
+					FailedTests: []string{"d", "e"},
+				},
+				ReplayingAfterRecordingResult: &vcr.Result{
+					PassedTests: []string{"a"},
+					FailedTests: []string{"b", "c"},
+				},
+				HasTerminatedTests: true,
+				RecordingErr:       fmt.Errorf("some error"),
+				BuildID:            "build-123",
+				PRNumber:           "pr-123",
+			},
+			want: strings.Join(
+				[]string{
+					"$\\textcolor{green}{\\textsf{Tests passed during RECORDING mode:}}$", "`a`[[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-pr-123/artifacts/build-123/recording/a.log)]",
+					"`b`[[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-pr-123/artifacts/build-123/recording/b.log)]",
+					"`c`[[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-pr-123/artifacts/build-123/recording/c.log)]",
+					"$\\textcolor{red}{\\textsf{Tests failed when rerunning REPLAYING mode:}}$",
+					"`b`[[Error message](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-pr-123/artifacts/build-123/build-log/replaying_build_after_recording/b_replaying_test.log)] [[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-pr-123/artifacts/build-123/replaying_after_recording/b.log)]",
+					"`c`[[Error message](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-pr-123/artifacts/build-123/build-log/replaying_build_after_recording/c_replaying_test.log)] [[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-pr-123/artifacts/build-123/replaying_after_recording/c.log)]",
+					"",
+					"",
+					"Tests failed due to non-determinism or randomness when the VCR replayed the response after the HTTP request was made.",
+					"",
+					"Please fix these to complete your PR. If you believe these test failures to be incorrect or unrelated to your change, or if you have any questions, please raise the concern with your reviewer.",
+					"",
+					"",
+					"---",
+					"",
+					"",
+					"$\\textcolor{red}{\\textsf{Tests failed during RECORDING mode:}}$",
+					"`d`[[Error message](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-pr-123/artifacts/build-123/build-log/recording_build/d_recording_test.log)] [[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-pr-123/artifacts/build-123/recording/d.log)]",
+					"`e`[[Error message](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-pr-123/artifacts/build-123/build-log/recording_build/e_recording_test.log)] [[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-pr-123/artifacts/build-123/recording/e.log)]",
+					"",
+					"$\\textcolor{red}{\\textsf{Several tests got terminated during RECORDING mode.}}$",
+					"$\\textcolor{red}{\\textsf{Errors occurred during RECORDING mode. Please fix them to complete your PR.}}$",
+					"",
+					"",
+					"View the [build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-pr-123/artifacts/build-123/build-log/recording_test.log) or the [debug log](https://console.cloud.google.com/storage/browser/ci-vcr-logs/beta/refs/heads/auto-pr-pr-123/artifacts/build-123/recording) for each test",
+				},
+				"\n",
+			),
+		},
+		{
+			name: "ReplayingAfterRecordingResult does not have failed tests",
+			data: recordReplay{
+				RecordingResult: &vcr.Result{
+					PassedTests: []string{"a", "b", "c"},
+				},
+				ReplayingAfterRecordingResult: &vcr.Result{
+					PassedTests: []string{"a", "b", "c"},
+				},
+				AllRecordingPassed: true,
+				BuildID:            "build-123",
+				PRNumber:           "pr-123",
+			},
+			want: strings.Join(
+				[]string{
+					"$\\textcolor{green}{\\textsf{Tests passed during RECORDING mode:}}$", "`a`[[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-pr-123/artifacts/build-123/recording/a.log)]",
+					"`b`[[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-pr-123/artifacts/build-123/recording/b.log)]",
+					"`c`[[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-pr-123/artifacts/build-123/recording/c.log)]",
+					"",
+					"$\\textcolor{green}{\\textsf{No issues found for passed tests after REPLAYING rerun.}}$",
+					"",
+					"---",
+					"",
+					"",
+					"",
+					"",
+					"$\\textcolor{green}{\\textsf{All tests passed!}}$",
+					"",
+					"View the [build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-pr-123/artifacts/build-123/build-log/recording_test.log) or the [debug log](https://console.cloud.google.com/storage/browser/ci-vcr-logs/beta/refs/heads/auto-pr-pr-123/artifacts/build-123/recording) for each test",
+				},
+				"\n",
+			),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := formatRecordReplay(tc.data)
+			if err != nil {
+				t.Fatalf("Failed to format comment: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("formatRecordReplay() returned unexpected difference (-want +got):\n%s", diff)
+			}
 		})
 	}
 }

--- a/.ci/magician/cmd/test_terraform_vcr_test_analytics.tmpl
+++ b/.ci/magician/cmd/test_terraform_vcr_test_analytics.tmpl
@@ -1,0 +1,20 @@
+#### Tests analytics
+Total tests: {{add (add (len .ReplayingResult.PassedTests) (len .ReplayingResult.PassedTests)) (len .ReplayingResult.FailedTests) }}
+Passed tests: {{len .ReplayingResult.PassedTests}}
+Skipped tests: {{len .ReplayingResult.SkippedTests}}
+Affected tests: {{len .ReplayingResult.FailedTests}}
+
+<details>
+<summary>Click here to see the affected service packages</summary>
+<blockquote>
+{{if .RunFullVCR}}
+All service packages are affected
+{{else if gt (len .AffectedServices) 0}}
+<ul>
+{{range .AffectedServices}}{{. | printf "<li>%s</li>\n"}}{{end}}
+</ul>
+{{else}}
+None
+{{end}}
+</blockquote>
+</details>

--- a/.ci/magician/cmd/test_terraform_vcr_with_replay_failed_tests.tmpl
+++ b/.ci/magician/cmd/test_terraform_vcr_with_replay_failed_tests.tmpl
@@ -1,0 +1,12 @@
+#### Action taken
+<details>
+<summary>Found {{len .ReplayingResult.FailedTests}} affected test(s) by replaying old test recordings. Starting RECORDING based on the most recent commit. Click here to see the affected tests
+</summary>
+<blockquote>
+<ul>
+{{range .ReplayingResult.FailedTests}}{{. | printf "<li>%s</li>\n"}}{{end}}
+</ul>
+</blockquote>
+</details>
+
+[Get to know how VCR tests work](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/contributing/#general-contributing-steps)

--- a/.ci/magician/cmd/test_terraform_vcr_without_replay_failed_tests.tmpl
+++ b/.ci/magician/cmd/test_terraform_vcr_without_replay_failed_tests.tmpl
@@ -1,0 +1,7 @@
+{{- if .ReplayingErr -}}
+$\textcolor{red}{\textsf{Errors occurred during REPLAYING mode. Please fix them to complete your PR.}}$
+{{- else -}}
+$\textcolor{green}{\textsf{All tests passed!}}$
+{{- end}}
+
+View the [build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-{{.PRNumber}}/artifacts/{{.BuildID}}/build-log/replaying_test.log)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

https://github.com/hashicorp/terraform-provider-google/issues/17633

A test PR can be viewd at: https://github.com/GoogleCloudPlatform/magic-modules/pull/10910 (check the latest comment)
The recording debug log does not work(404), but it seems to be an existing issue (eg. https://github.com/GoogleCloudPlatform/magic-modules/pull/10876)


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
