### PR TITLE
update BackendService timeoutSec description

### DIFF
--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -1281,8 +1281,10 @@ properties:
   - !ruby/object:Api::Type::Integer
     name: 'timeoutSec'
     description: |
-      How many seconds to wait for the backend before considering it a
-      failed request. Default is 30 seconds. Valid range is [1, 86400].
+      The backend service timeout has a different meaning depending on the type of load balancer.
+      For more information see, [Backend service settings](https://cloud.google.com/compute/docs/reference/rest/v1/backendServices).
+      The default is 30 seconds.
+      The full range of timeout values allowed goes from 1 through 2,147,483,647 seconds.
     default_from_api: true
   - !ruby/object:Api::Type::NestedObject
     name: 'logConfig'

--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -1225,8 +1225,10 @@ properties:
   - !ruby/object:Api::Type::Integer
     name: 'timeoutSec'
     description: |
-      How many seconds to wait for the backend before considering it a
-      failed request. Default is 30 seconds. Valid range is [1, 86400].
+      The backend service timeout has a different meaning depending on the type of load balancer.
+      For more information see, [Backend service settings](https://cloud.google.com/compute/docs/reference/rest/v1/backendServices).
+      The default is 30 seconds.
+      The full range of timeout values allowed goes from 1 through 2,147,483,647 seconds.
     default_from_api: true
   - !ruby/object:Api::Type::NestedObject
     name: 'logConfig'


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Updates `timeout_sec`'s description in `google_compute_backend_service` and `google_compute_region_backend_service` .
https://github.com/hashicorp/terraform-provider-google/issues/13587

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

- Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes.
- [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran make test and make lint to ensure it passes unit and linter tests.
- Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests). - read only field
- [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
