### PR TITLE
Refactor some Compute tests to use the `context` function signature

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -3312,7 +3312,6 @@ func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfi
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
 						t, "google_compute_instance.foobar", &instance),
-					testAccCheckComputeInstanceNicAccessConfigHasSecurityPolicy(&instance, policyName),
 				),
 			},
 			{
@@ -3327,7 +3326,8 @@ func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfi
 func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateSwapPolicies(t *testing.T) {
 	var instance compute.Instance
 	randomString := acctest.RandString(t, 10)
-	policyName := "google_compute_region_security_policy.policyforinstance.self_link"
+	policyName1 := "google_compute_region_security_policy.policyforinstance.self_link"
+	policyName2 := "google_compute_region_security_policy.policyforinstance2.self_link"
 
 	context_1 := map[string]interface{}{
 		"instance_name":   fmt.Sprintf("tf-test-instance-%s", randomString),
@@ -3342,17 +3342,18 @@ func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfi
 		"policy_name_1":   fmt.Sprintf("tf-test-policy-%s", randomString),
 		"policy_name_2":   fmt.Sprintf("tf-test-policy2-%s", randomString),
 		"suffix":          randomString,
-		"policy_to_set_1": "google_compute_region_security_policy.policyforinstance.self_link",
-		"policy_to_set_2": "google_compute_region_security_policy.policyforinstance2.self_link",
+		// Add policies
+		"policy_to_set_1": policyName1,
+		"policy_to_set_2": policyName2,
 	}
 	context_3 := map[string]interface{}{
 		"instance_name":   fmt.Sprintf("tf-test-instance-%s", randomString),
 		"policy_name_1":   fmt.Sprintf("tf-test-policy-%s", randomString),
 		"policy_name_2":   fmt.Sprintf("tf-test-policy2-%s", randomString),
 		"suffix":          randomString,
-		// Policies to set are flipped round vs context_2
-		"policy_to_set_1": "google_compute_region_security_policy.policyforinstance2.self_link",
-		"policy_to_set_2": "google_compute_region_security_policy.policyforinstance.self_link",
+		// Policies switch places vs context_2
+		"policy_to_set_1": policyName2,
+		"policy_to_set_2": policyName1,
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -3377,7 +3378,7 @@ func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfi
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
 						t, "google_compute_instance.foobar", &instance),
-					testAccCheckComputeInstanceNicAccessConfigHasSecurityPolicy(&instance, policyName),
+					testAccCheckComputeInstanceNicAccessConfigHasSecurityPolicy(&instance, policyName1),
 					testAccCheckComputeInstanceNicAccessConfigHasSecurityPolicy(&instance, policyName2),
 				),
 			},
@@ -3392,7 +3393,7 @@ func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfi
 					testAccCheckComputeInstanceExists(
 						t, "google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceNicAccessConfigHasSecurityPolicy(&instance, policyName2),
-					testAccCheckComputeInstanceNicAccessConfigHasSecurityPolicy(&instance, policyName),
+					testAccCheckComputeInstanceNicAccessConfigHasSecurityPolicy(&instance, policyName1),
 				),
 			},
 			{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -3282,11 +3282,16 @@ func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfi
 	var instance compute.Instance
 	randomString := acctest.RandString(t, 10)
 	policyRef := "google_compute_region_security_policy.policyforinstance.self_link"
-	policyName := fmt.Sprintf("tf-test-policy-%s", randomString)
+	policyName1 := fmt.Sprintf("tf-test-policy-%s", randomString)
+	policyName2 := fmt.Sprintf("tf-test-policy2-%s", acctest.RandString(t, 10))
+
 	context := map[string]interface{}{
 		"instance_name":    fmt.Sprintf("tf-test-instance-%s", randomString),
-		"policy_name":      policyName,
+		"policy_name_1":    policyName1,
+		"policy_name_2":    policyName2,
 		"suffix":           randomString,
+
+		// This test intentionally has >1 policies provisioned but only uses one to define network interfaces
 		"nic_1_policy_ref": policyRef,
 		"nic_2_policy_ref": policyRef,
 	}
@@ -3301,7 +3306,7 @@ func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfi
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
 						t, "google_compute_instance.foobar", &instance),
-					testAccCheckComputeInstanceNicAccessConfigHasSecurityPolicy(&instance, policyName),
+					testAccCheckComputeInstanceNicAccessConfigHasSecurityPolicy(&instance, policyName1),
 				),
 			},
 			{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -8902,8 +8902,8 @@ resource "google_compute_instance" "foobar" {
 `, context)
 }
 
-func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateTwoPoliciesRemoveAccessConfig(suffix, policy, policy2, instance, policyToSetOne, policyToSetTwo string) string {
-	return fmt.Sprintf(`
+func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateTwoPoliciesRemoveAccessConfig(context map[string]interface{}) string {
+	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
   family  = "debian-11"
   project = "debian-cloud"
@@ -8912,7 +8912,7 @@ data "google_compute_image" "my_image" {
 # First activate advanced network DDoS protection for the desired region
 resource "google_compute_region_security_policy" "policyddosprotection" {
   region      = "europe-west1"
-  name        = "tf-test-policyddosprotection-%s"
+  name        = "tf-test-policyddosprotection-%{suffix}"
   description = "region security policy for instance"
   type        = "CLOUD_ARMOR_NETWORK"
   ddos_protection_config {
@@ -8922,19 +8922,19 @@ resource "google_compute_region_security_policy" "policyddosprotection" {
 
 resource "google_compute_network_edge_security_service" "edge_sec_service" {
   region          = "europe-west1"
-  name            = "tf-test-edgesecservice-%s"
+  name            = "tf-test-edgesecservice-%{suffix}"
   description     = "My basic resource using security policy"
   security_policy = google_compute_region_security_policy.policyddosprotection.self_link
 }
 
 resource "google_compute_network" "net" {
-  name                    = "tf-test-network-%s"
+  name                    = "tf-test-network-%{suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "subnet" {
   region                     = "europe-west1"
-  name                       = "tf-test-subnet-%s"
+  name                       = "tf-test-subnet-%{suffix}"
   ip_cidr_range              = "192.168.0.0/16"
   purpose                    = "PRIVATE"
   stack_type                 = "IPV4_ONLY"
@@ -8943,7 +8943,7 @@ resource "google_compute_subnetwork" "subnet" {
 
 resource "google_compute_subnetwork" "subnet-ipv6" {
   region                     = "europe-west1"
-  name                       = "tf-test-subnet-ip6-%s"
+  name                       = "tf-test-subnet-ip6-%{suffix}"
   ip_cidr_range              = "10.0.0.0/22"
   purpose                    = "PRIVATE"
   stack_type                 = "IPV4_IPV6"
@@ -8953,12 +8953,12 @@ resource "google_compute_subnetwork" "subnet-ipv6" {
 
 resource "google_compute_address" "normal-address" {
   region   = "europe-west1"
-  name     = "tf-test-addr-normal-%s"
+  name     = "tf-test-addr-normal-%{suffix}"
 }
 
 resource "google_compute_address" "ipv6-address" {
   region             = "europe-west1"
-  name               = "tf-test-addr-ipv6-%s"
+  name               = "tf-test-addr-ipv6-%{suffix}"
   address_type       = "EXTERNAL"
   ip_version         = "IPV6"
   network_tier       = "PREMIUM"
@@ -8967,13 +8967,13 @@ resource "google_compute_address" "ipv6-address" {
 }
 
 resource "google_compute_network" "net2" {
-  name                    = "tf-test-network2-%s"
+  name                    = "tf-test-network2-%{suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "subnet2" {
   region                     = "europe-west1"
-  name                       = "tf-test-subnet2-%s"
+  name                       = "tf-test-subnet2-%{suffix}"
   ip_cidr_range              = "192.170.0.0/20"
   purpose                    = "PRIVATE"
   stack_type                 = "IPV4_ONLY"
@@ -8982,7 +8982,7 @@ resource "google_compute_subnetwork" "subnet2" {
   
 resource "google_compute_subnetwork" "subnet-ipv62" {
   region                     = "europe-west1"
-  name                       = "tf-test-subnet-ip62-%s"
+  name                       = "tf-test-subnet-ip62-%{suffix}"
   ip_cidr_range              = "10.10.0.0/20"
   purpose                    = "PRIVATE"
   stack_type                 = "IPV4_IPV6"
@@ -8992,12 +8992,12 @@ resource "google_compute_subnetwork" "subnet-ipv62" {
 
 resource "google_compute_address" "normal-address2" {
   region   = "europe-west1"
-  name     = "tf-test-addr-normal2-%s"
+  name     = "tf-test-addr-normal2-%{suffix}"
 }
   
 resource "google_compute_address" "ipv6-address2" {
   region             = "europe-west1"
-  name               = "tf-test-addr-ipv62-%s"
+  name               = "tf-test-addr-ipv62-%{suffix}"
   address_type       = "EXTERNAL"
   ip_version         = "IPV6"
   network_tier       = "PREMIUM"
@@ -9043,8 +9043,8 @@ resource "google_compute_instance" "foobar" {
       name                        = "external-ipv6-access-config"
       network_tier                = "PREMIUM"
     }
-	# access config removed
-	security_policy = %s
+    # access config removed
+    security_policy = %{policy_to_set_2}
   }
 
   network_interface {
@@ -9057,15 +9057,15 @@ resource "google_compute_instance" "foobar" {
       name                        = "external-ipv6-access-config"
       network_tier                = "PREMIUM"
     }
-	# access config removed
-	security_policy = %s
+    # access config removed
+    security_policy = %{policy_to_set_2}
   }
 
   metadata = {
     foo = "bar"
   }
 }
-`, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, policy, policy2, instance, policyToSetOne, policyToSetTwo)
+`, context)
 }
 
 func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndAccessConfigsWithEmptyAndNullSecurityPolicies(suffix, instance string) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -3281,13 +3281,14 @@ func testAccComputeInstance_nic_securityPolicyCreateWithTwoAccessConfigsUpdateSe
 func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateRemoveAccessConfig(t *testing.T) {
 	var instance compute.Instance
 	randomString := acctest.RandString(t, 10)
-	policyReference := "google_compute_region_security_policy.policyforinstance.self_link"
+	policyRef := "google_compute_region_security_policy.policyforinstance.self_link"
+	policyName := fmt.Sprintf("tf-test-policy-%s", randomString)
 	context := map[string]interface{}{
-		"instance_name":   fmt.Sprintf("tf-test-instance-%s", randomString),
-		"policy_name":   fmt.Sprintf("tf-test-policy-%s", randomString),
-		"suffix":          randomString,
-		"nic_1_policy_ref": policyReference,
-		"nic_2_policy_ref": policyReference,
+		"instance_name":    fmt.Sprintf("tf-test-instance-%s", randomString),
+		"policy_name":      policyName,
+		"suffix":           randomString,
+		"nic_1_policy_ref": policyRef,
+		"nic_2_policy_ref": policyRef,
 	}
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -3184,10 +3184,27 @@ func testAccComputeInstance_nic_securityPolicyCreateWithEmptyAndNullSecurityPoli
 
 func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateOnlyOnePolicy(t *testing.T) {
 	var instance compute.Instance
-	var instanceName = fmt.Sprintf("tf-test-instance-%s", acctest.RandString(t, 10))
-	var policyName = fmt.Sprintf("tf-test-policy-%s", acctest.RandString(t, 10))
-	var policyName2 = fmt.Sprintf("tf-test-policy2-%s", acctest.RandString(t, 10))
-	var suffix = acctest.RandString(t, 10)
+	policyName1 := "google_compute_region_security_policy.policyforinstance.self_link"
+	policyName2 := "google_compute_region_security_policy.policyforinstance2.self_link"
+
+	randomString := acctest.RandString(t, 10)
+	context_1 := map[string]interface{}{
+		"instance_name":   fmt.Sprintf("tf-test-instance-%s", randomString),
+		"policy_name_1":   fmt.Sprintf("tf-test-policy-%s", randomString),
+		"policy_name_2":   fmt.Sprintf("tf-test-policy2-%s", randomString),
+		"suffix":          randomString,
+		"policy_to_set_1": policyName1,
+		"policy_to_set_2": policyName1,
+	}
+
+	context_2 := map[string]interface{}{
+		"instance_name":   fmt.Sprintf("tf-test-instance-%s", randomString),
+		"policy_name_1":   fmt.Sprintf("tf-test-policy-%s", randomString),
+		"policy_name_2":   fmt.Sprintf("tf-test-policy2-%s", randomString),
+		"suffix":          randomString,
+		"policy_to_set_1": policyName1,
+		"policy_to_set_2": policyName2,
+	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -3195,11 +3212,11 @@ func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfi
 		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateTwoPolicies(suffix, policyName, policyName2, instanceName, "google_compute_region_security_policy.policyforinstance.self_link", "google_compute_region_security_policy.policyforinstance.self_link"),
+				Config: testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateTwoPolicies(context_1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
 						t, "google_compute_instance.foobar", &instance),
-					testAccCheckComputeInstanceNicAccessConfigHasSecurityPolicy(&instance, policyName),
+					testAccCheckComputeInstanceNicAccessConfigHasSecurityPolicy(&instance, policyName1),
 				),
 			},
 			{
@@ -3208,7 +3225,7 @@ func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfi
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateTwoPolicies(suffix, policyName, policyName2, instanceName, "google_compute_region_security_policy.policyforinstance.self_link", "google_compute_region_security_policy.policyforinstance2.self_link"),
+				Config: testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateTwoPolicies(context_2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
 						t, "google_compute_instance.foobar", &instance),
@@ -3261,10 +3278,16 @@ func testAccComputeInstance_nic_securityPolicyCreateWithTwoAccessConfigsUpdateSe
 
 func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateRemoveAccessConfig(t *testing.T) {
 	var instance compute.Instance
-	var instanceName = fmt.Sprintf("tf-test-instance-%s", acctest.RandString(t, 10))
-	var policyName = fmt.Sprintf("tf-test-policy-%s", acctest.RandString(t, 10))
-	var policyName2 = fmt.Sprintf("tf-test-policy2-%s", acctest.RandString(t, 10))
-	var suffix = acctest.RandString(t, 10)
+	randomString := acctest.RandString(t, 10)
+	policyName := "google_compute_region_security_policy.policyforinstance.self_link"
+	context := map[string]interface{}{
+		"instance_name":   fmt.Sprintf("tf-test-instance-%s", randomString),
+		"policy_name_1":   fmt.Sprintf("tf-test-policy-%s", randomString),
+		"policy_name_2":   fmt.Sprintf("tf-test-policy2-%s", randomString),
+		"suffix":          randomString,
+		"policy_to_set_1": policyName,
+		"policy_to_set_2": policyName,
+	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -3272,7 +3295,7 @@ func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfi
 		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateTwoPolicies(suffix, policyName, policyName2, instanceName, "google_compute_region_security_policy.policyforinstance.self_link", "google_compute_region_security_policy.policyforinstance.self_link"),
+				Config: testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateTwoPolicies(context),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
 						t, "google_compute_instance.foobar", &instance),
@@ -3285,7 +3308,7 @@ func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfi
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateTwoPoliciesRemoveAccessConfig(suffix, policyName, policyName2, instanceName, "google_compute_region_security_policy.policyforinstance.self_link", "google_compute_region_security_policy.policyforinstance.self_link"),
+				Config: testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateTwoPoliciesRemoveAccessConfig(context),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
 						t, "google_compute_instance.foobar", &instance),
@@ -3303,10 +3326,34 @@ func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfi
 
 func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateSwapPolicies(t *testing.T) {
 	var instance compute.Instance
-	var instanceName = fmt.Sprintf("tf-test-instance-%s", acctest.RandString(t, 10))
-	var policyName = fmt.Sprintf("tf-test-policy-%s", acctest.RandString(t, 10))
-	var policyName2 = fmt.Sprintf("tf-test-policy2-%s", acctest.RandString(t, 10))
-	var suffix = acctest.RandString(t, 10)
+	randomString := acctest.RandString(t, 10)
+	policyName := "google_compute_region_security_policy.policyforinstance.self_link"
+
+	context_1 := map[string]interface{}{
+		"instance_name":   fmt.Sprintf("tf-test-instance-%s", randomString),
+		"policy_name_1":   fmt.Sprintf("tf-test-policy-%s", randomString),
+		"policy_name_2":   fmt.Sprintf("tf-test-policy2-%s", randomString),
+		"suffix":          randomString,
+		"policy_to_set_1": "\"\"",
+		"policy_to_set_2": "\"\"",
+	}
+	context_2 := map[string]interface{}{
+		"instance_name":   fmt.Sprintf("tf-test-instance-%s", randomString),
+		"policy_name_1":   fmt.Sprintf("tf-test-policy-%s", randomString),
+		"policy_name_2":   fmt.Sprintf("tf-test-policy2-%s", randomString),
+		"suffix":          randomString,
+		"policy_to_set_1": "google_compute_region_security_policy.policyforinstance.self_link",
+		"policy_to_set_2": "google_compute_region_security_policy.policyforinstance2.self_link",
+	}
+	context_3 := map[string]interface{}{
+		"instance_name":   fmt.Sprintf("tf-test-instance-%s", randomString),
+		"policy_name_1":   fmt.Sprintf("tf-test-policy-%s", randomString),
+		"policy_name_2":   fmt.Sprintf("tf-test-policy2-%s", randomString),
+		"suffix":          randomString,
+		// Policies to set are flipped round vs context_2
+		"policy_to_set_1": "google_compute_region_security_policy.policyforinstance2.self_link",
+		"policy_to_set_2": "google_compute_region_security_policy.policyforinstance.self_link",
+	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -3314,7 +3361,7 @@ func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfi
 		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateTwoPolicies(suffix, policyName, policyName2, instanceName, "\"\"", "\"\""),
+				Config: testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateTwoPolicies(context_1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
 						t, "google_compute_instance.foobar", &instance),
@@ -3326,7 +3373,7 @@ func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfi
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateTwoPolicies(suffix, policyName, policyName2, instanceName, "google_compute_region_security_policy.policyforinstance.self_link", "google_compute_region_security_policy.policyforinstance2.self_link"),
+				Config: testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateTwoPolicies(context_2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
 						t, "google_compute_instance.foobar", &instance),
@@ -3340,7 +3387,7 @@ func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfi
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateTwoPolicies(suffix, policyName, policyName2, instanceName, "google_compute_region_security_policy.policyforinstance2.self_link", "google_compute_region_security_policy.policyforinstance.self_link"),
+				Config: testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateTwoPolicies(context_3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
 						t, "google_compute_instance.foobar", &instance),
@@ -3354,7 +3401,7 @@ func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfi
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateTwoPolicies(suffix, policyName, policyName2, instanceName, "\"\"", "\"\""),
+				Config: testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateTwoPolicies(context_1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
 						t, "google_compute_instance.foobar", &instance),

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -3184,26 +3184,28 @@ func testAccComputeInstance_nic_securityPolicyCreateWithEmptyAndNullSecurityPoli
 
 func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateOnlyOnePolicy(t *testing.T) {
 	var instance compute.Instance
-	policyName1 := "google_compute_region_security_policy.policyforinstance.self_link"
-	policyName2 := "google_compute_region_security_policy.policyforinstance2.self_link"
+	policyName1 := fmt.Sprintf("tf-test-policy-%s", randomString)
+	policyName2 := fmt.Sprintf("tf-test-policy2-%s", randomString)
+	policyRef1 := "google_compute_region_security_policy.policyforinstance.self_link"
+	policyRef2 := "google_compute_region_security_policy.policyforinstance2.self_link"
 
 	randomString := acctest.RandString(t, 10)
 	context_1 := map[string]interface{}{
-		"instance_name":   fmt.Sprintf("tf-test-instance-%s", randomString),
-		"policy_name_1":   fmt.Sprintf("tf-test-policy-%s", randomString),
-		"policy_name_2":   fmt.Sprintf("tf-test-policy2-%s", randomString),
-		"suffix":          randomString,
-		"policy_to_set_1": policyName1,
-		"policy_to_set_2": policyName1,
+		"instance_name":    fmt.Sprintf("tf-test-instance-%s", randomString),
+		"policy_name_1":    policyName1,
+		"policy_name_2":    policyName2,
+		"suffix":           randomString,
+		"nic_1_policy_ref": policyRef1,
+		"nic_2_policy_ref": policyRef1,
 	}
 
 	context_2 := map[string]interface{}{
-		"instance_name":   fmt.Sprintf("tf-test-instance-%s", randomString),
-		"policy_name_1":   fmt.Sprintf("tf-test-policy-%s", randomString),
-		"policy_name_2":   fmt.Sprintf("tf-test-policy2-%s", randomString),
-		"suffix":          randomString,
-		"policy_to_set_1": policyName1,
-		"policy_to_set_2": policyName2,
+		"instance_name":    fmt.Sprintf("tf-test-instance-%s", randomString),
+		"policy_name_1":    policyName1,
+		"policy_name_2":    policyName2,
+		"suffix":           randomString,
+		"nic_1_policy_ref": policyRef1,
+		"nic_2_policy_ref": policyRef2,
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -3279,14 +3281,13 @@ func testAccComputeInstance_nic_securityPolicyCreateWithTwoAccessConfigsUpdateSe
 func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateRemoveAccessConfig(t *testing.T) {
 	var instance compute.Instance
 	randomString := acctest.RandString(t, 10)
-	policyName := "google_compute_region_security_policy.policyforinstance.self_link"
+	policyReference := "google_compute_region_security_policy.policyforinstance.self_link"
 	context := map[string]interface{}{
 		"instance_name":   fmt.Sprintf("tf-test-instance-%s", randomString),
-		"policy_name_1":   fmt.Sprintf("tf-test-policy-%s", randomString),
-		"policy_name_2":   fmt.Sprintf("tf-test-policy2-%s", randomString),
+		"policy_name":   fmt.Sprintf("tf-test-policy-%s", randomString),
 		"suffix":          randomString,
-		"policy_to_set_1": policyName,
-		"policy_to_set_2": policyName,
+		"nic_1_policy_ref": policyReference,
+		"nic_2_policy_ref": policyReference,
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -3326,34 +3327,36 @@ func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfi
 func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateSwapPolicies(t *testing.T) {
 	var instance compute.Instance
 	randomString := acctest.RandString(t, 10)
-	policyName1 := "google_compute_region_security_policy.policyforinstance.self_link"
-	policyName2 := "google_compute_region_security_policy.policyforinstance2.self_link"
+	policyName1 := fmt.Sprintf("tf-test-policy-%s", randomString)
+	policyName2 := fmt.Sprintf("tf-test-policy2-%s", randomString)
+	policyRef1 := "google_compute_region_security_policy.policyforinstance.self_link"
+	policyRef2 := "google_compute_region_security_policy.policyforinstance2.self_link"
 
 	context_1 := map[string]interface{}{
 		"instance_name":   fmt.Sprintf("tf-test-instance-%s", randomString),
-		"policy_name_1":   fmt.Sprintf("tf-test-policy-%s", randomString),
-		"policy_name_2":   fmt.Sprintf("tf-test-policy2-%s", randomString),
+		"policy_name_1":   policyName1,
+		"policy_name_2":   policyName2,
 		"suffix":          randomString,
-		"policy_to_set_1": "\"\"",
-		"policy_to_set_2": "\"\"",
+		"nic_1_policy_ref": "\"\"",
+		"nic_2_policy_ref": "\"\"",
 	}
 	context_2 := map[string]interface{}{
 		"instance_name":   fmt.Sprintf("tf-test-instance-%s", randomString),
-		"policy_name_1":   fmt.Sprintf("tf-test-policy-%s", randomString),
-		"policy_name_2":   fmt.Sprintf("tf-test-policy2-%s", randomString),
+		"policy_name_1":   policyName1,
+		"policy_name_2":   policyName2,
 		"suffix":          randomString,
 		// Add policies
-		"policy_to_set_1": policyName1,
-		"policy_to_set_2": policyName2,
+		"nic_1_policy_ref": policyRef1,
+		"nic_2_policy_ref": policyRef2,
 	}
 	context_3 := map[string]interface{}{
 		"instance_name":   fmt.Sprintf("tf-test-instance-%s", randomString),
-		"policy_name_1":   fmt.Sprintf("tf-test-policy-%s", randomString),
-		"policy_name_2":   fmt.Sprintf("tf-test-policy2-%s", randomString),
+		"policy_name_1":   policyName1,
+		"policy_name_2":   policyName2,
 		"suffix":          randomString,
 		// Policies switch places vs context_2
-		"policy_to_set_1": policyName2,
-		"policy_to_set_2": policyName1,
+		"nic_1_policy_ref": policyRef2,
+		"nic_2_policy_ref": policyRef1,
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -8788,7 +8791,7 @@ data "google_compute_image" "my_image" {
 # First activate advanced network DDoS protection for the desired region
 resource "google_compute_region_security_policy" "policyddosprotection" {
   region      = "europe-west1"
-  name        = "tf-test-policyddosprotection-%{suffix}"
+  name        = "%{policy_name_1}"
   description = "region security policy for instance"
   type        = "CLOUD_ARMOR_NETWORK"
   ddos_protection_config {
@@ -8923,7 +8926,7 @@ resource "google_compute_instance" "foobar" {
 	  network_tier = "PREMIUM"
       nat_ip = google_compute_address.normal-address.address
     }
-	security_policy = %{policy_to_set_1}
+	security_policy = %{nic_1_policy_ref}
   }
 
   network_interface {
@@ -8940,7 +8943,7 @@ resource "google_compute_instance" "foobar" {
 	  network_tier = "PREMIUM"
       nat_ip = google_compute_address.normal-address2.address
     }
-	security_policy = %{policy_to_set_2}
+	security_policy = %{nic_2_policy_ref}
   }
 
   metadata = {
@@ -8960,7 +8963,7 @@ data "google_compute_image" "my_image" {
 # First activate advanced network DDoS protection for the desired region
 resource "google_compute_region_security_policy" "policyddosprotection" {
   region      = "europe-west1"
-  name        = "tf-test-policyddosprotection-%{suffix}"
+  name        = "%{policy_name_1}"
   description = "region security policy for instance"
   type        = "CLOUD_ARMOR_NETWORK"
   ddos_protection_config {
@@ -9092,7 +9095,7 @@ resource "google_compute_instance" "foobar" {
       network_tier                = "PREMIUM"
     }
     # access config removed
-    security_policy = %{policy_to_set_2}
+    security_policy = %{nic_1_policy_ref}
   }
 
   network_interface {
@@ -9106,7 +9109,7 @@ resource "google_compute_instance" "foobar" {
       network_tier                = "PREMIUM"
     }
     # access config removed
-    security_policy = %{policy_to_set_2}
+    security_policy = %{nic_2_policy_ref}
   }
 
   metadata = {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -8730,8 +8730,8 @@ resource "google_compute_instance" "foobar" {
 `, suffix, suffix, suffix, suffix, policy, instance, policyToSetOne, desiredStatus)
 }
 
-func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateTwoPolicies(suffix, policy, policy2, instance, policyToSetOne, policyToSetTwo string) string {
-	return fmt.Sprintf(`
+func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateTwoPolicies(context map[string]interface{}) string {
+	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
   family  = "debian-11"
   project = "debian-cloud"
@@ -8740,7 +8740,7 @@ data "google_compute_image" "my_image" {
 # First activate advanced network DDoS protection for the desired region
 resource "google_compute_region_security_policy" "policyddosprotection" {
   region      = "europe-west1"
-  name        = "tf-test-policyddosprotection-%s"
+  name        = "tf-test-policyddosprotection-%{suffix}"
   description = "region security policy for instance"
   type        = "CLOUD_ARMOR_NETWORK"
   ddos_protection_config {
@@ -8750,19 +8750,19 @@ resource "google_compute_region_security_policy" "policyddosprotection" {
 
 resource "google_compute_network_edge_security_service" "edge_sec_service" {
   region          = "europe-west1"
-  name            = "tf-test-edgesecservice-%s"
+  name            = "tf-test-edgesecservice-%{suffix}"
   description     = "My basic resource using security policy"
   security_policy = google_compute_region_security_policy.policyddosprotection.self_link
 }
 
 resource "google_compute_network" "net" {
-  name                    = "tf-test-network-%s"
+  name                    = "tf-test-network-%{suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "subnet" {
   region                     = "europe-west1"
-  name                       = "tf-test-subnet-%s"
+  name                       = "tf-test-subnet-%{suffix}"
   ip_cidr_range              = "192.168.0.0/16"
   purpose                    = "PRIVATE"
   stack_type                 = "IPV4_ONLY"
@@ -8771,7 +8771,7 @@ resource "google_compute_subnetwork" "subnet" {
 
 resource "google_compute_subnetwork" "subnet-ipv6" {
   region                     = "europe-west1"
-  name                       = "tf-test-subnet-ip6-%s"
+  name                       = "tf-test-subnet-ip6-%{suffix}"
   ip_cidr_range              = "10.0.0.0/22"
   purpose                    = "PRIVATE"
   stack_type                 = "IPV4_IPV6"
@@ -8781,12 +8781,12 @@ resource "google_compute_subnetwork" "subnet-ipv6" {
 
 resource "google_compute_address" "normal-address" {
   region   = "europe-west1"
-  name     = "tf-test-addr-normal-%s"
+  name     = "tf-test-addr-normal-%{suffix}"
 }
 
 resource "google_compute_address" "ipv6-address" {
   region             = "europe-west1"
-  name               = "tf-test-addr-ipv6-%s"
+  name               = "tf-test-addr-ipv6-%{suffix}"
   address_type       = "EXTERNAL"
   ip_version         = "IPV6"
   network_tier       = "PREMIUM"
@@ -8795,13 +8795,13 @@ resource "google_compute_address" "ipv6-address" {
 }
 
 resource "google_compute_network" "net2" {
-  name                    = "tf-test-network2-%s"
+  name                    = "tf-test-network2-%{suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "subnet2" {
   region                     = "europe-west1"
-  name                       = "tf-test-subnet2-%s"
+  name                       = "tf-test-subnet2-%{suffix}"
   ip_cidr_range              = "192.170.0.0/20"
   purpose                    = "PRIVATE"
   stack_type                 = "IPV4_ONLY"
@@ -8810,7 +8810,7 @@ resource "google_compute_subnetwork" "subnet2" {
   
 resource "google_compute_subnetwork" "subnet-ipv62" {
   region                     = "europe-west1"
-  name                       = "tf-test-subnet-ip62-%s"
+  name                       = "tf-test-subnet-ip62-%{suffix}"
   ip_cidr_range              = "10.10.0.0/20"
   purpose                    = "PRIVATE"
   stack_type                 = "IPV4_IPV6"
@@ -8820,12 +8820,12 @@ resource "google_compute_subnetwork" "subnet-ipv62" {
 
 resource "google_compute_address" "normal-address2" {
   region   = "europe-west1"
-  name     = "tf-test-addr-normal2-%s"
+  name     = "tf-test-addr-normal2-%{suffix}"
 }
   
 resource "google_compute_address" "ipv6-address2" {
   region             = "europe-west1"
-  name               = "tf-test-addr-ipv62-%s"
+  name               = "tf-test-addr-ipv62-%{suffix}"
   address_type       = "EXTERNAL"
   ip_version         = "IPV6"
   network_tier       = "PREMIUM"
@@ -8835,7 +8835,7 @@ resource "google_compute_address" "ipv6-address2" {
 
 resource "google_compute_region_security_policy" "policyforinstance" {
   region      = "europe-west1"
-  name        = "%s"
+  name        = "%{policy_name_1}"
   description = "region security policy to set to instance"
   type        = "CLOUD_ARMOR_NETWORK"
   depends_on  = [google_compute_network_edge_security_service.edge_sec_service]
@@ -8843,14 +8843,14 @@ resource "google_compute_region_security_policy" "policyforinstance" {
 
 resource "google_compute_region_security_policy" "policyforinstance2" {
   region      = "europe-west1"
-  name        = "%s"
+  name        = "%{policy_name_2}"
   description = "region security policy 2 to set to instance"
   type        = "CLOUD_ARMOR_NETWORK"
   depends_on  = [google_compute_network_edge_security_service.edge_sec_service]
 }
 
 resource "google_compute_instance" "foobar" {
-  name         = "%s"
+  name         = "%{instance_name}"
   machine_type = "e2-medium"
   zone         = "europe-west1-b"
   tags         = ["foo", "bar"]
@@ -8875,7 +8875,7 @@ resource "google_compute_instance" "foobar" {
 	  network_tier = "PREMIUM"
       nat_ip = google_compute_address.normal-address.address
     }
-	security_policy = %s
+	security_policy = %{policy_to_set_1}
   }
 
   network_interface {
@@ -8892,14 +8892,14 @@ resource "google_compute_instance" "foobar" {
 	  network_tier = "PREMIUM"
       nat_ip = google_compute_address.normal-address2.address
     }
-	security_policy = %s
+	security_policy = %{policy_to_set_2}
   }
 
   metadata = {
     foo = "bar"
   }
 }
-`, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, policy, policy2, instance, policyToSetOne, policyToSetTwo)
+`, context)
 }
 
 func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateTwoPoliciesRemoveAccessConfig(suffix, policy, policy2, instance, policyToSetOne, policyToSetTwo string) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -3184,12 +3184,12 @@ func testAccComputeInstance_nic_securityPolicyCreateWithEmptyAndNullSecurityPoli
 
 func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateOnlyOnePolicy(t *testing.T) {
 	var instance compute.Instance
+	randomString := acctest.RandString(t, 10)
 	policyName1 := fmt.Sprintf("tf-test-policy-%s", randomString)
 	policyName2 := fmt.Sprintf("tf-test-policy2-%s", randomString)
 	policyRef1 := "google_compute_region_security_policy.policyforinstance.self_link"
 	policyRef2 := "google_compute_region_security_policy.policyforinstance2.self_link"
 
-	randomString := acctest.RandString(t, 10)
 	context_1 := map[string]interface{}{
 		"instance_name":    fmt.Sprintf("tf-test-instance-%s", randomString),
 		"policy_name_1":    policyName1,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -8792,7 +8792,7 @@ data "google_compute_image" "my_image" {
 # First activate advanced network DDoS protection for the desired region
 resource "google_compute_region_security_policy" "policyddosprotection" {
   region      = "europe-west1"
-  name        = "%{policy_name_1}"
+  name        = "tf-test-policyddosprotection-%{suffix}"
   description = "region security policy for instance"
   type        = "CLOUD_ARMOR_NETWORK"
   ddos_protection_config {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
I was looking at https://github.com/hashicorp/terraform-provider-google/issues/17838 and realised that changing the tests there are tough because there are lots of arguments passed into config and formatting of the config string is hard to follow.

To enable those tests being edited, I decided to refactor some tests so that configs are generated using a config map instead of multiple arguments.


**Note: I don't have the ability to run these tests in the GCP projects available to me.**

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
