### PR TITLE
Make magician subcommands use RunE and return errors instead of calling os.Exit directly

### DIFF
--- a/.ci/magician/cmd/check_cassettes.go
+++ b/.ci/magician/cmd/check_cassettes.go
@@ -43,37 +43,33 @@ var checkCassettesCmd = &cobra.Command{
 ` + listCCEnvironmentVariables() + `
 
 	It prints a list of tests that failed in replaying mode along with all test output.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		env := make(map[string]string, len(ccEnvironmentVariables))
 		for _, ev := range ccEnvironmentVariables {
 			val, ok := os.LookupEnv(ev)
 			if !ok {
-				fmt.Printf("Did not provide %s environment variable\n", ev)
-				os.Exit(1)
+				return fmt.Errorf("did not provide %s environment variable", ev)
 			}
 			env[ev] = val
 		}
 
 		githubToken, ok := lookupGithubTokenOrFallback("GITHUB_TOKEN_DOWNSTREAMS")
 		if !ok {
-			fmt.Println("Did not provide GITHUB_TOKEN_DOWNSTREAMS or GITHUB_TOKEN environment variables")
-			os.Exit(1)
+			return fmt.Errorf("did not provide GITHUB_TOKEN_DOWNSTREAMS or GITHUB_TOKEN environment variables")
 		}
 
 		rnr, err := exec.NewRunner()
 		if err != nil {
-			fmt.Println("Error creating Runner: ", err)
-			os.Exit(1)
+			return fmt.Errorf("error creating Runner: %w", err)
 		}
 
 		ctlr := source.NewController(env["GOPATH"], "modular-magician", githubToken, rnr)
 
 		vt, err := vcr.NewTester(env, rnr)
 		if err != nil {
-			fmt.Println("Error creating VCR tester: ", err)
-			os.Exit(1)
+			return fmt.Errorf("error creating VCR tester: %w", err)
 		}
-		execCheckCassettes(env["COMMIT_SHA"], vt, ctlr)
+		return execCheckCassettes(env["COMMIT_SHA"], vt, ctlr)
 	},
 }
 
@@ -93,10 +89,9 @@ func listCCEnvironmentVariables() string {
 	return result
 }
 
-func execCheckCassettes(commit string, vt *vcr.Tester, ctlr *source.Controller) {
+func execCheckCassettes(commit string, vt *vcr.Tester, ctlr *source.Controller) error {
 	if err := vt.FetchCassettes(provider.Beta, "main", ""); err != nil {
-		fmt.Println("Error fetching cassettes: ", err)
-		os.Exit(1)
+		return fmt.Errorf("error fetching cassettes: %w", err)
 	}
 
 	providerRepo := &source.Repo{
@@ -105,8 +100,7 @@ func execCheckCassettes(commit string, vt *vcr.Tester, ctlr *source.Controller) 
 	}
 	ctlr.SetPath(providerRepo)
 	if err := ctlr.Clone(providerRepo); err != nil {
-		fmt.Println("Error cloning provider: ", err)
-		os.Exit(1)
+		return fmt.Errorf("error cloning provider: %w", err)
 	}
 	vt.SetRepoPath(provider.Beta, providerRepo.Path)
 
@@ -115,8 +109,7 @@ func execCheckCassettes(commit string, vt *vcr.Tester, ctlr *source.Controller) 
 		fmt.Println("Error running VCR: ", err)
 	}
 	if err := vt.UploadLogs("vcr-check-cassettes", "", "", false, false, vcr.Replaying, provider.Beta); err != nil {
-		fmt.Println("Error uploading logs: ", err)
-		os.Exit(1)
+		return fmt.Errorf("error uploading logs: %w", err)
 	}
 	fmt.Println(len(result.FailedTests), " failed tests: ", result.FailedTests)
 	// TODO(trodge) report these failures to bigquery
@@ -124,9 +117,9 @@ func execCheckCassettes(commit string, vt *vcr.Tester, ctlr *source.Controller) 
 	fmt.Println(len(result.SkippedTests), " skipped tests: ", result.SkippedTests)
 
 	if err := vt.Cleanup(); err != nil {
-		fmt.Println("Error cleaning up vcr tester: ", err)
-		os.Exit(1)
+		return fmt.Errorf("error cleaning up vcr tester: %w", err)
 	}
+	return nil
 }
 
 func init() {

--- a/.ci/magician/cmd/generate_comment.go
+++ b/.ci/magician/cmd/generate_comment.go
@@ -97,13 +97,12 @@ var generateCommentCmd = &cobra.Command{
 	5. Report the results in a PR comment.
 	6. Run unit tests for the missing test detector.
 	`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		env := make(map[string]string, len(gcEnvironmentVariables))
 		for _, ev := range gcEnvironmentVariables {
 			val, ok := os.LookupEnv(ev)
 			if !ok {
-				fmt.Printf("Did not provide %s environment variable\n", ev)
-				os.Exit(1)
+				return fmt.Errorf("did not provide %s environment variable", ev)
 			}
 			env[ev] = val
 		}
@@ -111,24 +110,21 @@ var generateCommentCmd = &cobra.Command{
 		for _, tokenName := range []string{"GITHUB_TOKEN_DOWNSTREAMS", "GITHUB_TOKEN_MAGIC_MODULES"} {
 			val, ok := lookupGithubTokenOrFallback(tokenName)
 			if !ok {
-				fmt.Printf("Did not provide %s or GITHUB_TOKEN environment variable\n", tokenName)
-				os.Exit(1)
+				return fmt.Errorf("did not provide %s or GITHUB_TOKEN environment variable", tokenName)
 			}
 			env[tokenName] = val
 		}
 		gh := github.NewClient(env["GITHUB_TOKEN_MAGIC_MODULES"])
 		rnr, err := exec.NewRunner()
 		if err != nil {
-			fmt.Println("Error creating a runner: ", err)
-			os.Exit(1)
+			return fmt.Errorf("error creating a runner: %w", err)
 		}
 		ctlr := source.NewController(filepath.Join("workspace", "go"), "modular-magician", env["GITHUB_TOKEN_DOWNSTREAMS"], rnr)
 		prNumber, err := strconv.Atoi(env["PR_NUMBER"])
 		if err != nil {
-			fmt.Println("Error parsing PR_NUMBER: ", err)
-			os.Exit(1)
+			return fmt.Errorf("error parsing PR_NUMBER: %w", err)
 		}
-		execGenerateComment(
+		return execGenerateComment(
 			prNumber,
 			env["GITHUB_TOKEN_MAGIC_MODULES"],
 			env["BUILD_ID"],
@@ -150,7 +146,7 @@ func listGCEnvironmentVariables() string {
 	return result
 }
 
-func execGenerateComment(prNumber int, ghTokenMagicModules, buildId, buildStep, projectId, commitSha string, gh GithubClient, rnr ExecRunner, ctlr *source.Controller) {
+func execGenerateComment(prNumber int, ghTokenMagicModules, buildId, buildStep, projectId, commitSha string, gh GithubClient, rnr ExecRunner, ctlr *source.Controller) error {
 	errors := map[string][]string{"Other": []string{}}
 
 	pullRequest, err := gh.GetPullRequest(strconv.Itoa(prNumber))
@@ -387,15 +383,14 @@ func execGenerateComment(prNumber int, ghTokenMagicModules, buildId, buildStep, 
 	// Post diff comment
 	message, err := formatDiffComment(data)
 	if err != nil {
-		fmt.Println("Error formatting message: ", err)
 		fmt.Printf("Data: %v\n", data)
-		os.Exit(1)
+		return fmt.Errorf("error formatting message: %w", err)
 	}
 	if err := gh.PostComment(strconv.Itoa(prNumber), message); err != nil {
-		fmt.Printf("Error posting comment to PR %d: %v\n", prNumber, err)
 		fmt.Println("Comment: ", message)
-		os.Exit(1)
+		return fmt.Errorf("error posting comment to PR %d: %w", prNumber, err)
 	}
+	return nil
 }
 
 // Build the diff processor for tpg or tpgb

--- a/.ci/magician/cmd/generate_downstream.go
+++ b/.ci/magician/cmd/generate_downstream.go
@@ -41,13 +41,12 @@ var generateDownstreamCmd = &cobra.Command{
 
 	The following environment variables should be set:
 ` + listGDEnvironmentVariables(),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		env := make(map[string]string, len(gdEnvironmentVariables))
 		for _, ev := range gdEnvironmentVariables {
 			val, ok := os.LookupEnv(ev)
 			if !ok {
-				fmt.Printf("Did not provide %s environment variable\n", ev)
-				os.Exit(1)
+				return fmt.Errorf("did not provide %s environment variable", ev)
 			}
 			env[ev] = val
 		}
@@ -65,28 +64,24 @@ var generateDownstreamCmd = &cobra.Command{
 		gh := github.NewClient(githubToken)
 		rnr, err := exec.NewRunner()
 		if err != nil {
-			fmt.Println("Error creating a runner: ", err)
-			os.Exit(1)
+			return fmt.Errorf("error creating a runner: %w", err)
 		}
 		ctlr := source.NewController(env["GOPATH"], "modular-magician", githubToken, rnr)
 		oldToken := os.Getenv("GITHUB_TOKEN")
 		if err := os.Setenv("GITHUB_TOKEN", githubToken); err != nil {
-			fmt.Println("Error setting GITHUB_TOKEN environment variable: ", err)
-			os.Exit(1)
+			return fmt.Errorf("error setting GITHUB_TOKEN environment variable: %w", err)
 		}
 		defer func() {
 			if err := os.Setenv("GITHUB_TOKEN", oldToken); err != nil {
 				fmt.Println("Error setting GITHUB_TOKEN environment variable: ", err)
-				os.Exit(1)
 			}
 		}()
 
 		if len(args) != 4 {
-			fmt.Printf("Wrong number of arguments %d, expected 4\n", len(args))
-			os.Exit(1)
+			return fmt.Errorf("wrong number of arguments %d, expected 4", len(args))
 		}
 
-		execGenerateDownstream(env["BASE_BRANCH"], args[0], args[1], args[2], args[3], gh, rnr, ctlr)
+		return execGenerateDownstream(env["BASE_BRANCH"], args[0], args[1], args[2], args[3], gh, rnr, ctlr)
 	},
 }
 
@@ -98,7 +93,7 @@ func listGDEnvironmentVariables() string {
 	return result
 }
 
-func execGenerateDownstream(baseBranch, command, repo, version, ref string, gh GithubClient, rnr ExecRunner, ctlr *source.Controller) {
+func execGenerateDownstream(baseBranch, command, repo, version, ref string, gh GithubClient, rnr ExecRunner, ctlr *source.Controller) error {
 	if baseBranch == "" {
 		baseBranch = "main"
 	}
@@ -106,8 +101,7 @@ func execGenerateDownstream(baseBranch, command, repo, version, ref string, gh G
 	mmLocalPath := filepath.Join(rnr.GetCWD(), "..", "..")
 	mmCopyPath := filepath.Join(mmLocalPath, "..", fmt.Sprintf("mm-%s-%s-%s", repo, version, command))
 	if _, err := rnr.Run("cp", []string{"-rp", mmLocalPath, mmCopyPath}, nil); err != nil {
-		fmt.Println("Error copying magic modules: ", err)
-		os.Exit(1)
+		return fmt.Errorf("error copying magic modules: %w", err)
 	}
 	mmRepo := &source.Repo{
 		Name: "magic-modules",
@@ -116,36 +110,30 @@ func execGenerateDownstream(baseBranch, command, repo, version, ref string, gh G
 
 	downstreamRepo, scratchRepo, commitMessage, err := cloneRepo(mmRepo, baseBranch, repo, version, command, ref, rnr, ctlr)
 	if err != nil {
-		fmt.Println("Error cloning repo: ", err)
-		os.Exit(1)
+		return fmt.Errorf("error cloning repo: %w", err)
 	}
 
 	if err := rnr.PushDir(mmCopyPath); err != nil {
-		fmt.Println("Error changing directory to copied magic modules: ", err)
-		os.Exit(1)
+		return fmt.Errorf("error changing directory to copied magic modules: %w", err)
 	}
 
 	if err := setGitConfig(rnr); err != nil {
-		fmt.Println("Error setting config: ", err)
-		os.Exit(1)
+		return fmt.Errorf("error setting config: %w", err)
 	}
 
 	if err := runMake(downstreamRepo, command, rnr); err != nil {
-		fmt.Println("Error running make: ", err)
-		os.Exit(1)
+		return fmt.Errorf("error running make: %w", err)
 	}
 
 	var pullRequest *github.PullRequest
 	if command == "downstream" {
 		pullRequest, err = getPullRequest(baseBranch, ref, gh)
 		if err != nil {
-			fmt.Println("Error getting pull request: ", err)
-			os.Exit(1)
+			return fmt.Errorf("error getting pull request: %w", err)
 		}
 		if repo == "terraform" {
 			if err := addChangelogEntry(pullRequest, rnr); err != nil {
-				fmt.Println("Error adding changelog entry: ", err)
-				os.Exit(1)
+				return fmt.Errorf("error adding changelog entry: %w", err)
 			}
 		}
 	}
@@ -156,16 +144,15 @@ func execGenerateDownstream(baseBranch, command, repo, version, ref string, gh G
 	}
 
 	if _, err := rnr.Run("git", []string{"push", ctlr.URL(scratchRepo), scratchRepo.Branch, "-f"}, nil); err != nil {
-		fmt.Println("Error pushing commit: ", err)
-		os.Exit(1)
+		return fmt.Errorf("error pushing commit: %w", err)
 	}
 
 	if commitErr == nil && command == "downstream" {
 		if err := mergePullRequest(downstreamRepo, scratchRepo, scratchCommitSha, pullRequest, rnr, gh); err != nil {
-			fmt.Println("Error merging pull request: ", err)
-			os.Exit(1)
+			return fmt.Errorf("error merging pull request: %w", err)
 		}
 	}
+	return nil
 }
 
 func cloneRepo(mmRepo *source.Repo, baseBranch, repo, version, command, ref string, rnr ExecRunner, ctlr *source.Controller) (*source.Repo, *source.Repo, string, error) {
@@ -320,8 +307,7 @@ func createCommit(scratchRepo *source.Repo, commitMessage string, rnr ExecRunner
 
 	commitSha, err := rnr.Run("git", []string{"rev-parse", "HEAD"}, nil)
 	if err != nil {
-		fmt.Println("Error retrieving commit sha: ", err)
-		os.Exit(1)
+		return "", fmt.Errorf("error retrieving commit sha: %w", err)
 	}
 
 	commitSha = strings.TrimSpace(commitSha)

--- a/.ci/magician/cmd/membership_checker.go
+++ b/.ci/magician/cmd/membership_checker.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"magician/cloudbuild"
 	"magician/github"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -45,7 +44,7 @@ var membershipCheckerCmd = &cobra.Command{
 	`,
 	// This can change to cobra.ExactArgs(2) after at least a 2-week soak
 	Args: cobra.RangeArgs(2, 6),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		prNumber := args[0]
 		fmt.Println("PR Number: ", prNumber)
 
@@ -54,20 +53,18 @@ var membershipCheckerCmd = &cobra.Command{
 
 		githubToken, ok := lookupGithubTokenOrFallback("GITHUB_TOKEN_MAGIC_MODULES")
 		if !ok {
-			fmt.Println("Did not provide GITHUB_TOKEN_MAGIC_MODULES or GITHUB_TOKEN environment variables")
-			os.Exit(1)
+			return fmt.Errorf("did not provide GITHUB_TOKEN_MAGIC_MODULES or GITHUB_TOKEN environment variables")
 		}
 		gh := github.NewClient(githubToken)
 		cb := cloudbuild.NewClient()
-		execMembershipChecker(prNumber, commitSha, gh, cb)
+		return execMembershipChecker(prNumber, commitSha, gh, cb)
 	},
 }
 
-func execMembershipChecker(prNumber, commitSha string, gh GithubClient, cb CloudbuildClient) {
+func execMembershipChecker(prNumber, commitSha string, gh GithubClient, cb CloudbuildClient) error {
 	pullRequest, err := gh.GetPullRequest(prNumber)
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
 
 	author := pullRequest.User.Login
@@ -79,12 +76,12 @@ func execMembershipChecker(prNumber, commitSha string, gh GithubClient, cb Cloud
 	if trusted {
 		err = cb.ApproveCommunityChecker(prNumber, commitSha)
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			return err
 		}
 	} else {
 		gh.AddLabels(prNumber, []string{"awaiting-approval"})
 	}
+	return nil
 }
 
 func init() {

--- a/.ci/magician/cmd/request_reviewer.go
+++ b/.ci/magician/cmd/request_reviewer.go
@@ -45,24 +45,22 @@ var requestReviewerCmd = &cobra.Command{
 			c. As appropriate, posts a welcome comment on the PR.
 	`,
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		prNumber := args[0]
 		fmt.Println("PR Number: ", prNumber)
 		githubToken, ok := os.LookupEnv("GITHUB_TOKEN")
 		if !ok {
-			fmt.Println("Did not provide GITHUB_TOKEN environment variable")
-			os.Exit(1)
+			return fmt.Errorf("did not provide GITHUB_TOKEN environment variable")
 		}
 		gh := github.NewClient(githubToken)
-		execRequestReviewer(prNumber, gh)
+		return execRequestReviewer(prNumber, gh)
 	},
 }
 
-func execRequestReviewer(prNumber string, gh GithubClient) {
+func execRequestReviewer(prNumber string, gh GithubClient) error {
 	pullRequest, err := gh.GetPullRequest(prNumber)
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
 
 	author := pullRequest.User.Login
@@ -71,14 +69,12 @@ func execRequestReviewer(prNumber string, gh GithubClient) {
 
 		requestedReviewers, err := gh.GetPullRequestRequestedReviewers(prNumber)
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			return err
 		}
 
 		previousReviewers, err := gh.GetPullRequestPreviousReviewers(prNumber)
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			return err
 		}
 
 		reviewersToRequest, newPrimaryReviewer := github.ChooseCoreReviewers(requestedReviewers, previousReviewers)
@@ -86,8 +82,7 @@ func execRequestReviewer(prNumber string, gh GithubClient) {
 		if len(reviewersToRequest) > 0 {
 			err = gh.RequestPullRequestReviewers(prNumber, reviewersToRequest)
 			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
+				return err
 			}
 		}
 
@@ -95,11 +90,11 @@ func execRequestReviewer(prNumber string, gh GithubClient) {
 			comment := github.FormatReviewerComment(newPrimaryReviewer)
 			err = gh.PostComment(prNumber, comment)
 			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
+				return err
 			}
 		}
 	}
+	return nil
 }
 
 func init() {

--- a/.ci/magician/cmd/request_service_reviewers.go
+++ b/.ci/magician/cmd/request_service_reviewers.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"magician/github"
 	"math/rand"
-	"os"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/magic-modules/tools/issue-labeler/labeler"
@@ -36,17 +35,16 @@ var requestServiceReviewersCmd = &cobra.Command{
 	If a PR has more than 3 service labels, the command will not do anything.
 	`,
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		prNumber := args[0]
 		fmt.Println("PR Number: ", prNumber)
 
 		githubToken, ok := lookupGithubTokenOrFallback("GITHUB_TOKEN_MAGIC_MODULES")
 		if !ok {
-			fmt.Println("Did not provide GITHUB_TOKEN_MAGIC_MODULES or GITHUB_TOKEN environment variable")
-			os.Exit(1)
+			return fmt.Errorf("did not provide GITHUB_TOKEN_MAGIC_MODULES or GITHUB_TOKEN environment variable")
 		}
 		gh := github.NewClient(githubToken)
-		execRequestServiceReviewers(prNumber, gh, labeler.EnrolledTeamsYaml)
+		return execRequestServiceReviewers(prNumber, gh, labeler.EnrolledTeamsYaml)
 	},
 }
 
@@ -55,29 +53,25 @@ type LabelData struct {
 	Team string `yaml:"team,omitempty"`
 }
 
-func execRequestServiceReviewers(prNumber string, gh GithubClient, enrolledTeamsYaml []byte) {
+func execRequestServiceReviewers(prNumber string, gh GithubClient, enrolledTeamsYaml []byte) error {
 	pullRequest, err := gh.GetPullRequest(prNumber)
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
 
 	enrolledTeams := make(map[string]LabelData)
 	if err := yaml.Unmarshal(enrolledTeamsYaml, &enrolledTeams); err != nil {
-		fmt.Printf("Error unmarshalling enrolled teams yaml: %s", err)
-		os.Exit(1)
+		return fmt.Errorf("error unmarshalling enrolled teams yaml: %w", err)
 	}
 
 	requestedReviewers, err := gh.GetPullRequestRequestedReviewers(prNumber)
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
 
 	previousReviewers, err := gh.GetPullRequestPreviousReviewers(prNumber)
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
 
 	// If more than three service labels are impacted, don't request reviews.
@@ -96,7 +90,7 @@ func execRequestServiceReviewers(prNumber string, gh GithubClient, enrolledTeams
 
 	if teamCount > 3 {
 		fmt.Println("Provider-wide change (>3 services impacted); not requesting service team reviews")
-		return
+		return nil
 	}
 
 	// For each service team, check if one of the team members is already a reviewer. Rerequest
@@ -150,8 +144,9 @@ func execRequestServiceReviewers(prNumber string, gh GithubClient, enrolledTeams
 		exitCode = 1
 	}
 	if exitCode != 0 {
-		os.Exit(1)
+		return fmt.Errorf("exit code = %d", exitCode)
 	}
+	return nil
 }
 
 func init() {

--- a/.ci/magician/cmd/test_tgc_integration.go
+++ b/.ci/magician/cmd/test_tgc_integration.go
@@ -20,22 +20,20 @@ var testTGCIntegrationCmd = &cobra.Command{
 	1. GOPATH
 	2. GITHUB_TOKEN_MAGIC_MODULES
 	`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		goPath, ok := os.LookupEnv("GOPATH")
 		if !ok {
-			fmt.Println("Did not provide GOPATH environment variable")
-			os.Exit(1)
+			return fmt.Errorf("did not provide GOPATH environment variable")
 		}
 
 		githubToken, ok := lookupGithubTokenOrFallback("GITHUB_TOKEN_MAGIC_MODULES")
 		if !ok {
-			fmt.Println("Did not provide GITHUB_TOKEN_MAGIC_MODULES or GITHUB_TOKEN environment variables")
-			os.Exit(1)
+			return fmt.Errorf("did not provide GITHUB_TOKEN_MAGIC_MODULES or GITHUB_TOKEN environment variables")
 		}
 
 		rnr, err := exec.NewRunner()
 		if err != nil {
-			fmt.Println("Error creating runner: ", err)
+			return fmt.Errorf("error creating runner: %w", err)
 			os.Exit(1)
 		}
 
@@ -43,11 +41,11 @@ var testTGCIntegrationCmd = &cobra.Command{
 
 		gh := github.NewClient(githubToken)
 
-		execTestTGCIntegration(args[0], args[1], args[2], args[3], args[4], args[5], "modular-magician", rnr, ctlr, gh)
+		return execTestTGCIntegration(args[0], args[1], args[2], args[3], args[4], args[5], "modular-magician", rnr, ctlr, gh)
 	},
 }
 
-func execTestTGCIntegration(prNumber, mmCommit, buildID, projectID, buildStep, ghRepo, githubUsername string, rnr ExecRunner, ctlr *source.Controller, gh GithubClient) {
+func execTestTGCIntegration(prNumber, mmCommit, buildID, projectID, buildStep, ghRepo, githubUsername string, rnr ExecRunner, ctlr *source.Controller, gh GithubClient) error {
 	newBranch := "auto-pr-" + prNumber
 	repo := &source.Repo{
 		Name:   ghRepo,
@@ -55,17 +53,14 @@ func execTestTGCIntegration(prNumber, mmCommit, buildID, projectID, buildStep, g
 	}
 	ctlr.SetPath(repo)
 	if err := ctlr.Clone(repo); err != nil {
-		fmt.Println("Error cloning repo: ", err)
-		os.Exit(1)
+		return fmt.Errorf("error cloning repo: %w", err)
 	}
 	if err := rnr.PushDir(repo.Path); err != nil {
-		fmt.Println("Error changing to repo dir: ", err)
-		os.Exit(1)
+		return fmt.Errorf("error changing to repo dir: %w", err)
 	}
 	diffs, err := rnr.Run("git", []string{"diff", "--name-only", "HEAD~1"}, nil)
 	if err != nil {
-		fmt.Println("Error diffing repo: ", err)
-		os.Exit(1)
+		return fmt.Errorf("error diffing repo: %w", err)
 	}
 	hasGoFiles := false
 	for _, diff := range strings.Split(diffs, "\n") {
@@ -76,15 +71,14 @@ func execTestTGCIntegration(prNumber, mmCommit, buildID, projectID, buildStep, g
 	}
 	if !hasGoFiles {
 		fmt.Println("Skipping tests: No go files changed")
-		os.Exit(0)
+		return nil
 	}
 
 	fmt.Println("Running tests: Go files changed")
 
 	targetURL := fmt.Sprintf("https://console.cloud.google.com/cloud-build/builds;region=global/%s;step=%s?project=%s", buildID, buildStep, projectID)
 	if err := gh.PostBuildStatus(prNumber, ghRepo+"-test-integration", "pending", targetURL, mmCommit); err != nil {
-		fmt.Println("Error posting build status: ", err)
-		os.Exit(1)
+		return fmt.Errorf("error posting build status: %w", err)
 	}
 
 	if _, err := rnr.Run("go", []string{"mod", "edit", "-replace", fmt.Sprintf("github.com/hashicorp/terraform-provider-google-beta=github.com/%s/terraform-provider-google-beta@%s", githubUsername, newBranch)}, nil); err != nil {
@@ -104,9 +98,9 @@ func execTestTGCIntegration(prNumber, mmCommit, buildID, projectID, buildStep, g
 	}
 
 	if err := gh.PostBuildStatus(prNumber, ghRepo+"-test-integration", state, targetURL, mmCommit); err != nil {
-		fmt.Println("Error posting build status: ", err)
-		os.Exit(1)
+		return fmt.Errorf("error posting build status: %w", err)
 	}
+	return nil
 }
 
 func init() {

--- a/.ci/magician/cmd/test_tpg.go
+++ b/.ci/magician/cmd/test_tpg.go
@@ -37,31 +37,29 @@ var testTPGCmd = &cobra.Command{
         2. COMMIT_SHA
         3. PR_NUMBER
 	`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		version := os.Getenv("VERSION")
 		commit := os.Getenv("COMMIT_SHA")
 		pr := os.Getenv("PR_NUMBER")
 
 		githubToken, ok := lookupGithubTokenOrFallback("GITHUB_TOKEN_MAGIC_MODULES")
 		if !ok {
-			fmt.Println("Did not provide GITHUB_TOKEN_MAGIC_MODULES or GITHUB_TOKEN environment variables")
-			os.Exit(1)
+			return fmt.Errorf("did not provide GITHUB_TOKEN_MAGIC_MODULES or GITHUB_TOKEN environment variables")
 		}
 		gh := github.NewClient(githubToken)
 
-		execTestTPG(version, commit, pr, gh)
+		return execTestTPG(version, commit, pr, gh)
 	},
 }
 
-func execTestTPG(version, commit, pr string, gh ttGithub) {
+func execTestTPG(version, commit, pr string, gh ttGithub) error {
 	var repo string
 	if version == "ga" {
 		repo = "terraform-provider-google"
 	} else if version == "beta" {
 		repo = "terraform-provider-google-beta"
 	} else {
-		fmt.Println("invalid version specified")
-		os.Exit(1)
+		return fmt.Errorf("invalid version specified")
 	}
 
 	if err := gh.CreateWorkflowDispatchEvent("test-tpg.yml", map[string]any{
@@ -70,9 +68,9 @@ func execTestTPG(version, commit, pr string, gh ttGithub) {
 		"branch": "auto-pr-" + pr,
 		"sha":    commit,
 	}); err != nil {
-		fmt.Printf("Error creating workflow dispatch event: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("error creating workflow dispatch event: %w", err)
 	}
+	return nil
 }
 
 func init() {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

https://github.com/hashicorp/terraform-provider-google/issues/17479
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
