### PR TITLE
[AlloyDB] Support project IDs and project numbers for PSC instances 

### DIFF
--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -296,7 +296,6 @@ properties:
         item_type: Api::Type::String
         description: |
           List of consumer projects that are allowed to create PSC endpoints to service-attachments to this instance.
-          These should be specified as project numbers only.
         diff_suppress_func: tpgresource.ProjectNumberDiffSuppressWithoutPrefix
       - !ruby/object:Api::Type::String
         name: 'pscDnsName'

--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -297,8 +297,7 @@ properties:
         description: |
           List of consumer projects that are allowed to create PSC endpoints to service-attachments to this instance.
           These should be specified as project numbers only.
-        item_validation: !ruby/object:Provider::Terraform::Validation
-          regex: '^\d+$'
+        diff_suppress_func: tpgresource.ProjectNumberDiffSuppressWithoutPrefix
       - !ruby/object:Api::Type::String
         name: 'pscDnsName'
         output: true

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
@@ -765,7 +765,7 @@ resource "google_alloydb_instance" "default" {
     cpu_count = 2
   }
   psc_instance_config {
-	allowed_consumer_projects = ["${data.google_project.project.number}", "1044355742748"]
+	allowed_consumer_projects = ["${data.google_project.project.number}", "alloydb-psc-cep"]
   }
 }
 resource "google_alloydb_cluster" "default" {

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.erb
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.erb
@@ -282,6 +282,23 @@ func LastSlashDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
 }
 
 // Suppress diffs when the value read from api
+// has the project number instead of the project name.
+// This function suppresses the difference when the project ID is not prefixed with the string "projects".
+func ProjectNumberDiffSuppressWithoutPrefix(k, old, new string, _ *schema.ResourceData) bool {
+	// Ignore list size changes
+	if strings.HasSuffix(k, ".#") {
+		return false
+	}
+	var a2, b2 string
+	reN := regexp.MustCompile("\\d+")
+	re := regexp.MustCompile("[^/]+")
+	replacement := []byte("equal")
+	a2 = string(reN.ReplaceAll([]byte(old), replacement))
+	b2 = string(re.ReplaceAll([]byte(new), replacement))
+	return a2 == b2
+}
+
+// Suppress diffs when the value read from api
 // has the project number instead of the project name
 func ProjectNumberDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
 	var a2, b2 string


### PR DESCRIPTION
This PR addresses the issue raised: https://github.com/hashicorp/terraform-provider-google/issues/18327. 

With this change, PSC instances can specify the field `allowed_consumer_projects` as either project IDs or project numbers. 

Details about why this change was implemented this way can be found here - https://yaqs.corp.google.com/eng/q/1374949186138537984. Briefly, we want to support the customer specifying either project numbers or IDs, however, the API always returns project numbers. 

```release-note:enhancement 
alloydb: allowed `google_alloydb_instance.psc_instance_config.allowed_consumer_projects` to be specified as either project numbers or project IDs.  
```
