### PR TITLE
fix: added ENTERPRISE option to GKE Hub Fleet Security Posture setting

### DIFF
--- a/mmv1/products/gkehub2/Fleet.yaml
+++ b/mmv1/products/gkehub2/Fleet.yaml
@@ -130,6 +130,7 @@ properties:
             values:
               - DISABLED
               - BASIC
+              - ENTERPRISE
           - !ruby/object:Api::Type::Enum
             name: "vulnerabilityMode"
             description: Sets which mode to use for vulnerability scanning.


### PR DESCRIPTION
Similar to the [cluster](https://github.com/hashicorp/terraform-provider-google/issues/18313) needing to honor the new setting for ENTERPRISE security posture, GKE Hub Fleet configurations also need to support the new setting.  This PR aims to add that setting.  


```release-note:enhancement
gkehub2: Added `ENTERPRISE` option to `SecurityPostureConfig` on `google_gke_hub_fleet` resource
```
