### PR TITLE
Add Service Networking VPC Service Controls resource.

### DIFF
--- a/mmv1/products/servicenetworking/VPCServiceControls.yaml
+++ b/mmv1/products/servicenetworking/VPCServiceControls.yaml
@@ -61,6 +61,7 @@ examples:
     primary_resource_id: "default"
     vars:
       network_name: "example-network"
+      psa_range_name: "psa-range"
 autogen_async: true
 async: !ruby/object:Api::OpAsync
   actions: [] # we just need the boilerplate async code, we'll call the methods manually

--- a/mmv1/products/servicenetworking/VPCServiceControls.yaml
+++ b/mmv1/products/servicenetworking/VPCServiceControls.yaml
@@ -1,0 +1,105 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'VPCServiceControls'
+base_url: ''
+skip_delete: true
+id_format: 'services/{{service}}/projects/{{project}}/networks/{{network}}'
+import_format:
+  - 'services/{{service}}/projects/{{project}}/networks/{{network}}'
+references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+    'Private Google Access with VPC Service Controls': 'https://cloud.google.com/vpc-service-controls/docs/private-connectivity'
+    'Set up private connectivity to Google APIs and services': 'https://cloud.google.com/vpc-service-controls/docs/set-up-private-connectivity'
+    'Enable VPC Service Controls for service networking': 'https://cloud.google.com/sdk/gcloud/reference/services/vpc-peerings/enable-vpc-service-controls'
+  api: 'https://cloud.google.com/service-infrastructure/docs/service-networking/reference/rest/v1/services'
+description: |
+  Manages the VPC Service Controls configuration for a service
+  networking connection
+
+  When enabled, Google Cloud makes the following
+  route configuration changes in the service producer VPC network:
+  - Removes the IPv4 default route (destination 0.0.0.0/0,
+    next hop default internet gateway), Google Cloud then creates an
+    IPv4 route for destination 199.36.153.4/30 using the default
+    internet gateway next hop.
+  - Creates Cloud DNS managed private zones and authorizes those zones
+    for the service producer VPC network. The zones include
+    googleapis.com, gcr.io, pkg.dev, notebooks.cloud.google.com,
+    kernels.googleusercontent.com, backupdr.cloud.google.com, and
+    backupdr.googleusercontent.com as necessary domains or host names
+    for Google APIs and services that are compatible with VPC Service
+    Controls. Record data in the zones resolves all host names to
+    199.36.153.4, 199.36.153.5, 199.36.153.6, and 199.36.153.7.
+
+  When disabled, Google Cloud makes the following route configuration
+  changes in the service producer VPC network:
+  - Restores a default route (destination 0.0.0.0/0, next hop default
+    internet gateway)
+  - Deletes the Cloud DNS managed private zones that provided the host
+    name overrides.
+docs: !ruby/object:Provider::Terraform::Docs
+  note: |
+    Destroying a `google_service_networking_vpc_service_controls`
+    resource will remove it from state, but will not change the
+    underlying VPC Service Controls configuration for the service
+    producer network.
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: "service_networking_vpc_service_controls_basic"
+    primary_resource_id: "default"
+    vars:
+      network_name: "example-network"
+autogen_async: true
+async: !ruby/object:Api::OpAsync
+  actions: [] # we just need the boilerplate async code, we'll call the methods manually
+  include_project: true
+  operation: !ruby/object:Api::OpAsync::Operation
+    base_url: '{{op_id}}'
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  custom_create: templates/terraform/custom_create/service_networking_vpc_service_controls.go.erb
+  custom_update: templates/terraform/custom_create/service_networking_vpc_service_controls.go.erb
+  constants: templates/terraform/constants/service_networking_vpc_service_controls.go.erb
+  pre_read: templates/terraform/pre_read/service_networking_vpc_service_controls.go.erb
+parameters:
+  - !ruby/object:Api::Type::String
+    name: 'network'
+    required: true
+    immutable: true
+    url_param_only: true
+    description: |
+      The network that the consumer is using to connect with services.
+  - !ruby/object:Api::Type::String
+    name: 'service'
+    required: true
+    url_param_only: true
+    immutable: true
+    description: |
+      The service that is managing peering connectivity for a service
+      producer's organization. For Google services that support this
+      functionality, this value is `servicenetworking.googleapis.com`.
+  - !ruby/object:Api::Type::String
+    name: 'project'
+    # required: true
+    immutable: true
+    ignore_read: true
+    description: |-
+      The id of the Google Cloud project containing the consumer network.
+properties:
+  - !ruby/object:Api::Type::Boolean
+    name: 'enabled'
+    required: true
+    description: |-
+      Desired VPC Service Controls state service producer VPC network, as
+      described at the top of this page.

--- a/mmv1/products/servicenetworking/VPCServiceControls.yaml
+++ b/mmv1/products/servicenetworking/VPCServiceControls.yaml
@@ -15,6 +15,7 @@
 name: 'VPCServiceControls'
 base_url: ''
 skip_delete: true
+exclude_tgc: true # excluding tgc because of helpers in custom_code.constants
 id_format: 'services/{{service}}/projects/{{project}}/networks/{{network}}'
 import_format:
   - 'services/{{service}}/projects/{{project}}/networks/{{network}}'

--- a/mmv1/products/servicenetworking/product.yaml
+++ b/mmv1/products/servicenetworking/product.yaml
@@ -1,0 +1,22 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Product
+name: ServiceNetworking
+display_name: Service Networking
+versions:
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: https://servicenetworking.googleapis.com/v1/
+scopes:
+  - https://www.googleapis.com/auth/cloud-platform

--- a/mmv1/templates/terraform/constants/service_networking_vpc_service_controls.go.erb
+++ b/mmv1/templates/terraform/constants/service_networking_vpc_service_controls.go.erb
@@ -1,0 +1,76 @@
+func resourceServiceNetworkingVPCServiceControlsSet(d *schema.ResourceData, meta interface{}, config *transport_tpg.Config) error {
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return err
+	}
+	projectNumber, err := getProjectNumber(d, config, project, userAgent)
+	if err != nil {
+		return err
+	}
+
+	network := d.Get("network").(string)
+	enabled := d.Get("enabled").(bool)
+
+	obj := make(map[string]interface{})
+	obj["consumerNetwork"] = fmt.Sprintf("projects/%s/global/networks/%s", projectNumber, network)
+
+	url, err := tpgresource.ReplaceVars(d, config, "{{ServiceNetworkingBasePath}}services/{{service}}")
+	if err != nil {
+		return err
+	}
+
+	if enabled {
+		url = url + ":enableVpcServiceControls"
+	} else {
+		url = url + ":disableVpcServiceControls"
+	}
+
+	log.Printf("[DEBUG] Setting service networking VPC service controls: %#v", obj)
+	billingProject := ""
+
+	// err == nil indicates that the billing_project value was found
+	if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+		billingProject = bp
+	}
+
+	headers := make(http.Header)
+
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "PATCH",
+		Project:   billingProject,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Body:      obj,
+		Timeout:   d.Timeout(schema.TimeoutCreate),
+		Headers:   headers,
+	})
+	if err != nil {
+		return fmt.Errorf("Error creating VPCServiceControls: %s", err)
+	}
+
+	id, err := tpgresource.ReplaceVars(d, config, "services/{{service}}/projects/{{project}}/networks/{{network}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+
+	err = ServiceNetworkingOperationWaitTime(
+		config, res, "Setting service networking VPC service controls", userAgent, project,
+		d.Timeout(schema.TimeoutCreate))
+
+	if err != nil {
+		// The resource didn't actually create
+		d.SetId("")
+		return fmt.Errorf("Error waiting to set service networking VPC service controls: %s", err)
+	}
+
+	log.Printf("[DEBUG] Finished setting service networking VPC service controls %q: %#v", d.Id(), res)
+
+	return resourceServiceNetworkingVPCServiceControlsRead(d, meta)
+}

--- a/mmv1/templates/terraform/custom_create/service_networking_vpc_service_controls.go.erb
+++ b/mmv1/templates/terraform/custom_create/service_networking_vpc_service_controls.go.erb
@@ -1,0 +1,1 @@
+return resourceServiceNetworkingVPCServiceControlsSet(d, meta, config)

--- a/mmv1/templates/terraform/examples/service_networking_vpc_service_controls_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/service_networking_vpc_service_controls_basic.tf.erb
@@ -5,7 +5,7 @@ resource "google_compute_network" "default" {
 
 # Create an IP address
 resource "google_compute_global_address" "default" {
-  name          = "psa-range"
+  name          = "<%= ctx[:vars]['psa_range_name'] %>"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16

--- a/mmv1/templates/terraform/examples/service_networking_vpc_service_controls_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/service_networking_vpc_service_controls_basic.tf.erb
@@ -1,0 +1,28 @@
+# Create a VPC
+resource "google_compute_network" "default" {
+  name = "<%= ctx[:vars]['network_name'] %>"
+}
+
+# Create an IP address
+resource "google_compute_global_address" "default" {
+  name          = "psa-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.default.id
+}
+
+# Create a private connection
+resource "google_service_networking_connection" "default" {
+  network                 = google_compute_network.default.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.default.name]
+}
+
+# Enable VPC-SC on the producer network
+resource "google_service_networking_vpc_service_controls" "<%= ctx[:primary_resource_id] %>" {
+  network    = google_compute_network.default.name
+  service    = "servicenetworking.googleapis.com"
+  enabled    = true
+  depends_on = [google_service_networking_connection.default]
+}

--- a/mmv1/templates/terraform/pre_read/service_networking_vpc_service_controls.go.erb
+++ b/mmv1/templates/terraform/pre_read/service_networking_vpc_service_controls.go.erb
@@ -1,0 +1,16 @@
+project, err := tpgresource.GetProject(d, config)
+if err != nil {
+	return err
+}
+projectNumber, err := getProjectNumber(d, config, project, userAgent)
+if err != nil {
+	return err
+}
+
+service := d.Get("service").(string)
+network := d.Get("network").(string)
+parent := fmt.Sprintf("services/%s/projects/%s/global/networks/%s", service, projectNumber, network)
+url, err = tpgresource.ReplaceVars(d, config, "{{ServiceNetworkingBasePath}}"+parent+"/vpcServiceControls")
+if err != nil {
+	return err
+}

--- a/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
+++ b/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
@@ -551,7 +551,7 @@ func BootstrapSharedServiceNetworkingConnection(t *testing.T, testId string, par
 		}
 
 		log.Printf("[DEBUG] Waiting for service networking connection creation to finish")
-		if err := tpgservicenetworking.ServiceNetworkingOperationWaitTime(config, op, "Create Service Networking Connection", config.UserAgent, projectId, 4*time.Minute); err != nil {
+		if err := tpgservicenetworking.ServiceNetworkingOperationWaitTimeHW(config, op, "Create Service Networking Connection", config.UserAgent, projectId, 4*time.Minute); err != nil {
 			t.Fatalf("Error bootstrapping shared test service networking connection: %s", err)
 		}
 	}

--- a/mmv1/third_party/terraform/fwmodels/provider_model.go.erb
+++ b/mmv1/third_party/terraform/fwmodels/provider_model.go.erb
@@ -41,7 +41,6 @@ type ProviderModel struct {
 	RuntimeconfigCustomEndpoint     types.String `tfsdk:"runtimeconfig_custom_endpoint"`
 <% end -%>
 	IAMCustomEndpoint               types.String `tfsdk:"iam_custom_endpoint"`
-	ServiceNetworkingCustomEndpoint types.String `tfsdk:"service_networking_custom_endpoint"`
 	TagsLocationCustomEndpoint      types.String `tfsdk:"tags_location_custom_endpoint"`
 
 	// dcl

--- a/mmv1/third_party/terraform/fwprovider/framework_provider.go.erb
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider.go.erb
@@ -200,12 +200,6 @@ func (p *FrameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
                     transport_tpg.CustomEndpointValidator(),
                 },
             },
-            "service_networking_custom_endpoint": &schema.StringAttribute{
-                Optional:     true,
-                Validators: []validator.String{
-                    transport_tpg.CustomEndpointValidator(),
-                },
-            },
             "tags_location_custom_endpoint": &schema.StringAttribute{
                 Optional:     true,
                 Validators: []validator.String{

--- a/mmv1/third_party/terraform/provider/provider.go.erb
+++ b/mmv1/third_party/terraform/provider/provider.go.erb
@@ -364,7 +364,6 @@ func ProviderConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 	config.RuntimeConfigBasePath = d.Get(transport_tpg.RuntimeConfigCustomEndpointEntryKey).(string)
 	<% end -%>
 	config.IAMBasePath = d.Get(transport_tpg.IAMCustomEndpointEntryKey).(string)
-	config.ServiceNetworkingBasePath = d.Get(transport_tpg.ServiceNetworkingCustomEndpointEntryKey).(string)
 	config.ServiceUsageBasePath = d.Get(transport_tpg.ServiceUsageCustomEndpointEntryKey).(string)
 	config.BigtableAdminBasePath = d.Get(transport_tpg.BigtableAdminCustomEndpointEntryKey).(string)
 	config.TagsLocationBasePath = d.Get(transport_tpg.TagsLocationCustomEndpointEntryKey).(string)

--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/services/containeraws"
 	"github.com/hashicorp/terraform-provider-google/google/services/containerazure"
 	"github.com/hashicorp/terraform-provider-google/google/services/dataflow"
-	"github.com/hashicorp/terraform-provider-google/google/services/servicenetworking"
 	"github.com/hashicorp/terraform-provider-google/google/tpgiamresource"
 )
 

--- a/mmv1/third_party/terraform/services/servicenetworking/resource_google_service_networking_peered_dns_domain.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_google_service_networking_peered_dns_domain.go
@@ -135,7 +135,7 @@ func resourceGoogleServiceNetworkingPeeredDNSDomainCreate(d *schema.ResourceData
 		return err
 	}
 
-	if err := ServiceNetworkingOperationWaitTime(config, op, "Create Service Networking Peered DNS Domain", userAgent, project, d.Timeout(schema.TimeoutCreate)); err != nil {
+	if err := ServiceNetworkingOperationWaitTimeHW(config, op, "Create Service Networking Peered DNS Domain", userAgent, project, d.Timeout(schema.TimeoutCreate)); err != nil {
 		return err
 	}
 

--- a/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
@@ -117,7 +117,7 @@ func resourceServiceNetworkingConnectionCreate(d *schema.ResourceData, meta inte
 		return err
 	}
 
-	if err := ServiceNetworkingOperationWaitTime(config, op, "Create Service Networking Connection", userAgent, project, d.Timeout(schema.TimeoutCreate)); err != nil {
+	if err := ServiceNetworkingOperationWaitTimeHW(config, op, "Create Service Networking Connection", userAgent, project, d.Timeout(schema.TimeoutCreate)); err != nil {
 		return err
 	}
 
@@ -246,7 +246,7 @@ func resourceServiceNetworkingConnectionUpdate(d *schema.ResourceData, meta inte
 		if err != nil {
 			return err
 		}
-		if err := ServiceNetworkingOperationWaitTime(config, op, "Update Service Networking Connection", userAgent, project, d.Timeout(schema.TimeoutUpdate)); err != nil {
+		if err := ServiceNetworkingOperationWaitTimeHW(config, op, "Update Service Networking Connection", userAgent, project, d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return err
 		}
 	}
@@ -297,7 +297,7 @@ func resourceServiceNetworkingConnectionDelete(d *schema.ResourceData, meta inte
 		return err
 	}
 
-	if err := ServiceNetworkingOperationWaitTime(config, op, "Delete Service Networking Connection", userAgent, project, d.Timeout(schema.TimeoutCreate)); err != nil {
+	if err := ServiceNetworkingOperationWaitTimeHW(config, op, "Delete Service Networking Connection", userAgent, project, d.Timeout(schema.TimeoutCreate)); err != nil {
 		return errwrap.Wrapf("Unable to remove Service Networking Connection, err: {{err}}", err)
 	}
 

--- a/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_vpc_service_controls_test.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_vpc_service_controls_test.go
@@ -1,0 +1,74 @@
+package servicenetworking_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccServiceNetworkingVPCServiceControls_update(t *testing.T) {
+	t.Parallel()
+
+	network := fmt.Sprintf("tf-test-example-network%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceNetworkingVPCServiceControls_full(network, "true"),
+			},
+			{
+				ResourceName:            "google_service_networking_vpc_service_controls.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"network", "project", "service"},
+			},
+			{
+				Config: testAccServiceNetworkingVPCServiceControls_full(network, "false"),
+			},
+			{
+				ResourceName:            "google_service_networking_vpc_service_controls.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"network", "project", "service"},
+			},
+		},
+	})
+}
+
+func testAccServiceNetworkingVPCServiceControls_full(network, enabled string) string {
+	return fmt.Sprintf(`
+# Create a VPC
+resource "google_compute_network" "default" {
+  name = "%s"
+}
+
+# Create an IP address
+resource "google_compute_global_address" "default" {
+  name          = "psa-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.default.id
+}
+
+# Create a private connection
+resource "google_service_networking_connection" "default" {
+  network                 = google_compute_network.default.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.default.name]
+}
+
+# Enable VPC-SC on the producer network
+resource "google_service_networking_vpc_service_controls" "default" {
+  network    = google_compute_network.default.name
+  service    = "servicenetworking.googleapis.com"
+  enabled    = %s
+  depends_on = [google_service_networking_connection.default]
+}
+`, network, enabled)
+}

--- a/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_vpc_service_controls_test.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_vpc_service_controls_test.go
@@ -11,15 +11,13 @@ import (
 
 func TestAccServiceNetworkingVPCServiceControls_update(t *testing.T) {
 	t.Parallel()
-
-	network := fmt.Sprintf("tf-test-example-network%s", acctest.RandString(t, 10))
-
+	suffix := acctest.RandString(t, 10)
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceNetworkingVPCServiceControls_full(network, "true"),
+				Config: testAccServiceNetworkingVPCServiceControls_full(suffix, "true"),
 			},
 			{
 				ResourceName:            "google_service_networking_vpc_service_controls.default",
@@ -28,7 +26,7 @@ func TestAccServiceNetworkingVPCServiceControls_update(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"network", "project", "service"},
 			},
 			{
-				Config: testAccServiceNetworkingVPCServiceControls_full(network, "false"),
+				Config: testAccServiceNetworkingVPCServiceControls_full(suffix, "false"),
 			},
 			{
 				ResourceName:            "google_service_networking_vpc_service_controls.default",
@@ -40,16 +38,16 @@ func TestAccServiceNetworkingVPCServiceControls_update(t *testing.T) {
 	})
 }
 
-func testAccServiceNetworkingVPCServiceControls_full(network, enabled string) string {
+func testAccServiceNetworkingVPCServiceControls_full(suffix, enabled string) string {
 	return fmt.Sprintf(`
 # Create a VPC
 resource "google_compute_network" "default" {
-  name = "%s"
+  name = "tf-test-example-network%s"
 }
 
 # Create an IP address
 resource "google_compute_global_address" "default" {
-  name          = "psa-range"
+  name          = "tf-test-psa-range%s"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
@@ -70,5 +68,5 @@ resource "google_service_networking_vpc_service_controls" "default" {
   enabled    = %s
   depends_on = [google_service_networking_connection.default]
 }
-`, network, enabled)
+`, suffix, suffix, enabled)
 }

--- a/mmv1/third_party/terraform/services/servicenetworking/service_networking_operation_hw.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/service_networking_operation_hw.go
@@ -8,14 +8,14 @@ import (
 	"google.golang.org/api/servicenetworking/v1"
 )
 
-type ServiceNetworkingOperationWaiter struct {
+type ServiceNetworkingOperationWaiterHW struct {
 	Service             *servicenetworking.APIService
 	Project             string
 	UserProjectOverride bool
 	tpgresource.CommonOperationWaiter
 }
 
-func (w *ServiceNetworkingOperationWaiter) QueryOp() (interface{}, error) {
+func (w *ServiceNetworkingOperationWaiterHW) QueryOp() (interface{}, error) {
 	opGetCall := w.Service.Operations.Get(w.Op.Name)
 	if w.UserProjectOverride {
 		opGetCall.Header().Add("X-Goog-User-Project", w.Project)
@@ -23,8 +23,8 @@ func (w *ServiceNetworkingOperationWaiter) QueryOp() (interface{}, error) {
 	return opGetCall.Do()
 }
 
-func ServiceNetworkingOperationWaitTime(config *transport_tpg.Config, op *servicenetworking.Operation, activity, userAgent, project string, timeout time.Duration) error {
-	w := &ServiceNetworkingOperationWaiter{
+func ServiceNetworkingOperationWaitTimeHW(config *transport_tpg.Config, op *servicenetworking.Operation, activity, userAgent, project string, timeout time.Duration) error {
+	w := &ServiceNetworkingOperationWaiterHW{
 		Service:             config.NewServiceNetworkingClient(userAgent),
 		Project:             project,
 		UserProjectOverride: config.UserProjectOverride,

--- a/mmv1/third_party/terraform/transport/config.go.erb
+++ b/mmv1/third_party/terraform/transport/config.go.erb
@@ -216,7 +216,6 @@ type Config struct {
 	ResourceManagerV3BasePath string
 	IAMBasePath string
 	CloudIoTBasePath string
-	ServiceNetworkingBasePath string
 	BigtableAdminBasePath string
 	TagsLocationBasePath string
 
@@ -237,7 +236,6 @@ const DataflowBasePathKey = "Dataflow"
 const IAMBasePathKey = "IAM"
 const IamCredentialsBasePathKey = "IamCredentials"
 const ResourceManagerV3BasePathKey = "ResourceManagerV3"
-const ServiceNetworkingBasePathKey = "ServiceNetworking"
 const BigtableAdminBasePathKey = "BigtableAdmin"
 const ContainerAwsBasePathKey = "ContainerAws"
 const ContainerAzureBasePathKey = "ContainerAzure"
@@ -258,7 +256,6 @@ var DefaultBasePaths = map[string]string{
 	IAMBasePathKey : "https://iam.googleapis.com/v1/",
 	IamCredentialsBasePathKey : "https://iamcredentials.googleapis.com/v1/",
 	ResourceManagerV3BasePathKey : "https://cloudresourcemanager.googleapis.com/v3/",
-	ServiceNetworkingBasePathKey : "https://servicenetworking.googleapis.com/v1/",
 	BigtableAdminBasePathKey : "https://bigtableadmin.googleapis.com/v2/",
 	ContainerAwsBasePathKey:  "https://{{location}}-gkemulticloud.googleapis.com/v1/",
 	ContainerAzureBasePathKey: "https://{{location}}-gkemulticloud.googleapis.com/v1/",
@@ -1274,7 +1271,6 @@ func ConfigureBasePaths(c *Config) {
 	c.IamCredentialsBasePath = DefaultBasePaths[IamCredentialsBasePathKey]
 	c.ResourceManagerV3BasePath = DefaultBasePaths[ResourceManagerV3BasePathKey]
 	c.IAMBasePath = DefaultBasePaths[IAMBasePathKey]
-	c.ServiceNetworkingBasePath = DefaultBasePaths[ServiceNetworkingBasePathKey]
 	c.BigQueryBasePath = DefaultBasePaths[BigQueryBasePathKey]
 	c.BigtableAdminBasePath = DefaultBasePaths[BigtableAdminBasePathKey]
 	c.TagsLocationBasePath = DefaultBasePaths[TagsLocationBasePathKey]


### PR DESCRIPTION
This PR add a new resource to manage service networking VPC-SC

Related Issue hashicorp/terraform-provider-google#9317

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_service_networking_vpc_service_controls`
```
