### PR TITLE
remove os.Exit in magician subcommands

### DIFF
--- a/.ci/magician/cmd/generate_downstream.go
+++ b/.ci/magician/cmd/generate_downstream.go
@@ -142,7 +142,7 @@ func execGenerateDownstream(baseBranch, command, repo, version, ref string, gh G
 	if commitErr != nil {
 		fmt.Println("Error creating commit: ", commitErr)
 		if !strings.Contains(commitErr.Error(), "nothing to commit") {
-			os.Exit(1)
+			return fmt.Errorf("error creating commit: %w", commitErr)
 		}
 	}
 

--- a/.ci/magician/cmd/scheduled_pr_reminders.go
+++ b/.ci/magician/cmd/scheduled_pr_reminders.go
@@ -63,8 +63,7 @@ var scheduledPrReminders = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		githubToken, ok := os.LookupEnv("GITHUB_TOKEN")
 		if !ok {
-			fmt.Println("Did not provide GITHUB_TOKEN environment variable")
-			os.Exit(1)
+			return fmt.Errorf("did not provide GITHUB_TOKEN environment variable")
 		}
 		gh := github.NewClient(nil).WithAuthToken(githubToken)
 		return execScheduledPrReminders(gh)

--- a/.ci/magician/cmd/test_tgc_integration.go
+++ b/.ci/magician/cmd/test_tgc_integration.go
@@ -34,7 +34,6 @@ var testTGCIntegrationCmd = &cobra.Command{
 		rnr, err := exec.NewRunner()
 		if err != nil {
 			return fmt.Errorf("error creating runner: %w", err)
-			os.Exit(1)
 		}
 
 		ctlr := source.NewController(goPath, "modular-magician", githubToken, rnr)

--- a/.ci/magician/cmd/wait_for_commit.go
+++ b/.ci/magician/cmd/wait_for_commit.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"magician/exec"
 	"magician/source"
-	"os"
 	"strings"
 	"time"
 
@@ -33,8 +32,7 @@ var waitForCommitCmd = &cobra.Command{
 
 		rnr, err := exec.NewRunner()
 		if err != nil {
-			fmt.Println("Error creating Runner: ", err)
-			os.Exit(1)
+			return fmt.Errorf("error creating Runner: %w", err)
 		}
 
 		return execWaitForCommit(syncBranchPrefix, baseBranch, sha, rnr)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Follow up on https://github.com/GoogleCloudPlatform/magic-modules/pull/10891 to remove os.Exit. 
Original issue: https://github.com/hashicorp/terraform-provider-google/issues/17479


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
