### PR TITLE
[#18217] Update schedulingHasChangeWithoutReboot to force reboot if min_node_cpus is updated

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.erb
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.erb
@@ -702,45 +702,41 @@ func schedulingHasChangeRequiringReboot(d *schema.ResourceData) bool {
 // Terraform doesn't correctly calculate changes on schema.Set, so we do it manually
 // https://github.com/hashicorp/terraform-plugin-sdk/issues/98
 func schedulingHasChangeWithoutReboot(d *schema.ResourceData) bool {
-	if !d.HasChange("scheduling") {
-		// This doesn't work correctly, which is why this method exists
-		// But it is here for posterity
-		return false
-	}
-	o, n := d.GetChange("scheduling")
-	oScheduling := o.([]interface{})[0].(map[string]interface{})
-	newScheduling := n.([]interface{})[0].(map[string]interface{})
-
-	if schedulingHasChangeRequiringReboot(d) {
-		return false
-	}
-
-	if oScheduling["automatic_restart"] != newScheduling["automatic_restart"] {
-		return true
-	}
-
-	if oScheduling["preemptible"] != newScheduling["preemptible"] {
-		return true
-	}
-
-	if oScheduling["on_host_maintenance"] != newScheduling["on_host_maintenance"] {
-		return true
-	}
-
-	if oScheduling["min_node_cpus"] != newScheduling["min_node_cpus"] {
-		return true
-	}
-
-	if oScheduling["provisioning_model"] != newScheduling["provisioning_model"] {
-		return true
-	}
-
-	if oScheduling["instance_termination_action"] != newScheduling["instance_termination_action"] {
-			return true
-	}
-
-	return false
-}
+    if !d.HasChange("scheduling") {
+      // This doesn't work correctly, which is why this method exists
+      // But it is here for posterity
+      return false
+    }
+    o, n := d.GetChange("scheduling")
+    oScheduling := o.([]interface{})[0].(map[string]interface{})
+    newScheduling := n.([]interface{})[0].(map[string]interface{})
+  
+    if schedulingHasChangeRequiringReboot(d) {
+      return false
+    }
+  
+    if oScheduling["automatic_restart"] != newScheduling["automatic_restart"] {
+      return true
+    }
+  
+    if oScheduling["preemptible"] != newScheduling["preemptible"] {
+      return true
+    }
+  
+    if oScheduling["on_host_maintenance"] != newScheduling["on_host_maintenance"] {
+      return true
+    }
+  
+    if oScheduling["provisioning_model"] != newScheduling["provisioning_model"] {
+      return true
+    }
+  
+    if oScheduling["instance_termination_action"] != newScheduling["instance_termination_action"] {
+      return true
+    }
+  
+    return false
+  }
 
 <% unless version == 'ga' -%>
 func hasMaxRunDurationChanged(oScheduling, nScheduling map[string]interface{}) bool {


### PR DESCRIPTION
Update schedulingHasChangeWithoutReboot to force reboot if min_node_cpus is updated.

Fixes [hashicorp/terraform-provider-google/issues/18217](https://github.com/hashicorp/terraform-provider-google/issues/18217).

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: Updated schedulingHasChangeWithoutReboot to force reboot if min_node_cpus is updated.
```
