### PR TITLE
Add allowlistedCertificates field to TrustConfig

### DIFF
--- a/mmv1/products/certificatemanager/TrustConfig.yaml
+++ b/mmv1/products/certificatemanager/TrustConfig.yaml
@@ -55,8 +55,6 @@ examples:
     primary_resource_id: 'default'
     vars:
       trust_config_name: 'trust-config'
-custom_code: !ruby/object:Provider::Terraform::CustomCode
-  pre_update: templates/terraform/pre_update/certificate_manager_trust_config.go.erb
 parameters:
   - !ruby/object:Api::Type::String
     name: 'name'
@@ -92,7 +90,6 @@ properties:
   - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     description: 'Set of label tags associated with the trust config.'
-    immutable: true
   - !ruby/object:Api::Type::String
     name: 'description'
     description: |

--- a/mmv1/products/certificatemanager/TrustConfig.yaml
+++ b/mmv1/products/certificatemanager/TrustConfig.yaml
@@ -50,6 +50,11 @@ examples:
     primary_resource_id: 'default'
     vars:
       trust_config_name: 'trust-config'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'certificate_manager_trust_config_allowlisted_certificates'
+    primary_resource_id: 'default'
+    vars:
+      trust_config_name: 'trust-config'
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   pre_update: templates/terraform/pre_update/certificate_manager_trust_config.go.erb
 parameters:
@@ -124,3 +129,15 @@ properties:
                   PEM intermediate certificate used for building up paths for validation.
                   Each certificate provided in PEM format may occupy up to 5kB.
                 sensitive: true
+  - !ruby/object:Api::Type::Array
+    name: allowlistedCertificates
+    description: |
+       Allowlisted PEM-encoded certificates. A certificate matching an allowlisted certificate is always considered valid as long as
+       the certificate is parseable, proof of private key possession is established, and constraints on the certificate's SAN field are met.
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties:
+        - !ruby/object:Api::Type::String
+          name: 'pemCertificate'
+          description: |
+            PEM certificate that is allowlisted. The certificate can be up to 5k bytes, and must be a parseable X.509 certificate.
+          required: true

--- a/mmv1/templates/terraform/examples/certificate_manager_trust_config_allowlisted_certificates.tf.erb
+++ b/mmv1/templates/terraform/examples/certificate_manager_trust_config_allowlisted_certificates.tf.erb
@@ -3,9 +3,13 @@ resource "google_certificate_manager_trust_config" "<%= ctx[:primary_resource_id
   description = "A sample trust config resource with allowlisted certificates"
   location = "global"
 
-  allowlisted_certificates {
+  allowlisted_certificates  {
     pem_certificate = file("test-fixtures/cert.pem") 
   }
+  allowlisted_certificates  {
+    pem_certificate = file("test-fixtures/cert2.pem") 
+  }
+  
   labels = {
     foo = "bar"
   }

--- a/mmv1/templates/terraform/examples/certificate_manager_trust_config_allowlisted_certificates.tf.erb
+++ b/mmv1/templates/terraform/examples/certificate_manager_trust_config_allowlisted_certificates.tf.erb
@@ -1,0 +1,12 @@
+resource "google_certificate_manager_trust_config" "<%= ctx[:primary_resource_id] %>" {
+  name        = "<%= ctx[:vars]["trust_config_name"] %>"
+  description = "A sample trust config resource with allowlisted certificates"
+  location = "global"
+
+  allowlisted_certificates {
+    pem_certificate = file("test-fixtures/cert.pem") 
+  }
+  labels = {
+    foo = "bar"
+  }
+}

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_trust_config_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_trust_config_test.go
@@ -46,7 +46,7 @@ func testAccCertificateManagerTrustConfig_update0(context map[string]interface{}
 resource "google_certificate_manager_trust_config" "default" {
   name        = "tf-test-trust-config%{random_suffix}"
   description = "sample description for the trust config"
-  location    = "us-central1"
+  location = "global"
 
   trust_stores {
     trust_anchors { 
@@ -55,6 +55,10 @@ resource "google_certificate_manager_trust_config" "default" {
     intermediate_cas { 
       pem_certificate = file("test-fixtures/cert.pem")
     }
+  }
+
+  allowlisted_certificates  {
+    pem_certificate = file("test-fixtures/cert.pem") 
   }
 
   labels = {
@@ -69,7 +73,7 @@ func testAccCertificateManagerTrustConfig_update1(context map[string]interface{}
 resource "google_certificate_manager_trust_config" "default" {
   name        = "tf-test-trust-config%{random_suffix}"
   description = "sample description for the trust config 2"
-  location    = "us-central1"
+  location    = "global"
 
   trust_stores {
     trust_anchors { 
@@ -78,6 +82,10 @@ resource "google_certificate_manager_trust_config" "default" {
     intermediate_cas { 
       pem_certificate = file("test-fixtures/cert2.pem")
     }
+  }
+
+  allowlisted_certificates  {
+    pem_certificate = file("test-fixtures/cert.pem") 
   }
 
   labels = {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This CL adds allowlistedCertificates field to TrustConfig resource.
Fixes https://github.com/hashicorp/terraform-provider-google/issues/18170 and https://github.com/hashicorp/terraform-provider-google/issues/18385

Tests that I run: 
`make testacc TEST=./google/services/certificatemanager TESTARGS='-run=TestAccCertificateManagerTrustConfig_certificateManagerTrustConfigAllowlistedCertificatesExample'`

`make testacc TEST=./google/services/certificatemanager TESTARGS='-run=TestAccCertificateManagerTrustConfig_update'`

Manual tests that I performed: 
- Create a resource with one allowlisted
- Add one more cert to the resource
- Remove one cert from the resoruce

<!--

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
certificatemanager: added `allowlisted_certificates` to `google_certificate_manager_trust_config`
```
