### PR TITLE
Added MMv1 resource reference page

### DIFF
--- a/docs/content/develop/custom-code.md
+++ b/docs/content/develop/custom-code.md
@@ -1,6 +1,6 @@
 ---
 title: "Add custom resource code"
-weight: 32
+weight: 39
 ---
 
 # Add custom resource code

--- a/docs/content/develop/resource-reference.md
+++ b/docs/content/develop/resource-reference.md
@@ -1,0 +1,318 @@
+---
+title: "MMv1 resource reference"
+weight: 32
+aliases:
+  - /reference/resource-reference
+  - /reference/iam-policy-reference
+---
+
+# MMv1 resource reference
+
+This page documents commonly-used properties for resources. For a full list of
+available properties, see [resource.rb ↗](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/api/resource.rb).
+
+## Basic
+
+### `name`
+
+API resource name.
+
+### `description`
+
+Resource description. Used in documentation.
+
+Example:
+
+```yaml
+description: |
+  This is a multi-line description
+  of a resource.
+```
+
+### `references`
+
+Links to reference documentation for a resource. Contains two attributes:
+
+- `guides`: Link to quickstart in the API's Guides section
+- `api`: Link to the REST API reference for the resource
+
+Example:
+
+```yaml
+references: !ruby/object:Api::Resource::ReferenceLinks
+     guides:
+      'Create and connect to a database': 'https://cloud.google.com/alloydb/docs/quickstart/create-and-connect'
+     api: 'https://cloud.google.com/alloydb/docs/reference/rest/v1/projects.locations.backups'
+```
+
+### `min_version: beta`
+Marks the field (and any subfields) as beta-only. Ensure a beta version block
+is present in provider.yaml.
+
+### `docs`
+Inserts styled markdown into the header of the resource's page in the provider
+documentation. Can contain two attributes:
+
+- `warning`: Warning text which will be displayed at the top of the resource docs on a yellow background.
+- `note`: Note text which will be displayed at the top of the resource docs on a blue background.
+
+Example:
+
+```yaml
+docs: !ruby/object:Provider::Terraform::Docs
+  warning: |
+    This is a multi-line warning and will be
+    displayed on a yellow background.
+  note: |
+    This is a multi-line note and will be
+    displayed on a blue background.
+```
+
+
+## API interactions
+
+### `base_url`
+
+URL for the resource's [standard List method](https://google.aip.dev/132).
+Terraform field names enclosed in double curly braces are replaced with
+the field values from the resource at runtime.
+
+```yaml
+base_url: 'projects/{{project}}/locations/{{location}}/resourcenames'
+```
+
+### `self_link`
+
+URL for the resource's [standard Get method](https://google.aip.dev/131).
+Terraform field names enclosed in double curly braces are replaced with
+the field values from the resource at runtime.
+
+```yaml
+self_link: 'projects/{{project}}/locations/{{location}}/resourcenames/{{name}}'
+```
+
+### `immutable`
+
+If true, the resource and all its fields are considered immutable - that is,
+only creatable, not updatable. Individual fields can override this if they
+have a custom update method in the API.
+
+See [Best practices: ForceNew](https://googlecloudplatform.github.io/magic-modules/best-practices/#forcenew) for more information.
+
+Default: `false`
+
+Example:
+
+```yaml
+immutable: true
+```
+
+### `timeouts`
+
+Overrides one or more timeouts, in minutes. All timeouts default to 20.
+
+Example:
+
+```yaml
+timeouts: !ruby/object:Api::Timeouts
+  insert_minutes: 40
+  update_minutes: 40
+  delete_minutes: 40
+```
+
+### `create_url`
+
+URL for the resource's [standard Create method](https://google.aip.dev/133), including query parameters.
+Terraform field names enclosed in double curly braces are replaced with
+the field values from the resource at runtime.
+
+Example:
+
+```yaml
+create_url: 'projects/{{project}}/locations/{{location}}/resourcenames?resourceId={{name}}'
+```
+
+### `create_verb`
+
+Overrides the HTTP verb used to create a new resource.
+Allowed values: `:POST`, `:PUT`, `:PATCH`.
+
+Default: `:POST`
+
+```yaml
+create_verb: :PATCH
+```
+
+### `update_url`
+Overrides the URL for the resource's [standard Update method](https://google.aip.dev/134).
+If unset, the [`self_link` URL](#self_link) is used by default.
+Terraform field names enclosed in double curly braces are replaced with
+the field values from the resource at runtime.
+
+```yaml
+update_url: 'projects/{{project}}/locations/{{location}}/resourcenames/{{name}}'
+```
+
+### `update_verb`
+
+The HTTP verb used to update a resource. Allowed values: `:POST`, `:PUT`, `:PATCH`.
+
+Default: `:PUT`.
+
+Example:
+
+```yaml
+update_verb: :PATCH
+```
+
+### `update_mask`
+
+If true, the resource sets an `updateMask` query parameter listing modified
+fields when updating the resource. If false, it doesn't.
+
+Default: `false`
+
+Example:
+
+```yaml
+update_mask: true
+```
+
+### `delete_url`
+
+Overrides the URL for the resource's [standard Delete method](https://google.aip.dev/135).
+If unset, the [`self_link` URL](#self_link) is used by default.
+Terraform field names enclosed in double curly braces are replaced with
+the field values from the resource at runtime.
+
+Example:
+
+```yaml
+delete_url: 'projects/{{project}}/locations/{{location}}/resourcenames/{{name}}'
+```
+
+### `delete_verb`
+Overrides the HTTP verb used to delete a resource.
+Allowed values: `:POST`, `:PUT`, `:PATCH`, `:DELETE`.
+
+Default: `:DELETE`
+
+Example:
+
+```yaml
+delete_verb: :POST
+```
+
+### `autogen_async`
+
+If true, code for handling long-running operations is generated along with
+the resource. If false, that code isn't generated and must be handwritten.
+
+Default: `false`
+
+```yaml
+autogen_async: true
+```
+
+### `async`
+
+Sets parameters for handling operations returned by the API. Can contain several attributes:
+
+- `actions`: Overrides which API calls return operations. Default: `['create', 'update', 'delete']`
+- `operation.base_url`: This should always be set to `'{{op_id}}'` unless you know that's wrong.
+- `result.resource_inside_response`: If true, the provider sets the resource's Terraform ID after
+  the resource is created, taking into account values that are set by the API at create time. This
+  is only possible when the completed operation's JSON includes the created resource in the
+  "response" field. If false, the provider sets the resource's Terraform ID before the resource is
+  created, based only on the resource configuration. Default: `false`.
+
+Example:
+
+```yaml
+async: !ruby/object:Api::OpAsync
+  actions: ['create', 'update', 'delete']
+  operation: !ruby/object:Api::OpAsync::Operation
+    base_url: '{{op_id}}'
+  result: !ruby/object:Api::OpAsync::Result
+    resource_inside_response: true
+```
+
+## IAM resources
+
+### `iam_policy`
+
+Allows configuration of generated IAM resources. Supports the following common
+attributes – for a full reference, see
+[iam_policy.rb ↗](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/api/resource/iam_policy.rb):
+
+- `parent_resource_attribute`: Name of the field on the terraform IAM resources
+  which references the parent resource.
+- `method_name_separator`: Character preceding setIamPolicy in the full URL for
+  the API method. Usually `:`.
+- `fetch_iam_policy_verb`: HTTP method for getIamPolicy. Usually `:POST`.
+  Allowed values: `:GET`, `:POST`. Default: `:GET`
+- `set_iam_policy_verb`: HTTP method for getIamPolicy. Usually `:POST`.
+  Allowed values: :POST, :PUT. Default: :POST
+- `import_format`: Must match the parent resource's `import_format` (or `self_link` if
+  `import_format` is unset), but with the `parent_resource_attribute`
+  value substituted for the final field.
+- `allowed_iam_role`: Valid IAM role that can be set by generated tests. Default: `'roles/viewer'`
+- `iam_conditions_request_type`: If IAM conditions are supported, set this attribute to indicate how the
+  conditions should be passed to the API. Allowed values: `:QUERY_PARAM`,
+  `:REQUEST_BODY`, `:QUERY_PARAM_NESTED`. Note: `:QUERY_PARAM_NESTED` should
+  only be used if the query param field contains a `.`
+- `min_version: beta`: Marks IAM support as beta-only.
+
+Example:
+
+```yaml
+iam_policy: !ruby/object:Api::Resource::IamPolicy
+  parent_resource_attribute: 'cloud_function'
+  method_name_separator: ':'
+  fetch_iam_policy_verb: :POST
+  import_format: [
+    'projects/{{project}}/locations/{{location}}/resourcenames/{{cloud_function}}',
+    '{{cloud_function}}'
+  ]
+  allowed_iam_role: 'roles/viewer'
+  iam_conditions_request_type: :REQUEST_BODY
+  min_version: beta
+```
+
+## Resource behavior
+
+### `custom_code`
+
+Injects arbitrary logic into a generated resource. For more information, see [Add custom resource code]({{< ref "/develop/custom-code" >}}).
+
+### `mutex`
+
+All resources (of all kinds) that share a mutex value will block rather than
+executing concurrent API requests. Terraform field names enclosed in double
+curly braces are replaced with the field values from the resource at runtime.
+
+Example:
+
+```yaml
+mutex: alloydb/instance/{{name}}
+```
+
+## Fields
+
+### `parameters`
+
+Contains a list of [fields]({{< ref "/develop/field-reference" >}}). By convention,
+these should be the fields that are part URL parameters such as `location` and `name`.
+
+### `properties`
+
+Contains a list of [fields]({{< ref "/develop/field-reference" >}}). By convention,
+these should be fields that aren't part of the URL parameters.
+
+Example:
+
+```yaml
+properties:
+  - !ruby/object:Api::Type::String
+    name: 'fieldOne'
+```

--- a/docs/content/develop/resource.md
+++ b/docs/content/develop/resource.md
@@ -80,14 +80,6 @@ For more information about types of resources and the generation process overall
    # provider.yaml.
    # min_version: beta
 
-   # Inserts styled markdown into the header of the resource's page in the
-   # provider documentation.
-   # docs: !ruby/object:Provider::Terraform::Docs
-   #   warning: |
-   #     MULTILINE_WARNING_MARKDOWN
-   #   note: |
-   #     MULTILINE_NOTE_MARKDOWN
-
    # URL for the resource's standard List method. https://google.aip.dev/132
    # Terraform field names enclosed in double curly braces are replaced with
    # the field values from the resource at runtime.
@@ -102,20 +94,11 @@ For more information about types of resources and the generation process overall
    # have a custom update method in the API.
    # immutable: true
 
-   # Overrides one or more timeouts, in minutes. All timeouts default to 20.
-   # timeouts: !ruby/object:Api::Timeouts
-   #   insert_minutes: 20 
-   #   update_minutes: 20 
-   #   delete_minutes: 20 
-
    # URL for the resource's standard Create method, including query parameters.
    # https://google.aip.dev/133
    # Terraform field names enclosed in double curly braces are replaced with
    # the field values from the resource at runtime.
    create_url: 'projects/{{project}}/locations/{{location}}/resourcenames?resourceId={{name}}'
-   # Overrides the HTTP verb used to create a new resource.
-   # Allowed values: :POST, :PUT, :PATCH. Default: :POST
-   # create_verb: :POST
 
    # Overrides the URL for the resource's standard Update method. (If unset, the
    # self_link URL is used by default.) https://google.aip.dev/134
@@ -128,15 +111,6 @@ For more information about types of resources and the generation process overall
    # fields when updating the resource. If false, it does not.
    update_mask: true
 
-   # Overrides the URL for the resource's standard Delete method. (If unset, the
-   # self_link URL is used by default.) https://google.aip.dev/135
-   # Terraform field names enclosed in double curly braces are replaced with
-   # the field values from the resource at runtime.
-   # delete_url: 'projects/{{project}}/locations/{{location}}/resourcenames/{{name}}'
-   # Overrides the HTTP verb used to delete a resource.
-   # Allowed values: :POST, :PUT, :PATCH, :DELETE. Default: :DELETE
-   # delete_verb: :DELETE
-
    # If true, code for handling long-running operations is generated along with
    # the resource. If false, that code is not generated.
    autogen_async: true
@@ -147,20 +121,6 @@ For more information about types of resources and the generation process overall
      # actions: ['create', 'update', 'delete']
      operation: !ruby/object:Api::OpAsync::Operation
        base_url: '{{op_id}}'
-
-     # If true, the provider sets the resource's Terraform ID after the resource is created,
-     # taking into account values that are set by the API at create time. This is only possible
-     # when the completed operation's JSON includes the created resource in the "response" field.
-     # If false (or unset), the provider sets the resource's Terraform ID before the resource is
-     # created, based only on the resource configuration.
-     # result: !ruby/object:Api::OpAsync::Result
-     #   resource_inside_response: true
-
-   # All resources (of all kinds) that share a mutex value block rather than
-   # executing concurrent API requests.
-   # Terraform field names enclosed in double curly braces are replaced with
-   # the field values from the resource at runtime.
-   # mutex: RESOURCE_NAME/{{name}}
 
    parameters:
      - !ruby/object:Api::Type::String
@@ -185,7 +145,7 @@ For more information about types of resources and the generation process overall
 3. Modify the template as needed to match the API resource's documented behavior.
 4. Delete all remaining comments in the resource configuration (including attribute descriptions) that were copied from the above template.
 
-> **Note:** The template includes the most commonly-used fields. For a comprehensive reference, see [ResourceName.yaml reference ↗]({{<ref "/reference/resource-reference.md" >}}).
+> **Note:** The template includes the most commonly-used fields. For a comprehensive reference, see [MMv1 resource reference ↗]({{<ref "/develop/resource-reference.md" >}}).
 {{< /tab >}}
 {{< tab "Handwritten" >}}
 > **Warning:** Handwritten resources are more difficult to develop and maintain. New handwritten resources will only be accepted if implementing the resource in MMv1 would require entirely overriding two or more CRUD methods.
@@ -415,10 +375,8 @@ iam_policy: !ruby/object:Api::Resource::IamPolicy
   # Usually `:`
   method_name_separator: ':'
   # HTTP method for getIamPolicy. Usually :POST.
-  # Allowed values: :GET, :POST. Default: :GET
   fetch_iam_policy_verb: :POST
-  # Overrides the HTTP method for setIamPolicy.
-  # Allowed values: :POST, :PUT. Default: :POST
+  # Overrides the HTTP method for setIamPolicy. Default: :POST
   # set_iam_policy_verb: :POST
 
   # Must match the parent resource's `import_format` (or `self_link` if
@@ -427,8 +385,6 @@ iam_policy: !ruby/object:Api::Resource::IamPolicy
   import_format: [
     'projects/{{project}}/locations/{{location}}/resourcenames/{{resource_name}}'
   ]
-  # Valid IAM role that can be set by generated tests. Default: 'roles/viewer'
-  # allowed_iam_role: 'roles/viewer'
 
   # If IAM conditions are supported, set this attribute to indicate how the
   # conditions should be passed to the API. Allowed values: :QUERY_PARAM,
@@ -440,7 +396,7 @@ iam_policy: !ruby/object:Api::Resource::IamPolicy
   # min_version: beta
 ```
 
-2. Modify the template as needed to match the API resource's documented behavior. These are the most commonly-used fields. For a comprehensive reference, see [IAM policy YAML reference ↗]({{<ref "/reference/iam-policy-reference.md" >}}).
+2. Modify the template as needed to match the API resource's documented behavior. These are the most commonly-used fields. For a comprehensive reference, see [MMv1 resource reference: `iam_policy` ↗]({{<ref "/develop/resource-reference#iam_policy" >}}).
 3. Delete all remaining comments in the IAM configuration (including attribute descriptions) that were copied from the above template.
 {{< /tab >}}
 {{< tab "Handwritten" >}}

--- a/docs/content/reference/iam-policy-reference.md
+++ b/docs/content/reference/iam-policy-reference.md
@@ -1,6 +1,0 @@
----
-title: "IAM policy YAML reference ↗"
-weight: 30
-bookHref: "https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/api/resource/iam_policy.rb"
----
-FORCE MENU RENDER

--- a/docs/content/reference/resource-reference.md
+++ b/docs/content/reference/resource-reference.md
@@ -1,6 +1,0 @@
----
-title: "Resource YAML reference ↗"
-weight: 20
-bookHref: "https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/api/resource.rb"
----
-FORCE MENU RENDER


### PR DESCRIPTION
This is not intended to be thorough - just getting the initial work out of the way to document the most common options and reduce cruft in the quickstart templates. This should make it easier to make incremental additions going forward.

![localhost_1313_magic-modules_develop_resource-reference_ (1)](https://github.com/GoogleCloudPlatform/magic-modules/assets/299979/3749fead-af0f-4f44-b226-1668a72c9812)


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
