### PR TITLE
add redis self service update support

### DIFF
--- a/mmv1/products/redis/Instance.yaml
+++ b/mmv1/products/redis/Instance.yaml
@@ -399,6 +399,9 @@ properties:
           can not go beyond, including reschedule.
           A timestamp in RFC3339 UTC "Zulu" format, with nanosecond
           resolution and up to nine fractional digits.
+  - !ruby/object:Api::Type::String
+    name: maintenanceVersion
+    description: The self service update maintenance version.
   - !ruby/object:Api::Type::Integer
     name: memorySizeGb
     description: Redis memory size in GiB.

--- a/mmv1/products/redis/Instance.yaml
+++ b/mmv1/products/redis/Instance.yaml
@@ -402,6 +402,8 @@ properties:
   - !ruby/object:Api::Type::String
     name: maintenanceVersion
     description: The self service update maintenance version.
+    required: false
+    default_from_api: true
   - !ruby/object:Api::Type::Integer
     name: memorySizeGb
     description: Redis memory size in GiB.

--- a/mmv1/third_party/terraform/services/redis/resource_redis_instance_test.go
+++ b/mmv1/third_party/terraform/services/redis/resource_redis_instance_test.go
@@ -255,6 +255,41 @@ func TestAccRedisInstance_redisInstanceAuthEnabled(t *testing.T) {
 	})
 }
 
+func TestAccRedisInstance_selfServiceUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckRedisInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRedisInstance_selfServiceUpdate20240411_00_00(context),
+			},
+			{
+				ResourceName:            "google_redis_instance.cache",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"region"},
+			},
+			{
+				Config: testAccRedisInstance_selfServiceUpdate20240503_00_00(context),
+			},
+			{
+				ResourceName:            "google_redis_instance.cache",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"region"},
+			},
+		},
+	})
+}
+
+
 func TestAccRedisInstance_downgradeRedisVersion(t *testing.T) {
 	t.Parallel()
 
@@ -370,6 +405,26 @@ resource "google_redis_instance" "cache" {
   name           = "tf-test-memory-cache%{random_suffix}"
   memory_size_gb = 1
   auth_enabled = false
+}
+`, context)
+}
+
+func testAccRedisInstance_selfServiceUpdate20240411_00_00(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_redis_instance" "cache" {
+  name           = "tf-test-memory-cache%{random_suffix}"
+  memory_size_gb = 1
+  maintenance_version = "20240411_00_00"
+}
+`, context)
+}
+
+func testAccRedisInstance_selfServiceUpdate20240503_00_00(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_redis_instance" "cache" {
+  name           = "tf-test-memory-cache%{random_suffix}"
+  memory_size_gb = 1
+  maintenance_version = "20240503_00_00"
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/redis/resource_redis_instance_test.go
+++ b/mmv1/third_party/terraform/services/redis/resource_redis_instance_test.go
@@ -289,7 +289,6 @@ func TestAccRedisInstance_selfServiceUpdate(t *testing.T) {
 	})
 }
 
-
 func TestAccRedisInstance_downgradeRedisVersion(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
add redis self service update support

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
redis: added `maintenance_version` field to `google_redis_instance`
```
