### PR TITLE
feat(billingbudget): support project level recicipients on budgets

### DIFF
--- a/mmv1/products/billingbudget/Budget.yaml
+++ b/mmv1/products/billingbudget/Budget.yaml
@@ -440,6 +440,7 @@ properties:
       - 'notificationsRule.schemaVersion'
       - 'notificationsRule.monitoringNotificationChannels'
       - 'notificationsRule.disableDefaultIamRecipients'
+      - 'notificationsRule.enableProjectLevelRecipients'
     properties:
       - !ruby/object:Api::Type::String
         name: pubsubTopic
@@ -479,6 +480,15 @@ properties:
           when a threshold is exceeded. Default recipients are
           those with Billing Account Administrators and Billing
           Account Users IAM roles for the target account.
+      - !ruby/object:Api::Type::Boolean
+        name: enableProjectLevelRecipients
+        default_value: false
+        description: |
+          When set to true, and when the budget has a single project configured,
+          notifications will be sent to project level recipients of that project.
+          This field will be ignored if the budget has multiple or no project configured.
+
+          Currently, project level recipients are the users with Owner role on a cloud project.
   - !ruby/object:Api::Type::Enum
     name: ownershipScope
     description: |

--- a/mmv1/products/billingbudget/Budget.yaml
+++ b/mmv1/products/billingbudget/Budget.yaml
@@ -69,6 +69,13 @@ examples:
     test_env_vars:
       billing_acct: :MASTER_BILLING_ACCT
   - !ruby/object:Provider::Terraform::Examples
+    name: 'billing_budget_notify_project_recipient'
+    primary_resource_id: 'budget'
+    vars:
+      budget_name: 'Example Billing Budget'
+    test_env_vars:
+      billing_acct: :MASTER_BILLING_ACCT
+  - !ruby/object:Provider::Terraform::Examples
     name: 'billing_budget_customperiod'
     primary_resource_id: 'budget'
     vars:

--- a/mmv1/templates/terraform/examples/billing_budget_notify_project_recipient.tf.erb
+++ b/mmv1/templates/terraform/examples/billing_budget_notify_project_recipient.tf.erb
@@ -21,6 +21,7 @@ resource "google_billing_budget" "<%= ctx[:primary_resource_id] %>" {
   }
 
   all_updates_rule {
-    enable_project_level_recipients = true
+    monitoring_notification_channels = []
+    enable_project_level_recipients  = true
   }
 }

--- a/mmv1/templates/terraform/examples/billing_budget_notify_project_recipient.tf.erb
+++ b/mmv1/templates/terraform/examples/billing_budget_notify_project_recipient.tf.erb
@@ -1,0 +1,26 @@
+data "google_billing_account" "account" {
+  billing_account = "<%= ctx[:test_env_vars]['billing_acct'] -%>"
+}
+
+data "google_project" "project" {
+}
+
+resource "google_billing_budget" "<%= ctx[:primary_resource_id] %>" {
+  billing_account = data.google_billing_account.account.id
+  display_name    = "<%= ctx[:vars]['budget_name'] %>"
+
+  budget_filter {
+    projects = ["projects/${data.google_project.project.number}"]
+  }
+
+  amount {
+    specified_amount {
+      currency_code = "USD"
+      units         = "100000"
+    }
+  }
+
+  all_updates_rule {
+    enable_project_level_recipients = true
+  }
+}


### PR DESCRIPTION
Support for setting the project level recipients: https://cloud.google.com/billing/docs/reference/budget/rest/v1beta1/billingAccounts.budgets#allupdatesrule. 

FIXES https://github.com/hashicorp/terraform-provider-google/issues/18182
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
```release-note:enhancement
billingbudget: added `enable_project_level_recipients` field to `google_billing_budget` resource
```