### PR TITLE
Updated description of connection_draining_timeout_sec, balancing_mode and  outlier_detection in backend_service and regional_backend_service before changing defaults

### DIFF
--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -165,6 +165,8 @@ properties:
 
             See the [Backend Services Overview](https://cloud.google.com/load-balancing/docs/backend-service#balancing-mode)
             for an explanation of load balancing modes.
+
+            From version 6.0.0 default value will be UTILIZATION to match default GCP value.
         - !ruby/object:Api::Type::Double
           name: 'capacityScaler'
           send_empty_value: true
@@ -964,6 +966,9 @@ properties:
       Settings controlling eviction of unhealthy hosts from the load balancing pool.
       Applicable backend service types can be a global backend service with the
       loadBalancingScheme set to INTERNAL_SELF_MANAGED or EXTERNAL_MANAGED.
+
+      From version 6.0.0 outlierDetection default terraform values will be removed to match default GCP value.
+      Default values are enforce by GCP without providing them.
     properties:
       - !ruby/object:Api::Type::NestedObject
         name: 'baseEjectionTime'

--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -164,6 +164,8 @@ properties:
 
             See the [Backend Services Overview](https://cloud.google.com/load-balancing/docs/backend-service#balancing-mode)
             for an explanation of load balancing modes.
+
+            From version 6.0.0 default value will be UTILIZATION to match default GCP value.
         - !ruby/object:Api::Type::Double
           name: 'capacityScaler'
           description: |
@@ -658,6 +660,8 @@ properties:
         description: |
           Time for which instance will be drained (not accept new
           connections, but still work to finish started).
+
+          From version 6.0.0 ConnectionDrainingTimeoutSec default value will be 300 to match default GCP value.
   - !ruby/object:Api::Type::Time
     name: 'creationTimestamp'
     description: |
@@ -873,6 +877,9 @@ properties:
       Settings controlling eviction of unhealthy hosts from the load balancing pool.
       This field is applicable only when the `load_balancing_scheme` is set
       to INTERNAL_MANAGED and the `protocol` is set to HTTP, HTTPS, or HTTP2.
+
+      From version 6.0.0 outlierDetection default terraform values will be removed to match default GCP value.
+      Default values are enforce by GCP without providing them.
     properties:
       - !ruby/object:Api::Type::NestedObject
         name: 'baseEjectionTime'


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Adds info in the description of `connection_draining_timeout_sec`, `balancing_mode` and `outlier_detection` about breaking change in the next major release. 

https://github.com/hashicorp/terraform-provider-google/issues/13478
https://github.com/hashicorp/terraform-provider-google/issues/12299
https://github.com/hashicorp/terraform-provider-google/issues/15210
https://github.com/hashicorp/terraform-provider-google/issues/17257
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:note
compute: Updated field description of `connection_draining_timeout_sec`, `balancing_mode` and `outlier_detection` in `google_compute_region_backend_service` and `google_compute_backend_service`  to inform that default values will be changed
```
