### PR TITLE
`google_storage_bucket`: fix `custom_placement_config` values not normalized

### DIFF
--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
@@ -1172,6 +1172,10 @@ func flattenBucketCustomPlacementConfig(cfc *storage.BucketCustomPlacementConfig
 func expandBucketDataLocations(configured interface{}) []string {
 	l := configured.(*schema.Set).List()
 
+	// Since we only want uppercase values to prevent unnecessary diffs, we can do a comparison
+	// to determine whether or not to include the value as part of the request.
+
+	// This extra check comes from the limitations of both DiffStateFunc and StateFunc towards types of Sets,Lists, and Maps.
 	req := make([]string, 0, len(l))
 	for _, raw := range l {
 		if raw.(string) == strings.ToUpper(raw.(string)) {

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
@@ -496,6 +496,9 @@ func ResourceStorageBucket() *schema.Resource {
 							MinItems: 2,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
+								StateFunc: func(s interface{}) string {
+									return strings.ToUpper(s.(string))
+								},
 							},
 							Description: `The list of individual regions that comprise a dual-region bucket. See the docs for a list of acceptable regions. Note: If any of the data_locations changes, it will recreate the bucket.`,
 						},
@@ -1171,7 +1174,9 @@ func expandBucketDataLocations(configured interface{}) []string {
 
 	req := make([]string, 0, len(l))
 	for _, raw := range l {
-		req = append(req, raw.(string))
+		if raw.(string) == strings.ToUpper(raw.(string)) {
+			req = append(req, raw.(string))
+		}
 	}
 	return req
 }

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
@@ -272,29 +272,6 @@ func TestAccStorageBucket_dualLocation_lowercase(t *testing.T) {
 	})
 }
 
-func TestAccStorageBucket_dualLocation_lowercase(t *testing.T) {
-	t.Parallel()
-
-	bucketName := acctest.TestBucketName(t)
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccStorageBucketDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccStorageBucket_dualLocation_lowercase(bucketName),
-			},
-			{
-				ResourceName:            "google_storage_bucket.bucket",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy"},
-			},
-		},
-	})
-}
-
 func TestAccStorageBucket_dualLocation_versionChange(t *testing.T) {
 	// Test is not parallel because ENVs are set.
 	// Need to skip VCR as this test downloads providers from the Terraform Registry

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
@@ -289,7 +289,6 @@ func TestAccStorageBucket_dualLocation_versionChange(t *testing.T) {
 		CheckDestroy: testAccStorageBucketDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				// Context: this was an addidental breaking change introduced with muxing
 				Config: testAccStorageBucket_dualLocation(bucketName),
 				ExternalProviders: map[string]resource.ExternalProvider{
 					"google": {

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
@@ -249,6 +249,29 @@ func TestAccStorageBucket_dualLocation(t *testing.T) {
 	})
 }
 
+func TestAccStorageBucket_dualLocation_lowercase(t *testing.T) {
+	t.Parallel()
+
+	bucketName := acctest.TestBucketName(t)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccStorageBucketDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStorageBucket_dualLocation_lowercase(bucketName),
+			},
+			{
+				ResourceName:            "google_storage_bucket.bucket",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+		},
+	})
+}
+
 func TestAccStorageBucket_dualLocation_rpo(t *testing.T) {
 	t.Parallel()
 	bucketName := acctest.TestBucketName(t)
@@ -1709,6 +1732,19 @@ resource "google_storage_bucket" "bucket" {
   force_destroy = true
   custom_placement_config {
     data_locations = ["ASIA-EAST1", "ASIA-SOUTHEAST1"]
+  }
+}
+`, bucketName)
+}
+
+func testAccStorageBucket_dualLocation_lowercase(bucketName string) string {
+	return fmt.Sprintf(`
+resource "google_storage_bucket" "bucket" {
+  name          = "%s"
+  location      = "ASIA"
+  force_destroy = true
+  custom_placement_config {
+    data_locations = ["asia-east1", "asia-southeast1"]
   }
 }
 `, bucketName)

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
@@ -272,6 +272,82 @@ func TestAccStorageBucket_dualLocation_lowercase(t *testing.T) {
 	})
 }
 
+func TestAccStorageBucket_dualLocation_lowercase(t *testing.T) {
+	t.Parallel()
+
+	bucketName := acctest.TestBucketName(t)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccStorageBucketDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStorageBucket_dualLocation_lowercase(bucketName),
+			},
+			{
+				ResourceName:            "google_storage_bucket.bucket",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+		},
+	})
+}
+
+func TestAccStorageBucket_dualLocation_versionChange(t *testing.T) {
+	// Test is not parallel because ENVs are set.
+	// Need to skip VCR as this test downloads providers from the Terraform Registry
+	acctest.SkipIfVcr(t)
+
+	creds := envvar.GetTestCredsFromEnv()
+	project := envvar.GetTestProjectFromEnv()
+	t.Setenv("GOOGLE_CREDENTIALS", creds)
+	t.Setenv("GOOGLE_PROJECT", project)
+
+	bucketName := acctest.TestBucketName(t)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		CheckDestroy: testAccStorageBucketDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				// Context: this was an addidental breaking change introduced with muxing
+				Config: testAccStorageBucket_dualLocation(bucketName),
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"google": {
+						VersionConstraint: "5.30.0",
+						Source:            "hashicorp/google",
+					},
+				},
+			},
+			{
+				ResourceName: "google_storage_bucket.bucket",
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"google": {
+						VersionConstraint: "5.30.0",
+						Source:            "hashicorp/google",
+					},
+				},
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+			{
+				Config:                   testAccStorageBucket_dualLocation(bucketName),
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+			},
+			{
+				ResourceName:             "google_storage_bucket.bucket",
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+				ImportState:              true,
+				ImportStateVerify:        true,
+				ImportStateVerifyIgnore:  []string{"force_destroy"},
+			},
+		},
+	})
+}
+
 func TestAccStorageBucket_dualLocation_rpo(t *testing.T) {
 	t.Parallel()
 	bucketName := acctest.TestBucketName(t)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Resolves https://github.com/hashicorp/terraform-provider-google/issues/18035

Solution was to use `StateFunc` which converts the values in `data_locations` to be set as uppercase before storing into state. However as stated in the linked issue, there's a known problem with SDK that when using `StateFunc` in a nested attribute such as `type.Set` it will add the new value instead of replacing.

But by ignoring values in `data_locations` when expanding that *aren't* all capitalized, we can ensure that the final state will only include what we specified in `StateFunc`

```go
for _, raw := range l {
		if raw.(string) == strings.ToUpper(raw.(string)) {
			req = append(req, raw.(string))
		}
	}
}
```	

test output:
`TestAccStorageBucket_dualLocation_lowercase` - newly added test
```bash
(base) ┌─(~/Dev/terraform-provider-google)───────────────────────────────────────(mau@mau-JKDT676NCP:s008)─┐
└─(14:40:36 on main ✹)──> envchain GCLOUD make testacc TEST=./google/services/storage TESTARGS='-run=TestAccStorageBucket_dualLocation_lowercase'                                                    ──(Mon,Jun10)─┘
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/storage -v -run=TestAccStorageBucket_dualLocation_lowercase -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccStorageBucket_dualLocation_lowercase
=== PAUSE TestAccStorageBucket_dualLocation_lowercase
=== CONT  TestAccStorageBucket_dualLocation_lowercase
--- PASS: TestAccStorageBucket_dualLocation_lowercase (20.90s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/storage  22.114s
```
`TestAccStorageBucket_dualLocation_versionChange` - newly added test to ensure that behavior for user doesn't change:
```bash
(base) ┌─(~/Dev/terraform-provider-google)───────────────────────────────────────(mau@mau-JKDT676NCP:s008)─┐
└─(12:10:48 on main ✹)──> envchain GCLOUD make testacc TEST=./google/services/storage TESTARGS='-run=TestAccStorageBucket_dualLocation_versionChange'
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/storage -v -run=TestAccStorageBucket_dualLocation_versionChange -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccStorageBucket_dualLocation_versionChange
--- PASS: TestAccStorageBucket_dualLocation_versionChange (48.35s)
PASS
```
`TestAccStorageBucket_dualLocation`:
```bash
(base) ┌─(~/Dev/terraform-provider-google)──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────(mau@mau-JKDT676NCP:s008)─┐
└─(14:48:58 on main ✹)──> envchain GCLOUD make testacc TEST=./google/services/storage TESTARGS='-run=TestAccStorageBucket_dualLocation'                                                              ──(Mon,Jun10)─┘
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/storage -v -run=TestAccStorageBucket_dualLocation -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccStorageBucket_dualLocation
=== PAUSE TestAccStorageBucket_dualLocation
=== RUN   TestAccStorageBucket_dualLocation_lowercase
=== PAUSE TestAccStorageBucket_dualLocation_lowercase
=== RUN   TestAccStorageBucket_dualLocation_rpo
=== PAUSE TestAccStorageBucket_dualLocation_rpo
=== CONT  TestAccStorageBucket_dualLocation
=== CONT  TestAccStorageBucket_dualLocation_rpo
=== CONT  TestAccStorageBucket_dualLocation_lowercase
--- PASS: TestAccStorageBucket_dualLocation_lowercase (21.61s)
--- PASS: TestAccStorageBucket_dualLocation (23.27s)
--- PASS: TestAccStorageBucket_dualLocation_rpo (49.14s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/storage  50.278s
```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
storage: fixed `custom_placement_config` values not normalized in `google_storage_bucket`
```
