### PR TITLE
Fixed review requests on issue comment from author

### DIFF
--- a/.github/workflows/request-reviewer.yml
+++ b/.github/workflows/request-reviewer.yml
@@ -15,14 +15,13 @@ on:
 
 jobs:
   request-review:
-    # if: github.event.pull_request && github.event.pull_request.draft == false && (github.event.comment.user.login == github.event.issue.user.login || github.event.action != 'created')
+    if: (github.event.action == 'created' && github.event.issue.draft == false && github.event.comment.user.login == github.event.issue.user.login) || (github.event.action != 'created' && github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - run: echo "${{ toJSON(github.event) }}"
       - name: Checkout Repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
       - name: Set up Go

--- a/.github/workflows/request-reviewer.yml
+++ b/.github/workflows/request-reviewer.yml
@@ -15,13 +15,14 @@ on:
 
 jobs:
   request-review:
-    if: github.event.pull_request && github.event.pull_request.draft == false && (github.event.sender.login == github.event.issue.user.login || github.event.action != 'created')
+    # if: github.event.pull_request && github.event.pull_request.draft == false && (github.event.comment.user.login == github.event.issue.user.login || github.event.action != 'created')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - run: echo "${{ toJSON(github.event) }}"
       - name: Checkout Repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
       - name: Set up Go

--- a/.github/workflows/request-reviewer.yml
+++ b/.github/workflows/request-reviewer.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   request-review:
-    if: github.event.pull_request && github.event.pull_request.draft == false && (github.event.sender.login == github.event.pull_request.user.login || github.event.action != 'created')
+    if: github.event.pull_request && github.event.pull_request.draft == false && (github.event.sender.login == github.event.issue.user.login || github.event.action != 'created')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
According to https://docs.github.com/en/webhooks/webhook-events-and-payloads#issue_comment the data for comment creation should be in issue, not pull_request

Note that pull request comments (on specific lines of files) are separate and are currently intentionally not included here.

~This should be possible to test by having the reviewer leave a review, then having me leave a comment - I believe the issue comment portion of the logic should run based off of what is in this PR.~ This all runs off the main branch so it won't be possible to test before merge. However, I think the logic should be more clear now so I am more confident in it.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
