### PR TITLE
[Prep for 6.0.0 release branch] Make downstream waiter compatible with non-linear history for main

### DIFF
--- a/.ci/magician/cmd/wait_for_commit.go
+++ b/.ci/magician/cmd/wait_for_commit.go
@@ -52,39 +52,23 @@ func execWaitForCommit(syncBranchPrefix, baseBranch, sha string, runner source.R
 	}
 
 	for {
-		if baseBranch != "main" {
-			output, err := gitRevParse("origin/"+syncBranch, runner)
-			if err != nil {
-				return err
-			}
-			syncHead := strings.TrimSpace(output)
-
-			output, err = gitRevParse(sha+"~", runner)
-			if err != nil {
-				return err
-			}
-			baseParent := strings.TrimSpace(output)
-			if syncHead == baseParent {
-				return nil
-			}
-			fmt.Println("sync branch is at: ", syncHead)
-			fmt.Println("current commit is: ", sha)
-		} else {
-			output, err := runner.Run("git", []string{"log", "--pretty=%H", "--reverse", fmt.Sprintf("origin/%s..origin/main", syncBranch)}, nil)
-			if err != nil {
-				return err
-			}
-			commits := strings.Split(output, "\n")
-			commit := ""
-			if len(commits) > 0 {
-				commit = strings.TrimSpace(commits[0])
-			}
-			if commit == sha {
-				return nil
-			}
-			fmt.Println("git log says waiting on: ", commit)
-			fmt.Println("command says waiting on: ", sha)
+		output, err := gitRevParse("origin/"+syncBranch, runner)
+		if err != nil {
+			return err
 		}
+		syncHead := strings.TrimSpace(output)
+
+		output, err = gitRevParse(sha+"~", runner)
+		if err != nil {
+			return err
+		}
+		baseParent := strings.TrimSpace(output)
+		if syncHead == baseParent {
+			return nil
+		}
+		fmt.Println("sync branch is at: ", syncHead)
+		fmt.Println("current commit is: ", sha)
+		
 		if _, err := runner.Run("git", []string{"fetch", "origin", syncBranch}, nil); err != nil {
 			return err
 		}

--- a/.ci/magician/cmd/wait_for_commit_test.go
+++ b/.ci/magician/cmd/wait_for_commit_test.go
@@ -44,9 +44,11 @@ func TestExecWaitForCommit(t *testing.T) {
 			baseBranch: "main",
 			calledMethods: []string{
 				"git merge-base --is-ancestor sha origin/sync-branch",
-				"git log --pretty=%H --reverse origin/sync-branch..origin/main",
+				"git rev-parse --short origin/sync-branch",
+				"git rev-parse --short sha~",
 				"git fetch origin sync-branch",
-				"git log --pretty=%H --reverse origin/sync-branch..origin/main",
+				"git rev-parse --short origin/sync-branch",
+				"git rev-parse --short sha~",
 			},
 			runResults: map[string][]runResult{
 				"cwd git [merge-base --is-ancestor sha origin/sync-branch] map[]": {
@@ -55,12 +57,20 @@ func TestExecWaitForCommit(t *testing.T) {
 						err: fmt.Errorf("exit error 1"),
 					},
 				},
-				"cwd git [log --pretty=%H --reverse origin/sync-branch..origin/main] map[]": {
+				"cwd git [rev-parse --short origin/sync-branch] map[]": {
 					{
-						out: "sha2\nsha\n\n",
+						out: "sha-x",
 					},
 					{
-						out: "sha\n\n",
+						out: "sha-z",
+					},
+				},
+				"cwd git [rev-parse --short sha~] map[]": {
+					{
+						out: "sha-y",
+					},
+					{
+						out: "sha-z",
 					},
 				},
 				"cwd git [fetch origin sync-branch] map[]": {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
