### PR TITLE
Support absolute override dir for generator

### DIFF
--- a/mmv1/compiler.rb
+++ b/mmv1/compiler.rb
@@ -119,6 +119,14 @@ end
 
 if override_dir
   Google::LOGGER.info "Using override directory '#{override_dir}'"
+
+  # Normalize override dir to a path that is relative to the magic-modules directory
+  # This is needed for templates that concatenate pwd + override dir + path
+  if Pathname.new(override_dir).absolute?
+    override_dir = Pathname.new(override_dir).relative_path_from(__dir__).to_s
+    Google::LOGGER.info "Override directory normalized to relative path '#{override_dir}'"
+  end
+
   Dir["#{override_dir}/products/**/product.yaml"].each do |file_path|
     product = File.dirname(Pathname.new(file_path).relative_path_from(override_dir))
     all_product_files.push(product) unless all_product_files.include? product


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Currently, absolute paths can't be used for the `override_dir` (ie. `make mmv1 OVERRIDES=...` or `-r`), because we concatenate paths in a few places in our templates. Instead, it must be relative to the magic-modules repo directory.

Example error when providing absolute path:
`/Users/ryanoaks/projects/magic-modules-private-overrides/artifacts/magic-modules/mmv1/compile/core.rb:141:in 'read': No such file or directory @ rb_sysopen - /Users/ryanoaks/projects/magic-modules-private-overrides/artifacts/magic-modules/mmv1//Users/ryanoaks/projects/magic-modules-private-overrides/examples/backend_service_ip_address_selection_policy.tf.erb (Errno::ENOENT)`

This PR allows absolute paths by immediately checking if the path is absolute, and if it is, changing it to be relative to magic-modules.

Testing: I've confirmed locally that with this change, relative override paths still work, and absolute paths now work as well.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
