### PR TITLE
Bump min gke version to fix TestAccContainerNodePool_fastSocket

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -1878,7 +1878,7 @@ resource "google_container_cluster" "cluster" {
   name               = "%s"
   location           = "us-central1-f"
   initial_node_count = 1
-  min_master_version = "1.25"
+  min_master_version = "1.28"
   deletion_protection = false
   network    = "%s"
   subnetwork    = "%s"


### PR DESCRIPTION
Fixes [#18276](https://github.com/hashicorp/terraform-provider-google/issues/18276)

Test `TestAccContainerNodePool_fastSocket` is failing because 1.25 is past end of life. Bumping to 1.28 because 1.27 end of life on GKE is scheduled for 2024-08-31 which is fairly soon.


```release-note:none
```
