### PR TITLE
Add tlsEarlyData support to TargetHttpsProxy.

### DIFF
--- a/mmv1/products/compute/TargetHttpsProxy.yaml
+++ b/mmv1/products/compute/TargetHttpsProxy.yaml
@@ -130,6 +130,18 @@ properties:
     update_url: 'projects/{{project}}/global/targetHttpsProxies/{{name}}/setQuicOverride'
     default_value: :NONE
     custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.erb'
+  - !ruby/object:Api::Type::Enum
+    name: 'tlsEarlyData'
+    description: |
+      Specifies whether TLS 1.3 0-RTT Data (“Early Data”) should be accepted for this service.
+      Early Data allows a TLS resumption handshake to include the initial application payload
+      (a HTTP request) alongside the handshake, reducing the effective round trips to “zero”.
+      This applies to TLS 1.3 connections over TCP (HTTP/2) as well as over UDP (QUIC/h3).
+    values:
+      - :STRICT
+      - :PERMISSIVE
+      - :DISABLED
+    default_value: :DISABLED
   - !ruby/object:Api::Type::Array
     name: 'certificateManagerCertificates'
     description: |

--- a/mmv1/products/compute/TargetHttpsProxy.yaml
+++ b/mmv1/products/compute/TargetHttpsProxy.yaml
@@ -141,7 +141,7 @@ properties:
       - :STRICT
       - :PERMISSIVE
       - :DISABLED
-    default_value: :DISABLED
+    default_from_api: true
   - !ruby/object:Api::Type::Array
     name: 'certificateManagerCertificates'
     description: |

--- a/mmv1/third_party/terraform/services/compute/resource_compute_target_https_proxy_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_target_https_proxy_test.go.erb
@@ -226,6 +226,7 @@ resource "google_compute_target_https_proxy" "foobar" {
     google_compute_ssl_certificate.foobar2.self_link,
   ]
   quic_override = "ENABLE"
+  tls_early_data = "STRICT"
 }
 
 resource "google_compute_backend_service" "foobar" {

--- a/mmv1/third_party/tgc/tests/data/example_compute_target_https_proxy.json
+++ b/mmv1/third_party/tgc/tests/data/example_compute_target_https_proxy.json
@@ -15,7 +15,6 @@
           "projects/{{.Provider.project}}/global/sslCertificates/ssl-certificate-id"
         ],
         "sslPolicy": "projects/{{.Provider.project}}/global/sslPolicies/ssl-policy-id",
-	"tlsEarlyData": "DISABLED",
         "urlMap": "projects/{{.Provider.project}}/global/urlMaps/url-map-id"
       }
     }

--- a/mmv1/third_party/tgc/tests/data/example_compute_target_https_proxy.json
+++ b/mmv1/third_party/tgc/tests/data/example_compute_target_https_proxy.json
@@ -15,6 +15,7 @@
           "projects/{{.Provider.project}}/global/sslCertificates/ssl-certificate-id"
         ],
         "sslPolicy": "projects/{{.Provider.project}}/global/sslPolicies/ssl-policy-id",
+	"tlsEarlyData": "DISABLED",
         "urlMap": "projects/{{.Provider.project}}/global/urlMaps/url-map-id"
       }
     }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/18421

Tests that I run:
```
make testacc TEST=./google/services/compute TESTARGS='-run=TestAccComputeTargetHttpsProxy_'
```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `tlsEarlyData` field to `google_compute_target_https_proxy` resource
```
