### PR TITLE
Revert extraneous whitespace changes from #10904

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.erb
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.erb
@@ -702,41 +702,41 @@ func schedulingHasChangeRequiringReboot(d *schema.ResourceData) bool {
 // Terraform doesn't correctly calculate changes on schema.Set, so we do it manually
 // https://github.com/hashicorp/terraform-plugin-sdk/issues/98
 func schedulingHasChangeWithoutReboot(d *schema.ResourceData) bool {
-    if !d.HasChange("scheduling") {
-      // This doesn't work correctly, which is why this method exists
-      // But it is here for posterity
-      return false
-    }
-    o, n := d.GetChange("scheduling")
-    oScheduling := o.([]interface{})[0].(map[string]interface{})
-    newScheduling := n.([]interface{})[0].(map[string]interface{})
-  
-    if schedulingHasChangeRequiringReboot(d) {
-      return false
-    }
-  
-    if oScheduling["automatic_restart"] != newScheduling["automatic_restart"] {
-      return true
-    }
-  
-    if oScheduling["preemptible"] != newScheduling["preemptible"] {
-      return true
-    }
-  
-    if oScheduling["on_host_maintenance"] != newScheduling["on_host_maintenance"] {
-      return true
-    }
-  
-    if oScheduling["provisioning_model"] != newScheduling["provisioning_model"] {
-      return true
-    }
-  
-    if oScheduling["instance_termination_action"] != newScheduling["instance_termination_action"] {
-      return true
-    }
-  
-    return false
-  }
+	if !d.HasChange("scheduling") {
+		// This doesn't work correctly, which is why this method exists
+		// But it is here for posterity
+		return false
+	}
+	o, n := d.GetChange("scheduling")
+	oScheduling := o.([]interface{})[0].(map[string]interface{})
+	newScheduling := n.([]interface{})[0].(map[string]interface{})
+
+	if schedulingHasChangeRequiringReboot(d) {
+		return false
+	}
+
+	if oScheduling["automatic_restart"] != newScheduling["automatic_restart"] {
+		return true
+	}
+
+	if oScheduling["preemptible"] != newScheduling["preemptible"] {
+		return true
+	}
+
+	if oScheduling["on_host_maintenance"] != newScheduling["on_host_maintenance"] {
+		return true
+	}
+
+	if oScheduling["provisioning_model"] != newScheduling["provisioning_model"] {
+		return true
+	}
+
+	if oScheduling["instance_termination_action"] != newScheduling["instance_termination_action"] {
+			return true
+	}
+
+	return false
+}
 
 <% unless version == 'ga' -%>
 func hasMaxRunDurationChanged(oScheduling, nScheduling map[string]interface{}) bool {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

https://github.com/GoogleCloudPlatform/magic-modules/pull/10904 introduced some whitespace changes that prevented our EAP patch from applying cleanly. The previous format also looks more correct and consistent with the file, so I've reverted those whitespace changes in this repo to resolve the patch issue.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
