### PR TITLE
Fix flaky DiscoveryConfig.yaml tests

### DIFF
--- a/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_discovery_config_test.go
+++ b/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_discovery_config_test.go
@@ -52,7 +52,7 @@ func testAccDataLossPreventionDiscoveryConfig_BasicUpdate(t *testing.T) {
 				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time"},
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
 			},
 			{
 				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigUpdate(context),
@@ -61,7 +61,7 @@ func testAccDataLossPreventionDiscoveryConfig_BasicUpdate(t *testing.T) {
 				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time"},
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
 			},
 		},
 	})
@@ -88,7 +88,7 @@ func testAccDataLossPreventionDiscoveryConfig_OrgUpdate(t *testing.T) {
 				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time"},
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
 			},
 			{
 				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigOrgFolderPaused(context),
@@ -97,7 +97,7 @@ func testAccDataLossPreventionDiscoveryConfig_OrgUpdate(t *testing.T) {
 				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time"},
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
 			},
 		},
 	})
@@ -123,7 +123,7 @@ func testAccDataLossPreventionDiscoveryConfig_ActionsUpdate(t *testing.T) {
 				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time"},
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
 			},
 			{
 				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigActions(context),
@@ -132,7 +132,7 @@ func testAccDataLossPreventionDiscoveryConfig_ActionsUpdate(t *testing.T) {
 				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time"},
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
 			},
 			{
 				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigActionsSensitivity(context),
@@ -141,7 +141,7 @@ func testAccDataLossPreventionDiscoveryConfig_ActionsUpdate(t *testing.T) {
 				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time"},
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
 			},
 		},
 	})
@@ -167,7 +167,7 @@ func testAccDataLossPreventionDiscoveryConfig_ConditionsCadenceUpdate(t *testing
 				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time"},
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
 			},
 			{
 				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigConditionsCadence(context),
@@ -176,7 +176,7 @@ func testAccDataLossPreventionDiscoveryConfig_ConditionsCadenceUpdate(t *testing
 				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time"},
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
 			},
 		},
 	})
@@ -202,7 +202,7 @@ func testAccDataLossPreventionDiscoveryConfig_FilterUpdate(t *testing.T) {
 				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time"},
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
 			},
 			{
 				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigFilterRegexesAndConditions(context),
@@ -211,7 +211,7 @@ func testAccDataLossPreventionDiscoveryConfig_FilterUpdate(t *testing.T) {
 				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time"},
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
 			},
 		},
 	})
@@ -237,7 +237,7 @@ func testAccDataLossPreventionDiscoveryConfig_CloudSqlUpdate(t *testing.T) {
 				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time"},
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
 			},
 			{
 				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigUpdateCloudSql(context),
@@ -246,7 +246,7 @@ func testAccDataLossPreventionDiscoveryConfig_CloudSqlUpdate(t *testing.T) {
 				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time"},
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
 			},
 		},
 	})
@@ -272,7 +272,7 @@ func testAccDataLossPreventionDiscoveryConfig_BqSingleTable(t *testing.T) {
 				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time"},
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
 			},
 			{
 				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigBqSingleUpdate(context),
@@ -281,7 +281,7 @@ func testAccDataLossPreventionDiscoveryConfig_BqSingleTable(t *testing.T) {
 				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time"},
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
 			},
 		},
 	})
@@ -307,7 +307,7 @@ func testAccDataLossPreventionDiscoveryConfig_SqlSingleTable(t *testing.T) {
 				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time"},
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
 			},
 			{
 				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigCloudSqlSingleUpdate(context),
@@ -316,7 +316,7 @@ func testAccDataLossPreventionDiscoveryConfig_SqlSingleTable(t *testing.T) {
 				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time"},
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
 			},
 		},
 	})
@@ -342,7 +342,7 @@ func testAccDataLossPreventionDiscoveryConfig_SecretsUpdate(t *testing.T) {
 				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time"},
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
 			},
 			{
 				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigSecretsUpdate(context),
@@ -351,7 +351,7 @@ func testAccDataLossPreventionDiscoveryConfig_SecretsUpdate(t *testing.T) {
 				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time"},
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
 			},
 		},
 	})


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fix flakiness in DiscoveryConfig.yaml tests; errors and timestamp fields should not be verified in update tests, as these are dynamic and will change across the lifespan of the resource as DLP performs scans.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
