### PR TITLE
Increase timeouts on `google_sql_database_instance` to 90m

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.erb
@@ -129,9 +129,9 @@ func ResourceSqlDatabaseInstance() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(40 * time.Minute),
-			Update: schema.DefaultTimeout(30 * time.Minute),
-			Delete: schema.DefaultTimeout(30 * time.Minute),
+			Create: schema.DefaultTimeout(90 * time.Minute),
+			Update: schema.DefaultTimeout(90 * time.Minute),
+			Delete: schema.DefaultTimeout(90 * time.Minute),
 		},
 
 		CustomizeDiff: customdiff.All(

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -578,9 +578,9 @@ performing filtering in a Terraform config.
 `google_sql_database_instance` provides the following
 [Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options:
 
-- `create` - Default is 40 minutes.
-- `update` - Default is 30 minutes.
-- `delete` - Default is 30 minutes.
+- `create` - Default is 90 minutes.
+- `update` - Default is 90 minutes.
+- `delete` - Default is 90 minutes.
 
 ## Import
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

```
------- Stdout: -------
=== RUN   TestAccSqlDatabaseInstance_basicClone
=== PAUSE TestAccSqlDatabaseInstance_basicClone
=== CONT  TestAccSqlDatabaseInstance_basicClone
    vcr_utils.go:152: Step 1/2 error: Error running apply: exit status 1
        Error: Error waiting for Create Instance: timeout while waiting for state to become 'DONE' (last state: 'RUNNING', timeout: 40m0s)
          with google_sql_database_instance.instance,
          on terraform_plugin_test.tf line 2, in resource "google_sql_database_instance" "instance":
           2: resource "google_sql_database_instance" "instance" {
--- FAIL: TestAccSqlDatabaseInstance_basicClone (2407.16s)
FAIL
```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
sql: increased timeouts on `google_sql_database_instance` to 90m to account for longer-running actions such as creation through cloning
```
