### PR TITLE
compute: promote `google_compute_network_attachment` GA

### DIFF
--- a/mmv1/products/compute/Instance.yaml
+++ b/mmv1/products/compute/Instance.yaml
@@ -526,7 +526,6 @@ properties:
         - !ruby/object:Api::Type::ResourceRef
           name: 'networkAttachment'
           resource: 'networkAttachment'
-          min_version: beta
           imports: 'selfLink'
           description: |
             The URL of the network attachment that this interface should connect to in the following format:

--- a/mmv1/products/compute/NetworkAttachment.yaml
+++ b/mmv1/products/compute/NetworkAttachment.yaml
@@ -13,7 +13,6 @@
 
 --- !ruby/object:Api::Resource
 name: 'NetworkAttachment'
-min_version: beta
 kind: 'compute#networkAttachment'
 description: |
   A network attachment is a resource that lets a producer Virtual Private Cloud (VPC) network initiate connections to a consumer VPC network through a Private Service Connect interface.

--- a/mmv1/templates/terraform/examples/network_attachment_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/network_attachment_basic.tf.erb
@@ -1,5 +1,4 @@
 resource "google_compute_network_attachment" "default" {
-    provider = google-beta
     name = "<%= ctx[:vars]['resource_name'] %>"
     region = "us-central1"
     description = "basic network attachment description"
@@ -19,13 +18,11 @@ resource "google_compute_network_attachment" "default" {
 }
 
 resource "google_compute_network" "default" {
-    provider = google-beta
     name = "<%= ctx[:vars]['network_name'] %>"
     auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "default" {
-    provider = google-beta
     name = "<%= ctx[:vars]['subnetwork_name'] %>"
     region = "us-central1"
 
@@ -34,7 +31,6 @@ resource "google_compute_subnetwork" "default" {
 }
 
 resource "google_project" "rejected_producer_project" {
-    provider = google-beta
     project_id      = "<%= ctx[:vars]['rejected_producer_project_name'] %>"
     name            = "<%= ctx[:vars]['rejected_producer_project_name'] %>"
     org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"
@@ -42,7 +38,6 @@ resource "google_project" "rejected_producer_project" {
 }
 
 resource "google_project" "accepted_producer_project" {
-    provider = google-beta
     project_id      = "<%= ctx[:vars]['accepted_producer_project_name'] %>"
     name            = "<%= ctx[:vars]['accepted_producer_project_name'] %>"
     org_id          = "<%= ctx[:test_env_vars]['org_id'] %>"

--- a/mmv1/templates/terraform/examples/network_attachment_instance_usage.tf.erb
+++ b/mmv1/templates/terraform/examples/network_attachment_instance_usage.tf.erb
@@ -1,11 +1,9 @@
 resource "google_compute_network" "default" {
-    provider = google-beta
     name = "<%= ctx[:vars]['network_name'] %>"
     auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "default" {
-    provider = google-beta
     name   = "<%= ctx[:vars]['subnetwork_name'] %>"
     region = "us-central1"
 
@@ -14,7 +12,6 @@ resource "google_compute_subnetwork" "default" {
 }
 
 resource "google_compute_network_attachment" "<%= ctx[:primary_resource_id] %>" {
-    provider = google-beta
     name   = "<%= ctx[:vars]['resource_name'] %>"
     region = "us-central1"
     description = "my basic network attachment"
@@ -24,7 +21,6 @@ resource "google_compute_network_attachment" "<%= ctx[:primary_resource_id] %>" 
 }
 
 resource "google_compute_instance" "default" {
-    provider = google-beta
     name         = "<%= ctx[:vars]['instance_name'] %>"
     zone         = "us-central1-a"
     machine_type = "e2-micro"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Network attachment ([doc](https://cloud.google.com/vpc/docs/about-network-attachments),  [API reference](https://cloud.google.com/compute/docs/reference/rest/v1/networkAttachments)) is no longer beta.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: promote `google_compute_network_attachment` GA
```
