### PR TITLE
feat: Add Pub/Sub Subscription support for specifying a service account

### DIFF
--- a/mmv1/products/pubsub/Subscription.yaml
+++ b/mmv1/products/pubsub/Subscription.yaml
@@ -65,6 +65,15 @@ examples:
       dataset_id: 'example_dataset'
       table_id: 'example_table'
   - !ruby/object:Provider::Terraform::Examples
+    name: 'pubsub_subscription_push_bq_service_account'
+    primary_resource_id: 'example'
+    vars:
+      topic_name: 'example-topic'
+      subscription_name: 'example-subscription'
+      dataset_id: 'example_dataset'
+      table_id: 'example_table'
+      service_account_id: 'example-bqw'
+  - !ruby/object:Provider::Terraform::Examples
     name: 'pubsub_subscription_push_cloudstorage'
     primary_resource_id: 'example'
     vars:
@@ -78,6 +87,14 @@ examples:
       topic_name: 'example-topic'
       subscription_name: 'example-subscription'
       bucket_name: 'example-bucket'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'pubsub_subscription_push_cloudstorage_service_account'
+    primary_resource_id: 'example'
+    vars:
+      topic_name: 'example-topic'
+      subscription_name: 'example-subscription'
+      bucket_name: 'example-bucket'
+      service_account_id: 'example-stw'
 docs: !ruby/object:Provider::Terraform::Docs
   note: |
     You can retrieve the email of the Google Managed Pub/Sub Service Account used for forwarding
@@ -150,6 +167,12 @@ properties:
           When true and use_topic_schema or use_table_schema is true, any fields that are a part of the topic schema or message schema that
           are not part of the BigQuery table schema are dropped when writing to BigQuery. Otherwise, the schemas must be kept in sync
           and any messages with extra fields are not written and remain in the subscription's backlog.
+      - !ruby/object:Api::Type::String
+        name: 'serviceAccountEmail'
+        description: |
+          The service account to use to write to BigQuery. If not specified, the Pub/Sub
+          [service agent](https://cloud.google.com/iam/docs/service-agents),
+          service-{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com, is used.
   - !ruby/object:Api::Type::NestedObject
     name: 'cloudStorageConfig'
     conflicts:
@@ -207,6 +230,12 @@ properties:
             name: 'writeMetadata'
             description: |
               When true, write the subscription name, messageId, publishTime, attributes, and orderingKey as additional fields in the output.
+      - !ruby/object:Api::Type::String
+        name: 'serviceAccountEmail'
+        description: |
+          The service account to use to write to Cloud Storage. If not specified, the Pub/Sub
+          [service agent](https://cloud.google.com/iam/docs/service-agents),
+          service-{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com, is used.
   - !ruby/object:Api::Type::NestedObject
     name: 'pushConfig'
     conflicts:

--- a/mmv1/templates/terraform/examples/pubsub_subscription_push_bq_service_account.tf.erb
+++ b/mmv1/templates/terraform/examples/pubsub_subscription_push_bq_service_account.tf.erb
@@ -1,0 +1,56 @@
+resource "google_pubsub_topic" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['topic_name'] %>"
+}
+
+resource "google_pubsub_subscription" "<%= ctx[:primary_resource_id] %>" {
+  name  = "<%= ctx[:vars]['subscription_name'] %>"
+  topic = google_pubsub_topic.<%= ctx[:primary_resource_id] %>.id
+
+  bigquery_config {
+    table = "${google_bigquery_table.test.project}.${google_bigquery_table.test.dataset_id}.${google_bigquery_table.test.table_id}"
+    service_account_email = google_service_account.bq_write_service_account.email
+  }
+
+  depends_on = [google_service_account.bq_write_service_account, google_project_iam_member.viewer, google_project_iam_member.editor]
+}
+
+data "google_project" "project" {
+}
+
+resource "google_service_account" "bq_write_service_account" {
+  account_id = "<%= ctx[:vars]['service_account_id'] %>"
+  display_name = "BQ Write Service Account"
+}
+
+resource "google_project_iam_member" "viewer" {
+  project = data.google_project.project.project_id
+  role   = "roles/bigquery.metadataViewer"
+  member = "serviceAccount:${google_service_account.bq_write_service_account.email}"
+}
+
+resource "google_project_iam_member" "editor" {
+  project = data.google_project.project.project_id
+  role   = "roles/bigquery.dataEditor"
+  member = "serviceAccount:${google_service_account.bq_write_service_account.email}"
+}
+
+resource "google_bigquery_dataset" "test" {
+  dataset_id = "<%= ctx[:vars]['dataset_id'] %>"
+}
+
+resource "google_bigquery_table" "test" {
+  deletion_protection = false
+  table_id   = "<%= ctx[:vars]['table_id'] %>"
+  dataset_id = google_bigquery_dataset.test.dataset_id
+
+  schema = <<EOF
+[
+  {
+    "name": "data",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "The data"
+  }
+]
+EOF
+}

--- a/mmv1/templates/terraform/examples/pubsub_subscription_push_cloudstorage_service_account.tf.erb
+++ b/mmv1/templates/terraform/examples/pubsub_subscription_push_cloudstorage_service_account.tf.erb
@@ -1,0 +1,46 @@
+resource "google_storage_bucket" "<%= ctx[:primary_resource_id] %>" {
+  name  = "<%= ctx[:vars]['bucket_name'] %>"
+  location = "US"
+  uniform_bucket_level_access = true
+}
+
+resource "google_pubsub_topic" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['topic_name'] %>"
+}
+
+resource "google_pubsub_subscription" "<%= ctx[:primary_resource_id] %>" {
+  name  = "<%= ctx[:vars]['subscription_name'] %>"
+  topic = google_pubsub_topic.<%= ctx[:primary_resource_id] %>.id
+
+  cloud_storage_config {
+    bucket = google_storage_bucket.<%= ctx[:primary_resource_id] %>.name
+
+    filename_prefix = "pre-"
+    filename_suffix = "-%{random_suffix}"
+    filename_datetime_format = "YYYY-MM-DD/hh_mm_ssZ"
+
+    max_bytes = 1000
+    max_duration = "300s"
+
+    service_account_email = google_service_account.storage_write_service_account.email
+  }
+  depends_on = [
+    google_service_account.storage_write_service_account,
+    google_storage_bucket.<%= ctx[:primary_resource_id] %>,
+    google_storage_bucket_iam_member.admin,
+  ]
+}
+
+data "google_project" "project" {
+}
+
+resource "google_service_account" "storage_write_service_account" {
+  account_id = "<%= ctx[:vars]['service_account_id'] %>"
+  display_name = "Storage Write Service Account"
+}
+
+resource "google_storage_bucket_iam_member" "admin" {
+  bucket = google_storage_bucket.<%= ctx[:primary_resource_id] %>.name
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${google_service_account.storage_write_service_account.email}"
+}

--- a/mmv1/third_party/terraform/services/pubsub/resource_pubsub_subscription_test.go
+++ b/mmv1/third_party/terraform/services/pubsub/resource_pubsub_subscription_test.go
@@ -185,7 +185,7 @@ func TestAccPubsubSubscriptionBigQuery_update(t *testing.T) {
 		CheckDestroy:             testAccCheckPubsubSubscriptionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPubsubSubscriptionBigQuery_basic(dataset, table, topic, subscriptionShort, false),
+				Config: testAccPubsubSubscriptionBigQuery_basic(dataset, table, topic, subscriptionShort, false, ""),
 			},
 			{
 				ResourceName:      "google_pubsub_subscription.foo",
@@ -194,7 +194,51 @@ func TestAccPubsubSubscriptionBigQuery_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccPubsubSubscriptionBigQuery_basic(dataset, table, topic, subscriptionShort, true),
+				Config: testAccPubsubSubscriptionBigQuery_basic(dataset, table, topic, subscriptionShort, true, ""),
+			},
+			{
+				ResourceName:      "google_pubsub_subscription.foo",
+				ImportStateId:     subscriptionShort,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccPubsubSubscriptionBigQuery_serviceAccount(t *testing.T) {
+	t.Parallel()
+
+	dataset := fmt.Sprintf("tftestdataset%s", acctest.RandString(t, 10))
+	table := fmt.Sprintf("tf-test-table-%s", acctest.RandString(t, 10))
+	topic := fmt.Sprintf("tf-test-topic-%s", acctest.RandString(t, 10))
+	subscriptionShort := fmt.Sprintf("tf-test-sub-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckPubsubSubscriptionDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPubsubSubscriptionBigQuery_basic(dataset, table, topic, subscriptionShort, false, "bq-test-sa"),
+			},
+			{
+				ResourceName:      "google_pubsub_subscription.foo",
+				ImportStateId:     subscriptionShort,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccPubsubSubscriptionBigQuery_basic(dataset, table, topic, subscriptionShort, true, ""),
+			},
+			{
+				ResourceName:      "google_pubsub_subscription.foo",
+				ImportStateId:     subscriptionShort,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccPubsubSubscriptionBigQuery_basic(dataset, table, topic, subscriptionShort, true, "bq-test-sa2"),
 			},
 			{
 				ResourceName:      "google_pubsub_subscription.foo",
@@ -219,7 +263,7 @@ func TestAccPubsubSubscriptionCloudStorage_update(t *testing.T) {
 		CheckDestroy:             testAccCheckPubsubSubscriptionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPubsubSubscriptionCloudStorage_basic(bucket, topic, subscriptionShort, "", "", "", 0, ""),
+				Config: testAccPubsubSubscriptionCloudStorage_basic(bucket, topic, subscriptionShort, "", "", "", 0, "", ""),
 			},
 			{
 				ResourceName:      "google_pubsub_subscription.foo",
@@ -228,7 +272,50 @@ func TestAccPubsubSubscriptionCloudStorage_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccPubsubSubscriptionCloudStorage_basic(bucket, topic, subscriptionShort, "pre-", "-suffix", "YYYY-MM-DD/hh_mm_ssZ", 1000, "300s"),
+				Config: testAccPubsubSubscriptionCloudStorage_basic(bucket, topic, subscriptionShort, "pre-", "-suffix", "YYYY-MM-DD/hh_mm_ssZ", 1000, "300s", ""),
+			},
+			{
+				ResourceName:      "google_pubsub_subscription.foo",
+				ImportStateId:     subscriptionShort,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccPubsubSubscriptionCloudStorage_serviceAccount(t *testing.T) {
+	t.Parallel()
+
+	bucket := fmt.Sprintf("tf-test-bucket-%s", acctest.RandString(t, 10))
+	topic := fmt.Sprintf("tf-test-topic-%s", acctest.RandString(t, 10))
+	subscriptionShort := fmt.Sprintf("tf-test-sub-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckPubsubSubscriptionDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPubsubSubscriptionCloudStorage_basic(bucket, topic, subscriptionShort, "", "", "", 0, "", "gcs-test-sa"),
+			},
+			{
+				ResourceName:      "google_pubsub_subscription.foo",
+				ImportStateId:     subscriptionShort,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccPubsubSubscriptionCloudStorage_basic(bucket, topic, subscriptionShort, "pre-", "-suffix", "YYYY-MM-DD/hh_mm_ssZ", 1000, "300s", ""),
+			},
+			{
+				ResourceName:      "google_pubsub_subscription.foo",
+				ImportStateId:     subscriptionShort,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccPubsubSubscriptionCloudStorage_basic(bucket, topic, subscriptionShort, "", "", "", 0, "", "gcs-test-sa2"),
 			},
 			{
 				ResourceName:      "google_pubsub_subscription.foo",
@@ -435,10 +522,30 @@ resource "google_pubsub_subscription" "foo" {
 `, topic, subscription, label, deadline, exactlyOnceDelivery)
 }
 
-func testAccPubsubSubscriptionBigQuery_basic(dataset, table, topic, subscription string, useTableSchema bool) string {
-	return fmt.Sprintf(`
-data "google_project" "project" { }
+func testAccPubsubSubscriptionBigQuery_basic(dataset, table, topic, subscription string, useTableSchema bool, serviceAccountId string) string {
+	serivceAccountEmailField := ""
+	serivceAccountResource := ""
+	if serviceAccountId != "" {
+		serivceAccountResource = fmt.Sprintf(`
+resource "google_service_account" "bq_write_service_account" {
+  account_id   = "%s"
+  display_name = "BQ Write Service Account"
+}
 
+resource "google_project_iam_member" "viewer" {
+	project = data.google_project.project.project_id
+	role   = "roles/bigquery.metadataViewer"
+	member = "serviceAccount:${google_service_account.bq_write_service_account.email}"
+}
+
+resource "google_project_iam_member" "editor" {
+	project = data.google_project.project.project_id
+	role   = "roles/bigquery.dataEditor"
+	member = "serviceAccount:${google_service_account.bq_write_service_account.email}"
+}`, serviceAccountId)
+		serivceAccountEmailField = "service_account_email = google_service_account.bq_write_service_account.email"
+	} else {
+		serivceAccountResource = fmt.Sprintf(`
 resource "google_project_iam_member" "viewer" {
 	project = data.google_project.project.project_id
 	role   = "roles/bigquery.metadataViewer"
@@ -450,6 +557,13 @@ resource "google_project_iam_member" "editor" {
 	role   = "roles/bigquery.dataEditor"
 	member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
 }
+	`)
+	}
+
+	return fmt.Sprintf(`
+data "google_project" "project" { }
+
+%s
 
 resource "google_bigquery_dataset" "test" {
 	dataset_id = "%s"
@@ -483,6 +597,7 @@ resource "google_pubsub_subscription" "foo" {
   bigquery_config {
     table = "${google_bigquery_table.test.project}.${google_bigquery_table.test.dataset_id}.${google_bigquery_table.test.table_id}"
     use_table_schema = %t
+		%s
   }
 
   depends_on = [
@@ -490,10 +605,10 @@ resource "google_pubsub_subscription" "foo" {
     google_project_iam_member.editor
   ]
 }
-`, dataset, table, topic, subscription, useTableSchema)
+	`, serivceAccountResource, dataset, table, topic, subscription, useTableSchema, serivceAccountEmailField)
 }
 
-func testAccPubsubSubscriptionCloudStorage_basic(bucket, topic, subscription, filenamePrefix, filenameSuffix, filenameDatetimeFormat string, maxBytes int, maxDuration string) string {
+func testAccPubsubSubscriptionCloudStorage_basic(bucket, topic, subscription, filenamePrefix, filenameSuffix, filenameDatetimeFormat string, maxBytes int, maxDuration string, serviceAccountId string) string {
 	filenamePrefixString := ""
 	if filenamePrefix != "" {
 		filenamePrefixString = fmt.Sprintf(`filename_prefix = "%s"`, filenamePrefix)
@@ -514,19 +629,45 @@ func testAccPubsubSubscriptionCloudStorage_basic(bucket, topic, subscription, fi
 	if maxDuration != "" {
 		maxDurationString = fmt.Sprintf(`max_duration = "%s"`, maxDuration)
 	}
-	return fmt.Sprintf(`
-data "google_project" "project" { }
+
+	serivceAccountEmailField := ""
+	serivceAccountResource := ""
+	if serviceAccountId != "" {
+		serivceAccountResource = fmt.Sprintf(`
+resource "google_service_account" "storage_write_service_account" {
+  account_id   = "%s"
+  display_name = "Write Service Account"
+}
 
 resource "google_storage_bucket_iam_member" "admin" {
   bucket = google_storage_bucket.test.name
   role   = "roles/storage.admin"
-  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+	member = "serviceAccount:${google_service_account.storage_write_service_account.email}"
 }
+
+resource "google_project_iam_member" "editor" {
+	project = data.google_project.project.project_id
+	role   = "roles/bigquery.dataEditor"
+	member = "serviceAccount:${google_service_account.storage_write_service_account.email}"
+}`, serviceAccountId)
+		serivceAccountEmailField = "service_account_email = google_service_account.storage_write_service_account.email"
+	} else {
+		serivceAccountResource = fmt.Sprintf(`
+resource "google_storage_bucket_iam_member" "admin" {
+  bucket = google_storage_bucket.test.name
+  role   = "roles/storage.admin"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+}`)
+	}
+	return fmt.Sprintf(`
+data "google_project" "project" { }
 
 resource "google_storage_bucket" "test" {
   name = "%s"
   location = "US"
 }
+
+%s
 
 resource "google_pubsub_topic" "foo" {
   name = "%s"
@@ -543,6 +684,7 @@ resource "google_pubsub_subscription" "foo" {
     %s
     %s
     %s
+		%s
   }
 
   depends_on = [
@@ -550,7 +692,7 @@ resource "google_pubsub_subscription" "foo" {
     google_storage_bucket_iam_member.admin,
   ]
 }
-`, bucket, topic, subscription, filenamePrefixString, filenameSuffixString, filenameDatetimeString, maxBytesString, maxDurationString)
+`, bucket, serivceAccountResource, topic, subscription, filenamePrefixString, filenameSuffixString, filenameDatetimeString, maxBytesString, maxDurationString, serivceAccountEmailField)
 }
 
 func testAccPubsubSubscription_topicOnly(topic string) string {


### PR DESCRIPTION
Add Pub/Sub Subscription support for specifying a service account for BigQuery and Cloud Storage export subscriptions

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
pubsub: added `bigquery_config.service_account_email` field to `google_pubsub_subscription` resource
```
