### PR TITLE
Remove redundant `resource.TestStep`

### DIFF
--- a/mmv1/third_party/terraform/services/binaryauthorization/resource_binary_authorization_attestor_test.go.erb
+++ b/mmv1/third_party/terraform/services/binaryauthorization/resource_binary_authorization_attestor_test.go.erb
@@ -127,7 +127,7 @@ func TestAccBinaryAuthorizationAttestor_update(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckBinaryAuthorizationAttestorDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccBinaryAuthorizationAttestorBasic(name),
 			},
 			{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_autoscaler_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_autoscaler_test.go.erb
@@ -22,18 +22,18 @@ func TestAccComputeAutoscaler_update(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeAutoscalerDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeAutoscaler_basic(itName, tpName, igmName, autoscalerName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_autoscaler.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccComputeAutoscaler_update(itName, tpName, igmName, autoscalerName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_autoscaler.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -56,10 +56,10 @@ func TestAccComputeAutoscaler_multicondition(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeAutoscalerDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeAutoscaler_multicondition(itName, tpName, igmName, autoscalerName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_autoscaler.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -81,10 +81,10 @@ func TestAccComputeAutoscaler_scaleDownControl(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeAutoscalerDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeAutoscaler_scaleDownControl(itName, tpName, igmName, autoscalerName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_autoscaler.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -106,10 +106,10 @@ func TestAccComputeAutoscaler_scalingSchedule(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeAutoscalerDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeAutoscaler_scalingSchedule(itName, tpName, igmName, autoscalerName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_autoscaler.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -131,10 +131,10 @@ func TestAccComputeAutoscaler_scaleInControl(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeAutoscalerDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeAutoscaler_scaleInControl(itName, tpName, igmName, autoscalerName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_autoscaler.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -156,10 +156,10 @@ func TestAccComputeAutoscaler_scaleInControlFixed(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeAutoscalerDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeAutoscaler_scaleInControlFixed(itName, tpName, igmName, autoscalerName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_autoscaler.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.erb
@@ -21,19 +21,19 @@ func TestAccComputeBackendService_basic(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_basic(serviceName, checkName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_backend_service.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_basicModified(
 					serviceName, checkName, extraCheckName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_backend_service.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -54,20 +54,20 @@ func TestAccComputeBackendService_withBackend(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_withBackend(
 					serviceName, igName, itName, checkName, 10),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_backend_service.lipsum",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_withBackend(
 					serviceName, igName, itName, checkName, 20),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_backend_service.lipsum",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -86,26 +86,26 @@ func TestAccComputeBackendService_withBackendAndMaxUtilization(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_withBackend(
 					serviceName, igName, itName, checkName, 10),
 			},
-			resource.TestStep{
+			{
 				ResourceName:            "google_compute_backend_service.lipsum",
 				ImportState:             true,
 				ImportStateVerify:       true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_withBackendAndMaxUtilization(
 					serviceName, igName, itName, checkName, 10),
 				PlanOnly: true,
 				ExpectNonEmptyPlan: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_withBackendAndMaxUtilization(
 					serviceName, igName, itName, checkName, 10),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_backend_service.lipsum",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -124,21 +124,21 @@ func TestAccComputeBackendService_withBackendAndIAP(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_withBackendAndIAP(
 					serviceName, igName, itName, checkName, 10),
 			},
-			resource.TestStep{
+			{
 				ResourceName:            "google_compute_backend_service.lipsum",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"iap.0.oauth2_client_secret"},
 			},
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_withBackend(
 					serviceName, igName, itName, checkName, 10),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_backend_service.lipsum",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -158,20 +158,20 @@ func TestAccComputeBackendService_updatePreservesOptionalParameters(t *testing.T
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_withSessionAffinity(
 					serviceName, checkName, "initial-description", "GENERATED_COOKIE"),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_backend_service.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_withSessionAffinity(
 					serviceName, checkName, "updated-description", "GENERATED_COOKIE"),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_backend_service.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -191,10 +191,10 @@ func TestAccComputeBackendService_withConnectionDraining(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_withConnectionDraining(serviceName, checkName, 10),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_backend_service.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -214,18 +214,18 @@ func TestAccComputeBackendService_withConnectionDrainingAndUpdate(t *testing.T) 
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_withConnectionDraining(serviceName, checkName, 10),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_backend_service.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_basic(serviceName, checkName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_backend_service.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -245,10 +245,10 @@ func TestAccComputeBackendService_withHttpsHealthCheck(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_withHttpsHealthCheck(serviceName, checkName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_backend_service.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -356,11 +356,11 @@ func TestAccComputeBackendService_withCDNEnabled(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_withCDNEnabled(
 					serviceName, checkName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_backend_service.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -380,20 +380,20 @@ func TestAccComputeBackendService_withSessionAffinity(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_withSessionAffinity(
 					serviceName, checkName, "description", "CLIENT_IP"),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_backend_service.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_withSessionAffinity(
 					serviceName, checkName, "description", "GENERATED_COOKIE"),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_backend_service.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -413,11 +413,11 @@ func TestAccComputeBackendService_withAffinityCookieTtlSec(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_withAffinityCookieTtlSec(
 					serviceName, checkName, "description", "GENERATED_COOKIE", 300),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_backend_service.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -439,20 +439,20 @@ func TestAccComputeBackendService_withMaxConnections(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_withMaxConnections(
 					serviceName, igName, itName, checkName, 10),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_backend_service.lipsum",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_withMaxConnections(
 					serviceName, igName, itName, checkName, 20),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_backend_service.lipsum",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -474,20 +474,20 @@ func TestAccComputeBackendService_withMaxConnectionsPerInstance(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_withMaxConnectionsPerInstance(
 					serviceName, igName, itName, checkName, 10),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_backend_service.lipsum",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_withMaxConnectionsPerInstance(
 					serviceName, igName, itName, checkName, 20),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_backend_service.lipsum",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -581,18 +581,18 @@ func TestAccComputeBackendService_withCustomHeaders(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_withCustomHeaders(serviceName, checkName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_backend_service.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_basic(serviceName, checkName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_backend_service.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.erb
@@ -537,7 +537,7 @@ func TestAccComputeDisk_fromSnapshot(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeDiskDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeDisk_fromSnapshot(projectName, firstDiskName, snapshotName, diskName, "self_link"),
 			},
 			{
@@ -545,7 +545,7 @@ func TestAccComputeDisk_fromSnapshot(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccComputeDisk_fromSnapshot(projectName, firstDiskName, snapshotName, diskName, "name"),
 			},
 			{
@@ -568,7 +568,7 @@ func TestAccComputeDisk_encryption(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeDiskDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeDisk_encryption(diskName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeDiskExists(
@@ -668,7 +668,7 @@ func TestAccComputeDisk_deleteDetach(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeDiskDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeDisk_deleteDetach(instanceName, diskName),
 			},
 			{
@@ -680,7 +680,7 @@ func TestAccComputeDisk_deleteDetach(t *testing.T) {
 			// listed as attached to the disk; the instance is created after the
 			// disk. and the disk's properties aren't refreshed unless there's
 			// another step
-			resource.TestStep{
+			{
 				Config: testAccComputeDisk_deleteDetach(instanceName, diskName),
 			},
 			{
@@ -706,7 +706,7 @@ func TestAccComputeDisk_deleteDetachIGM(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeDiskDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeDisk_deleteDetachIGM(diskName, mgrName),
 			},
 			{
@@ -718,7 +718,7 @@ func TestAccComputeDisk_deleteDetachIGM(t *testing.T) {
 			// listed as attached to the disk; the instance is created after the
 			// disk. and the disk's properties aren't refreshed unless there's
 			// another step
-			resource.TestStep{
+			{
 				Config: testAccComputeDisk_deleteDetachIGM(diskName, mgrName),
 			},
 			{
@@ -727,7 +727,7 @@ func TestAccComputeDisk_deleteDetachIGM(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			// Change the disk name to recreate the instances
-			resource.TestStep{
+			{
 				Config: testAccComputeDisk_deleteDetachIGM(diskName2, mgrName),
 			},
 			{
@@ -736,7 +736,7 @@ func TestAccComputeDisk_deleteDetachIGM(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			// Add the extra step like before
-			resource.TestStep{
+			{
 				Config: testAccComputeDisk_deleteDetachIGM(diskName2, mgrName),
 			},
 			{
@@ -1308,7 +1308,7 @@ func TestAccComputeDisk_encryptionWithRSAEncryptedKey(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeDiskDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeDisk_encryptionWithRSAEncryptedKey(diskName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeDiskExists(

--- a/mmv1/third_party/terraform/services/compute/resource_compute_forwarding_rule_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_forwarding_rule_test.go.erb
@@ -20,19 +20,19 @@ func TestAccComputeForwardingRule_update(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeForwardingRuleDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeForwardingRule_basic(poolName, ruleName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_forwarding_rule.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
         ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
-			resource.TestStep{
+			{
 				Config: testAccComputeForwardingRule_update(poolName, ruleName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_forwarding_rule.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -56,19 +56,19 @@ func TestAccComputeForwardingRule_ip(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeForwardingRuleDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeForwardingRule_ip(addrName, poolName, ruleName, addressRefFieldID),
 			},
-			resource.TestStep{
+			{
 				ResourceName:            "google_compute_forwarding_rule.foobar",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"ip_address"}, // ignore ip_address because we've specified it by ID
 			},
-			resource.TestStep{
+			{
 				Config: testAccComputeForwardingRule_ip(addrName, poolName, ruleName, addressRefFieldRaw),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_forwarding_rule.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -124,11 +124,11 @@ func TestAccComputeForwardingRule_networkTier(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeForwardingRuleDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeForwardingRule_networkTier(poolName, ruleName),
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_forwarding_rule.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -151,11 +151,11 @@ func TestAccComputeForwardingRule_serviceDirectoryRegistrations(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeForwardingRuleDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeForwardingRule_serviceDirectoryRegistrations(poolName, ruleName, svcDirNamespace, serviceName),
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_forwarding_rule.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -177,10 +177,10 @@ func TestAccComputeForwardingRule_forwardingRuleVpcPscExampleUpdate(t *testing.T
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeForwardingRuleDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeForwardingRule_forwardingRuleVpcPscExample(context),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_forwarding_rule.default",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_global_address_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_global_address_test.go.erb
@@ -17,10 +17,10 @@ func TestAccComputeGlobalAddress_ipv6(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeGlobalAddressDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeGlobalAddress_ipv6(acctest.RandString(t, 10)),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_global_address.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -37,10 +37,10 @@ func TestAccComputeGlobalAddress_internal(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeGlobalAddressDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeGlobalAddress_internal(acctest.RandString(t, 10), acctest.RandString(t, 10)),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_global_address.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.erb
@@ -1529,12 +1529,12 @@ func expandAllInstancesConfig(old []interface{}, new []interface{}) *compute.Ins
 		for _, raw := range old {
 			if raw != nil {
 				data := raw.(map[string]interface{})
-				for k, _ := range data["metadata"].(map[string]interface{}) {
+				for k := range data["metadata"].(map[string]interface{}) {
 					if _, exist := properties.Metadata[k]; !exist {
 						properties.NullFields = append(properties.NullFields, fmt.Sprintf("Metadata.%s", k))
 					}
 				}
-				for k, _ := range data["labels"].(map[string]interface{}) {
+				for k := range data["labels"].(map[string]interface{}) {
 					if _, exist := properties.Labels[k]; !exist {
 						properties.NullFields = append(properties.NullFields, fmt.Sprintf("Labels.%s", k))
 					}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -906,17 +906,17 @@ func TestAccComputeInstance_with375GbScratchDisk(t *testing.T) {
 					testAccCheckComputeInstanceExists(
 						t, "google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceScratchDisk(&instance, []map[string]string{
-						map[string]string{
+						{
 							"interface": "NVME",
 						},
-						map[string]string{
+						{
 							"interface": "SCSI",
 						},
-						map[string]string{
+						{
 							"interface": "NVME",
 							"deviceName": "nvme-local-ssd",
 						},
-						map[string]string{
+						{
 							"interface": "SCSI",
 							"deviceName": "scsi-local-ssd",
 						},
@@ -948,22 +948,22 @@ func TestAccComputeInstance_with18TbScratchDisk(t *testing.T) {
 					testAccCheckComputeInstanceExists(
 						t, "google_compute_instance.foobar", &instance),
 					testAccCheckComputeInstanceScratchDisk(&instance, []map[string]string{
-						map[string]string{
+						{
 							"interface": "NVME",
 						},
-						map[string]string{
+						{
 							"interface": "NVME",
 						},
-						map[string]string{
+						{
 							"interface": "NVME",
 						},
-						map[string]string{
+						{
 							"interface": "NVME",
 						},
-						map[string]string{
+						{
 							"interface": "NVME",
 						},
-						map[string]string{
+						{
 							"interface": "NVME",
 						},
 					}),

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_autoscaler_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_autoscaler_test.go.erb
@@ -20,7 +20,7 @@ func TestAccComputeRegionAutoscaler_update(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeRegionAutoscalerDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeRegionAutoscaler_basic(itName, tpName, igmName, autoscalerName),
 			},
 			{
@@ -28,7 +28,7 @@ func TestAccComputeRegionAutoscaler_update(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccComputeRegionAutoscaler_update(itName, tpName, igmName, autoscalerName),
 			},
 			{
@@ -53,10 +53,10 @@ func TestAccComputeRegionAutoscaler_scaleDownControl(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeRegionAutoscalerDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeRegionAutoscaler_scaleDownControl(itName, tpName, igmName, autoscalerName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_region_autoscaler.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -78,10 +78,10 @@ func TestAccComputeRegionAutoscaler_scalingSchedule(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeRegionAutoscalerDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeRegionAutoscaler_scalingSchedule(itName, tpName, igmName, autoscalerName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_region_autoscaler.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -103,10 +103,10 @@ func TestAccComputeRegionAutoscaler_scaleInControl(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeRegionAutoscalerDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeRegionAutoscaler_scaleInControl(itName, tpName, igmName, autoscalerName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_region_autoscaler.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.erb
@@ -22,7 +22,7 @@ func TestAccComputeRegionBackendService_basic(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeRegionBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeRegionBackendService_basic(serviceName, checkName),
 			},
 			{
@@ -30,7 +30,7 @@ func TestAccComputeRegionBackendService_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccComputeRegionBackendService_basicModified(
 					serviceName, checkName, extraCheckName),
 			},
@@ -54,7 +54,7 @@ func TestAccComputeRegionBackendService_ilbBasic_withUnspecifiedProtocol(t *test
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeRegionBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeRegionBackendService_ilbBasic_withUnspecifiedProtocol(serviceName, checkName),
 			},
 			{
@@ -142,7 +142,7 @@ func TestAccComputeRegionBackendService_withBackendMultiNic(t *testing.T) {
                 ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
                 CheckDestroy:             testAccCheckComputeRegionBackendServiceDestroyProducer(t),
                 Steps: []resource.TestStep{
-                        resource.TestStep{
+                        {
                                 Config: testAccComputeRegionBackendService_withBackendMultiNic(
                                         serviceName, net1Name, net2Name, igName, itName, checkName, 10),
                         },
@@ -166,7 +166,7 @@ func TestAccComputeRegionBackendService_withConnectionDrainingAndUpdate(t *testi
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeRegionBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeRegionBackendService_withConnectionDraining(serviceName, checkName, 10),
 			},
 			{
@@ -174,7 +174,7 @@ func TestAccComputeRegionBackendService_withConnectionDrainingAndUpdate(t *testi
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccComputeRegionBackendService_basic(serviceName, checkName),
 			},
 			{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.erb
@@ -3405,7 +3405,7 @@ resource "google_compute_region_instance_template" "foobar" {
     automatic_restart = false
     provisioning_model = "SPOT"
     instance_termination_action = "DELETE"
-	<% unless version == 'ga' -%>
+<% unless version == 'ga' -%>
     max_run_duration {
 	nanos = 123
 	seconds = 60

--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -35,35 +35,35 @@ func schemaContainerdConfig() *schema.Schema {
 		Description: "Parameters for containerd configuration.",
 		MaxItems:    1,
 		Elem: &schema.Resource{Schema: map[string]*schema.Schema{
-			"private_registry_access_config": &schema.Schema{
+			"private_registry_access_config": {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Description: "Parameters for private container registries configuration.",
 				MaxItems:    1,
 				Elem: &schema.Resource{Schema: map[string]*schema.Schema{
-					"enabled": &schema.Schema{
+					"enabled": {
 						Type:        schema.TypeBool,
 						Required:    true,
 						Description: "Whether or not private registries are configured.",
 					},
-					"certificate_authority_domain_config": &schema.Schema{
+					"certificate_authority_domain_config": {
 						Type:        schema.TypeList,
 						Optional:    true,
 						Description: "Parameters for configuring CA certificate and domains.",
 						Elem: &schema.Resource{Schema: map[string]*schema.Schema{
-							"fqdns": &schema.Schema{
+							"fqdns": {
 								Type:        schema.TypeList,
 								Required:    true,
 								Description: "List of fully-qualified-domain-names. IPv4s and port specification are supported.",
 								Elem:        &schema.Schema{Type: schema.TypeString},
 							},
-							"gcp_secret_manager_certificate_config": &schema.Schema{
+							"gcp_secret_manager_certificate_config": {
 								Type:        schema.TypeList,
 								Required:    true,
 								Description: "Parameters for configuring a certificate hosted in GCP SecretManager.",
 								MaxItems:    1,
 								Elem: &schema.Resource{Schema: map[string]*schema.Schema{
-									"secret_uri": &schema.Schema{
+									"secret_uri": {
 										Type:        schema.TypeString,
 										Required:    true,
 										Description: "URI for the secret that hosts a certificate. Must be in the format 'projects/PROJECT_NUM/secrets/SECRET_NAME/versions/VERSION_OR_LATEST'.",
@@ -134,7 +134,7 @@ func schemaNodeConfig() *schema.Schema {
 					Description:  `Type of the disk attached to each node. Such as pd-standard, pd-balanced or pd-ssd`,
 				},
 
-				"guest_accelerator": &schema.Schema{
+				"guest_accelerator": {
 					Type:     schema.TypeList,
 					Optional: true,
 					Computed: true,
@@ -145,20 +145,20 @@ func schemaNodeConfig() *schema.Schema {
 					Description: `List of the type and count of accelerator cards attached to the instance.`,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
-							"count": &schema.Schema{
+							"count": {
 								Type:     schema.TypeInt,
 								Required: true,
 								ForceNew: true,
 								Description: `The number of the accelerator cards exposed to an instance.`,
 							},
-							"type": &schema.Schema{
+							"type": {
 								Type:             schema.TypeString,
 								Required:         true,
 								ForceNew:         true,
 								DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName,
 								Description: `The accelerator type resource name.`,
 							},
-							"gpu_driver_installation_config": &schema.Schema{
+							"gpu_driver_installation_config": {
 								Type:         schema.TypeList,
 								MaxItems:     1,
 								Optional:     true,
@@ -167,7 +167,7 @@ func schemaNodeConfig() *schema.Schema {
 								Description:  `Configuration for auto installation of GPU driver.`,
 								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
-										"gpu_driver_version": &schema.Schema{
+										"gpu_driver_version": {
 											Type:         schema.TypeString,
 											Required:     true,
 											ForceNew:     true,
@@ -177,13 +177,13 @@ func schemaNodeConfig() *schema.Schema {
 									},
 								},
 							},
-							"gpu_partition_size": &schema.Schema{
+							"gpu_partition_size": {
 								Type:             schema.TypeString,
 								Optional:         true,
 								ForceNew:         true,
 								Description: `Size of partitions to create on the GPU. Valid values are described in the NVIDIA mig user guide (https://docs.nvidia.com/datacenter/tesla/mig-user-guide/#partitioning)`,
 							},
-							"gpu_sharing_config": &schema.Schema{
+							"gpu_sharing_config": {
 								Type:         schema.TypeList,
 								MaxItems:     1,
 								Optional:     true,
@@ -192,13 +192,13 @@ func schemaNodeConfig() *schema.Schema {
 								Description:  `Configuration for GPU sharing.`,
 								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
-										"gpu_sharing_strategy": &schema.Schema{
+										"gpu_sharing_strategy": {
 											Type:        schema.TypeString,
 											Required:    true,
 											ForceNew:    true,
 											Description: `The type of GPU sharing strategy to enable on the GPU node. Possible values are described in the API package (https://pkg.go.dev/google.golang.org/api/container/v1#GPUSharingConfig)`,
 										},
-										"max_shared_clients_per_gpu": &schema.Schema{
+										"max_shared_clients_per_gpu": {
 											Type:        schema.TypeInt,
 											Required:    true,
 											ForceNew:    true,
@@ -322,7 +322,7 @@ func schemaNodeConfig() *schema.Schema {
 								ForceNew:     true,
 								Description:  `Disk image to create the secondary boot disk from`,
 							},
-							"mode": &schema.Schema{
+							"mode": {
 								Type:         schema.TypeString,
 								Optional:     true,
 								ForceNew:     true,
@@ -455,7 +455,7 @@ func schemaNodeConfig() *schema.Schema {
 					Description: `The list of instance tags applied to all nodes.`,
 				},
 
-				"shielded_instance_config": &schema.Schema{
+				"shielded_instance_config": {
 					Type:     schema.TypeList,
 					Optional: true,
 					Computed: true,
@@ -641,7 +641,7 @@ func schemaNodeConfig() *schema.Schema {
 					Description: `Setting this field will assign instances of this pool to run on the specified node group. This is useful for running workloads on sole tenant nodes.`,
 				},
 
-				"advanced_machine_features": &schema.Schema{
+				"advanced_machine_features": {
 					Type:        schema.TypeList,
 					Optional:    true,
 					MaxItems:    1,

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -629,7 +629,7 @@ func ResourceContainerCluster() *schema.Resource {
 										ForceNew:    true,
 										Description: `The Customer Managed Encryption Key used to encrypt the boot disk attached to each node in the node pool.`,
 									},
-									"shielded_instance_config": &schema.Schema{
+									"shielded_instance_config": {
 										Type:        schema.TypeList,
 										Optional:    true,
 										Description: `Shielded Instance options.`,

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_migratev1.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_migratev1.go.erb
@@ -398,7 +398,7 @@ func resourceContainerClusterResourceV1() *schema.Resource {
 										ForceNew:    true,
 										Description: `The Customer Managed Encryption Key used to encrypt the boot disk attached to each node in the node pool.`,
 									},
-									"shielded_instance_config": &schema.Schema{
+									"shielded_instance_config": {
 										Type:        schema.TypeList,
 										Optional:    true,
 										Description: `Shielded Instance options.`,

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -2059,7 +2059,7 @@ func TestAccContainerCluster_withNodePoolAutoscaling(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckContainerNodePoolDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccContainerCluster_withNodePoolAutoscaling(clusterName, npName, networkName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.with_node_pool", "node_pool.0.autoscaling.0.min_node_count", "1"),
@@ -2072,7 +2072,7 @@ func TestAccContainerCluster_withNodePoolAutoscaling(t *testing.T) {
 				ImportStateVerify:	 true,
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
-			resource.TestStep{
+			{
 				Config: testAccContainerCluster_withNodePoolUpdateAutoscaling(clusterName, npName, networkName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.with_node_pool", "node_pool.0.autoscaling.0.min_node_count", "1"),
@@ -2085,7 +2085,7 @@ func TestAccContainerCluster_withNodePoolAutoscaling(t *testing.T) {
 				ImportStateVerify:	 true,
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
-			resource.TestStep{
+			{
 				Config: testAccContainerCluster_withNodePoolBasic(clusterName, npName, networkName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckNoResourceAttr("google_container_cluster.with_node_pool", "node_pool.0.autoscaling.0.min_node_count"),
@@ -2115,7 +2115,7 @@ func TestAccContainerCluster_withNodePoolCIA(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy: testAccCheckContainerNodePoolDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccContainerRegionalCluster_withNodePoolCIA(clusterName, npName, networkName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.with_node_pool", "node_pool.0.autoscaling.0.min_node_count", "0"),
@@ -2131,7 +2131,7 @@ func TestAccContainerCluster_withNodePoolCIA(t *testing.T) {
 				ImportStateVerify:	 true,
 				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
 			},
-			resource.TestStep{
+			{
 				Config: testAccContainerRegionalClusterUpdate_withNodePoolCIA(clusterName, npName, networkName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.with_node_pool", "node_pool.0.autoscaling.0.min_node_count", "0"),
@@ -2147,7 +2147,7 @@ func TestAccContainerCluster_withNodePoolCIA(t *testing.T) {
 				ImportStateVerify:	 true,
 				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
 			},
-			resource.TestStep{
+			{
 				Config: testAccContainerRegionalCluster_withNodePoolBasic(clusterName, npName, networkName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckNoResourceAttr("google_container_cluster.with_node_pool", "node_pool.0.autoscaling.0.min_node_count"),
@@ -10768,7 +10768,7 @@ func TestAccContainerCluster_privateRegistry(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccContainerCluster_privateRegistryEnabled(secretID, clusterName, networkName, subnetworkName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(
@@ -10816,7 +10816,7 @@ func TestAccContainerCluster_privateRegistry(t *testing.T) {
 					),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccContainerCluster_withNodePoolPrivateRegistry(secretID, clusterName, nodePoolName, networkName, subnetworkName),
 			},
 			{
@@ -10825,7 +10825,7 @@ func TestAccContainerCluster_privateRegistry(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
-			resource.TestStep{
+			{
 				Config: testAccContainerCluster_withNodeConfigPrivateRegistry(secretID, clusterName, networkName, subnetworkName),
 			},
 			{

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
@@ -134,42 +134,42 @@ var schemaBlueGreenSettings = &schema.Schema{
 }
 
 var schemaNodePool = map[string]*schema.Schema{
-	"autoscaling": &schema.Schema{
+	"autoscaling": {
 		Type:        schema.TypeList,
 		Optional:    true,
 		MaxItems:    1,
 		Description: `Configuration required by cluster autoscaler to adjust the size of the node pool to the current cluster usage.`,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"min_node_count": &schema.Schema{
+				"min_node_count": {
 					Type:         schema.TypeInt,
 					Optional:     true,
 					ValidateFunc: validation.IntAtLeast(0),
 					Description:  `Minimum number of nodes per zone in the node pool. Must be >=0 and <= max_node_count. Cannot be used with total limits.`,
 				},
 
-				"max_node_count": &schema.Schema{
+				"max_node_count": {
 					Type:         schema.TypeInt,
 					Optional:     true,
 					ValidateFunc: validation.IntAtLeast(0),
 					Description:  `Maximum number of nodes per zone in the node pool. Must be >= min_node_count. Cannot be used with total limits.`,
 				},
 
-				"total_min_node_count": &schema.Schema{
+				"total_min_node_count": {
 					Type:         schema.TypeInt,
 					Optional:     true,
 					ValidateFunc: validation.IntAtLeast(0),
 					Description:  `Minimum number of all nodes in the node pool. Must be >=0 and <= total_max_node_count. Cannot be used with per zone limits.`,
 				},
 
-				"total_max_node_count": &schema.Schema{
+				"total_max_node_count": {
 					Type:         schema.TypeInt,
 					Optional:     true,
 					ValidateFunc: validation.IntAtLeast(0),
 					Description:  `Maximum number of all nodes in the node pool. Must be >= total_min_node_count. Cannot be used with per zone limits.`,
 				},
 
-				"location_policy": &schema.Schema{
+				"location_policy": {
 					Type:         schema.TypeString,
 					Optional:     true,
 					Computed:     true,
@@ -226,7 +226,7 @@ var schemaNodePool = map[string]*schema.Schema{
 		},
 	},
 
-	"max_pods_per_node": &schema.Schema{
+	"max_pods_per_node": {
 		Type:        schema.TypeInt,
 		Optional:    true,
 		ForceNew:    true,
@@ -279,7 +279,7 @@ var schemaNodePool = map[string]*schema.Schema{
 		},
 	},
 
-	"initial_node_count": &schema.Schema{
+	"initial_node_count": {
 		Type:        schema.TypeInt,
 		Optional:    true,
 		ForceNew:    true,
@@ -326,7 +326,7 @@ var schemaNodePool = map[string]*schema.Schema{
 		},
 	},
 
-	"name": &schema.Schema{
+	"name": {
 		Type:        schema.TypeString,
 		Optional:    true,
 		Computed:    true,
@@ -334,7 +334,7 @@ var schemaNodePool = map[string]*schema.Schema{
 		Description: `The name of the node pool. If left blank, Terraform will auto-generate a unique name.`,
 	},
 
-	"name_prefix": &schema.Schema{
+	"name_prefix": {
 		Type:        schema.TypeString,
 		Optional:    true,
 		Computed:    true,

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -25,10 +25,10 @@ func TestAccContainerNodePool_basic(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_basic(cluster, np, networkName, subnetworkName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_container_node_pool.np",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -180,10 +180,10 @@ func TestAccContainerNodePool_namePrefix(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_namePrefix(cluster, "tf-np-", networkName, subnetworkName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:            "google_container_node_pool.np",
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -207,10 +207,10 @@ func TestAccContainerNodePool_noName(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_noName(cluster, networkName, subnetworkName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_container_node_pool.np",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -273,10 +273,10 @@ func TestAccContainerNodePool_withNodeConfig(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_withNodeConfig(cluster, nodePool, networkName, subnetworkName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_container_node_pool.np_with_node_config",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -284,10 +284,10 @@ func TestAccContainerNodePool_withNodeConfig(t *testing.T) {
 				// but will still cause an import diff
 				ImportStateVerifyIgnore: []string{"autoscaling.#", "node_config.0.taint"},
 			},
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_withNodeConfigUpdate(cluster, nodePool, networkName, subnetworkName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_container_node_pool.np_with_node_config",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -312,18 +312,18 @@ func TestAccContainerNodePool_withTaintsUpdate(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_basic(cluster, nodePool, networkName, subnetworkName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_container_node_pool.np",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_withTaintsUpdate(cluster, nodePool, networkName, subnetworkName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_container_node_pool.np",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -926,10 +926,10 @@ func TestAccContainerNodePool_withGPU(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_withGPU(cluster, np, networkName, subnetworkName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_container_node_pool.np_with_gpu",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -957,7 +957,7 @@ func TestAccContainerNodePool_withManagement(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_withManagement(cluster, nodePool, "", networkName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
@@ -968,12 +968,12 @@ func TestAccContainerNodePool_withManagement(t *testing.T) {
 						"google_container_node_pool.np_with_management", "management.0.auto_upgrade", "true"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_container_node_pool.np_with_management",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_withManagement(cluster, nodePool, management, networkName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
@@ -984,7 +984,7 @@ func TestAccContainerNodePool_withManagement(t *testing.T) {
 						"google_container_node_pool.np_with_management", "management.0.auto_upgrade", "false"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_container_node_pool.np_with_management",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -1006,10 +1006,10 @@ func TestAccContainerNodePool_withNodeConfigScopeAlias(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_withNodeConfigScopeAlias(cluster, np, networkName, subnetworkName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_container_node_pool.np_with_node_config_scope_alias",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -1032,38 +1032,38 @@ func TestAccContainerNodePool_regionalAutoscaling(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_regionalAutoscaling(cluster, np, networkName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_node_pool.np", "autoscaling.0.min_node_count", "1"),
 					resource.TestCheckResourceAttr("google_container_node_pool.np", "autoscaling.0.max_node_count", "3"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_container_node_pool.np",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_updateAutoscaling(cluster, np, networkName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_node_pool.np", "autoscaling.0.min_node_count", "0"),
 					resource.TestCheckResourceAttr("google_container_node_pool.np", "autoscaling.0.max_node_count", "5"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_container_node_pool.np",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_basic(cluster, np, networkName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckNoResourceAttr("google_container_node_pool.np", "autoscaling.0.min_node_count"),
 					resource.TestCheckNoResourceAttr("google_container_node_pool.np", "autoscaling.0.max_node_count"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_container_node_pool.np",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -1089,7 +1089,7 @@ func TestAccContainerNodePool_totalSize(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_totalSize(cluster, np, networkName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_node_pool.np", "autoscaling.0.total_min_node_count", "4"),
@@ -1097,12 +1097,12 @@ func TestAccContainerNodePool_totalSize(t *testing.T) {
 					resource.TestCheckResourceAttr("google_container_node_pool.np", "autoscaling.0.location_policy", "BALANCED"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_container_node_pool.np",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_updateTotalSize(cluster, np, networkName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_node_pool.np", "autoscaling.0.total_min_node_count", "2"),
@@ -1110,19 +1110,19 @@ func TestAccContainerNodePool_totalSize(t *testing.T) {
 					resource.TestCheckResourceAttr("google_container_node_pool.np", "autoscaling.0.location_policy", "ANY"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_container_node_pool.np",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_basicTotalSize(cluster, np, networkName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckNoResourceAttr("google_container_node_pool.np", "autoscaling.0.min_node_count"),
 					resource.TestCheckNoResourceAttr("google_container_node_pool.np", "autoscaling.0.max_node_count"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_container_node_pool.np",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -1147,38 +1147,38 @@ func TestAccContainerNodePool_autoscaling(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_autoscaling(cluster, np, networkName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_node_pool.np", "autoscaling.0.min_node_count", "1"),
 					resource.TestCheckResourceAttr("google_container_node_pool.np", "autoscaling.0.max_node_count", "3"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_container_node_pool.np",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_updateAutoscaling(cluster, np, networkName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_node_pool.np", "autoscaling.0.min_node_count", "0"),
 					resource.TestCheckResourceAttr("google_container_node_pool.np", "autoscaling.0.max_node_count", "5"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_container_node_pool.np",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_basic(cluster, np, networkName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckNoResourceAttr("google_container_node_pool.np", "autoscaling.0.min_node_count"),
 					resource.TestCheckNoResourceAttr("google_container_node_pool.np", "autoscaling.0.max_node_count"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_container_node_pool.np",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -1283,10 +1283,10 @@ func TestAccContainerNodePool_regionalClusters(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_regionalClusters(cluster, np, networkName, subnetworkName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_container_node_pool.np",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -1388,10 +1388,10 @@ func TestAccContainerNodePool_shieldedInstanceConfig(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_shieldedInstanceConfig(cluster, np, networkName, subnetworkName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:            "google_container_node_pool.np",
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -1486,10 +1486,10 @@ func TestAccContainerNodePool_ephemeralStorageConfig(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_ephemeralStorageConfig(cluster, np, networkName, subnetworkName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:            "google_container_node_pool.np",
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -1657,15 +1657,15 @@ func TestAccContainerNodePool_secondaryBootDisks(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_secondaryBootDisks(cluster, np, networkName, subnetworkName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:            "google_container_node_pool.np",
 				ImportState:             true,
 				ImportStateVerify:       true,
 			},
-			resource.TestStep{
+			{
 				ResourceName:            "google_container_node_pool.np-no-mode",
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -1738,10 +1738,10 @@ func TestAccContainerNodePool_gcfsConfig(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_gcfsConfig(cluster, np, networkName, subnetworkName),
 			},
-			resource.TestStep{
+			{
 				ResourceName:            "google_container_node_pool.np",
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -4772,7 +4772,7 @@ func TestAccContainerNodePool_privateRegistry(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccContainerNodePool_privateRegistryEnabled(secretID, cluster, nodepool, networkName, subnetworkName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(

--- a/mmv1/third_party/terraform/services/dns/resource_dns_managed_zone_test.go.erb
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_managed_zone_test.go.erb
@@ -57,18 +57,18 @@ func TestAccDNSManagedZone_privateUpdate(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDNSManagedZoneDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDnsManagedZone_privateUpdate(zoneSuffix, "network-1", "network-2"),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_dns_managed_zone.private",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccDnsManagedZone_privateUpdate(zoneSuffix, "network-2", "network-3"),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_dns_managed_zone.private",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -87,18 +87,18 @@ func TestAccDNSManagedZone_dnssec_update(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDNSManagedZoneDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDnsManagedZone_dnssec_on(zoneSuffix),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_dns_managed_zone.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccDnsManagedZone_dnssec_off(zoneSuffix),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_dns_managed_zone.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -117,10 +117,10 @@ func TestAccDNSManagedZone_dnssec_empty(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDNSManagedZoneDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDnsManagedZone_dnssec_empty(zoneSuffix),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_dns_managed_zone.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -139,18 +139,18 @@ func TestAccDNSManagedZone_privateForwardingUpdate(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDNSManagedZoneDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDnsManagedZone_privateForwardingUpdate(zoneSuffix, "172.16.1.10", "172.16.1.20", "default", "private"),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_dns_managed_zone.private",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccDnsManagedZone_privateForwardingUpdate(zoneSuffix, "172.16.1.10", "192.168.1.1", "private", "default"),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_dns_managed_zone.private",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -211,10 +211,10 @@ func TestAccDNSManagedZone_reverseLookup(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDNSManagedZoneDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDnsManagedZone_reverseLookup(zoneSuffix),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_dns_managed_zone.reverse",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/mmv1/third_party/terraform/services/dns/resource_dns_policy_test.go.erb
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_policy_test.go.erb
@@ -19,18 +19,18 @@ func TestAccDNSPolicy_update(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDNSPolicyDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDnsPolicy_privateUpdate(policySuffix, "true", "172.16.1.10", "172.16.1.30", "network-1"),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_dns_policy.example-policy",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccDnsPolicy_privateUpdate(policySuffix, "false", "172.16.1.20", "172.16.1.40", "network-2"),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_dns_policy.example-policy",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/mmv1/third_party/terraform/services/dns/resource_dns_response_policy_rule_test.go.erb
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_response_policy_rule_test.go.erb
@@ -20,18 +20,18 @@ func TestAccDNSResponsePolicyRule_update(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 		CheckDestroy:             testAccCheckDNSResponsePolicyRuleDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDnsResponsePolicyRule_privateUpdate(responsePolicyRuleSuffix, "network-1"),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_dns_response_policy_rule.example-response-policy-rule",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccDnsResponsePolicyRule_privateUpdate(responsePolicyRuleSuffix, "network-2"),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_dns_response_policy_rule.example-response-policy-rule",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/mmv1/third_party/terraform/services/dns/resource_dns_response_policy_test.go.erb
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_response_policy_test.go.erb
@@ -20,26 +20,26 @@ func TestAccDNSResponsePolicy_update(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 		CheckDestroy:             testAccCheckDNSResponsePolicyDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDnsResponsePolicy_privateUpdate(responsePolicySuffix, "network-1"),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_dns_response_policy.example-response-policy",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccDnsResponsePolicy_privateUpdate(responsePolicySuffix, "network-2"),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_dns_response_policy.example-response-policy",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccDnsResponsePolicy_removeNetworks(responsePolicySuffix),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_dns_response_policy.example-response-policy",
 				ImportState:       true,
 				ImportStateVerify: true,


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Remove redundant `resource.TestStep`, which is causing the diffs when converting the handwritten files, as the Go code uses [format library](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/provider/template_data.go#L191), and the ruby code uses [format command](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/provider/file_template.rb#L87).

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
