### PR TITLE
Add resource tags to BigQuery Dataset in the Beta provider

### DIFF
--- a/mmv1/products/bigquery/Dataset.yaml
+++ b/mmv1/products/bigquery/Dataset.yaml
@@ -90,6 +90,19 @@ examples:
     skip_test: true
     vars:
       dataset_id: 'example_dataset'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'bigquery_dataset_resource_tags'
+    min_version: beta
+    primary_resource_id: 'dataset'
+    primary_resource_name:
+      'fmt.Sprintf("tf_test_dataset%s", context["random_suffix"])'
+    skip_docs: true
+    vars:
+      dataset_id: 'dataset'
+      tag_key1: 'tag_key1'
+      tag_value1: 'tag_value1'
+      tag_key2: 'tag_key2'
+      tag_value2: 'tag_value2'
 virtual_fields:
   - !ruby/object:Api::Type::Boolean
     name: 'delete_contents_on_destroy'
@@ -400,3 +413,12 @@ properties:
 
       LOGICAL is the default if this flag isn't specified.
     default_from_api: true
+  - !ruby/object:Api::Type::KeyValuePairs
+    name: 'resourceTags'
+    min_version: beta
+    description: |
+      The tags attached to this table. Tag keys are globally unique. Tag key is expected to be
+      in the namespaced format, for example "123456789012/environment" where 123456789012 is the
+      ID of the parent organization or project resource for this tag key. Tag value is expected
+      to be the short name, for example "Production". See [Tag definitions](/iam/docs/tags-access-control#definitions)
+      for more details.

--- a/mmv1/templates/terraform/examples/bigquery_dataset_resource_tags.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_dataset_resource_tags.tf.erb
@@ -1,0 +1,41 @@
+data "google_project" "project" {
+  provider = "google-beta"
+}
+
+resource "google_tags_tag_key" "tag_key1" {
+  provider = "google-beta"
+  parent = "projects/${data.google_project.project.number}"
+  short_name = "<%= ctx[:vars]['tag_key1'] %>"
+}
+
+resource "google_tags_tag_value" "tag_value1" {
+  provider = "google-beta"
+  parent = "tagKeys/${google_tags_tag_key.tag_key1.name}"
+  short_name = "<%= ctx[:vars]['tag_value1'] %>"
+}
+
+resource "google_tags_tag_key" "tag_key2" {
+  provider = "google-beta"
+  parent = "projects/${data.google_project.project.number}"
+  short_name = "<%= ctx[:vars]['tag_key2'] %>"
+}
+
+resource "google_tags_tag_value" "tag_value2" {
+  provider = "google-beta"
+  parent = "tagKeys/${google_tags_tag_key.tag_key2.name}"
+  short_name = "<%= ctx[:vars]['tag_value2'] %>"
+}
+
+resource "google_bigquery_dataset" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+
+  dataset_id                  = "<%= ctx[:vars]['dataset_id'] %>"
+  friendly_name               = "test"
+  description                 = "This is a test description"
+  location                    = "EU"
+
+  resource_tags = {
+    "${data.google_project.project.project_id}/${google_tags_tag_key.tag_key1.short_name}" = "${google_tags_tag_value.tag_value1.short_name}"
+    "${data.google_project.project.project_id}/${google_tags_tag_key.tag_key2.short_name}" = "${google_tags_tag_value.tag_value2.short_name}"
+  }
+}

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_dataset_test.go.erb
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_dataset_test.go.erb
@@ -1,3 +1,6 @@
+<% autogen_exception -%>
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
 package bigquery_test
 
 import (
@@ -418,6 +421,42 @@ func TestAccBigQueryDataset_invalidLongID(t *testing.T) {
 	})
 }
 
+<% unless version == 'ga' -%>
+func TestAccBigQueryDataset_bigqueryDatasetResourceTags_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckBigQueryDatasetDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryDataset_bigqueryDatasetResourceTags_basic(context),
+			},
+			{
+				ResourceName:            "google_bigquery_dataset.dataset",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccBigQueryDataset_bigqueryDatasetResourceTags_update(context),
+			},
+			{
+				ResourceName:            "google_bigquery_dataset.dataset",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+<% end -%>
 func testAccAddTable(t *testing.T, datasetID string, tableID string) resource.TestCheckFunc {
 	// Not actually a check, but adds a table independently of terraform
 	return func(s *terraform.State) error {
@@ -735,3 +774,95 @@ resource "google_bigquery_dataset" "test" {
 }
 `, datasetID)
 }
+<% unless version == 'ga' -%>
+
+func testAccBigQueryDataset_bigqueryDatasetResourceTags_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+  provider = "google-beta"
+}
+
+resource "google_tags_tag_key" "tag_key1" {
+  provider = google-beta
+  parent = "projects/${data.google_project.project.number}"
+  short_name = "tf_test_tag_key1%{random_suffix}"
+}
+
+resource "google_tags_tag_value" "tag_value1" {
+  provider = google-beta
+  parent = "tagKeys/${google_tags_tag_key.tag_key1.name}"
+  short_name = "tf_test_tag_value1%{random_suffix}"
+}
+
+resource "google_tags_tag_key" "tag_key2" {
+  provider = google-beta
+  parent = "projects/${data.google_project.project.number}"
+  short_name = "tf_test_tag_key2%{random_suffix}"
+}
+
+resource "google_tags_tag_value" "tag_value2" {
+  provider = google-beta
+  parent = "tagKeys/${google_tags_tag_key.tag_key2.name}"
+  short_name = "tf_test_tag_value2%{random_suffix}"
+}
+
+resource "google_bigquery_dataset" "dataset" {
+  provider = google-beta
+
+  dataset_id                  = "dataset%{random_suffix}"
+  friendly_name               = "test"
+  description                 = "This is a test description"
+  location                    = "EU"
+
+  resource_tags = {
+    "${data.google_project.project.project_id}/${google_tags_tag_key.tag_key1.short_name}" = "${google_tags_tag_value.tag_value1.short_name}"
+    "${data.google_project.project.project_id}/${google_tags_tag_key.tag_key2.short_name}" = "${google_tags_tag_value.tag_value2.short_name}"
+  }
+}
+`, context)
+}
+
+func testAccBigQueryDataset_bigqueryDatasetResourceTags_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+  provider = "google-beta"
+}
+
+resource "google_tags_tag_key" "tag_key1" {
+  provider = google-beta
+  parent = "projects/${data.google_project.project.number}"
+  short_name = "tf_test_tag_key1%{random_suffix}"
+}
+
+resource "google_tags_tag_value" "tag_value1" {
+  provider = google-beta
+  parent = "tagKeys/${google_tags_tag_key.tag_key1.name}"
+  short_name = "tf_test_tag_value1%{random_suffix}"
+}
+
+resource "google_tags_tag_key" "tag_key2" {
+  provider = google-beta
+  parent = "projects/${data.google_project.project.number}"
+  short_name = "tf_test_tag_key2%{random_suffix}"
+}
+
+resource "google_tags_tag_value" "tag_value2" {
+  provider = google-beta
+  parent = "tagKeys/${google_tags_tag_key.tag_key2.name}"
+  short_name = "tf_test_tag_value2%{random_suffix}"
+}
+
+resource "google_bigquery_dataset" "dataset" {
+  provider = google-beta
+
+  dataset_id                  = "dataset%{random_suffix}"
+  friendly_name               = "test"
+  description                 = "This is a test description"
+  location                    = "EU"
+
+  resource_tags = {
+  }
+}
+`, context)
+}
+<% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds support for resource tags to BigQuery Dataset in the Beta provider.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigquery: added `resource_tags` field to `google_bigquery_dataset` resource (beta)
```
