### PR TITLE
add update support to big_query field on google_vertex_ai_feature_group resource

### DIFF
--- a/mmv1/products/vertexai/FeatureGroup.yaml
+++ b/mmv1/products/vertexai/FeatureGroup.yaml
@@ -90,6 +90,8 @@ properties:
   - !ruby/object:Api::Type::NestedObject
     name: bigQuery
     description: Indicates that features for this group come from BigQuery Table/View. By default treats the source as a sparse time series source, which is required to have an entityId and a feature_timestamp column in the source.
+    update_mask_fields:
+      - 'bigQuery.entityIdColumns'
     properties:
       - !ruby/object:Api::Type::NestedObject
         name: bigQuerySource
@@ -103,5 +105,5 @@ properties:
             description: 'BigQuery URI to a table, up to 2000 characters long. For example: `bq://projectId.bqDatasetId.bqTableId.`'
       - !ruby/object:Api::Type::Array
         name: entityIdColumns
-        description: Columns to construct entityId / row keys. Currently only supports 1 entity_id_column. If not provided defaults to entityId.
+        description: Columns to construct entityId / row keys. If not provided defaults to entityId.
         item_type: Api::Type::String

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_feature_group_test.go
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_feature_group_test.go
@@ -79,6 +79,12 @@ resource "google_bigquery_table" "sample_table" {
         "mode": "NULLABLE"
     },
     {
+        "name": "test_entity_column",
+        "type": "STRING",
+        "mode": "NULLABLE",
+        "description": "test secondary entity column"
+    },
+    {
         "name": "feature_timestamp",
         "type": "TIMESTAMP",
         "mode": "NULLABLE"
@@ -103,7 +109,7 @@ func testAccVertexAIFeatureGroup_updated(context map[string]interface{}) string 
     big_query_source {
         input_uri = "bq://${google_bigquery_table.sample_table.project}.${google_bigquery_table.sample_table.dataset_id}.${google_bigquery_table.sample_table.table_id}"
     }
-    entity_id_columns = ["feature_id"]
+    entity_id_columns = ["feature_id","test_entity_column"]
   }
 }
 
@@ -125,6 +131,12 @@ resource "google_bigquery_table" "sample_table" {
         "name": "feature_id",
         "type": "STRING",
         "mode": "NULLABLE"
+    },
+    {
+        "name": "test_entity_column",
+        "type": "STRING",
+        "mode": "NULLABLE",
+        "description": "test secondary entity column"
     },
     {
         "name": "feature_timestamp",


### PR DESCRIPTION
Add update_mask_fields to bigquery nestedfield on feature_group resource 


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
vertexai: added update support for `big_query.entity_id_columns` field on `google_vertex_ai_feature_group` resource
```
