### PR TITLE
Add support for CMEK datasets to terraform.

### DIFF
--- a/mmv1/products/healthcare/Dataset.yaml
+++ b/mmv1/products/healthcare/Dataset.yaml
@@ -35,6 +35,15 @@ examples:
       dataset_name: 'example-dataset'
       location: 'us-central1'
       time_zone: 'America/New_York'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'healthcare_dataset_cmek'
+    primary_resource_id: 'default'
+    vars:
+      dataset_name: 'example-dataset'
+      location: 'us-central1'
+      time_zone: 'America/New_York'
+      key_name: 'example-key'
+      keyring_name: 'example-keyring'
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   decoder: templates/terraform/decoders/long_name_to_self_link.go.erb
 parameters:
@@ -66,3 +75,18 @@ properties:
       The fully qualified name of this dataset
     output: true
     ignore_read: true
+  - !ruby/object:Api::Type::NestedObject
+    name: 'encryptionSpec'
+    required: false
+    immutable: true
+    default_from_api: true
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'kmsKeyName'
+        description: |
+          KMS encryption key that is used to secure this dataset and its sub-resources. The key used for
+          encryption and the dataset must be in the same location. If empty, the default Google encryption
+          key will be used to secure this dataset. The format is
+          projects/{projectId}/locations/{locationId}/keyRings/{keyRingId}/cryptoKeys/{keyId}.
+        required: false
+        immutable: true

--- a/mmv1/templates/terraform/examples/healthcare_dataset_cmek.tf.erb
+++ b/mmv1/templates/terraform/examples/healthcare_dataset_cmek.tf.erb
@@ -1,0 +1,36 @@
+data "google_project" "project" {}
+
+resource "google_healthcare_dataset" "default" {
+  name      = "<%= ctx[:vars]['dataset_name'] %>"
+  location  = "us-central1"
+  time_zone = "UTC"
+
+  encryption_spec {
+    kms_key_name = google_kms_crypto_key.crypto_key.id
+  }
+
+  depends_on = [
+    google_kms_crypto_key_iam_binding.healthcare_cmek_keyuser
+  ]
+}
+
+resource "google_kms_crypto_key" "crypto_key" {
+  name     = "<%= ctx[:vars]['key_name'] %>"
+  key_ring = google_kms_key_ring.key_ring.id
+  purpose  = "ENCRYPT_DECRYPT"
+}
+
+resource "google_kms_key_ring" "key_ring" {
+  name     = "<%= ctx[:vars]['keyring_name'] %>"
+  location = "us-central1"
+}
+
+resource "google_kms_crypto_key_iam_binding" "healthcare_cmek_keyuser" {
+  crypto_key_id = google_kms_crypto_key.crypto_key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  members = [
+    "serviceAccount:service-${data.google_project.project.number}@gcp-sa-healthcare.iam.gserviceaccount.com",
+  ]
+}
+
+


### PR DESCRIPTION
Fixes
https://github.com/terraform-google-modules/terraform-google-healthcare/issues/102.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
healthcare: added `encryptionSpec` field to `google_healthcare_dataset` resource
```
