### PR TITLE
Bigtable: Adds ignore_warning to gc policy resource

### DIFF
--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_gc_policy.go
@@ -216,6 +216,17 @@ func ResourceBigtableGCPolicy() *schema.Resource {
 				in a replicated instance. Possible values are: "ABANDON".`,
 				ValidateFunc: validation.StringInSlice([]string{"ABANDON", ""}, false),
 			},
+
+			"ignore_warnings": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Description: `Allows ignoring warnings when updating the GC policy. This can be used
+				to increase the gc policy on replicated clusters. Doing this may make clusters be
+				inconsistent for a longer period of time, before using this make sure you understand
+				the risks listed at https://cloud.google.com/bigtable/docs/garbage-collection#increasing`,
+				Default: false,
+			},
+
 		},
 		UseJSONNumber: true,
 	}
@@ -253,9 +264,14 @@ func resourceBigtableGCPolicyUpsert(d *schema.ResourceData, meta interface{}) er
 
 	tableName := d.Get("table").(string)
 	columnFamily := d.Get("column_family").(string)
+	ignoreWarnings := d.Get("ignore_warnings").(bool)
+	updateOpts := []bigtable.GCPolicyOption{}
+	if (ignoreWarnings) {
+		updateOpts = append(updateOpts, bigtable.IgnoreWarnings())
+	}
 
 	retryFunc := func() error {
-		reqErr := c.SetGCPolicy(ctx, tableName, columnFamily, gcPolicy)
+		reqErr := c.SetGCPolicyWithOptions(ctx, tableName, columnFamily, gcPolicy, updateOpts...)
 		return reqErr
 	}
 	// The default create timeout is 20 minutes.

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_gc_policy_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_gc_policy_test.go
@@ -39,6 +39,43 @@ func TestAccBigtableGCPolicy_basic(t *testing.T) {
 	})
 }
 
+func TestAccBigtableGCPolicy_ignoreWarnings(t *testing.T) {
+	// bigtable instance does not use the shared HTTP client, this test creates an instance
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+
+	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	tableName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	familyName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	cluster1Name := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	cluster2Name := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	gcRulesOriginal := `{"rules":[{"max_age":"10h"}]}`
+	gcRulesNew := `{"rules":[{"max_age":"12h"}]}`
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckBigtableGCPolicyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigtableGCPolicyIgnoreWarning(instanceName, tableName, familyName, cluster1Name, cluster2Name, gcRulesOriginal, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccBigtableGCPolicyExists(t, "google_bigtable_gc_policy.policy", true),
+					resource.TestCheckResourceAttr("google_bigtable_gc_policy.policy", "gc_rules", gcRulesOriginal),
+				),
+			},
+			{
+				Config: testAccBigtableGCPolicyIgnoreWarning(instanceName, tableName, familyName, cluster1Name, cluster2Name, gcRulesNew, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccBigtableGCPolicyExists(t, "google_bigtable_gc_policy.policy", true),
+					resource.TestCheckResourceAttr("google_bigtable_gc_policy.policy", "gc_rules", gcRulesNew),
+				),
+			},
+		},
+	})
+}
+
 func TestAccBigtableGCPolicy_abandoned(t *testing.T) {
 	// bigtable instance does not use the shared HTTP client, this test creates an instance
 	acctest.SkipIfVcr(t)
@@ -561,6 +598,49 @@ resource "google_bigtable_gc_policy" "policy" {
   }
 }
 `, instanceName, instanceName, tableName, family, family)
+}
+
+func testAccBigtableGCPolicyIgnoreWarning(instanceName, tableName, family string, cluster1 string, cluster2 string, gcRule string, ignoreWarnings bool) string {
+	return fmt.Sprintf(`
+resource "google_bigtable_instance" "instance" {
+  name = "%s"
+
+  cluster {
+    cluster_id = "%s"
+		num_nodes  = 1
+    zone       = "us-central1-b"
+  }
+
+  cluster {
+    cluster_id = "%s"
+		num_nodes  = 1
+    zone       = "us-central1-c"
+  }
+
+  deletion_protection = false
+}
+
+resource "google_bigtable_table" "table" {
+  name          = "%s"
+  instance_name = google_bigtable_instance.instance.id
+
+  column_family {
+    family = "%s"
+  }
+}
+
+resource "google_bigtable_gc_policy" "policy" {
+  instance_name = google_bigtable_instance.instance.id
+  table         = google_bigtable_table.table.name
+  column_family = "%s"
+	gc_rules = <<EOF
+	%s
+	EOF
+
+	ignore_warnings = %t
+	deletion_policy = "ABANDON"
+}
+`, instanceName, cluster1, cluster2, tableName, family, family, gcRule, ignoreWarnings)
 }
 
 func testAccBigtableGCPolicyToBeAbandoned(instanceName, tableName, family string) string {

--- a/mmv1/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
@@ -166,6 +166,9 @@ The following arguments are supported:
 
     Possible values are: `ABANDON`.
 
+* `ignore_warnings` - (Optional) Boolean for whether to allow ignoring warnings when updating the gc policy.
+    Setting this to `true` allows relaxing the gc policy for replicated clusters by up to 90 days, but keep in mind this may increase how long clusters are inconsistent. Make sure
+    you understand the risks listed at https://cloud.google.com/bigtable/docs/garbage-collection#increasing before setting this option.
 -----
 
 `max_age` supports the following arguments:


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds `ignore_warning` to `bigtable_gc_policy`, which allows relaxing the gc policy for replicated tables. This is the same approach currently used for [bigtable_app_profiles](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigtable_app_profile#ignore_warnings), and is preferable to always setting this to `true` on the backend request due to possible undesired [side effects](https://cloud.google.com/bigtable/docs/garbage-collection#increasing) of doing so, either accidentally or due to being unaware of these side effects.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

. [x] Not linking an issue since I think the description provides enough context
. [x] `ignore_warnings` not in [ga](https://github.com/hashicorp/terraform-provider-google/blob/main/google/services/bigtable/resource_bigtable_gc_policy.go) nor in [beta](https://github.com/hashicorp/terraform-provider-google-beta/blob/main/google-beta/services/bigtable/resource_bigtable_gc_policy.go)
. [x] Added test covering new field, all resources are prefixed by `tf-test`
. [x] Manually added documentation

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigtable: added `ignore_warnings` field to `bigtable_gc_policy` resource
```
