### PR TITLE
Add  Custom Error Responses support to UrlMap

### DIFF
--- a/mmv1/products/compute/UrlMap.yaml
+++ b/mmv1/products/compute/UrlMap.yaml
@@ -285,7 +285,8 @@ properties:
     description: Specifies the custom error response policies that must be
       applied when the backend service or backend bucket responds with an error.
       Can be defined for the urlMap, pathMatcher or routeRule/pathRule. The most
-      specific customErrorPolicy that matches the error response applies.
+      specific customErrorResponsePolicy that matches the error response applies.
+    min_version: beta
     properties:
       - !ruby/object:Api::Type::Array
         name: 'errorResponseRules'
@@ -422,7 +423,8 @@ properties:
           description: Specifies the custom error response policies that must be
             applied when the backend service or backend bucket responds with an error.
             Can be defined for the urlMap, pathMatcher or routeRule/pathRule. The most
-            specific customErrorPolicy that matches the error response applies.
+            specific customErrorResponsePolicy that matches the error response applies.
+          min_version: beta
           properties:
             - !ruby/object:Api::Type::Array
               name: 'errorResponseRules'
@@ -816,10 +818,11 @@ properties:
                             The value must be between 0 and 1000
               - !ruby/object:Api::Type::NestedObject
                 name: 'customErrorResponsePolicy'
+                min_version: beta
                 description: Specifies the custom error response policies that must be
                   applied when the backend service or backend bucket responds with an error.
                   Can be defined for the urlMap, pathMatcher or routeRule/pathRule. The most
-                  specific customErrorPolicy that matches the error response applies.
+                  specific customErrorResponsePolicy that matches the error response applies.
                 properties:
                   - !ruby/object:Api::Type::Array
                     name: 'errorResponseRules'
@@ -1588,10 +1591,11 @@ properties:
                             The value must be between 0 and 1000
               - !ruby/object:Api::Type::NestedObject
                 name: 'customErrorResponsePolicy'
+                min_version: beta
                 description: Specifies the custom error response policies that must be
                   applied when the backend service or backend bucket responds with an error.
                   Can be defined for the urlMap, pathMatcher or routeRule/pathRule. The most
-                  specific customErrorPolicy that matches the error response applies.
+                  specific customErrorResponsePolicy that matches the error response applies.
                 properties:
                   - !ruby/object:Api::Type::Array
                     name: 'errorResponseRules'

--- a/mmv1/products/compute/UrlMap.yaml
+++ b/mmv1/products/compute/UrlMap.yaml
@@ -280,6 +280,43 @@ properties:
       `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase
       letter, and all following characters must be a dash, lowercase letter, or digit,
       except the last character, which cannot be a dash.
+  - !ruby/object:Api::Type::NestedObject
+    name: 'defaultCustomErrorResponsePolicy'
+    description: Specifies the custom error response policies that must be
+      applied when the backend service or backend bucket responds with an error.
+      Can be defined for the urlMap, pathMatcher or routeRule/pathRule. The most
+      specific customErrorPolicy that matches the error response applies.
+    properties:
+      - !ruby/object::Api::Type::Array
+        name: 'errorResponseRules'
+        description: Specifies the rules to match the error response. Rules defined
+          for specific HTTP error status codes have higher precedence over rules defined
+          for HTTP status code classes.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object::Api::Type::Array
+              name: 'matchResponseCodes'
+              item_type: !ruby/object:Api::Type::String
+              description: |
+                HTTP error status code, or class of error status codes to match against.
+                Example status codes are '501', '403', and example status code classes are
+                '4xx' and '5xx'.
+            - !ruby/object:Api::Type::String
+              name: 'path'
+              description: |
+                Path to redirect to for the backend service or backend bucket to get
+                the custom error response.
+            - !ruby/object::Api::Type::Integer
+              name: 'overrideResponseCode'
+              description: |
+                Optional HTTP status code returned with the response containing the custom
+                error content. If not specified, the original HTTP status code will be
+                returned with the custom error content.
+      - !ruby/object:Api::Type::ResourceRef
+        name: 'errorService'
+        resource: 'BackendService'
+        description: |
+          The backend service or backend bucket to fetch the custom error content from.
   - !ruby/object:Api::Type::Array
     name: "path_matcher"
     api_name: 'pathMatchers'
@@ -375,6 +412,43 @@ properties:
           required: true
           description: |
             The name to which this PathMatcher is referred by the HostRule.
+        - !ruby/object:Api::Type::NestedObject
+          name: 'defaultCustomErrorResponsePolicy'
+          description: Specifies the custom error response policies that must be
+            applied when the backend service or backend bucket responds with an error.
+            Can be defined for the urlMap, pathMatcher or routeRule/pathRule. The most
+            specific customErrorPolicy that matches the error response applies.
+          properties:
+            - !ruby/object::Api::Type::Array
+              name: 'errorResponseRules'
+              description: Specifies the rules to match the error response. Rules defined
+                for specific HTTP error status codes have higher precedence over rules
+                defined for HTTP status code classes.
+              item_type: !ruby/object:Api::Type::NestedObject
+                properties:
+                  - !ruby/object::Api::Type::Array
+                    name: 'matchResponseCodes'
+                    item_type: !ruby/object:Api::Type::String
+                    description: |
+                      HTTP error status code, or class of error status codes to match
+                      against.  Example status codes are '501', '403', and example status
+                      code classes are '4xx' and '5xx'.
+                  - !ruby/object:Api::Type::String
+                    name: 'path'
+                    description: |
+                      Path to redirect to for the backend service or backend bucket to get
+                      the custom error response.
+                  - !ruby/object::Api::Type::Integer
+                    name: 'overrideResponseCode'
+                    description: |
+                      Optional HTTP status code returned with the response containing the
+                      custom error content. If not specified, the original HTTP status code
+                      will be returned with the custom error content.
+            - !ruby/object:Api::Type::ResourceRef
+              name: 'errorService'
+              resource: 'BackendService'
+              description: |
+                The backend service or backend bucket to fetch the custom error content from.
         - !ruby/object:Api::Type::Array
           name: 'path_rule'
           api_name: pathRules
@@ -730,6 +804,44 @@ properties:
                             been directed to a backendService, subsequent requests will be sent to the same
                             backendService as determined by the BackendService's session affinity policy.
                             The value must be between 0 and 1000
+              - !ruby/object:Api::Type::NestedObject
+                name: 'customErrorResponsePolicy'
+                description: Specifies the custom error response policies that must be
+                  applied when the backend service or backend bucket responds with an error.
+                  Can be defined for the urlMap, pathMatcher or routeRule/pathRule. The most
+                  specific customErrorPolicy that matches the error response applies.
+                properties:
+                  - !ruby/object::Api::Type::Array
+                    name: 'errorResponseRules'
+                    description: Specifies the rules to match the error response. Rules defined
+                      for specific HTTP error status codes have higher precedence over rules
+                      defined for HTTP status code classes.
+                    item_type: !ruby/object:Api::Type::NestedObject
+                      properties:
+                        - !ruby/object::Api::Type::Array
+                          name: 'matchResponseCodes'
+                          item_type: !ruby/object:Api::Type::String
+                          description: |
+                            HTTP error status code, or class of error status codes to match
+                            against.  Example status codes are '501', '403', and example status
+                            code classes are '4xx' and '5xx'.
+                        - !ruby/object:Api::Type::String
+                          name: 'path'
+                          description: |
+                            Path to redirect to for the backend service or backend bucket to get
+                            the custom error response.
+                        - !ruby/object::Api::Type::Integer
+                          name: 'overrideResponseCode'
+                          description: |
+                            Optional HTTP status code returned with the response containing the
+                            custom error content. If not specified, the original HTTP status code
+                            will be returned with the custom error content.
+                  - !ruby/object:Api::Type::ResourceRef
+                    name: 'errorService'
+                    resource: 'BackendService'
+                    description: |
+                      The backend service or backend bucket to fetch the custom error content
+                      from.
               - !ruby/object:Api::Type::NestedObject
                 name: 'urlRedirect'
                 description: |
@@ -1459,6 +1571,44 @@ properties:
                             been directed to a backendService, subsequent requests will be sent to the same
                             backendService as determined by the BackendService's session affinity policy.
                             The value must be between 0 and 1000
+              - !ruby/object:Api::Type::NestedObject
+                name: 'customErrorResponsePolicy'
+                description: Specifies the custom error response policies that must be
+                  applied when the backend service or backend bucket responds with an error.
+                  Can be defined for the urlMap, pathMatcher or routeRule/pathRule. The most
+                  specific customErrorPolicy that matches the error response applies.
+                properties:
+                  - !ruby/object::Api::Type::Array
+                    name: 'errorResponseRules'
+                    description: Specifies the rules to match the error response. Rules defined
+                      for specific HTTP error status codes have higher precedence over rules
+                      defined for HTTP status code classes.
+                    item_type: !ruby/object:Api::Type::NestedObject
+                      properties:
+                        - !ruby/object::Api::Type::Array
+                          name: 'matchResponseCodes'
+                          item_type: !ruby/object:Api::Type::String
+                          description: |
+                            HTTP error status code, or class of error status codes to match
+                            against.  Example status codes are '501', '403', and example status
+                            code classes are '4xx' and '5xx'.
+                        - !ruby/object:Api::Type::String
+                          name: 'path'
+                          description: |
+                            Path to redirect to for the backend service or backend bucket to get
+                            the custom error response.
+                        - !ruby/object::Api::Type::Integer
+                          name: 'overrideResponseCode'
+                          description: |
+                            Optional HTTP status code returned with the response containing the
+                            custom error content. If not specified, the original HTTP status code
+                            will be returned with the custom error content.
+                  - !ruby/object:Api::Type::ResourceRef
+                    name: 'errorService'
+                    resource: 'BackendService'
+                    description: |
+                      The backend service or backend bucket to fetch the custom error content
+                      from.
               - !ruby/object:Api::Type::NestedObject
                 name: 'urlRedirect'
                 description: |

--- a/mmv1/products/compute/UrlMap.yaml
+++ b/mmv1/products/compute/UrlMap.yaml
@@ -287,26 +287,29 @@ properties:
       Can be defined for the urlMap, pathMatcher or routeRule/pathRule. The most
       specific customErrorPolicy that matches the error response applies.
     properties:
-      - !ruby/object::Api::Type::Array
+      - !ruby/object:Api::Type::Array
         name: 'errorResponseRules'
         description: Specifies the rules to match the error response. Rules defined
           for specific HTTP error status codes have higher precedence over rules defined
           for HTTP status code classes.
+        required: true
         item_type: !ruby/object:Api::Type::NestedObject
           properties:
-            - !ruby/object::Api::Type::Array
+            - !ruby/object:Api::Type::Array
               name: 'matchResponseCodes'
-              item_type: !ruby/object:Api::Type::String
+              item_type: Api::Type::String
               description: |
                 HTTP error status code, or class of error status codes to match against.
                 Example status codes are '501', '403', and example status code classes are
                 '4xx' and '5xx'.
+              required: true
             - !ruby/object:Api::Type::String
               name: 'path'
               description: |
                 Path to redirect to for the backend service or backend bucket to get
                 the custom error response.
-            - !ruby/object::Api::Type::Integer
+              required: true
+            - !ruby/object:Api::Type::Integer
               name: 'overrideResponseCode'
               description: |
                 Optional HTTP status code returned with the response containing the custom
@@ -317,6 +320,8 @@ properties:
         resource: 'BackendService'
         description: |
           The backend service or backend bucket to fetch the custom error content from.
+        required: true
+        imports: 'selfLink'
   - !ruby/object:Api::Type::Array
     name: "path_matcher"
     api_name: 'pathMatchers'
@@ -419,26 +424,29 @@ properties:
             Can be defined for the urlMap, pathMatcher or routeRule/pathRule. The most
             specific customErrorPolicy that matches the error response applies.
           properties:
-            - !ruby/object::Api::Type::Array
+            - !ruby/object:Api::Type::Array
               name: 'errorResponseRules'
               description: Specifies the rules to match the error response. Rules defined
                 for specific HTTP error status codes have higher precedence over rules
                 defined for HTTP status code classes.
+              required: true
               item_type: !ruby/object:Api::Type::NestedObject
                 properties:
-                  - !ruby/object::Api::Type::Array
+                  - !ruby/object:Api::Type::Array
                     name: 'matchResponseCodes'
-                    item_type: !ruby/object:Api::Type::String
+                    item_type: Api::Type::String
                     description: |
                       HTTP error status code, or class of error status codes to match
                       against.  Example status codes are '501', '403', and example status
                       code classes are '4xx' and '5xx'.
+                    required: true
                   - !ruby/object:Api::Type::String
                     name: 'path'
                     description: |
                       Path to redirect to for the backend service or backend bucket to get
                       the custom error response.
-                  - !ruby/object::Api::Type::Integer
+                    required: true
+                  - !ruby/object:Api::Type::Integer
                     name: 'overrideResponseCode'
                     description: |
                       Optional HTTP status code returned with the response containing the
@@ -449,6 +457,8 @@ properties:
               resource: 'BackendService'
               description: |
                 The backend service or backend bucket to fetch the custom error content from.
+              required: true
+              imports: 'selfLink'
         - !ruby/object:Api::Type::Array
           name: 'path_rule'
           api_name: pathRules
@@ -811,26 +821,29 @@ properties:
                   Can be defined for the urlMap, pathMatcher or routeRule/pathRule. The most
                   specific customErrorPolicy that matches the error response applies.
                 properties:
-                  - !ruby/object::Api::Type::Array
+                  - !ruby/object:Api::Type::Array
                     name: 'errorResponseRules'
                     description: Specifies the rules to match the error response. Rules defined
                       for specific HTTP error status codes have higher precedence over rules
                       defined for HTTP status code classes.
+                    required: true
                     item_type: !ruby/object:Api::Type::NestedObject
                       properties:
-                        - !ruby/object::Api::Type::Array
+                        - !ruby/object:Api::Type::Array
                           name: 'matchResponseCodes'
-                          item_type: !ruby/object:Api::Type::String
+                          item_type: Api::Type::String
                           description: |
                             HTTP error status code, or class of error status codes to match
                             against.  Example status codes are '501', '403', and example status
                             code classes are '4xx' and '5xx'.
+                          required: true
                         - !ruby/object:Api::Type::String
                           name: 'path'
                           description: |
                             Path to redirect to for the backend service or backend bucket to get
                             the custom error response.
-                        - !ruby/object::Api::Type::Integer
+                          required: true
+                        - !ruby/object:Api::Type::Integer
                           name: 'overrideResponseCode'
                           description: |
                             Optional HTTP status code returned with the response containing the
@@ -842,6 +855,8 @@ properties:
                     description: |
                       The backend service or backend bucket to fetch the custom error content
                       from.
+                    required: true
+                    imports: 'selfLink'
               - !ruby/object:Api::Type::NestedObject
                 name: 'urlRedirect'
                 description: |
@@ -1578,26 +1593,29 @@ properties:
                   Can be defined for the urlMap, pathMatcher or routeRule/pathRule. The most
                   specific customErrorPolicy that matches the error response applies.
                 properties:
-                  - !ruby/object::Api::Type::Array
+                  - !ruby/object:Api::Type::Array
                     name: 'errorResponseRules'
                     description: Specifies the rules to match the error response. Rules defined
                       for specific HTTP error status codes have higher precedence over rules
                       defined for HTTP status code classes.
+                    required: true
                     item_type: !ruby/object:Api::Type::NestedObject
                       properties:
-                        - !ruby/object::Api::Type::Array
+                        - !ruby/object:Api::Type::Array
                           name: 'matchResponseCodes'
-                          item_type: !ruby/object:Api::Type::String
+                          item_type: Api::Type::String
                           description: |
                             HTTP error status code, or class of error status codes to match
                             against.  Example status codes are '501', '403', and example status
                             code classes are '4xx' and '5xx'.
+                          required: true
                         - !ruby/object:Api::Type::String
                           name: 'path'
                           description: |
                             Path to redirect to for the backend service or backend bucket to get
                             the custom error response.
-                        - !ruby/object::Api::Type::Integer
+                          required: true
+                        - !ruby/object:Api::Type::Integer
                           name: 'overrideResponseCode'
                           description: |
                             Optional HTTP status code returned with the response containing the
@@ -1609,6 +1627,8 @@ properties:
                     description: |
                       The backend service or backend bucket to fetch the custom error content
                       from.
+                    required: true
+                    imports: 'selfLink'
               - !ruby/object:Api::Type::NestedObject
                 name: 'urlRedirect'
                 description: |

--- a/mmv1/templates/terraform/examples/url_map_with_custom_error_response_policy.tf.erb
+++ b/mmv1/templates/terraform/examples/url_map_with_custom_error_response_policy.tf.erb
@@ -1,0 +1,109 @@
+# [START cloudloadbalancing_url_map_with_custom_error_response_policy]
+resource "google_compute_url_map" "<%= ctx[:primary_resource_id] %>" {
+  name        = "<%= ctx[:vars]['url_map_name'] %>"
+  description = "a description"
+
+  default_service = google_compute_backend_bucket.static.id
+
+  default_custom_error_response_policy {
+    error_response_rules {
+      match_response_codes {
+        '4xx'
+      }
+      path = '/four_hundred_response.html'
+      override_response_code = 404
+    }
+    error_service = google_compute_backend_bucket.static.id
+  }
+
+
+  host_rulr {
+    hosts        = ["mysite.com"]
+    path_matcher = "mysite"
+  }
+
+  host_rule {
+    hosts        = ["myothersite.com"]
+    path_matcher = "otherpaths"
+  }
+
+  path_matcher {
+    name            = "mysite"
+    default_service = google_compute_backend_bucket.static.id
+
+    path_rule {
+      paths   = ["/home"]
+      service = google_compute_backend_bucket.static.id
+    }
+
+    path_rule {
+      paths   = ["/login"]
+      service = google_compute_backend_service.login.id
+
+      custom_error_response_policy {
+        error_response_rules {
+          match_response_codes {
+            '403'
+          }
+          path = '/forbidden.html'
+        }
+        error_service = google_compute_backend_bucket.static.id
+      }
+    }
+
+    path_rule {
+      paths   = ["/static"]
+      service = google_compute_backend_bucket.static.id
+    }
+  }
+
+  path_matcher {
+    name            = "otherpaths"
+    default_service = google_compute_backend_bucket.static.id
+
+    default_custom_error_response_policy {
+      error_response_rules {
+        match_response_codes {
+          '401'
+        }
+        path = '/four_hundred_one_response.html'
+      }
+      error_service =google_compute_backend_bucket.static.id
+    }
+  }
+
+  test {
+    service = google_compute_backend_bucket.static.id
+    host    = "example.com"
+    path    = "/home"
+  }
+}
+
+resource "google_compute_backend_service" "login" {
+  name        = "<%= ctx[:vars]['login_backend_service_name'] %>"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = [google_compute_http_health_check.default.id]
+}
+
+resource "google_compute_http_health_check" "default" {
+  name               = "<%= ctx[:vars]['http_health_check_name'] %>"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+resource "google_compute_backend_bucket" "static" {
+  name        = "<%= ctx[:vars]['backend_bucket_name'] %>"
+  bucket_name = google_storage_bucket.static.name
+  enable_cdn  = true
+}
+
+resource "google_storage_bucket" "static" {
+  name     = "<%= ctx[:vars]['storage_bucket_name'] %>"
+  location = "US"
+}
+# [END cloudloadbalancing_url_map_with_custom_error_response_policy]
+


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add support for Custom Error Responses to customize error responses when using Global external Application Load Balancers (https://cloud.google.com/load-balancing/docs/https/custom-error-response)

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `default_custom_error_response_policy` and `custom_error_response_policy` fields to  `google_compute_url_map`  resource (beta)
```
