### PR TITLE
Make firebase_hosting_site upsert on creation

### DIFF
--- a/mmv1/products/firebasehosting/Site.yaml
+++ b/mmv1/products/firebasehosting/Site.yaml
@@ -24,6 +24,8 @@ references: !ruby/object:Api::Resource::ReferenceLinks
   guides:
     'Official Documentation': 'https://firebase.google.com/docs/hosting'
   api: 'https://firebase.google.com/docs/reference/hosting/rest/v1beta1/projects.sites'
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  pre_create: templates/terraform/pre_create/firebasehosting_site.go.erb
 import_format:
   ['projects/{{project}}/sites/{{site_id}}', 'sites/{{site_id}}', '{{site_id}}']
 examples:

--- a/mmv1/templates/terraform/pre_create/firebasehosting_site.go.erb
+++ b/mmv1/templates/terraform/pre_create/firebasehosting_site.go.erb
@@ -1,0 +1,27 @@
+
+// Check if the Firebase hostng site already exits. Do an update if so.
+
+getUrl, err := tpgresource.ReplaceVars(d, config, "{{FirebaseHostingBasePath}}projects/{{project}}/sites/{{site_id}}")
+if err != nil {
+	return err
+}
+_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+	Config:    config,
+	Method:    "GET",
+	Project:   billingProject,
+	RawURL:    getUrl,
+	UserAgent: userAgent,
+	Headers:   headers,
+})
+
+if err == nil {
+	// Hosting site already exists
+	log.Printf("[DEBUG] Firebase hosting site already exists %s", d.Get("site_id"))
+	// Replace import id for the resource id
+	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/sites/{{site_id}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+	return resourceFirebaseHostingSiteUpdate(d, meta)
+}

--- a/mmv1/third_party/terraform/services/firebasehosting/resource_firebase_hosting_site_test.go.erb
+++ b/mmv1/third_party/terraform/services/firebasehosting/resource_firebase_hosting_site_test.go.erb
@@ -61,19 +61,10 @@ func TestAccFirebaseHostingSite_firebasehostingSiteUpsert(t *testing.T) {
 		CheckDestroy:             testAccCheckFirebaseHostingSiteDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFirebaseHostingSite_firebasehostingSiteCreate(context),
+				Config: testAccFirebaseHostingSite_firebasehostingSiteUpsert(context),
 			},
 			{
-				ResourceName:            "google_firebase_hosting_site.create",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"site_id"},
-			},
-			{
-				Config: testAccFirebaseHostingSite_firebasehostingSiteCreateAgain(context),
-			},
-			{
-				ResourceName:            "google_firebase_hosting_site.create_again",
+				ResourceName:            "google_firebase_hosting_site.create2",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"site_id"},
@@ -117,30 +108,20 @@ resource "google_firebase_hosting_site" "update" {
 `, context)
 }
 
-func testAccFirebaseHostingSite_firebasehostingSiteCreate(context map[string]interface{}) string {
+func testAccFirebaseHostingSite_firebasehostingSiteUpsert(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_firebase_hosting_site" "create" {
   provider = google-beta
   project  = "%{project_id}"
   site_id = "%{site_id}%{random_suffix}"
 }
-`, context)
-}
 
-
-func testAccFirebaseHostingSite_firebasehostingSiteCreateAgain(context map[string]interface{}) string {
-	return acctest.Nprintf(`
-resource "google_firebase_web_app" "app" {
-  provider = google-beta
-  project  = "%{project_id}"
-  display_name = "tf-test Test web app for Firebase Hosting"
-}
-
-resource "google_firebase_hosting_site" "create_again" {
+resource "google_firebase_hosting_site" "create2" {
   provider = google-beta
   project  = "%{project_id}"
   site_id = "%{site_id}%{random_suffix}"
-  app_id = google_firebase_web_app.app.app_id
+
+  depends_on = [google_firebase_hosting_site.create]
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/firebasehosting/resource_firebase_hosting_site_test.go.erb
+++ b/mmv1/third_party/terraform/services/firebasehosting/resource_firebase_hosting_site_test.go.erb
@@ -46,6 +46,43 @@ func TestAccFirebaseHostingSite_firebasehostingSiteUpdate(t *testing.T) {
 	})
 }
 
+func TestAccFirebaseHostingSite_firebasehostingSiteUpsert(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project_id":    envvar.GetTestProjectFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+		"site_id":       "tf-test-site-upsert",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckFirebaseHostingSiteDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFirebaseHostingSite_firebasehostingSiteCreate(context),
+			},
+			{
+				ResourceName:            "google_firebase_hosting_site.create",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"site_id"},
+			},
+			{
+				Config: testAccFirebaseHostingSite_firebasehostingSiteCreateAgain(context),
+			},
+			{
+				ResourceName:            "google_firebase_hosting_site.create_again",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"site_id"},
+			},
+		},
+	})
+}
+
+
 func testAccFirebaseHostingSite_firebasehostingSiteBeforeUpdate(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_firebase_web_app" "before" {
@@ -76,6 +113,34 @@ resource "google_firebase_hosting_site" "update" {
   project  = "%{project_id}"
   site_id = "%{site_id}%{random_suffix}"
   app_id = google_firebase_web_app.after.app_id
+}
+`, context)
+}
+
+func testAccFirebaseHostingSite_firebasehostingSiteCreate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_firebase_hosting_site" "create" {
+  provider = google-beta
+  project  = "%{project_id}"
+  site_id = "%{site_id}%{random_suffix}"
+}
+`, context)
+}
+
+
+func testAccFirebaseHostingSite_firebasehostingSiteCreateAgain(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_firebase_web_app" "app" {
+  provider = google-beta
+  project  = "%{project_id}"
+  display_name = "tf-test Test web app for Firebase Hosting"
+}
+
+resource "google_firebase_hosting_site" "create_again" {
+  provider = google-beta
+  project  = "%{project_id}"
+  site_id = "%{site_id}%{random_suffix}"
+  app_id = google_firebase_web_app.app.app_id
 }
 `, context)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This will provide a pathway for users to associate a web app with an existing hosting site without running `terraform import` in between. This behavior is necessary because the default Hosting site is currently provisioned outside of Terraform, which causes trouble for many users as indicated in https://github.com/hashicorp/terraform-provider-google/issues/12955#issuecomment-2172442248

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
firebasehosting: allowed associating a web app with an existing Site.
```
