### PR TITLE
Use `id` in getting started guide

### DIFF
--- a/mmv1/third_party/terraform/website/docs/guides/getting_started.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/getting_started.html.markdown
@@ -100,23 +100,23 @@ are used as a short way to identify resources, and a resource's display name in
 the Cloud Console will be the one defined in the `name` field.
 
 When linking resources in a Terraform config though, you'll primarily want to
-use a different field, the `self_link` of a resource. Like `name`, nearly every
-resource has a `self_link`. They look like:
+use a different field, the `id` of a resource. Every Terraform resource has an
+`id`. In the Google provider they look like:
 
 ```
-{{API base url}}/projects/{{your project}}/{{location type}}/{{location}}/{{resource type}}/{{name}}
+projects/{{your project}}/{{location type}}/{{location}}/{{resource type}}/{{name}}
 ```
 
 For example, the instance defined earlier in a project named `foo` will have
-the `self_link`:
+the `id`:
 
 ```
-https://www.googleapis.com/compute/v1/projects/foo/zones/us-central1-c/instances/terraform-instance
+projects/foo/zones/us-central1-c/instances/terraform-instance
 ```
 
-A resource's `self_link` is a unique reference to that resource. When
+A resource's `id` is a unique reference to that resource. When
 linking two resources in Terraform, you can use Terraform interpolation to
-avoid typing out the self link! Let's use a `google_compute_network` to
+avoid typing out the id! Let's use a `google_compute_network` to
 demonstrate.
 
 Add this block to your config:
@@ -136,7 +136,7 @@ with a subnetwork in each region. Next, change the network of the
 network_interface {
 -  # A default network is created for all GCP projects
 -  network = "default"
-+  network = google_compute_network.vpc_network.self_link
++  network = google_compute_network.vpc_network.id
   access_config {
 ```
 
@@ -211,7 +211,7 @@ resource "google_compute_instance" "vm_instance" {
 
   network_interface {
     # A default network is created for all GCP projects
-    network = google_compute_network.vpc_network.self_link
+    network = google_compute_network.vpc_network.id
     access_config {
     }
   }
@@ -237,7 +237,7 @@ a virtual machine on Google Cloud Platform. The key concepts unique to GCP are:
     * and how to use a default `project` in your provider
 * What a resource being global, regional, or zonal means on GCP
     * and how to specify a default `region` and `zone`
-* How GCP uses `name` and `self_link` to identify resources
+* How GCP uses `name` and `id` to identify resources
 * How to add GCP service account credentials to Terraform
 
 Run `terraform destroy` to tear down your resources.

--- a/mmv1/third_party/terraform/website/docs/guides/getting_started.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/getting_started.html.markdown
@@ -101,7 +101,7 @@ the Cloud Console will be the one defined in the `name` field.
 
 When linking resources in a Terraform config though, you'll primarily want to
 use a different field, the `id` of a resource. Every Terraform resource has an
-`id`. In the Google provider they look like:
+`id`. In the Google provider they generally look like:
 
 ```
 projects/{{your project}}/{{location type}}/{{location}}/{{resource type}}/{{name}}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This content was pretty stale- we use `id` now and `self_link` is no longer general

Confirmed the test config applies stably:

```
$ terraform apply
google_compute_network.vpc_network: Refreshing state... [id=projects/graphite-test-rileykarson/global/networks/terraform-network]
google_compute_instance.vm_instance: Refreshing state... [id=projects/graphite-test-rileykarson/zones/us-central1-a/instances/terraform-instance]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
