### PR TITLE
Make sweeper for google_vmwareengine_network handwritten, fix how it accesses data from the list operation, add looping through locations

### DIFF
--- a/mmv1/products/vmwareengine/Network.yaml
+++ b/mmv1/products/vmwareengine/Network.yaml
@@ -43,6 +43,10 @@ async: !ruby/object:Api::OpAsync
 import_format:
   ["projects/{{project}}/locations/{{location}}/vmwareEngineNetworks/{{name}}"]
 autogen_async: true
+
+# There is a handwritten sweeper that provides a list of locations to sweep
+skip_sweeper: true
+
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: "vmware_engine_network_standard"

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_sweeper.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_sweeper.go
@@ -73,7 +73,7 @@ func testSweepVmwareengineNetwork(region string) error {
 			return nil
 		}
 
-		resourceList, ok := res["networks"]
+		resourceList, ok := res["vmwareEngineNetworks"]
 		if !ok {
 			log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
 			return nil

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_sweeper.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_sweeper.go
@@ -40,7 +40,7 @@ func testSweepVmwareengineNetwork(region string) error {
 	//   * global location
 	//   * regions used for this resource type's acc tests in the past
 	//   * the 'region' passed to the sweeper
-	locations := []string{"global", "us-central1", "southamerica-west1", "me-west1", region}
+	locations := []string{region, "global", "southamerica-west1", "me-west1"}
 	for _, location := range locations {
 		log.Printf("[INFO][SWEEPER_LOG] Beginning the process of sweeping location '%s'.", location)
 

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_sweeper.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_sweeper.go
@@ -60,7 +60,7 @@ func testSweepVmwareengineNetwork(region string) error {
 		listUrl, err := tpgresource.ReplaceVars(d, config, listTemplate)
 		if err != nil {
 			log.Printf("[INFO][SWEEPER_LOG] error preparing sweeper list url: %s", err)
-			return nil
+			continue
 		}
 
 		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
@@ -72,13 +72,13 @@ func testSweepVmwareengineNetwork(region string) error {
 		})
 		if err != nil {
 			log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)
-			return nil
+			continue
 		}
 
 		resourceList, ok := res["vmwareEngineNetworks"]
 		if !ok {
 			log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
-			return nil
+			continue
 		}
 
 		rl := resourceList.([]interface{})
@@ -90,7 +90,7 @@ func testSweepVmwareengineNetwork(region string) error {
 			obj := ri.(map[string]interface{})
 			if obj["name"] == nil {
 				log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
-				return nil
+				continue
 			}
 
 			name := tpgresource.GetResourceNameFromSelfLink(obj["name"].(string))
@@ -104,7 +104,7 @@ func testSweepVmwareengineNetwork(region string) error {
 			deleteUrl, err := tpgresource.ReplaceVars(d, config, deleteTemplate)
 			if err != nil {
 				log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
-				return nil
+				continue
 			}
 			deleteUrl = deleteUrl + name
 

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_sweeper.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_sweeper.go
@@ -42,6 +42,7 @@ func testSweepVmwareengineNetwork(region string) error {
 	//   * the 'region' passed to the sweeper
 	locations := []string{"global", "us-central1", "southamerica-west1", "me-west1", region}
 	for _, location := range locations {
+		log.Printf("[INFO][SWEEPER_LOG] Beginning the process of sweeping location '%s'.", location)
 
 		// Setup variables to replace in list template
 		d := &tpgresource.ResourceDataMock{

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_sweeper.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_sweeper.go
@@ -41,6 +41,7 @@ func testSweepVmwareengineNetwork(region string) error {
 	//   * regions used for this resource type's acc tests in the past
 	//   * the 'region' passed to the sweeper
 	locations := []string{region, "global", "southamerica-west1", "me-west1"}
+	log.Printf("[INFO][SWEEPER_LOG] Sweeping will include these locations: %v.", locations)
 	for _, location := range locations {
 		log.Printf("[INFO][SWEEPER_LOG] Beginning the process of sweeping location '%s'.", location)
 

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_sweeper.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_sweeper.go
@@ -41,7 +41,7 @@ func testSweepVmwareengineNetwork(region string) error {
 	//   * regions used for this resource type's acc tests in the past
 	//   * the 'region' passed to the sweeper
 	locations := []string{"global", "us-central1", "southamerica-west1", "me-west1", region}
-	for location := range locations {
+	for _, location := range locations {
 
 		// Setup variables to replace in list template
 		d := &tpgresource.ResourceDataMock{

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_sweeper.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_sweeper.go
@@ -1,0 +1,130 @@
+package vmwareengine
+
+import (
+	"context"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/sweeper"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func init() {
+	sweeper.AddTestSweepers("VmwareengineNetwork", testSweepVmwareengineNetwork)
+}
+
+// At the time of writing, the CI only passes us-central1 as the region
+func testSweepVmwareengineNetwork(region string) error {
+	resourceName := "VmwareengineNetwork"
+	log.Printf("[INFO][SWEEPER_LOG] Starting sweeper for %s", resourceName)
+
+	config, err := sweeper.SharedConfigForRegion(region)
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error getting shared config for region: %s", err)
+		return err
+	}
+
+	err = config.LoadAndValidate(context.Background())
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error loading: %s", err)
+		return err
+	}
+
+	t := &testing.T{}
+	billingId := envvar.GetTestBillingAccountFromEnv(t)
+
+	// List of location values includes:
+	//   * global location
+	//   * regions used for this resource type's acc tests in the past
+	//   * the 'region' passed to the sweeper
+	locations := []string{"global", "us-central1", "southamerica-west1", "me-west1", region}
+	for location := range locations {
+
+		// Setup variables to replace in list template
+		d := &tpgresource.ResourceDataMock{
+			FieldsInSchema: map[string]interface{}{
+				"project":         config.Project,
+				"region":          location,
+				"location":        location,
+				"zone":            "-",
+				"billing_account": billingId,
+			},
+		}
+
+		listTemplate := strings.Split("https://vmwareengine.googleapis.com/v1/projects/{{project}}/locations/{{location}}/vmwareEngineNetworks", "?")[0]
+		listUrl, err := tpgresource.ReplaceVars(d, config, listTemplate)
+		if err != nil {
+			log.Printf("[INFO][SWEEPER_LOG] error preparing sweeper list url: %s", err)
+			return nil
+		}
+
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   config.Project,
+			RawURL:    listUrl,
+			UserAgent: config.UserAgent,
+		})
+		if err != nil {
+			log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)
+			return nil
+		}
+
+		resourceList, ok := res["networks"]
+		if !ok {
+			log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
+			return nil
+		}
+
+		rl := resourceList.([]interface{})
+
+		log.Printf("[INFO][SWEEPER_LOG] Found %d items in %s list response.", len(rl), resourceName)
+		// Keep count of items that aren't sweepable for logging.
+		nonPrefixCount := 0
+		for _, ri := range rl {
+			obj := ri.(map[string]interface{})
+			if obj["name"] == nil {
+				log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
+				return nil
+			}
+
+			name := tpgresource.GetResourceNameFromSelfLink(obj["name"].(string))
+			// Skip resources that shouldn't be sweeped
+			if !sweeper.IsSweepableTestResource(name) {
+				nonPrefixCount++
+				continue
+			}
+
+			deleteTemplate := "https://vmwareengine.googleapis.com/v1/projects/{{project}}/locations/{{location}}/vmwareEngineNetworks/{{name}}"
+			deleteUrl, err := tpgresource.ReplaceVars(d, config, deleteTemplate)
+			if err != nil {
+				log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
+				return nil
+			}
+			deleteUrl = deleteUrl + name
+
+			// Don't wait on operations as we may have a lot to delete
+			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "DELETE",
+				Project:   config.Project,
+				RawURL:    deleteUrl,
+				UserAgent: config.UserAgent,
+			})
+			if err != nil {
+				log.Printf("[INFO][SWEEPER_LOG] Error deleting for url %s : %s", deleteUrl, err)
+			} else {
+				log.Printf("[INFO][SWEEPER_LOG] Sent delete request for %s resource: %s", resourceName, name)
+			}
+		}
+
+		if nonPrefixCount > 0 {
+			log.Printf("[INFO][SWEEPER_LOG] %d items were non-sweepable and skipped.", nonPrefixCount)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/18471

The existing sweeper only sweeps in us-central1 (the value provided to the sweeper in TeamCity by default)/can only sweep a single location at once.

This PR:
* updates the sweeper to sweep a list of predetermined locations, in addition to the location passed into the sweeper.
* updates the sweeper to be able to use data returned from the API list method ([9214e48](https://github.com/GoogleCloudPlatform/magic-modules/pull/10994/commits/9214e4879d6f63312814948c5d4f9061cdc8acf0)) 
    *  Currently the sweeper cannot find the "networks" field in the response JSON and concludes there's nothing to delete. The linked commit should fix this.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
