### PR TITLE
Make `google_vpc_access_connector` acc tests use a bootstrapped VPC network

### DIFF
--- a/mmv1/products/vpcaccess/Connector.yaml
+++ b/mmv1/products/vpcaccess/Connector.yaml
@@ -46,11 +46,17 @@ examples:
     primary_resource_id: 'connector'
     vars:
       name: 'vpc-con'
+      network_name: 'default'
+    test_vars_overrides:
+      network_name: 'acctest.BootstrapSharedServiceNetworkingConnection(t, "vpc-access-connector")'
   - !ruby/object:Provider::Terraform::Examples
     name: 'vpc_access_connector_shared_vpc'
     primary_resource_id: 'connector'
     vars:
       name: 'vpc-con'
+      network_name: 'default'
+    test_vars_overrides:
+      network_name: 'acctest.BootstrapSharedServiceNetworkingConnection(t, "vpc-access-connector")'
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   encoder: templates/terraform/encoders/no_send_name.go.erb
   post_create: templates/terraform/post_create/sleep.go.erb

--- a/mmv1/templates/terraform/examples/vpc_access_connector.tf.erb
+++ b/mmv1/templates/terraform/examples/vpc_access_connector.tf.erb
@@ -1,5 +1,5 @@
 resource "google_vpc_access_connector" "connector" {
   name          = "<%= ctx[:vars]['name'] %>"
   ip_cidr_range = "10.8.0.0/28"
-  network       = "default"
+  network       = "<%= ctx[:vars]['network_name'] %>"
 }

--- a/mmv1/templates/terraform/examples/vpc_access_connector_shared_vpc.tf.erb
+++ b/mmv1/templates/terraform/examples/vpc_access_connector_shared_vpc.tf.erb
@@ -10,10 +10,5 @@ resource "google_compute_subnetwork" "custom_test" {
   name          = "<%= ctx[:vars]['name'] %>"
   ip_cidr_range = "10.2.0.0/28"
   region        = "us-central1"
-  network       = google_compute_network.custom_test.id
-}
-
-resource "google_compute_network" "custom_test" {
-  name                    = "<%= ctx[:vars]['name'] %>"
-  auto_create_subnetworks = false
+  network       = "<%= ctx[:vars]['network_name'] %>"
 }


### PR DESCRIPTION

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This is to address some CIDR related test failures: https://github.com/GoogleCloudPlatform/magic-modules/pull/10313#issuecomment-2175660015

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
