### PR TITLE
Remove labels custom_diff functions when converting yaml files

### DIFF
--- a/mmv1/products/compute/go_Disk.yaml
+++ b/mmv1/products/compute/go_Disk.yaml
@@ -72,7 +72,6 @@ custom_code:
 custom_diff:
   - 'customdiff.ForceNewIfChange("size", IsDiskShrinkage)'
   - 'hyperDiskIopsUpdateDiffSupress'
-  - 'tpgresource.SetLabelsDiff'
 examples:
   - name: 'disk_basic'
     primary_resource_id: 'default'

--- a/mmv1/products/compute/go_Firewall.yaml
+++ b/mmv1/products/compute/go_Firewall.yaml
@@ -161,6 +161,7 @@ properties:
     description: |
       An optional description of this resource. Provide this property when
       you create the resource.
+    send_empty_value: true
   - name: 'destinationRanges'
     type: Array
     description: |

--- a/mmv1/products/compute/go_ForwardingRule.yaml
+++ b/mmv1/products/compute/go_ForwardingRule.yaml
@@ -50,7 +50,6 @@ custom_code:
   post_create: 'templates/terraform/post_create/go/labels.tmpl'
 custom_diff:
   - 'forwardingRuleCustomizeDiff'
-  - 'tpgresource.SetLabelsDiff'
 legacy_long_form_project: true
 examples:
   - name: 'internal_http_lb_with_mig_backend'

--- a/mmv1/products/compute/go_RegionDisk.yaml
+++ b/mmv1/products/compute/go_RegionDisk.yaml
@@ -70,7 +70,6 @@ custom_code:
 custom_diff:
   - 'customdiff.ForceNewIfChange("size", IsDiskShrinkage)'
   - 'hyperDiskIopsUpdateDiffSupress'
-  - 'tpgresource.SetLabelsDiff'
 examples:
   - name: 'region_disk_basic'
     primary_resource_id: 'regiondisk'

--- a/mmv1/products/datafusion/go_Instance.yaml
+++ b/mmv1/products/datafusion/go_Instance.yaml
@@ -305,6 +305,7 @@ properties:
       If accelerators are enabled it is possible a permadiff will be created with the Options field.
       Users will need to either manually update their state file to include these diffed options, or include the field in a [lifecycle ignore changes block](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes).
     item_type:
+      type: NestedObject
       properties:
         - name: 'acceleratorType'
           type: Enum
@@ -323,4 +324,3 @@ properties:
           enum_values:
             - 'ENABLED'
             - 'DISABLED'
-      type: NestedObject

--- a/mmv1/templates/terraform/yaml_conversion.erb
+++ b/mmv1/templates/terraform/yaml_conversion.erb
@@ -398,9 +398,14 @@ custom_code:
   test_check_destroy: '<%= object.convert_go_file( object.custom_code.test_check_destroy )%>'
 <%    end -%>
 <%  end -%>
-<%  unless object.custom_diff.empty? || (object.custom_diff.size == 1 && object.custom_diff.include?("tpgresource.SetLabelsDiff")) -%>
+<% 
+custom_diff = object.custom_diff.reject {
+  |cdiff| cdiff == "tpgresource.SetLabelsDiff" || cdiff == "tpgresource.SetMetadataLabelsDiff" || cdiff == "tpgresource.SetAnnotationsDiff" || cdiff == "tpgresource.SetMetadataAnnotationsDiff"
+}
+-%>
+<%  unless custom_diff.empty? -%>
 custom_diff:
-<%    object.custom_diff.each do |cdiff| -%>
+<%    custom_diff.each do |cdiff| -%>
   - '<%= cdiff %>'
 <%    end -%>
 <%  end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Remove labels custom_diff functions when converting yaml files, as these custom_diff functions will be added automatically when generating providers. This change will remove the duplicate `tpgresource.SetLabelsDiff,` in https://github.com/c2thorn/terraform-provider-google-beta/commit/454fe003f3defc230546136ecd07506918fed9b8#diff-67e94c4fcb06d69a1414f20fe740ea9973a4ec598b27222476aba3abc2e18a36

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
