### PR TITLE
make index_configs O+C in google_logging_organization_bucket_config

### DIFF
--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config.go
@@ -93,6 +93,7 @@ See [Enabling CMEK for Logging Buckets](https://cloud.google.com/logging/docs/ro
 		Type:        schema.TypeSet,
 		MaxItems:    20,
 		Optional:    true,
+		Computed:    true,
 		Description: `A list of indexed fields and related configuration data.`,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This should fix the failing test `TestAccLoggingBucketConfigOrganization_basic` in VCR (and also nightly)

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
logging: fixed a permadiff on `index_configs` in `google_logging_organization_bucket_config` resource
```
