### PR TITLE
Correct redisVersion behavior

### DIFF
--- a/mmv1/products/redis/Instance.yaml
+++ b/mmv1/products/redis/Instance.yaml
@@ -423,9 +423,9 @@ properties:
   - !ruby/object:Api::Type::String
     name: redisVersion
     description: |
-      The version of Redis software. If not provided, latest supported
-      version will be used. Please check the API documentation linked
-      at the top for the latest valid values.
+      The version of Redis software. If not provided, the current recommended
+      version will be used for creation. For updates, a not provided version has no effect.
+      Please check the API documentation linked at the top for the latest valid values.
     default_from_api: true
     update_url: 'projects/{{project}}/locations/{{region}}/instances/{{name}}:upgrade'
     update_verb: :POST


### PR DESCRIPTION
Especially in Terraform we encounter a different behavior. Try to clarify, what the actual behavior is.

Basically not provided version either defaults to recommended version (for creation) or is ignored.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
