### PR TITLE
Add handwritten sweeper for  google_vmwareengine_private_cloud

### DIFF
--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_sweeper.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_sweeper.go
@@ -61,7 +61,7 @@ func testSweepVmwareenginePrivateCloud(region string) error {
 		listUrl, err := tpgresource.ReplaceVars(d, config, listTemplate)
 		if err != nil {
 			log.Printf("[INFO][SWEEPER_LOG] error preparing sweeper list url: %s", err)
-			return nil
+			continue
 		}
 
 		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
@@ -73,7 +73,7 @@ func testSweepVmwareenginePrivateCloud(region string) error {
 		})
 		if err != nil {
 			log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)
-			return nil
+			continue
 		}
 
 		resourceList, ok := res["privateClouds"]
@@ -91,7 +91,7 @@ func testSweepVmwareenginePrivateCloud(region string) error {
 			obj := ri.(map[string]interface{})
 			if obj["name"] == nil {
 				log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
-				return nil
+				continue
 			}
 
 			name := tpgresource.GetResourceNameFromSelfLink(obj["name"].(string))
@@ -105,7 +105,7 @@ func testSweepVmwareenginePrivateCloud(region string) error {
 			deleteUrl, err := tpgresource.ReplaceVars(d, config, deleteTemplate)
 			if err != nil {
 				log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
-				return nil
+				continue
 			}
 			deleteUrl = deleteUrl + name
 

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_sweeper.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_sweeper.go
@@ -39,7 +39,7 @@ func testSweepVmwareenginePrivateCloud(region string) error {
 
 	// List of location values includes:
 	//   * global location
-	//   * regions used for this resource type's acc tests in the past
+	//   * zones used for this resource type's acc tests in the past
 	//   * the 'region' passed to the sweeper
 	locations := []string{region, "southamerica-west1-a", "me-west1-a"}
 	log.Printf("[INFO][SWEEPER_LOG] Sweeping will include these locations: %v.", locations)

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_sweeper.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_sweeper.go
@@ -1,0 +1,135 @@
+package vmwareengine
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/sweeper"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func init() {
+	sweeper.AddTestSweepers("VmwareenginePrivateCloud", testSweepVmwareenginePrivateCloud)
+}
+
+// At the time of writing, the CI only passes us-central1 as the region
+func testSweepVmwareenginePrivateCloud(region string) error {
+	resourceName := "VmwareenginePrivateCloud"
+	log.Printf("[INFO][SWEEPER_LOG] Starting sweeper for %s", resourceName)
+
+	config, err := sweeper.SharedConfigForRegion(region)
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error getting shared config for region: %s", err)
+		return err
+	}
+
+	err = config.LoadAndValidate(context.Background())
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error loading: %s", err)
+		return err
+	}
+
+	t := &testing.T{}
+	billingId := envvar.GetTestBillingAccountFromEnv(t)
+
+	// List of location values includes:
+	//   * global location
+	//   * regions used for this resource type's acc tests in the past
+	//   * the 'region' passed to the sweeper
+	locations := []string{region, "southamerica-west1-a", "me-west1-a"}
+	for _, location := range locations {
+		log.Printf("[INFO][SWEEPER_LOG] Beginning the process of sweeping location '%s'.", location)
+
+		// Setup variables to replace in list template
+		d := &tpgresource.ResourceDataMock{
+			FieldsInSchema: map[string]interface{}{
+				"project":         config.Project,
+				"region":          location,
+				"location":        location,
+				"zone":            "-",
+				"billing_account": billingId,
+			},
+		}
+
+		listTemplate := strings.Split("https://vmwareengine.googleapis.com/v1/projects/{{project}}/locations/{{location}}/privateClouds", "?")[0]
+		listUrl, err := tpgresource.ReplaceVars(d, config, listTemplate)
+		if err != nil {
+			log.Printf("[INFO][SWEEPER_LOG] error preparing sweeper list url: %s", err)
+			return nil
+		}
+
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   config.Project,
+			RawURL:    listUrl,
+			UserAgent: config.UserAgent,
+		})
+		if err != nil {
+			log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)
+			return nil
+		}
+
+		resourceList, ok := res["privateClouds"]
+		if !ok {
+			log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
+			continue
+		}
+
+		rl := resourceList.([]interface{})
+
+		log.Printf("[INFO][SWEEPER_LOG] Found %d items in %s list response.", len(rl), resourceName)
+		// Keep count of items that aren't sweepable for logging.
+		nonPrefixCount := 0
+		for _, ri := range rl {
+			obj := ri.(map[string]interface{})
+			if obj["name"] == nil {
+				log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
+				return nil
+			}
+
+			name := tpgresource.GetResourceNameFromSelfLink(obj["name"].(string))
+			// Skip resources that shouldn't be sweeped
+			if !sweeper.IsSweepableTestResource(name) {
+				nonPrefixCount++
+				continue
+			}
+
+			// We force delete the Private Cloud and ensure there's no delay in deletion
+			force := true
+			delayHours := 0
+			deleteTemplate := fmt.Sprintf("https://vmwareengine.googleapis.com/v1/projects/{{project}}/locations/{{location}}/privateClouds/{{name}}?force=%t&delayHours=%d", force, delayHours)
+			deleteUrl, err := tpgresource.ReplaceVars(d, config, deleteTemplate)
+			if err != nil {
+				log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
+				return nil
+			}
+			deleteUrl = deleteUrl + name
+
+			// Don't wait on operations as we may have a lot to delete
+			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "DELETE",
+				Project:   config.Project,
+				RawURL:    deleteUrl,
+				UserAgent: config.UserAgent,
+			})
+			if err != nil {
+				log.Printf("[INFO][SWEEPER_LOG] Error deleting for url %s : %s", deleteUrl, err)
+			} else {
+				log.Printf("[INFO][SWEEPER_LOG] Sent delete request for %s resource: %s", resourceName, name)
+			}
+		}
+
+		if nonPrefixCount > 0 {
+			log.Printf("[INFO][SWEEPER_LOG] %d items were non-sweepable and skipped.", nonPrefixCount)
+		}
+	}
+
+	return nil
+}

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_sweeper.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_sweeper.go
@@ -100,16 +100,18 @@ func testSweepVmwareenginePrivateCloud(region string) error {
 				continue
 			}
 
-			// We force delete the Private Cloud and ensure there's no delay in deletion
-			force := true
-			delayHours := 0
-			deleteTemplate := fmt.Sprintf("https://vmwareengine.googleapis.com/v1/projects/{{project}}/locations/{{location}}/privateClouds/{{name}}?force=%t&delayHours=%d", force, delayHours)
+			deleteTemplate := "https://vmwareengine.googleapis.com/v1/projects/{{project}}/locations/{{location}}/privateClouds/{{name}}"
 			deleteUrl, err := tpgresource.ReplaceVars(d, config, deleteTemplate)
 			if err != nil {
 				log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
 				return nil
 			}
 			deleteUrl = deleteUrl + name
+
+			// We force delete the Private Cloud and ensure there's no delay in deletion
+			force := true
+			delayHours := 0
+			deleteUrl = deleteUrl + fmt.Sprintf("?force=%t&delayHours=%d", force, delayHours)
 
 			// Don't wait on operations as we may have a lot to delete
 			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_sweeper.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_sweeper.go
@@ -42,6 +42,7 @@ func testSweepVmwareenginePrivateCloud(region string) error {
 	//   * regions used for this resource type's acc tests in the past
 	//   * the 'region' passed to the sweeper
 	locations := []string{region, "southamerica-west1-a", "me-west1-a"}
+	log.Printf("[INFO][SWEEPER_LOG] Sweeping will include these locations: %v.", locations)
 	for _, location := range locations {
 		log.Printf("[INFO][SWEEPER_LOG] Beginning the process of sweeping location '%s'.", location)
 

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_sweeper.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_sweeper.go
@@ -38,7 +38,6 @@ func testSweepVmwareenginePrivateCloud(region string) error {
 	billingId := envvar.GetTestBillingAccountFromEnv(t)
 
 	// List of location values includes:
-	//   * global location
 	//   * zones used for this resource type's acc tests in the past
 	//   * the 'region' passed to the sweeper
 	locations := []string{region, "southamerica-west1-a", "me-west1-a"}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/18485

This PR adds a sweeper for private cloud resources. Note that PCs can have long deletion times - to speed this up[ I pass parameters into the DELETE HTTP request to try speed up deletion.](https://github.com/GoogleCloudPlatform/magic-modules/pull/11002#discussion_r1647648806)

Here are some builds in TeamCity using this sweeper: https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_GoogleCloud_GOOGLE_MMUPSTREAMTESTS_SERVICE_SWEEPER__MANUAL?branch=refs%2Fheads%2Fauto-pr-11002&buildTypeTab=overview&mode=builds

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
