### PR TITLE
Make sweeper for google_vmwareengine_cluster handwritten, add iteration over loop of regions/locations

### DIFF
--- a/mmv1/products/vmwareengine/Cluster.yaml
+++ b/mmv1/products/vmwareengine/Cluster.yaml
@@ -49,6 +49,8 @@ async: !ruby/object:Api::OpAsync
 import_format: ["{{%parent}}/clusters/{{name}}"]
 id_format: "{{parent}}/clusters/{{name}}"
 autogen_async: true
+# There is a handwritten sweeper that provides a list of locations to sweep
+skip_sweeper: true
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: "vmware_engine_cluster_basic"

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_sweeper.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_sweeper.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-google-beta/google-beta/envvar"
-	"github.com/hashicorp/terraform-provider-google-beta/google-beta/sweeper"
-	"github.com/hashicorp/terraform-provider-google-beta/google-beta/tpgresource"
-	transport_tpg "github.com/hashicorp/terraform-provider-google-beta/google-beta/transport"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/sweeper"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 func init() {

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_sweeper.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_sweeper.go
@@ -60,7 +60,7 @@ func testSweepVmwareengineCluster(region string) error {
 		listUrl, err := tpgresource.ReplaceVars(d, config, listTemplate)
 		if err != nil {
 			log.Printf("[INFO][SWEEPER_LOG] error preparing sweeper list url: %s", err)
-			return nil
+			continue
 		}
 
 		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
@@ -72,7 +72,7 @@ func testSweepVmwareengineCluster(region string) error {
 		})
 		if err != nil {
 			log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)
-			return nil
+			continue
 		}
 
 		resourceList, ok := res["clusters"]
@@ -90,7 +90,7 @@ func testSweepVmwareengineCluster(region string) error {
 			obj := ri.(map[string]interface{})
 			if obj["name"] == nil {
 				log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
-				return nil
+				continue
 			}
 
 			name := tpgresource.GetResourceNameFromSelfLink(obj["name"].(string))
@@ -104,7 +104,7 @@ func testSweepVmwareengineCluster(region string) error {
 			deleteUrl, err := tpgresource.ReplaceVars(d, config, deleteTemplate)
 			if err != nil {
 				log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
-				return nil
+				continue
 			}
 			deleteUrl = deleteUrl + name
 

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_sweeper.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_sweeper.go
@@ -41,6 +41,7 @@ func testSweepVmwareengineCluster(region string) error {
 	//   * regions used for this resource type's acc tests in the past
 	//   * the 'region' passed to the sweeper
 	locations := []string{region, "global", "southamerica-west1", "me-west1"}
+	log.Printf("[INFO][SWEEPER_LOG] Sweeping will include these locations: %v.", locations)
 	for _, location := range locations {
 		log.Printf("[INFO][SWEEPER_LOG] Beginning the process of sweeping location '%s'.", location)
 

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_sweeper.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_sweeper.go
@@ -2,6 +2,7 @@ package vmwareengine
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 	"testing"
@@ -55,76 +56,119 @@ func testSweepVmwareengineCluster(region string) error {
 			},
 		}
 
-		listTemplate := strings.Split("https://vmwareengine.googleapis.com/v1/{{parent}}/clusters", "?")[0]
-		listUrl, err := tpgresource.ReplaceVars(d, config, listTemplate)
+		log.Printf("[INFO][SWEEPER_LOG] looking for parent resources in location '%s'.", location)
+		privateCloudNames, err := listPrivateCloudsInLocation(d, config)
 		if err != nil {
-			log.Printf("[INFO][SWEEPER_LOG] error preparing sweeper list url: %s", err)
+			log.Printf("[INFO][SWEEPER_LOG] error finding parental resources in location %s: %s", location, err)
 			continue
 		}
+		for _, parent := range privateCloudNames {
 
-		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-			Config:    config,
-			Method:    "GET",
-			Project:   config.Project,
-			RawURL:    listUrl,
-			UserAgent: config.UserAgent,
-		})
-		if err != nil {
-			log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)
-			continue
-		}
+			// `parent` will be string of form projects/my-project/locations/us-central1-a/privateClouds/my-cloud
+			listUrl := fmt.Sprintf("https://vmwareengine.googleapis.com/v1/projects/%s/clusters", parent)
 
-		resourceList, ok := res["clusters"]
-		if !ok {
-			log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
-			continue
-		}
-
-		rl := resourceList.([]interface{})
-
-		log.Printf("[INFO][SWEEPER_LOG] Found %d items in %s list response.", len(rl), resourceName)
-		// Keep count of items that aren't sweepable for logging.
-		nonPrefixCount := 0
-		for _, ri := range rl {
-			obj := ri.(map[string]interface{})
-			if obj["name"] == nil {
-				log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
-				continue
-			}
-
-			name := tpgresource.GetResourceNameFromSelfLink(obj["name"].(string))
-			// Skip resources that shouldn't be sweeped
-			if !sweeper.IsSweepableTestResource(name) {
-				nonPrefixCount++
-				continue
-			}
-
-			deleteTemplate := "https://vmwareengine.googleapis.com/v1/{{parent}}/clusters/{{name}}"
-			deleteUrl, err := tpgresource.ReplaceVars(d, config, deleteTemplate)
-			if err != nil {
-				log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
-				continue
-			}
-			deleteUrl = deleteUrl + name
-
-			// Don't wait on operations as we may have a lot to delete
-			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 				Config:    config,
-				Method:    "DELETE",
+				Method:    "GET",
 				Project:   config.Project,
-				RawURL:    deleteUrl,
+				RawURL:    listUrl,
 				UserAgent: config.UserAgent,
 			})
 			if err != nil {
-				log.Printf("[INFO][SWEEPER_LOG] Error deleting for url %s : %s", deleteUrl, err)
-			} else {
-				log.Printf("[INFO][SWEEPER_LOG] Sent delete request for %s resource: %s", resourceName, name)
+				log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)
+				continue
 			}
-		}
 
-		if nonPrefixCount > 0 {
-			log.Printf("[INFO][SWEEPER_LOG] %d items were non-sweepable and skipped.", nonPrefixCount)
+			resourceList, ok := res["clusters"]
+			if !ok {
+				log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
+				continue
+			}
+
+			rl := resourceList.([]interface{})
+
+			log.Printf("[INFO][SWEEPER_LOG] Found %d items in %s list response.", len(rl), resourceName)
+			// Keep count of items that aren't sweepable for logging.
+			nonPrefixCount := 0
+			for _, ri := range rl {
+				obj := ri.(map[string]interface{})
+				if obj["name"] == nil {
+					log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
+					continue
+				}
+
+				name := tpgresource.GetResourceNameFromSelfLink(obj["name"].(string))
+				// Skip resources that shouldn't be sweeped
+				if !sweeper.IsSweepableTestResource(name) {
+					nonPrefixCount++
+					continue
+				}
+
+				deleteTemplate := "https://vmwareengine.googleapis.com/v1/{{parent}}/clusters/{{name}}"
+				deleteUrl, err := tpgresource.ReplaceVars(d, config, deleteTemplate)
+				if err != nil {
+					log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
+					continue
+				}
+				deleteUrl = deleteUrl + name
+
+				// Don't wait on operations as we may have a lot to delete
+				_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+					Config:    config,
+					Method:    "DELETE",
+					Project:   config.Project,
+					RawURL:    deleteUrl,
+					UserAgent: config.UserAgent,
+				})
+				if err != nil {
+					log.Printf("[INFO][SWEEPER_LOG] Error deleting for url %s : %s", deleteUrl, err)
+				} else {
+					log.Printf("[INFO][SWEEPER_LOG] Sent delete request for %s resource: %s", resourceName, name)
+				}
+			}
+
+			if nonPrefixCount > 0 {
+				log.Printf("[INFO][SWEEPER_LOG] %d items were non-sweepable and skipped.", nonPrefixCount)
+			}
 		}
 	}
 	return nil
+}
+
+func listPrivateCloudsInLocation(d *tpgresource.ResourceDataMock, config *transport_tpg.Config) ([]string, error) {
+	listTemplate := strings.Split("https://vmwareengine.googleapis.com/v1/projects/{{project}}/locations/{{location}}/privateClouds", "?")[0]
+	listUrl, err := tpgresource.ReplaceVars(d, config, listTemplate)
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error preparing sweeper list url: %s", err)
+		return nil, err
+	}
+
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   config.Project,
+		RawURL:    listUrl,
+		UserAgent: config.UserAgent,
+	})
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)
+		return nil, err
+	}
+
+	resourceList, ok := res["privateClouds"]
+	if !ok {
+		log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
+		return nil, fmt.Errorf("nothing found in response")
+	}
+
+	rl := resourceList.([]interface{})
+	privateCloudNames := []string{}
+	for _, r := range rl {
+		resource := r.(map[string]interface{})
+		if name, ok := resource["name"]; ok {
+			privateCloudNames = append(privateCloudNames, name.(string))
+		}
+
+	}
+	return privateCloudNames, nil
 }

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_sweeper.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_sweeper.go
@@ -37,10 +37,9 @@ func testSweepVmwareengineCluster(region string) error {
 	billingId := envvar.GetTestBillingAccountFromEnv(t)
 
 	// List of location values includes:
-	//   * global location
-	//   * regions used for this resource type's acc tests in the past
+	//   * zones used for this resource type's acc tests in the past
 	//   * the 'region' passed to the sweeper
-	locations := []string{region, "global", "southamerica-west1", "me-west1"}
+	locations := []string{region, "us-central1-a", "southamerica-west1-a", "me-west1-a"}
 	log.Printf("[INFO][SWEEPER_LOG] Sweeping will include these locations: %v.", locations)
 	for _, location := range locations {
 		log.Printf("[INFO][SWEEPER_LOG] Beginning the process of sweeping location '%s'.", location)
@@ -51,7 +50,7 @@ func testSweepVmwareengineCluster(region string) error {
 				"project":         config.Project,
 				"region":          location,
 				"location":        location,
-				"zone":            "-",
+				"zone":            location,
 				"billing_account": billingId,
 			},
 		}

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_sweeper.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_sweeper.go
@@ -40,7 +40,7 @@ func testSweepVmwareengineCluster(region string) error {
 	// List of location values includes:
 	//   * zones used for this resource type's acc tests in the past
 	//   * the 'region' passed to the sweeper
-	locations := []string{region, "us-central1-a", "southamerica-west1-a", "me-west1-a"}
+	locations := []string{region, "us-central1-a", "us-central1-b", "southamerica-west1-a", "southamerica-west1-b", "me-west1-a", "me-west1-b"}
 	log.Printf("[INFO][SWEEPER_LOG] Sweeping will include these locations: %v.", locations)
 	for _, location := range locations {
 		log.Printf("[INFO][SWEEPER_LOG] Beginning the process of sweeping location '%s'.", location)

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_sweeper.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_sweeper.go
@@ -1,0 +1,130 @@
+package vmwareengine
+
+import (
+	"context"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-google-beta/google-beta/envvar"
+	"github.com/hashicorp/terraform-provider-google-beta/google-beta/sweeper"
+	"github.com/hashicorp/terraform-provider-google-beta/google-beta/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google-beta/google-beta/transport"
+)
+
+func init() {
+	sweeper.AddTestSweepers("VmwareengineCluster", testSweepVmwareengineCluster)
+}
+
+// At the time of writing, the CI only passes us-central1 as the region
+func testSweepVmwareengineCluster(region string) error {
+	resourceName := "VmwareengineCluster"
+	log.Printf("[INFO][SWEEPER_LOG] Starting sweeper for %s", resourceName)
+
+	config, err := sweeper.SharedConfigForRegion(region)
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error getting shared config for region: %s", err)
+		return err
+	}
+
+	err = config.LoadAndValidate(context.Background())
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error loading: %s", err)
+		return err
+	}
+
+	t := &testing.T{}
+	billingId := envvar.GetTestBillingAccountFromEnv(t)
+
+	// List of location values includes:
+	//   * global location
+	//   * regions used for this resource type's acc tests in the past
+	//   * the 'region' passed to the sweeper
+	locations := []string{region, "global", "southamerica-west1", "me-west1"}
+	for _, location := range locations {
+		log.Printf("[INFO][SWEEPER_LOG] Beginning the process of sweeping location '%s'.", location)
+
+		// Setup variables to replace in list template
+		d := &tpgresource.ResourceDataMock{
+			FieldsInSchema: map[string]interface{}{
+				"project":         config.Project,
+				"region":          location,
+				"location":        location,
+				"zone":            "-",
+				"billing_account": billingId,
+			},
+		}
+
+		listTemplate := strings.Split("https://vmwareengine.googleapis.com/v1/{{parent}}/clusters", "?")[0]
+		listUrl, err := tpgresource.ReplaceVars(d, config, listTemplate)
+		if err != nil {
+			log.Printf("[INFO][SWEEPER_LOG] error preparing sweeper list url: %s", err)
+			return nil
+		}
+
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   config.Project,
+			RawURL:    listUrl,
+			UserAgent: config.UserAgent,
+		})
+		if err != nil {
+			log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)
+			return nil
+		}
+
+		resourceList, ok := res["clusters"]
+		if !ok {
+			log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
+			continue
+		}
+
+		rl := resourceList.([]interface{})
+
+		log.Printf("[INFO][SWEEPER_LOG] Found %d items in %s list response.", len(rl), resourceName)
+		// Keep count of items that aren't sweepable for logging.
+		nonPrefixCount := 0
+		for _, ri := range rl {
+			obj := ri.(map[string]interface{})
+			if obj["name"] == nil {
+				log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
+				return nil
+			}
+
+			name := tpgresource.GetResourceNameFromSelfLink(obj["name"].(string))
+			// Skip resources that shouldn't be sweeped
+			if !sweeper.IsSweepableTestResource(name) {
+				nonPrefixCount++
+				continue
+			}
+
+			deleteTemplate := "https://vmwareengine.googleapis.com/v1/{{parent}}/clusters/{{name}}"
+			deleteUrl, err := tpgresource.ReplaceVars(d, config, deleteTemplate)
+			if err != nil {
+				log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
+				return nil
+			}
+			deleteUrl = deleteUrl + name
+
+			// Don't wait on operations as we may have a lot to delete
+			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "DELETE",
+				Project:   config.Project,
+				RawURL:    deleteUrl,
+				UserAgent: config.UserAgent,
+			})
+			if err != nil {
+				log.Printf("[INFO][SWEEPER_LOG] Error deleting for url %s : %s", deleteUrl, err)
+			} else {
+				log.Printf("[INFO][SWEEPER_LOG] Sent delete request for %s resource: %s", resourceName, name)
+			}
+		}
+
+		if nonPrefixCount > 0 {
+			log.Printf("[INFO][SWEEPER_LOG] %d items were non-sweepable and skipped.", nonPrefixCount)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
PR is related to:
* google_vmwareengine_private_cloud  sweeper changes https://github.com/GoogleCloudPlatform/magic-modules/pull/11002
* google_vmwareengine_network  sweeper changes https://github.com/GoogleCloudPlatform/magic-modules/pull/10994

This sweeper may not be 100% necessary, as the sweeper for Private Clouds force deletes them, i.e. removes all resources inside including clusters: https://github.com/GoogleCloudPlatform/magic-modules/pull/11002/files#r1647648806

The generated sweeper isn't functional though, so this PR could pivot to removing the generated sweeper only.


```release-note:none

```
