### PR TITLE
Add Resource SCC V1 Project Notification Config

### DIFF
--- a/mmv1/products/securitycenter/ProjectNotificationConfig.yaml
+++ b/mmv1/products/securitycenter/ProjectNotificationConfig.yaml
@@ -38,7 +38,7 @@ examples:
       topic_name: 'my-topic'
       config_id: 'my-config'
     test_env_vars:
-      project: :PROJECT_NAME
+      project: PROJECT_NAME
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/scc_source_self_link_as_name_set_organization.go.erb
   post_create: templates/terraform/post_create/set_computed_name.erb

--- a/mmv1/products/securitycenter/ProjectNotificationConfig.yaml
+++ b/mmv1/products/securitycenter/ProjectNotificationConfig.yaml
@@ -40,7 +40,7 @@ examples:
     test_env_vars:
       project: :PROJECT_NAME
 custom_code: !ruby/object:Provider::Terraform::CustomCode
-  custom_import: templates/terraform/custom_import/scc_source_self_link_as_name_set_organization.go.erb
+  custom_import: templates/terraform/custom_import/self_link_as_name_set_project.go.erb
   post_create: templates/terraform/post_create/set_computed_name.erb
 parameters:
   - !ruby/object:Api::Type::String

--- a/mmv1/products/securitycenter/ProjectNotificationConfig.yaml
+++ b/mmv1/products/securitycenter/ProjectNotificationConfig.yaml
@@ -13,9 +13,9 @@
 
 --- !ruby/object:Api::Resource
 name: 'ProjectNotificationConfig'
-base_url: projects/{{projectId}}/notificationConfigs
+base_url: projects/{{project}}/notificationConfigs
 self_link: '{{name}}'
-create_url: projects/{{projectId}}/notificationConfigs?configId={{config_id}}
+create_url: projects/{{project}}/notificationConfigs?configId={{config_id}}
 update_verb: :PATCH
 update_mask: true
 description: |
@@ -44,12 +44,12 @@ custom_code: !ruby/object:Provider::Terraform::CustomCode
   post_create: templates/terraform/post_create/set_computed_name.erb
 parameters:
   - !ruby/object:Api::Type::String
-    name: projectId
+    name: project
     required: true
     immutable: true
     url_param_only: true
     description: |
-      The projectId whose Cloud Security Command Center the Notification
+      The project whose Cloud Security Command Center the Notification
       Config lives in.
   - !ruby/object:Api::Type::String
     name: configId

--- a/mmv1/products/securitycenter/ProjectNotificationConfig.yaml
+++ b/mmv1/products/securitycenter/ProjectNotificationConfig.yaml
@@ -38,7 +38,7 @@ examples:
       topic_name: 'my-topic'
       config_id: 'my-config'
     test_env_vars:
-      org_id: :ORG_ID
+      project: :project
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/scc_source_self_link_as_name_set_organization.go.erb
   post_create: templates/terraform/post_create/set_computed_name.erb

--- a/mmv1/products/securitycenter/ProjectNotificationConfig.yaml
+++ b/mmv1/products/securitycenter/ProjectNotificationConfig.yaml
@@ -38,7 +38,7 @@ examples:
       topic_name: 'my-topic'
       config_id: 'my-config'
     test_env_vars:
-      project: :project
+      project: :PROJECT_NAME
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/scc_source_self_link_as_name_set_organization.go.erb
   post_create: templates/terraform/post_create/set_computed_name.erb

--- a/mmv1/products/securitycenter/ProjectNotificationConfig.yaml
+++ b/mmv1/products/securitycenter/ProjectNotificationConfig.yaml
@@ -39,6 +39,8 @@ examples:
       config_id: 'my-config'
     test_env_vars:
       project: :PROJECT_NAME
+    ignore_read_extra:
+      - 'project'
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/self_link_as_name_set_project.go.erb
   post_create: templates/terraform/post_create/set_computed_name.erb

--- a/mmv1/products/securitycenter/ProjectNotificationConfig.yaml
+++ b/mmv1/products/securitycenter/ProjectNotificationConfig.yaml
@@ -38,7 +38,7 @@ examples:
       topic_name: 'my-topic'
       config_id: 'my-config'
     test_env_vars:
-      project: PROJECT_NAME
+      project: :PROJECT_NAME
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/scc_source_self_link_as_name_set_organization.go.erb
   post_create: templates/terraform/post_create/set_computed_name.erb

--- a/mmv1/products/securitycenter/ProjectNotificationConfig.yaml
+++ b/mmv1/products/securitycenter/ProjectNotificationConfig.yaml
@@ -44,14 +44,6 @@ custom_code: !ruby/object:Provider::Terraform::CustomCode
   post_create: templates/terraform/post_create/set_computed_name.erb
 parameters:
   - !ruby/object:Api::Type::String
-    name: project
-    required: true
-    immutable: true
-    url_param_only: true
-    description: |
-      The project whose Cloud Security Command Center the Notification
-      Config lives in.
-  - !ruby/object:Api::Type::String
     name: configId
     required: true
     immutable: true

--- a/mmv1/products/securitycenter/ProjectNotificationConfig.yaml
+++ b/mmv1/products/securitycenter/ProjectNotificationConfig.yaml
@@ -1,0 +1,122 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'ProjectNotificationConfig'
+base_url: projects/{{projectId}}/notificationConfigs
+self_link: '{{name}}'
+create_url: projects/{{projectId}}/notificationConfigs?configId={{config_id}}
+update_verb: :PATCH
+update_mask: true
+description: |
+  A Cloud Security Command Center (Cloud SCC) notification configs. A
+  notification config is a Cloud SCC resource that contains the
+  configuration to send notifications for create/update events of
+  findings, assets and etc.
+  ~> **Note:** In order to use Cloud SCC resources, your organization must be enrolled
+  in [SCC Standard/Premium](https://cloud.google.com/security-command-center/docs/quickstart-security-command-center).
+  Without doing so, you may run into errors during resource creation.
+references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+    'Official Documentation': 'https://cloud.google.com/security-command-center/docs'
+  api: 'https://cloud.google.com/security-command-center/docs/reference/rest/v1/projects.notificationConfigs'
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'scc_project_notification_config_basic'
+    primary_resource_id: 'custom_notification_config'
+    vars:
+      topic_name: 'my-topic'
+      config_id: 'my-config'
+    test_env_vars:
+      org_id: :ORG_ID
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  custom_import: templates/terraform/custom_import/scc_source_self_link_as_name_set_organization.go.erb
+  post_create: templates/terraform/post_create/set_computed_name.erb
+parameters:
+  - !ruby/object:Api::Type::String
+    name: projectId
+    required: true
+    immutable: true
+    url_param_only: true
+    description: |
+      The projectId whose Cloud Security Command Center the Notification
+      Config lives in.
+  - !ruby/object:Api::Type::String
+    name: configId
+    required: true
+    immutable: true
+    url_param_only: true
+    description: |
+      This must be unique within the organization.
+properties:
+  - !ruby/object:Api::Type::String
+    name: name
+    output: true
+    description: |
+      The resource name of this notification config, in the format
+      `projects/{{projectId}}/notificationConfigs/{{config_id}}`.
+  - !ruby/object:Api::Type::String
+    name: description
+    description: |
+      The description of the notification config (max of 1024 characters).
+    validation: !ruby/object:Provider::Terraform::Validation
+      function: 'validation.StringLenBetween(0, 1024)'
+  - !ruby/object:Api::Type::String
+    name: pubsubTopic
+    required: true
+    description: |
+      The Pub/Sub topic to send notifications to. Its format is
+      "projects/[project_id]/topics/[topic]".
+  - !ruby/object:Api::Type::String
+    name: serviceAccount
+    output: true
+    description: |
+      The service account that needs "pubsub.topics.publish" permission to
+      publish to the Pub/Sub topic.
+  - !ruby/object:Api::Type::NestedObject
+    name: streamingConfig
+    required: true
+    description: |
+      The config for triggering streaming-based notifications.
+    update_mask_fields:
+      - 'streamingConfig.filter'
+    properties:
+      - !ruby/object:Api::Type::String
+        name: filter
+        required: true
+        description: |
+          Expression that defines the filter to apply across create/update
+          events of assets or findings as specified by the event type. The
+          expression is a list of zero or more restrictions combined via
+          logical operators AND and OR. Parentheses are supported, and OR
+          has higher precedence than AND.
+
+          Restrictions have the form <field> <operator> <value> and may have
+          a - character in front of them to indicate negation. The fields
+          map to those defined in the corresponding resource.
+
+          The supported operators are:
+
+          * = for all value types.
+          * >, <, >=, <= for integer values.
+          * :, meaning substring matching, for strings.
+
+          The supported value types are:
+
+          * string literals in quotes.
+          * integer literals without quotes.
+          * boolean literals true and false without quotes.
+
+          See
+          [Filtering notifications](https://cloud.google.com/security-command-center/docs/how-to-api-filter-notifications)
+          for information on how to write a filter.

--- a/mmv1/templates/terraform/examples/scc_project_notification_config_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/scc_project_notification_config_basic.tf.erb
@@ -4,7 +4,7 @@ resource "google_pubsub_topic" "scc_project_notification" {
 
 resource "google_scc_project_notification_config" "<%= ctx[:primary_resource_id] %>" {
   config_id    = "<%= ctx[:vars]['config_id'] %>"
-  organization = "<%= ctx[:test_env_vars]['org_id'] %>"
+  project_id = "<%= ctx[:test_env_vars]['project_id'] %>"
   description  = "My custom Cloud Security Command Center Finding Notification Configuration"
   pubsub_topic =  google_pubsub_topic.scc_project_notification.id
 

--- a/mmv1/templates/terraform/examples/scc_project_notification_config_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/scc_project_notification_config_basic.tf.erb
@@ -1,0 +1,14 @@
+resource "google_pubsub_topic" "scc_project_notification" {
+  name = "<%= ctx[:vars]['topic_name'] %>"
+}
+
+resource "google_scc_project_notification_config" "<%= ctx[:primary_resource_id] %>" {
+  config_id    = "<%= ctx[:vars]['config_id'] %>"
+  organization = "<%= ctx[:test_env_vars]['org_id'] %>"
+  description  = "My custom Cloud Security Command Center Finding Notification Configuration"
+  pubsub_topic =  google_pubsub_topic.scc_project_notification.id
+
+  streaming_config {
+    filter = "category = \"OPEN_FIREWALL\" AND state = \"ACTIVE\""
+  }
+}

--- a/mmv1/templates/terraform/examples/scc_project_notification_config_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/scc_project_notification_config_basic.tf.erb
@@ -4,7 +4,7 @@ resource "google_pubsub_topic" "scc_project_notification" {
 
 resource "google_scc_project_notification_config" "<%= ctx[:primary_resource_id] %>" {
   config_id    = "<%= ctx[:vars]['config_id'] %>"
-  project_id = "<%= ctx[:test_env_vars]['project_id'] %>"
+  project_id   = "<%= ctx[:test_env_vars]['project_id'] %>"
   description  = "My custom Cloud Security Command Center Finding Notification Configuration"
   pubsub_topic =  google_pubsub_topic.scc_project_notification.id
 

--- a/mmv1/templates/terraform/examples/scc_project_notification_config_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/scc_project_notification_config_basic.tf.erb
@@ -4,7 +4,7 @@ resource "google_pubsub_topic" "scc_project_notification" {
 
 resource "google_scc_project_notification_config" "<%= ctx[:primary_resource_id] %>" {
   config_id    = "<%= ctx[:vars]['config_id'] %>"
-  project_id   = "<%= ctx[:test_env_vars]['project_id'] %>"
+  project      = "<%= ctx[:test_env_vars]['project'] %>"
   description  = "My custom Cloud Security Command Center Finding Notification Configuration"
   pubsub_topic =  google_pubsub_topic.scc_project_notification.id
 

--- a/mmv1/third_party/terraform/services/securitycenter/resource_scc_project_notification_config_test.go
+++ b/mmv1/third_party/terraform/services/securitycenter/resource_scc_project_notification_config_test.go
@@ -12,7 +12,7 @@ func TestAccSecurityCenterProjectNotificationConfig_updateStreamingConfigFilter(
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"project_id":    envvar.GetTestProjectFromEnv(t),
+		"project_id":    envvar.GetTestProjectFromEnv(),
 		"random_suffix": acctest.RandString(t, 10),
 	}
 
@@ -28,7 +28,7 @@ func TestAccSecurityCenterProjectNotificationConfig_updateStreamingConfigFilter(
 				ResourceName:            "google_scc_project_notification_config.custom_notification_config",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"project", "config_id"},
+				ImportStateVerifyIgnore: []string{"projectId", "config_id"},
 			},
 			{
 				Config: testAccSecurityCenterProjectNotificationConfig_updateStreamingConfigFilter(context),
@@ -37,7 +37,7 @@ func TestAccSecurityCenterProjectNotificationConfig_updateStreamingConfigFilter(
 				ResourceName:            "google_scc_project_notification_config.custom_notification_config",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"project", "config_id"},
+				ImportStateVerifyIgnore: []string{"projectId", "config_id"},
 			},
 		},
 	})
@@ -51,7 +51,7 @@ resource "google_pubsub_topic" "scc_project_notification" {
 
 resource "google_scc_project_notification_config" "custom_notification_config" {
   config_id    = "tf-test-my-config%{random_suffix}"
-  project      = "%{project_id}"
+  projectId      = "%{project_id}"
   description  = "My custom Cloud Security Command Center Finding Notification Configuration"
   pubsub_topic =  google_pubsub_topic.scc_project_notification.id
 

--- a/mmv1/third_party/terraform/services/securitycenter/resource_scc_project_notification_config_test.go
+++ b/mmv1/third_party/terraform/services/securitycenter/resource_scc_project_notification_config_test.go
@@ -28,8 +28,7 @@ func TestAccSecurityCenterProjectNotificationConfig_updateStreamingConfigFilter(
 				ResourceName:            "google_scc_project_notification_config.custom_notification_config",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"project", "config_id"},
-				IgnoreReadExtra: 		 []string{"project"},
+				ImportStateVerifyIgnore: []string{"project", "config_id"},				
 			},
 			{
 				Config: testAccSecurityCenterProjectNotificationConfig_updateStreamingConfigFilter(context),
@@ -39,7 +38,6 @@ func TestAccSecurityCenterProjectNotificationConfig_updateStreamingConfigFilter(
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"project", "config_id"},
-				IgnoreReadExtra: 		 []string{"project"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/securitycenter/resource_scc_project_notification_config_test.go
+++ b/mmv1/third_party/terraform/services/securitycenter/resource_scc_project_notification_config_test.go
@@ -12,7 +12,7 @@ func TestAccSecurityCenterProjectNotificationConfig_updateStreamingConfigFilter(
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"project":    envvar.GetTestProjectFromEnv(),
+		"project":       envvar.GetTestProjectFromEnv(),
 		"random_suffix": acctest.RandString(t, 10),
 	}
 

--- a/mmv1/third_party/terraform/services/securitycenter/resource_scc_project_notification_config_test.go
+++ b/mmv1/third_party/terraform/services/securitycenter/resource_scc_project_notification_config_test.go
@@ -28,7 +28,7 @@ func TestAccSecurityCenterProjectNotificationConfig_updateStreamingConfigFilter(
 				ResourceName:            "google_scc_project_notification_config.custom_notification_config",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"project", "config_id"},				
+				ImportStateVerifyIgnore: []string{"project", "config_id"},
 			},
 			{
 				Config: testAccSecurityCenterProjectNotificationConfig_updateStreamingConfigFilter(context),

--- a/mmv1/third_party/terraform/services/securitycenter/resource_scc_project_notification_config_test.go
+++ b/mmv1/third_party/terraform/services/securitycenter/resource_scc_project_notification_config_test.go
@@ -29,6 +29,7 @@ func TestAccSecurityCenterProjectNotificationConfig_updateStreamingConfigFilter(
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"project", "config_id"},
+				IgnoreReadExtra: 		 []string{"project"},
 			},
 			{
 				Config: testAccSecurityCenterProjectNotificationConfig_updateStreamingConfigFilter(context),
@@ -38,6 +39,7 @@ func TestAccSecurityCenterProjectNotificationConfig_updateStreamingConfigFilter(
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"project", "config_id"},
+				IgnoreReadExtra: 		 []string{"project"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/securitycenter/resource_scc_project_notification_config_test.go
+++ b/mmv1/third_party/terraform/services/securitycenter/resource_scc_project_notification_config_test.go
@@ -12,7 +12,7 @@ func TestAccSecurityCenterProjectNotificationConfig_updateStreamingConfigFilter(
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"project_id":    envvar.GetTestProjectFromEnv(),
+		"project":    envvar.GetTestProjectFromEnv(),
 		"random_suffix": acctest.RandString(t, 10),
 	}
 
@@ -28,7 +28,7 @@ func TestAccSecurityCenterProjectNotificationConfig_updateStreamingConfigFilter(
 				ResourceName:            "google_scc_project_notification_config.custom_notification_config",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"project_id", "config_id"},
+				ImportStateVerifyIgnore: []string{"project", "config_id"},
 			},
 			{
 				Config: testAccSecurityCenterProjectNotificationConfig_updateStreamingConfigFilter(context),
@@ -37,7 +37,7 @@ func TestAccSecurityCenterProjectNotificationConfig_updateStreamingConfigFilter(
 				ResourceName:            "google_scc_project_notification_config.custom_notification_config",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"project_id", "config_id"},
+				ImportStateVerifyIgnore: []string{"project", "config_id"},
 			},
 		},
 	})
@@ -51,7 +51,7 @@ resource "google_pubsub_topic" "scc_project_notification" {
 
 resource "google_scc_project_notification_config" "custom_notification_config" {
   config_id    = "tf-test-my-config%{random_suffix}"
-  project_id   = "%{project_id}"
+  project      = "%{project}"
   description  = "My custom Cloud Security Command Center Finding Notification Configuration"
   pubsub_topic =  google_pubsub_topic.scc_project_notification.id
 

--- a/mmv1/third_party/terraform/services/securitycenter/resource_scc_project_notification_config_test.go
+++ b/mmv1/third_party/terraform/services/securitycenter/resource_scc_project_notification_config_test.go
@@ -28,7 +28,7 @@ func TestAccSecurityCenterProjectNotificationConfig_updateStreamingConfigFilter(
 				ResourceName:            "google_scc_project_notification_config.custom_notification_config",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"projectId", "config_id"},
+				ImportStateVerifyIgnore: []string{"project_id", "config_id"},
 			},
 			{
 				Config: testAccSecurityCenterProjectNotificationConfig_updateStreamingConfigFilter(context),
@@ -37,7 +37,7 @@ func TestAccSecurityCenterProjectNotificationConfig_updateStreamingConfigFilter(
 				ResourceName:            "google_scc_project_notification_config.custom_notification_config",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"projectId", "config_id"},
+				ImportStateVerifyIgnore: []string{"project_id", "config_id"},
 			},
 		},
 	})
@@ -51,7 +51,7 @@ resource "google_pubsub_topic" "scc_project_notification" {
 
 resource "google_scc_project_notification_config" "custom_notification_config" {
   config_id    = "tf-test-my-config%{random_suffix}"
-  projectId      = "%{project_id}"
+  project_id   = "%{project_id}"
   description  = "My custom Cloud Security Command Center Finding Notification Configuration"
   pubsub_topic =  google_pubsub_topic.scc_project_notification.id
 

--- a/mmv1/third_party/terraform/services/securitycenter/resource_scc_project_notification_config_test.go
+++ b/mmv1/third_party/terraform/services/securitycenter/resource_scc_project_notification_config_test.go
@@ -61,22 +61,3 @@ resource "google_scc_project_notification_config" "custom_notification_config" {
 }
 `, context)
 }
-
-func testAccSecurityCenterProjectNotificationConfig_sccProjectNotificationConfigBasicExample(context map[string]interface{}) string {
-	return acctest.Nprintf(`
-resource "google_pubsub_topic" "scc_project_notification" {
-  name = "tf-test-my-topic%{random_suffix}"
-}
-
-resource "google_scc_project_notification_config" "custom_notification_config" {
-  config_id    = "tf-test-my-config%{random_suffix}"
-  project      = "%{project}"
-  description  = "My custom Cloud Security Command Center Finding Notification Configuration"
-  pubsub_topic = google_pubsub_topic.scc_project_notification.id
-
-  streaming_config {
-    filter = "category = \"OPEN_FIREWALL\" AND state = \"ACTIVE\""
-  }
-}
-`, context)
-}

--- a/mmv1/third_party/terraform/services/securitycenter/resource_scc_project_notification_config_test.go
+++ b/mmv1/third_party/terraform/services/securitycenter/resource_scc_project_notification_config_test.go
@@ -53,10 +53,29 @@ resource "google_scc_project_notification_config" "custom_notification_config" {
   config_id    = "tf-test-my-config%{random_suffix}"
   project      = "%{project}"
   description  = "My custom Cloud Security Command Center Finding Notification Configuration"
-  pubsub_topic =  google_pubsub_topic.scc_project_notification.id
+  pubsub_topic = google_pubsub_topic.scc_project_notification.id
 
   streaming_config {
     filter = "category = \"OPEN_FIREWALL\""
+  }
+}
+`, context)
+}
+
+func testAccSecurityCenterProjectNotificationConfig_sccProjectNotificationConfigBasicExample(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_pubsub_topic" "scc_project_notification" {
+  name = "tf-test-my-topic%{random_suffix}"
+}
+
+resource "google_scc_project_notification_config" "custom_notification_config" {
+  config_id    = "tf-test-my-config%{random_suffix}"
+  project      = "%{project}"
+  description  = "My custom Cloud Security Command Center Finding Notification Configuration"
+  pubsub_topic = google_pubsub_topic.scc_project_notification.id
+
+  streaming_config {
+    filter = "category = \"OPEN_FIREWALL\" AND state = \"ACTIVE\""
   }
 }
 `, context)

--- a/mmv1/third_party/terraform/services/securitycenter/resource_scc_project_notification_config_test.go
+++ b/mmv1/third_party/terraform/services/securitycenter/resource_scc_project_notification_config_test.go
@@ -1,0 +1,63 @@
+package securitycenter_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccSecurityCenterProjectNotificationConfig_updateStreamingConfigFilter(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project_id":    envvar.GetTestProjectFromEnv(t),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecurityCenterProjectNotificationConfigDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecurityCenterProjectNotificationConfig_sccProjectNotificationConfigBasicExample(context),
+			},
+			{
+				ResourceName:            "google_scc_project_notification_config.custom_notification_config",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"project", "config_id"},
+			},
+			{
+				Config: testAccSecurityCenterProjectNotificationConfig_updateStreamingConfigFilter(context),
+			},
+			{
+				ResourceName:            "google_scc_project_notification_config.custom_notification_config",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"project", "config_id"},
+			},
+		},
+	})
+}
+
+func testAccSecurityCenterProjectNotificationConfig_updateStreamingConfigFilter(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_pubsub_topic" "scc_project_notification" {
+  name = "tf-test-my-topic%{random_suffix}"
+}
+
+resource "google_scc_project_notification_config" "custom_notification_config" {
+  config_id    = "tf-test-my-config%{random_suffix}"
+  project      = "%{project_id}"
+  description  = "My custom Cloud Security Command Center Finding Notification Configuration"
+  pubsub_topic =  google_pubsub_topic.scc_project_notification.id
+
+  streaming_config {
+    filter = "category = \"OPEN_FIREWALL\""
+  }
+}
+`, context)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Related to http://b/309603080.

Bug Description: https://github.com/hashicorp/terraform-provider-google/issues/16427

Adding new template for SCC API V1 Project Notification Config
https://cloud.google.com/security-command-center/docs/reference/rest/v1/projects.notificationConfigs

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_scc_project_notification_config`
```
