### PR TITLE
Fix resource_compute_shared_reservation_update encoder

### DIFF
--- a/mmv1/products/compute/Reservation.yaml
+++ b/mmv1/products/compute/Reservation.yaml
@@ -141,6 +141,7 @@ properties:
         description: |
           Type of sharing for this shared-reservation
         default_from_api: true
+        immutable: true
       - !ruby/object:Api::Type::Map
         name: 'projectMap'
         description: |

--- a/mmv1/templates/terraform/update_encoder/go/reservation.go.tmpl
+++ b/mmv1/templates/terraform/update_encoder/go/reservation.go.tmpl
@@ -37,10 +37,27 @@
 		// Set project_map.
 		projectMap := make(map[string]interface{})
 		old, new := d.GetChange("share_settings")
-		oldMap := old.([]interface{})[0].(map[string]interface{})["project_map"]
-		newMap := new.([]interface{})[0].(map[string]interface{})["project_map"]
-		before := oldMap.(*schema.Set)
-		after := newMap.(*schema.Set)
+
+		var before *schema.Set
+		if oldSlice, ok := old.([]interface{}); ok && len(oldSlice) > 0 {
+			if oldMap, ok := oldSlice[0].(map[string]interface{})["project_map"]; ok {
+				before = oldMap.(*schema.Set)
+			} else {
+				before = schema.NewSet(schema.HashString, []interface{}{})
+			}
+		} else {
+			before = schema.NewSet(schema.HashString, []interface{}{})
+		}
+		var after *schema.Set
+		if newSlice, ok := new.([]interface{}); ok && len(newSlice) > 0 {
+			if newMap, ok := newSlice[0].(map[string]interface{})["project_map"]; ok {
+				after = newMap.(*schema.Set)
+			} else {
+				after = schema.NewSet(schema.HashString, []interface{}{})
+			}
+		} else {
+			after = schema.NewSet(schema.HashString, []interface{}{})
+		}
 
 		for _, raw := range after.Difference(before).List() {
 			original := raw.(map[string]interface{})
@@ -56,10 +73,10 @@
 			}
 			projectMap[transformedId] = singleProject
 			// add added projects to updateMask
-			if firstProject != true {
-				maskId = fmt.Sprintf("%s%s", "&paths=shareSettings.projectMap.", original["project_id"])
+			if !firstProject {
+				maskId = fmt.Sprintf("%s%s", "&paths=shareSettings.projectMap.", original["id"])
 			} else {
-				maskId = fmt.Sprintf("%s%s", "?paths=shareSettings.projectMap.", original["project_id"])
+				maskId = fmt.Sprintf("%s%s", "?paths=shareSettings.projectMap.", original["id"])
 				firstProject = false
 			}
 			decodedPath, _ := url.QueryUnescape(maskId)
@@ -86,7 +103,7 @@
 				projectNum := project.ProjectNumber
 				projectIdOrNum = fmt.Sprintf("%d", projectNum)
 			}
-			if firstProject != true {
+			if !firstProject {
 				maskId = fmt.Sprintf("%s%s", "&paths=shareSettings.projectMap.", projectIdOrNum)
 			} else {
 				maskId = fmt.Sprintf("%s%s", "?paths=shareSettings.projectMap.", projectIdOrNum)

--- a/mmv1/templates/terraform/update_encoder/reservation.go.erb
+++ b/mmv1/templates/terraform/update_encoder/reservation.go.erb
@@ -39,10 +39,27 @@
 		// Set project_map.
 		projectMap := make(map[string]interface{})
 		old, new := d.GetChange("share_settings")
-		oldMap := old.([]interface{})[0].(map[string]interface{})["project_map"]
-		newMap := new.([]interface{})[0].(map[string]interface{})["project_map"]
-		before := oldMap.(*schema.Set)
-		after := newMap.(*schema.Set)
+
+		var before *schema.Set
+		if oldSlice, ok := old.([]interface{}); ok && len(oldSlice) > 0 {
+			if oldMap, ok := oldSlice[0].(map[string]interface{})["project_map"]; ok {
+				before = oldMap.(*schema.Set)
+			} else {
+				before = schema.NewSet(schema.HashString, []interface{}{})
+			}
+		} else {
+			before = schema.NewSet(schema.HashString, []interface{}{})
+		}
+		var after *schema.Set
+		if newSlice, ok := new.([]interface{}); ok && len(newSlice) > 0 {
+			if newMap, ok := newSlice[0].(map[string]interface{})["project_map"]; ok {
+				after = newMap.(*schema.Set)
+			} else {
+				after = schema.NewSet(schema.HashString, []interface{}{})
+			}
+		} else {
+			after = schema.NewSet(schema.HashString, []interface{}{})
+		}
 
 		for _, raw := range after.Difference(before).List() {
 			original := raw.(map[string]interface{})
@@ -58,10 +75,10 @@
 			}
 			projectMap[transformedId] = singleProject
 			// add added projects to updateMask
-			if firstProject != true {
-				maskId = fmt.Sprintf("%s%s", "&paths=shareSettings.projectMap.", original["project_id"])
+			if !firstProject {
+				maskId = fmt.Sprintf("%s%s", "&paths=shareSettings.projectMap.", original["id"])
 			} else {
-				maskId = fmt.Sprintf("%s%s", "?paths=shareSettings.projectMap.", original["project_id"])
+				maskId = fmt.Sprintf("%s%s", "?paths=shareSettings.projectMap.", original["id"])
 				firstProject = false
 			}
 			decodedPath, _ := url.QueryUnescape(maskId)
@@ -88,7 +105,7 @@
 				projectNum := project.ProjectNumber
 				projectIdOrNum = fmt.Sprintf("%d", projectNum)
 			}
-			if firstProject != true {
+			if !firstProject {
 				maskId = fmt.Sprintf("%s%s", "&paths=shareSettings.projectMap.", projectIdOrNum)
 			} else {
 				maskId = fmt.Sprintf("%s%s", "?paths=shareSettings.projectMap.", projectIdOrNum)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_shared_reservation_update_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_shared_reservation_update_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestAccComputeSharedReservation_update(t *testing.T) {
-	acctest.SkipIfVcr(t) // large number of parallel resources.
 	t.Parallel()
 
 	context := map[string]interface{}{


### PR DESCRIPTION
Fix resource_compute_shared_reservation_update encoder to avoid crashes on resource update
Fixes [hashicorp/terraform-provider-google/16208](https://github.com/hashicorp/terraform-provider-google/issues/16208)


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed a crash in `google_compute_reservation` resource where `share_settings` field has changes  
```
