### PR TITLE
Add support for endpoint src and dest for network connectivity tests

### DIFF
--- a/docs/content/get-started/generate-providers.md
+++ b/docs/content/get-started/generate-providers.md
@@ -34,6 +34,7 @@ If you are familiar with Docker or Podman, you may want to use the experimental 
 1. Use rbenv to install ruby 3.1.0
    ```bash
    rbenv install 3.1.0
+   rbenv init
    ```
 1. [Install go](https://go.dev/doc/install)
 1. Add the following values to your environment settings such as `.bashrc`:

--- a/mmv1/products/networkmanagement/ConnectivityTest.yaml
+++ b/mmv1/products/networkmanagement/ConnectivityTest.yaml
@@ -45,6 +45,33 @@ examples:
       network: 'connectivity-vpc'
       source_addr: 'src-addr'
       dest_addr: 'dest-addr'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'network_management_connectivity_test_cloudrun_v2'
+    primary_resource_id: 'cloudrun-v2-test'
+    vars:
+      primary_resource_name: 'cloudrun-v2-test'
+      network: 'connectivity-vpc'
+      source_cloudrun: 'src-cloudrun-v2'
+      dest_cloudrun: 'dest-cloudrun-v2'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'network_management_connectivity_test_cloudfunctions2'
+    primary_resource_id: 'cloudfunctions2-test'
+    vars:
+      primary_resource_name: 'cloudfunctions2-test'
+      source_cloudfunction: 'src-cloudfunctions2'
+      dest_cloudfunction: 'dest-cloudfunctions2'
+      bucket_name: 'gcf-source'
+      zip_path: 'function-source.zip'
+    test_env_vars:
+      project: :PROJECT_NAME
+    test_vars_overrides:
+      zip_path: '"../cloudfunctions2/test-fixtures/function-source.zip"'
+      location:
+        '"us-central1"'
+        # ignore these fields during import step
+    ignore_read_extra:
+      - 'build_config.0.source.0.storage_source.0.object'
+      - 'build_config.0.source.0.storage_source.0.bucket'
 properties:
   - !ruby/object:Api::Type::String
     name: name
@@ -93,6 +120,8 @@ properties:
       - 'source.network'
       - 'source.networkType'
       - 'source.projectId'
+      - 'source.forwardingRule'
+      - 'source.cloudsql'
     properties:
       - !ruby/object:Api::Type::String
         name: ipAddress
@@ -133,6 +162,48 @@ properties:
              that you provide is from the service project. In this case,
              the network that the IP address resides in is defined in the
              host project.
+      - !ruby/object:Api::Type::String
+        name: forwardingRule
+        description: |-
+          ID of the Forwarding Rule in one of the following formats:
+          1. projects/{project}/global/forwardingRules/{id}
+          2. projects/{project}/regions/{region}/forwardingRules/{id}
+      - !ruby/object:Api::Type::String
+        name: gkeMasterCluster
+        description: |-
+          A cluster URI for Google Kubernetes Engine master.
+      - !ruby/object:Api::Type::String
+        name: cloudSqlInstance
+        description: |-
+          A Cloud SQL instance URI.
+      - !ruby/object:Api::Type::NestedObject
+        name: cloudFunction
+        description: |
+          Reference to a cloud function
+        properties:
+          - !ruby/object:Api::Type::String
+            name: uri
+            description: |-
+              A Cloud Function URI.
+      - !ruby/object:Api::Type::NestedObject
+        name: appEngineVersion
+        description: |
+          Reference to an App engine service version.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: uri
+            description: |-
+              A App Engine service URI.
+      - !ruby/object:Api::Type::NestedObject
+        name: cloudRunRevision
+        description: |
+          Reference to a Cloud Run revision.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: uri
+            description: |-
+              A Cloud Run revision URI.
+              The format is: projects/{project}/locations/{location}/revisions/{revision}
   - !ruby/object:Api::Type::NestedObject
     name: 'destination'
     required: true
@@ -192,6 +263,48 @@ properties:
           that you provide is from the service project. In this case, the
           network that the IP address resides in is defined in the host
           project.
+      - !ruby/object:Api::Type::String
+        name: forwardingRule
+        description: |-
+          ID of the Forwarding Rule in one of the following formats:
+          1. projects/{project}/global/forwardingRules/{id}
+          2. projects/{project}/regions/{region}/forwardingRules/{id}
+      - !ruby/object:Api::Type::String
+        name: gkeMasterCluster
+        description: |-
+          A cluster URI for Google Kubernetes Engine master.
+      - !ruby/object:Api::Type::String
+        name: cloudSqlInstance
+        description: |-
+          A Cloud SQL instance URI.
+      - !ruby/object:Api::Type::NestedObject
+        name: cloudFunction
+        description: |
+          Reference to a cloud function
+        properties:
+          - !ruby/object:Api::Type::String
+            name: uri
+            description: |-
+              A Cloud Function URI.
+      - !ruby/object:Api::Type::NestedObject
+        name: appEngineVersion
+        description: |
+          Reference to an App engine service version.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: uri
+            description: |-
+              A App Engine service URI.
+      - !ruby/object:Api::Type::NestedObject
+        name: cloudRunRevision
+        description: |
+          Reference to a Cloud Run revision.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: uri
+            description: |-
+              A Cloud Run revision URI.
+              The format is: projects/{project}/locations/{location}/revisions/{revision}
   - !ruby/object:Api::Type::String
     name: protocol
     description: |-

--- a/mmv1/products/networkmanagement/ConnectivityTest.yaml
+++ b/mmv1/products/networkmanagement/ConnectivityTest.yaml
@@ -54,6 +54,37 @@ examples:
       source_cloudrun: 'src-cloudrun-v2'
       dest_cloudrun: 'dest-cloudrun-v2'
   - !ruby/object:Provider::Terraform::Examples
+    name: 'network_management_connectivity_test_cloudsql'
+    primary_resource_id: 'cloudsql-test'
+    vars:
+      primary_resource_name: 'cloudsql-test'
+      network: 'connectivity-vpc'
+      source_cloudrun: 'src-cloudsql'
+      dest_cloudrun: 'dest-cloudsql'
+      deletion_protection: 'true'
+    test_vars_overrides:
+      deletion_protection: 'false'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'network_management_connectivity_test_forwarding_rule'
+    primary_resource_id: 'forwarding-rule-test'
+    vars:
+      primary_resource_name: 'forwarding-rule-test'
+      source_forwarding_rule: 'src-forwarding-rule'
+      dest_forwarding_rule: 'src-forwarding-rule'
+      deletion_protection: 'true'
+    test_vars_overrides:
+      deletion_protection: 'false'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'network_management_connectivity_test_gke_master'
+    primary_resource_id: 'gke-master-test'
+    vars:
+      primary_resource_name: 'gke-master-test'
+      source_gke: 'src-gke'
+      dest_gke: 'dst-gke'
+      deletion_protection: 'true'
+    test_vars_overrides:
+      deletion_protection: 'false'
+  - !ruby/object:Provider::Terraform::Examples
     name: 'network_management_connectivity_test_cloudfunctions2'
     primary_resource_id: 'cloudfunctions2-test'
     vars:
@@ -186,15 +217,6 @@ properties:
             description: |-
               A Cloud Function URI.
       - !ruby/object:Api::Type::NestedObject
-        name: appEngineVersion
-        description: |
-          Reference to an App engine service version.
-        properties:
-          - !ruby/object:Api::Type::String
-            name: uri
-            description: |-
-              A App Engine service URI.
-      - !ruby/object:Api::Type::NestedObject
         name: cloudRunRevision
         description: |
           Reference to a Cloud Run revision.
@@ -286,15 +308,6 @@ properties:
             name: uri
             description: |-
               A Cloud Function URI.
-      - !ruby/object:Api::Type::NestedObject
-        name: appEngineVersion
-        description: |
-          Reference to an App engine service version.
-        properties:
-          - !ruby/object:Api::Type::String
-            name: uri
-            description: |-
-              A App Engine service URI.
       - !ruby/object:Api::Type::NestedObject
         name: cloudRunRevision
         description: |

--- a/mmv1/templates/terraform/examples/go/network_management_connectivity_test_cloudfunctions2.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/network_management_connectivity_test_cloudfunctions2.tf.tmpl
@@ -1,0 +1,81 @@
+# [START networkmanagement_test_cloudfunction2]
+resource "google_network_management_connectivity_test" "{{$.PrimaryResourceId}}" {
+  name = "{{index $.Vars "primary_resource_name"}}"
+  source {
+    cloud_function {
+      uri = google_cloudfunctions2_function.source.id
+    } 
+  }
+
+  destination {
+    cloud_function {
+      uri = google_cloudfunctions2_function.dest.id
+    } 
+  }
+
+  protocol = "TCP"
+  labels = {
+    env = "test"
+  }
+}
+
+locals {
+  project = "{{index $.TestEnvVars "project"}}" # Google Cloud Platform Project ID
+}
+
+resource "google_storage_bucket" "bucket" {
+  name     = "${local.project}-{{index $.Vars "bucket_name"}}"  # Every bucket name must be globally unique
+  location = "US"
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket_object" "object" {
+  name   = "function-source.zip"
+  bucket = google_storage_bucket.bucket.name
+  source = "{{index $.Vars "zip_path"}}"  # Add path to the zipped function source code
+}
+
+resource "google_cloudfunctions2_function" "source" {
+  name = "{{index $.Vars "source_cloudfunction"}}"
+  location = "us-central1"
+ 
+  build_config {
+    runtime = "nodejs16"
+    entry_point = "helloHttp"  # Set the entry point 
+    source {
+      storage_source {
+        bucket = google_storage_bucket.bucket.name
+        object = google_storage_bucket_object.object.name
+      }
+    }
+  }
+ 
+  service_config {
+    max_instance_count  = 1
+    available_memory    = "256M"
+    timeout_seconds     = 60
+  }
+}
+
+resource "google_cloudfunctions2_function" "dest" {
+  name = "{{index $.Vars "dest_cloudfunction"}}"
+  location = "us-central1"
+ 
+  build_config {
+    runtime = "nodejs16"
+    entry_point = "helloHttp"  # Set the entry point 
+    source {
+      storage_source {
+        bucket = google_storage_bucket.bucket.name
+        object = google_storage_bucket_object.object.name
+      }
+    }
+  }
+ 
+  service_config {
+    max_instance_count  = 1
+    available_memory    = "256M"
+    timeout_seconds     = 60
+  }
+}
+# [END networkmanagement_test_cloudfunction2]

--- a/mmv1/templates/terraform/examples/go/network_management_connectivity_test_cloudrun_v2.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/network_management_connectivity_test_cloudrun_v2.tf.tmpl
@@ -1,0 +1,61 @@
+# [START networkmanagement_test_cloudrun_v2]
+resource "google_network_management_connectivity_test" "{{$.PrimaryResourceId}}" {
+  name = "{{index $.Vars "primary_resource_name"}}"
+  source {
+    cloud_run_revision {
+      uri = google_cloud_run_v2_service.source.id
+    }
+  }
+
+  destination {
+    cloud_run_revision {
+      uri = google_cloud_run_v2_service.dest.id
+    }
+  }
+
+  protocol = "TCP"
+  labels = {
+    env = "test"
+  }
+}
+
+resource "google_compute_network" "vpc" {
+  name = "{{index $.Vars "network_name"}}"
+}
+
+resource "google_cloud_run_v2_service" "source" {
+  name     = "{{index $.Vars "source_cloudrun"}}"
+  location = "us-central1"
+  ingress = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+
+    vpc_access {
+      network_interfaces {
+        network = google_compute_network.vpc.id
+      }
+    }
+  }
+}
+
+resource "google_cloud_run_v2_service" "dest" {
+  name     = "{{index $.Vars "dest_cloudrun"}}"
+  location = "us-central1"
+  ingress = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+
+    vpc_access {
+      network_interfaces {
+        network = google_compute_network.vpc.id
+      }
+    }
+  }
+}
+# [END networkmanagement_test_cloudrun_v2]

--- a/mmv1/templates/terraform/examples/network_management_connectivity_test_cloudfunctions2.tf.erb
+++ b/mmv1/templates/terraform/examples/network_management_connectivity_test_cloudfunctions2.tf.erb
@@ -78,4 +78,4 @@ resource "google_cloudfunctions2_function" "dest" {
     timeout_seconds     = 60
   }
 }
-# [END networkmanagement_test_cloudfunction2]q
+# [END networkmanagement_test_cloudfunction2]

--- a/mmv1/templates/terraform/examples/network_management_connectivity_test_cloudfunctions2.tf.erb
+++ b/mmv1/templates/terraform/examples/network_management_connectivity_test_cloudfunctions2.tf.erb
@@ -1,0 +1,81 @@
+# [START networkmanagement_test_cloudfunction2]
+resource "google_network_management_connectivity_test" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['primary_resource_name'] %>"
+  source {
+    cloud_function {
+      uri = google_cloudfunctions2_function.source.id
+    } 
+  }
+
+  destination {
+    cloud_function {
+      uri = google_cloudfunctions2_function.dest.id
+    } 
+  }
+
+  protocol = "TCP"
+  labels = {
+    env = "test"
+  }
+}
+
+locals {
+  project = "<%= ctx[:test_env_vars]['project'] %>" # Google Cloud Platform Project ID
+}
+
+resource "google_storage_bucket" "bucket" {
+  name     = "${local.project}-<%= ctx[:vars]['bucket_name'] %>"  # Every bucket name must be globally unique
+  location = "US"
+  uniform_bucket_level_access = true
+}
+ 
+resource "google_storage_bucket_object" "object" {
+  name   = "function-source.zip"
+  bucket = google_storage_bucket.bucket.name
+  source = "<%= ctx[:vars]['zip_path'] %>"  # Add path to the zipped function source code
+}
+
+resource "google_cloudfunctions2_function" "source" {
+  name = "<%= ctx[:vars]['source_cloudfunction'] %>"
+  location = "us-central1"
+ 
+  build_config {
+    runtime = "nodejs16"
+    entry_point = "helloHttp"  # Set the entry point 
+    source {
+      storage_source {
+        bucket = google_storage_bucket.bucket.name
+        object = google_storage_bucket_object.object.name
+      }
+    }
+  }
+ 
+  service_config {
+    max_instance_count  = 1
+    available_memory    = "256M"
+    timeout_seconds     = 60
+  }
+}
+
+resource "google_cloudfunctions2_function" "dest" {
+  name = "<%= ctx[:vars]['dest_cloudfunction'] %>"
+  location = "us-central1"
+ 
+  build_config {
+    runtime = "nodejs16"
+    entry_point = "helloHttp"  # Set the entry point 
+    source {
+      storage_source {
+        bucket = google_storage_bucket.bucket.name
+        object = google_storage_bucket_object.object.name
+      }
+    }
+  }
+ 
+  service_config {
+    max_instance_count  = 1
+    available_memory    = "256M"
+    timeout_seconds     = 60
+  }
+}
+# [END networkmanagement_test_cloudfunction2]q

--- a/mmv1/templates/terraform/examples/network_management_connectivity_test_cloudrun_v2.tf.erb
+++ b/mmv1/templates/terraform/examples/network_management_connectivity_test_cloudrun_v2.tf.erb
@@ -58,4 +58,4 @@ resource "google_cloud_run_v2_service" "dest" {
     }
   }
 }
-# [END networkmanagement_test_cloudrun_v2]q
+# [END networkmanagement_test_cloudrun_v2]

--- a/mmv1/templates/terraform/examples/network_management_connectivity_test_cloudrun_v2.tf.erb
+++ b/mmv1/templates/terraform/examples/network_management_connectivity_test_cloudrun_v2.tf.erb
@@ -1,0 +1,61 @@
+# [START networkmanagement_test_cloudrun_v2]
+resource "google_network_management_connectivity_test" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['primary_resource_name'] %>"
+  source {
+    cloud_run_revision {
+      uri = google_cloud_run_v2_service.source.id
+    } 
+  }
+
+  destination {
+    cloud_run_revision {
+      uri = google_cloud_run_v2_service.dest.id
+    } 
+  }
+
+  protocol = "TCP"
+  labels = {
+    env = "test"
+  }
+}
+
+resource "google_compute_network" "vpc" {
+  name = "<%= ctx[:vars]['network'] %>"
+}
+
+resource "google_cloud_run_v2_service" "source" {
+  name     = "<%= ctx[:vars]['source_cloudrun'] %>"
+  location = "us-central1"
+  ingress = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+    
+    vpc_access {
+      network_interfaces {
+        network = google_compute_network.vpc.id
+      }
+    }
+  }
+}
+
+resource "google_cloud_run_v2_service" "dest" {
+  name     = "<%= ctx[:vars]['dest_cloudrun'] %>"
+  location = "us-central1"
+  ingress = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+
+    vpc_access {
+      network_interfaces {
+        network = google_compute_network.vpc.id
+      }
+    }
+  }
+}
+# [END networkmanagement_test_cloudrun_v2]q

--- a/mmv1/templates/terraform/examples/network_management_connectivity_test_cloudsql.tf.erb
+++ b/mmv1/templates/terraform/examples/network_management_connectivity_test_cloudsql.tf.erb
@@ -1,0 +1,53 @@
+# [START networkmanagement_test_cloudsql]
+resource "google_network_management_connectivity_test" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['primary_resource_name'] %>"
+  source {
+    cloud_sql_instance = google_sql_database_instance.source.self_link
+  }
+
+  destination {
+    cloud_sql_instance = google_sql_database_instance.dest.self_link
+  }
+
+  protocol = "TCP"
+  labels = {
+    env = "test"
+  }
+}
+
+resource "google_compute_network" "vpc" {
+  name = "<%= ctx[:vars]['network'] %>"
+}
+
+resource "google_sql_database_instance" "source" {
+  name                = "<%= ctx[:vars]['source_cloudsql'] %>"
+  database_version    = "POSTGRES_15"
+  region              = "us-central1"
+  deletion_protection = "<%= ctx[:vars]['deletion_protection'] %>"
+
+  settings {
+    tier = "db-f1-micro"
+    ip_configuration {
+      ipv4_enabled                                  = false
+      private_network                               = google_compute_network.vpc.id
+      enable_private_path_for_google_cloud_services = true
+    }
+  }
+}
+
+resource "google_sql_database_instance" "dest" {
+  name                = "<%= ctx[:vars]['dest_cloudsql'] %>"
+  database_version    = "POSTGRES_15"
+  region              = "us-central1"
+  deletion_protection = "<%= ctx[:vars]['deletion_protection'] %>"
+
+  settings {
+    tier = "db-f1-micro"
+    ip_configuration {
+      ipv4_enabled                                  = false
+      private_network                               = google_compute_network.vpc.id
+      enable_private_path_for_google_cloud_services = true
+    }
+  }
+}
+# [END networkmanagement_test_cloudsql]

--- a/mmv1/templates/terraform/examples/network_management_connectivity_test_forwarding_rule.tf.erb
+++ b/mmv1/templates/terraform/examples/network_management_connectivity_test_forwarding_rule.tf.erb
@@ -1,0 +1,37 @@
+# [START networkmanagement_test_forwarding_rule]
+resource "google_network_management_connectivity_test" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['primary_resource_name'] %>"
+  source {
+    forwarding_rule = google_compute_forwarding_rule.source.id
+  }
+
+  destination {
+    forwarding_rule = google_compute_forwarding_rule.dest.id
+  }
+
+  protocol = "TCP"
+  labels = {
+    env = "test"
+  }
+}
+
+resource "google_compute_target_pool" "source" {
+  name = "<%= ctx[:vars]['source_forwarding_rule'] %>"
+}
+
+resource "google_compute_forwarding_rule" "source" {
+  name        = "<%= ctx[:vars]['source_forwarding_rule'] %>"
+  target     = google_compute_target_pool.source.id
+  port_range = "80"
+}
+
+resource "google_compute_target_pool" "dest" {
+  name = "<%= ctx[:vars]['dest_forwarding_rule'] %>"
+}
+
+resource "google_compute_forwarding_rule" "dest" {
+  name        = "<%= ctx[:vars]['dest_forwarding_rule'] %>"
+  target     = google_compute_target_pool.dest.id
+  port_range = "80"
+}
+# [END networkmanagement_test_forwarding_rule]

--- a/mmv1/templates/terraform/examples/network_management_connectivity_test_gke_master.tf.erb
+++ b/mmv1/templates/terraform/examples/network_management_connectivity_test_gke_master.tf.erb
@@ -1,0 +1,35 @@
+# [START networkmanagement_test_gke_master]
+resource "google_network_management_connectivity_test" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['primary_resource_name'] %>"
+  source {
+    forwarding_rule = google_compute_forwarding_rule.source.id
+  }
+
+  destination {
+    forwarding_rule = google_compute_forwarding_rule.dest.id
+  }
+
+  protocol = "TCP"
+  labels = {
+    env = "test"
+  }
+}
+
+resource "google_container_cluster" "source" {
+  name     = "<%= ctx[:vars]['source_gke'] %>"
+  location = "us-central1-a"
+
+  deletion_protection      = "<%= ctx[:vars]['deletion_protection'] %>"
+  remove_default_node_pool = true
+  initial_node_count       = 1
+}
+
+resource "google_container_cluster" "dest" {
+  name     = "<%= ctx[:vars]['dest_gke'] %>"
+  location = "us-central1-a"
+
+  deletion_protection      = "<%= ctx[:vars]['deletion_protection'] %>"
+  remove_default_node_pool = true
+  initial_node_count       = 1
+}
+# [END networkmanagement_test_gke_master]


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Solves [16908](https://github.com/hashicorp/terraform-provider-google/issues/16908) by adding endpoint fields from the API that's missing (see [API reference](https://cloud.google.com/network-intelligence-center/docs/connectivity-tests/reference/networkmanagement/rest/v1/projects.locations.global.connectivityTests#Endpoint)) 

I've added and ran light acceptance tests that can be run (cloudrun and cloudfunction source and destinations). 

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
networkmanagement: added `forwardingRule`, `gkeMasterCluster`, `cloudSqlInstance`, `cloudFunction`, `cloudRunRevision`, and `cloudRunRevision` for the `source` and `dest` fields to the `ConnectivityTest` resource
```
