### PR TITLE
Add 6.0.0 feature branch instructions back in

### DIFF
--- a/docs/content/develop/breaking-changes/make-a-breaking-change.md
+++ b/docs/content/develop/breaking-changes/make-a-breaking-change.md
@@ -63,7 +63,7 @@ The general process for contributing a breaking change to the
 1. Make the `main` branch forwards-compatible with the major release
 2. Add deprecations and warnings to the `main` branch of `magic-modules`
 3. Add upgrade guide entries to the `main` branch of `magic-modules`
-4. Make the breaking change on ~~`FEATURE-BRANCH-major-release-{{% param "majorVersion" %}}`~~ `main` temporarily
+4. Make the breaking change on `FEATURE-BRANCH-major-release-{{% param "majorVersion" %}}`
 
 These are covered in more detail in the following sections. The upgrade guide
 and the actual breaking change will be merged only after both are completed.
@@ -184,11 +184,36 @@ The upgrade guide and the actual breaking change will be merged only after both 
 
 ### Make the breaking change on `FEATURE-BRANCH-major-release-{{% param "majorVersion" %}}`
 
-> [!CAUTION]
-> `FEATURE-BRANCH-major-release-{{% param "majorVersion" %}}` is not yet ready. If you want to make your
-> breaking change ahead of time (possibly for early review), please submit a PR on `main` with the title prefix "6.0.0 - ". 
-> Ensure that a Github Issue is created as per all PR's, and our team will manually switch your PR over to
-> `FEATURE-BRANCH-major-release-{{% param "majorVersion" %}} when it is ready.
+When working on your breaking change, make sure that your base branch
+is `FEATURE-BRANCH-major-release-{{% param "majorVersion" %}}`. This
+means that you will follow the standard
+[contribution process]({{< ref "/get-started/contribution-process" >}})
+with the following changes:
+
+1. Before you start, check out and sync your local `magic-modules` and provider
+   repositories with the upstream major release branches.
+   ```bash
+   cd ~/magic-modules
+   git checkout FEATURE-BRANCH-major-release-{{% param "majorVersion" %}}
+   git pull --ff-only origin FEATURE-BRANCH-major-release-{{% param "majorVersion" %}}
+   cd $GOPATH/src/github.com/hashicorp/terraform-provider-google
+   git checkout FEATURE-BRANCH-major-release-{{% param "majorVersion" %}}
+   git pull --ff-only origin FEATURE-BRANCH-major-release-{{% param "majorVersion" %}}
+   cd $GOPATH/src/github.com/hashicorp/terraform-provider-google-beta
+   git checkout FEATURE-BRANCH-major-release-{{% param "majorVersion" %}}
+   git pull --ff-only origin FEATURE-BRANCH-major-release-{{% param "majorVersion" %}}
+   ```
+1. Make sure that any deprecation notices and warnings that you added in previous sections
+   are present on the major release branch. Changes to the `main` branch will be
+   merged into the major release branch every Monday.
+1. Make the breaking change.
+1. Remove any deprecation notices and warnings (including in documentation) not already removed by the breaking change.
+1. When you create your pull request,
+   [change the base branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-base-branch-of-a-pull-request)
+   to `FEATURE-BRANCH-major-release-{{% param "majorVersion" %}}`
+1. To resolve merge conflicts with `git rebase` or `git merge`, use `FEATURE-BRANCH-major-release-{{% param "majorVersion" %}}` instead of `main`.
+
+The upgrade guide and the actual breaking change will be merged only after both are completed.
 
 ## What's next?
 


### PR DESCRIPTION


This reverts commit 64ac7343f38762501c3e6e40f409e99353eeb8b2.

The contribution window is open, so the old instructions apply

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
