### PR TITLE
Custom Update ordering diffs

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -1476,6 +1476,10 @@ func (r Resource) PropertiesByCustomUpdateGroups() []UpdateGroup {
 			UpdateVerb:      prop.UpdateVerb,
 			UpdateId:        prop.UpdateId,
 			FingerprintName: prop.FingerprintName}
+
+		if slices.Contains(updateGroups, groupedProperty){
+			continue
+		}
 		updateGroups = append(updateGroups, groupedProperty)
 	}
 	sort.Slice(updateGroups, func(i, j int) bool { return updateGroups[i].UpdateId < updateGroups[i].UpdateId })

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -17,6 +17,7 @@ import (
 	"maps"
 	"regexp"
 	"strings"
+	"sort"
 
 	"github.com/GoogleCloudPlatform/magic-modules/mmv1/api/product"
 	"github.com/GoogleCloudPlatform/magic-modules/mmv1/api/resource"
@@ -1465,6 +1466,20 @@ func (r Resource) PropertiesByCustomUpdate() map[UpdateGroup][]*Type {
 		groupedCustomUpdateProps[groupedProperty] = append(groupedCustomUpdateProps[groupedProperty], prop)
 	}
 	return groupedCustomUpdateProps
+}
+
+func (r Resource) PropertiesByCustomUpdateGroups() []UpdateGroup {
+	customUpdateProps := r.propertiesWithCustomUpdate(r.RootProperties())
+	var updateGroups []UpdateGroup
+	for _, prop := range customUpdateProps {
+		groupedProperty := UpdateGroup{UpdateUrl: prop.UpdateUrl,
+			UpdateVerb:      prop.UpdateVerb,
+			UpdateId:        prop.UpdateId,
+			FingerprintName: prop.FingerprintName}
+		updateGroups = append(updateGroups, groupedProperty)
+	}
+	sort.Slice(updateGroups, func(i, j int) bool { return updateGroups[i].UpdateId < updateGroups[i].UpdateId })
+	return updateGroups
 }
 
 func (r Resource) FieldSpecificUpdateMethods() bool {

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -830,10 +830,11 @@ if len(updateMask) > 0 {
 {{-         end}}{{/*if not immutable*/}}
 {{          if $.FieldSpecificUpdateMethods }}
     d.Partial(true)
-{{             range $index, $props := $.PropertiesByCustomUpdate }}
-if d.HasChange("{{ join ($.PropertyNamesToStrings $props) "\") || d.HasChange(\""}}") {
+{{             $CustomUpdateProps := $.PropertiesByCustomUpdate }}
+{{             range $group := $.PropertiesByCustomUpdateGroups }}
+if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $group)) "\") || d.HasChange(\""}}") {
         obj := make(map[string]interface{})
-{{		            if $index.FingerprintName }}
+{{		            if $group.FingerprintName }}
         getUrl, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}{{$.ProductMetadata.Name}}BasePath{{"}}"}}{{$.SelfLinkUri}}")
         if err != nil {
             return err
@@ -866,10 +867,10 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings $props) "\") || d.HasChange(\"
             return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("{{ $.ResourceName -}} %q", d.Id()))
         }
 
-        obj["{{ $index.FingerprintName }}"] = getRes["{{ $index.FingerprintName }}"]
+        obj["{{ $group.FingerprintName }}"] = getRes["{{ $group.FingerprintName }}"]
 
 {{                  end  }}{{/*if FingerprintName*/}}
-{{                  range $propsByKey := $.CustomUpdatePropertiesByKey $index.UpdateUrl $index.UpdateId $index.FingerprintName $index.UpdateVerb }}
+{{                  range $propsByKey := $.CustomUpdatePropertiesByKey $group.UpdateUrl $group.UpdateId $group.FingerprintName $group.UpdateVerb }}
         {{ $propsByKey.ApiName -}}Prop, err := expand{{ if $.NestedQuery -}}Nested{{ end }}{{ $.ResourceName -}}{{ camelize $propsByKey.Name "upper"  -}}({{ if $propsByKey.FlattenObject }}nil{{else}}d.Get("{{underscore $propsByKey.Name}}"){{ end }}, d, config)
         if err != nil {
             return err
@@ -916,7 +917,7 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings $props) "\") || d.HasChange(\"
         transport_tpg.MutexStore.Lock(lockName)
         defer transport_tpg.MutexStore.Unlock(lockName)
 {{-                 end}}
-        url, err := tpgresource.ReplaceVars{{if $.LegacyLongFormProject -}}ForId{{ end -}}(d, config, "{{"{{"}}{{$.ProductMetadata.Name}}BasePath{{"}}"}}{{ $index.UpdateUrl }}")
+        url, err := tpgresource.ReplaceVars{{if $.LegacyLongFormProject -}}ForId{{ end -}}(d, config, "{{"{{"}}{{$.ProductMetadata.Name}}BasePath{{"}}"}}{{ $group.UpdateUrl }}")
         if err != nil {
             return err
         }
@@ -939,7 +940,7 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings $props) "\") || d.HasChange(\"
 
         res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
             Config: config,
-            Method: "{{ $index.UpdateVerb }}",
+            Method: "{{ $group.UpdateVerb }}",
             Project: billingProject,
             RawURL: url,
             UserAgent: userAgent,


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Resolved diffs in order of custom update groups: previous issues resulted from go maps being unordered -- every generation would result in new random diffs. added a layer of sorted keys that serves as basis for template iteration.

https://diff.googleplex.com/#key=0bHXRhFA5GZv

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
