### PR TITLE
Add support for Config Sync enabled field in ConfigManagement Fleet-level default config

### DIFF
--- a/mmv1/products/gkehub2/Feature.yaml
+++ b/mmv1/products/gkehub2/Feature.yaml
@@ -287,6 +287,9 @@ properties:
                 name: sourceFormat
                 description: 'Specifies whether the Config Sync Repo is in hierarchical or unstructured mode'
               - !ruby/object:Api::Type::Boolean
+                name: enabled
+                description: 'Enables the installation of ConfigSync. If set to true, ConfigSync resources will be created and the other ConfigSync fields will be applied if exist. If set to false, all other ConfigSync fields will be ignored, ConfigSync resources will be deleted. If omitted, ConfigSync resources will be managed depends on the presence of the git or oci field.'
+              - !ruby/object:Api::Type::Boolean
                 name: preventDrift
                 description: 'Set to true to enable the Config Sync admission webhook to prevent drifts. If set to `false`, disables the Config Sync admission webhook and does not prevent drifts.'
               - !ruby/object:Api::Type::NestedObject

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go.erb
@@ -531,8 +531,9 @@ resource "google_gke_hub_feature" "feature" {
   fleet_default_member_config {
     configmanagement {
       version = "1.16.1"
-     config_sync {
-       prevent_drift = true
+      config_sync {
+        enabled = true
+        prevent_drift = true
         source_format = "unstructured"
         oci {
           sync_repo = "us-central1-docker.pkg.dev/corp-gke-build-artifacts/acm/configs:latest"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add support for Config Sync enabled field in ConfigManagement Fleet-level default config. Note this field is already supported in Pantheon UI and gcloud.

The Config Sync enabled field was added in
https://github.com/GoogleCloudPlatform/declarative-resource-client-library/commit/c3703a0fa7616e91efb18fd82366d73a561a5b62.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**


```release-note:enhancement
gkehub: added `config_sync.enabled` field to ConfigManagement `fleet_default_member_config`
```
