### PR TITLE
Fix typos in docker image data source docs

### DIFF
--- a/mmv1/third_party/terraform/website/docs/d/artifact_registry_docker_image.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/artifact_registry_docker_image.html.markdown
@@ -21,9 +21,9 @@ resource "google_artifact_registry_repository" "my_repo" {
 }
 
 data "google_artifact_registry_docker_image" "my_image" {
-  repository = google_artifact_registry_repository.my_repo.id
-  image      = "my-image"
-  tag        = "my-tag"
+  location      = google_artifact_registry_repository.my_repo.location
+  repository_id = google_artifact_registry_repository.my_repo.repository_id
+  image         = "my-image:my-tag"
 }
 
 resource "google_cloud_run_v2_service" "default" {
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `location` - (Required) The location of the artifact registry.
 
-* `repository_id` - (Required) The last part of the repository name. to fetch from.
+* `repository_id` - (Required) The last part of the repository name to fetch from.
 
 * `image_name` - (Required) The image name to fetch. If no digest or tag is provided, then the latest modified image will be used.
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
The example in the docs for `google_artifact_registry_docker_image` is not representative of using the data source, and there is a small typo in the argument section.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
