### PR TITLE
Add example for using TimespanConfig successfully without row_limit_percent or row_limit set

### DIFF
--- a/mmv1/products/dlp/JobTrigger.yaml
+++ b/mmv1/products/dlp/JobTrigger.yaml
@@ -117,6 +117,13 @@ examples:
       trigger: 'trigger'
     test_env_vars:
       project: :PROJECT_NAME
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'dlp_job_trigger_timespan_config_big_query'
+    primary_resource_id: 'timespan_config_big_query'
+    vars:
+      trigger: 'trigger'
+    test_env_vars:
+      project: :PROJECT_NAME
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   encoder: templates/terraform/encoders/dlp_job_trigger.go.erb
   decoder: templates/terraform/decoders/dlp_job_trigger.go.erb
@@ -938,7 +945,8 @@ properties:
                 name: 'sampleMethod'
                 description: |
                   How to sample rows if not all rows are scanned. Meaningful only when used in conjunction with either
-                  rowsLimit or rowsLimitPercent. If not specified, rows are scanned in the order BigQuery reads them.
+                  rowsLimit or rowsLimitPercent. If not specified, rows are scanned in the order BigQuery reads them. 
+                  If TimespanConfig is set, set this to an empty string to avoid using the default value.
                 values:
                   - :TOP
                   - :RANDOM_START

--- a/mmv1/products/dlp/JobTrigger.yaml
+++ b/mmv1/products/dlp/JobTrigger.yaml
@@ -945,7 +945,7 @@ properties:
                 name: 'sampleMethod'
                 description: |
                   How to sample rows if not all rows are scanned. Meaningful only when used in conjunction with either
-                  rowsLimit or rowsLimitPercent. If not specified, rows are scanned in the order BigQuery reads them. 
+                  rowsLimit or rowsLimitPercent. If not specified, rows are scanned in the order BigQuery reads them.
                   If TimespanConfig is set, set this to an empty string to avoid using the default value.
                 values:
                   - :TOP

--- a/mmv1/templates/terraform/examples/dlp_job_trigger_timespan_config_big_query.tf.erb
+++ b/mmv1/templates/terraform/examples/dlp_job_trigger_timespan_config_big_query.tf.erb
@@ -1,0 +1,43 @@
+resource "google_data_loss_prevention_job_trigger" "<%= ctx[:primary_resource_id] %>" {
+    parent = "projects/<%= ctx[:test_env_vars]['project'] %>"
+    description  = "BigQuery DLP Job Trigger with timespan config and row limit"
+    display_name = "bigquery-dlp-job-trigger-limit-timespan"
+
+    triggers {
+        schedule {
+            recurrence_period_duration ="86400s"
+        }
+    }
+
+    inspect_job {
+        inspect_template_name = "projects/test/locations/global/inspectTemplates/6425492983381733900" 
+        storage_config {
+            big_query_options {
+                table_reference {
+                    project_id = "project"
+                    dataset_id = "dataset"
+                    table_id   = "table"
+                }
+                sample_method = ""
+            }
+
+            timespan_config {
+                start_time = "2023-01-01T00:00:23Z"
+                timestamp_field {
+                    name = "timestamp"
+                }
+            }
+        }
+
+        actions {
+            save_findings {
+                output_config {
+                    table {
+                        project_id = "project"
+                        dataset_id = "output"
+                    }
+                }
+            }
+        }
+}
+}

--- a/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_job_trigger_test.go
+++ b/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_job_trigger_test.go
@@ -487,6 +487,32 @@ func TestAccDataLossPreventionJobTrigger_dlpJobTrigger_withSensitivityScore(t *t
 	})
 }
 
+func TestAccDataLossPreventionJobTrigger_dlpJobTriggerCreateWithTimespanConfigBigQuery(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project":       envvar.GetTestProjectFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataLossPreventionJobTriggerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataLossPreventionJobTrigger_dlpJobTrigger_rowLimit_timespanConfig(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_job_trigger.bigquery_row_limit_timespan",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parent", "inspect_job.0.storage_config.0.big_query_options.0.sample_method"},
+			},
+		},
+	})
+}
+
 func testAccDataLossPreventionJobTrigger_dlpJobTriggerBasic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_data_loss_prevention_job_trigger" "basic" {
@@ -2744,6 +2770,55 @@ resource "google_data_loss_prevention_job_trigger" "basic" {
 						sensitivity_score {
 							score = "SENSITIVITY_HIGH"
 						}
+					}
+				}
+			}
+		}
+	}
+}
+`, context)
+}
+
+func testAccDataLossPreventionJobTrigger_dlpJobTrigger_rowLimit_timespanConfig(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+
+resource "google_data_loss_prevention_job_trigger" "bigquery_row_limit_timespan" {
+	parent       = "projects/%{project}"
+	description  = "BigQuery DLP Job Trigger with timespan config and row limit"
+	display_name = "bigquery-dlp-job-trigger-limit-timespan"
+
+	triggers {
+		schedule {
+			recurrence_period_duration ="86400s"
+		}
+	}
+
+	inspect_job {
+		inspect_template_name = "projects/test/locations/global/inspectTemplates/6425492983381733900" 
+		storage_config {
+			big_query_options {
+				table_reference {
+					project_id = "project"
+					dataset_id = "dataset"
+					table_id   = "table"
+				}
+				sample_method = ""
+			}
+
+			timespan_config {
+				start_time = "2023-01-01T00:00:23Z"
+				timestamp_field {
+					name = "timestamp"
+				}
+			}
+		}
+
+		actions {
+			save_findings {
+				output_config {
+					table {
+						project_id = "project"
+						dataset_id = "output"
 					}
 				}
 			}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
TimespanConfig in JobTrigger cannot be set if sampleMethod is also set — this is an API-side restriction. Unfortunately, a previous magic-module contributor erroneously set a default value for sampleMethod, which caused requests to fail.

Add example detailing the correct workaround (removing the default value is a breaking change), which is to set sampleMethod to a blank string when setting TimespanConfig.

This should allow us to close https://github.com/hashicorp/terraform-provider-google/issues/14096. 
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
