### PR TITLE
Added stack_type (enum) and gateway_ip_version (enum) to HAVPN resource

### DIFF
--- a/mmv1/products/compute/HaVpnGateway.yaml
+++ b/mmv1/products/compute/HaVpnGateway.yaml
@@ -135,6 +135,17 @@ properties:
     values:
       - :IPV4_ONLY
       - :IPV4_IPV6
+      - :IPV6_ONLY
+    immutable: true
+    custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.erb'
+  - !ruby/object:Api::Type::Enum
+    name: 'gatewayIpVersion'
+    description: |
+      The IP family of the gateway IPs for the HA-VPN gateway interfaces. If not specified, IPV4 will be used.
+    default_value: :IPV4
+    values:
+      - :IPV4
+      - :IPV6
     immutable: true
     custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.erb'
   - !ruby/object:Api::Type::Array

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_ha_vpn_gateway_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_ha_vpn_gateway_test.go
@@ -24,14 +24,14 @@ func TestAccDataSourceComputeHaVpnGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckDataSourceStateMatchesResourceState("data.google_compute_ha_vpn_gateway.ha_gateway", "google_compute_ha_vpn_gateway.ha_gateway"),
 					resource.TestCheckResourceAttr("data.google_compute_ha_vpn_gateway.ha_gateway", "gateway_ip_version", "IPV4"),
-					resource.TestCheckResourceAttr("data.googlecompute_ha_vpn_gateway.ha_gateway", "stack_type", "IPV4_ONLY"),
+					resource.TestCheckResourceAttr("data.google_compute_ha_vpn_gateway.ha_gateway", "stack_type", "IPV4_ONLY"),
 				),
 			}, {
 				Config: testAccDataSourceComputeHaVpnGatewayFields(fmt.Sprintf("%s-2", gwName), gatewayIpVersion, stackType),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckDataSourceStateMatchesResourceState("data.google_compute_ha_vpn_gateway.ha_gateway", "google_compute_ha_vpn_gateway.ha_gateway"),
 					resource.TestCheckResourceAttr("data.google_compute_ha_vpn_gateway.ha_gateway", "gateway_ip_version", gatewayIpVersion),
-					resource.TestCheckResourceAttr("data.googlecompute_ha_vpn_gateway.ha_gateway", "stack_type", stackType),
+					resource.TestCheckResourceAttr("data.google_compute_ha_vpn_gateway.ha_gateway", "stack_type", stackType),
 				),
 			},
 		},
@@ -56,7 +56,7 @@ data "google_compute_ha_vpn_gateway" "ha_gateway" {
 `, gwName, gwName)
 }
 
-func testAccDataSourceComputeHaVpnGatewayFields(gwName, gateway_ip_version, stack_type string) string {
+func testAccDataSourceComputeHaVpnGatewayFields(gwName, gatewayIpVersion, stackType string) string {
 	return fmt.Sprintf(`
 resource "google_compute_ha_vpn_gateway" "ha_gateway" {
   name     			 = "%s"

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_ha_vpn_gateway_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_ha_vpn_gateway_test.go
@@ -73,5 +73,5 @@ resource "google_compute_network" "network1" {
 data "google_compute_ha_vpn_gateway" "ha_gateway" {
   name = google_compute_ha_vpn_gateway.ha_gateway.name
 }
-`, gwName, gatewayIpVersion, stackType, gwName)
+`, gwName, gateway_ip_version, stack_type, gwName)
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_ha_vpn_gateway_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_ha_vpn_gateway_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceComputeHaVpnGateway(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceComputeHaVpnGatewayConfig(gwName),
-				Check:  resource.ComposeTestCheckFunc(
+				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckDataSourceStateMatchesResourceState("data.google_compute_ha_vpn_gateway.ha_gateway", "google_compute_ha_vpn_gateway.ha_gateway"),
 					resource.TestCheckResourceAttr("data.google_compute_ha_vpn_gateway.ha_gateway", "gateway_ip_version", "IPV4"),
 				),

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_ha_vpn_gateway_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_ha_vpn_gateway_test.go
@@ -12,6 +12,8 @@ func TestAccDataSourceComputeHaVpnGateway(t *testing.T) {
 	t.Parallel()
 
 	gwName := fmt.Sprintf("tf-%s", acctest.RandString(t, 10))
+	gatewayIpVersion := "IPV6"
+	stackType := "IPV6_ONLY"
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -22,6 +24,14 @@ func TestAccDataSourceComputeHaVpnGateway(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckDataSourceStateMatchesResourceState("data.google_compute_ha_vpn_gateway.ha_gateway", "google_compute_ha_vpn_gateway.ha_gateway"),
 					resource.TestCheckResourceAttr("data.google_compute_ha_vpn_gateway.ha_gateway", "gateway_ip_version", "IPV4"),
+					resource.TestCheckResourceAttr("data.googlecompute_ha_vpn_gateway.ha_gateway", "stack_type", "IPV4_ONLY"),
+				),
+			}, {
+				Config: testAccDataSourceComputeHaVpnGatewayFields(fmt.Sprintf("%s-2", gwName), gatewayIpVersion, stackType),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceState("data.google_compute_ha_vpn_gateway.ha_gateway", "google_compute_ha_vpn_gateway.ha_gateway"),
+					resource.TestCheckResourceAttr("data.google_compute_ha_vpn_gateway.ha_gateway", "gateway_ip_version", gatewayIpVersion),
+					resource.TestCheckResourceAttr("data.googlecompute_ha_vpn_gateway.ha_gateway", "stack_type", stackType),
 				),
 			},
 		},
@@ -44,4 +54,24 @@ data "google_compute_ha_vpn_gateway" "ha_gateway" {
   name = google_compute_ha_vpn_gateway.ha_gateway.name
 }
 `, gwName, gwName)
+}
+
+func testAccDataSourceComputeHaVpnGatewayFields(gwName, gateway_ip_version, stack_type string) string {
+	return fmt.Sprintf(`
+resource "google_compute_ha_vpn_gateway" "ha_gateway" {
+  name     			 = "%s"
+  network  			 = google_compute_network.network1.id
+  gateway_ip_version = "%s"
+  stack_type		 = "%s"
+}
+
+resource "google_compute_network" "network1" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+data "google_compute_ha_vpn_gateway" "ha_gateway" {
+  name = google_compute_ha_vpn_gateway.ha_gateway.name
+}
+`, gwName, gatewayIpVersion, stackType, gwName)
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_ha_vpn_gateway_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_ha_vpn_gateway_test.go
@@ -19,7 +19,10 @@ func TestAccDataSourceComputeHaVpnGateway(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceComputeHaVpnGatewayConfig(gwName),
-				Check:  acctest.CheckDataSourceStateMatchesResourceState("data.google_compute_ha_vpn_gateway.ha_gateway", "google_compute_ha_vpn_gateway.ha_gateway"),
+				Check:  resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceState("data.google_compute_ha_vpn_gateway.ha_gateway", "google_compute_ha_vpn_gateway.ha_gateway"),
+					resource.TestCheckResourceAttr("data.google_compute_ha_vpn_gateway.ha_gateway", "gateway_ip_version", "IPV4"),
+				),
 			},
 		},
 	})
@@ -30,8 +33,6 @@ func testAccDataSourceComputeHaVpnGatewayConfig(gwName string) string {
 resource "google_compute_ha_vpn_gateway" "ha_gateway" {
   name     = "%s"
   network  = google_compute_network.network1.id
-  stack_type = "IPV4_ONLY"
-  gateway_ip_version = "IPV4"
 }
 
 resource "google_compute_network" "network1" {

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_ha_vpn_gateway_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_ha_vpn_gateway_test.go
@@ -30,6 +30,8 @@ func testAccDataSourceComputeHaVpnGatewayConfig(gwName string) string {
 resource "google_compute_ha_vpn_gateway" "ha_gateway" {
   name     = "%s"
   network  = google_compute_network.network1.id
+  stack_type = "IPV4_ONLY"
+  gateway_ip_version = "IPV4"
 }
 
 resource "google_compute_network" "network1" {
@@ -39,26 +41,6 @@ resource "google_compute_network" "network1" {
 
 data "google_compute_ha_vpn_gateway" "ha_gateway" {
   name = google_compute_ha_vpn_gateway.ha_gateway.name
-}
-`, gwName, gwName)
-}
-
-func testAccDataSourceComputeHaVpnGatewayConfigStack(gwName string) string {
-	return fmt.Sprintf(`
-resource "google_compute_ha_vpn_gateway" "ha_gateway" {
-  name     = "%s"
-  network  = google_compute_network.network1.id
-}
-
-resource "google_compute_network" "network1" {
-  name                    = "%s"
-  auto_create_subnetworks = false
-}
-
-data "google_compute_ha_vpn_gateway" "ha_gateway" {
-  name = google_compute_ha_vpn_gateway.ha_gateway.name
-  stack_type = IPV4_ONLY
-  gateway_ip_version = IPV4
 }
 `, gwName, gwName)
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_ha_vpn_gateway_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_ha_vpn_gateway_test.go
@@ -73,5 +73,5 @@ resource "google_compute_network" "network1" {
 data "google_compute_ha_vpn_gateway" "ha_gateway" {
   name = google_compute_ha_vpn_gateway.ha_gateway.name
 }
-`, gwName, gateway_ip_version, stack_type, gwName)
+`, gwName, gatewayIpVersion, stackType, gwName)
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_ha_vpn_gateway_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_ha_vpn_gateway_test.go
@@ -42,3 +42,23 @@ data "google_compute_ha_vpn_gateway" "ha_gateway" {
 }
 `, gwName, gwName)
 }
+
+func testAccDataSourceComputeHaVpnGatewayConfigStack(gwName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_ha_vpn_gateway" "ha_gateway" {
+  name     = "%s"
+  network  = google_compute_network.network1.id
+}
+
+resource "google_compute_network" "network1" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+data "google_compute_ha_vpn_gateway" "ha_gateway" {
+  name = google_compute_ha_vpn_gateway.ha_gateway.name
+  stack_type = IPV4_ONLY
+  gateway_ip_version = IPV4
+}
+`, gwName, gwName)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Modified the following fields in HA VPN Gateway resource (b/291919420):
- stack_type (enum): Added option IPV6_ONLY
- gateway_ip_version (enum): Added new enum field "gateway_ip_version" with possible values IPV4 and IPV6

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `stack_type`, and `gateway_ip_version` fields to `google_compute_router` resource
```
