### PR TITLE
Corrected us-central1a usage in TGC tests

### DIFF
--- a/mmv1/third_party/tgc/tests/data/example_pubsub_lite_subscription.json
+++ b/mmv1/third_party/tgc/tests/data/example_pubsub_lite_subscription.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "//pubsublite.googleapis.com/projects/{{.Provider.project}}/locations/us-central1a/subscriptions/example-subscription",
+    "name": "//pubsublite.googleapis.com/projects/{{.Provider.project}}/locations/us-central1-a/subscriptions/example-subscription",
     "asset_type": "pubsublite.googleapis.com/Subscription",
     "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}",
     "resource": {
@@ -12,7 +12,7 @@
         "deliveryConfig": {
           "deliveryRequirement": "DELIVER_AFTER_STORED"
         },
-        "topic": "projects/{{.Provider.project}}/locations/us-central1a/topics/my-topic"
+        "topic": "projects/{{.Provider.project}}/locations/us-central1-a/topics/my-topic"
       }
     }
   }

--- a/mmv1/third_party/tgc/tests/data/example_pubsub_lite_subscription.tf
+++ b/mmv1/third_party/tgc/tests/data/example_pubsub_lite_subscription.tf
@@ -30,7 +30,7 @@ provider "google" {
 resource "google_pubsub_lite_subscription" "example" {
   name  = "example-subscription"
   topic = "my-topic"
-  zone = "us-central1a"
+  zone = "us-central1-a"
   delivery_config {
     delivery_requirement = "DELIVER_AFTER_STORED"
   }

--- a/mmv1/third_party/tgc/tests/data/example_pubsub_lite_topic.json
+++ b/mmv1/third_party/tgc/tests/data/example_pubsub_lite_topic.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "//pubsublite.googleapis.com/projects/{{.Provider.project}}/locations/us-central1a/topics/example-topic",
+    "name": "//pubsublite.googleapis.com/projects/{{.Provider.project}}/locations/us-central1-a/topics/example-topic",
     "asset_type": "pubsublite.googleapis.com/Topic",
     "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}",
     "resource": {
@@ -17,7 +17,7 @@
           "count": 1
         },
         "reservationConfig": {
-          "throughputReservation": "projects/{{.Provider.project}}/locations/us-central/reservations/example-reservation"
+          "throughputReservation": "projects/{{.Provider.project}}/locations/us-central1/reservations/example-reservation"
         },
         "retentionConfig": {
           "perPartitionBytes": "32212254720"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Follow-up for https://github.com/GoogleCloudPlatform/magic-modules/pull/10714. This zone was never valid, so fixing it shouldn't be hiding any problem that didn't already exist.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
