### PR TITLE
fix: Allow Pub/Sub Topic update to remove schema settings

### DIFF
--- a/mmv1/products/pubsub/Topic.yaml
+++ b/mmv1/products/pubsub/Topic.yaml
@@ -124,7 +124,6 @@ properties:
     name: 'schemaSettings'
     description: |
       Settings for validating messages published against a schema.
-    default_from_api: true
     properties:
       - !ruby/object:Api::Type::String
         name: 'schema'

--- a/mmv1/third_party/terraform/services/pubsub/resource_pubsub_topic_test.go
+++ b/mmv1/third_party/terraform/services/pubsub/resource_pubsub_topic_test.go
@@ -94,6 +94,9 @@ func TestAccPubsubTopic_schema(t *testing.T) {
 				Config: testAccPubsubTopic_updateWithNewSchema(topic, schema2),
 			},
 			{
+				Config: testAccPubsubTopic_updateWithNewSchema(topic, ""),
+			},
+			{
 				ResourceName:      "google_pubsub_topic.bar",
 				ImportStateId:     topic,
 				ImportState:       true,
@@ -228,7 +231,8 @@ resource "google_pubsub_topic" "bar" {
 }
 
 func testAccPubsubTopic_updateWithNewSchema(topic, schema string) string {
-	return fmt.Sprintf(`
+	if schema != "" {
+		return fmt.Sprintf(`
 resource "google_pubsub_schema" "foo" {
 	name = "%s"
 	type = "PROTOCOL_BUFFER"
@@ -243,6 +247,13 @@ resource "google_pubsub_topic" "bar" {
   }
 }
 `, schema, topic)
+	} else {
+		return fmt.Sprintf(`
+		resource "google_pubsub_topic" "bar" {
+			name = "%s"
+		}
+		`, topic)
+	}
 }
 
 func testAccPubsubTopic_updateWithKinesisIngestionSettings(topic string) string {

--- a/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
@@ -113,3 +113,9 @@ Description of the change and how users should adjust their configuration (if ne
 ### `settings.ip_configuration.require_ssl` is now removed
 
 Removed in favor of field `settings.ip_configuration.ssl_mode`.
+
+## Resource: `google_pubsub_topic`
+
+### `schema_settings` no longer has a default value
+
+An empty value means the setting should be cleared.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Remove default_from_api from Pub/Sub Topic schemaSettings so that schema settings can be removed from a topic. Fixes https://github.com/hashicorp/terraform-provider-google/issues/15925.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
pubsub: Allow `schema_settings` of `google_pubsub_topic` to be removed
```
