### PR TITLE
6.0.0 cassettes

### DIFF
--- a/.ci/magician/vcr/tester.go
+++ b/.ci/magician/vcr/tester.go
@@ -97,7 +97,8 @@ func (vt *Tester) FetchCassettes(version provider.Version, baseBranch, prNumber 
 	}
 	cassettePath = filepath.Join(vt.baseDir, "cassettes", version.String())
 	vt.rnr.Mkdir(cassettePath)
-	if baseBranch != "FEATURE-BRANCH-major-release-5.0.0" {
+	if baseBranch != "FEATURE-BRANCH-major-release-6.0.0" {
+		// pull main cassettes (major release uses branch specific casssettes as primary ones)
 		bucketPath := fmt.Sprintf("gs://ci-vcr-cassettes/%sfixtures/*", version.BucketPath())
 		if err := vt.fetchBucketPath(bucketPath, cassettePath); err != nil {
 			fmt.Println("Error fetching cassettes: ", err)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Let's follow what we did for 5.0.0 for now to use FEATURE-BRANCH-major-release-6.0.0 branch specific casssettes as primary ones. I made it to only target 6.0.0 instead of `FEATURE-BRANCH-major-release-*` for now, as I want to find a better way for future major releases.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
