### PR TITLE
add sqlAssertion rule

### DIFF
--- a/mmv1/products/dataplex/Datascan.yaml
+++ b/mmv1/products/dataplex/Datascan.yaml
@@ -428,6 +428,16 @@ properties:
                   required: true
                   description: |
                     The SQL expression.
+            - !ruby/object:Api::Type::NestedObject
+              name: 'sqlAssertion'
+              description: |
+                Table rule which evaluates whether any row matches invalid state.
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: 'sqlStatement'
+                  required: true
+                  description: |
+                    The SQL Statement.
   - !ruby/object:Api::Type::NestedObject
     name: 'dataProfileSpec'
     allow_empty_object: true

--- a/mmv1/templates/terraform/examples/dataplex_datascan_full_quality.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_datascan_full_quality.tf.erb
@@ -94,6 +94,13 @@ resource "google_dataplex_datascan" "<%= ctx[:primary_resource_id] %>" {
         sql_expression = "COUNT(*) > 0"
       }
     }
+    
+    rules {
+      dimension = "VALIDITY"
+      sql_assertion {
+        sql_expression = "select * from bigquery-public-data.austin_bikeshare.bikeshare_stations where station_id is null"
+      }
+    }
   }
 
 

--- a/mmv1/templates/terraform/examples/dataplex_datascan_full_quality.tf.erb
+++ b/mmv1/templates/terraform/examples/dataplex_datascan_full_quality.tf.erb
@@ -98,7 +98,7 @@ resource "google_dataplex_datascan" "<%= ctx[:primary_resource_id] %>" {
     rules {
       dimension = "VALIDITY"
       sql_assertion {
-        sql_expression = "select * from bigquery-public-data.austin_bikeshare.bikeshare_stations where station_id is null"
+        sql_statement = "select * from bigquery-public-data.austin_bikeshare.bikeshare_stations where station_id is null"
       }
     }
   }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add SqlAssertion to Data Quality Scan rules.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dataplex: added `sql_assertion` field to `google_dataplex_datascan` resource
```
