### PR TITLE
Fix Go rewrite diffs for ForceNew, ExactlyOneOf, AtLeastOneOf, and ConflictsWith

### DIFF
--- a/mmv1/api/type.go
+++ b/mmv1/api/type.go
@@ -1326,13 +1326,19 @@ func (t *Type) GoLiteral(value interface{}) string {
 
 // def force_new?(property, resource)
 func (t *Type) IsForceNew() bool {
+	if t.IsA("KeyValueLabels") && t.ResourceMetadata.RootLabels() {
+		return false
+	}
+
+	if t.IsA("KeyValueTerraformLabels") && !t.ResourceMetadata.Updatable() && !t.ResourceMetadata.RootLabels() {
+		return true
+	}
+
 	parent := t.Parent()
-	return (((!t.Output || t.IsA("KeyValueEffectiveLabels")) &&
+	return (!t.Output || t.IsA("KeyValueEffectiveLabels")) &&
 		(t.Immutable ||
-			(t.ResourceMetadata.Immutable && t.UpdateUrl == "" && !t.Immutable &&
+			(t.ResourceMetadata.Immutable && t.UpdateUrl == "" &&
 				(parent == nil ||
 					(parent.IsForceNew() &&
-						!(parent.FlattenObject && t.IsA("KeyValueLabels"))))))) ||
-		(t.IsA("KeyValueTerraformLabels") &&
-			t.ResourceMetadata.Updatable() && !t.ResourceMetadata.RootLabels()))
+						!(parent.FlattenObject && t.IsA("KeyValueLabels"))))))
 }

--- a/mmv1/api/type.go
+++ b/mmv1/api/type.go
@@ -566,7 +566,7 @@ func (t Type) AtLeastOneOfList() []string {
 // Returns list of properties that needs exactly one of their fields set.
 // func (t *Type) exactly_one_of_list() {
 func (t Type) ExactlyOneOfList() []string {
-	if t.ResourceMetadata == nil || t.Parent() != nil {
+	if t.ResourceMetadata == nil {
 		return []string{}
 	}
 
@@ -1345,4 +1345,63 @@ func (t *Type) IsForceNew() bool {
 				(parent == nil ||
 					(parent.IsForceNew() &&
 						!(parent.FlattenObject && t.IsA("KeyValueLabels"))))))
+}
+
+// Returns an updated path for a given Terraform field path (e.g.
+// 'a_field', 'parent_field.0.child_name'). Returns nil if the property
+// is not included in the resource's properties and removes keys that have
+// been flattened
+// FYI: Fields that have been renamed should use the new name, however, flattened
+// fields still need to be included, ie:
+// flattenedField > newParent > renameMe should be passed to this function as
+// flattened_field.0.new_parent.0.im_renamed
+// TODO(emilymye): Change format of input for
+// exactly_one_of/at_least_one_of/etc to use camelcase, MM properities and
+// convert to snake in this method
+// def get_property_schema_path(schema_path, resource)
+func (t *Type) GetPropertySchemaPath(schemaPath string) string {
+	nestedProps := t.ResourceMetadata.UserProperites()
+
+	var pathTkns []string
+	for _, pname := range strings.Split(schemaPath, ".0.") {
+		camelPname := google.Camelize(pname, "lower")
+		index := slices.IndexFunc(nestedProps, func(p *Type) bool {
+			return p.Name == camelPname
+		})
+
+		// if we couldn't find it, see if it was renamed at the top level
+		if index == -1 {
+			index = slices.IndexFunc(nestedProps, func(p *Type) bool {
+				return p.Name == schemaPath
+			})
+		}
+
+		if index == -1 {
+			continue
+		}
+
+		prop := nestedProps[index]
+
+		nestedProps = prop.NestedProperties()
+		if !prop.FlattenObject {
+			pathTkns = append(pathTkns, google.Underscore(pname))
+		}
+	}
+
+	if len(pathTkns) == 0 || pathTkns[len(pathTkns)-1] == "" {
+		return ""
+	}
+
+	return strings.Join(pathTkns[:], ".0.")
+}
+
+func (t Type) GetPropertySchemaPathList(propertyList []string) []string {
+	var list []string
+	for _, path := range propertyList {
+		path = t.GetPropertySchemaPath(path)
+		if path != "" {
+			list = append(list, path)
+		}
+	}
+	return list
 }

--- a/mmv1/api/type.go
+++ b/mmv1/api/type.go
@@ -293,12 +293,12 @@ func (t *Type) SetDefault(r *Resource) {
 	switch {
 	case t.IsA("Array"):
 		t.ItemType.ParentName = t.Name
-		t.ItemType.ParentMetadata = t.ParentMetadata
+		t.ItemType.ParentMetadata = t
 		t.ItemType.SetDefault(r)
 	case t.IsA("Map"):
 		t.KeyExpander = "tpgresource.ExpandString"
 		t.ValueType.ParentName = t.Name
-		t.ValueType.ParentMetadata = t.ParentMetadata
+		t.ValueType.ParentMetadata = t
 		t.ValueType.SetDefault(r)
 	case t.IsA("NestedObject"):
 		if t.Name == "" {
@@ -443,7 +443,11 @@ func (t *Type) GetPrefix() string {
 
 			t.Prefix = fmt.Sprintf("%s%s", nestedPrefix, t.ResourceMetadata.ResourceName())
 		} else {
-			t.Prefix = fmt.Sprintf("%s%s", t.ParentMetadata.GetPrefix(), t.ParentMetadata.TitlelizeProperty())
+			if t.ParentMetadata != nil && (t.ParentMetadata.IsA("Array") || t.ParentMetadata.IsA("Map")) {
+				t.Prefix = t.ParentMetadata.GetPrefix()
+			} else {
+				t.Prefix = fmt.Sprintf("%s%s", t.ParentMetadata.GetPrefix(), t.ParentMetadata.TitlelizeProperty())
+			}
 		}
 	}
 	return t.Prefix

--- a/mmv1/provider/terraform.go
+++ b/mmv1/provider/terraform.go
@@ -858,39 +858,6 @@ func (t Terraform) GetMmv1ServicesInVersion(products []*api.Product) []string {
 //
 // end
 //
-// # Returns an updated path for a given Terraform field path (e.g.
-// # 'a_field', 'parent_field.0.child_name'). Returns nil if the property
-// # is not included in the resource's properties and removes keys that have
-// # been flattened
-// # FYI: Fields that have been renamed should use the new name, however, flattened
-// # fields still need to be included, ie:
-// # flattenedField > newParent > renameMe should be passed to this function as
-// # flattened_field.0.new_parent.0.im_renamed
-// # TODO(emilymye): Change format of input for
-// # exactly_one_of/at_least_one_of/etc to use camelcase, MM properities and
-// # convert to snake in this method
-// def get_property_schema_path(schema_path, resource)
-//
-//	nested_props = resource.properties
-//	prop = nil
-//	path_tkns = schema_path.split('.0.').map do |pname|
-//	  camel_pname = pname.camelize(:lower)
-//	  prop = nested_props.find { |p| p.name == camel_pname }
-//	  # if we couldn't find it, see if it was renamed at the top level
-//	  prop = nested_props.find { |p| p.name == schema_path } if prop.nil?
-//	  return nil if prop.nil?
-//
-//	  nested_props = prop.nested_properties || []
-//	  prop.flatten_object ? nil : pname.underscore
-//	end
-//	if path_tkns.empty? || path_tkns[-1].nil?
-//	  nil
-//	else
-//	  path_tkns.compact.join('.0.')
-//	end
-//
-// end
-//
 // # Capitalize the first letter of a property name.
 // # E.g. "creationTimestamp" becomes "CreationTimestamp".
 // def titlelize_property(property)

--- a/mmv1/templates/terraform/schema_property.go.tmpl
+++ b/mmv1/templates/terraform/schema_property.go.tmpl
@@ -166,16 +166,16 @@ Default value: {{ .ItemType.DefaultValue -}}
     Default: {{ .GoLiteral .DefaultValue -}},
 {{ end -}}
 {{ if or .Conflicting .Conflicts -}}
-    ConflictsWith: {{ .GoLiteral .Conflicting  -}},
+    ConflictsWith: {{ .GoLiteral (.GetPropertySchemaPathList .Conflicting)  -}},
 {{ end -}}
 {{ if or .AtLeastOneOfList .AtLeastOneOf -}}
-    AtLeastOneOf: {{ .GoLiteral .AtLeastOneOfList  -}},
+    AtLeastOneOf: {{ .GoLiteral (.GetPropertySchemaPathList .AtLeastOneOfList) -}},
 {{ end -}}
 {{ if or .ExactlyOneOfList .ExactlyOneOf -}}
-    ExactlyOneOf: {{ .GoLiteral .ExactlyOneOfList  -}},
+    ExactlyOneOf: {{ .GoLiteral (.GetPropertySchemaPathList .ExactlyOneOfList) -}},
 {{ end -}}
 {{ if or .RequiredWithList .RequiredWith -}}
-    RequiredWith: {{ .GoLiteral .RequiredWithList  -}},
+    RequiredWith: {{ .GoLiteral (.GetPropertySchemaPathList .RequiredWithList) -}},
 {{ end -}}
 },
 {{- end -}}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fix Go rewriting diffs 
1. “ForceNew: true,” in labels field for [resource_compute_interconnect](https://github.com/c2thorn/terraform-provider-google-beta/commit/39f444405cb44469b35f91677cd38127b4c84d9e#diff-c5fe02ef6d64d0e4f16aeca08339500f0571b212f546cbbcb818c95b14f7b841R127)
2. “ForceNew: true,” in ip_cidr_range and range_name for [resource_compute_subnetwork.go](https://github.com/c2thorn/terraform-provider-google-beta/commit/39f444405cb44469b35f91677cd38127b4c84d9e#diff-0fb3f296c74e78df5ca33f93d3f3ada9f40d9fad606ebf4207149b1874bc441bR279)
3. [ExactlyOneOf](https://github.com/c2thorn/terraform-provider-google-beta/commit/39f444405cb44469b35f91677cd38127b4c84d9e#diff-12073130e78def2c372d6e6db47e76669b354a344a6eeded6e40029dbc6e59eaR112) 
google-beta/services/compute/resource_compute_organization_security_policy_rule.go
google-beta/services/compute/resource_compute_region_url_map.go
google-beta/services/compute/resource_compute_reservation.go
google-beta/services/compute/resource_compute_target_ssl_proxy.go
google-beta/services/compute/resource_compute_url_map.go
4. [ConflictsWith](https://github.com/c2thorn/terraform-provider-google-beta/commit/39f444405cb44469b35f91677cd38127b4c84d9e#diff-c980cedaca40a43a6988ff57c1253f8063849faf6d9413c9c056262f45dd6b06R142)
google-beta/services/pubsub/resource_pubsub_subscription.go
5. AtLeastOneOf

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
