### PR TITLE
Logging bucket index_configs documentation fixes

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/logging_billing_account_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_billing_account_bucket_config.html.markdown
@@ -36,9 +36,9 @@ resource "google_logging_billing_account_bucket_config" "example-billing-account
   retention_days  = 30
   bucket_id       = "_Default"
 	
-  index_configs   = {
-    file_path   = "jsonPayload.request.status"
-    type        = "INDEX_TYPE_STRING"
+  index_configs {
+    field_path = "jsonPayload.request.status"
+    type       = "INDEX_TYPE_STRING"
   }
 }
 ```

--- a/mmv1/third_party/terraform/website/docs/r/logging_billing_account_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_billing_account_bucket_config.html.markdown
@@ -62,7 +62,7 @@ The following arguments are supported:
 <a name="nested_index_configs"></a>The `index_configs` block supports:
 
 * `field_path` - The LogEntry field path to index.
-  Note that some paths are automatically indexed, and other paths are not eligible for indexing. See [indexing documentation]( https://cloud.google.com/logging/docs/view/advanced-queries#indexed-fields) for details.
+  Note that some paths are automatically indexed, and other paths are not eligible for indexing. See [indexing documentation](https://cloud.google.com/logging/docs/analyze/custom-index) for details.
 
 * `type` - The type of data in this index. Allowed types include `INDEX_TYPE_UNSPECIFIED`, `INDEX_TYPE_STRING` and `INDEX_TYPE_INTEGER`.
 

--- a/mmv1/third_party/terraform/website/docs/r/logging_folder_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_folder_bucket_config.html.markdown
@@ -26,9 +26,9 @@ resource "google_logging_folder_bucket_config" "basic" {
   retention_days = 30
   bucket_id      = "_Default"
   
-  index_configs   = {
-    file_path   = "jsonPayload.request.status"
-    type        = "INDEX_TYPE_STRING"
+  index_configs {
+    field_path = "jsonPayload.request.status"
+    type       = "INDEX_TYPE_STRING"
   }
 }
 ```

--- a/mmv1/third_party/terraform/website/docs/r/logging_folder_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_folder_bucket_config.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 <a name="nested_index_configs"></a>The `index_configs` block supports:
 
 * `field_path` - The LogEntry field path to index.
-  Note that some paths are automatically indexed, and other paths are not eligible for indexing. See [indexing documentation]( https://cloud.google.com/logging/docs/view/advanced-queries#indexed-fields) for details.
+  Note that some paths are automatically indexed, and other paths are not eligible for indexing. See [indexing documentation](https://cloud.google.com/logging/docs/analyze/custom-index) for details.
 
 * `type` - The type of data in this index. Allowed types include `INDEX_TYPE_UNSPECIFIED`, `INDEX_TYPE_STRING` and `INDEX_TYPE_INTEGER`.
 

--- a/mmv1/third_party/terraform/website/docs/r/logging_organization_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_organization_bucket_config.html.markdown
@@ -25,9 +25,9 @@ resource "google_logging_organization_bucket_config" "basic" {
   retention_days = 30
   bucket_id      = "_Default"
   
-  index_configs  = {
-    file_path = "jsonPayload.request.status"
-    type      = "INDEX_TYPE_STRING"
+  index_configs {
+    field_path = "jsonPayload.request.status"
+    type       = "INDEX_TYPE_STRING"
   }
 }
 ```

--- a/mmv1/third_party/terraform/website/docs/r/logging_organization_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_organization_bucket_config.html.markdown
@@ -51,7 +51,7 @@ The following arguments are supported:
 <a name="nested_index_configs"></a>The `index_configs` block supports:
 
 * `field_path` - The LogEntry field path to index.
-  Note that some paths are automatically indexed, and other paths are not eligible for indexing. See [indexing documentation]( https://cloud.google.com/logging/docs/view/advanced-queries#indexed-fields) for details.
+  Note that some paths are automatically indexed, and other paths are not eligible for indexing. See [indexing documentation](https://cloud.google.com/logging/docs/analyze/custom-index) for details.
 
 * `type` - The type of data in this index. Allowed types include `INDEX_TYPE_UNSPECIFIED`, `INDEX_TYPE_STRING` and `INDEX_TYPE_INTEGER`.
 

--- a/mmv1/third_party/terraform/website/docs/r/logging_project_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_project_bucket_config.html.markdown
@@ -102,9 +102,9 @@ resource "google_logging_project_bucket_config" "example-project-bucket-index-co
   retention_days   = 30
   bucket_id        = "custom-bucket"
 
-  index_configs   = {
-    file_path   = "jsonPayload.request.status"
-    type        = "INDEX_TYPE_STRING"
+  index_configs {
+    field_path = "jsonPayload.request.status"
+    type       = "INDEX_TYPE_STRING"
   }
 }
 ```

--- a/mmv1/third_party/terraform/website/docs/r/logging_project_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_project_bucket_config.html.markdown
@@ -156,7 +156,7 @@ See [Enabling CMEK for Logging Buckets](https://cloud.google.com/logging/docs/ro
 <a name="nested_index_configs"></a>The `index_configs` block supports:
 
 * `field_path` - The LogEntry field path to index.
-Note that some paths are automatically indexed, and other paths are not eligible for indexing. See [indexing documentation]( https://cloud.google.com/logging/docs/view/advanced-queries#indexed-fields) for details.
+Note that some paths are automatically indexed, and other paths are not eligible for indexing. See [indexing documentation](https://cloud.google.com/logging/docs/analyze/custom-index) for details.
 
 * `type` - The type of data in this index. Allowed types include `INDEX_TYPE_UNSPECIFIED`, `INDEX_TYPE_STRING` and `INDEX_TYPE_INTEGER`.
 


### PR DESCRIPTION
- Fix logging bucket index_configs examples
- Fix log bucket indexing documentation link

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR fixes documentation for the various logging bucket resources, specifically the index_config examples. It was incorrectly written as a map in the example, but the attributes documentation and tests show that index_config is a block.
This will close two issues:
- https://github.com/hashicorp/terraform-provider-google/issues/18536
- https://github.com/hashicorp/terraform-provider-google/issues/13287

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
