### PR TITLE
Fix clashing fields in workstation_config ephemeral directories test.

### DIFF
--- a/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
+++ b/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
@@ -391,7 +391,6 @@ resource "google_workstations_workstation_config" "default" {
 	gce_pd {
  	      disk_type = "pd-standard"
 	      source_image = google_compute_image.test_source_image.id
-	      read_only  = true
     	}
   }
 


### PR DESCRIPTION
This PR fixes the broken test reported in https://github.com/hashicorp/terraform-provider-google/issues/18105. We added this test in PR https://github.com/GoogleCloudPlatform/magic-modules/pull/10042 with an invalid config case, so recent improvements to the API validation have caused it to start failing.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/18105

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
