### PR TITLE
Update destroy_scheduled_duration default value description

### DIFF
--- a/mmv1/products/kms/CryptoKey.yaml
+++ b/mmv1/products/kms/CryptoKey.yaml
@@ -149,7 +149,7 @@ properties:
     immutable: true
     description: |
       The period of time that versions of this key spend in the DESTROY_SCHEDULED state before transitioning to DESTROYED.
-      If not specified at creation time, the default duration is 24 hours.
+      If not specified at creation time, the default duration is 30 days.
     default_from_api: true
   - !ruby/object:Api::Type::Boolean
     name: 'importOnly'


### PR DESCRIPTION
The field's default value has been updated as part of https://cloud.google.com/kms/docs/key-destruction-msa

Looking for guidance on wether we need some sort of release note or not.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
