### PR TITLE
Fix Go rewrite diffs for default_value and ExtraSchemaEntry

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -1467,8 +1467,8 @@ func (r Resource) propertiesWithCustomUpdate(properties []*Type) []*Type {
 	})
 }
 
-func (r Resource) PropertiesByCustomUpdate() map[UpdateGroup][]*Type {
-	customUpdateProps := r.propertiesWithCustomUpdate(r.RootProperties())
+func (r Resource) PropertiesByCustomUpdate(properties []*Type) map[UpdateGroup][]*Type {
+	customUpdateProps := r.propertiesWithCustomUpdate(properties)
 	groupedCustomUpdateProps := map[UpdateGroup][]*Type{}
 	for _, prop := range customUpdateProps {
 		groupedProperty := UpdateGroup{UpdateUrl: prop.UpdateUrl,
@@ -1499,11 +1499,11 @@ func (r Resource) PropertiesByCustomUpdateGroups() []UpdateGroup {
 }
 
 func (r Resource) FieldSpecificUpdateMethods() bool {
-	return (len(r.PropertiesByCustomUpdate()) > 0)
+	return (len(r.PropertiesByCustomUpdate(r.RootProperties())) > 0)
 }
 
-func (r Resource) CustomUpdatePropertiesByKey(updateUrl string, updateId string, fingerprintName string, updateVerb string) []*Type {
-	groupedProperties := r.PropertiesByCustomUpdate()
+func (r Resource) CustomUpdatePropertiesByKey(properties []*Type, updateUrl string, updateId string, fingerprintName string, updateVerb string) []*Type {
+	groupedProperties := r.PropertiesByCustomUpdate(properties)
 	groupedProperty := UpdateGroup{UpdateUrl: updateUrl,
 		UpdateVerb:      updateVerb,
 		UpdateId:        updateId,

--- a/mmv1/products/compute/RegionSslCertificate.yaml
+++ b/mmv1/products/compute/RegionSslCertificate.yaml
@@ -78,7 +78,7 @@ examples:
     ignore_read_extra:
       - 'name_prefix'
 custom_code: !ruby/object:Provider::Terraform::CustomCode
-  constants: templates/terraform/constants/go/compute_certificate.go.tmpl
+  constants: templates/terraform/constants/compute_certificate.go.erb
   extra_schema_entry: templates/terraform/extra_schema_entry/ssl_certificate.erb
 parameters:
   - !ruby/object:Api::Type::ResourceRef

--- a/mmv1/products/compute/go_Address.yaml
+++ b/mmv1/products/compute/go_Address.yaml
@@ -114,7 +114,7 @@ properties:
       The type of address to reserve.
       Note: if you set this argument's value as `INTERNAL` you need to leave the `network_tier` argument unset in that resource block.
     custom_flatten: 'templates/terraform/custom_flatten/go/default_if_empty.tmpl'
-    default_value: EXTERNAL
+    default_value: "EXTERNAL"
     enum_values:
       - 'INTERNAL'
       - 'EXTERNAL'

--- a/mmv1/products/compute/go_Autoscaler.yaml
+++ b/mmv1/products/compute/go_Autoscaler.yaml
@@ -151,7 +151,7 @@ properties:
         type: String
         description: |
           Defines operating mode for this policy.
-        default_value: ON
+        default_value: "ON"
       - name: 'scaleDownControl'
         type: NestedObject
         description: |
@@ -262,7 +262,7 @@ properties:
 
               - OPTIMIZE_AVAILABILITY. Predictive autoscaling improves availability by monitoring daily and weekly load patterns and scaling out ahead of anticipated demand.
             custom_flatten: 'templates/terraform/custom_flatten/go/default_if_empty.tmpl'
-            default_value: NONE
+            default_value: "NONE"
       - name: 'metric'
         type: Array
         description: |
@@ -359,7 +359,7 @@ properties:
                 TimeSeries are returned upon the query execution, the autoscaler
                 will sum their respective values to obtain its scaling value.
               min_version: 'beta'
-              default_value: resource.type = gce_instance
+              default_value: "resource.type = gce_instance"
       - name: 'loadBalancingUtilization'
         type: NestedObject
         description: |
@@ -398,7 +398,7 @@ properties:
               type: String
               description: |
                 The time zone to be used when interpreting the schedule. The value of this field must be a time zone name from the tz database: http://en.wikipedia.org/wiki/Tz_database.
-              default_value: UTC
+              default_value: "UTC"
             - name: 'durationSec'
               type: Integer
               description: |

--- a/mmv1/products/compute/go_BackendService.yaml
+++ b/mmv1/products/compute/go_BackendService.yaml
@@ -150,7 +150,7 @@ properties:
             for an explanation of load balancing modes.
 
             From version 6.0.0 default value will be UTILIZATION to match default GCP value.
-          default_value: UTILIZATION
+          default_value: "UTILIZATION"
           enum_values:
             - 'UTILIZATION'
             - 'RATE'
@@ -771,7 +771,7 @@ properties:
       load balancing cannot be used with the other. For more information, refer to
       [Choosing a load balancer](https://cloud.google.com/load-balancing/docs/backend-service).
     immutable: true
-    default_value: EXTERNAL
+    default_value: "EXTERNAL"
     enum_values:
       - 'EXTERNAL'
       - 'INTERNAL_SELF_MANAGED'

--- a/mmv1/products/compute/go_Disk.yaml
+++ b/mmv1/products/compute/go_Disk.yaml
@@ -347,8 +347,8 @@ properties:
       Specifies the disk interface to use for attaching this disk, which is either SCSI or NVME. The default is SCSI.
     min_version: 'beta'
     url_param_only: true
-    diff_suppress_func: AlwaysDiffSuppress
-    default_value: SCSI
+    diff_suppress_func: 'AlwaysDiffSuppress'
+    default_value: "SCSI"
     deprecation_message: '`interface` is deprecated and will be removed in a future major release. This field is no longer used and can be safely removed from your configurations; disk interfaces are automatically determined on attachment.'
   - name: 'sourceDisk'
     type: String
@@ -384,7 +384,7 @@ properties:
     diff_suppress_func: 'tpgresource.CompareResourceNames'
     custom_flatten: 'templates/terraform/custom_flatten/go/name_from_self_link.tmpl'
     custom_expand: 'templates/terraform/custom_expand/go/resourceref_with_validation.go.tmpl'
-    default_value: pd-standard
+    default_value: "pd-standard"
     resource: 'DiskType'
     imports: 'selfLink'
   - name: 'image'

--- a/mmv1/products/compute/go_ForwardingRule.yaml
+++ b/mmv1/products/compute/go_ForwardingRule.yaml
@@ -299,7 +299,7 @@ properties:
       When reading an `IPAddress`, the API always returns the IP
       address number.
     default_from_api: true
-    diff_suppress_func: InternalIpDiffSuppress
+    diff_suppress_func: 'InternalIpDiffSuppress'
   - name: 'IPProtocol'
     type: Enum
     description: |
@@ -344,7 +344,7 @@ properties:
 
       For more information about forwarding rules, refer to
       [Forwarding rule concepts](https://cloud.google.com/load-balancing/docs/forwarding-rule-concepts).
-    default_value: EXTERNAL
+    default_value: "EXTERNAL"
     enum_values:
       - 'EXTERNAL'
       - 'EXTERNAL_MANAGED'
@@ -412,7 +412,7 @@ properties:
 
       @pattern: \d+(?:-\d+)?
     default_from_api: true
-    diff_suppress_func: PortRangeDiffSuppress
+    diff_suppress_func: 'PortRangeDiffSuppress'
   - name: 'ports'
     type: Array
     description: |

--- a/mmv1/products/compute/go_GlobalAddress.yaml
+++ b/mmv1/products/compute/go_GlobalAddress.yaml
@@ -130,7 +130,7 @@ properties:
       * EXTERNAL indicates public/external single IP address.
       * INTERNAL indicates internal IP ranges belonging to some network.
     diff_suppress_func: 'tpgresource.EmptyOrDefaultStringSuppress("EXTERNAL")'
-    default_value: EXTERNAL
+    default_value: "EXTERNAL"
     enum_values:
       - 'EXTERNAL'
       - 'INTERNAL'

--- a/mmv1/products/compute/go_GlobalForwardingRule.yaml
+++ b/mmv1/products/compute/go_GlobalForwardingRule.yaml
@@ -255,7 +255,7 @@ properties:
       When reading an `IPAddress`, the API always returns the IP
       address number.
     default_from_api: true
-    diff_suppress_func: InternalIpDiffSuppress
+    diff_suppress_func: 'InternalIpDiffSuppress'
   - name: 'IPProtocol'
     type: Enum
     description: |
@@ -308,7 +308,7 @@ properties:
 
       For more information about forwarding rules, refer to
       [Forwarding rule concepts](https://cloud.google.com/load-balancing/docs/forwarding-rule-concepts).
-    default_value: EXTERNAL
+    default_value: "EXTERNAL"
     enum_values:
       - 'EXTERNAL'
       - 'EXTERNAL_MANAGED'
@@ -433,7 +433,7 @@ properties:
       cannot have overlapping `portRange`s.
 
       @pattern: \d+(?:-\d+)?
-    diff_suppress_func: PortRangeDiffSuppress
+    diff_suppress_func: 'PortRangeDiffSuppress'
   - name: 'subnetwork'
     type: ResourceRef
     description: |

--- a/mmv1/products/compute/go_HaVpnGateway.yaml
+++ b/mmv1/products/compute/go_HaVpnGateway.yaml
@@ -127,7 +127,7 @@ properties:
       If not specified, IPV4_ONLY will be used.
     immutable: true
     custom_flatten: 'templates/terraform/custom_flatten/go/default_if_empty.tmpl'
-    default_value: IPV4_ONLY
+    default_value: "IPV4_ONLY"
     enum_values:
       - 'IPV4_ONLY'
       - 'IPV4_IPV6'

--- a/mmv1/products/compute/go_HealthCheck.yaml
+++ b/mmv1/products/compute/go_HealthCheck.yaml
@@ -213,7 +213,7 @@ properties:
           - 'http_health_check.0.port_name'
           - 'http_health_check.0.proxy_header'
           - 'http_health_check.0.port_specification'
-        default_value: /
+        default_value: "/"
       - name: 'response'
         type: String
         description: |
@@ -267,7 +267,7 @@ properties:
           - 'http_health_check.0.port_name'
           - 'http_health_check.0.proxy_header'
           - 'http_health_check.0.port_specification'
-        default_value: NONE
+        default_value: "NONE"
         enum_values:
           - 'NONE'
           - 'PROXY_V1'
@@ -338,7 +338,7 @@ properties:
           - 'https_health_check.0.port_name'
           - 'https_health_check.0.proxy_header'
           - 'https_health_check.0.port_specification'
-        default_value: /
+        default_value: "/"
       - name: 'response'
         type: String
         description: |
@@ -392,7 +392,7 @@ properties:
           - 'https_health_check.0.port_name'
           - 'https_health_check.0.proxy_header'
           - 'https_health_check.0.port_specification'
-        default_value: NONE
+        default_value: "NONE"
         enum_values:
           - 'NONE'
           - 'PROXY_V1'
@@ -499,7 +499,7 @@ properties:
           - 'tcp_health_check.0.port_name'
           - 'tcp_health_check.0.proxy_header'
           - 'tcp_health_check.0.port_specification'
-        default_value: NONE
+        default_value: "NONE"
         enum_values:
           - 'NONE'
           - 'PROXY_V1'
@@ -605,7 +605,7 @@ properties:
           - 'ssl_health_check.0.port_name'
           - 'ssl_health_check.0.proxy_header'
           - 'ssl_health_check.0.port_specification'
-        default_value: NONE
+        default_value: "NONE"
         enum_values:
           - 'NONE'
           - 'PROXY_V1'
@@ -675,7 +675,7 @@ properties:
           - 'http2_health_check.0.port_name'
           - 'http2_health_check.0.proxy_header'
           - 'http2_health_check.0.port_specification'
-        default_value: /
+        default_value: "/"
       - name: 'response'
         type: String
         description: |
@@ -729,7 +729,7 @@ properties:
           - 'http2_health_check.0.port_name'
           - 'http2_health_check.0.proxy_header'
           - 'http2_health_check.0.port_specification'
-        default_value: NONE
+        default_value: "NONE"
         enum_values:
           - 'NONE'
           - 'PROXY_V1'

--- a/mmv1/products/compute/go_HttpHealthCheck.yaml
+++ b/mmv1/products/compute/go_HttpHealthCheck.yaml
@@ -107,7 +107,7 @@ properties:
     description: |
       The request path of the HTTP health check request.
       The default value is /.
-    default_value: /
+    default_value: "/"
   - name: 'timeoutSec'
     type: Integer
     description: |

--- a/mmv1/products/compute/go_HttpsHealthCheck.yaml
+++ b/mmv1/products/compute/go_HttpsHealthCheck.yaml
@@ -107,7 +107,7 @@ properties:
     description: |
       The request path of the HTTPS health check request.
       The default value is /.
-    default_value: /
+    default_value: "/"
   - name: 'timeoutSec'
     type: Integer
     description: |

--- a/mmv1/products/compute/go_Image.yaml
+++ b/mmv1/products/compute/go_Image.yaml
@@ -219,7 +219,7 @@ properties:
           should be TAR. This is just a container and transmission format
           and not a runtime format. Provided by the client when the disk
           image is created.
-        default_value: TAR
+        default_value: "TAR"
         enum_values:
           - 'TAR'
       - name: 'sha1'

--- a/mmv1/products/compute/go_Instance.yaml
+++ b/mmv1/products/compute/go_Instance.yaml
@@ -593,13 +593,13 @@ properties:
         at_least_one_of:
           - 'confidential_instance_config.0.enable_confidential_compute'
           - 'confidential_instance_config.0.confidential_instance_type'
+        deprecation_message: '`enableConfidentialCompute` is deprecated and will be removed in a future major release. Use `confidentialInstanceType: SEV` instead.'
       - name: 'confidentialInstanceType'
         type: Enum
         description: |
           The confidential computing technology the instance uses.
           SEV is an AMD feature. One of the following values: SEV, SEV_SNP.
           If SEV_SNP, min_cpu_platform = "AMD Milan" is currently required.
-        min_version: 'beta'
         at_least_one_of:
           - 'confidential_instance_config.0.enable_confidential_compute'
           - 'confidential_instance_config.0.confidential_instance_type'

--- a/mmv1/products/compute/go_InterconnectAttachment.yaml
+++ b/mmv1/products/compute/go_InterconnectAttachment.yaml
@@ -300,7 +300,7 @@ properties:
       attachment must be created with this option.
     immutable: true
     custom_flatten: 'templates/terraform/custom_flatten/go/default_if_empty.tmpl'
-    default_value: NONE
+    default_value: "NONE"
     enum_values:
       - 'NONE'
       - 'IPSEC'

--- a/mmv1/products/compute/go_ManagedSslCertificate.yaml
+++ b/mmv1/products/compute/go_ManagedSslCertificate.yaml
@@ -65,8 +65,8 @@ async:
     path: 'error/errors'
     message: 'message'
 collection_url_key: 'items'
-custom_code: !ruby/object:Provider::Terraform::CustomCode
-  constants: templates/terraform/constants/compute_managed_ssl_certificate.go.erb
+custom_code:
+  constants: 'templates/terraform/constants/go/compute_managed_ssl_certificate.go.tmpl'
 examples:
   - name: 'managed_ssl_certificate_basic'
     primary_resource_id: 'default'
@@ -130,7 +130,7 @@ properties:
     description: |
       Enum field whose value is always `MANAGED` - used to signal to the API
       which type this is.
-    default_value: MANAGED
+    default_value: "MANAGED"
     enum_values:
       - 'MANAGED'
   - name: 'subjectAlternativeNames'

--- a/mmv1/products/compute/go_Network.yaml
+++ b/mmv1/products/compute/go_Network.yaml
@@ -175,7 +175,7 @@ properties:
       Set the order that Firewall Rules and Firewall Policies are evaluated.
     update_url: 'projects/{{project}}/global/networks/{{name}}'
     update_verb: 'PATCH'
-    default_value: AFTER_CLASSIC_FIREWALL
+    default_value: "AFTER_CLASSIC_FIREWALL"
     enum_values:
       - 'BEFORE_CLASSIC_FIREWALL'
       - 'AFTER_CLASSIC_FIREWALL'

--- a/mmv1/products/compute/go_NetworkEndpointGroup.yaml
+++ b/mmv1/products/compute/go_NetworkEndpointGroup.yaml
@@ -56,8 +56,8 @@ async:
     path: 'error/errors'
     message: 'message'
 collection_url_key: 'items'
-custom_code: !ruby/object:Provider::Terraform::CustomCode
-  constants: templates/terraform/constants/compute_network_endpoint_group.go.erb
+custom_code:
+  constants: 'templates/terraform/constants/go/compute_network_endpoint_group.go.tmpl'
 examples:
   - name: 'network_endpoint_group'
     primary_resource_id: 'neg'
@@ -112,7 +112,7 @@ properties:
       CONNECTION balancing modes.
 
       Possible values include: GCE_VM_IP, GCE_VM_IP_PORT, NON_GCP_PRIVATE_IP_PORT, INTERNET_IP_PORT, INTERNET_FQDN_PORT, SERVERLESS, and PRIVATE_SERVICE_CONNECT.
-    default_value: GCE_VM_IP_PORT
+    default_value: "GCE_VM_IP_PORT"
     enum_values:
       - 'GCE_VM_IP'
       - 'GCE_VM_IP_PORT'

--- a/mmv1/products/compute/go_NodeGroup.yaml
+++ b/mmv1/products/compute/go_NodeGroup.yaml
@@ -122,7 +122,7 @@ properties:
     type: String
     description: |
       Specifies how to handle instances when a node in the group undergoes maintenance. Set to one of: DEFAULT, RESTART_IN_PLACE, or MIGRATE_WITHIN_NODE_GROUP. The default value is DEFAULT.
-    default_value: DEFAULT
+    default_value: "DEFAULT"
   - name: 'maintenanceWindow'
     type: NestedObject
     description: |

--- a/mmv1/products/compute/go_NodeTemplate.yaml
+++ b/mmv1/products/compute/go_NodeTemplate.yaml
@@ -149,7 +149,7 @@ properties:
     type: Enum
     description: |
       CPU overcommit.
-    default_value: NONE
+    default_value: "NONE"
     enum_values:
       - 'ENABLED'
       - 'NONE'

--- a/mmv1/products/compute/go_OrganizationSecurityPolicy.yaml
+++ b/mmv1/products/compute/go_OrganizationSecurityPolicy.yaml
@@ -88,6 +88,6 @@ properties:
       is "FIREWALL".
     min_version: 'beta'
     immutable: true
-    default_value: FIREWALL
+    default_value: "FIREWALL"
     enum_values:
       - 'FIREWALL'

--- a/mmv1/products/compute/go_OrganizationSecurityPolicyRule.yaml
+++ b/mmv1/products/compute/go_OrganizationSecurityPolicyRule.yaml
@@ -90,7 +90,7 @@ properties:
           Preconfigured versioned expression. For organization security policy rules,
           the only supported type is "FIREWALL".
         min_version: 'beta'
-        default_value: FIREWALL
+        default_value: "FIREWALL"
         enum_values:
           - 'FIREWALL'
       - name: 'config'

--- a/mmv1/products/compute/go_PacketMirroring.yaml
+++ b/mmv1/products/compute/go_PacketMirroring.yaml
@@ -138,7 +138,7 @@ properties:
       - name: 'direction'
         type: Enum
         description: Direction of traffic to mirror.
-        default_value: BOTH
+        default_value: "BOTH"
         enum_values:
           - 'INGRESS'
           - 'EGRESS'

--- a/mmv1/products/compute/go_PerInstanceConfig.yaml
+++ b/mmv1/products/compute/go_PerInstanceConfig.yaml
@@ -166,7 +166,7 @@ properties:
               type: Enum
               description: |
                 The mode of the disk.
-              default_value: READ_WRITE
+              default_value: "READ_WRITE"
               enum_values:
                 - 'READ_ONLY'
                 - 'READ_WRITE'
@@ -178,7 +178,7 @@ properties:
                 `NEVER` - detach the disk when the VM is deleted, but do not delete the disk.
                 `ON_PERMANENT_INSTANCE_DELETION` will delete the stateful disk when the VM is permanently
                 deleted from the instance group.
-              default_value: NEVER
+              default_value: "NEVER"
               enum_values:
                 - 'NEVER'
                 - 'ON_PERMANENT_INSTANCE_DELETION'
@@ -195,7 +195,7 @@ properties:
               type: Enum
               description: |
                 These stateful IPs will never be released during autohealing, update or VM instance recreate operations. This flag is used to configure if the IP reservation should be deleted after it is no longer used by the group, e.g. when the given instance or the whole group is deleted.
-              default_value: NEVER
+              default_value: "NEVER"
               enum_values:
                 - 'NEVER'
                 - 'ON_PERMANENT_INSTANCE_DELETION'
@@ -224,7 +224,7 @@ properties:
               type: Enum
               description: |
                 These stateful IPs will never be released during autohealing, update or VM instance recreate operations. This flag is used to configure if the IP reservation should be deleted after it is no longer used by the group, e.g. when the given instance or the whole group is deleted.
-              default_value: NEVER
+              default_value: "NEVER"
               enum_values:
                 - 'NEVER'
                 - 'ON_PERMANENT_INSTANCE_DELETION'

--- a/mmv1/products/compute/go_RegionAutoscaler.yaml
+++ b/mmv1/products/compute/go_RegionAutoscaler.yaml
@@ -138,7 +138,7 @@ properties:
         type: String
         description: |
           Defines operating mode for this policy.
-        default_value: ON
+        default_value: "ON"
       - name: 'scaleDownControl'
         type: NestedObject
         description: |
@@ -247,7 +247,7 @@ properties:
 
               - OPTIMIZE_AVAILABILITY. Predictive autoscaling improves availability by monitoring daily and weekly load patterns and scaling out ahead of anticipated demand.
             custom_flatten: 'templates/terraform/custom_flatten/go/default_if_empty.tmpl'
-            default_value: NONE
+            default_value: "NONE"
       - name: 'metric'
         type: Array
         description: |
@@ -380,7 +380,7 @@ properties:
               type: String
               description: |
                 The time zone to be used when interpreting the schedule. The value of this field must be a time zone name from the tz database: http://en.wikipedia.org/wiki/Tz_database.
-              default_value: UTC
+              default_value: "UTC"
             - name: 'durationSec'
               type: Integer
               description: |

--- a/mmv1/products/compute/go_RegionBackendService.yaml
+++ b/mmv1/products/compute/go_RegionBackendService.yaml
@@ -149,7 +149,7 @@ properties:
             for an explanation of load balancing modes.
 
             From version 6.0.0 default value will be UTILIZATION to match default GCP value.
-          default_value: CONNECTION
+          default_value: "CONNECTION"
           enum_values:
             - 'UTILIZATION'
             - 'RATE'
@@ -777,7 +777,7 @@ properties:
       balancing cannot be used with the other(s). For more information, refer to
       [Choosing a load balancer](https://cloud.google.com/load-balancing/docs/backend-service).
     immutable: true
-    default_value: INTERNAL
+    default_value: "INTERNAL"
     enum_values:
       - 'EXTERNAL'
       - 'EXTERNAL_MANAGED'
@@ -1188,7 +1188,7 @@ properties:
 
           `PER_SESSION`: The Connection Tracking is performed as per the
           configured Session Affinity. It matches the configured Session Affinity.
-        default_value: PER_CONNECTION
+        default_value: "PER_CONNECTION"
         enum_values:
           - 'PER_CONNECTION'
           - 'PER_SESSION'
@@ -1211,7 +1211,7 @@ properties:
           If set to `ALWAYS_PERSIST`, existing connections always persist on
           unhealthy backends regardless of protocol and session affinity. It is
           generally not recommended to use this mode overriding the default.
-        default_value: DEFAULT_FOR_PROTOCOL
+        default_value: "DEFAULT_FOR_PROTOCOL"
         enum_values:
           - 'DEFAULT_FOR_PROTOCOL'
           - 'NEVER_PERSIST'

--- a/mmv1/products/compute/go_RegionDisk.yaml
+++ b/mmv1/products/compute/go_RegionDisk.yaml
@@ -286,7 +286,7 @@ properties:
       create the disk. Provide this when creating the disk.
     custom_flatten: 'templates/terraform/custom_flatten/go/name_from_self_link.tmpl'
     custom_expand: 'templates/terraform/custom_expand/go/resourceref_with_validation.go.tmpl'
-    default_value: pd-standard
+    default_value: "pd-standard"
     resource: 'RegionDiskType'
     imports: 'selfLink'
   - name: 'interface'
@@ -295,8 +295,8 @@ properties:
       Specifies the disk interface to use for attaching this disk, which is either SCSI or NVME. The default is SCSI.
     min_version: 'beta'
     url_param_only: true
-    diff_suppress_func: AlwaysDiffSuppress
-    default_value: SCSI
+    diff_suppress_func: 'AlwaysDiffSuppress'
+    default_value: "SCSI"
     deprecation_message: '`interface` is deprecated and will be removed in a future major release. This field is no longer used and can be safely removed from your configurations; disk interfaces are automatically determined on attachment.'
   - name: 'sourceDisk'
     type: String

--- a/mmv1/products/compute/go_RegionHealthCheck.yaml
+++ b/mmv1/products/compute/go_RegionHealthCheck.yaml
@@ -220,7 +220,7 @@ properties:
           - 'http_health_check.0.port_name'
           - 'http_health_check.0.proxy_header'
           - 'http_health_check.0.port_specification'
-        default_value: /
+        default_value: "/"
       - name: 'response'
         type: String
         description: |
@@ -274,7 +274,7 @@ properties:
           - 'http_health_check.0.port_name'
           - 'http_health_check.0.proxy_header'
           - 'http_health_check.0.port_specification'
-        default_value: NONE
+        default_value: "NONE"
         enum_values:
           - 'NONE'
           - 'PROXY_V1'
@@ -345,7 +345,7 @@ properties:
           - 'https_health_check.0.port_name'
           - 'https_health_check.0.proxy_header'
           - 'https_health_check.0.port_specification'
-        default_value: /
+        default_value: "/"
       - name: 'response'
         type: String
         description: |
@@ -399,7 +399,7 @@ properties:
           - 'https_health_check.0.port_name'
           - 'https_health_check.0.proxy_header'
           - 'https_health_check.0.port_specification'
-        default_value: NONE
+        default_value: "NONE"
         enum_values:
           - 'NONE'
           - 'PROXY_V1'
@@ -506,7 +506,7 @@ properties:
           - 'tcp_health_check.0.port_name'
           - 'tcp_health_check.0.proxy_header'
           - 'tcp_health_check.0.port_specification'
-        default_value: NONE
+        default_value: "NONE"
         enum_values:
           - 'NONE'
           - 'PROXY_V1'
@@ -612,7 +612,7 @@ properties:
           - 'ssl_health_check.0.port_name'
           - 'ssl_health_check.0.proxy_header'
           - 'ssl_health_check.0.port_specification'
-        default_value: NONE
+        default_value: "NONE"
         enum_values:
           - 'NONE'
           - 'PROXY_V1'
@@ -682,7 +682,7 @@ properties:
           - 'http2_health_check.0.port_name'
           - 'http2_health_check.0.proxy_header'
           - 'http2_health_check.0.port_specification'
-        default_value: /
+        default_value: "/"
       - name: 'response'
         type: String
         description: |
@@ -736,7 +736,7 @@ properties:
           - 'http2_health_check.0.port_name'
           - 'http2_health_check.0.proxy_header'
           - 'http2_health_check.0.port_specification'
-        default_value: NONE
+        default_value: "NONE"
         enum_values:
           - 'NONE'
           - 'PROXY_V1'

--- a/mmv1/products/compute/go_RegionNetworkEndpointGroup.yaml
+++ b/mmv1/products/compute/go_RegionNetworkEndpointGroup.yaml
@@ -136,7 +136,7 @@ properties:
     type: Enum
     description: |
       Type of network endpoints in this network endpoint group. Defaults to SERVERLESS.
-    default_value: SERVERLESS
+    default_value: "SERVERLESS"
     enum_values:
       - 'SERVERLESS'
       - 'PRIVATE_SERVICE_CONNECT'

--- a/mmv1/products/compute/go_RegionPerInstanceConfig.yaml
+++ b/mmv1/products/compute/go_RegionPerInstanceConfig.yaml
@@ -167,7 +167,7 @@ properties:
               type: Enum
               description: |
                 The mode of the disk.
-              default_value: READ_WRITE
+              default_value: "READ_WRITE"
               enum_values:
                 - 'READ_ONLY'
                 - 'READ_WRITE'
@@ -179,7 +179,7 @@ properties:
                 `NEVER` - detach the disk when the VM is deleted, but do not delete the disk.
                 `ON_PERMANENT_INSTANCE_DELETION` will delete the stateful disk when the VM is permanently
                 deleted from the instance group.
-              default_value: NEVER
+              default_value: "NEVER"
               enum_values:
                 - 'NEVER'
                 - 'ON_PERMANENT_INSTANCE_DELETION'
@@ -196,7 +196,7 @@ properties:
               type: Enum
               description: |
                 These stateful IPs will never be released during autohealing, update or VM instance recreate operations. This flag is used to configure if the IP reservation should be deleted after it is no longer used by the group, e.g. when the given instance or the whole group is deleted.
-              default_value: NEVER
+              default_value: "NEVER"
               enum_values:
                 - 'NEVER'
                 - 'ON_PERMANENT_INSTANCE_DELETION'
@@ -225,7 +225,7 @@ properties:
               type: Enum
               description: |
                 These stateful IPs will never be released during autohealing, update or VM instance recreate operations. This flag is used to configure if the IP reservation should be deleted after it is no longer used by the group, e.g. when the given instance or the whole group is deleted.
-              default_value: NEVER
+              default_value: "NEVER"
               enum_values:
                 - 'NEVER'
                 - 'ON_PERMANENT_INSTANCE_DELETION'

--- a/mmv1/products/compute/go_RegionSslCertificate.yaml
+++ b/mmv1/products/compute/go_RegionSslCertificate.yaml
@@ -50,6 +50,7 @@ async:
 collection_url_key: 'items'
 custom_code:
   extra_schema_entry: 'templates/terraform/extra_schema_entry/go/ssl_certificate.tmpl'
+  constants: 'templates/terraform/constants/go/compute_certificate.go.tmpl'
 examples:
   - name: 'region_ssl_certificate_basic'
     primary_resource_id: 'default'

--- a/mmv1/products/compute/go_RegionSslPolicy.yaml
+++ b/mmv1/products/compute/go_RegionSslPolicy.yaml
@@ -91,7 +91,7 @@ properties:
       See the [official documentation](https://cloud.google.com/compute/docs/load-balancing/ssl-policies#profilefeaturesupport)
       for information on what cipher suites each profile provides. If
       `CUSTOM` is used, the `custom_features` attribute **must be set**.
-    default_value: COMPATIBLE
+    default_value: "COMPATIBLE"
     enum_values:
       - 'COMPATIBLE'
       - 'MODERN'
@@ -102,7 +102,7 @@ properties:
     description: |
       The minimum version of SSL protocol that can be used by the clients
       to establish a connection with the load balancer.
-    default_value: TLS_1_0
+    default_value: "TLS_1_0"
     enum_values:
       - 'TLS_1_0'
       - 'TLS_1_1'

--- a/mmv1/products/compute/go_RegionTargetTcpProxy.yaml
+++ b/mmv1/products/compute/go_RegionTargetTcpProxy.yaml
@@ -95,7 +95,7 @@ properties:
     description: |
       Specifies the type of proxy header to append before sending data to
       the backend.
-    default_value: NONE
+    default_value: "NONE"
     enum_values:
       - 'NONE'
       - 'PROXY_V1'

--- a/mmv1/products/compute/go_Reservation.yaml
+++ b/mmv1/products/compute/go_Reservation.yaml
@@ -232,7 +232,7 @@ properties:
                   description: |
                     The disk interface to use for attaching this disk.
                   immutable: true
-                  default_value: SCSI
+                  default_value: "SCSI"
                   enum_values:
                     - 'SCSI'
                     - 'NVME'

--- a/mmv1/products/compute/go_ResourcePolicy.yaml
+++ b/mmv1/products/compute/go_ResourcePolicy.yaml
@@ -215,7 +215,7 @@ properties:
             description: |
               Specifies the behavior to apply to scheduled snapshots when
               the source disk is deleted.
-            default_value: KEEP_AUTO_SNAPSHOTS
+            default_value: "KEEP_AUTO_SNAPSHOTS"
             enum_values:
               - 'KEEP_AUTO_SNAPSHOTS'
               - 'APPLY_RETENTION_POLICY'

--- a/mmv1/products/compute/go_Route.yaml
+++ b/mmv1/products/compute/go_Route.yaml
@@ -72,8 +72,8 @@ async:
     message: 'message'
 collection_url_key: 'items'
 custom_code:
-  constants: templates/terraform/constants/compute_route.go.erb
   extra_schema_entry: 'templates/terraform/extra_schema_entry/go/route.tmpl'
+  constants: 'templates/terraform/constants/go/compute_route.go.tmpl'
   decoder: 'templates/terraform/decoders/go/route.tmpl'
 error_retry_predicates:
 

--- a/mmv1/products/compute/go_Router.yaml
+++ b/mmv1/products/compute/go_Router.yaml
@@ -126,7 +126,7 @@ properties:
         type: Enum
         description: |
           User-specified flag to indicate which mode to use for advertisement.
-        default_value: DEFAULT
+        default_value: "DEFAULT"
         enum_values:
           - 'DEFAULT'
           - 'CUSTOM'

--- a/mmv1/products/compute/go_RouterNat.yaml
+++ b/mmv1/products/compute/go_RouterNat.yaml
@@ -448,7 +448,7 @@ properties:
       If `PRIVATE` NAT used for private IP translation.
     min_version: 'beta'
     immutable: true
-    default_value: PUBLIC
+    default_value: "PUBLIC"
     enum_values:
       - 'PUBLIC'
       - 'PRIVATE'

--- a/mmv1/products/compute/go_SslPolicy.yaml
+++ b/mmv1/products/compute/go_SslPolicy.yaml
@@ -89,7 +89,7 @@ properties:
       See the [official documentation](https://cloud.google.com/compute/docs/load-balancing/ssl-policies#profilefeaturesupport)
       for information on what cipher suites each profile provides. If
       `CUSTOM` is used, the `custom_features` attribute **must be set**.
-    default_value: COMPATIBLE
+    default_value: "COMPATIBLE"
     enum_values:
       - 'COMPATIBLE'
       - 'MODERN'
@@ -100,7 +100,7 @@ properties:
     description: |
       The minimum version of SSL protocol that can be used by the clients
       to establish a connection with the load balancer.
-    default_value: TLS_1_0
+    default_value: "TLS_1_0"
     enum_values:
       - 'TLS_1_0'
       - 'TLS_1_1'

--- a/mmv1/products/compute/go_Subnetwork.yaml
+++ b/mmv1/products/compute/go_Subnetwork.yaml
@@ -292,7 +292,7 @@ properties:
           - 'log_config.0.flow_sampling'
           - 'log_config.0.metadata'
           - 'log_config.0.filterExpr'
-        default_value: INTERVAL_5_SEC
+        default_value: "INTERVAL_5_SEC"
         enum_values:
           - 'INTERVAL_5_SEC'
           - 'INTERVAL_30_SEC'
@@ -325,7 +325,7 @@ properties:
           - 'log_config.0.flow_sampling'
           - 'log_config.0.metadata'
           - 'log_config.0.filterExpr'
-        default_value: INCLUDE_ALL_METADATA
+        default_value: "INCLUDE_ALL_METADATA"
         enum_values:
           - 'EXCLUDE_ALL_METADATA'
           - 'INCLUDE_ALL_METADATA'
@@ -349,7 +349,7 @@ properties:
           - 'log_config.0.flow_sampling'
           - 'log_config.0.metadata'
           - 'log_config.0.filterExpr'
-        default_value: true
+        default_value: "true"
   - name: 'stackType'
     type: Enum
     description: |

--- a/mmv1/products/compute/go_TargetHttpsProxy.yaml
+++ b/mmv1/products/compute/go_TargetHttpsProxy.yaml
@@ -120,7 +120,7 @@ properties:
     update_url: 'projects/{{project}}/global/targetHttpsProxies/{{name}}/setQuicOverride'
     update_verb: 'POST'
     custom_flatten: 'templates/terraform/custom_flatten/go/default_if_empty.tmpl'
-    default_value: NONE
+    default_value: "NONE"
     enum_values:
       - 'NONE'
       - 'ENABLE'

--- a/mmv1/products/compute/go_TargetInstance.yaml
+++ b/mmv1/products/compute/go_TargetInstance.yaml
@@ -130,7 +130,7 @@ properties:
       NAT option controlling how IPs are NAT'ed to the instance.
       Currently only NO_NAT (default value) is supported.
     immutable: true
-    default_value: NO_NAT
+    default_value: "NO_NAT"
     enum_values:
       - 'NO_NAT'
   - name: 'securityPolicy'

--- a/mmv1/products/compute/go_TargetSslProxy.yaml
+++ b/mmv1/products/compute/go_TargetSslProxy.yaml
@@ -88,7 +88,7 @@ properties:
       the backend.
     update_url: 'projects/{{project}}/global/targetSslProxies/{{name}}/setProxyHeader'
     update_verb: 'POST'
-    default_value: NONE
+    default_value: "NONE"
     enum_values:
       - 'NONE'
       - 'PROXY_V1'

--- a/mmv1/products/compute/go_TargetTcpProxy.yaml
+++ b/mmv1/products/compute/go_TargetTcpProxy.yaml
@@ -87,7 +87,7 @@ properties:
       the backend.
     update_url: 'projects/{{project}}/global/targetTcpProxies/{{name}}/setProxyHeader'
     update_verb: 'POST'
-    default_value: NONE
+    default_value: "NONE"
     enum_values:
       - 'NONE'
       - 'PROXY_V1'

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -149,8 +149,10 @@ func Resource{{ $.ResourceName -}}() *schema.Resource {
             },
 {{-   end}}
 {{- end}}
-{{/* TODO Q2 function to compile custom code lines ($.CustomCode.extra_schema_entry) */}}
-{{- if $.HasProject -}}
+{{- if $.CustomCode.ExtraSchemaEntry }} 
+    {{ $.CustomTemplate $.CustomCode.ExtraSchemaEntry false -}}
+{{- end}}
+{{ if $.HasProject -}}
             "project": {
                 Type:     schema.TypeString,
                 Optional: true,
@@ -609,7 +611,7 @@ func resource{{ $.ResourceName -}}Read(d *schema.ResourceData, meta interface{})
 {{- range $prop := $.VirtualFields }}
 {{      if not (eq $prop.DefaultValue nil) -}}
     if _, ok := d.GetOkExists("{{ $prop.Name -}}"); !ok {
-        if err := d.Set("{{ $prop.Name -}}", {{ $prop.DefaultValue -}}); err != nil {
+        if err := d.Set("{{ $prop.Name -}}", {{ $prop.GoLiteral $prop.DefaultValue -}}); err != nil {
             return fmt.Errorf("Error setting {{ $prop.Name -}}: %s", err)
         }
     }
@@ -829,7 +831,7 @@ if len(updateMask) > 0 {
 {{-         end}}{{/*if not immutable*/}}
 {{-          if $.FieldSpecificUpdateMethods }}
     d.Partial(true)
-{{             $CustomUpdateProps := $.PropertiesByCustomUpdate }}
+{{             $CustomUpdateProps := $.PropertiesByCustomUpdate $.RootProperties }}
 {{             range $group := $.PropertiesByCustomUpdateGroups }}
 if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $group)) "\") || d.HasChange(\""}}") {
         obj := make(map[string]interface{})
@@ -869,7 +871,7 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $gro
         obj["{{ $group.FingerprintName }}"] = getRes["{{ $group.FingerprintName }}"]
 
 {{                  end  }}{{/*if FingerprintName*/}}
-{{                  range $propsByKey := $.CustomUpdatePropertiesByKey $group.UpdateUrl $group.UpdateId $group.FingerprintName $group.UpdateVerb }}
+{{                  range $propsByKey := $.CustomUpdatePropertiesByKey $.AllUserProperties $group.UpdateUrl $group.UpdateId $group.FingerprintName $group.UpdateVerb }}
         {{ $propsByKey.ApiName -}}Prop, err := expand{{ if $.NestedQuery -}}Nested{{ end }}{{ $.ResourceName -}}{{ camelize $propsByKey.Name "upper"  -}}({{ if $propsByKey.FlattenObject }}nil{{else}}d.Get("{{underscore $propsByKey.Name}}"){{ end }}, d, config)
         if err != nil {
             return err
@@ -1150,7 +1152,7 @@ func resource{{ $.ResourceName }}Import(d *schema.ResourceData, meta interface{}
     // Explicitly set virtual fields to default values on import
             {{- range $vf := $.VirtualFields }}
                 {{- if not (eq $vf.DefaultValue nil) }}
-    if err := d.Set("{{ $vf.Name }}", {{ $vf.DefaultValue }}); err != nil {
+    if err := d.Set("{{ $vf.Name }}", {{ $vf.GoLiteral $vf.DefaultValue }}); err != nil {
         return nil, fmt.Errorf("Error setting {{ $vf.Name }}: %s", err)
     }
                 {{- end }}

--- a/mmv1/templates/terraform/unordered_list_customize_diff.go.tmpl
+++ b/mmv1/templates/terraform/unordered_list_customize_diff.go.tmpl
@@ -1,5 +1,5 @@
 {{- define "UnorderedListCustomizeDiff" }}
-keys := diff.GetChangedKeysPrefix({{ underscore $.Name }})
+keys := diff.GetChangedKeysPrefix("{{ underscore $.Name }}")
 if len(keys) == 0 {
     return nil
 }
@@ -28,11 +28,11 @@ for i := 0; i < count; i++ {
     }
 }
 
-oldSet := schema.NewSet(schema.HashResource(Resource{{ $.ResourceMetadata.ResourceName }}().Schema[{{ underscore $.Name }}].Elem.(*schema.Resource)), old)
-newSet := schema.NewSet(schema.HashResource(Resource{{ $.ResourceMetadata.ResourceName }}().Schema[{{ underscore $.Name }}].Elem.(*schema.Resource)), new)
+oldSet := schema.NewSet(schema.HashResource(Resource{{ $.ResourceMetadata.ResourceName }}().Schema["{{ underscore $.Name }}"].Elem.(*schema.Resource)), old)
+newSet := schema.NewSet(schema.HashResource(Resource{{ $.ResourceMetadata.ResourceName }}().Schema["{{ underscore $.Name }}"].Elem.(*schema.Resource)), new)
 
 if oldSet.Equal(newSet) {
-    if err := diff.Clear({{ underscore $.Name }}); err != nil {
+    if err := diff.Clear("{{ underscore $.Name }}"); err != nil {
         return err
     }
 }

--- a/mmv1/templates/terraform/yaml_conversion_field.erb
+++ b/mmv1/templates/terraform/yaml_conversion_field.erb
@@ -151,7 +151,7 @@
 <%  end -%>
 <%  end -%>
 <%  unless property.default_value.nil? -%>
-    default_value: <%= property.default_value %>
+    default_value: <%= go_literal(property.default_value) %>
 <%  end -%>
 <%  unless property.deprecation_message.nil? -%>
     deprecation_message: '<%= property.deprecation_message %>'


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
1. Fix the default_value when converting resource yaml files
2. Render ExtraSchemaEntry in resource.tmpl

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
