### PR TITLE
`KMS`: add plural data source for `resource_google_kms_key_ring`

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
@@ -135,6 +135,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_kms_crypto_key":                            kms.DataSourceGoogleKmsCryptoKey(),
 	"google_kms_crypto_key_version":                    kms.DataSourceGoogleKmsCryptoKeyVersion(),
 	"google_kms_key_ring":                              kms.DataSourceGoogleKmsKeyRing(),
+	"google_kms_key_rings":                              kms.DataSourceGoogleKmsKeyRings(),
 	"google_kms_secret":                                kms.DataSourceGoogleKmsSecret(),
 	"google_kms_secret_ciphertext":                     kms.DataSourceGoogleKmsSecretCiphertext(),
 	<% unless version == 'ga' -%>

--- a/mmv1/third_party/terraform/services/kms/data_source_google_kms_key_rings.go
+++ b/mmv1/third_party/terraform/services/kms/data_source_google_kms_key_rings.go
@@ -1,5 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
 package kms
 
 import (

--- a/mmv1/third_party/terraform/services/kms/data_source_google_kms_key_rings.go
+++ b/mmv1/third_party/terraform/services/kms/data_source_google_kms_key_rings.go
@@ -1,0 +1,171 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+package kms
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceGoogleKmsKeyRings() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGoogleKmsKeyRingsRead,
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Project ID of the project.`,
+			},
+			"location": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The canonical id for the location. For example: "us-east1".`,
+			},
+			"filter": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Description: `
+					The filter argument is used to add a filter query parameter that limits which keys are retrieved by the data source: ?filter={{filter}}.
+					Example values:
+					
+					* "name:my-key-" will retrieve key rings that contain "my-key-" anywhere in their name. Note: names take the form projects/{{project}}/locations/{{location}}/keyRings/{{keyRing}}.
+					* "name=projects/my-project/locations/global/keyRings/my-key-ring" will only retrieve a key ring with that exact name.
+					
+					[See the documentation about using filters](https://cloud.google.com/kms/docs/sorting-and-filtering)
+				`,
+			},
+			"key_rings": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "A list of all the retrieved key rings",
+				Elem: &schema.Resource{
+					// schema isn't used from resource_kms_key_ring due to having project and location fields which are empty when grabbed in a list.
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGoogleKmsKeyRingsRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+
+	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/locations/{{location}}/keyRings")
+	if err != nil {
+		return err
+	}
+	d.SetId(id)
+
+	log.Printf("[DEBUG] Searching for keyrings")
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	billingProject := ""
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return fmt.Errorf("Error fetching project for keyRings: %s", err)
+	}
+	billingProject = project
+
+	// err == nil indicates that the billing_project value was found
+	if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+		billingProject = bp
+	}
+
+	var keyRings []interface{}
+
+	params := make(map[string]string)
+	if filter, ok := d.GetOk("filter"); ok {
+		log.Printf("[DEBUG] Search for key rings using filter ?filter=%s", filter.(string))
+		params["filter"] = filter.(string)
+		if err != nil {
+			return err
+		}
+	}
+
+	url, err := tpgresource.ReplaceVars(d, config, "{{KMSBasePath}}projects/{{project}}/locations/{{location}}/keyRings")
+	if err != nil {
+		return err
+	}
+
+	for {
+		url, err = transport_tpg.AddQueryParams(url, params)
+		if err != nil {
+			return err
+		}
+
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   billingProject,
+			RawURL:    url,
+			UserAgent: userAgent,
+		})
+		if err != nil {
+			return fmt.Errorf("Error retrieving buckets: %s", err)
+		}
+
+		if res["keyRings"] == nil {
+			break
+		}
+		pageKeyRings, err := flattenKMSKeyRingsList(config, res["keyRings"])
+		if err != nil {
+			return fmt.Errorf("error flattening key rings list: %s", err)
+		}
+		keyRings = append(keyRings, pageKeyRings...)
+
+		pToken, ok := res["nextPageToken"]
+		if ok && pToken != nil && pToken.(string) != "" {
+			params["pageToken"] = pToken.(string)
+		} else {
+			break
+		}
+	}
+
+	log.Printf("[DEBUG] Found %d key rings", len(keyRings))
+	if err := d.Set("key_rings", keyRings); err != nil {
+		return fmt.Errorf("error setting key rings: %s", err)
+	}
+
+	return nil
+}
+
+// flattenKMSKeyRingsList flattens a list of key rings
+func flattenKMSKeyRingsList(config *transport_tpg.Config, keyRingsList interface{}) ([]interface{}, error) {
+	var keyRings []interface{}
+	for _, k := range keyRingsList.([]interface{}) {
+		keyRing := k.(map[string]interface{})
+
+		parsedId, err := parseKmsKeyRingId(keyRing["name"].(string), config)
+		if err != nil {
+			return nil, err
+		}
+
+		data := map[string]interface{}{}
+		// The google_kms_key_rings resource and dataset set
+		// id as the value of name (projects/{{project}}/locations/{{location}}/keyRings/{{name}})
+		// and set name is set as just {{name}}.
+		data["id"] = keyRing["name"]
+		data["name"] = parsedId.Name
+
+		keyRings = append(keyRings, data)
+	}
+
+	return keyRings, nil
+}

--- a/mmv1/third_party/terraform/services/kms/data_source_google_kms_key_rings.go
+++ b/mmv1/third_party/terraform/services/kms/data_source_google_kms_key_rings.go
@@ -66,6 +66,10 @@ func dataSourceGoogleKmsKeyRingsRead(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return err
 	}
+
+	if filter, ok := d.GetOk("filter"); ok {
+		id += "/filter=" + filter.(string)
+	}
 	d.SetId(id)
 
 	log.Printf("[DEBUG] Searching for keyrings")
@@ -124,6 +128,8 @@ func dataSourceGoogleKmsKeyRingsList(d *schema.ResourceData, meta interface{}) (
 	if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
 		billingProject = bp
 	}
+
+	d.Set("project", billingProject)
 
 	headers := make(http.Header)
 	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{

--- a/mmv1/third_party/terraform/services/kms/data_source_google_kms_key_rings.go
+++ b/mmv1/third_party/terraform/services/kms/data_source_google_kms_key_rings.go
@@ -1,9 +1,10 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
 package kms
 
 import (
 	"fmt"
 	"log"
-	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
@@ -66,61 +67,22 @@ func dataSourceGoogleKmsKeyRingsRead(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return err
 	}
-
 	if filter, ok := d.GetOk("filter"); ok {
 		id += "/filter=" + filter.(string)
 	}
 	d.SetId(id)
 
 	log.Printf("[DEBUG] Searching for keyrings")
-	res, err := dataSourceGoogleKmsKeyRingsList(d, meta)
-	if err != nil {
-		return err
-	}
-
-	// Check for keyRings field, as empty response lacks keyRings
-	// If found, set data in the data source's `keyRing` field
-	if keyRings, ok := res["keyRings"].([]interface{}); ok {
-		log.Printf("[DEBUG] Found %d key rings", len(keyRings))
-		value, err := flattenKMSKeyRingsList(d, config, keyRings)
-		if err != nil {
-			return fmt.Errorf("error flattening key rings list: %s", err)
-		}
-		if err := d.Set("key_rings", value); err != nil {
-			return fmt.Errorf("error setting key rings: %s", err)
-		}
-	} else {
-		log.Printf("[DEBUG] Found 0 key rings")
-	}
-
-	return nil
-}
-
-func dataSourceGoogleKmsKeyRingsList(d *schema.ResourceData, meta interface{}) (map[string]interface{}, error) {
-	config := meta.(*transport_tpg.Config)
 	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {
-		return nil, err
-	}
-
-	url, err := tpgresource.ReplaceVars(d, config, "{{KMSBasePath}}projects/{{project}}/locations/{{location}}/keyRings")
-	if err != nil {
-		return nil, err
-	}
-
-	if filter, ok := d.GetOk("filter"); ok {
-		log.Printf("[DEBUG] Search for key rings using filter ?filter=%s", filter.(string))
-		url, err = transport_tpg.AddQueryParams(url, map[string]string{"filter": filter.(string)})
-		if err != nil {
-			return nil, err
-		}
+		return err
 	}
 
 	billingProject := ""
 
 	project, err := tpgresource.GetProject(d, config)
 	if err != nil {
-		return nil, fmt.Errorf("Error fetching project for keyRings: %s", err)
+		return fmt.Errorf("Error fetching project for keyRings: %s", err)
 	}
 	billingProject = project
 
@@ -129,34 +91,69 @@ func dataSourceGoogleKmsKeyRingsList(d *schema.ResourceData, meta interface{}) (
 		billingProject = bp
 	}
 
-	d.Set("project", billingProject)
+	var keyRings []interface{}
 
-	headers := make(http.Header)
-	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-		Config:    config,
-		Method:    "GET",
-		Project:   billingProject,
-		RawURL:    url,
-		UserAgent: userAgent,
-		Headers:   headers,
-	})
+	params := make(map[string]string)
+	if filter, ok := d.GetOk("filter"); ok {
+		log.Printf("[DEBUG] Search for key rings using filter ?filter=%s", filter.(string))
+		params["filter"] = filter.(string)
+		if err != nil {
+			return err
+		}
+	}
+
+	url, err := tpgresource.ReplaceVars(d, config, "{{KMSBasePath}}projects/{{project}}/locations/{{location}}/keyRings")
 	if err != nil {
-		return nil, transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("KMSKeyRing %q", d.Id()))
+		return err
 	}
 
-	if res == nil {
-		// Decoding the object has resulted in it being gone. It may be marked deleted
-		log.Printf("[DEBUG] Removing KMSKeyRing because it no longer exists.")
-		d.SetId("")
-		return nil, nil
+	for {
+		url, err = transport_tpg.AddQueryParams(url, params)
+		if err != nil {
+			return err
+		}
+
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:               config,
+			Method:               "GET",
+			Project:              billingProject,
+			RawURL:               url,
+			UserAgent:            userAgent,
+			ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{transport_tpg.Is429RetryableQuotaError},
+		})
+		if err != nil {
+			return fmt.Errorf("Error retrieving buckets: %s", err)
+		}
+
+		if res["keyRings"] == nil {
+			break
+		}
+		pageKeyRings, err := flattenKMSKeyRingsList(config, res["keyRings"])
+		if err != nil {
+			return fmt.Errorf("error flattening key rings list: %s", err)
+		}
+		keyRings = append(keyRings, pageKeyRings...)
+
+		pToken, ok := res["nextPageToken"]
+		if ok && pToken != nil && pToken.(string) != "" {
+			params["pageToken"] = pToken.(string)
+		} else {
+			break
+		}
 	}
-	return res, nil
+
+	log.Printf("[DEBUG] Found %d key rings", len(keyRings))
+	if err := d.Set("key_rings", keyRings); err != nil {
+		return fmt.Errorf("error setting key rings: %s", err)
+	}
+
+	return nil
 }
 
 // flattenKMSKeyRingsList flattens a list of key rings
-func flattenKMSKeyRingsList(d *schema.ResourceData, config *transport_tpg.Config, keyRingsList []interface{}) ([]interface{}, error) {
+func flattenKMSKeyRingsList(config *transport_tpg.Config, keyRingsList interface{}) ([]interface{}, error) {
 	var keyRings []interface{}
-	for _, k := range keyRingsList {
+	for _, k := range keyRingsList.([]interface{}) {
 		keyRing := k.(map[string]interface{})
 
 		parsedId, err := parseKmsKeyRingId(keyRing["name"].(string), config)

--- a/mmv1/third_party/terraform/services/kms/data_source_google_kms_key_rings_test.go
+++ b/mmv1/third_party/terraform/services/kms/data_source_google_kms_key_rings_test.go
@@ -66,10 +66,5 @@ data "google_kms_key_rings" "all_key_rings" {
   location = "%{location}"
   %{filter}
 }
-data "google_project" "project" {
-}
-output "project_number" {
-  value = data.google_project.project.number
-}
 `, context)
 }

--- a/mmv1/third_party/terraform/services/kms/data_source_google_kms_key_rings_test.go
+++ b/mmv1/third_party/terraform/services/kms/data_source_google_kms_key_rings_test.go
@@ -66,5 +66,10 @@ data "google_kms_key_rings" "all_key_rings" {
   location = "%{location}"
   %{filter}
 }
+data "google_project" "project" {
+}
+output "project_number" {
+  value = data.google_project.project.number
+}
 `, context)
 }

--- a/mmv1/third_party/terraform/services/kms/data_source_google_kms_key_rings_test.go
+++ b/mmv1/third_party/terraform/services/kms/data_source_google_kms_key_rings_test.go
@@ -1,0 +1,67 @@
+package kms_test
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccDataSourceGoogleKmsKeyRings_basic(t *testing.T) {
+	kms := acctest.BootstrapKMSKey(t)
+	idPath := strings.Split(kms.KeyRing.Name, "/")
+	location := idPath[3]
+	keyRingsID := fmt.Sprintf("projects/%s/locations/%s/keyRings", idPath[1], location)
+	context := map[string]interface{}{
+		"filter":   "", // Can be overridden using 2nd argument to config funcs
+		"location": location,
+	}
+
+	randomString := acctest.RandString(t, 10)
+	filterNameFindSharedKeyRings := "filter = \"name:tftest-shared-\""
+	filterNameFindsNoKeyRings := fmt.Sprintf("filter = \"name:%s\"", randomString)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleKmsKeyRings_basic(context, ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_kms_key_rings.all_key_rings", "id", keyRingsID),
+					resource.TestMatchResourceAttr("data.google_kms_key_rings.all_key_rings", "key_rings.#", regexp.MustCompile("[1-9]+[0-9]*")),
+				),
+			},
+			{
+				Config: testAccDataSourceGoogleKmsKeyRings_basic(context, filterNameFindSharedKeyRings),
+				Check: resource.ComposeTestCheckFunc(
+					// This filter should retrieve the bootstrapped KMS key rings used by the test
+					resource.TestCheckResourceAttr("data.google_kms_key_rings.all_key_rings", "id", keyRingsID),
+					resource.TestMatchResourceAttr("data.google_kms_key_rings.all_key_rings", "key_rings.#", regexp.MustCompile("[1-9]+[0-9]*")),
+				),
+			},
+			{
+				Config: testAccDataSourceGoogleKmsKeyRings_basic(context, filterNameFindsNoKeyRings),
+				Check: resource.ComposeTestCheckFunc(
+					// This filter should retrieve no keys
+					resource.TestCheckResourceAttr("data.google_kms_key_rings.all_key_rings", "id", keyRingsID),
+					resource.TestCheckResourceAttr("data.google_kms_key_rings.all_key_rings", "key_rings.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleKmsKeyRings_basic(context map[string]interface{}, filter string) string {
+	context["filter"] = filter
+
+	return acctest.Nprintf(`
+data "google_kms_key_rings" "all_key_rings" {
+  location = "%{location}"
+  %{filter}
+}
+`, context)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR adds a new plural data source `google_kms_key_rings`.

Note:
- It's necessary to explicitly add the `id` field to the schema for each individual key ring. Similar behavior also appears here: https://github.com/GoogleCloudPlatform/magic-modules/pull/11053
- One attribute is missing which is the `createTime`. Only reason why this wasn't ended in this PR is due the attribute not being included in `resource_google_kms_key_ring.go`

Running locally:
```
└─(16:10:49 on main ✹ ✭)──> envchain GCLOUD make testacc TEST=./google/services/kms TESTARGS='-run TestAccDataSourceGoogleKmsKeyRings_basic'                                                     2 ↵ ──(Wed,Jun26)─┘
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/kms -v -run TestAccDataSourceGoogleKmsKeyRings_basic -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceGoogleKmsKeyRings_basic
2024/06/26 16:11:06 [INFO] Authenticating using configured Google JSON 'credentials'...
2024/06/26 16:11:06 [INFO]   -- Scopes: [https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/userinfo.email]
2024/06/26 16:11:06 [INFO] Authenticating using configured Google JSON 'credentials'...
2024/06/26 16:11:06 [INFO]   -- Scopes: [https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/userinfo.email]
2024/06/26 16:11:06 [DEBUG] Waiting for state to become: [success]
2024/06/26 16:11:06 [INFO] Terraform is using this identity: mauricio-alvarezleon@hc-terraform-testing.iam.gserviceaccount.com
2024/06/26 16:11:06 [INFO] Instantiating Google Cloud KMS client for path https://cloudkms.googleapis.com/
2024/06/26 16:11:06 [DEBUG] Retry Transport: starting RoundTrip retry loop
2024/06/26 16:11:06 [DEBUG] Retry Transport: request attempt 0
2024/06/26 16:11:07 [DEBUG] Retry Transport: Stopping retries, last request was successful
2024/06/26 16:11:07 [DEBUG] Retry Transport: Returning after 1 attempts
2024/06/26 16:11:07 [DEBUG] Retry Transport: starting RoundTrip retry loop
2024/06/26 16:11:07 [DEBUG] Retry Transport: request attempt 0
2024/06/26 16:11:07 [DEBUG] Retry Transport: Stopping retries, last request was successful
2024/06/26 16:11:07 [DEBUG] Retry Transport: Returning after 1 attempts
--- PASS: TestAccDataSourceGoogleKmsKeyRings_basic (25.72s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/kms      26.964s
```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/


Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
`google_kms_key_rings`
```
