### PR TITLE
Fix typo in `google_pubsub_subscription` terraform manual page

### DIFF
--- a/mmv1/products/pubsub/Subscription.yaml
+++ b/mmv1/products/pubsub/Subscription.yaml
@@ -140,7 +140,7 @@ properties:
       - !ruby/object:Api::Type::String
         name: 'table'
         description: |
-          The name of the table to which to write data, of the form {projectId}:{datasetId}.{tableId}
+          The name of the table to which to write data, of the form {projectId}.{datasetId}.{tableId}
         required: true
       - !ruby/object:Api::Type::Boolean
         name: 'useTopicSchema'


### PR DESCRIPTION
Fix that the field `bigquery_config.table` should be of format `{project}.${dataset}.${table}`, not `${project}:${dataset}.${table}`.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
