### PR TITLE
Fix acceptance tests for `google_workstations_workstation_config` following `vm_tags` field being added

### DIFF
--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -76,7 +76,6 @@ examples:
       tag_key1: 'tag_key1'
       tag_value1: 'tag_value1'
       project_id: 'my-new-project'
-      project_name: 'my-new-project'
       org_id: '123456789'
     test_vars_overrides:
       project_id: 'fmt.Sprintf("tf-test-workstation-proj-%s", acctest.RandString(t, 10))'

--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -75,6 +75,13 @@ examples:
       workstation_config_name: 'workstation-config'
       tag_key1: 'tag_key1'
       tag_value1: 'tag_value1'
+      project_id: 'my-new-project'
+      project_name: 'my-new-project'
+      org_id: '123456789'
+    test_vars_overrides:
+      project_id: 'fmt.Sprintf("tf-test-workstation-proj-%s", context["random_suffix"])'
+      project_name: 'fmt.Sprintf("tf-test-workstation-proj-%s", context["random_suffix"])'
+      org_id: 'envvar.GetTestOrgFromEnv(t)'
   - !ruby/object:Provider::Terraform::Examples
     name: 'workstation_config_container'
     min_version: beta

--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -73,10 +73,12 @@ examples:
     vars:
       workstation_cluster_name: 'workstation-cluster'
       workstation_config_name: 'workstation-config'
-      tag_key1: 'tag_key1'
-      tag_value1: 'tag_value1'
+      key_short_name: 'keyname'
+      value_short_name: 'valuename'
       org_id: '123456789'
     test_vars_overrides:
+      key_short_name: '"tf-test-key-" + acctest.RandString(t, 10)'
+      value_short_name: '"tf-test-value-" + acctest.RandString(t, 10)'
       org_id: 'envvar.GetTestOrgFromEnv(t)'
   - !ruby/object:Provider::Terraform::Examples
     name: 'workstation_config_container'

--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -75,11 +75,6 @@ examples:
       workstation_config_name: 'workstation-config'
       tag_key1: 'tag_key1'
       tag_value1: 'tag_value1'
-      project_id: 'my-new-project'
-      org_id: '123456789'
-    test_vars_overrides:
-      project_id: 'fmt.Sprintf("tf-test-proj-%s", acctest.RandString(t, 10))'
-      org_id: 'envvar.GetTestOrgFromEnv(t)'
   - !ruby/object:Provider::Terraform::Examples
     name: 'workstation_config_container'
     min_version: beta

--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -75,6 +75,9 @@ examples:
       workstation_config_name: 'workstation-config'
       tag_key1: 'tag_key1'
       tag_value1: 'tag_value1'
+      org_id: '123456789'
+    test_vars_overrides:
+      org_id: 'envvar.GetTestOrgFromEnv(t)'
   - !ruby/object:Provider::Terraform::Examples
     name: 'workstation_config_container'
     min_version: beta

--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -79,8 +79,7 @@ examples:
       project_name: 'my-new-project'
       org_id: '123456789'
     test_vars_overrides:
-      project_id: 'fmt.Sprintf("tf-test-workstation-proj-%s", context["random_suffix"])'
-      project_name: 'fmt.Sprintf("tf-test-workstation-proj-%s", context["random_suffix"])'
+      project_id: 'fmt.Sprintf("tf-test-workstation-proj-%s", acctest.RandString(t, 10))'
       org_id: 'envvar.GetTestOrgFromEnv(t)'
   - !ruby/object:Provider::Terraform::Examples
     name: 'workstation_config_container'

--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -78,7 +78,7 @@ examples:
       project_id: 'my-new-project'
       org_id: '123456789'
     test_vars_overrides:
-      project_id: 'fmt.Sprintf("tf-test-workstation-proj-%s", acctest.RandString(t, 10))'
+      project_id: 'fmt.Sprintf("tf-test-proj-%s", acctest.RandString(t, 10))'
       org_id: 'envvar.GetTestOrgFromEnv(t)'
   - !ruby/object:Provider::Terraform::Examples
     name: 'workstation_config_container'

--- a/mmv1/templates/terraform/examples/workstation_config_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/workstation_config_basic.tf.erb
@@ -1,6 +1,6 @@
 resource "google_tags_tag_key" "tag_key1" {
   provider = "google-beta"
-  parent = "organizations/<%= ctx[:test_env_vars]['org_id'] %>"
+  parent = "organizations/<%= ctx[:vars]['org_id'] %>"
   short_name = "<%= ctx[:vars]['tag_key1'] %>"
 }
 

--- a/mmv1/templates/terraform/examples/workstation_config_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/workstation_config_basic.tf.erb
@@ -1,10 +1,3 @@
-resource "google_project" "project" {
-  provider = "google-beta"
-  project_id = "<%= ctx[:vars]['project_id'] %>"
-  name       = "<%= ctx[:vars]['project_id'] %>"
-  org_id     = "<%= ctx[:vars]['org_id'] %>"
-}
-  
 resource "google_tags_tag_key" "tag_key1" {
   provider = "google-beta"
   parent = "organizations/<%= ctx[:test_env_vars]['org_id'] %>"

--- a/mmv1/templates/terraform/examples/workstation_config_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/workstation_config_basic.tf.erb
@@ -1,13 +1,13 @@
 resource "google_tags_tag_key" "tag_key1" {
-  provider = "google-beta"
-  parent = "organizations/<%= ctx[:vars]['org_id'] %>"
-  short_name = "<%= ctx[:vars]['tag_key1'] %>"
+  provider   = google-beta
+  parent     = "organizations/<%= ctx[:vars]['org_id'] %>"
+  short_name = "<%= ctx[:vars]['key_short_name'] %>"
 }
 
 resource "google_tags_tag_value" "tag_value1" {
-  provider = "google-beta"
-  parent = "tagKeys/${google_tags_tag_key.tag_key1.name}"
-  short_name = "<%= ctx[:vars]['tag_value1'] %>"
+  provider   = google-beta
+  parent     = "tagKeys/${google_tags_tag_key.tag_key1.name}"
+  short_name = "<%= ctx[:vars]['value_short_name'] %>"
 }
 
 resource "google_compute_network" "default" {

--- a/mmv1/templates/terraform/examples/workstation_config_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/workstation_config_basic.tf.erb
@@ -2,7 +2,7 @@ resource "google_project" "project" {
   provider = "google-beta"
   project_id = "<%= ctx[:vars]['project_id'] %>"
   name       = "<%= ctx[:vars]['project_id'] %>"
-  org_id     = "<%= ctx[:test_env_vars]['org_id'] %>"
+  org_id     = "<%= ctx[:vars]['org_id'] %>"
 }
   
 resource "google_tags_tag_key" "tag_key1" {

--- a/mmv1/templates/terraform/examples/workstation_config_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/workstation_config_basic.tf.erb
@@ -65,7 +65,7 @@ resource "google_workstations_workstation_config" "<%= ctx[:primary_resource_id]
       disable_public_ip_addresses = true
       disable_ssh                 = false
       vm_tags = {
-        "tagKeys/${google_tags_tag_key.tag_key1.short_name}" = "tagValues/${google_tags_tag_value.tag_value1.short_name}"
+        "tagKeys/${google_tags_tag_key.tag_key1.name}" = "tagValues/${google_tags_tag_value.tag_value1.name}"
       }
     }
   }

--- a/mmv1/templates/terraform/examples/workstation_config_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/workstation_config_basic.tf.erb
@@ -1,4 +1,5 @@
 resource "google_project" "project" {
+  provider = "google-beta"
   project_id = "<%= ctx[:vars]['project_id'] %>"
   name       = "<%= ctx[:vars]['project_id'] %>"
   org_id     = "<%= ctx[:test_env_vars]['org_id'] %>"

--- a/mmv1/third_party/terraform/services/workstations/go/resource_workstations_workstation_config_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/workstations/go/resource_workstations_workstation_config_test.go.tmpl
@@ -707,8 +707,11 @@ func testAccWorkstationsWorkstationConfig_readinessChecks(context map[string]int
 func TestAccWorkstationsWorkstationConfig_update(t *testing.T) {
 	t.Parallel()
 
+	randString := acctest.RandString(t, 10)
 	context := map[string]interface{}{
-		"random_suffix": acctest.RandString(t, 10),
+		"random_suffix": randString,
+		"project_id":    fmt.Sprintf("tf-test-proj-%s", randString),
+		"org_id":        envvar.GetTestOrgFromEnv(t),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -749,6 +752,24 @@ func TestAccWorkstationsWorkstationConfig_update(t *testing.T) {
 
 func testAccWorkstationsWorkstationConfig_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
+resource "google_project" "project" {
+  provider = "google-beta"
+  project_id = "%{project_id}"
+  name       = "%{project_id}"
+  org_id     = "%{org_id}"
+}
+  
+resource "google_tags_tag_key" "tag_key1" {
+  provider = "google-beta"
+  parent = "organizations/"
+  short_name = "tf_test_tag_key1%{random_suffix}"
+}
+
+resource "google_tags_tag_value" "tag_value1" {
+  provider = "google-beta"
+  parent = "tagKeys/${google_tags_tag_key.tag_key1.name}"
+  short_name = "tf_test_tag_value1%{random_suffix}"
+}
 resource "google_compute_network" "default" {
   provider                = google-beta
   name                    = "tf-test-workstation-cluster%{random_suffix}"

--- a/mmv1/third_party/terraform/services/workstations/go/resource_workstations_workstation_config_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/workstations/go/resource_workstations_workstation_config_test.go.tmpl
@@ -755,13 +755,13 @@ func testAccWorkstationsWorkstationConfig_update(context map[string]interface{})
 resource "google_tags_tag_key" "tag_key1" {
   provider = google-beta
   parent = "organizations/%{org_id}"
-  short_name = "tf_test_tag_key1%{random_suffix}" // Needs to be updated to match .tf.erb
+  short_name = "%{key_short_name}"
 }
 
 resource "google_tags_tag_value" "tag_value1" {
   provider = google-beta
   parent = "tagKeys/${google_tags_tag_key.tag_key1.name}"
-  short_name = "tf_test_tag_value1%{random_suffix}" // Needs to be updated to match .tf.erb
+  short_name = "%{key_short_name}"
 }
 resource "google_compute_network" "default" {
   provider                = google-beta

--- a/mmv1/third_party/terraform/services/workstations/go/resource_workstations_workstation_config_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/workstations/go/resource_workstations_workstation_config_test.go.tmpl
@@ -710,9 +710,11 @@ func TestAccWorkstationsWorkstationConfig_update(t *testing.T) {
 
 	randString := acctest.RandString(t, 10)
 	context := map[string]interface{}{
-		"random_suffix": randString,
-		"project_id":    fmt.Sprintf("tf-test-proj-%s", randString),
-		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"random_suffix":    randString,
+		"project_id":       fmt.Sprintf("tf-test-proj-%s", randString),
+		"key_short_name":   fmt.Sprintf("tf-test-key-%s", randString),
+		"value_short_name": fmt.Sprintf("tf-test-value-%s", randString),
+		"org_id":           envvar.GetTestOrgFromEnv(t),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -762,7 +764,7 @@ resource "google_tags_tag_key" "tag_key1" {
 resource "google_tags_tag_value" "tag_value1" {
   provider = google-beta
   parent = "tagKeys/${google_tags_tag_key.tag_key1.name}"
-  short_name = "%{key_short_name}"
+  short_name = "%{value_short_name}"
 }
 resource "google_compute_network" "default" {
   provider                = google-beta

--- a/mmv1/third_party/terraform/services/workstations/go/resource_workstations_workstation_config_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/workstations/go/resource_workstations_workstation_config_test.go.tmpl
@@ -2,6 +2,7 @@ package workstations_test
 {{- if ne $.TargetVersionName "ga" }}
 
 import (
+	"fmt"
 	"testing"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"

--- a/mmv1/third_party/terraform/services/workstations/go/resource_workstations_workstation_config_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/workstations/go/resource_workstations_workstation_config_test.go.tmpl
@@ -1333,22 +1333,22 @@ func TestAccWorkstationsWorkstationConfig_vmTags(t *testing.T) {
 }
 
 func testAccWorkstationsWorkstationConfig_vmTags(context map[string]interface{}) string {
-	return acctest.Nprintf(`
-  data "google_project" "project" {
-    provider = "google-beta"
-  }
-  
-  resource "google_tags_tag_key" "tag_key1" {
-    provider = google-beta
-    parent = "projects/${data.google_project.project.number}"
-    short_name = "tf_test_tag_key1%{random_suffix}"
-  }
-  
-  resource "google_tags_tag_value" "tag_value1" {
-    provider = google-beta
-    parent = "tagKeys/${google_tags_tag_key.tag_key1.name}"
-    short_name = "tf_test_tag_value1%{random_suffix}"
-  }
+return acctest.Nprintf(`
+data "google_project" "project" {
+  provider = google-beta
+}
+
+resource "google_tags_tag_key" "tag_key1" {
+  provider = google-beta
+  parent = "projects/${data.google_project.project.number}"
+  short_name = "tf_test_tag_key1%{random_suffix}"
+}
+
+resource "google_tags_tag_value" "tag_value1" {
+  provider = google-beta
+  parent = "tagKeys/${google_tags_tag_key.tag_key1.name}"
+  short_name = "tf_test_tag_value1%{random_suffix}"
+}
 
 resource "google_compute_network" "default" {
   provider                = google-beta

--- a/mmv1/third_party/terraform/services/workstations/go/resource_workstations_workstation_config_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/workstations/go/resource_workstations_workstation_config_test.go.tmpl
@@ -761,7 +761,7 @@ resource "google_project" "project" {
   
 resource "google_tags_tag_key" "tag_key1" {
   provider = "google-beta"
-  parent = "organizations/"
+  parent = "organizations/%{org_id}"
   short_name = "tf_test_tag_key1%{random_suffix}"
 }
 

--- a/mmv1/third_party/terraform/services/workstations/go/resource_workstations_workstation_config_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/workstations/go/resource_workstations_workstation_config_test.go.tmpl
@@ -752,13 +752,6 @@ func TestAccWorkstationsWorkstationConfig_update(t *testing.T) {
 
 func testAccWorkstationsWorkstationConfig_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_project" "project" {
-  provider = "google-beta"
-  project_id = "%{project_id}"
-  name       = "%{project_id}"
-  org_id     = "%{org_id}"
-}
-  
 resource "google_tags_tag_key" "tag_key1" {
   provider = "google-beta"
   parent = "organizations/%{org_id}"

--- a/mmv1/third_party/terraform/services/workstations/go/resource_workstations_workstation_config_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/workstations/go/resource_workstations_workstation_config_test.go.tmpl
@@ -4,6 +4,7 @@ package workstations_test
 import (
 	"testing"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/mmv1/third_party/terraform/services/workstations/go/resource_workstations_workstation_config_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/workstations/go/resource_workstations_workstation_config_test.go.tmpl
@@ -753,15 +753,15 @@ func TestAccWorkstationsWorkstationConfig_update(t *testing.T) {
 func testAccWorkstationsWorkstationConfig_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_tags_tag_key" "tag_key1" {
-  provider = "google-beta"
+  provider = google-beta
   parent = "organizations/%{org_id}"
-  short_name = "tf_test_tag_key1%{random_suffix}"
+  short_name = "tf_test_tag_key1%{random_suffix}" // Needs to be updated to match .tf.erb
 }
 
 resource "google_tags_tag_value" "tag_value1" {
-  provider = "google-beta"
+  provider = google-beta
   parent = "tagKeys/${google_tags_tag_key.tag_key1.name}"
-  short_name = "tf_test_tag_value1%{random_suffix}"
+  short_name = "tf_test_tag_value1%{random_suffix}" // Needs to be updated to match .tf.erb
 }
 resource "google_compute_network" "default" {
   provider                = google-beta

--- a/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
+++ b/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
@@ -3,10 +3,8 @@ package workstations_test
 <% unless version == "ga" -%>
 
 import (
-  "fmt"
 	"testing"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	"github.com/hashicorp/terraform-provider-google/google/envvar"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -710,11 +708,8 @@ func testAccWorkstationsWorkstationConfig_readinessChecks(context map[string]int
 func TestAccWorkstationsWorkstationConfig_update(t *testing.T) {
 	t.Parallel()
 
-	randString := acctest.RandString(t, 10)
 	context := map[string]interface{}{
-		"random_suffix": randString,
-		"project_id":    fmt.Sprintf("tf-test-proj-%s", randString),
-		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"random_suffix": acctest.RandString(t, 10),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -755,13 +750,6 @@ func TestAccWorkstationsWorkstationConfig_update(t *testing.T) {
 
 func testAccWorkstationsWorkstationConfig_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_project" "project" {
-  provider = "google-beta"
-  project_id = "%{project_id}"
-  name       = "%{project_id}"
-  org_id     = "%{org_id}"
-}
-  
 resource "google_tags_tag_key" "tag_key1" {
   provider = "google-beta"
   parent = "organizations/%{org_id}"

--- a/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
+++ b/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
@@ -709,9 +709,13 @@ func testAccWorkstationsWorkstationConfig_readinessChecks(context map[string]int
 func TestAccWorkstationsWorkstationConfig_update(t *testing.T) {
 	t.Parallel()
 
+	randString := acctest.RandString(t, 10)
 	context := map[string]interface{}{
-		"random_suffix": acctest.RandString(t, 10),
-		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"random_suffix":    randString,
+		"project_id":       fmt.Sprintf("tf-test-proj-%s", randString),
+		"key_short_name":   fmt.Sprintf("tf-test-key-%s", randString),
+		"value_short_name": fmt.Sprintf("tf-test-value-%s", randString),
+		"org_id":           envvar.GetTestOrgFromEnv(t),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
+++ b/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
@@ -5,6 +5,7 @@ package workstations_test
 import (
 	"testing"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -710,6 +711,7 @@ func TestAccWorkstationsWorkstationConfig_update(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
+		"org_id":        envvar.GetTestOrgFromEnv(t),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
+++ b/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
@@ -1340,13 +1340,13 @@ data "google_project" "project" {
 resource "google_tags_tag_key" "tag_key1" {
   provider = google-beta
   parent = "projects/${data.google_project.project.number}"
-  short_name = "%{key_short_name}"
+  short_name = "tf_test_tag_key1%{random_suffix}"
 }
 
 resource "google_tags_tag_value" "tag_value1" {
   provider = google-beta
   parent = "tagKeys/${google_tags_tag_key.tag_key1.name}"
-  short_name = "%{value_short_name}"
+  short_name = "tf_test_tag_value1%{random_suffix}"
 }
 
 resource "google_compute_network" "default" {

--- a/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
+++ b/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
@@ -3,6 +3,7 @@ package workstations_test
 <% unless version == "ga" -%>
 
 import (
+	"fmt"
 	"testing"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"

--- a/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
+++ b/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
@@ -708,8 +708,11 @@ func testAccWorkstationsWorkstationConfig_readinessChecks(context map[string]int
 func TestAccWorkstationsWorkstationConfig_update(t *testing.T) {
 	t.Parallel()
 
+	randString := acctest.RandString(t, 10)
 	context := map[string]interface{}{
-		"random_suffix": acctest.RandString(t, 10),
+		"random_suffix": randString,
+		"project_id":    fmt.Sprintf("tf-test-proj-%s", randString),
+		"org_id":        envvar.GetTestOrgFromEnv(t),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -750,6 +753,25 @@ func TestAccWorkstationsWorkstationConfig_update(t *testing.T) {
 
 func testAccWorkstationsWorkstationConfig_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
+resource "google_project" "project" {
+  provider = "google-beta"
+  project_id = "%{project_id}"
+  name       = "%{project_id}"
+  org_id     = "%{org_id}"
+}
+  
+resource "google_tags_tag_key" "tag_key1" {
+  provider = "google-beta"
+  parent = "organizations/"
+  short_name = "tf_test_tag_key1%{random_suffix}"
+}
+
+resource "google_tags_tag_value" "tag_value1" {
+  provider = "google-beta"
+  parent = "tagKeys/${google_tags_tag_key.tag_key1.name}"
+  short_name = "tf_test_tag_value1%{random_suffix}"
+}
+
 resource "google_compute_network" "default" {
   provider                = google-beta
   name                    = "tf-test-workstation-cluster%{random_suffix}"

--- a/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
+++ b/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
@@ -762,7 +762,7 @@ resource "google_project" "project" {
   
 resource "google_tags_tag_key" "tag_key1" {
   provider = "google-beta"
-  parent = "organizations/"
+  parent = "organizations/%{org_id}"
   short_name = "tf_test_tag_key1%{random_suffix}"
 }
 

--- a/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
+++ b/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
@@ -753,13 +753,13 @@ func testAccWorkstationsWorkstationConfig_update(context map[string]interface{})
 resource "google_tags_tag_key" "tag_key1" {
   provider = "google-beta"
   parent = "organizations/%{org_id}"
-  short_name = "tf_test_tag_key1%{random_suffix}"
+  short_name = "%{key_short_name}"
 }
 
 resource "google_tags_tag_value" "tag_value1" {
   provider = "google-beta"
   parent = "tagKeys/${google_tags_tag_key.tag_key1.name}"
-  short_name = "tf_test_tag_value1%{random_suffix}"
+  short_name = "%{value_short_name}"
 }
 
 resource "google_compute_network" "default" {
@@ -1333,21 +1333,21 @@ func TestAccWorkstationsWorkstationConfig_vmTags(t *testing.T) {
 
 func testAccWorkstationsWorkstationConfig_vmTags(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-  data "google_project" "project" {
-    provider = "google-beta"
-  }
-  
-  resource "google_tags_tag_key" "tag_key1" {
-    provider = google-beta
-    parent = "projects/${data.google_project.project.number}"
-    short_name = "tf_test_tag_key1%{random_suffix}"
-  }
-  
-  resource "google_tags_tag_value" "tag_value1" {
-    provider = google-beta
-    parent = "tagKeys/${google_tags_tag_key.tag_key1.name}"
-    short_name = "tf_test_tag_value1%{random_suffix}"
-  }
+data "google_project" "project" {
+  provider = google-beta
+}
+
+resource "google_tags_tag_key" "tag_key1" {
+  provider = google-beta
+  parent = "projects/${data.google_project.project.number}"
+  short_name = "%{key_short_name}"
+}
+
+resource "google_tags_tag_value" "tag_value1" {
+  provider = google-beta
+  parent = "tagKeys/${google_tags_tag_key.tag_key1.name}"
+  short_name = "%{value_short_name}"
+}
 
 resource "google_compute_network" "default" {
   provider                = google-beta

--- a/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
+++ b/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
@@ -3,8 +3,10 @@ package workstations_test
 <% unless version == "ga" -%>
 
 import (
+  "fmt"
 	"testing"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
+++ b/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.erb
@@ -751,13 +751,13 @@ func TestAccWorkstationsWorkstationConfig_update(t *testing.T) {
 func testAccWorkstationsWorkstationConfig_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_tags_tag_key" "tag_key1" {
-  provider = "google-beta"
+  provider = google-beta
   parent = "organizations/%{org_id}"
   short_name = "%{key_short_name}"
 }
 
 resource "google_tags_tag_value" "tag_value1" {
-  provider = "google-beta"
+  provider = google-beta
   parent = "tagKeys/${google_tags_tag_key.tag_key1.name}"
   short_name = "%{value_short_name}"
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


Some tests fail in VCR following https://github.com/GoogleCloudPlatform/magic-modules/pull/11015, for example: https://github.com/GoogleCloudPlatform/magic-modules/pull/11074#issuecomment-2197166383

```
    vcr_utils.go:152: Step 1/6 error: Error running pre-apply refresh: exit status 1
        
        Error: Inconsistent dependency lock file
        
        The following dependency selections recorded in the lock file are
        inconsistent with the current configuration:
          - provider registry.terraform.io/hashicorp/google: required by this configuration but no version is selected
        
        To make the initial dependency selections that will initialize the dependency
        lock file, run:
          terraform init

```


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
