### PR TITLE
Autoscaler maxreplicas fix

### DIFF
--- a/mmv1/products/compute/Autoscaler.yaml
+++ b/mmv1/products/compute/Autoscaler.yaml
@@ -137,6 +137,7 @@ properties:
           to. This is required when creating or updating an autoscaler. The
           maximum number of replicas should not be lower than minimal number
           of replicas.
+        send_empty_value: true
         required: true
       - !ruby/object:Api::Type::Integer
         name: 'cooldownPeriod'

--- a/mmv1/products/compute/RegionAutoscaler.yaml
+++ b/mmv1/products/compute/RegionAutoscaler.yaml
@@ -117,6 +117,7 @@ properties:
           to. This is required when creating or updating an autoscaler. The
           maximum number of replicas should not be lower than minimal number
           of replicas.
+        send_empty_value: true
         required: true
       - !ruby/object:Api::Type::Integer
         name: 'cooldownPeriod'


### PR DESCRIPTION
This PR removes unnecessary requirements reported in https://github.com/hashicorp/terraform-provider-google/issues/18332.

This was an inconsistency, since in both [terraform registry](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_autoscaler#min_replicas) and [Google Cloud documentation](https://cloud.google.com/compute/docs/reference/rest/v1/autoscalers) it's not specified that the value cannot be 0.

Google Cloud API gives you ability to create Autoscaler or Regional Autoscaler which have both `minReplicas` and `maxReplicas` set to 0. I've created one in Google Cloud Console and it worked just fine.

For the reported issue , I checked and request was missing `max_num_replica` field. For both zonal and regional autoscaler resources, I checked and `min_num_replica` field has send_empty_value set, while `max_num_replica` field doesn't. If we read the [documentation](https://github.com/GoogleCloudPlatform/magic-modules/blob/4abf95bc8d1b3451af255c59267abd98618838b5/docs/content/develop/field-reference.md#send_empty_value) of `send_empty_value`, this is the reason why `max_num_replica` was omitted entirely from the API request, when it was set to 0.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/18332

```release-note:bug
compute: fixed a bug preventing the creation of `google_compute_autoscaler` and `google_compute_region_autoscaler` resources if both `maxReplicas` and `minReplicas` were configured as zero.
```
