### PR TITLE
Fix DataprocCluster sweeper to use clusters field from API response

### DIFF
--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_sweeper.go
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_sweeper.go
@@ -66,7 +66,7 @@ func testSweepDataprocCluster(region string) error {
 		return nil
 	}
 
-	resourceList, ok := res["policies"]
+	resourceList, ok := res["clusters"]
 	if !ok {
 		log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
 		return nil


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

I noticed that these resources weren't being cleaned up, and then saw in our logs that it was finding all of the clusters, but returning `Nothing found in response.`.

From observing the response, I think `clusters` is what we want, and my best guess is that this was a copy-paste error when it was initially added.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
