### PR TITLE
Add pre-read for importing log view from previous versions

### DIFF
--- a/mmv1/products/logging/LogView.yaml
+++ b/mmv1/products/logging/LogView.yaml
@@ -52,6 +52,7 @@ examples:
     skip_docs: true
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   encoder: templates/terraform/encoders/logging_log_view.go.erb
+  pre_read: templates/terraform/pre_read/logging_log_view.go.erb
 parameters:
   - !ruby/object:Api::Type::String
     name: parent

--- a/mmv1/templates/terraform/pre_read/logging_log_view.go.erb
+++ b/mmv1/templates/terraform/pre_read/logging_log_view.go.erb
@@ -1,0 +1,19 @@
+<%- # the license inside this block applies to this file
+        # Copyright 2024 Google Inc.
+        # Licensed under the Apache License, Version 2.0 (the "License");
+        # you may not use this file except in compliance with the License.
+        # You may obtain a copy of the License at
+        #
+        #     http://www.apache.org/licenses/LICENSE-2.0
+        #
+        # Unless required by applicable law or agreed to in writing, software
+        # distributed under the License is distributed on an "AS IS" BASIS,
+        # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        # See the License for the specific language governing permissions and
+        # limitations under the License.
+-%>
+resourceLoggingLogViewEncoder(d, nil, nil)
+url, err = tpgresource.ReplaceVars(d, config, "{{LoggingBasePath}}{{parent}}/locations/{{location}}/buckets/{{bucket}}/views/{{name}}")
+if err != nil {
+	return err
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This fixes an issue with importing log views created with the DCL-based provider.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
