### PR TITLE
Make ResourcePolicy updatable to avoid recreation of it.

### DIFF
--- a/mmv1/products/compute/ResourcePolicy.yaml
+++ b/mmv1/products/compute/ResourcePolicy.yaml
@@ -15,8 +15,9 @@
 name: 'ResourcePolicy'
 kind: 'compute#resourcePolicy'
 base_url: projects/{{project}}/regions/{{region}}/resourcePolicies
-immutable: true
 has_self_link: true
+update_verb: :PATCH
+update_url: projects/{{project}}/regions/{{region}}/resourcePolicies/{{name}}
 collection_url_key: 'items'
 description: |
   A policy that can be attached to a resource to specify or schedule actions on that resource.

--- a/mmv1/third_party/terraform/services/compute/resource_compute_disk_resource_policy_attachment_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_disk_resource_policy_attachment_test.go
@@ -13,7 +13,6 @@ func TestAccComputeDiskResourcePolicyAttachment_update(t *testing.T) {
 
 	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	policyName := fmt.Sprintf("tf-test-policy-%s", acctest.RandString(t, 10))
-	policyName2 := fmt.Sprintf("tf-test-policy-%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -29,7 +28,7 @@ func TestAccComputeDiskResourcePolicyAttachment_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeDiskResourcePolicyAttachment_basic(diskName, policyName2),
+				Config: testAccComputeDiskResourcePolicyAttachment_update(diskName, policyName),
 			},
 			{
 				ResourceName: "google_compute_disk_resource_policy_attachment.foobar",
@@ -68,6 +67,46 @@ resource "google_compute_resource_policy" "foobar" {
       daily_schedule {
         days_in_cycle = 1
         start_time = "04:00"
+      }
+    }
+  }
+}
+
+resource "google_compute_disk_resource_policy_attachment" "foobar" {
+  name = google_compute_resource_policy.foobar.name
+  disk = google_compute_disk.foobar.name
+  zone = "us-central1-c"
+}
+`, diskName, policyName)
+}
+
+func testAccComputeDiskResourcePolicyAttachment_update(diskName, policyName string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_disk" "foobar" {
+  name  = "%s"
+  image = data.google_compute_image.my_image.self_link
+  size  = 1000
+  type  = "pd-extreme"
+  zone  = "us-central1-c"
+  labels = {
+    my-label = "my-label-value"
+  }
+  provisioned_iops = 90000
+}
+
+resource "google_compute_resource_policy" "foobar" {
+  name = "%s"
+  region = "us-central1"
+  snapshot_schedule_policy {
+    schedule {
+      daily_schedule {
+        days_in_cycle = 1
+        start_time = "05:00"
       }
     }
   }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.erb
@@ -794,6 +794,38 @@ func TestAccComputeDisk_resourcePolicies(t *testing.T) {
 <% end -%>
 
 <% unless version == 'ga' -%>
+func TestAccComputeDisk_updateResourcePolicies(t *testing.T) {
+	t.Parallel()
+
+	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	policyName := fmt.Sprintf("tf-test-policy-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeDisk_resourcePolicies(diskName, policyName),
+			},
+			{
+				ResourceName:      "google_compute_disk.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeDisk_updateResourcePolicies(diskName, policyName),
+			},
+			{
+				ResourceName:      "google_compute_disk.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+<% end -%>
+
+<% unless version == 'ga' -%>
 func TestAccComputeDisk_multiWriter(t *testing.T) {
 	t.Parallel()
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
@@ -1205,6 +1237,39 @@ resource "google_compute_resource_policy" "foo" {
       daily_schedule {
         days_in_cycle = 1
         start_time    = "04:00"
+      }
+    }
+  }
+}
+
+resource "google_compute_disk" "foobar" {
+  name     = "%s"
+  image    = data.google_compute_image.my_image.self_link
+  size     = 50
+  type     = "pd-ssd"
+  zone     = "us-central1-a"
+  resource_policies = [google_compute_resource_policy.foo.self_link]
+}
+`, policyName, diskName)
+}
+<% end -%>
+
+<% unless version == 'ga' -%>
+func testAccComputeDisk_updateResourcePolicies(diskName, policyName string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_resource_policy" "foo" {
+  name     = "%s"
+  region   = "us-central1"
+  snapshot_schedule_policy {
+    schedule {
+      daily_schedule {
+        days_in_cycle = 1
+        start_time    = "05:00"
       }
     }
   }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
The lack of PATCH method results in bugs such as orphaned snapshots when users use Terraform to edit snapshot schedules for disks, since Terraform will plan to delete and recreate a new one, which differs from what we have in our APIs.
Therefore, make ResourcePolicy updatable at resource level to fix that.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran make test and make lint to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
resource_policy: make the resource updatable.
```
