### PR TITLE
fixed permadiffs on `environment_variables` in cloudfunctions2 function

### DIFF
--- a/mmv1/products/cloudfunctions2/Function.yaml
+++ b/mmv1/products/cloudfunctions2/Function.yaml
@@ -52,6 +52,7 @@ import_format:
 taint_resource_on_failed_create: true
 autogen_async: true
 custom_code: !ruby/object:Provider::Terraform::CustomCode
+  constants: 'templates/terraform/constants/cloudfunctions2_function.go.erb'
   encoder: 'templates/terraform/encoders/cloudfunctions2_runtime_update_policy.go.erb'
 examples:
   - !ruby/object:Provider::Terraform::Examples
@@ -559,6 +560,7 @@ properties:
         description:
           'Environment variables that shall be available during function
           execution.'
+        diff_suppress_func: 'environmentVariablesDiffSuppress'
       - !ruby/object:Api::Type::Integer
         name: 'maxInstanceCount'
         description: |

--- a/mmv1/templates/terraform/constants/cloudfunctions2_function.go.erb
+++ b/mmv1/templates/terraform/constants/cloudfunctions2_function.go.erb
@@ -1,0 +1,14 @@
+// Suppress diffs for the system environment variables
+func environmentVariablesDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	if k == "service_config.0.environment_variables.LOG_EXECUTION_ID" && new == "" {
+		return true
+	}
+
+	// Let diff be determined by environment_variables (above)
+	if strings.HasPrefix(k, "service_config.0.environment_variables.%") {
+		return true
+	}
+
+	// For other keys, don't suppress diff.
+	return false
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This change fixed permadiffs on system environment_variables in cloudfunctions2 function

It also fixed the failed tests for the resource `google_cloudfunctions2_function`

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
cloudfunctions2: fixed permadiffs on `service_config.environment_variables` field in `google_cloudfunctions2_function` resource
```
