### PR TITLE
Move Globaladdress.Labels to GA

### DIFF
--- a/mmv1/products/compute/GlobalAddress.yaml
+++ b/mmv1/products/compute/GlobalAddress.yaml
@@ -93,7 +93,6 @@ properties:
       Labels to apply to this address.  A list of key->value pairs.
     update_verb: :POST
     update_url: 'projects/{{project}}/global/addresses/{{name}}/setLabels'
-    min_version: beta
   - !ruby/object:Api::Type::Fingerprint
     name: 'labelFingerprint'
     description: |

--- a/mmv1/products/compute/go_GlobalAddress.yaml
+++ b/mmv1/products/compute/go_GlobalAddress.yaml
@@ -91,7 +91,6 @@ properties:
     type: KeyValueLabels
     description: |
       Labels to apply to this address.  A list of key->value pairs.
-    min_version: 'beta'
     immutable: false
     update_url: 'projects/{{project}}/global/addresses/{{name}}/setLabels'
     update_verb: 'POST'


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/18627

Moves the `GlobalAddress.Labels` property and `GlobalAddres.SetLabels` method to GA.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: move `labels` field on `google_compute_global_address` resource from Beta to GA
```
