### PR TITLE
only check if commit exists in sync branches in downstream builds

### DIFF
--- a/.ci/magician/cmd/generate_downstream.go
+++ b/.ci/magician/cmd/generate_downstream.go
@@ -97,23 +97,24 @@ func execGenerateDownstream(baseBranch, command, repo, version, ref string, gh G
 	if baseBranch == "" {
 		baseBranch = "main"
 	}
-
-	var syncBranchPrefix string
-	if repo == "terraform" {
-		if version == "beta" {
-			syncBranchPrefix = "tpgb-sync"
-		} else if version == "ga" {
-			syncBranchPrefix = "tpg-sync"
+	if command == "downstream" {
+		var syncBranchPrefix string
+		if repo == "terraform" {
+			if version == "beta" {
+				syncBranchPrefix = "tpgb-sync"
+			} else if version == "ga" {
+				syncBranchPrefix = "tpg-sync"
+			}
+		} else if repo == "terraform-google-conversion" {
+			syncBranchPrefix = "tgc-sync"
+		} else if repo == "tf-oics" {
+			syncBranchPrefix = "tf-oics-sync"
 		}
-	} else if repo == "terraform-google-conversion" {
-		syncBranchPrefix = "tgc-sync"
-	} else if repo == "tf-oics" {
-		syncBranchPrefix = "tf-oics-sync"
-	}
-	syncBranch := getSyncBranch(syncBranchPrefix, baseBranch)
-	if syncBranchHasCommit(ref, syncBranch, rnr) {
-		fmt.Printf("Sync branch %s already has commit %s, skipping generation\n", syncBranch, ref)
-		os.Exit(0)
+		syncBranch := getSyncBranch(syncBranchPrefix, baseBranch)
+		if syncBranchHasCommit(ref, syncBranch, rnr) {
+			fmt.Printf("Sync branch %s already has commit %s, skipping generation\n", syncBranch, ref)
+			os.Exit(0)
+		}
 	}
 
 	mmLocalPath := filepath.Join(rnr.GetCWD(), "..", "..")


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

https://github.com/GoogleCloudPlatform/magic-modules/pull/10647 implements a check to detect if the commit is already in sync branches. This should only happen in downstream builds but not PR generation.

During the PR generation, it will use PR number as the commit sha, and https://github.com/GoogleCloudPlatform/magic-modules/pull/11095 is a case that `11095` is detected in the sync branches (as https://github.com/GoogleCloudPlatform/magic-modules/commit/110956fc14ae187bc899bdf7871c8518f33c9ca8 is a commit in the main) and stopped the generation in upstream magician branches, and therefore, failed the generate-diffs.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
