### PR TITLE
Fixed the permadiffs in purpose of networksecurity address

### DIFF
--- a/mmv1/products/networksecurity/AddressGroup.yaml
+++ b/mmv1/products/networksecurity/AddressGroup.yaml
@@ -146,6 +146,7 @@ properties:
     name: "purpose"
     description: |
       List of supported purposes of the Address Group.
+    default_from_api: true
     item_type: !ruby/object:Api::Type::Enum
       name: 'undefined'
       description: |


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
There is a default value for `purpose` field in API side.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
networksecurity: fixed permadiffs on `purpose` field in `google_network_security_address_group` resource (beta)
```
