### PR TITLE
Revert "Fix `content` in `google_storage_bucket_object_content` datasource"

### DIFF
--- a/mmv1/third_party/terraform/services/storage/data_source_storage_bucket_object_content.go
+++ b/mmv1/third_party/terraform/services/storage/data_source_storage_bucket_object_content.go
@@ -18,6 +18,7 @@ func DataSourceGoogleStorageBucketObjectContent() *schema.Resource {
 
 	tpgresource.AddRequiredFieldsToSchema(dsSchema, "bucket")
 	tpgresource.AddRequiredFieldsToSchema(dsSchema, "name")
+	tpgresource.AddOptionalFieldsToSchema(dsSchema, "content")
 
 	return &schema.Resource{
 		Read:   dataSourceGoogleStorageBucketObjectContentRead,

--- a/mmv1/third_party/terraform/services/storage/data_source_storage_bucket_object_content_test.go
+++ b/mmv1/third_party/terraform/services/storage/data_source_storage_bucket_object_content_test.go
@@ -47,30 +47,3 @@ resource "google_storage_bucket" "contenttest" {
 	force_destroy = true
 }`, content, bucket)
 }
-
-func TestAccDataSourceStorageBucketObjectContent_Issue15717(t *testing.T) {
-
-	bucket := "tf-bucket-object-content-" + acctest.RandString(t, 10)
-	content := "qwertyuioasdfghjk1234567!!@#$*"
-
-	config := fmt.Sprintf(`
-%s
-
-output "output" {
-	value = replace(data.google_storage_bucket_object_content.default.content, "q", "Q")
-}`, testAccDataSourceStorageBucketObjectContent_Basic(content, bucket))
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		Steps: []resource.TestStep{
-			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("data.google_storage_bucket_object_content.default", "content"),
-					resource.TestCheckResourceAttr("data.google_storage_bucket_object_content.default", "content", content),
-				),
-			},
-		},
-	})
-}

--- a/mmv1/third_party/terraform/website/docs/d/storage_bucket_object_content.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/storage_bucket_object_content.html.markdown
@@ -41,4 +41,4 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `content` - (Computed) The content of the object.
+* `content` - (Computed) [Content-Language](https://tools.ietf.org/html/rfc7231#section-3.1.3.2) of the object content.


### PR DESCRIPTION

This reverts commit 2d56f5903766dd2825c13b8c1b82cd3a7252c36a, a breaking change.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
storage: fixed an issue where plans with a dependency on the `content` field in the `google_storage_bucket_object_content` data source could erroneously fail (revert)
```
