### PR TITLE
Adding customLearnedRanges and customLearnedRoutePriority to Router.yaml resource

### DIFF
--- a/mmv1/products/compute/Router.yaml
+++ b/mmv1/products/compute/Router.yaml
@@ -55,6 +55,7 @@ examples:
       network_name: 'my-network'
     ignore_read_extra:
       - advertisedIpRanges
+      - customLearnedIpRanges
   - !ruby/object:Provider::Terraform::Examples
     name: 'compute_router_encrypted_interconnect'
     primary_resource_id: 'encrypted-interconnect-router'
@@ -63,6 +64,7 @@ examples:
       network_name: 'test-network'
     ignore_read_extra:
       - advertisedIpRanges
+      - customLearnedIpRanges
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   constants: templates/terraform/constants/router.go.erb
 custom_diff: [
@@ -178,6 +180,25 @@ properties:
               description: |
                 User-specified description for the IP range.
               send_empty_value: true
+       - !ruby/object:Api::Type::Array
+         name: customLearnedIpRanges
+         description: |
+           A list of user-defined custom learned route IP address ranges for a BGP session.
+         send_empty_value: true
+         custom_flatten: 'templates/terraform/custom_flatten/compute_router_range_learned.go.erb'
+         item_type: !ruby/object:Api::Type::NestedObject
+           properties:
+             - !ruby/object:Api::Type::String
+               name: range
+               required: true
+               description: |
+                 The custom learned route IP address range. The value must be a
+                 CIDR-formatted string.
+               send_empty_value: true
+      - !ruby/object:Api::Type::Integer
+        name: customLearnedRoutePriority
+        description: "The user-defined custom learned route priority for a BGP session.This value is applied \nto all custom learned route ranges for the session. You can choose a value from 0 to 65335.\n"
+        default_from_api: true
       - !ruby/object:Api::Type::Integer
         name: keepaliveInterval
         description: |

--- a/mmv1/products/compute/Router.yaml
+++ b/mmv1/products/compute/Router.yaml
@@ -188,13 +188,13 @@ properties:
         custom_flatten: 'templates/terraform/custom_flatten/compute_router_range_learned.go.erb'
         item_type: !ruby/object:Api::Type::NestedObject
           properties:
-           - !ruby/object:Api::Type::String
-             name: range
-             required: true
-             description: |
-               The custom learned route IP address range. The value must be a
-               CIDR-formatted string.
-             send_empty_value: true
+            - !ruby/object:Api::Type::String
+              name: range
+              required: true
+              description: |
+                The custom learned route IP address range. The value must be a
+                CIDR-formatted string.
+              send_empty_value: true
       - !ruby/object:Api::Type::Integer
         name: customLearnedRoutePriority
         description: "The user-defined custom learned route priority for a BGP session.This value is applied \nto all custom learned route ranges for the session. You can choose a value from 0 to 65335.\n"

--- a/mmv1/products/compute/Router.yaml
+++ b/mmv1/products/compute/Router.yaml
@@ -180,21 +180,21 @@ properties:
               description: |
                 User-specified description for the IP range.
               send_empty_value: true
-       - !ruby/object:Api::Type::Array
-         name: customLearnedIpRanges
-         description: |
-           A list of user-defined custom learned route IP address ranges for a BGP session.
-         send_empty_value: true
-         custom_flatten: 'templates/terraform/custom_flatten/compute_router_range_learned.go.erb'
-         item_type: !ruby/object:Api::Type::NestedObject
-           properties:
-             - !ruby/object:Api::Type::String
-               name: range
-               required: true
-               description: |
-                 The custom learned route IP address range. The value must be a
-                 CIDR-formatted string.
-               send_empty_value: true
+      - !ruby/object:Api::Type::Array
+        name: customLearnedIpRanges
+        description: |
+          A list of user-defined custom learned route IP address ranges for a BGP session.
+        send_empty_value: true
+        custom_flatten: 'templates/terraform/custom_flatten/compute_router_range_learned.go.erb'
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+           - !ruby/object:Api::Type::String
+             name: range
+             required: true
+             description: |
+               The custom learned route IP address range. The value must be a
+               CIDR-formatted string.
+             send_empty_value: true
       - !ruby/object:Api::Type::Integer
         name: customLearnedRoutePriority
         description: "The user-defined custom learned route priority for a BGP session.This value is applied \nto all custom learned route ranges for the session. You can choose a value from 0 to 65335.\n"

--- a/mmv1/templates/terraform/custom_flatten/compute_router_range_learned.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/compute_router_range_learned.go.erb
@@ -1,0 +1,44 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2024 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return v
+	}
+	l := v.([]interface{})
+	apiData := make([]map[string]interface{}, 0, len(l))
+	for _, raw := range l {
+		original := raw.(map[string]interface{})
+		if len(original) < 1 {
+			// Do not include empty json objects coming back from the api
+			continue
+		}
+		apiData = append(apiData, map[string]interface{}{
+			"description": original["description"],
+			"range":  original["range"],
+		})
+	}
+	configData := []map[string]interface{}{}
+	if v, ok := d.GetOk("custom_learned_ip_ranges"); ok {
+		for _, item := range v.([]interface{}) {
+			configData = append(configData, item.(map[string]interface{}))
+		}
+	}
+	sorted, err := tpgresource.SortMapsByConfigOrder(configData, apiData, "range")
+	if err != nil {
+		log.Printf("[ERROR] Could not support API response for customLearnedIpRanges.0.range: %s", err)
+		return apiData
+	}
+	return sorted
+}

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_router_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_router_test.go
@@ -41,6 +41,13 @@ resource "google_compute_router" "foobar" {
   network = google_compute_network.foobar.name
   bgp {
     asn = 64514
+    custom_learned_ip_ranges {
+      range = "1.2.3.4"
+    }
+    custom_learned_ip_ranges {
+      range = "6.7.0.0/16"
+    }
+	custom_learned_route_priority= 200
   }
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_test.go.erb
@@ -189,6 +189,38 @@ func TestAccComputeRouter_addAndUpdateIdentifierRangeBgp(t *testing.T) {
 	})
 }
 
+func TestAccComputeRouter_addAndUpdateCustomRangePriorityBgp(t *testing.T) {
+	t.Parallel()
+
+	testId := acctest.RandString(t, 10)
+	routerName := fmt.Sprintf("tf-test-router-%s", testId)
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRouterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRouter_addCustomRangePriorityBgp(routerName),
+			},
+			{
+				ResourceName:      "google_compute_router.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouter_updateCustomRangePriorityBgp(routerName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_compute_router.foobar", "bgp.0.custom_learned_route_priority", "210"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_router.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
 func testAccComputeRouterBasic(routerName, resourceRegion string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
@@ -334,6 +366,66 @@ resource "google_compute_router" "foobar" {
       range = "6.7.0.0/16"
     }
 	identifier_range = "169.254.8.8/30"
+    keepalive_interval = 25
+  }
+}
+`, routerName, routerName)
+}
+func testAccComputeRouter_addCustomRangePriorityBgp(routerName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  name                    = "%s-net"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_router" "foobar" {
+  name    = "%s"
+  network = google_compute_network.foobar.name
+  bgp {
+    asn               = 64514
+    advertise_mode    = "CUSTOM"
+    advertised_groups = ["ALL_SUBNETS"]
+    advertised_ip_ranges {
+      range = "1.2.3.4"
+    }
+    advertised_ip_ranges {
+      range = "6.7.0.0/16"
+    }
+	
+	custom_learned_ip_ranges {
+      range = "6.7.0.0/17"
+    }
+	custom_learned_route_priority=200
+    keepalive_interval = 25
+  }
+}
+`, routerName, routerName)
+}
+
+func testAccComputeRouter_updateCustomRangePriorityBgp(routerName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  name                    = "%s-net"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_router" "foobar" {
+  name    = "%s"
+  network = google_compute_network.foobar.name
+  bgp {
+    asn               = 64514
+    advertise_mode    = "CUSTOM"
+    advertised_groups = ["ALL_SUBNETS"]
+    advertised_ip_ranges {
+      range = "1.2.3.4"
+    }
+    advertised_ip_ranges {
+      range = "6.7.0.0/16"
+    }
+	custom_learned_ip_ranges {
+      range = "6.7.0.0/18"
+    }
+	custom_learned_route_priority=210
     keepalive_interval = 25
   }
 }


### PR DESCRIPTION
Adding customLearnedIPRanges and customLearnedRoutePriority fields to Router.yaml resource.: https://buganizer.corp.google.com/issues/318495423


```release-note:enhancement
compute: added `custom_learned_ip_ranges` and 'custom_learned_range_priority' fields to `google_compute_router` resource
```
