### PR TITLE
Update ACM version to highest valid version number

### DIFF
--- a/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.erb
@@ -107,7 +107,7 @@ resource "google_gke_hub_feature_membership" "feature_member_1" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership.membership_id
   configmanagement {
-    version = "1.15.1"
+    version = "1.18.2"
     config_sync {
       source_format = "hierarchy"
       git {
@@ -124,7 +124,7 @@ resource "google_gke_hub_feature_membership" "feature_member_2" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership_second.membership_id
   configmanagement {
-    version = "1.15.1"
+    version = "1.18.2"
     config_sync {
       source_format = "hierarchy"
       git {
@@ -156,7 +156,7 @@ resource "google_gke_hub_feature_membership" "feature_member_1" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership.membership_id
   configmanagement {
-    version = "1.15.1"
+    version = "1.18.2"
     config_sync {
       source_format = "hierarchy"
       git {
@@ -173,7 +173,7 @@ resource "google_gke_hub_feature_membership" "feature_member_2" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership_second.membership_id
   configmanagement {
-    version = "1.15.1"
+    version = "1.18.2"
     config_sync {
       source_format = "hierarchy"
       git {
@@ -211,7 +211,7 @@ resource "google_gke_hub_feature_membership" "feature_member_2" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership_second.membership_id
   configmanagement {
-    version = "1.15.1"
+    version = "1.18.2"
     config_sync {
       source_format = "unstructured"
       git {
@@ -239,7 +239,7 @@ resource "google_gke_hub_feature_membership" "feature_member_3" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership_third.membership_id
   configmanagement {
-    version = "1.15.1"
+    version = "1.18.2"
     config_sync {
       source_format = "hierarchy"
       git {
@@ -267,7 +267,7 @@ resource "google_gke_hub_feature_membership" "feature_member_4" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership_fourth.membership_id
   configmanagement {
-    version = "1.15.1"
+    version = "1.18.2"
     policy_controller {
       enabled = true
       audit_interval_seconds = "100"
@@ -304,7 +304,7 @@ resource "google_gke_hub_feature_membership" "feature_member_3" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership_third.membership_id
   configmanagement {
-    version = "1.15.1"
+    version = "1.18.2"
     policy_controller {
       enabled = true
       audit_interval_seconds = "100"
@@ -421,7 +421,7 @@ resource "google_gke_hub_feature_membership" "feature_member" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership.membership_id
   configmanagement {
-    version = "1.15.1"
+    version = "1.18.2"
     config_sync {
       git {
         sync_repo      = "https://github.com/hashicorp/terraform"
@@ -487,7 +487,7 @@ resource "google_gke_hub_feature_membership" "feature_member" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership.membership_id
   configmanagement {
-    version = "1.15.1"
+    version = "1.18.2"
     config_sync {
       git {
         sync_repo      = "https://github.com/hashicorp/terraform"
@@ -559,7 +559,7 @@ resource "google_gke_hub_feature_membership" "feature_member" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership.membership_id
   configmanagement {
-    version = "1.15.1"
+    version = "1.18.2"
     config_sync {
       git {
         sync_repo   = "https://github.com/hashicorp/terraform"
@@ -648,7 +648,7 @@ resource "google_gke_hub_feature_membership" "feature_member" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership_acmoci.membership_id
   configmanagement {
-    version = "1.15.1"
+    version = "1.18.2"
     config_sync {
       source_format = "unstructured"
       oci {
@@ -697,7 +697,7 @@ resource "google_gke_hub_feature_membership" "feature_member" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership_acmoci.membership_id
   configmanagement {
-    version = "1.15.1"
+    version = "1.18.2"
     config_sync {
       source_format = "hierarchy"
       oci {
@@ -746,7 +746,7 @@ resource "google_gke_hub_feature_membership" "feature_member" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership_acmoci.membership_id
   configmanagement {
-    version = "1.15.1"
+    version = "1.18.2"
     policy_controller {
       enabled = true
       audit_interval_seconds = "100"


### PR DESCRIPTION
Current supported versions are 1.16.0, 1.16.1, 1.16.2, 1.16.3, 1.17.0, 1.17.1, 1.17.2, 1.17.3, 1.18.0, 1.18.1, 1.18.2

This will fix an error happening 100% since May:

```
Error: Error creating FeatureMembership: googleapi: Error 400: InvalidValueError for field version: unsupported ACM version 1.15.1 for Membership projects/PROJECT_NUMBER/locations/global/memberships/tf-test1jorkx1127k, supported versions are 1.16.0, 1.16.1, 1.16.2, 1.16.3, 1.17.0, 1.17.1, 1.17.2, 1.17.3, 1.18.0
```

By updating the version we're likely to unmask some non-empty plan test failures that were occurring previously in the test history

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
