### PR TITLE
Make `TestAccDataprocMetastoreService_dataprocMetastoreServiceAutoscalingNoLimitConfigExample` beta-only

### DIFF
--- a/mmv1/products/metastore/Service.yaml
+++ b/mmv1/products/metastore/Service.yaml
@@ -160,6 +160,7 @@ examples:
       metastore_service_name: 'test-service'
   - !ruby/object:Provider::Terraform::Examples
     name: 'dataproc_metastore_service_autoscaling_no_limit_config'
+    min_version: beta
     primary_resource_id: 'test_resource'
     vars:
       metastore_service_name: 'test-service'

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_autoscaling_no_limit_config.tf.erb
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_autoscaling_no_limit_config.tf.erb
@@ -1,4 +1,5 @@
 resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta  
   service_id = "<%= ctx[:vars]['metastore_service_name'] %>"
   location   = "us-central1"
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The affected example & derived test(s) include [the beta-only field autoscaling_config](https://github.com/GoogleCloudPlatform/magic-modules/blob/aa0fe465572e7407d3352a34841f346916de786f/mmv1/products/metastore/Service.yaml#L265-L267)

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
