### PR TITLE
Add check to `TestAccComputeNetworkPeeringRoutesConfig_networkPeeringRoutesConfigGkeExample ` to assert peering name is present

### DIFF
--- a/mmv1/templates/terraform/examples/network_peering_routes_config_gke.tf.erb
+++ b/mmv1/templates/terraform/examples/network_peering_routes_config_gke.tf.erb
@@ -51,3 +51,10 @@ resource "google_container_cluster" "private_cluster" {
   }
   deletion_protection  = "<%= ctx[:vars]['deletion_protection'] %>"
 }
+
+check "peering_name_present" {
+  assert {
+    condition     = google_container_cluster.private_cluster.private_cluster_config[0].peering_name != ""
+    error_message = "google_container_cluster.private_cluster.private_cluster_config[0].peering_name needs to return a name"
+  }
+}


### PR DESCRIPTION
This is to try and address errors on google_compute_network_peering_routes_config: "Error 400: Required field '' not specified, required".

Testing hypothesis that the value for peering is being set as ""

```
------- Stdout: -------
=== RUN   TestAccComputeNetworkPeeringRoutesConfig_networkPeeringRoutesConfigGkeExample
=== PAUSE TestAccComputeNetworkPeeringRoutesConfig_networkPeeringRoutesConfigGkeExample
=== CONT  TestAccComputeNetworkPeeringRoutesConfig_networkPeeringRoutesConfigGkeExample
    vcr_utils.go:152: Step 1/2 error: Error running apply: exit status 1
        Error: Error creating NetworkPeeringRoutesConfig: googleapi: Error 400: Required field '' not specified, required
          with google_compute_network_peering_routes_config.peering_gke_routes,
          on terraform_plugin_test.tf line 2, in resource "google_compute_network_peering_routes_config" "peering_gke_routes":
           2: resource "google_compute_network_peering_routes_config" "peering_gke_routes" {
--- FAIL: TestAccComputeNetworkPeeringRoutesConfig_networkPeeringRoutesConfigGkeExample (651.37s)
FAIL
```

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
