### PR TITLE
Make acc test using beta field only be in beta codebase

### DIFF
--- a/mmv1/products/compute/NetworkAttachment.yaml
+++ b/mmv1/products/compute/NetworkAttachment.yaml
@@ -55,7 +55,8 @@ examples:
       org_id: :ORG_ID
       billing_account: :BILLING_ACCT
   - !ruby/object:Provider::Terraform::Examples
-    name: 'network_attachment_instance_usage'
+  - name: 'network_attachment_instance_usage'
+    min_version: beta
     primary_resource_id: 'default'
     vars:
       resource_name: 'basic-network-attachment'

--- a/mmv1/products/compute/go_NetworkAttachment.yaml
+++ b/mmv1/products/compute/go_NetworkAttachment.yaml
@@ -56,6 +56,7 @@ examples:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
   - name: 'network_attachment_instance_usage'
+    min_version: beta
     primary_resource_id: 'default'
     vars:
       resource_name: 'basic-network-attachment'


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


This is to address this test failure in the GA nightly tests

```
------- Stdout: -------
=== RUN   TestAccComputeNetworkAttachment_networkAttachmentInstanceUsageExample
=== PAUSE TestAccComputeNetworkAttachment_networkAttachmentInstanceUsageExample
=== CONT  TestAccComputeNetworkAttachment_networkAttachmentInstanceUsageExample
    vcr_utils.go:152: Step 1/2 error: Error running pre-apply refresh: exit status 1
        Error: Unsupported argument
          on terraform_plugin_test.tf line 40, in resource "google_compute_instance" "default":
          40:         network_attachment = google_compute_network_attachment.default.self_link
        An argument named "network_attachment" is not expected here.
--- FAIL: TestAccComputeNetworkAttachment_networkAttachmentInstanceUsageExample (0.38s)
FAIL
```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
