### PR TITLE
BigQueryDestinationConfig to include merge and Append-only as configure write modes

### DIFF
--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -1059,7 +1059,7 @@ properties:
           - destination_config.0.gcs_destination_config
           - destination_config.0.bigquery_destination_config
         description: |
-          A configuration for how data should be loaded to Cloud Storage.
+          A configuration for how data should be loaded to Google BigQuery.
         properties:
           - !ruby/object:Api::Type::String
             name: 'dataFreshness'

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -165,7 +165,7 @@ examples:
     primary_resource_id:
       'default'
       # Random provider
-    skip_vcr: true
+    skip_vcr: false
     vars:
       stream_id: 'my-stream'
       private_connection_id: 'my-connection'

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -165,6 +165,7 @@ examples:
     primary_resource_id:
       'default'
       # Random provider
+    skip_vcr: true
     vars:
       stream_id: 'my-stream'
       private_connection_id: 'my-connection'

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -159,6 +159,25 @@ examples:
         'acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
     oics_vars_overrides:
       deletion_protection: 'false'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'datastream_stream_bigquery_append_only'
+    external_providers: ["random", "time"]
+    primary_resource_id:
+      'default'
+      # Random provider
+    skip_vcr: true
+    vars:
+      stream_id: 'my-stream'
+      private_connection_id: 'my-connection'
+      network_name: 'my-network'
+      source_connection_profile_id: 'source-profile'
+      database_instance_name: 'my-instance'
+      deletion_protection: 'true'
+      destination_connection_profile_id: 'destination-profile'
+    test_vars_overrides:
+      deletion_protection: 'false'
+    oics_vars_overrides:
+      deletion_protection: 'false'
 parameters:
   - !ruby/object:Api::Type::String
     name: streamId

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -1125,7 +1125,9 @@ properties:
               - destination_config.0.bigquery_destination_config.0.merge
               - destination_config.0.bigquery_destination_config.0.append_only
             description: |
-              Merge mode defines that all changes to a table will be merged at the destination Google BigQuery table.
+              Merge mode defines that all changes to a table will be merged at the destination Google BigQuery
+              table. This is the default write mode. When selected, BigQuery reflects the way the data is stored
+              in the source database. With Merge mode, no historical record of the change events is kept.
             properties: []
           - !ruby/object:Api::Type::NestedObject
             name: 'appendOnly'
@@ -1135,7 +1137,9 @@ properties:
               - destination_config.0.bigquery_destination_config.0.merge
               - destination_config.0.bigquery_destination_config.0.append_only
             description: |
-              AppendOnly mode defines that all changes to a table will be written to the destination Google BigQuery table.
+              AppendOnly mode defines that the stream of changes (INSERT, UPDATE-INSERT, UPDATE-DELETE and DELETE
+              events) to a source table will be written to the destination Google BigQuery table, retaining the
+              historical state of the data.
             properties: []
   - !ruby/object:Api::Type::String
     name: 'state'

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -165,7 +165,6 @@ examples:
     primary_resource_id:
       'default'
       # Random provider
-    skip_vcr: false
     vars:
       stream_id: 'my-stream'
       private_connection_id: 'my-connection'

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -1121,6 +1121,7 @@ properties:
             name: 'merge'
             send_empty_value: true
             allow_empty_object: true
+            immutable: true
             exactly_one_of:
               - destination_config.0.bigquery_destination_config.0.merge
               - destination_config.0.bigquery_destination_config.0.append_only
@@ -1133,6 +1134,7 @@ properties:
             name: 'appendOnly'
             send_empty_value: true
             allow_empty_object: true
+            immutable: true
             exactly_one_of:
               - destination_config.0.bigquery_destination_config.0.merge
               - destination_config.0.bigquery_destination_config.0.append_only

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -1117,6 +1117,26 @@ properties:
                       table. The BigQuery Service Account associated with your project requires access to this
                       encryption key. i.e. projects/{project}/locations/{location}/keyRings/{key_ring}/cryptoKeys/{cryptoKey}.
                       See https://cloud.google.com/bigquery/docs/customer-managed-encryption for more information.
+          - !ruby/object:Api::Type::NestedObject
+            name: 'merge'
+            send_empty_value: true
+            allow_empty_object: true
+            exactly_one_of:
+              - destination_config.0.bigquery_destination_config.0.merge
+              - destination_config.0.bigquery_destination_config.0.append_only
+            description: |
+              Merge mode defines that all changes to a table will be merged at the destination Google BigQuery table.
+            properties: []
+          - !ruby/object:Api::Type::NestedObject
+            name: 'appendOnly'
+            send_empty_value: true
+            allow_empty_object: true
+            exactly_one_of:
+              - destination_config.0.bigquery_destination_config.0.merge
+              - destination_config.0.bigquery_destination_config.0.append_only
+            description: |
+              AppendOnly mode defines that all changes to a table will be written to the destination Google BigQuery table.
+            properties: []
   - !ruby/object:Api::Type::String
     name: 'state'
     description: The state of the stream.

--- a/mmv1/templates/terraform/examples/datastream_stream_bigquery_append_only.tf.erb
+++ b/mmv1/templates/terraform/examples/datastream_stream_bigquery_append_only.tf.erb
@@ -1,6 +1,3 @@
-data "google_project" "project" {
-}
-
 resource "google_sql_database_instance" "instance" {
     name             = "<%= ctx[:vars]['database_instance_name'] %>"
     database_version = "MYSQL_8_0"
@@ -69,15 +66,6 @@ resource "google_datastream_connection_profile" "source_connection_profile" {
     }
 }
 
-data "google_bigquery_default_service_account" "bq_sa" {
-}
-
-resource "google_kms_crypto_key_iam_member" "bigquery_key_user" {
-  crypto_key_id = "<%= ctx[:vars]['bigquery_destination_table_kms_key_name'] %>"
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:${data.google_bigquery_default_service_account.bq_sa.email}"
-}
-
 resource "google_datastream_connection_profile" "destination_connection_profile" {
     display_name          = "Connection profile"
     location              = "us-central1"
@@ -87,9 +75,6 @@ resource "google_datastream_connection_profile" "destination_connection_profile"
 }
 
 resource "google_datastream_stream" "<%= ctx[:primary_resource_id] %>" {
-    depends_on = [
-        google_kms_crypto_key_iam_member.bigquery_key_user
-    ]
     stream_id = "<%= ctx[:vars]['stream_id'] %>"
     location = "us-central1"
     display_name = "my stream"
@@ -103,7 +88,6 @@ resource "google_datastream_stream" "<%= ctx[:primary_resource_id] %>" {
             source_hierarchy_datasets {
                 dataset_template {
                     location = "us-central1"
-                    kms_key_name = "<%= ctx[:vars]['bigquery_destination_table_kms_key_name'] %>"
                 }
             }
             append_only {}

--- a/mmv1/templates/terraform/examples/datastream_stream_bigquery_append_only.tf.erb
+++ b/mmv1/templates/terraform/examples/datastream_stream_bigquery_append_only.tf.erb
@@ -1,3 +1,6 @@
+data "google_project" "project" {
+}
+
 resource "google_sql_database_instance" "instance" {
     name             = "<%= ctx[:vars]['database_instance_name'] %>"
     database_version = "MYSQL_8_0"

--- a/mmv1/templates/terraform/examples/datastream_stream_bigquery_append_only.tf.erb
+++ b/mmv1/templates/terraform/examples/datastream_stream_bigquery_append_only.tf.erb
@@ -106,7 +106,7 @@ resource "google_datastream_stream" "<%= ctx[:primary_resource_id] %>" {
                     kms_key_name = "<%= ctx[:vars]['bigquery_destination_table_kms_key_name'] %>"
                 }
             }
-            merge {}
+            append_only {}
         }
     }
 

--- a/mmv1/third_party/tgc/tests/data/example_google_datastream_stream.json
+++ b/mmv1/third_party/tgc/tests/data/example_google_datastream_stream.json
@@ -119,7 +119,9 @@
                 "backfillNone": null,
                 "destinationConfig": {
                     "bigqueryDestinationConfig": {
-                        "dataFreshness": "900s"
+                        "appendOnly": null,
+                        "dataFreshness": "900s",
+                        "merge": {}
                     }
                 },
                 "displayName": "postgres to bigQuery",

--- a/mmv1/third_party/tgc/tests/data/example_google_datastream_stream.tf
+++ b/mmv1/third_party/tgc/tests/data/example_google_datastream_stream.tf
@@ -35,6 +35,7 @@ resource "google_datastream_stream" "default" {
       single_target_dataset {
         dataset_id = google_bigquery_dataset.postgres.id
       }
+      merge {}
     }
   }
 

--- a/mmv1/third_party/tgc/tests/data/example_google_datastream_stream_append_only.json
+++ b/mmv1/third_party/tgc/tests/data/example_google_datastream_stream_append_only.json
@@ -1,0 +1,158 @@
+[
+    {
+        "name": "//bigquery.googleapis.com/projects/{{.Provider.project}}/datasets/stpostgres",
+        "asset_type": "bigquery.googleapis.com/Dataset",
+        "resource": {
+            "version": "v2",
+            "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/bigquery/v2/rest",
+            "discovery_name": "Dataset",
+            "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
+            "data": {
+                "datasetReference": {
+                    "datasetId": "stpostgres"
+                },
+                "description": "Database of postgres",
+                "friendlyName": "stpostgres",
+                "location": "us-central1"
+            }
+        },
+        "ancestors": ["organizations/{{.OrgID}}"],
+        "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}"
+    },
+    {
+        "name": "//cloudsql.googleapis.com/projects/{{.Provider.project}}/instances/instance-stream-name",
+        "asset_type": "sqladmin.googleapis.com/Instance",
+        "resource": {
+            "version": "v1beta4",
+            "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/sqladmin/v1beta4/rest",
+            "discovery_name": "DatabaseInstance",
+            "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
+            "data": {
+                "databaseVersion": "MYSQL_8_0",
+                "name": "instance-stream-name",
+                "project": "{{.Provider.project}}",
+                "region": "us-central1",
+                "settings": {
+                    "activationPolicy": "ALWAYS",
+                    "availabilityType": "ZONAL",
+                    "backupConfiguration": {
+                        "binaryLogEnabled": true,
+                        "enabled": true
+                    },
+                    "dataDiskType": "PD_SSD",
+                    "ipConfiguration": {
+                        "authorizedNetworks": [
+                            {
+                                "value": "34.72.28.29"
+                            },
+                            {
+                                "value": "34.71.242.81"
+                            },
+                            {
+                                "value": "34.67.234.134"
+                            },
+                            {
+                                "value": "34.67.6.157"
+                            },
+                            {
+                                "value": "34.72.239.218"
+                            }
+                        ],
+                        "ipv4Enabled": true,
+                        "requireSsl": false
+                    },
+                    "pricingPlan": "PER_USE",
+                    "storageAutoResize": true,
+                    "tier": "db-f1-micro"
+                }
+            }
+        },
+        "ancestors": ["organizations/{{.OrgID}}"],
+        "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}"
+    },
+    {
+        "name": "//datastream.googleapis.com/projects/{{.Provider.project}}/locations/us-central1/connectionProfiles/dest-st-profile",
+        "asset_type": "datastream.googleapis.com/ConnectionProfile",
+        "resource": {
+            "version": "v1",
+            "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/datastream/v1/rest",
+            "discovery_name": "ConnectionProfile",
+            "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
+            "data": {
+                "bigqueryProfile": {},
+                "displayName": "Connection profile"
+            }
+        },
+        "ancestors": ["organizations/{{.OrgID}}"],
+        "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}"
+    },
+    {
+        "name": "//datastream.googleapis.com/projects/{{.Provider.project}}/locations/us-central1/connectionProfiles/source-profile-st",
+        "asset_type": "datastream.googleapis.com/ConnectionProfile",
+        "resource": {
+            "version": "v1",
+            "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/datastream/v1/rest",
+            "discovery_name": "ConnectionProfile",
+            "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
+            "data": {
+                "bigqueryProfile": null,
+                "displayName": "Source connection profile",
+                "mysqlProfile": {
+                    "port": 3306,
+                    "username": "my-user"
+                }
+            }
+        },
+        "ancestors": ["organizations/{{.OrgID}}"],
+        "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}"
+    },
+    {
+        "name": "//datastream.googleapis.com/projects/{{.Provider.project}}/locations/us-central1/streams/postgres-bigquery",
+        "asset_type": "datastream.googleapis.com/Stream",
+        "resource": {
+            "version": "v1",
+            "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/datastream/v1/rest",
+            "discovery_name": "Stream",
+            "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
+            "data": {
+                "backfillAll": {},
+                "backfillNone": null,
+                "destinationConfig": {
+                    "bigqueryDestinationConfig": {
+                        "appendOnly": {},
+                        "dataFreshness": "900s",
+                        "merge": null
+                    }
+                },
+                "displayName": "postgres to bigQuery",
+                "sourceConfig": {
+                    "mysqlSourceConfig": {
+                        "maxConcurrentBackfillTasks": 0,
+                        "maxConcurrentCdcTasks": 0
+                    },
+                    "oracleSourceConfig": null,
+                    "postgresqlSourceConfig": null,
+                    "sqlServerSourceConfig": null
+                }
+            }
+        },
+        "ancestors": ["organizations/{{.OrgID}}"],
+        "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}"
+    },
+    {
+        "name": "//sqladmin.googleapis.com/projects/{{.Provider.project}}/instances/instance-stream-name/databases/db",
+        "asset_type": "sqladmin.googleapis.com/Database",
+        "resource": {
+            "version": "v1beta4",
+            "discovery_document_uri": "https://www.googleapis.com/discovery/v1/apis/sqladmin/v1beta4/rest",
+            "discovery_name": "Database",
+            "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
+            "data": {
+                "instance": "instance-stream-name",
+                "name": "db"
+            }
+        },
+        "ancestors": ["organizations/{{.OrgID}}"],
+        "ancestry_path": "{{.Ancestry}}/project/{{.Provider.project}}"
+    }
+]

--- a/mmv1/third_party/tgc/tests/data/example_google_datastream_stream_append_only.tf
+++ b/mmv1/third_party/tgc/tests/data/example_google_datastream_stream_append_only.tf
@@ -1,0 +1,119 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google-beta"
+      version = "~> {{.Provider.version}}"
+    }
+  }
+}
+
+provider "google" {
+  {{if .Provider.credentials }}credentials = "{{.Provider.credentials}}"{{end}}
+}
+
+resource "google_bigquery_dataset" "postgres" {
+  dataset_id    = "stpostgres"
+  friendly_name = "stpostgres"
+  description   = "Database of postgres"
+  location      = "us-central1"
+}
+
+resource "google_datastream_stream" "default" {
+  display_name  = "postgres to bigQuery"
+  location      = "us-central1"
+  stream_id     = "postgres-bigquery"
+
+   source_config {
+    source_connection_profile = google_datastream_connection_profile.source_connection_profile.id
+    mysql_source_config {}
+  }
+
+  destination_config {
+    destination_connection_profile = google_datastream_connection_profile.destination_connection_profile2.id
+    bigquery_destination_config {
+      data_freshness = "900s"
+      single_target_dataset {
+        dataset_id = google_bigquery_dataset.postgres.id
+      }
+      append_only {}
+    }
+  }
+
+  backfill_all {
+  }
+
+}
+
+resource "google_datastream_connection_profile" "destination_connection_profile2" {
+    display_name          = "Connection profile"
+    location              = "us-central1"
+    connection_profile_id = "dest-st-profile"
+    bigquery_profile {}
+}
+
+resource "google_sql_database_instance" "instance" {
+    name             = "instance-stream-name"
+    database_version = "MYSQL_8_0"
+    region           = "us-central1"
+    settings {
+        tier = "db-f1-micro"
+        backup_configuration {
+            enabled            = true
+            binary_log_enabled = true
+        }
+
+        ip_configuration {
+            // Datastream IPs will vary by region.
+            authorized_networks {
+                value = "34.71.242.81"
+            }
+
+            authorized_networks {
+                value = "34.72.28.29"
+            }
+
+            authorized_networks {
+                value = "34.67.6.157"
+            }
+
+            authorized_networks {
+                value = "34.67.234.134"
+            }
+
+            authorized_networks {
+                value = "34.72.239.218"
+            }
+        }
+    }
+
+    deletion_protection  = false
+}
+
+resource "google_sql_database" "db" {
+    instance = google_sql_database_instance.instance.name
+    name     = "db"
+}
+
+resource "random_password" "pwd" {
+    length = 16
+    special = false
+}
+
+resource "google_sql_user" "user" {
+    name     = "my-user"
+    instance = google_sql_database_instance.instance.name
+    host     = "%"
+    password = random_password.pwd.result
+}
+
+resource "google_datastream_connection_profile" "source_connection_profile" {
+    display_name          = "Source connection profile"
+    location              = "us-central1"
+    connection_profile_id = "source-profile-st"
+
+    mysql_profile {
+        hostname = google_sql_database_instance.instance.public_ip_address
+        username = google_sql_user.user.name
+        password = google_sql_user.user.password
+    }
+}


### PR DESCRIPTION
This PR introduces the recently released (GA) append only write mode for Cloud Datastream Google BigQuery destination.

```release-note:enhancement
datastream: added `merge` and `appendOnly` fields to `google_datastream_stream` resource
```
