### PR TITLE
Promote support for BigQuery dataset resource tags to GA

### DIFF
--- a/mmv1/products/bigquery/Dataset.yaml
+++ b/mmv1/products/bigquery/Dataset.yaml
@@ -92,7 +92,6 @@ examples:
       dataset_id: 'example_dataset'
   - !ruby/object:Provider::Terraform::Examples
     name: 'bigquery_dataset_resource_tags'
-    min_version: beta
     primary_resource_id: 'dataset'
     primary_resource_name:
       'fmt.Sprintf("tf_test_dataset%s", context["random_suffix"])'
@@ -399,7 +398,6 @@ properties:
     default_from_api: true
   - !ruby/object:Api::Type::KeyValuePairs
     name: 'resourceTags'
-    min_version: beta
     description: |
       The tags attached to this table. Tag keys are globally unique. Tag key is expected to be
       in the namespaced format, for example "123456789012/environment" where 123456789012 is the

--- a/mmv1/templates/terraform/examples/bigquery_dataset_resource_tags.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_dataset_resource_tags.tf.erb
@@ -1,34 +1,27 @@
 data "google_project" "project" {
-  provider = "google-beta"
 }
 
 resource "google_tags_tag_key" "tag_key1" {
-  provider = "google-beta"
   parent = "projects/${data.google_project.project.number}"
   short_name = "<%= ctx[:vars]['tag_key1'] %>"
 }
 
 resource "google_tags_tag_value" "tag_value1" {
-  provider = "google-beta"
   parent = "tagKeys/${google_tags_tag_key.tag_key1.name}"
   short_name = "<%= ctx[:vars]['tag_value1'] %>"
 }
 
 resource "google_tags_tag_key" "tag_key2" {
-  provider = "google-beta"
   parent = "projects/${data.google_project.project.number}"
   short_name = "<%= ctx[:vars]['tag_key2'] %>"
 }
 
 resource "google_tags_tag_value" "tag_value2" {
-  provider = "google-beta"
   parent = "tagKeys/${google_tags_tag_key.tag_key2.name}"
   short_name = "<%= ctx[:vars]['tag_value2'] %>"
 }
 
 resource "google_bigquery_dataset" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
-
   dataset_id                  = "<%= ctx[:vars]['dataset_id'] %>"
   friendly_name               = "test"
   description                 = "This is a test description"

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_dataset_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_dataset_test.go
@@ -1,4 +1,3 @@
-<% autogen_exception -%>
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 package bigquery_test
@@ -421,7 +420,6 @@ func TestAccBigQueryDataset_invalidLongID(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccBigQueryDataset_bigqueryDatasetResourceTags_update(t *testing.T) {
 	t.Parallel()
 
@@ -431,7 +429,7 @@ func TestAccBigQueryDataset_bigqueryDatasetResourceTags_update(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckBigQueryDatasetDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -456,7 +454,6 @@ func TestAccBigQueryDataset_bigqueryDatasetResourceTags_update(t *testing.T) {
 	})
 }
 
-<% end -%>
 func testAccAddTable(t *testing.T, datasetID string, tableID string) resource.TestCheckFunc {
 	// Not actually a check, but adds a table independently of terraform
 	return func(s *terraform.State) error {
@@ -774,41 +771,33 @@ resource "google_bigquery_dataset" "test" {
 }
 `, datasetID)
 }
-<% unless version == 'ga' -%>
 
 func testAccBigQueryDataset_bigqueryDatasetResourceTags_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_project" "project" {
-  provider = "google-beta"
 }
 
 resource "google_tags_tag_key" "tag_key1" {
-  provider = google-beta
   parent = "projects/${data.google_project.project.number}"
   short_name = "tf_test_tag_key1%{random_suffix}"
 }
 
 resource "google_tags_tag_value" "tag_value1" {
-  provider = google-beta
   parent = "tagKeys/${google_tags_tag_key.tag_key1.name}"
   short_name = "tf_test_tag_value1%{random_suffix}"
 }
 
 resource "google_tags_tag_key" "tag_key2" {
-  provider = google-beta
   parent = "projects/${data.google_project.project.number}"
   short_name = "tf_test_tag_key2%{random_suffix}"
 }
 
 resource "google_tags_tag_value" "tag_value2" {
-  provider = google-beta
   parent = "tagKeys/${google_tags_tag_key.tag_key2.name}"
   short_name = "tf_test_tag_value2%{random_suffix}"
 }
 
 resource "google_bigquery_dataset" "dataset" {
-  provider = google-beta
-
   dataset_id                  = "dataset%{random_suffix}"
   friendly_name               = "test"
   description                 = "This is a test description"
@@ -825,36 +814,29 @@ resource "google_bigquery_dataset" "dataset" {
 func testAccBigQueryDataset_bigqueryDatasetResourceTags_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_project" "project" {
-  provider = "google-beta"
 }
 
 resource "google_tags_tag_key" "tag_key1" {
-  provider = google-beta
   parent = "projects/${data.google_project.project.number}"
   short_name = "tf_test_tag_key1%{random_suffix}"
 }
 
 resource "google_tags_tag_value" "tag_value1" {
-  provider = google-beta
   parent = "tagKeys/${google_tags_tag_key.tag_key1.name}"
   short_name = "tf_test_tag_value1%{random_suffix}"
 }
 
 resource "google_tags_tag_key" "tag_key2" {
-  provider = google-beta
   parent = "projects/${data.google_project.project.number}"
   short_name = "tf_test_tag_key2%{random_suffix}"
 }
 
 resource "google_tags_tag_value" "tag_value2" {
-  provider = google-beta
   parent = "tagKeys/${google_tags_tag_key.tag_key2.name}"
   short_name = "tf_test_tag_value2%{random_suffix}"
 }
 
 resource "google_bigquery_dataset" "dataset" {
-  provider = google-beta
-
   dataset_id                  = "dataset%{random_suffix}"
   friendly_name               = "test"
   description                 = "This is a test description"
@@ -865,4 +847,3 @@ resource "google_bigquery_dataset" "dataset" {
 }
 `, context)
 }
-<% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
First added to the beta provider at https://github.com/GoogleCloudPlatform/magic-modules/pull/10971.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigquery: added `resource_tags` field to `google_bigquery_dataset` resource (ga)
```
