### PR TITLE
Fix wrong field value example in the iap client resource

### DIFF
--- a/mmv1/products/iap/Client.yaml
+++ b/mmv1/products/iap/Client.yaml
@@ -58,7 +58,7 @@ parameters:
     description: |
       Identifier of the brand to which this client
       is attached to. The format is
-      `projects/{project_number}/brands/{brand_id}/identityAwareProxyClients/{client_id}`.
+      `projects/{project_number}/brands/{brand_id}`.
     immutable: true
     required: true
     url_param_only: true


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The example in the doc for google_iap_client has a wrong argument field example. The `brand` field does not have `/identityAwareProxyClients/{client_id}` part, while the client has that field.

ref: https://cloud.google.com/iap/docs/reference/rest/v1/projects.brands.identityAwareProxyClients/create
> brand
> Required. Path to create the client in. In the following format: projects/{projectNumber/id}/brands/{brand}

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
