### PR TITLE
Fix duplicate attribute field in the iap client resource documentation

### DIFF
--- a/mmv1/products/iap/Client.yaml
+++ b/mmv1/products/iap/Client.yaml
@@ -39,9 +39,6 @@ examples:
     test_env_vars:
       org_id: :ORG_ID
       org_domain: :ORG_DOMAIN
-docs: !ruby/object:Provider::Terraform::Docs
-  attributes: |
-    * `client_id`: The OAuth2 ID of the client.
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   post_create: templates/terraform/post_create/iap_client.go.erb
   custom_import: templates/terraform/custom_import/iap_client.go.erb


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The `client_id` attribute in google_iap_client is described twice.

![スクリーンショット 2024-07-10 13 00 01](https://github.com/GoogleCloudPlatform/magic-modules/assets/6166778/259daa00-854a-48f9-99c7-de712c629cd9)


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
