### PR TITLE
Bigtable: add data_boost_isolation_read_only support for the Data Boost feature.

### DIFF
--- a/mmv1/products/bigtable/AppProfile.yaml
+++ b/mmv1/products/bigtable/AppProfile.yaml
@@ -161,6 +161,8 @@ properties:
     default_from_api: true
     description: |
       The standard options used for isolating this app profile's traffic from other use cases.
+    conflicts:
+      - dataBoostIsolationReadOnly
     properties:
       - !ruby/object:Api::Type::Enum
         name: 'priority'
@@ -171,3 +173,17 @@ properties:
           - :PRIORITY_LOW
           - :PRIORITY_MEDIUM
           - :PRIORITY_HIGH
+  - !ruby/object:Api::Type::NestedObject
+    name: 'dataBoostIsolationReadOnly'
+    description: |
+      Specifies that this app profile is intended for read-only usage via the Data Boost feature.
+    conflicts:
+      - standardIsolation
+    properties:
+      - !ruby/object:Api::Type::Enum
+        name: 'compute_billing_owner'
+        required: true
+        description: |
+          The Compute Billing Owner for this Data Boost App Profile.
+        values:
+          - :HOST_PAYS

--- a/mmv1/products/bigtable/AppProfile.yaml
+++ b/mmv1/products/bigtable/AppProfile.yaml
@@ -162,7 +162,7 @@ properties:
     description: |
       The standard options used for isolating this app profile's traffic from other use cases.
     conflicts:
-      - dataBoostIsolationReadOnly
+      - data_boost_isolation_read_only
     properties:
       - !ruby/object:Api::Type::Enum
         name: 'priority'
@@ -178,7 +178,7 @@ properties:
     description: |
       Specifies that this app profile is intended for read-only usage via the Data Boost feature.
     conflicts:
-      - standardIsolation
+      - standard_isolation
     properties:
       - !ruby/object:Api::Type::Enum
         name: 'computeBillingOwner'

--- a/mmv1/products/bigtable/AppProfile.yaml
+++ b/mmv1/products/bigtable/AppProfile.yaml
@@ -181,7 +181,7 @@ properties:
       - standardIsolation
     properties:
       - !ruby/object:Api::Type::Enum
-        name: 'compute_billing_owner'
+        name: 'computeBillingOwner'
         required: true
         description: |
           The Compute Billing Owner for this Data Boost App Profile.

--- a/mmv1/templates/terraform/examples/bigtable_app_profile_data_boost.tf.erb
+++ b/mmv1/templates/terraform/examples/bigtable_app_profile_data_boost.tf.erb
@@ -17,7 +17,7 @@ resource "google_bigtable_app_profile" "ap" {
   // Requests will be routed to the following cluster.
   single_cluster_routing {
     cluster_id                 = "cluster-1"
-    allow_transactional_writes = true
+    allow_transactional_writes = false
   }
 
   data_boost_isolation_read_only {

--- a/mmv1/templates/terraform/examples/bigtable_app_profile_data_boost.tf.erb
+++ b/mmv1/templates/terraform/examples/bigtable_app_profile_data_boost.tf.erb
@@ -1,0 +1,28 @@
+resource "google_bigtable_instance" "instance" {
+  name = "<%= ctx[:vars]['instance_name'] %>"
+  cluster {
+    cluster_id   = "cluster-1"
+    zone         = "us-central1-b"
+    num_nodes    = 3
+    storage_type = "SSD"
+  }
+
+  deletion_protection  = "<%= ctx[:vars]['deletion_protection'] %>"
+}
+
+resource "google_bigtable_app_profile" "ap" {
+  instance       = google_bigtable_instance.instance.name
+  app_profile_id = "<%= ctx[:vars]['app_profile_name'] %>"
+
+  // Requests will be routed to the following cluster.
+  single_cluster_routing {
+    cluster_id                 = "cluster-1"
+    allow_transactional_writes = true
+  }
+
+  data_boost_isolation_read_only {
+    compute_billing_owner = "HOST_PAYS"
+  }
+
+  ignore_warnings = true
+}

--- a/mmv1/templates/terraform/pre_update/bigtable_app_profile.go.erb
+++ b/mmv1/templates/terraform/pre_update/bigtable_app_profile.go.erb
@@ -32,6 +32,16 @@ if newRouting != oldRouting {
 		}
 	}
 }
+
+_, hasStandardIsolation := obj["standardIsolation"]
+_, hasDataBoostIsolationReadOnly := obj["dataBoostIsolationReadOnly"]
+if hasStandardIsolation && hasDataBoostIsolationReadOnly {
+    // Due to the "conflicts" both fields should be present only if neither was
+    // previously specified and the user is now manually adding dataBoostIsolationReadOnly.
+    delete(obj, "standardIsolation")
+    updateMask = append(updateMask, "dataBoostIsolationReadOnly")
+}
+
 // updateMask is a URL parameter but not present in the schema, so ReplaceVars
 // won't set it
 url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_app_profile_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_app_profile_test.go
@@ -432,7 +432,7 @@ resource "google_bigtable_app_profile" "ap" {
 `, instanceName, instanceName, instanceName, instanceName, instanceName, instanceName)
 }
 
-func testAccBigtableAppProfile_updateSSD(instanceName string) string {
+func testAccBigtableAppProfile_updateSSDWithPriority(instanceName string) string {
 	return fmt.Sprintf(`
 resource "google_bigtable_instance" "instance" {
   name = "%s"
@@ -537,7 +537,7 @@ func TestAccBigtableAppProfile_updateStandardIsolationToDataBoost(t *testing.T) 
 		CheckDestroy:             testAccCheckBigtableAppProfileDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigtableAppProfile_updateSSD(instanceName),
+				Config: testAccBigtableAppProfile_updateSSDWithPriority(instanceName),
 			},
 			{
 				ResourceName:            "google_bigtable_app_profile.ap",
@@ -547,6 +547,40 @@ func TestAccBigtableAppProfile_updateStandardIsolationToDataBoost(t *testing.T) 
 			},
 			{
 				Config: testAccBigtableAppProfile_updateDataBoost(instanceName),
+			},
+			{
+				ResourceName:            "google_bigtable_app_profile.ap",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ignore_warnings"},
+			},
+		},
+	})
+}
+
+func TestAccBigtableAppProfile_updateDataBoostToStandardIsolation(t *testing.T) {
+	// bigtable instance does not use the shared HTTP client, this test creates an instance
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+
+	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckBigtableAppProfileDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigtableAppProfile_updateDataBoost(instanceName),
+			},
+			{
+				ResourceName:            "google_bigtable_app_profile.ap",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ignore_warnings"},
+			},
+			{
+				Config: testAccBigtableAppProfile_updateSSDWithPriority(instanceName),
 			},
 			{
 				ResourceName:            "google_bigtable_app_profile.ap",

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_app_profile_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_app_profile_test.go
@@ -466,7 +466,11 @@ resource "google_bigtable_app_profile" "ap" {
 
   single_cluster_routing {
     cluster_id                 = %q
-    allow_transactional_writes = true
+    allow_transactional_writes = false
+  }
+
+  standard_isolation {
+    priority = "PRIORITY_MEDIUM"
   }
 
   ignore_warnings               = true
@@ -508,7 +512,7 @@ resource "google_bigtable_app_profile" "ap" {
 
   single_cluster_routing {
     cluster_id                 = %q
-    allow_transactional_writes = true
+    allow_transactional_writes = false
   }
 
   data_boost_isolation_read_only {

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_app_profile_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_app_profile_test.go
@@ -554,31 +554,6 @@ func TestAccBigtableAppProfile_updateStandardIsolationToDataBoost(t *testing.T) 
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"ignore_warnings"},
 			},
-		},
-	})
-}
-
-func TestAccBigtableAppProfile_updateDataBoostToStandardIsolation(t *testing.T) {
-	// bigtable instance does not use the shared HTTP client, this test creates an instance
-	acctest.SkipIfVcr(t)
-	t.Parallel()
-
-	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckBigtableAppProfileDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccBigtableAppProfile_updateDataBoost(instanceName),
-			},
-			{
-				ResourceName:            "google_bigtable_app_profile.ap",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ignore_warnings"},
-			},
 			{
 				Config: testAccBigtableAppProfile_updateSSDWithPriority(instanceName),
 			},

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_app_profile_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_app_profile_test.go
@@ -431,3 +431,125 @@ resource "google_bigtable_app_profile" "ap" {
 }
 `, instanceName, instanceName, instanceName, instanceName, instanceName, instanceName)
 }
+
+func testAccBigtableAppProfile_updateSSD(instanceName string) string {
+	return fmt.Sprintf(`
+resource "google_bigtable_instance" "instance" {
+  name = "%s"
+  cluster {
+    cluster_id   = "%s"
+    zone         = "us-central1-b"
+    num_nodes    = 1
+    storage_type = "SSD"
+  }
+
+  cluster {
+    cluster_id   = "%s2"
+    zone         = "us-central1-a"
+    num_nodes    = 1
+    storage_type = "SSD"
+  }
+
+  cluster {
+    cluster_id   = "%s3"
+    zone         = "us-central1-c"
+    num_nodes    = 1
+    storage_type = "SSD"
+  }
+
+  deletion_protection = false
+}
+
+resource "google_bigtable_app_profile" "ap" {
+  instance       = google_bigtable_instance.instance.id
+  app_profile_id = "test"
+
+  single_cluster_routing {
+    cluster_id                 = %q
+    allow_transactional_writes = true
+  }
+
+  ignore_warnings               = true
+}
+`, instanceName, instanceName, instanceName, instanceName, instanceName)
+}
+
+func testAccBigtableAppProfile_updateDataBoost(instanceName string) string {
+	return fmt.Sprintf(`
+resource "google_bigtable_instance" "instance" {
+  name = "%s"
+  cluster {
+    cluster_id   = "%s"
+    zone         = "us-central1-b"
+    num_nodes    = 1
+    storage_type = "SSD"
+  }
+
+  cluster {
+    cluster_id   = "%s2"
+    zone         = "us-central1-a"
+    num_nodes    = 1
+    storage_type = "SSD"
+  }
+
+  cluster {
+    cluster_id   = "%s3"
+    zone         = "us-central1-c"
+    num_nodes    = 1
+    storage_type = "SSD"
+  }
+
+  deletion_protection = false
+}
+
+resource "google_bigtable_app_profile" "ap" {
+  instance       = google_bigtable_instance.instance.id
+  app_profile_id = "test"
+
+  single_cluster_routing {
+    cluster_id                 = %q
+    allow_transactional_writes = true
+  }
+
+  data_boost_isolation_read_only {
+    compute_billing_owner = "HOST_PAYS"
+  }
+
+  ignore_warnings               = true
+}
+`, instanceName, instanceName, instanceName, instanceName, instanceName)
+}
+
+func TestAccBigtableAppProfile_updateStandardIsolationToDataBoost(t *testing.T) {
+	// bigtable instance does not use the shared HTTP client, this test creates an instance
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+
+	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckBigtableAppProfileDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigtableAppProfile_updateSSD(instanceName),
+			},
+			{
+				ResourceName:            "google_bigtable_app_profile.ap",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ignore_warnings"},
+			},
+			{
+				Config: testAccBigtableAppProfile_updateDataBoost(instanceName),
+			},
+			{
+				ResourceName:            "google_bigtable_app_profile.ap",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ignore_warnings"},
+			},
+		},
+	})
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Bigtable: add data_boost_isolation_read_only support for the Data Boost feature.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigtable: added `data_boost_isolation_read_only` and `data_boost_isolation_read_only.compute_billing_owner` fields to `google_bigtable_app_profile` resource
```
