### PR TITLE
Add cloud_storage_target field in google_data_loss_prevention_discovery_config

### DIFF
--- a/mmv1/products/dlp/DiscoveryConfig.yaml
+++ b/mmv1/products/dlp/DiscoveryConfig.yaml
@@ -74,6 +74,12 @@ examples:
     primary_resource_id: 'cloud_sql'
     test_env_vars:
       project: :PROJECT_NAME
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'dlp_discovery_config_cloud_storage'
+    skip_test: true
+    primary_resource_id: 'cloud_storage'
+    test_env_vars:
+      project: :PROJECT_NAME
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   encoder: templates/terraform/encoders/wrap_object.go.erb
   decoder: templates/terraform/decoders/unwrap_resource.go.erb
@@ -485,6 +491,128 @@ properties:
             # The fields below are necessary to include the "secretsDiscoveryTarget" target in the payload
           send_empty_value: true
           allow_empty_object: true
+        - !ruby/object:Api::Type::NestedObject
+          name: cloudStorageTarget
+          description: Cloud Storage target for Discovery. The first target to match a bucket will be the one applied.
+          properties:
+            - !ruby/object:Api::Type::NestedObject
+              name: filter
+              description: The buckets the generation_cadence applies to. The first target with a matching filter will be the one to apply to a bucket.
+              required: true
+              properties:
+                - !ruby/object:Api::Type::NestedObject
+                  name: collection
+                  description: A specific set of buckets for this filter to apply to.
+                  properties:
+                    - !ruby/object:Api::Type::NestedObject
+                      name: includeRegexes
+                      description: A collection of regular expressions to match a file store against.
+                      properties:
+                        - !ruby/object:Api::Type::Array
+                          name: patterns
+                          description: The group of regular expression patterns to match against one or more file stores. Maximum of 100 entries. The sum of all lengths of regular expressions can't exceed 10 KiB.
+                          item_type: !ruby/object:Api::Type::NestedObject
+                            properties:
+                              - !ruby/object:Api::Type::NestedObject
+                                name: cloudStorageRegex
+                                description: Regex for Cloud Storage.
+                                properties:
+                                  - !ruby/object:Api::Type::String
+                                    name: projectIdRegex
+                                    description: For organizations, if unset, will match all projects.
+                                  - !ruby/object:Api::Type::String
+                                    name: bucketNameRegex
+                                    description: 'Regex to test the bucket name against. If empty, all buckets match. Example: "marketing2021" or "(marketing)\d{4}" will both match the bucket gs://marketing2021'
+                - !ruby/object:Api::Type::NestedObject
+                  name: cloudStorageResourceReference
+                  description: The bucket to scan. Targets including this can only include one target (the target with this bucket). This enables profiling the contents of a single bucket, while the other options allow for easy profiling of many buckets within a project or an organization.
+                  properties:
+                    - !ruby/object:Api::Type::String
+                      name: bucketName
+                      description: The bucket to scan.
+                    - !ruby/object:Api::Type::String
+                      name: projectId
+                      description: If within a project-level config, then this must match the config's project id.
+                - !ruby/object:Api::Type::NestedObject
+                  name: others
+                  description: Match discovery resources not covered by any other filter.
+                  properties:
+                    []  # Meant to be an empty object with no properties. The fields below are necessary to include the "others" filter in the payload
+                  send_empty_value: true
+                  allow_empty_object: true
+            - !ruby/object:Api::Type::NestedObject
+              name: conditions
+              description: In addition to matching the filter, these conditions must be true before a profile is generated.
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: createdAfter
+                  description: File store must have been created after this date. Used to avoid backfilling. A timestamp in RFC3339 UTC "Zulu" format with nanosecond resolution and upto nine fractional digits.
+                - !ruby/object:Api::Type::String
+                  name: minAge
+                  description: Duration format. Minimum age a file store must have. If set, the value must be 1 hour or greater.
+                - !ruby/object:Api::Type::NestedObject
+                  name: cloudStorageConditions
+                  description: Cloud Storage conditions.
+                  properties:
+                    - !ruby/object:Api::Type::Array
+                      name: includedObjectAttributes
+                      description: Only objects with the specified attributes will be scanned. If an object has one of the specified attributes but is inside an excluded bucket, it will not be scanned. Defaults to [ALL_SUPPORTED_OBJECTS]. A profile will be created even if no objects match the included_object_attributes.
+                      item_type: !ruby/object:Api::Type::Enum
+                        name: 'undefined'
+                        description: |
+                          This field only has a name and description because of MM
+                          limitations. It should not appear in downstreams.
+                        values:
+                          - :ALL_SUPPORTED_OBJECTS
+                          - :STANDARD
+                          - :NEARLINE
+                          - :COLDLINE
+                          - :ARCHIVE
+                          - :REGIONAL
+                          - :MULTI_REGIONAL
+                          - :DURABLE_REDUCED_AVAILABILITY
+                    - !ruby/object:Api::Type::Array
+                      name: includedBucketAttributes
+                      description: Only objects with the specified attributes will be scanned. Defaults to [ALL_SUPPORTED_BUCKETS] if unset.
+                      item_type: !ruby/object:Api::Type::Enum
+                        name: 'undefined'
+                        description: |
+                          This field only has a name and description because of MM
+                          limitations. It should not appear in downstreams.
+                        values:
+                          - :ALL_SUPPORTED_BUCKETS
+                          - :AUTOCLASS_DISABLED
+                          - :AUTOCLASS_ENABLED
+            - !ruby/object:Api::Type::NestedObject
+              name: generationCadence
+              description: How often and when to update profiles. New buckets that match both the filter and conditions are scanned as quickly as possible depending on system capacity.
+              properties:
+                - !ruby/object:Api::Type::Enum
+                  name: refreshFrequency
+                  description: Data changes in Cloud Storage can't trigger reprofiling. If you set this field, profiles are refreshed at this frequency regardless of whether the underlying buckets have changes. Defaults to never.
+                  values:
+                    - :UPDATE_FREQUENCY_NEVER
+                    - :UPDATE_FREQUENCY_DAILY
+                    - :UPDATE_FREQUENCY_MONTHLY
+                - !ruby/object:Api::Type::NestedObject
+                  name: inspectTemplateModifiedCadence
+                  description: Governs when to update data profiles when the inspection rules defined by the `InspectTemplate` change. If not set, changing the template will not cause a data profile to update.
+                  properties:
+                    - !ruby/object:Api::Type::Enum
+                      name: 'frequency'
+                      description: How frequently data profiles can be updated when the template is modified. Defaults to never.
+                      values:
+                        - :UPDATE_FREQUENCY_NEVER
+                        - :UPDATE_FREQUENCY_DAILY
+                        - :UPDATE_FREQUENCY_MONTHLY
+            - !ruby/object:Api::Type::NestedObject
+              name: disabled
+              description: Disable profiling for buckets that match this filter.
+              properties:
+                []  # Meant to be an empty object with no properties - see here : https://cloud.google.com/sensitive-data-protection/docs/reference/rest/v2/organizations.locations.discoveryConfigs#disabled
+                # The fields below are necessary to include the "disabled" filter in the payload
+              send_empty_value: true
+              allow_empty_object: true
   - !ruby/object:Api::Type::Array
     name: 'errors'
     description: Output only. A stream of errors encountered when the config was activated. Repeated errors may result in the config automatically being paused. Output only field. Will return the last 100 errors. Whenever the config is modified this list will be cleared.

--- a/mmv1/templates/terraform/examples/dlp_discovery_config_cloud_storage.tf.erb
+++ b/mmv1/templates/terraform/examples/dlp_discovery_config_cloud_storage.tf.erb
@@ -1,0 +1,81 @@
+resource "google_data_loss_prevention_discovery_config" "<%= ctx[:primary_resource_id] %>" {
+    parent = "projects/<%= ctx[:test_env_vars]['project'] %>/locations/us"
+    location = "us"
+    status = "RUNNING"
+
+    targets {
+        cloud_storage_target {
+            filter {
+                collection {
+                    include_regexes {
+                        patterns {
+                            cloud_storage_regex {
+                                project_id_regex = "foo-project"
+                                bucket_name_regex = "bucket"
+                            }
+                        }
+                    }
+                }
+            }
+            conditions {
+                created_after = "2023-10-02T15:01:23Z"
+                min_age = "10800s"
+                cloud_storage_conditions {
+                    included_object_attributes = ["ALL_SUPPORTED_OBJECTS"]
+                    included_bucket_attributes = ["ALL_SUPPORTED_BUCKETS"]
+                }
+            }
+            generation_cadence {
+                inspect_template_modified_cadence {
+                    frequency = "UPDATE_FREQUENCY_DAILY"
+                }
+                refresh_frequency = "UPDATE_FREQUENCY_MONTHLY"
+            }
+        }
+    }
+    targets {
+        cloud_storage_target {
+            filter {
+                collection {
+                    include_regexes {
+                        patterns {
+                            cloud_storage_regex {
+                                project_id_regex = "foo-project"
+                                bucket_name_regex = "do-not-scan"
+                            }
+                        }
+                    }
+                }
+            }
+            disabled {}
+        }
+    }
+    targets {
+        cloud_storage_target {
+            filter {
+                others {}
+            }
+            generation_cadence {
+                schema_modified_cadence {
+                    types = ["NEW_COLUMNS"]
+                    frequency = "UPDATE_FREQUENCY_MONTHLY"
+                }
+                refresh_frequency = "UPDATE_FREQUENCY_MONTHLY"
+            }
+        }
+
+    }
+    inspect_templates = ["projects/%{project}/inspectTemplates/${google_data_loss_prevention_inspect_template.basic.name}"] 
+}
+
+resource "google_data_loss_prevention_inspect_template" "basic" {
+    parent = "projects/<%= ctx[:test_env_vars]['project'] %>"
+    description = "My description"
+    display_name = "display_name"
+
+    inspect_config {
+        info_types {
+            name = "EMAIL_ADDRESS"
+        }
+    }
+}

--- a/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_discovery_config_test.go
+++ b/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_discovery_config_test.go
@@ -19,6 +19,8 @@ func TestAccDataLossPreventionDiscoveryConfig_Update(t *testing.T) {
 		"bq_single":  testAccDataLossPreventionDiscoveryConfig_BqSingleTable,
 		"sql_single": testAccDataLossPreventionDiscoveryConfig_SqlSingleTable,
 		"secrets":    testAccDataLossPreventionDiscoveryConfig_SecretsUpdate,
+		"gcs":        testAccDataLossPreventionDiscoveryConfig_CloudStorageUpdate,
+		"gcs_single": testAccDataLossPreventionDiscoveryConfig_CloudStorageSingleBucket,
 	}
 	for name, tc := range testCases {
 		// shadow the tc variable into scope so that when
@@ -311,6 +313,76 @@ func testAccDataLossPreventionDiscoveryConfig_SqlSingleTable(t *testing.T) {
 			},
 			{
 				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigCloudSqlSingleUpdate(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
+			},
+		},
+	})
+}
+
+func testAccDataLossPreventionDiscoveryConfig_CloudStorageUpdate(t *testing.T) {
+
+	context := map[string]interface{}{
+		"project":       envvar.GetTestProjectFromEnv(),
+		"location":      envvar.GetTestRegionFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataLossPreventionDiscoveryConfigDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigStartCloudStorage(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
+			},
+			{
+				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigUpdateCloudStorage(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
+			},
+		},
+	})
+}
+
+func testAccDataLossPreventionDiscoveryConfig_CloudStorageSingleBucket(t *testing.T) {
+
+	context := map[string]interface{}{
+		"project":       envvar.GetTestProjectFromEnv(),
+		"location":      envvar.GetTestRegionFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataLossPreventionDiscoveryConfigDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigStartCloudStorage(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "parent", "last_run_time", "update_time", "errors"},
+			},
+			{
+				Config: testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigCloudStorageSingleUpdate(context),
 			},
 			{
 				ResourceName:            "google_data_loss_prevention_discovery_config.basic",
@@ -1007,6 +1079,171 @@ resource "google_data_loss_prevention_discovery_config" "basic" {
     targets {
        secrets_target {}
     }
+}
+`, context)
+}
+
+func testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigStartCloudStorage(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_data_loss_prevention_inspect_template" "basic" {
+    parent = "projects/%{project}"
+    description = "Description"
+    display_name = "Display"
+    inspect_config {
+        info_types {
+            name = "EMAIL_ADDRESS"
+        }
+    }
+}
+resource "google_data_loss_prevention_discovery_config" "basic" {
+    parent = "projects/%{project}/locations/%{location}"
+    location = "%{location}"
+    status = "RUNNING"
+    targets {
+        cloud_storage_target {
+            filter {
+                others {}
+            }
+			generation_cadence {
+                inspect_template_modified_cadence {
+                    frequency = "UPDATE_FREQUENCY_MONTHLY"
+                }
+                refresh_frequency = "UPDATE_FREQUENCY_MONTHLY"
+            }
+        }
+
+    }
+    inspect_templates = ["projects/%{project}/inspectTemplates/${google_data_loss_prevention_inspect_template.basic.name}"]
+}
+`, context)
+}
+
+func testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigUpdateCloudStorage(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_data_loss_prevention_inspect_template" "basic" {
+    parent = "projects/%{project}"
+    description = "Description"
+    display_name = "Display"
+    inspect_config {
+        info_types {
+            name = "EMAIL_ADDRESS"  
+        }
+    }
+}
+resource "google_data_loss_prevention_discovery_config" "basic" {
+    parent = "projects/%{project}/locations/%{location}"
+    location = "%{location}"
+    status = "RUNNING"
+    targets {
+        cloud_storage_target {
+            filter {
+                collection {
+                    include_regexes {
+                        patterns {
+                            cloud_storage_regex {
+                                project_id_regex = "foo-project"
+                                bucket_name_regex = "bucket"
+                            }
+                        }
+                    }
+                }
+            }
+            conditions {
+                created_after = "2023-10-02T15:01:23Z"
+                min_age = "10800s"
+                cloud_storage_conditions {
+                    included_object_attributes = ["ALL_SUPPORTED_OBJECTS"]
+                    included_bucket_attributes = ["ALL_SUPPORTED_BUCKETS"]
+                }
+            }
+            generation_cadence {
+                inspect_template_modified_cadence {
+                    frequency = "UPDATE_FREQUENCY_DAILY"
+                }
+                refresh_frequency = "UPDATE_FREQUENCY_MONTHLY"
+            }
+        }
+    }
+    targets {
+        cloud_storage_target {
+            filter {
+                collection {
+                    include_regexes {
+                        patterns {
+                            cloud_storage_regex {
+                                project_id_regex = "foo-project"
+                                bucket_name_regex = "do-not-scan"
+                            }
+                        }
+                    }
+                }
+            }
+            disabled {}
+        }
+    }
+    targets {
+        cloud_storage_target {
+            filter {
+                others {}
+            }
+            generation_cadence {
+                inspect_template_modified_cadence {
+                    frequency = "UPDATE_FREQUENCY_MONTHLY"
+                }
+                refresh_frequency = "UPDATE_FREQUENCY_MONTHLY"
+            }
+        }
+    }
+    inspect_templates = ["projects/%{project}/inspectTemplates/${google_data_loss_prevention_inspect_template.basic.name}"]
+}
+`, context)
+}
+
+func testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigCloudStorageSingleUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_data_loss_prevention_inspect_template" "basic" {
+    parent = "projects/%{project}"
+    description = "Description"
+    display_name = "Display"
+    inspect_config {
+        info_types {
+            name = "EMAIL_ADDRESS"  
+        }
+    }
+}
+resource "google_storage_bucket" "testbucket" {
+	name                        = "dlp_test_bucket%{random_suffix}"
+	location                    = "%{location}"
+	uniform_bucket_level_access = true
+}
+data "google_project" "project" {
+}
+resource "google_project_iam_member" "dlp_role" {
+    project = "%{project}"
+    role    = "roles/dlp.projectdriver"
+    member = "serviceAccount:service-${data.google_project.project.number}@dlp-api.iam.gserviceaccount.com"
+}
+resource "google_data_loss_prevention_discovery_config" "basic" {
+    parent = "projects/%{project}/locations/%{location}"
+    location = "%{location}"
+    status = "RUNNING"
+    targets {
+        cloud_storage_target {
+            filter {
+                cloud_storage_resource_reference {
+                    project_id = "%{project}"
+                    bucket_name = google_storage_bucket.testbucket.name
+                }
+            }
+			generation_cadence {
+                inspect_template_modified_cadence {
+                    frequency = "UPDATE_FREQUENCY_DAILY"
+                }
+                refresh_frequency = "UPDATE_FREQUENCY_DAILY"
+            }
+        }
+    }
+    inspect_templates = ["projects/%{project}/inspectTemplates/${google_data_loss_prevention_inspect_template.basic.name}"]
 }
 `, context)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**
```release-note:enhancement
dlp: added `cloud_storage_target` field to `google_data_loss_prevention_discovery_config` resource
```


