### PR TITLE
Terraform Support for Secret Manager CSI addon GA Version

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -1510,7 +1510,7 @@ func ResourceContainerCluster() *schema.Resource {
 				},
 			},
 <% end -%>
-<% unless version == "ga" -%>
+
 			"secret_manager_config": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -1527,7 +1527,6 @@ func ResourceContainerCluster() *schema.Resource {
 					},
 				},
 			},
-<% end -%>
 
 			"project": {
 				Type:        schema.TypeString,
@@ -2301,9 +2300,8 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 <% unless version == "ga" -%>
 		PodSecurityPolicyConfig: expandPodSecurityPolicyConfig(d.Get("pod_security_policy_config")),
 <% end -%>
-<% unless version == "ga" -%>
+
 		SecretManagerConfig: expandSecretManagerConfig(d.Get("secret_manager_config")),
-<% end -%>
 		Autoscaling:             expandClusterAutoscaling(d.Get("cluster_autoscaling"), d),
 		BinaryAuthorization:     expandBinaryAuthorization(d.Get("binary_authorization")),
 		Autopilot: &container.Autopilot{
@@ -2945,11 +2943,11 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	if err := d.Set("cluster_telemetry", flattenClusterTelemetry(cluster.ClusterTelemetry)); err != nil {
 		return err
 	}
+<% end -%>
 
 	if err := d.Set("secret_manager_config", flattenSecretManagerConfig(cluster.SecretManagerConfig)); err != nil {
 		return err
 	}
-<% end -%>
 
 	if err := d.Set("resource_labels", cluster.ResourceLabels); err != nil {
 		return fmt.Errorf("Error setting resource_labels: %s", err)
@@ -3935,7 +3933,6 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 <% end -%>
 
-<% unless version == 'ga' -%>
 	if d.HasChange("secret_manager_config") {
 		c := d.Get("secret_manager_config")
 		req := &container.UpdateClusterRequest{
@@ -3962,7 +3959,6 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 		log.Printf("[INFO] GKE cluster %s secret manager csi add-on has been updated", d.Id())
 	}
-<% end -%>
 
 	if d.HasChange("workload_identity_config") {
 		// Because GKE uses a non-RESTful update function, when removing the
@@ -5337,7 +5333,6 @@ func expandPodSecurityPolicyConfig(configured interface{}) *container.PodSecurit
 }
 <% end -%>
 
-<% unless version == 'ga' -%>
 func expandSecretManagerConfig(configured interface{}) *container.SecretManagerConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
@@ -5350,7 +5345,6 @@ func expandSecretManagerConfig(configured interface{}) *container.SecretManagerC
 		ForceSendFields: []string{"Enabled"},
 	}
 }
-<% end -%>
 
 func expandDefaultMaxPodsConstraint(v interface{}) *container.MaxPodsConstraint {
 	if v == nil {
@@ -6218,7 +6212,6 @@ func flattenPodSecurityPolicyConfig(c *container.PodSecurityPolicyConfig) []map[
 
 <% end -%>
 
-<% unless version == 'ga' -%>
 func flattenSecretManagerConfig(c *container.SecretManagerConfig) []map[string]interface{} {
 	if c == nil {
 		return []map[string]interface{}{
@@ -6233,8 +6226,6 @@ func flattenSecretManagerConfig(c *container.SecretManagerConfig) []map[string]i
 		},
 	}
 }
-
-<% end -%>
 
 func flattenResourceUsageExportConfig(c *container.ResourceUsageExportConfig) []map[string]interface{} {
 	if c == nil {
@@ -6685,7 +6676,6 @@ func podSecurityPolicyCfgSuppress(k, old, new string, r *schema.ResourceData) bo
 }
 <% end -%>
 
-<% unless version == 'ga' -%>
 func SecretManagerCfgSuppress(k, old, new string, r *schema.ResourceData) bool {
 	if k == "secret_manager_config.#" && old == "1" && new == "0" {
 		if v, ok := r.GetOk("secret_manager_config"); ok {
@@ -6699,7 +6689,6 @@ func SecretManagerCfgSuppress(k, old, new string, r *schema.ResourceData) bool {
 	}
 	return false
 }
-<% end -%>
 
 func containerClusterNetworkPolicyDiffSuppress(k, old, new string, r *schema.ResourceData) bool {
 	// if network_policy configuration is empty, we store it as populated and enabled=false, and

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -3267,7 +3267,6 @@ func TestAccContainerCluster_withIdentityServiceConfig(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccContainerCluster_withSecretManagerConfig(t *testing.T) {
 	t.Parallel()
 
@@ -3318,7 +3317,6 @@ func TestAccContainerCluster_withSecretManagerConfig(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func TestAccContainerCluster_withLoggingConfig(t *testing.T) {
 	t.Parallel()
@@ -9349,7 +9347,6 @@ resource "google_container_cluster" "primary" {
 `, name, networkName, subnetworkName)
 }
 
-<% unless version == 'ga' -%>
 func testAccContainerCluster_withSecretManagerConfigEnabled(name, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
@@ -9382,7 +9379,6 @@ resource "google_container_cluster" "primary" {
 }
 `, name, networkName, subnetworkName)
 }
-<% end -%>
 
 func testAccContainerCluster_withLoggingConfigEnabled(name, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -292,7 +292,7 @@ region are guaranteed to support the same version.
     [PodSecurityPolicy](https://cloud.google.com/kubernetes-engine/docs/how-to/pod-security-policies) feature.
     Structure is [documented below](#nested_pod_security_policy_config).
 
-* `secret_manager_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Configuration for the
+* `secret_manager_config` - (Optional) Configuration for the
     [SecretManagerConfig](https://cloud.google.com/secret-manager/docs/secret-manager-managed-csi-component) feature.
     Structure is [documented below](#nested_secret_manager_config).
 


### PR DESCRIPTION
Added a new field ```secret_manager_config``` to ```google_container_cluster``` in resource for ```terraform-provider-google```

This field provides secret manager gke add on for ga.

**Release Note Template for Downstream PRs (will be copied)**

```release-note: enhancement
container: added `secret_manager_config` field to `google_container_cluster` resource (ga)
```