### PR TITLE
TeamCity: Fix references to branches in 6.0.0 testing projects

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/projects/feature_branches/FEATURE-BRANCH-major-release-6.0.0.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/feature_branches/FEATURE-BRANCH-major-release-6.0.0.kt
@@ -24,7 +24,8 @@ object HashicorpVCSRootGa_featureBranchMajorRelease600: GitVcsRoot({
     url = "https://github.com/hashicorp/terraform-provider-${ProviderNameGa}"
     branch = "refs/heads/${branchName}"
     branchSpec = """
-        +:refs/heads/FEATURE-BRANCH-major-release-6*
+        +:(refs/heads/*)
+        -:refs/pulls/*
     """.trimIndent()
 })
 
@@ -33,7 +34,8 @@ object HashicorpVCSRootBeta_featureBranchMajorRelease600: GitVcsRoot({
     url = "https://github.com/hashicorp/terraform-provider-${ProviderNameBeta}"
     branch = "refs/heads/${branchName}"
     branchSpec = """
-        +:refs/heads/FEATURE-BRANCH-major-release-6*
+        +:(refs/heads/*)
+        -:refs/pulls/*
     """.trimIndent()
 })
 

--- a/mmv1/third_party/terraform/.teamcity/components/projects/feature_branches/FEATURE-BRANCH-major-release-6.0.0.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/feature_branches/FEATURE-BRANCH-major-release-6.0.0.kt
@@ -24,7 +24,7 @@ object HashicorpVCSRootGa_featureBranchMajorRelease600: GitVcsRoot({
     url = "https://github.com/hashicorp/terraform-provider-${ProviderNameGa}"
     branch = "refs/heads/${branchName}"
     branchSpec = """
-        +:FEATURE-BRANCH-major-release-6*
+        +:refs/heads/FEATURE-BRANCH-major-release-6*
     """.trimIndent()
 })
 
@@ -33,7 +33,7 @@ object HashicorpVCSRootBeta_featureBranchMajorRelease600: GitVcsRoot({
     url = "https://github.com/hashicorp/terraform-provider-${ProviderNameBeta}"
     branch = "refs/heads/${branchName}"
     branchSpec = """
-        +:FEATURE-BRANCH-major-release-6*
+        +:refs/heads/FEATURE-BRANCH-major-release-6*
     """.trimIndent()
 })
 
@@ -68,7 +68,7 @@ fun featureBranchMajorRelease600_Project(allConfig: AllContextParameters): Proje
                         HashicorpVCSRootGa_featureBranchMajorRelease600,
                         gaConfig,
                         NightlyTriggerConfiguration(
-                            branch = branchName, // Make triggered builds use the feature branch
+                            branch = "refs/heads/${branchName}", // Make triggered builds use the feature branch
                             daysOfWeek = "5"     // Thursday for GA, TeamCity numbers days Sun=1...Sat=7
                         ), 
                     )
@@ -88,7 +88,7 @@ fun featureBranchMajorRelease600_Project(allConfig: AllContextParameters): Proje
                         HashicorpVCSRootBeta_featureBranchMajorRelease600,
                         betaConfig,
                         NightlyTriggerConfiguration(
-                            branch = branchName, // Make triggered builds use the feature branch
+                            branch = "refs/heads/${branchName}", // Make triggered builds use the feature branch
                             daysOfWeek="6"       // Friday for Beta, TeamCity numbers days Sun=1...Sat=7
                         ),
                     )


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

After staring at the non-functional trigger in the UI:

<img width="696" alt="Screenshot 2024-07-11 at 12 28 50" src="https://github.com/GoogleCloudPlatform/magic-modules/assets/15078782/6f1fc5cf-ea19-4d34-9f13-a6bba20767b1">

and staring at this trigger

<img width="688" alt="Screenshot 2024-07-10 at 21 18 22 (1)" src="https://github.com/GoogleCloudPlatform/magic-modules/assets/15078782/d7bd20c2-616c-4032-a0cd-76ecc5d5f6a1">

I realised `refs/heads/` was missing in the feature branch testing triggers

...

And I found that the branch filter on the trigger is affected by the "branchSpec" on the VCS root. It looks like the branch spec produces a list of names which _may be mutated by the branch spec_. If you filter with `FEATURE-BRANCH-*` in the branch spec then the branch names available after (["logical branch name"](https://www.jetbrains.com/help/teamcity/working-with-feature-branches.html#Logical+Branch+Name)) are only the part of the branch name in the `*` bit. Parentheses are needed to override this behaviour. How the branchSpec is set up impacts what works in the branch filtering for a trigger. 🤯 

I've tested this, but only in newly-made test projects. I can't test in the 'live' project except letting 4am UTC pass and see what happens.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
