### PR TITLE
google_compute_public_advertised_prefix adding in output only shared_secret 

### DIFF
--- a/mmv1/products/compute/PublicAdvertisedPrefix.yaml
+++ b/mmv1/products/compute/PublicAdvertisedPrefix.yaml
@@ -75,3 +75,8 @@ properties:
       The IPv4 address range, in CIDR format, represented by this public
       advertised prefix.
     required: true
+  - !ruby/object:Api::Type::String
+    name: 'sharedSecret'
+    output: true
+    description: |
+      Output Only. The shared secret to be used for reverse DNS verification.


### PR DESCRIPTION
Adding in shared_secret 

fixes https://github.com/hashicorp/terraform-provider-google/issues/18171 

Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**


```release-note:enhancement
compute: added `shared_secret` field to `google_compute_public_advertised_prefix` resource
```
