### PR TITLE
chore(ci): move ExecRunner interface to exec package

### DIFF
--- a/.ci/magician/cmd/generate_comment.go
+++ b/.ci/magician/cmd/generate_comment.go
@@ -151,7 +151,7 @@ func listGCEnvironmentVariables() string {
 	return result
 }
 
-func execGenerateComment(prNumber int, ghTokenMagicModules, buildId, buildStep, projectId, commitSha string, gh GithubClient, rnr ExecRunner, ctlr *source.Controller) error {
+func execGenerateComment(prNumber int, ghTokenMagicModules, buildId, buildStep, projectId, commitSha string, gh GithubClient, rnr exec.ExecRunner, ctlr *source.Controller) error {
 	errors := map[string][]string{"Other": []string{}}
 
 	pullRequest, err := gh.GetPullRequest(strconv.Itoa(prNumber))
@@ -414,7 +414,7 @@ func execGenerateComment(prNumber int, ghTokenMagicModules, buildId, buildStep, 
 }
 
 // Build the diff processor for tpg or tpgb
-func buildDiffProcessor(diffProcessorPath, providerLocalPath string, env map[string]string, rnr ExecRunner) error {
+func buildDiffProcessor(diffProcessorPath, providerLocalPath string, env map[string]string, rnr exec.ExecRunner) error {
 	for _, path := range []string{"old", "new", "bin"} {
 		if err := rnr.RemoveAll(filepath.Join(diffProcessorPath, path)); err != nil {
 			return err
@@ -434,7 +434,7 @@ func buildDiffProcessor(diffProcessorPath, providerLocalPath string, env map[str
 	return rnr.PopDir()
 }
 
-func computeBreakingChanges(diffProcessorPath string, rnr ExecRunner) ([]BreakingChange, error) {
+func computeBreakingChanges(diffProcessorPath string, rnr exec.ExecRunner) ([]BreakingChange, error) {
 	if err := rnr.PushDir(diffProcessorPath); err != nil {
 		return nil, err
 	}
@@ -454,7 +454,7 @@ func computeBreakingChanges(diffProcessorPath string, rnr ExecRunner) ([]Breakin
 	return changes, rnr.PopDir()
 }
 
-func changedSchemaResources(diffProcessorPath string, rnr ExecRunner) ([]string, error) {
+func changedSchemaResources(diffProcessorPath string, rnr exec.ExecRunner) ([]string, error) {
 	if err := rnr.PushDir(diffProcessorPath); err != nil {
 		return nil, err
 	}
@@ -480,7 +480,7 @@ func changedSchemaResources(diffProcessorPath string, rnr ExecRunner) ([]string,
 // Run the missing test detector and return the results.
 // Returns an empty string unless there are missing tests.
 // Error will be nil unless an error occurs during setup.
-func detectMissingTests(diffProcessorPath, tpgbLocalPath string, rnr ExecRunner) (map[string]*MissingTestInfo, error) {
+func detectMissingTests(diffProcessorPath, tpgbLocalPath string, rnr exec.ExecRunner) (map[string]*MissingTestInfo, error) {
 	if err := rnr.PushDir(diffProcessorPath); err != nil {
 		return nil, err
 	}

--- a/.ci/magician/cmd/generate_downstream.go
+++ b/.ci/magician/cmd/generate_downstream.go
@@ -93,7 +93,7 @@ func listGDEnvironmentVariables() string {
 	return result
 }
 
-func execGenerateDownstream(baseBranch, command, repo, version, ref string, gh GithubClient, rnr ExecRunner, ctlr *source.Controller) error {
+func execGenerateDownstream(baseBranch, command, repo, version, ref string, gh GithubClient, rnr exec.ExecRunner, ctlr *source.Controller) error {
 	if baseBranch == "" {
 		baseBranch = "main"
 	}
@@ -177,7 +177,7 @@ func execGenerateDownstream(baseBranch, command, repo, version, ref string, gh G
 	return nil
 }
 
-func cloneRepo(mmRepo *source.Repo, baseBranch, repo, version, command, ref string, rnr ExecRunner, ctlr *source.Controller) (*source.Repo, *source.Repo, string, error) {
+func cloneRepo(mmRepo *source.Repo, baseBranch, repo, version, command, ref string, rnr exec.ExecRunner, ctlr *source.Controller) (*source.Repo, *source.Repo, string, error) {
 	downstreamRepo := &source.Repo{
 		Title:  repo,
 		Branch: baseBranch,
@@ -244,7 +244,7 @@ func cloneRepo(mmRepo *source.Repo, baseBranch, repo, version, command, ref stri
 	return downstreamRepo, scratchRepo, commitMessage, nil
 }
 
-func setGitConfig(rnr ExecRunner) error {
+func setGitConfig(rnr exec.ExecRunner) error {
 	if _, err := rnr.Run("git", []string{"config", "--local", "user.name", "Modular Magician"}, nil); err != nil {
 		return err
 	}
@@ -254,7 +254,7 @@ func setGitConfig(rnr ExecRunner) error {
 	return nil
 }
 
-func runMake(downstreamRepo *source.Repo, command string, rnr ExecRunner) error {
+func runMake(downstreamRepo *source.Repo, command string, rnr exec.ExecRunner) error {
 	switch downstreamRepo.Title {
 	case "terraform-google-conversion":
 		if _, err := rnr.Run("make", []string{"clean-tgc", "OUTPUT_PATH=" + downstreamRepo.Path}, nil); err != nil {
@@ -308,7 +308,7 @@ func getPullRequest(baseBranch, ref string, gh GithubClient) (*github.PullReques
 	return nil, fmt.Errorf("no pr found with merge commit sha %s and base branch %s", ref, baseBranch)
 }
 
-func createCommit(scratchRepo *source.Repo, commitMessage string, rnr ExecRunner) (string, error) {
+func createCommit(scratchRepo *source.Repo, commitMessage string, rnr exec.ExecRunner) (string, error) {
 	if err := rnr.PushDir(scratchRepo.Path); err != nil {
 		return "", err
 	}
@@ -338,7 +338,7 @@ func createCommit(scratchRepo *source.Repo, commitMessage string, rnr ExecRunner
 	return commitSha, err
 }
 
-func addChangelogEntry(downstreamRepo *source.Repo, pullRequest *github.PullRequest, rnr ExecRunner) error {
+func addChangelogEntry(downstreamRepo *source.Repo, pullRequest *github.PullRequest, rnr exec.ExecRunner) error {
 	if err := rnr.PushDir(downstreamRepo.Path); err != nil {
 		return err
 	}
@@ -349,7 +349,7 @@ func addChangelogEntry(downstreamRepo *source.Repo, pullRequest *github.PullRequ
 	return rnr.PopDir()
 }
 
-func mergePullRequest(downstreamRepo, scratchRepo *source.Repo, scratchRepoSha string, pullRequest *github.PullRequest, rnr ExecRunner, gh GithubClient) error {
+func mergePullRequest(downstreamRepo, scratchRepo *source.Repo, scratchRepoSha string, pullRequest *github.PullRequest, rnr exec.ExecRunner, gh GithubClient) error {
 	fmt.Printf(`Base: %s:%s
 Head: %s:%s
 `, downstreamRepo.Owner, downstreamRepo.Branch, scratchRepo.Owner, scratchRepo.Branch)

--- a/.ci/magician/cmd/interfaces.go
+++ b/.ci/magician/cmd/interfaces.go
@@ -39,15 +39,3 @@ type CloudbuildClient interface {
 	ApproveCommunityChecker(prNumber, commitSha string) error
 	TriggerMMPresubmitRuns(commitSha string, substitutions map[string]string) error
 }
-
-type ExecRunner interface {
-	GetCWD() string
-	Copy(src, dest string) error
-	Mkdir(path string) error
-	RemoveAll(path string) error
-	PushDir(path string) error
-	PopDir() error
-	WriteFile(name, data string) error
-	Run(name string, args []string, env map[string]string) (string, error)
-	MustRun(name string, args []string, env map[string]string) string
-}

--- a/.ci/magician/cmd/mock_runner_test.go
+++ b/.ci/magician/cmd/mock_runner_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"magician/exec"
 	"os"
 	"path/filepath"
 	"sort"
@@ -31,7 +32,7 @@ import (
 type ParameterList []any
 
 type MockRunner interface {
-	ExecRunner
+	exec.ExecRunner
 	Calls(method string) ([]ParameterList, bool)
 }
 

--- a/.ci/magician/cmd/test_terraform_vcr.go
+++ b/.ci/magician/cmd/test_terraform_vcr.go
@@ -133,7 +133,7 @@ var testTerraformVCRCmd = &cobra.Command{
 	},
 }
 
-func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, baseBranch string, gh GithubClient, rnr ExecRunner, ctlr *source.Controller, vt *vcr.Tester) error {
+func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, baseBranch string, gh GithubClient, rnr exec.ExecRunner, ctlr *source.Controller, vt *vcr.Tester) error {
 	newBranch := "auto-pr-" + prNumber
 	oldBranch := newBranch + "-old"
 

--- a/.ci/magician/cmd/test_tgc_integration.go
+++ b/.ci/magician/cmd/test_tgc_integration.go
@@ -44,7 +44,7 @@ var testTGCIntegrationCmd = &cobra.Command{
 	},
 }
 
-func execTestTGCIntegration(prNumber, mmCommit, buildID, projectID, buildStep, ghRepo, githubUsername string, rnr ExecRunner, ctlr *source.Controller, gh GithubClient) error {
+func execTestTGCIntegration(prNumber, mmCommit, buildID, projectID, buildStep, ghRepo, githubUsername string, rnr exec.ExecRunner, ctlr *source.Controller, gh GithubClient) error {
 	newBranch := "auto-pr-" + prNumber
 	repo := &source.Repo{
 		Name:   ghRepo,

--- a/.ci/magician/exec/interfaces.go
+++ b/.ci/magician/exec/interfaces.go
@@ -1,0 +1,17 @@
+package exec
+
+import "path/filepath"
+
+type ExecRunner interface {
+	GetCWD() string
+	Copy(src, dest string) error
+	Mkdir(path string) error
+	RemoveAll(path string) error
+	PushDir(path string) error
+	PopDir() error
+	WriteFile(name, data string) error
+	Run(name string, args []string, env map[string]string) (string, error)
+	MustRun(name string, args []string, env map[string]string) string
+	Walk(root string, fn filepath.WalkFunc) error
+	ReadFile(name string) (string, error)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
https://github.com/hashicorp/terraform-provider-google/issues/18249

moving the vcr/tester.go to cmd/tester.go
- modify the Tester struct to use ExecRunner to replace exec.Runner so the run can be mocked. 

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
