### PR TITLE
Add new zone to VmwareenginePrivateCloud sweeper

### DIFF
--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_sweeper.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_sweeper.go
@@ -40,7 +40,7 @@ func testSweepVmwareenginePrivateCloud(region string) error {
 	// List of location values includes:
 	//   * zones used for this resource type's acc tests in the past
 	//   * the 'region' passed to the sweeper
-	locations := []string{region, "southamerica-west1-a", "me-west1-a"}
+	locations := []string{region, "southamerica-west1-a", "me-west1-a", "me-west1-b"}
 	log.Printf("[INFO][SWEEPER_LOG] Sweeping will include these locations: %v.", locations)
 	for _, location := range locations {
 		log.Printf("[INFO][SWEEPER_LOG] Beginning the process of sweeping location '%s'.", location)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

When sweeping VMware Engine resources I've seen private clouds in this new zone. When running sweepers manually I can supply the zone as an input, but this PR ensures that scheduled sweeping will handle PCs in that zone

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
