### PR TITLE
Fix perma-diff on gpu_driver_installation_config for node_config

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -162,6 +162,7 @@ func schemaNodeConfig() *schema.Schema {
 								Type:         schema.TypeList,
 								MaxItems:     1,
 								Optional:     true,
+								Computed:     true,
 								ForceNew:     true,
 								ConfigMode: schema.SchemaConfigModeAttr,
 								Description:  `Configuration for auto installation of GPU driver.`,

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -4873,3 +4873,64 @@ resource "google_container_node_pool" "np" {
 }
 `, secretID, cluster, network, subnetwork, nodepool)
 }
+
+func TestAccContainerNodePool_defaultDriverInstallation(t *testing.T) {
+	t.Parallel()
+
+	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	np := fmt.Sprintf("tf-test-nodepool-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePool_defaultDriverInstallation(cluster, np),
+			},
+			{
+				ResourceName:      "google_container_node_pool.np",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccContainerNodePool_defaultDriverInstallation(cluster, np string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "cluster" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 3
+  deletion_protection = false
+
+  min_master_version = "1.30.1-gke.1329003"
+  release_channel {
+    channel = "RAPID"
+  }
+}
+
+resource "google_container_node_pool" "np" {
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  initial_node_count = 2
+  version            = "1.30.1-gke.1329003"
+
+  node_config {
+    service_account = "default"
+    machine_type = "n1-standard-8"
+
+    guest_accelerator {
+      type  = "nvidia-tesla-t4"
+      count = 1
+      gpu_sharing_config {
+	    gpu_sharing_strategy = "TIME_SHARING"
+	    max_shared_clients_per_gpu = 3
+      }
+    }
+  }
+}
+`, cluster, np)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Default on driver installation is applied to new node pool creation  in GKE 1.30. With this change, the terraform plan shows a diff on `gpu_driver_installation_config`, which will cause resource recreation.

```
gpu_driver_installation_config {
  gpu_driver_version = "DEFAULT"
}
```

This PR will fix the permdiff. More details on b/352610176

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: fixed perma-diff on `node_config.guest_accelerator.gpu_driver_installation_config` field in GKE 1.30+ in `google_container_node_pool` resource
```
