### PR TITLE
Adding route policies support to Router

### DIFF
--- a/mmv1/products/compute/RouterRoutePolicy.yaml
+++ b/mmv1/products/compute/RouterRoutePolicy.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google Inc.
+# Copyright 2024 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/mmv1/products/compute/RouterRoutePolicy.yaml
+++ b/mmv1/products/compute/RouterRoutePolicy.yaml
@@ -1,0 +1,172 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'RouterRoutePolicy'
+base_url: projects/{{project}}/regions/{{region}}/routers/{{router}}
+self_link: projects/{{project}}/regions/{{region}}/routers/{{router}}/getRoutePolicy?policy={{name}}
+create_url: projects/{{project}}/regions/{{region}}/routers/{{router}}/updateRoutePolicy
+update_url: projects/{{project}}/regions/{{region}}/routers/{{router}}/updateRoutePolicy
+delete_url: projects/{{project}}/regions/{{region}}/routers/{{router}}/deleteRoutePolicy?policy={{name}}
+create_verb: :POST
+update_verb: :POST
+update_mask: true
+delete_verb: :POST
+description: A route policy created in a router
+min_version: 'beta'
+references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+    'Google Cloud Router': 'https://cloud.google.com/router/docs/'
+  api: 'https://cloud.google.com/compute/docs/reference/rest/v1/routers'
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
+    kind: 'compute#operation'
+    path: 'name'
+    base_url: 'projects/{{project}}/regions/{{regions}}/operations/{{op_id}}'
+    wait_ms: 1000
+  result: !ruby/object:Api::OpAsync::Result
+    path: 'targetLink'
+  status: !ruby/object:Api::OpAsync::Status
+    path: 'status'
+    complete: 'DONE'
+    allowed:
+      - 'PENDING'
+      - 'RUNNING'
+      - 'DONE'
+  error: !ruby/object:Api::OpAsync::Error
+    path: 'error/errors'
+    message: 'message'
+id_format: '{{project}}/{{region}}/{{router}}/routePolicies/{{name}}'
+import_format: ['{{project}}/{{region}}/{{router}}/routePolicies/{{name}}']
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'router_route_policy_export'
+    primary_resource_id: 'rp-export'
+    vars:
+      router_name: 'my-router'
+      network_name: 'my-network'
+      subnet_name: 'my-subnetwork'
+      route_policy_name: 'my-rp1'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'router_route_policy_import'
+    primary_resource_id: 'rp-import'
+    vars:
+      router_name: 'my-router'
+      network_name: 'my-network'
+      subnet_name: 'my-subnetwork'
+      route_policy_name: 'my-rp2'
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  decoder: templates/terraform/decoders/unwrap_route_policy_resource.go.erb
+parameters:
+  - !ruby/object:Api::Type::ResourceRef
+    name: 'router'
+    resource: 'Router'
+    imports: name
+    description: |
+      The name of the Cloud Router in which this route policy will be configured.
+    required: true
+    immutable: true
+    url_param_only: true
+  - !ruby/object:Api::Type::ResourceRef
+    name: region
+    resource: Region
+    imports: name
+    description: Region where the router and NAT reside.
+    immutable: true
+    required: false
+    url_param_only: true
+    default_from_api: true
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
+  - !ruby/object:Api::Type::String
+    name: name
+    description: |
+      Name of the route policy. This policy's name, which must be a resource ID segment and unique within all policies owned by the Router
+    required: true
+    immutable: true
+properties:
+  - !ruby/object:Api::Type::Enum
+    name: type
+    description: |
+      This is policy's type, which is one of IMPORT or EXPORT
+    values:
+      - :ROUTE_POLICY_TYPE_IMPORT
+      - :ROUTE_POLICY_TYPE_EXPORT
+  - !ruby/object:Api::Type::Array
+    name: terms
+    description: |
+      List of terms (the order in the list is not important, they are evaluated in order of priority).
+    required: true
+    immutable: true
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties: 
+        - !ruby/object:Api::Type::Integer
+          name: priority
+          description: |
+            The evaluation priority for this term, which must be between 0 (inclusive) and 231 (exclusive), and unique within the list.
+          required: true
+        - !ruby/object:Api::Type::NestedObject
+          name: match
+          description: |
+            CEL expression evaluated against a route to determine if this term applies (see Policy Language). When not set, the term applies to all routes.
+          properties:
+            - !ruby/object:Api::Type::String
+              name: 'expression'
+              required: true
+              description:
+                Textual representation of an expression in Common Expression
+                Language syntax.
+            - !ruby/object:Api::Type::String
+              name: 'title'
+              description:
+                Title for the expression, i.e. a short string describing its
+                purpose.
+            - !ruby/object:Api::Type::String
+              name: 'description'
+              description: Description of the expression
+            - !ruby/object:Api::Type::String
+              name: 'location'
+              description:
+                String indicating the location of the expression for error
+                reporting, e.g. a file name and a position in the file
+        - !ruby/object:Api::Type::Array
+          name: actions
+          description: |
+            'CEL expressions to evaluate to modify a route when this term matches.'\
+          item_type: !ruby/object:Api::Type::NestedObject
+            properties: 
+              - !ruby/object:Api::Type::String
+                name: 'expression'
+                required: true
+                description: |
+                  Textual representation of an expression in Common Expression
+                  Language syntax.
+              - !ruby/object:Api::Type::String
+                name: 'title'
+                description: |
+                  Title for the expression, i.e. a short string describing its
+                  purpose.
+              - !ruby/object:Api::Type::String
+                name: 'description'
+                description: |
+                  Description of the expression
+              - !ruby/object:Api::Type::String
+                name: 'location'
+                description: |
+                  String indicating the location of the expression for error
+                  reporting, e.g. a file name and a position in the file
+  - !ruby/object:Api::Type::Fingerprint
+    name: 'fingerprint'
+    description: |
+      The fingerprint used for optimistic locking of this resource.  Used
+      internally during updates.
+    output: true

--- a/mmv1/products/compute/RouterRoutePolicy.yaml
+++ b/mmv1/products/compute/RouterRoutePolicy.yaml
@@ -108,7 +108,7 @@ properties:
     required: true
     immutable: true
     item_type: !ruby/object:Api::Type::NestedObject
-      properties: 
+      properties:
         - !ruby/object:Api::Type::Integer
           name: priority
           description: |
@@ -143,7 +143,7 @@ properties:
           description: |
             'CEL expressions to evaluate to modify a route when this term matches.'\
           item_type: !ruby/object:Api::Type::NestedObject
-            properties: 
+            properties:
               - !ruby/object:Api::Type::String
                 name: 'expression'
                 required: true

--- a/mmv1/templates/terraform/decoders/unwrap_route_policy_resource.go.erb
+++ b/mmv1/templates/terraform/decoders/unwrap_route_policy_resource.go.erb
@@ -1,0 +1,20 @@
+<%# The license inside this block applies to this file.
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-%>
+v, ok := res["resource"]
+if !ok || v == nil {
+  return res, nil
+}
+
+return v.(map[string]interface{}), nil

--- a/mmv1/templates/terraform/decoders/unwrap_route_policy_resource.go.erb
+++ b/mmv1/templates/terraform/decoders/unwrap_route_policy_resource.go.erb
@@ -1,5 +1,5 @@
 <%# The license inside this block applies to this file.
-# Copyright 2017 Google Inc.
+# Copyright 2018 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/mmv1/templates/terraform/examples/router_route_policy_export.tf.erb
+++ b/mmv1/templates/terraform/examples/router_route_policy_export.tf.erb
@@ -31,7 +31,7 @@ resource "google_compute_router_route_policy" "<%= ctx[:primary_resource_id] %>"
       expression = "destination == '10.0.0.0/12'"
 	  }
     actions {
-		  expression = "accept()"
+      expression = "accept()"
     }
   }
 }

--- a/mmv1/templates/terraform/examples/router_route_policy_export.tf.erb
+++ b/mmv1/templates/terraform/examples/router_route_policy_export.tf.erb
@@ -1,9 +1,11 @@
 resource "google_compute_network" "net" {
+  provider = google-beta
   name                    = "<%= ctx[:vars]['network_name'] %>"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "subnet" {
+  provider = google-beta
   name          = "<%= ctx[:vars]['subnet_name'] %>"
   network       = google_compute_network.net.id
   ip_cidr_range = "10.0.0.0/16"
@@ -11,12 +13,14 @@ resource "google_compute_subnetwork" "subnet" {
 }
 
 resource "google_compute_router" "router" {
+  provider = google-beta
   name    = "<%= ctx[:vars]['router_name'] %>"
   region  = google_compute_subnetwork.subnet.region
   network = google_compute_network.net.id
 }
 
 resource "google_compute_router_route_policy" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
   router = google_compute_router.router.name
   region = google_compute_router.router.region
 	name = "<%= ctx[:vars]['route_policy_name'] %>"

--- a/mmv1/templates/terraform/examples/router_route_policy_export.tf.erb
+++ b/mmv1/templates/terraform/examples/router_route_policy_export.tf.erb
@@ -1,11 +1,9 @@
 resource "google_compute_network" "net" {
-  provider = google-beta
   name                    = "<%= ctx[:vars]['network_name'] %>"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "subnet" {
-  provider = google-beta
   name          = "<%= ctx[:vars]['subnet_name'] %>"
   network       = google_compute_network.net.id
   ip_cidr_range = "10.0.0.0/16"
@@ -13,14 +11,12 @@ resource "google_compute_subnetwork" "subnet" {
 }
 
 resource "google_compute_router" "router" {
-  provider = google-beta
   name    = "<%= ctx[:vars]['router_name'] %>"
   region  = google_compute_subnetwork.subnet.region
   network = google_compute_network.net.id
 }
 
 resource "google_compute_router_route_policy" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
   router = google_compute_router.router.name
   region = google_compute_router.router.region
 	name = "<%= ctx[:vars]['route_policy_name'] %>"

--- a/mmv1/templates/terraform/examples/router_route_policy_export.tf.erb
+++ b/mmv1/templates/terraform/examples/router_route_policy_export.tf.erb
@@ -1,0 +1,37 @@
+resource "google_compute_network" "net" {
+  provider = google-beta
+  name                    = "<%= ctx[:vars]['network_name'] %>"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  provider = google-beta
+  name          = "<%= ctx[:vars]['subnet_name'] %>"
+  network       = google_compute_network.net.id
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+}
+
+resource "google_compute_router" "router" {
+  provider = google-beta
+  name    = "<%= ctx[:vars]['router_name'] %>"
+  region  = google_compute_subnetwork.subnet.region
+  network = google_compute_network.net.id
+}
+
+resource "google_compute_router_route_policy" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+  router = google_compute_router.router.name
+  region = google_compute_router.router.region
+	name = "<%= ctx[:vars]['route_policy_name'] %>"
+	type = "ROUTE_POLICY_TYPE_EXPORT"
+	terms {
+    priority = 1
+    match {
+      expression = "destination == '10.0.0.0/12'"
+	  }
+    actions {
+		  expression = "accept()"
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/router_route_policy_import.tf.erb
+++ b/mmv1/templates/terraform/examples/router_route_policy_import.tf.erb
@@ -31,7 +31,7 @@ resource "google_compute_router_route_policy" "<%= ctx[:primary_resource_id] %>"
       expression = "destination == '10.0.0.0/12'"
 	  }
     actions {
-		  expression = "accept()"
+      expression = "accept()"
     }
   }
 }

--- a/mmv1/templates/terraform/examples/router_route_policy_import.tf.erb
+++ b/mmv1/templates/terraform/examples/router_route_policy_import.tf.erb
@@ -1,0 +1,37 @@
+resource "google_compute_network" "net" {
+  provider = google-beta
+  name                    = "<%= ctx[:vars]['network_name'] %>"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  provider = google-beta
+  name          = "<%= ctx[:vars]['subnet_name'] %>"
+  network       = google_compute_network.net.id
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+}
+
+resource "google_compute_router" "router" {
+  provider = google-beta
+  name    = "<%= ctx[:vars]['router_name'] %>"
+  region  = google_compute_subnetwork.subnet.region
+  network = google_compute_network.net.id
+}
+
+resource "google_compute_router_route_policy" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+	name = "<%= ctx[:vars]['route_policy_name'] %>"
+  router = google_compute_router.router.name
+  region = google_compute_router.router.region
+	type = "ROUTE_POLICY_TYPE_IMPORT"
+	terms {
+    priority = 2
+    match {
+      expression = "destination == '10.0.0.0/12'"
+	  }
+    actions {
+		  expression = "accept()"
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/router_route_policy_import.tf.erb
+++ b/mmv1/templates/terraform/examples/router_route_policy_import.tf.erb
@@ -1,11 +1,9 @@
 resource "google_compute_network" "net" {
-  provider = google-beta
   name                    = "<%= ctx[:vars]['network_name'] %>"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "subnet" {
-  provider = google-beta
   name          = "<%= ctx[:vars]['subnet_name'] %>"
   network       = google_compute_network.net.id
   ip_cidr_range = "10.0.0.0/16"
@@ -13,14 +11,12 @@ resource "google_compute_subnetwork" "subnet" {
 }
 
 resource "google_compute_router" "router" {
-  provider = google-beta
   name    = "<%= ctx[:vars]['router_name'] %>"
   region  = google_compute_subnetwork.subnet.region
   network = google_compute_network.net.id
 }
 
 resource "google_compute_router_route_policy" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
 	name = "<%= ctx[:vars]['route_policy_name'] %>"
   router = google_compute_router.router.name
   region = google_compute_router.router.region

--- a/mmv1/templates/terraform/examples/router_route_policy_import.tf.erb
+++ b/mmv1/templates/terraform/examples/router_route_policy_import.tf.erb
@@ -1,9 +1,11 @@
 resource "google_compute_network" "net" {
+  provider = google-beta
   name                    = "<%= ctx[:vars]['network_name'] %>"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "subnet" {
+  provider = google-beta
   name          = "<%= ctx[:vars]['subnet_name'] %>"
   network       = google_compute_network.net.id
   ip_cidr_range = "10.0.0.0/16"
@@ -11,12 +13,14 @@ resource "google_compute_subnetwork" "subnet" {
 }
 
 resource "google_compute_router" "router" {
+  provider = google-beta
   name    = "<%= ctx[:vars]['router_name'] %>"
   region  = google_compute_subnetwork.subnet.region
   network = google_compute_network.net.id
 }
 
 resource "google_compute_router_route_policy" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
 	name = "<%= ctx[:vars]['route_policy_name'] %>"
   router = google_compute_router.router.name
   region = google_compute_router.router.region

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.erb
@@ -738,11 +738,13 @@ func testAccComputeRouterPeerWithMd5AuthKey(routerName string) string {
 func testAccComputeRouterWithRoutePolicies(routerName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
+  provider = google-beta
   name = "%s-net"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "foobar" {
+  provider = google-beta
   name          = "%s-subnet"
   network       = google_compute_network.foobar.self_link
   ip_cidr_range = "10.0.0.0/16"
@@ -750,17 +752,20 @@ resource "google_compute_subnetwork" "foobar" {
 }
 
 resource "google_compute_address" "foobar" {
+  provider = google-beta
   name   = "%s"
   region = google_compute_subnetwork.foobar.region
 }
 
 resource "google_compute_ha_vpn_gateway" "foobar" {
+  provider = google-beta
   name    = "%s-gateway"
   network = google_compute_network.foobar.self_link
   region  = google_compute_subnetwork.foobar.region
 }
 
 resource "google_compute_external_vpn_gateway" "external_gateway" {
+  provider = google-beta
   name            = "%s-external-gateway"
   redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
   description     = "An externally managed VPN gateway"
@@ -771,6 +776,7 @@ resource "google_compute_external_vpn_gateway" "external_gateway" {
 }
 
 resource "google_compute_router" "foobar" {
+  provider = google-beta
   name    = "%s"
   region  = google_compute_subnetwork.foobar.region
   network = google_compute_network.foobar.self_link
@@ -780,6 +786,7 @@ resource "google_compute_router" "foobar" {
 }
 
 resource "google_compute_vpn_tunnel" "foobar" {
+  provider = google-beta
   name               = "%s"
   region             = google_compute_subnetwork.foobar.region
   vpn_gateway = google_compute_ha_vpn_gateway.foobar.id
@@ -791,6 +798,7 @@ resource "google_compute_vpn_tunnel" "foobar" {
 }
 
 resource "google_compute_router_interface" "foobar" {
+  provider = google-beta
   name       = "%s"
   router     = google_compute_router.foobar.name
   region     = google_compute_router.foobar.region
@@ -798,6 +806,7 @@ resource "google_compute_router_interface" "foobar" {
 }
 
 resource "google_compute_router_route_policy" "rp-export" {
+  provider = google-beta
 	name = "%s-rp-export"
   router = google_compute_router.foobar.name
   region = google_compute_router.foobar.region
@@ -823,6 +832,7 @@ resource "google_compute_router_route_policy" "rp-export" {
 }
 
 resource "google_compute_router_route_policy" "rp-import" {
+  provider = google-beta
   name = "%s-rp-import"
   router = google_compute_router.foobar.name
   region = google_compute_router.foobar.region
@@ -848,6 +858,7 @@ resource "google_compute_router_route_policy" "rp-import" {
 }
 
 resource "google_compute_router_peer" "foobar" {
+  provider = google-beta
   name                      = "%s-peer"
   router                    = google_compute_router.foobar.name
   region                    = google_compute_router.foobar.region

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.erb
@@ -738,13 +738,11 @@ func testAccComputeRouterPeerWithMd5AuthKey(routerName string) string {
 func testAccComputeRouterWithRoutePolicies(routerName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
-  provider = google-beta
   name = "%s-net"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "foobar" {
-  provider = google-beta
   name          = "%s-subnet"
   network       = google_compute_network.foobar.self_link
   ip_cidr_range = "10.0.0.0/16"
@@ -752,20 +750,17 @@ resource "google_compute_subnetwork" "foobar" {
 }
 
 resource "google_compute_address" "foobar" {
-  provider = google-beta
   name   = "%s"
   region = google_compute_subnetwork.foobar.region
 }
 
 resource "google_compute_ha_vpn_gateway" "foobar" {
-  provider = google-beta
   name    = "%s-gateway"
   network = google_compute_network.foobar.self_link
   region  = google_compute_subnetwork.foobar.region
 }
 
 resource "google_compute_external_vpn_gateway" "external_gateway" {
-  provider = google-beta
   name            = "%s-external-gateway"
   redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
   description     = "An externally managed VPN gateway"
@@ -776,7 +771,6 @@ resource "google_compute_external_vpn_gateway" "external_gateway" {
 }
 
 resource "google_compute_router" "foobar" {
-  provider = google-beta
   name    = "%s"
   region  = google_compute_subnetwork.foobar.region
   network = google_compute_network.foobar.self_link
@@ -786,7 +780,6 @@ resource "google_compute_router" "foobar" {
 }
 
 resource "google_compute_vpn_tunnel" "foobar" {
-  provider = google-beta
   name               = "%s"
   region             = google_compute_subnetwork.foobar.region
   vpn_gateway = google_compute_ha_vpn_gateway.foobar.id
@@ -798,7 +791,6 @@ resource "google_compute_vpn_tunnel" "foobar" {
 }
 
 resource "google_compute_router_interface" "foobar" {
-  provider = google-beta
   name       = "%s"
   router     = google_compute_router.foobar.name
   region     = google_compute_router.foobar.region
@@ -806,7 +798,6 @@ resource "google_compute_router_interface" "foobar" {
 }
 
 resource "google_compute_router_route_policy" "rp-export" {
-  provider = google-beta
 	name = "%s-rp-export"
   router = google_compute_router.foobar.name
   region = google_compute_router.foobar.region
@@ -832,7 +823,6 @@ resource "google_compute_router_route_policy" "rp-export" {
 }
 
 resource "google_compute_router_route_policy" "rp-import" {
-  provider = google-beta
   name = "%s-rp-import"
   router = google_compute_router.foobar.name
   region = google_compute_router.foobar.region
@@ -858,7 +848,6 @@ resource "google_compute_router_route_policy" "rp-import" {
 }
 
 resource "google_compute_router_peer" "foobar" {
-  provider = google-beta
   name                      = "%s-peer"
   router                    = google_compute_router.foobar.name
   region                    = google_compute_router.foobar.region

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.erb
@@ -398,6 +398,29 @@ func TestAccComputeRouterPeer_UpdateMd5AuthenticationKey(t *testing.T) {
 	})
 }
 
+func TestAccComputeRouterPeer_addImportAndExportPolicy(t *testing.T) {
+  t.Parallel()
+
+  routerName := fmt.Sprintf("tf-test-router-%s", acctest.RandString(t, 10))
+	resourceName := "google_compute_router_peer.foobar"
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckComputeRouterPeerDestroyProducer(t),
+    Steps: []resource.TestStep{
+      {
+        Config: testAccComputeRouterWithRoutePolicies(routerName),
+        Check: resource.ComposeTestCheckFunc(
+          resource.TestCheckResourceAttr(resourceName, "import_policies.#", "1"),
+          resource.TestCheckResourceAttr(resourceName, "import_policies.0", fmt.Sprintf("%s-rp-import", routerName)),
+          resource.TestCheckResourceAttr(resourceName, "export_policies.#", "1"),
+          resource.TestCheckResourceAttr(resourceName, "export_policies.0", fmt.Sprintf("%s-rp-export", routerName)),
+        ),
+      },
+    },
+  })
+}
+
 func testAccCheckComputeRouterPeerDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
@@ -710,6 +733,142 @@ func testAccComputeRouterPeerWithMd5AuthKey(routerName string) string {
   }
 `, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName,
 		routerName, routerName)
+}
+
+func testAccComputeRouterWithRoutePolicies(routerName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  provider = google-beta
+  name = "%s-net"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "foobar" {
+  provider = google-beta
+  name          = "%s-subnet"
+  network       = google_compute_network.foobar.self_link
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+}
+
+resource "google_compute_address" "foobar" {
+  provider = google-beta
+  name   = "%s"
+  region = google_compute_subnetwork.foobar.region
+}
+
+resource "google_compute_ha_vpn_gateway" "foobar" {
+  provider = google-beta
+  name    = "%s-gateway"
+  network = google_compute_network.foobar.self_link
+  region  = google_compute_subnetwork.foobar.region
+}
+
+resource "google_compute_external_vpn_gateway" "external_gateway" {
+  provider = google-beta
+  name            = "%s-external-gateway"
+  redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
+  description     = "An externally managed VPN gateway"
+  interface {
+    id         = 0
+    ip_address = "8.8.8.8"
+  }
+}
+
+resource "google_compute_router" "foobar" {
+  provider = google-beta
+  name    = "%s"
+  region  = google_compute_subnetwork.foobar.region
+  network = google_compute_network.foobar.self_link
+  bgp {
+    asn = 64514
+  }
+}
+
+resource "google_compute_vpn_tunnel" "foobar" {
+  provider = google-beta
+  name               = "%s"
+  region             = google_compute_subnetwork.foobar.region
+  vpn_gateway = google_compute_ha_vpn_gateway.foobar.id
+  peer_external_gateway           = google_compute_external_vpn_gateway.external_gateway.id
+  peer_external_gateway_interface = 0  
+  shared_secret      = "unguessable"
+  router             = google_compute_router.foobar.name
+  vpn_gateway_interface           = 0
+}
+
+resource "google_compute_router_interface" "foobar" {
+  provider = google-beta
+  name       = "%s"
+  router     = google_compute_router.foobar.name
+  region     = google_compute_router.foobar.region
+  vpn_tunnel = google_compute_vpn_tunnel.foobar.name
+}
+
+resource "google_compute_router_route_policy" "rp-export" {
+  provider = google-beta
+	name = "%s-rp-export"
+  router = google_compute_router.foobar.name
+  region = google_compute_router.foobar.region
+  type = "ROUTE_POLICY_TYPE_EXPORT"
+	terms {
+    priority = 2
+    match {
+      expression = "destination == '10.0.0.0/12'"
+      title      = "export_expression"
+      description = "acceptance expression for export"
+    }
+    actions {
+	    expression = "accept()"
+    }
+  }
+  depends_on = [
+    google_compute_router_interface.foobar
+  ]
+}
+
+resource "google_compute_router_route_policy" "rp-import" {
+  provider = google-beta
+  name = "%s-rp-import"
+  router = google_compute_router.foobar.name
+  region = google_compute_router.foobar.region
+	type = "ROUTE_POLICY_TYPE_IMPORT"
+  terms {
+    priority = 1
+    match {
+      expression = "destination == '10.0.0.0/12'"
+      title      = "import_expression"
+      description = "acceptance expression for import"
+	  }
+    actions {
+		  expression = "accept()"
+    }
+  }
+  depends_on = [
+    google_compute_router_interface.foobar, google_compute_router_route_policy.rp-export
+  ]
+}
+
+resource "google_compute_router_peer" "foobar" {
+  provider = google-beta
+  name                      = "%s-peer"
+  router                    = google_compute_router.foobar.name
+  region                    = google_compute_router.foobar.region
+  peer_asn                  = 65515
+  advertised_route_priority = 100
+  interface                 = google_compute_router_interface.foobar.name
+  md5_authentication_key {
+    name = "%s-peer-key"
+    key = "%s-peer-key-value"
+  }
+  import_policies           = [google_compute_router_route_policy.rp-import.name]
+  export_policies           = [google_compute_router_route_policy.rp-export.name]
+  depends_on = [
+    google_compute_router_route_policy.rp-export, google_compute_router_route_policy.rp-import, google_compute_router_interface.foobar
+  ]
+}
+  `, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName,
+		routerName, routerName, routerName, routerName)
 }
 
 func testAccComputeRouterPeerWithMd5AuthKeyUpdate(routerName string) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.erb
@@ -398,6 +398,7 @@ func TestAccComputeRouterPeer_UpdateMd5AuthenticationKey(t *testing.T) {
 	})
 }
 
+<% unless version == "ga" -%>
 func TestAccComputeRouterPeer_addImportAndExportPolicy(t *testing.T) {
   t.Parallel()
 
@@ -420,6 +421,7 @@ func TestAccComputeRouterPeer_addImportAndExportPolicy(t *testing.T) {
     },
   })
 }
+<% end -%>
 
 func testAccCheckComputeRouterPeerDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
@@ -735,6 +737,7 @@ func testAccComputeRouterPeerWithMd5AuthKey(routerName string) string {
 		routerName, routerName)
 }
 
+<% unless version == "ga" -%>
 func testAccComputeRouterWithRoutePolicies(routerName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
@@ -878,6 +881,7 @@ resource "google_compute_router_peer" "foobar" {
   `, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName,
 		routerName, routerName, routerName, routerName)
 }
+<% end -%>
 
 func testAccComputeRouterPeerWithMd5AuthKeyUpdate(routerName string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.erb
@@ -817,9 +817,13 @@ resource "google_compute_router_route_policy" "rp-export" {
       expression = "destination == '10.0.0.0/12'"
       title      = "export_expression"
       description = "acceptance expression for export"
+      location = "location of the expression"
     }
     actions {
-	    expression = "accept()"
+      expression = "accept()"
+      title      = "export_action"
+      description = "acceptance action for export"
+      location = "location of the expression"
     }
   }
   depends_on = [
@@ -839,9 +843,13 @@ resource "google_compute_router_route_policy" "rp-import" {
       expression = "destination == '10.0.0.0/12'"
       title      = "import_expression"
       description = "acceptance expression for import"
+      location = "location of the expression"
 	  }
     actions {
-		  expression = "accept()"
+      expression = "accept()"
+      title      = "import_action"
+      description = "acceptance action for import"
+      location = "location of the expression"
     }
   }
   depends_on = [

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
@@ -263,6 +263,7 @@ assigns unused addresses from the 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64 range
 				ValidateFunc: verify.ValidateIpAddress,
 				Description:  `IPv4 address of the BGP interface outside Google Cloud Platform.`,
 			},
+<% unless version == "ga" -%>
 			"export_policies": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -287,6 +288,7 @@ Please use Beta API to use Route Policies.`,
 					Type: schema.TypeString,
 				},
 			},
+<% end -%>
 			"region": {
 				Type:             schema.TypeString,
 				Computed:         true,
@@ -457,6 +459,7 @@ func resourceComputeRouterBgpPeerCreate(d *schema.ResourceData, meta interface{}
 	} else if v, ok := d.GetOkExists("peer_ipv6_nexthop_address"); !tpgresource.IsEmptyValue(reflect.ValueOf(peerIpv4NexthopAddressProp)) && (ok || !reflect.DeepEqual(v, peerIpv4NexthopAddressProp)) {
 		obj["peerIpv4NexthopAddress"] = peerIpv4NexthopAddressProp
 	}
+<% unless version == "ga" -%>
 	exportPoliciesProp, err := expandNestedComputeRouterBgpPeerExportPolicies(d.Get("export_policies"), d, config)
 	if err != nil {
 		return err
@@ -469,6 +472,7 @@ func resourceComputeRouterBgpPeerCreate(d *schema.ResourceData, meta interface{}
 	} else if v, ok := d.GetOkExists("import_policies"); ok || !reflect.DeepEqual(v, importPoliciesProp) {
 		obj["importPolicies"] = importPoliciesProp
 	}
+<% end -%>
 	ipv6NexthopAddressProp, err := expandNestedComputeRouterBgpPeerIpv6NexthopAddress(d.Get("ipv6_nexthop_address"), d, config)
 	if err != nil {
 		return err
@@ -669,12 +673,14 @@ func resourceComputeRouterBgpPeerRead(d *schema.ResourceData, meta interface{}) 
 	if err := d.Set("peer_ipv4_nexthop_address", flattenNestedComputeRouterBgpPeerPeerIpv4NexthopAddress(res["peerIpv4NexthopAddress"], d, config)); err != nil {
 		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
 	}
+<% unless version == "ga" -%>
 	if err := d.Set("export_policies", flattenNestedComputeRouterBgpPeerExportPolicies(res["exportPolicies"], d, config)); err != nil {
 		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
 	}
 	if err := d.Set("import_policies", flattenNestedComputeRouterBgpPeerImportPolicies(res["importPolicies"], d, config)); err != nil {
 		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
 	}
+<% end -%>
 	if err := d.Set("ipv6_nexthop_address", flattenNestedComputeRouterBgpPeerIpv6NexthopAddress(res["ipv6NexthopAddress"], d, config)); err != nil {
 		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
 	}
@@ -788,6 +794,7 @@ func resourceComputeRouterBgpPeerUpdate(d *schema.ResourceData, meta interface{}
 	} else if v, ok := d.GetOkExists("peer_ipv4_nexthop_address"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, peerIpv4NexthopAddressProp)) {
 		obj["peerIpv4NexthopAddress"] = peerIpv4NexthopAddressProp
 	}
+<% unless version == "ga" -%>
 	exportPoliciesProp, err := expandNestedComputeRouterBgpPeerExportPolicies(d.Get("export_policies"), d, config)
 	if err != nil {
 		return err
@@ -800,6 +807,7 @@ func resourceComputeRouterBgpPeerUpdate(d *schema.ResourceData, meta interface{}
 	} else if v, ok := d.GetOkExists("import_policies"); ok || !reflect.DeepEqual(v, importPoliciesProp) {
 		obj["importPolicies"] = importPoliciesProp
 	}
+<% end -%>
 	ipv6NexthopAddressProp, err := expandNestedComputeRouterBgpPeerIpv6NexthopAddress(d.Get("ipv6_nexthop_address"), d, config)
 	if err != nil {
 		return err
@@ -1185,6 +1193,7 @@ func flattenNestedComputeRouterBgpPeerPeerIpv4NexthopAddress(v interface{}, d *s
 	return v
 }
 
+<% unless version == "ga" -%>
 func flattenNestedComputeRouterBgpPeerExportPolicies(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	return v
 }
@@ -1192,6 +1201,7 @@ func flattenNestedComputeRouterBgpPeerExportPolicies(v interface{}, d *schema.Re
 func flattenNestedComputeRouterBgpPeerImportPolicies(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	return v
 }
+<% end -%>
 
 func flattenNestedComputeRouterBgpPeerIpv6NexthopAddress(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	return v
@@ -1392,6 +1402,7 @@ func expandNestedComputeRouterBgpPeerPeerIpv4NexthopAddress(v interface{}, d tpg
 	return v, nil
 }
 
+<% unless version == "ga" -%>
 func expandNestedComputeRouterBgpPeerExportPolicies(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
 	return v, nil
 }
@@ -1399,6 +1410,7 @@ func expandNestedComputeRouterBgpPeerExportPolicies(v interface{}, d tpgresource
 func expandNestedComputeRouterBgpPeerImportPolicies(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
 	return v, nil
 }
+<% end -%>
 
 func expandNestedComputeRouterBgpPeerIpv6NexthopAddress(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
 	return v, nil

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
@@ -263,6 +263,30 @@ assigns unused addresses from the 2600:2d00:0:2::/64 or 2600:2d00:0:3::/64 range
 				ValidateFunc: verify.ValidateIpAddress,
 				Description:  `IPv4 address of the BGP interface outside Google Cloud Platform.`,
 			},
+			"export_policies": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Description: `routers.list of export policies applied to this peer, in the order they must be evaluated. 
+The name must correspond to an existing policy that has ROUTE_POLICY_TYPE_EXPORT type.
+
+Note that Route Policies are currently available in preview. 
+Please use Beta API to use Route Policies.`,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"import_policies": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Description: `routers.list of import policies applied to this peer, in the order they must be evaluated. 
+The name must correspond to an existing policy that has ROUTE_POLICY_TYPE_IMPORT type.
+
+Note that Route Policies are currently available in preview. 
+Please use Beta API to use Route Policies.`,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"region": {
 				Type:             schema.TypeString,
 				Computed:         true,
@@ -432,6 +456,18 @@ func resourceComputeRouterBgpPeerCreate(d *schema.ResourceData, meta interface{}
 		return err
 	} else if v, ok := d.GetOkExists("peer_ipv6_nexthop_address"); !tpgresource.IsEmptyValue(reflect.ValueOf(peerIpv4NexthopAddressProp)) && (ok || !reflect.DeepEqual(v, peerIpv4NexthopAddressProp)) {
 		obj["peerIpv4NexthopAddress"] = peerIpv4NexthopAddressProp
+	}
+	exportPoliciesProp, err := expandNestedComputeRouterBgpPeerExportPolicies(d.Get("export_policies"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("export_policies"); ok || !reflect.DeepEqual(v, exportPoliciesProp) {
+		obj["exportPolicies"] = exportPoliciesProp
+	}
+	importPoliciesProp, err := expandNestedComputeRouterBgpPeerImportPolicies(d.Get("import_policies"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("import_policies"); ok || !reflect.DeepEqual(v, importPoliciesProp) {
+		obj["importPolicies"] = importPoliciesProp
 	}
 	ipv6NexthopAddressProp, err := expandNestedComputeRouterBgpPeerIpv6NexthopAddress(d.Get("ipv6_nexthop_address"), d, config)
 	if err != nil {
@@ -633,6 +669,12 @@ func resourceComputeRouterBgpPeerRead(d *schema.ResourceData, meta interface{}) 
 	if err := d.Set("peer_ipv4_nexthop_address", flattenNestedComputeRouterBgpPeerPeerIpv4NexthopAddress(res["peerIpv4NexthopAddress"], d, config)); err != nil {
 		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
 	}
+	if err := d.Set("export_policies", flattenNestedComputeRouterBgpPeerExportPolicies(res["exportPolicies"], d, config)); err != nil {
+		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
+	}
+	if err := d.Set("import_policies", flattenNestedComputeRouterBgpPeerImportPolicies(res["importPolicies"], d, config)); err != nil {
+		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
+	}
 	if err := d.Set("ipv6_nexthop_address", flattenNestedComputeRouterBgpPeerIpv6NexthopAddress(res["ipv6NexthopAddress"], d, config)); err != nil {
 		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
 	}
@@ -745,6 +787,18 @@ func resourceComputeRouterBgpPeerUpdate(d *schema.ResourceData, meta interface{}
 		return err
 	} else if v, ok := d.GetOkExists("peer_ipv4_nexthop_address"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, peerIpv4NexthopAddressProp)) {
 		obj["peerIpv4NexthopAddress"] = peerIpv4NexthopAddressProp
+	}
+	exportPoliciesProp, err := expandNestedComputeRouterBgpPeerExportPolicies(d.Get("export_policies"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("export_policies"); ok || !reflect.DeepEqual(v, exportPoliciesProp) {
+		obj["exportPolicies"] = exportPoliciesProp
+	}
+	importPoliciesProp, err := expandNestedComputeRouterBgpPeerImportPolicies(d.Get("import_policies"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("import_policies"); ok || !reflect.DeepEqual(v, importPoliciesProp) {
+		obj["importPolicies"] = importPoliciesProp
 	}
 	ipv6NexthopAddressProp, err := expandNestedComputeRouterBgpPeerIpv6NexthopAddress(d.Get("ipv6_nexthop_address"), d, config)
 	if err != nil {
@@ -1131,6 +1185,14 @@ func flattenNestedComputeRouterBgpPeerPeerIpv4NexthopAddress(v interface{}, d *s
 	return v
 }
 
+func flattenNestedComputeRouterBgpPeerExportPolicies(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenNestedComputeRouterBgpPeerImportPolicies(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
 func flattenNestedComputeRouterBgpPeerIpv6NexthopAddress(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	return v
 }
@@ -1327,6 +1389,14 @@ func expandNestedComputeRouterBgpPeerIpv4NexthopAddress(v interface{}, d tpgreso
 }
 
 func expandNestedComputeRouterBgpPeerPeerIpv4NexthopAddress(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandNestedComputeRouterBgpPeerExportPolicies(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandNestedComputeRouterBgpPeerImportPolicies(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
 	return v, nil
 }
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_router_peer.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_router_peer.html.markdown
@@ -202,6 +202,141 @@ resource "google_compute_router_peer" "peer" {
   }
 ```
 
+## Example Usage - Router peer export and import policies
+
+```hcl
+  resource "google_compute_network" "network" {
+  provider = google-beta
+  name = "my-router-net"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  provider = google-beta
+  name          = "my-router-subnet"
+  network       = google_compute_network.network.self_link
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+}
+
+resource "google_compute_address" "address" {
+  provider = google-beta
+  name   = "my-router"
+  region = google_compute_subnetwork.subnetwork.region
+}
+
+resource "google_compute_ha_vpn_gateway" "vpn_gateway" {
+  provider = google-beta
+  name    = "my-router-gateway"
+  network = google_compute_network.network.self_link
+  region  = google_compute_subnetwork.subnetwork.region
+}
+
+resource "google_compute_external_vpn_gateway" "external_gateway" {
+  provider = google-beta
+  name            = "my-router-external-gateway"
+  redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
+  description     = "An externally managed VPN gateway"
+  interface {
+    id         = 0
+    ip_address = "8.8.8.8"
+  }
+}
+
+resource "google_compute_router" "router" {
+  provider = google-beta
+  name    = "my-router"
+  region  = google_compute_subnetwork.subnetwork.region
+  network = google_compute_network.network.self_link
+  bgp {
+    asn = 64514
+  }
+}
+
+resource "google_compute_vpn_tunnel" "vpn_tunnel" {
+  provider = google-beta
+  name               = "my-router"
+  region             = google_compute_subnetwork.subnetwork.region
+  vpn_gateway = google_compute_ha_vpn_gateway.vpn_gateway.id
+  peer_external_gateway           = google_compute_external_vpn_gateway.external_gateway.id
+  peer_external_gateway_interface = 0  
+  shared_secret      = "unguessable"
+  router             = google_compute_router.router.name
+  vpn_gateway_interface           = 0
+}
+
+resource "google_compute_router_interface" "router_interface" {
+  provider = google-beta
+  name       = "my-router"
+  router     = google_compute_router.router.name
+  region     = google_compute_router.router.region
+  vpn_tunnel = google_compute_vpn_tunnel.vpn_tunnel.name
+}
+
+resource "google_compute_router_route_policy" "rp-export" {
+  provider = google-beta
+	name = "my-router-rp-export"
+  router = google_compute_router.router.name
+  region = google_compute_router.router.region
+  type = "ROUTE_POLICY_TYPE_EXPORT"
+	terms {
+    priority = 2
+    match {
+      expression = "destination == '10.0.0.0/12'"
+      title      = "export_expression"
+      description = "acceptance expression for export"
+    }
+    actions {
+	    expression = "accept()"
+    }
+  }
+  depends_on = [
+    google_compute_router_interface.router_interface
+  ]
+}
+
+resource "google_compute_router_route_policy" "rp-import" {
+  provider = google-beta
+  name = "my-router-rp-import"
+  router = google_compute_router.router.name
+  region = google_compute_router.router.region
+	type = "ROUTE_POLICY_TYPE_IMPORT"
+  terms {
+    priority = 1
+    match {
+      expression = "destination == '10.0.0.0/12'"
+      title      = "import_expression"
+      description = "acceptance expression for import"
+	  }
+    actions {
+		  expression = "accept()"
+    }
+  }
+  depends_on = [
+    google_compute_router_interface.router_interface, google_compute_router_route_policy.rp-export
+  ]
+}
+
+resource "google_compute_router_peer" "router_peer" {
+  provider = google-beta
+  name                      = "my-router-peer"
+  router                    = google_compute_router.router.name
+  region                    = google_compute_router.router.region
+  peer_asn                  = 65515
+  advertised_route_priority = 100
+  interface                 = google_compute_router_interface.router_interface.name
+  md5_authentication_key {
+    name = "my-router-peer-key"
+    key = "my-router-peer-key-value"
+  }
+  import_policies           = [google_compute_router_route_policy.rp-import.name]
+  export_policies           = [google_compute_router_route_policy.rp-export.name]
+  depends_on = [
+    google_compute_router_route_policy.rp-export, google_compute_router_route_policy.rp-import, google_compute_router_interface.router_interface
+  ]
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -326,6 +461,16 @@ The following arguments are supported:
 * `peer_ipv4_nexthop_address` -
   (Optional)
   IPv4 address of the BGP interface outside Google Cloud Platform.
+
+*  `export_policies` -
+  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) 
+  routers.list of export policies applied to this peer, in the order they must be evaluated. 
+  The name must correspond to an existing policy that has ROUTE_POLICY_TYPE_EXPORT type.
+
+*  `import_policies` -
+  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) 
+  routers.list of import policies applied to this peer, in the order they must be evaluated. 
+  The name must correspond to an existing policy that has ROUTE_POLICY_TYPE_IMPORT type.
 
 * `region` -
   (Optional)

--- a/mmv1/third_party/terraform/website/docs/r/compute_router_peer.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_router_peer.html.markdown
@@ -287,7 +287,7 @@ resource "google_compute_router_route_policy" "rp-export" {
       description = "acceptance expression for export"
     }
     actions {
-	    expression = "accept()"
+      expression = "accept()"
     }
   }
   depends_on = [
@@ -309,7 +309,7 @@ resource "google_compute_router_route_policy" "rp-import" {
       description = "acceptance expression for import"
 	  }
     actions {
-		  expression = "accept()"
+      expression = "accept()"
     }
   }
   depends_on = [


### PR DESCRIPTION
This PR adds support for export_policies and import_policies on BGP peer in Router resource.
API to create a route policy: https://cloud.google.com/compute/docs/reference/rest/beta/routers/updateRoutePolicy
API to add import and export policies to BGP peer: https://cloud.google.com/compute/docs/reference/rest/beta/routers/update

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_compute_router_route_policy`
```

```release-note:enhancement
compute: added `export_policies` and `import_policies` fields  to `google_compute_router_peer` resource
```