### PR TITLE
feat: datastream sql server connection profile/stream from beta to GA

### DIFF
--- a/mmv1/products/datastream/ConnectionProfile.yaml
+++ b/mmv1/products/datastream/ConnectionProfile.yaml
@@ -74,7 +74,6 @@ examples:
     skip_test: true
   - !ruby/object:Provider::Terraform::Examples
     name: 'datastream_connection_profile_sql_server'
-    min_version: beta
     primary_resource_id: 'default'
     skip_test: true
     vars:
@@ -321,7 +320,6 @@ properties:
           Database for the PostgreSQL connection.
   - !ruby/object:Api::Type::NestedObject
     name: 'sqlServerProfile'
-    min_version: beta
     exactly_one_of:
       - oracle_profile
       - gcs_profile

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -109,7 +109,6 @@ examples:
       destination_connection_profile_id: 'destination-profile'
   - !ruby/object:Provider::Terraform::Examples
     name: 'datastream_stream_sql_server'
-    min_version: beta
     primary_resource_id: 'default'
     skip_test: true
     vars:
@@ -813,7 +812,6 @@ properties:
               function: 'validation.IntAtLeast(0)'
       - !ruby/object:Api::Type::NestedObject
         name: 'sqlServerSourceConfig'
-        min_version: beta
         allow_empty_object: true
         send_empty_value: true
         exactly_one_of:
@@ -1417,7 +1415,6 @@ properties:
                                 The ordinal position of the column in the table.
       - !ruby/object:Api::Type::NestedObject
         name: 'sqlServerExcludedObjects'
-        min_version: beta
         description: |
           SQL Server data source objects to avoid backfilling.
         properties:

--- a/mmv1/templates/terraform/examples/datastream_connection_profile_sql_server.tf.erb
+++ b/mmv1/templates/terraform/examples/datastream_connection_profile_sql_server.tf.erb
@@ -1,5 +1,4 @@
 resource "google_sql_database_instance" "instance" {
-	provider            = google-beta
     name                = "<%= ctx[:vars]['sql_server_name'] %>"
     database_version    = "SQLSERVER_2019_STANDARD"
     region              = "us-central1"
@@ -35,20 +34,17 @@ resource "google_sql_database_instance" "instance" {
 }
 
 resource "google_sql_database" "db" {
-	provider   = google-beta
     name       = "<%= ctx[:vars]['database_name'] %>"
     instance   = google_sql_database_instance.instance.name
 }
 
 resource "google_sql_user" "user" {
-    provider = google-beta
     name     = "<%= ctx[:vars]['database_user'] %>"
     instance = google_sql_database_instance.instance.name
     password = "<%= ctx[:vars]['database_password'] %>"
 }
 
 resource "google_datastream_connection_profile" "default" {
-    provider              = google-beta
     display_name          = "SQL Server Source"
     location              = "us-central1"
     connection_profile_id = "<%= ctx[:vars]['source_connection_profile_id'] %>"

--- a/mmv1/templates/terraform/examples/datastream_stream_sql_server.tf.erb
+++ b/mmv1/templates/terraform/examples/datastream_stream_sql_server.tf.erb
@@ -1,5 +1,4 @@
 resource "google_sql_database_instance" "instance" {
-    provider            = google-beta
     name                = "<%= ctx[:vars]['sql_server_name'] %>"
     database_version    = "SQLSERVER_2019_STANDARD"
     region              = "us-central1"
@@ -35,21 +34,18 @@ resource "google_sql_database_instance" "instance" {
 }
 
 resource "google_sql_database" "db" {
-    provider   = google-beta
     name       = "<%= ctx[:vars]['database_name'] %>"
     instance   = google_sql_database_instance.instance.name
     depends_on = [google_sql_user.user]
 }
 
 resource "google_sql_user" "user" {
-    provider = google-beta
     name     = "<%= ctx[:vars]['database_user'] %>"
     instance = google_sql_database_instance.instance.name
     password = "<%= ctx[:vars]['database_password'] %>"
 }
 
 resource "google_datastream_connection_profile" "source" {
-    provider              = google-beta
     display_name          = "SQL Server Source"
     location              = "us-central1"
     connection_profile_id = "<%= ctx[:vars]['source_connection_profile_id'] %>"
@@ -64,7 +60,6 @@ resource "google_datastream_connection_profile" "source" {
 }
 
 resource "google_datastream_connection_profile" "destination" {
-    provider              = google-beta
     display_name          = "BigQuery Destination"
     location              = "us-central1"
     connection_profile_id = "<%= ctx[:vars]['destination_connection_profile_id'] %>"
@@ -73,7 +68,6 @@ resource "google_datastream_connection_profile" "destination" {
 }
 
 resource "google_datastream_stream" "default" {
-    provider     = google-beta
     display_name = "SQL Server to BigQuery"
     location     = "us-central1"
     stream_id    = "<%= ctx[:vars]['stream_id'] %>"

--- a/mmv1/templates/terraform/examples/go/datastream_connection_profile_sql_server.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/datastream_connection_profile_sql_server.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_sql_database_instance" "instance" {
-	provider            = google-beta
     name                = "{{index $.Vars "sql_server_name"}}"
     database_version    = "SQLSERVER_2019_STANDARD"
     region              = "us-central1"
@@ -35,20 +34,17 @@ resource "google_sql_database_instance" "instance" {
 }
 
 resource "google_sql_database" "db" {
-	provider   = google-beta
     name       = "{{index $.Vars "database_name"}}"
     instance   = google_sql_database_instance.instance.name
 }
 
 resource "google_sql_user" "user" {
-    provider = google-beta
     name     = "{{index $.Vars "database_user"}}"
     instance = google_sql_database_instance.instance.name
     password = "{{index $.Vars "database_password"}}"
 }
 
 resource "google_datastream_connection_profile" "default" {
-    provider              = google-beta
     display_name          = "SQL Server Source"
     location              = "us-central1"
     connection_profile_id = "{{index $.Vars "source_connection_profile_id"}}"

--- a/mmv1/templates/terraform/examples/go/datastream_stream_sql_server.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/datastream_stream_sql_server.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_sql_database_instance" "instance" {
-    provider            = google-beta
     name                = "{{index $.Vars "sql_server_name"}}"
     database_version    = "SQLSERVER_2019_STANDARD"
     region              = "us-central1"
@@ -35,21 +34,18 @@ resource "google_sql_database_instance" "instance" {
 }
 
 resource "google_sql_database" "db" {
-    provider   = google-beta
     name       = "{{index $.Vars "database_name"}}"
     instance   = google_sql_database_instance.instance.name
     depends_on = [google_sql_user.user]
 }
 
 resource "google_sql_user" "user" {
-    provider = google-beta
     name     = "{{index $.Vars "database_user"}}"
     instance = google_sql_database_instance.instance.name
     password = "{{index $.Vars "database_password"}}"
 }
 
 resource "google_datastream_connection_profile" "source" {
-    provider              = google-beta
     display_name          = "SQL Server Source"
     location              = "us-central1"
     connection_profile_id = "{{index $.Vars "source_connection_profile_id"}}"
@@ -64,7 +60,6 @@ resource "google_datastream_connection_profile" "source" {
 }
 
 resource "google_datastream_connection_profile" "destination" {
-    provider              = google-beta
     display_name          = "BigQuery Destination"
     location              = "us-central1"
     connection_profile_id = "{{index $.Vars "destination_connection_profile_id"}}"
@@ -73,7 +68,6 @@ resource "google_datastream_connection_profile" "destination" {
 }
 
 resource "google_datastream_stream" "default" {
-    provider     = google-beta
     display_name = "SQL Server to BigQuery"
     location     = "us-central1"
     stream_id    = "{{index $.Vars "stream_id"}}"


### PR DESCRIPTION
Change Datastream SQL Server resources to GA

```release-note:enhancement
datastream: promoted `sql_server_profile` field in `google_datastream_connection_profile` resource from beta to GA
```
```release-note:enhancement
datastream: promoted `source_config.sql_server_source_config` and `backfill_all.sql_server_excluded_objects` fields in `google_datastream_stream` resource from beta to GA
```