### PR TITLE
Adding delay after SecuritySettings create to work around API inconsistency

### DIFF
--- a/mmv1/products/dialogflowcx/SecuritySettings.yaml
+++ b/mmv1/products/dialogflowcx/SecuritySettings.yaml
@@ -44,6 +44,8 @@ examples:
       project: :PROJECT_NAME
 id_format: 'projects/{{project}}/locations/{{location}}/securitySettings/{{name}}'
 import_format: ['projects/{{project}}/locations/{{location}}/securitySettings/{{name}}']
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  post_create: templates/terraform/post_create/sleep.go.erb
 properties:
   - !ruby/object:Api::Type::String
     name: 'name'


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

What it says on the tin. The create POST returns an ID that isn't always immediately GETable. Let's wait a few seconds and hope that fixes it.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/18735

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
dialogflowcx: fixed intermittent issues with retrieving resource state soon after creating `google_dialogflow_cx_security_settings` resources
```
