### PR TITLE
Add organization level mute config for SCC v2.

### DIFF
--- a/mmv1/products/securitycenterv2/OrganizationMuteConfig.yaml
+++ b/mmv1/products/securitycenterv2/OrganizationMuteConfig.yaml
@@ -1,0 +1,106 @@
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: 'OrganizationMuteConfig'
+base_url: organizations/{{organization}}/locations/{{location}}/muteConfigs
+self_link: 'organizations/{{organization}}/locations/{{location}}/muteConfigs/{{mute_config_id}}'
+create_url: organizations/{{organization}}/locations/{{location}}/muteConfigs?muteConfigId={{mute_config_id}}
+update_verb: :PATCH
+update_mask: true
+import_format:
+  - 'organizations/{{organization}}/locations/{{location}}/muteConfigs/{{mute_config_id}}'
+description: |
+  Mute Findings is a volume management feature in Security Command Center
+  that lets you manually or programmatically hide irrelevant findings,
+  and create filters to automatically silence existing and future
+  findings based on criteria you specify.
+references: !ruby/object:Api::Resource::ReferenceLinks
+  api: 'https://cloud.google.com/security-command-center/docs/reference/rest/v2/organizations.muteConfigs'
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'scc_v2_organization_mute_config_basic'
+    primary_resource_id: 'default'
+    vars:
+      mute_config_id: 'my-config'
+    test_env_vars:
+      org_id: :ORG_ID
+parameters:
+  - !ruby/object:Api::Type::String
+    name: organization
+    required: true
+    immutable: true
+    url_param_only: true
+    description: |
+      The organization whose Cloud Security Command Center the Mute
+      Config lives in.
+  - !ruby/object:Api::Type::String
+    name: location
+    immutable: true
+    url_param_only: true
+    default_value: global
+    description: |
+      location Id is provided by organization. If not provided, Use global as default.
+  - !ruby/object:Api::Type::String
+    name: mute_config_id
+    required: true
+    immutable: true
+    url_param_only: true
+    description: |
+      Unique identifier provided by the client within the parent scope.
+properties:
+  - !ruby/object:Api::Type::String
+    name: 'name'
+    output: true
+    description: |
+      Name of the mute config. Its format is
+      organizations/{organization}/locations/global/muteConfigs/{configId},
+      folders/{folder}/locations/global/muteConfigs/{configId},
+      or projects/{project}/locations/global/muteConfigs/{configId}
+  - !ruby/object:Api::Type::String
+    name: 'description'
+    description: A description of the mute config.
+  - !ruby/object:Api::Type::String
+    name: 'filter'
+    description: |
+      An expression that defines the filter to apply across create/update
+      events of findings. While creating a filter string, be mindful of
+      the scope in which the mute configuration is being created. E.g.,
+      If a filter contains project = X but is created under the
+      project = Y scope, it might not match any findings.
+    required: true
+  - !ruby/object:Api::Type::String
+    name: 'createTime'
+    description: |
+      The time at which the mute config was created. This field is set by
+      the server and will be ignored if provided on config creation.
+    output: true
+  - !ruby/object:Api::Type::String
+    name: 'updateTime'
+    description: |
+      Output only. The most recent time at which the mute config was
+      updated. This field is set by the server and will be ignored if
+      provided on config creation or update.
+    output: true
+  - !ruby/object:Api::Type::String
+    name: 'mostRecentEditor'
+    description: |
+      Email address of the user who last edited the mute config. This
+      field is set by the server and will be ignored if provided on
+      config creation or update.
+    output: true
+  - !ruby/object:Api::Type::String
+    name: 'type'
+    description: |
+      The type of the mute config.
+    required: true

--- a/mmv1/templates/terraform/examples/scc_v2_organization_mute_config_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/scc_v2_organization_mute_config_basic.tf.erb
@@ -1,0 +1,8 @@
+resource "google_scc_v2_organization_mute_config" "<%= ctx[:primary_resource_id] %>" {
+  mute_config_id    = "<%= ctx[:vars]['mute_config_id'] %>"
+  organization = "<%= ctx[:test_env_vars]['org_id'] %>"
+  location     = "global"
+  description  = "My custom Cloud Security Command Center Finding Organization mute Configuration"
+  filter = "severity = \"HIGH\""
+  type = "STATIC"
+}

--- a/mmv1/third_party/terraform/services/securitycenterv2/resource_scc_v2_organization_mute_config_test.go
+++ b/mmv1/third_party/terraform/services/securitycenterv2/resource_scc_v2_organization_mute_config_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
-func TestAccSecurityCenterV2OrganizationMuteConfig_basic(t *testing.T) {
+func TestAccSecurityCenterV2OrganizationMuteConfig_update(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{

--- a/mmv1/third_party/terraform/services/securitycenterv2/resource_scc_v2_organization_mute_config_test.go
+++ b/mmv1/third_party/terraform/services/securitycenterv2/resource_scc_v2_organization_mute_config_test.go
@@ -1,0 +1,73 @@
+package securitycenterv2_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccSecurityCenterV2OrganizationMuteConfig_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecurityCenterV2OrganizationMuteConfig_basic(context),
+			},
+			{
+				ResourceName:      "google_scc_v2_organization_mute_config.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"organization", "location", "mute_config_id",
+				},
+			},
+			{
+				Config: testAccSecurityCenterV2OrganizationMuteConfig_update(context),
+			},
+			{
+				ResourceName:      "google_scc_v2_organization_mute_config.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"organization", "location", "mute_config_id",
+				},
+			},
+		},
+	})
+}
+
+func testAccSecurityCenterV2OrganizationMuteConfig_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_scc_v2_organization_mute_config" "default" {
+  mute_config_id = "tf-test-config-%{random_suffix}"
+  organization   = "%{org_id}"
+  location       = "global"
+  description    = "A test organization mute config"
+  filter         = "severity = \"HIGH\""
+  type           = "STATIC"
+}
+`, context)
+}
+
+func testAccSecurityCenterV2OrganizationMuteConfig_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_scc_v2_organization_mute_config" "default" {
+  mute_config_id = "tf-test-config-%{random_suffix}"
+  organization   = "%{org_id}"
+  location       = "global"
+  description    = "An updated test organization mute config"
+  filter         = "severity = \"HIGH\""
+  type           = "STATIC"
+}
+`, context)
+}


### PR DESCRIPTION
Adding new template for SCC API V2 Organization Mute Config
https://cloud.google.com/security-command-center/docs/reference/rest/v2/organizations.muteConfigs

Release Note Template for Downstream PRs (will be copied)
`google_scc_v2_organization_mute_config`

```release-note:new-resource
`google_scc_v2_organization_mute_config`
```