### PR TITLE
Use the correct custom import for fields.

### DIFF
--- a/mmv1/products/firestore/Field.yaml
+++ b/mmv1/products/firestore/Field.yaml
@@ -89,7 +89,7 @@ examples:
     test_vars_overrides:
       delete_protection_state: '"DELETE_PROTECTION_DISABLED"'
 custom_code: !ruby/object:Provider::Terraform::CustomCode
-  custom_import: templates/terraform/custom_import/index_self_link_as_name_set_project.go.erb
+  custom_import: templates/terraform/custom_import/firestore_field.go.erb
   encoder: templates/terraform/encoders/firestore_field.go.erb
   custom_delete: templates/terraform/custom_delete/firestore_field_delete.go.erb
   test_check_destroy: templates/terraform/custom_check_destroy/firestore_field.go.erb

--- a/mmv1/third_party/terraform/services/firestore/resource_firestore_field_test.go
+++ b/mmv1/third_party/terraform/services/firestore/resource_firestore_field_test.go
@@ -46,28 +46,25 @@ func testAccFirestoreField_runUpdateTest(updateConfig string, useOwnProject bool
 				Config: testAccFirestoreField_firestoreFieldUpdateInitialExample(context, useOwnProject),
 			},
 			{
-				ResourceName:            fmt.Sprintf("google_firestore_field.%s", resourceName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"database", "collection", "field"},
+				ResourceName:      fmt.Sprintf("google_firestore_field.%s", resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: updateConfig,
 			},
 			{
-				ResourceName:            fmt.Sprintf("google_firestore_field.%s", resourceName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"database", "collection", "field"},
+				ResourceName:      fmt.Sprintf("google_firestore_field.%s", resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccFirestoreField_firestoreFieldUpdateInitialExample(context, useOwnProject),
 			},
 			{
-				ResourceName:            fmt.Sprintf("google_firestore_field.%s", resourceName),
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"database", "collection", "field"},
+				ResourceName:      fmt.Sprintf("google_firestore_field.%s", resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})


### PR DESCRIPTION
Use the correct custom import for fields.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/17313.

Verified with a local `terraform import` followed by `terraform plan`.

```release-note:bug
firestore: fixed missing import of `field` for `google_firestore_field`.
```
