### PR TITLE
Firestore: Mark identifier fields as immutable.

### DIFF
--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -175,7 +175,6 @@ properties:
   - !ruby/object:Api::Type::Enum
     name: type
     required: true
-    immutable: true
     description: |
       The type of the database.
       See https://cloud.google.com/datastore/docs/firestore-or-datastore

--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -175,6 +175,7 @@ properties:
   - !ruby/object:Api::Type::Enum
     name: type
     required: true
+    immutable: true
     description: |
       The type of the database.
       See https://cloud.google.com/datastore/docs/firestore-or-datastore

--- a/mmv1/products/firestore/Document.yaml
+++ b/mmv1/products/firestore/Document.yaml
@@ -64,17 +64,20 @@ parameters:
     default_value: '(default)'
     description: |
       The Firestore database id. Defaults to `"(default)"`.
+    immutable: true
     url_param_only: true
   - !ruby/object:Api::Type::String
     name: 'collection'
     description: |
       The collection ID, relative to database. For example: chatrooms or chatrooms/my-document/private-messages.
     required: true
+    immutable: true
     url_param_only: true
   - !ruby/object:Api::Type::String
     name: 'documentId'
     description: |
       The client-assigned document ID to use for this document during creation.
+    immutable: true
     required: true
     url_param_only: true
 properties:

--- a/mmv1/products/firestore/Field.yaml
+++ b/mmv1/products/firestore/Field.yaml
@@ -99,18 +99,21 @@ properties:
     default_value: '(default)'
     description: |
       The Firestore database id. Defaults to `"(default)"`.
+    immutable: true
     url_param_only: true
   - !ruby/object:Api::Type::String
     name: 'collection'
     description: |
       The id of the collection group to configure.
     required: true
+    immutable: true
     url_param_only: true
   - !ruby/object:Api::Type::String
     name: 'field'
     description: |
       The id of the field to configure.
     required: true
+    immutable: true
     url_param_only: true
   - !ruby/object:Api::Type::String
     name: name


### PR DESCRIPTION
This has the side effect that changing any of these fields will trigger the resource to be deleted and re-created, rather than executing a failed update.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/12897.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
firestore: fixes bug where fields database, collection, document_id, and field on resources could not be updated. 
```
