### PR TITLE
Use new VPC networks in private connection tests

### DIFF
--- a/mmv1/products/databasemigrationservice/PrivateConnection.yaml
+++ b/mmv1/products/databasemigrationservice/PrivateConnection.yaml
@@ -44,8 +44,6 @@ examples:
     vars:
       private_connection_id: 'my-connection'
       network_name: 'my-network'
-    test_vars_overrides:
-      network_name: 'acctest.BootstrapSharedTestNetwork(t, "dbms-privateconnection")'
 parameters:
   - !ruby/object:Api::Type::String
     name: privateConnectionId

--- a/mmv1/templates/terraform/examples/database_migration_service_private_connection.tf.erb
+++ b/mmv1/templates/terraform/examples/database_migration_service_private_connection.tf.erb
@@ -13,6 +13,7 @@ resource "google_database_migration_service_private_connection" "<%= ctx[:primar
 	}
 }
 
-data "google_compute_network" "default" {
+resource "google_compute_network" "default" {
   name = "<%= ctx[:vars]['network_name'] %>"
 }
+

--- a/mmv1/templates/terraform/examples/database_migration_service_private_connection.tf.erb
+++ b/mmv1/templates/terraform/examples/database_migration_service_private_connection.tf.erb
@@ -8,7 +8,7 @@ resource "google_database_migration_service_private_connection" "<%= ctx[:primar
 	}
 
 	vpc_peering_config {
-		vpc_name = data.google_compute_network.default.id
+		vpc_name = resource.google_compute_network.default.id
 		subnet = "10.0.0.0/29"
 	}
 }

--- a/mmv1/templates/terraform/examples/database_migration_service_private_connection.tf.erb
+++ b/mmv1/templates/terraform/examples/database_migration_service_private_connection.tf.erb
@@ -15,5 +15,6 @@ resource "google_database_migration_service_private_connection" "<%= ctx[:primar
 
 resource "google_compute_network" "default" {
   name = "<%= ctx[:vars]['network_name'] %>"
+  auto_create_subnetworks = false
 }
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/17384

The test currently uses a bootstrapped network for creating private connections. When a private connection creation fails, it leaves orphan resources linked to the peered subnet which prevents future runs from using that subnet. 

```release-note:none

```