### PR TITLE
suppress IT_PRIVATE from response to DEDICATED diff

### DIFF
--- a/mmv1/products/compute/Interconnect.yaml
+++ b/mmv1/products/compute/Interconnect.yaml
@@ -59,6 +59,8 @@ examples:
     primary_resource_id: 'example-interconnect'
     vars:
       interconnect_name: 'example-interconnect'
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  constants: templates/terraform/constants/interconnect.go.erb
 properties:
   - !ruby/object:Api::Type::String
     name: 'description'
@@ -120,6 +122,7 @@ properties:
       - :IT_PRIVATE
     required: true
     immutable: true
+    diff_suppress_func: InterconnectTypeDiffSuppress
   - !ruby/object:Api::Type::Boolean
     name: 'adminEnabled'
     send_empty_value: true

--- a/mmv1/templates/terraform/constants/interconnect.go.erb
+++ b/mmv1/templates/terraform/constants/interconnect.go.erb
@@ -1,3 +1,3 @@
 func InterconnectTypeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-    return old == "DEDICATED" && new == "IT_PRIVATE"
+    return old == "IT_PRIVATE" && new == "DEDICATED"
 }

--- a/mmv1/templates/terraform/constants/interconnect.go.erb
+++ b/mmv1/templates/terraform/constants/interconnect.go.erb
@@ -1,0 +1,3 @@
+func InterconnectTypeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+    return old == "DEDICATED" && new == "IT_PRIVATE"
+}

--- a/mmv1/templates/terraform/examples/compute_interconnect_basic_test.tf.erb
+++ b/mmv1/templates/terraform/examples/compute_interconnect_basic_test.tf.erb
@@ -3,7 +3,7 @@ data "google_project" "project" {}
 resource "google_compute_interconnect" "<%= ctx[:primary_resource_id] %>" {
   name                 = "<%= ctx[:vars]['interconnect_name'] %>"
   customer_name        = "internal_customer" # Special customer only available for Google testing.
-  interconnect_type    = "DEDICATED"        # Special type only available for Google testing.
+  interconnect_type    = "DEDICATED"
   link_type            = "LINK_TYPE_ETHERNET_10G_LR"
   location             = "https://www.googleapis.com/compute/v1/projects/${data.google_project.project.name}/global/interconnectLocations/z2z-us-east4-zone1-lciadl-a" # Special location only available for Google testing.
   requested_link_count = 1

--- a/mmv1/templates/terraform/examples/compute_interconnect_basic_test.tf.erb
+++ b/mmv1/templates/terraform/examples/compute_interconnect_basic_test.tf.erb
@@ -3,7 +3,7 @@ data "google_project" "project" {}
 resource "google_compute_interconnect" "<%= ctx[:primary_resource_id] %>" {
   name                 = "<%= ctx[:vars]['interconnect_name'] %>"
   customer_name        = "internal_customer" # Special customer only available for Google testing.
-  interconnect_type    = "IT_PRIVATE"        # Special type only available for Google testing.
+  interconnect_type    = "DEDICATED"        # Special type only available for Google testing.
   link_type            = "LINK_TYPE_ETHERNET_10G_LR"
   location             = "https://www.googleapis.com/compute/v1/projects/${data.google_project.project.name}/global/interconnectLocations/z2z-us-east4-zone1-lciadl-a" # Special location only available for Google testing.
   requested_link_count = 1

--- a/mmv1/templates/terraform/examples/interconnect_attachment_dedicated.tf.erb
+++ b/mmv1/templates/terraform/examples/interconnect_attachment_dedicated.tf.erb
@@ -3,7 +3,7 @@ data "google_project" "project" {}
 resource "google_compute_interconnect" "foobar" {
   name                 = "<%= ctx[:vars]['interconnect_name'] %>"
   customer_name        = "internal_customer" # Special customer only available for Google testing.
-  interconnect_type    = "IT_PRIVATE"        # Special type only available for Google testing.
+  interconnect_type    = "DEDICATED"        # Special type only available for Google testing.
   link_type            = "LINK_TYPE_ETHERNET_10G_LR"
   requested_link_count = 1
   location             = "https://www.googleapis.com/compute/v1/projects/${data.google_project.project.name}/global/interconnectLocations/z2z-us-east4-zone1-lciadl-a" # Special location only available for Google testing.

--- a/mmv1/templates/terraform/examples/interconnect_attachment_dedicated.tf.erb
+++ b/mmv1/templates/terraform/examples/interconnect_attachment_dedicated.tf.erb
@@ -3,7 +3,7 @@ data "google_project" "project" {}
 resource "google_compute_interconnect" "foobar" {
   name                 = "<%= ctx[:vars]['interconnect_name'] %>"
   customer_name        = "internal_customer" # Special customer only available for Google testing.
-  interconnect_type    = "DEDICATED"        # Special type only available for Google testing.
+  interconnect_type    = "DEDICATED"
   link_type            = "LINK_TYPE_ETHERNET_10G_LR"
   requested_link_count = 1
   location             = "https://www.googleapis.com/compute/v1/projects/${data.google_project.project.name}/global/interconnectLocations/z2z-us-east4-zone1-lciadl-a" # Special location only available for Google testing.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
In the interconnect resource, for the interconnect type DEDICATED, the api is responding with IT_PRIVATE type.
The request is to consider IT_PRIVATE and DEDICATED as synonyms in terraform.
Thus this PR to suppress the diff when API responds with IT_PRIVATE for DEDICATED type.

More context is in b/65386683

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: fixed perma-diff for `interconnect_type` being `DEDICATED` in `google_compute_interconnect` resource
```
