### PR TITLE
google_firestore_index: Add reference to google_firestore_field

### DIFF
--- a/mmv1/products/firestore/Index.yaml
+++ b/mmv1/products/firestore/Index.yaml
@@ -20,8 +20,9 @@ error_retry_predicates:
   ["transport_tpg.FirestoreIndex409Retry"]
 description: |
   Cloud Firestore indexes enable simple and complex queries against documents in a database.
-   This resource manages composite indexes and not single field indexes.
    Both Firestore Native and Datastore Mode indexes are supported.
+   This resource manages composite indexes and not single field indexes.
+   To manage single field indexes, use the `google_firestore_field` resource instead.
 references: !ruby/object:Api::Resource::ReferenceLinks
   guides:
     'Official Documentation': 'https://cloud.google.com/firestore/docs/query-data/indexing'


### PR DESCRIPTION
It's not clear from the docs how to use SFIs from Terraform. We should fix that.

```release-note:none

```
