### PR TITLE
Annotate immutable fields in ServerTlsPolicy.yaml

### DIFF
--- a/mmv1/products/networksecurity/ServerTlsPolicy.yaml
+++ b/mmv1/products/networksecurity/ServerTlsPolicy.yaml
@@ -150,6 +150,7 @@ properties:
     properties:
       - !ruby/object:Api::Type::Enum
         name: 'clientValidationMode'
+        immutable: true
         description: |
           When the client presents an invalid certificate or no certificate to the load balancer, the clientValidationMode specifies how the client connection is handled.
           Required if the policy is to be used with the external HTTPS load balancing. For Traffic Director it must be empty.
@@ -159,6 +160,7 @@ properties:
           - :REJECT_INVALID
       - !ruby/object:Api::Type::String
         name: 'clientValidationTrustConfig'
+        immutable: true
         description: |
           Reference to the TrustConfig from certificatemanager.googleapis.com namespace.
           If specified, the chain validation will be performed against certificates configured in the given TrustConfig.


### PR DESCRIPTION
Mark `ClientValidationTrustConfig` and `ClientValidationMode` immutable in Terraform.

Part of https://github.com/hashicorp/terraform-provider-google/issues/15453

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
networksecurity: added recreate functionality on update for `client_validation_mode` and `client_validation_trust_config` in  `google_network_security_server_tls_policy`
```
