### PR TITLE
Allow server_tls_policy property of compute_target_https_proxy to use update verb

### DIFF
--- a/mmv1/products/compute/TargetHttpsProxy.yaml
+++ b/mmv1/products/compute/TargetHttpsProxy.yaml
@@ -233,3 +233,5 @@ properties:
       INTERNAL_SELF_MANAGED and which with EXTERNAL, EXTERNAL_MANAGED
       loadBalancingScheme consult ServerTlsPolicy documentation.
       If left blank, communications are not encrypted.
+    update_verb: :PATCH
+    update_url: 'projects/{{project}}/targetHttpsProxies/{{name}}/setServerTlsPolicy'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_target_https_proxy_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_target_https_proxy_test.go.erb
@@ -18,8 +18,9 @@ import (
 )
 
 const (
-	canonicalSslCertificateTemplate = "https://www.googleapis.com/compute/v1/projects/%s/global/sslCertificates/%s"
-	canonicalCertificateMapTemplate = "//certificatemanager.googleapis.com/projects/%s/locations/global/certificateMaps/%s"
+	canonicalSslCertificateTemplate  = "https://www.googleapis.com/compute/v1/projects/%s/global/sslCertificates/%s"
+	canonicalCertificateMapTemplate  = "//certificatemanager.googleapis.com/projects/%s/locations/global/certificateMaps/%s"
+	canonicalServerTlsPolicyTemplate = "//networksecurity.googleapis.com/projects/%s/locations/global/serverTlsPolicies/%s"
 )
 
 func TestAccComputeTargetHttpsProxy_update(t *testing.T) {
@@ -40,9 +41,9 @@ func TestAccComputeTargetHttpsProxy_update(t *testing.T) {
 						t, "google_compute_target_https_proxy.foobar", &proxy),
 					testAccComputeTargetHttpsProxyDescription("Resource created for Terraform acceptance testing", &proxy),
 					testAccComputeTargetHttpsProxyHasSslCertificate(t, "tf-test-httpsproxy-cert1-"+resourceSuffix, &proxy),
+					testAccComputeTargetHttpsProxyHasServerTlsPolicy(t, "tf-test-server-tls-policy-"+resourceSuffix, &proxy),
 				),
 			},
-
 			{
 				Config: testAccComputeTargetHttpsProxy_basic2(resourceSuffix),
 				Check: resource.ComposeTestCheckFunc(
@@ -131,7 +132,20 @@ func testAccComputeTargetHttpsProxyHasSslCertificate(t *testing.T, cert string, 
 			}
 		}
 
-		return fmt.Errorf("Ssl certificate not found: expected'%s'", certUrl)
+		return fmt.Errorf("Ssl certificate not found: expected '%s'", certUrl)
+	}
+}
+
+func testAccComputeTargetHttpsProxyHasServerTlsPolicy(t *testing.T, policy string, proxy *compute.TargetHttpsProxy) resource.TestCheckFunc {
+  return func(s *terraform.State) error {
+		config := acctest.GoogleProviderConfig(t)
+		serverTlsPolicyUrl := fmt.Sprintf(canonicalServerTlsPolicyTemplate, config.Project, policy)
+
+    if tpgresource.ConvertSelfLinkToV1(proxy.ServerTlsPolicy) == serverTlsPolicyUrl {
+			return nil
+		}
+
+		return fmt.Errorf("Server Tls Policy not found: expected '%s'", serverTlsPolicyUrl)
 	}
 }
 
@@ -144,18 +158,21 @@ func testAccComputeTargetHttpsProxyHasCertificateMap(t *testing.T, certificateMa
 			return nil
 		}
 
-		return fmt.Errorf("certificate map not found: expected'%s'", certificateMapUrl)
+		return fmt.Errorf("certificate map not found: expected '%s'", certificateMapUrl)
 	}
 }
 
 func testAccComputeTargetHttpsProxy_basic1(id string) string {
 	return fmt.Sprintf(`
+data "google_project" "project" {}
+
 resource "google_compute_target_https_proxy" "foobar" {
-  description      = "Resource created for Terraform acceptance testing"
-  name             = "tf-test-httpsproxy-%s"
-  url_map          = google_compute_url_map.foobar.self_link
-  ssl_certificates = [google_compute_ssl_certificate.foobar1.self_link]
-  ssl_policy       = google_compute_ssl_policy.foobar.self_link
+  description       = "Resource created for Terraform acceptance testing"
+  name              = "tf-test-httpsproxy-%s"
+  url_map           = google_compute_url_map.foobar.self_link
+  ssl_certificates  = [google_compute_ssl_certificate.foobar1.self_link]
+  ssl_policy        = google_compute_ssl_policy.foobar.self_link
+  server_tls_policy = google_network_security_server_tls_policy.server_tls_policy.id
 }
 
 resource "google_compute_backend_service" "foobar" {
@@ -212,7 +229,25 @@ resource "google_compute_ssl_certificate" "foobar2" {
   private_key = file("test-fixtures/test.key")
   certificate = file("test-fixtures/test.crt")
 }
-`, id, id, id, id, id, id, id)
+
+resource "google_certificate_manager_trust_config" "trust_config" {
+  name     = "tf-test-trust-config-%s"
+  location = "global"
+
+  allowlisted_certificates  {
+    pem_certificate = file("test-fixtures/cert.pem")
+  }
+}
+
+resource "google_network_security_server_tls_policy" "server_tls_policy" {
+  name = "tf-test-server-tls-policy-%s"
+
+  mtls_policy {
+    client_validation_trust_config = "projects/${data.google_project.project.number}/locations/global/trustConfigs/${google_certificate_manager_trust_config.trust_config.name}"
+    client_validation_mode         = "ALLOW_INVALID_OR_MISSING_CLIENT_CERT"
+  }
+}
+`, id, id, id, id, id, id, id, id, id)
 }
 
 func testAccComputeTargetHttpsProxy_basic2(id string) string {
@@ -225,7 +260,7 @@ resource "google_compute_target_https_proxy" "foobar" {
     google_compute_ssl_certificate.foobar1.self_link,
     google_compute_ssl_certificate.foobar2.self_link,
   ]
-  quic_override = "ENABLE"
+  quic_override  = "ENABLE"
   tls_early_data = "STRICT"
 }
 
@@ -289,9 +324,9 @@ resource "google_compute_ssl_certificate" "foobar2" {
 func testAccComputeTargetHttpsProxy_certificateMap(id string) string {
 	return fmt.Sprintf(`
 resource "google_compute_target_https_proxy" "foobar" {
-  description      = "Resource created for Terraform acceptance testing"
-  name             = "tf-test-httpsproxy-%s"
-  url_map          = google_compute_url_map.foobar.self_link
+  description     = "Resource created for Terraform acceptance testing"
+  name            = "tf-test-httpsproxy-%s"
+  url_map         = google_compute_url_map.foobar.self_link
   certificate_map = "//certificatemanager.googleapis.com/${google_certificate_manager_certificate_map.map.id}"
 }
 
@@ -340,6 +375,5 @@ resource "google_certificate_manager_dns_authorization" "instance" {
   name   = "tf-test-dnsauthz-%s"
   domain = "mysite.com"
 }
-
 `, id, id, id, id, id, id, id, id)
 }


### PR DESCRIPTION
This PR updates the `compute_target_https_proxy` resource to allow the `server_tls_policy` property to use the `PATCH` verb for updates. This change is necessary to enable more flexible and efficient updates to the `server_tls_policy` configuration without needing to replace the entire resource.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: `google_compute_target_https_proxy` resource now supports using the `PATCH` verb for updates to the `server_tls_policy` property
```
