### PR TITLE
google_datastore_index: Deprecate

### DIFF
--- a/mmv1/products/datastore/Index.yaml
+++ b/mmv1/products/datastore/Index.yaml
@@ -24,20 +24,29 @@ references: !ruby/object:Api::Resource::ReferenceLinks
 identity:
   - indexId
 description: |
-  Describes a composite index for Cloud Datastore.
+  Describes a composite index for Firestore in Datastore Mode.
 id_format: 'projects/{{project}}/indexes/{{index_id}}'
 error_retry_predicates: ['transport_tpg.DatastoreIndex409Contention']
 autogen_async: true
 timeouts: !ruby/object:Api::Timeouts
   insert_minutes: 20
   delete_minutes: 20
+deprecation_message: >-
+  `datastore_index` is deprecated and will be removed in a future major release.
+  Use `firestore_index` instead; this resource is deprecated because it only supports the (default) database.
+  `firestore_index` supports both Firestore in Datastore Mode and Firestore Native indexes and supports both
+  named and the (default) database.
 docs: !ruby/object:Provider::Terraform::Docs
   warning: |
+    `datastore_index` is deprecated and will be removed in a future major release.
+    Use `firestore_index` instead; this resource is deprecated because it only supports the (default) database.
     This resource creates a Datastore Index on a project that has already
-    enabled a Datastore-compatible database. If you haven't already enabled
-    one, you can create a `google_app_engine_application` resource with
-    `database_type` set to `"CLOUD_DATASTORE_COMPATIBILITY"` to do so. Your
-    Datastore location will be the same as the App Engine location specified.
+    enabled a Datastore-compatible database.  If you haven't already created it, you may
+    create a `google_firestore_database` resource with `location_id` set
+    to your chosen location, and `type` set to `"DATASTORE_MODE"`.
+    If you wish to use App Engine, you may instead create a `google_app_engine_application` resource with
+    `database_type` set to `"CLOUD_DATASTORE_COMPATIBILITY"`.
+    Your Datastore location will be the same as the App Engine location specified.
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'datastore_index'

--- a/mmv1/products/firestore/Index.yaml
+++ b/mmv1/products/firestore/Index.yaml
@@ -20,8 +20,8 @@ error_retry_predicates:
   ["transport_tpg.FirestoreIndex409Retry"]
 description: |
   Cloud Firestore indexes enable simple and complex queries against documents in a database.
-   This resource manages composite indexes and not single
-  field indexes.
+   This resource manages composite indexes and not single field indexes.
+   Both Firestore Native and Datastore Mode indexes are supported.
 references: !ruby/object:Api::Resource::ReferenceLinks
   guides:
     'Official Documentation': 'https://cloud.google.com/firestore/docs/query-data/indexing'
@@ -51,9 +51,8 @@ docs: !ruby/object:Provider::Terraform::Docs
     a Firestore database. If you haven't already created it, you may
     create a `google_firestore_database` resource and `location_id` set
     to your chosen location. If you wish to use App Engine, you may
-    instead create a `google_app_engine_application` resource with
-    `database_type` set to `"CLOUD_FIRESTORE"`. Your Firestore location
-    will be the same as the App Engine location specified.
+    instead create a `google_app_engine_application` resource.
+    Your Firestore location will be the same as the App Engine location specified.
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'firestore_index_basic'


### PR DESCRIPTION
It's redundant with google_firestore_index, and the fact that it only supports the (default) database means that we get annoying test failures when the test runs more than once in a five-minute period or if the database doesn't get deleted correctly for whatever reason.

Googlers: see b/243079146

**Release Note Template for Downstream PRs (will be copied)**

```release-note:deprecation
datastore: deprecated the resource `google_datastore_index`. Use the `google_firestore_index` resource instead.
```
