### PR TITLE
Add deprecation notice for multi_region_auxiliary field in BQ reservation

### DIFF
--- a/mmv1/products/bigqueryreservation/Reservation.yaml
+++ b/mmv1/products/bigqueryreservation/Reservation.yaml
@@ -70,6 +70,7 @@ properties:
     description: |
       Applicable only for reservations located within one of the BigQuery multi-regions (US or EU).
       If set to true, this reservation is placed in the organization's secondary region which is designated for disaster recovery purposes. If false, this reservation is placed in the organization's default region.
+    deprecation_message: "`multi_region_auxiliary` is deprecated and will be removed in a future major release. This field is no longer supported by the BigQuery Reservation API."
   - !ruby/object:Api::Type::String
     name: 'edition'
     immutable: true


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add deprecation notice for multi_region_auxiliary field in BQ reservation as it's no longer supported

b/350571636

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:deprecation
bigqueryreservation: deprecated `multi_region_auxiliary` on `google_bigquery_reservation`.
```
