### PR TITLE
update cloudfunctionv2 test runtimes to nodejs18

### DIFF
--- a/mmv1/third_party/terraform/services/cloudfunctions2/data_source_google_cloudfunctions2_function_test.go
+++ b/mmv1/third_party/terraform/services/cloudfunctions2/data_source_google_cloudfunctions2_function_test.go
@@ -62,7 +62,7 @@ resource "google_cloudfunctions2_function" "function_http_v2" {
     env = "test"
   }
   build_config {
-    runtime = "nodejs12"
+    runtime = "nodejs18"
     entry_point = "helloHttp"
     source {
       storage_source {

--- a/mmv1/third_party/terraform/services/cloudfunctions2/resource_cloudfunctions2_function_test.go
+++ b/mmv1/third_party/terraform/services/cloudfunctions2/resource_cloudfunctions2_function_test.go
@@ -75,7 +75,7 @@ resource "google_cloudfunctions2_function" "terraform-test2" {
   }
 
   build_config {
-    runtime = "nodejs12"
+    runtime = "nodejs18"
     entry_point = "helloHttp"
     source {
       storage_source {
@@ -117,7 +117,7 @@ resource "google_cloudfunctions2_function" "terraform-test2" {
   }
   
   build_config {
-    runtime = "nodejs12"
+    runtime = "nodejs18"
     entry_point = "helloHttp"
     source {
       storage_source {
@@ -155,7 +155,7 @@ resource "google_cloudfunctions2_function" "terraform-test2" {
   description = "function test"
 
   build_config {
-    runtime = "nodejs16"
+    runtime = "nodejs18"
     entry_point = "helloHttp"
     environment_variables = {
         BUILD_CONFIG_TEST = "build_test"
@@ -274,7 +274,7 @@ resource "google_cloudfunctions2_function" "function" {
   description = "a new function"
 
   build_config {
-    runtime     = "nodejs12"
+    runtime     = "nodejs18"
     entry_point = "entryPoint" # Set the entry point in the code
     environment_variables = {
       BUILD_CONFIG_TEST = "build_test"
@@ -388,7 +388,7 @@ resource "google_cloudfunctions2_function" "terraform-test2" {
   }
 
   build_config {
-    runtime = "nodejs12"
+    runtime = "nodejs18"
     entry_point = "helloHttp"
     source {
       storage_source {
@@ -431,7 +431,7 @@ resource "google_cloudfunctions2_function" "terraform-test2" {
   }
 
   build_config {
-    runtime = "nodejs12"
+    runtime = "nodejs18"
     entry_point = "helloHttp"
     source {
       storage_source {
@@ -472,7 +472,7 @@ resource "google_cloudfunctions2_function" "terraform-test2" {
   }
   
   build_config {
-    runtime = "nodejs12"
+    runtime = "nodejs18"
     entry_point = "helloHttp"
     source {
       storage_source {


### PR DESCRIPTION
update cloudfunctionsV2 test case to use nodejs18 runtimes. The nodejs12 is end of lifecycle support

fixes #18638

```release-note:none

```
