### PR TITLE
Set disbaleSsh default value to true for workstation create

### DIFF
--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -276,6 +276,8 @@ properties:
               Whether instances have no public IP address.
           - !ruby/object:Api::Type::Boolean
             name: 'disableSsh'
+            default_value: true
+            send_empty_value: true
             description: |
               Whether to disable SSH access to the VM.
           - !ruby/object:Api::Type::Boolean

--- a/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
@@ -320,9 +320,9 @@ in GCP, including the labels configured through Terraform, the system, and other
 
 ## Resource: `google_workstations_workstation_config`
 
-### Disable SSH to root VM is set to true by default for workstation config.
+### `host.gce_instance.disable_ssh` now defaults to true
 
-* `disableSSH` field is set to true when creating configs. To enable SSH, please set `disableSSH` to false.
+* `disable_ssh` field now defaults to true. To enable SSH, please set `disable_ssh` to false.
 
 ## Removals
 

--- a/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
@@ -318,6 +318,12 @@ on the resource through Terraform and the default labels configured on the provi
 * The new output-only `effective_labels` field lists all of labels present on the resource
 in GCP, including the labels configured through Terraform, the system, and other clients.
 
+## Resource: `google_workstations_workstation_config`
+
+### Disable SSH to root VM is set to true by default for workstation config.
+
+* `disableSSH` field is set to true when creating configs. To enable SSH, please set `disableSSH` to false.
+
 ## Removals
 
 ### Resource: `google_identity_platform_project_default_config` is now removed


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fixes https://github.com/hashicorp/terraform-provider-google/issues/19094
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
workstation: `host.gce_instance.disable_ssh` now defaults to true for `google_workstations_workstation_config`
```
