### PR TITLE
Add support for allowed_ports field to terraform

### DIFF
--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -574,6 +574,24 @@ properties:
     description: |
       Disables support for plain TCP connections in the workstation. By default the service supports TCP connections via a websocket relay. Setting this option to true disables that relay, which prevents the usage of services that require plain tcp connections, such as ssh. When enabled, all communication must occur over https or wss.
   - !ruby/object:Api::Type::Array
+    name: 'allowedPorts'
+    description: |
+      A list of ports specifying single ports or ranges of ports that
+      are externally accessible in the workstation.
+      Allowed ports must be one of 22, 80, or within range 1024-65535.
+      If not specified defaults to ports 22, 80, and ports 1024-65535.
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties:
+        - !ruby/object:Api::Type::Integer
+          name: 'first'
+          description: |
+            Starting port number for the current range of ports.
+      properties:
+        - !ruby/object:Api::Type::Integer
+          name: 'last'
+          description: |
+            Ending port number for the current range of ports.  
+  - !ruby/object:Api::Type::Array
     name: 'conditions'
     description: |-
       Status conditions describing the current resource state.

--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -586,11 +586,10 @@ properties:
           name: 'first'
           description: |
             Starting port number for the current range of ports.
-      properties:
         - !ruby/object:Api::Type::Integer
           name: 'last'
           description: |
-            Ending port number for the current range of ports.  
+            Ending port number for the current range of ports.
   - !ruby/object:Api::Type::Array
     name: 'conditions'
     description: |-

--- a/mmv1/templates/terraform/examples/workstation_config_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/workstation_config_basic.tf.erb
@@ -69,4 +69,18 @@ resource "google_workstations_workstation_config" "<%= ctx[:primary_resource_id]
       }
     }
   }
+  allowed_ports = [
+    {
+      first: 22
+      last:22
+    }
+    {
+      first: 80
+      last: 80
+    }
+    {
+      first: 8000
+      last: 9000
+    }
+  ]
 }

--- a/mmv1/templates/terraform/examples/workstation_config_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/workstation_config_basic.tf.erb
@@ -73,11 +73,11 @@ resource "google_workstations_workstation_config" "<%= ctx[:primary_resource_id]
     {
       first: 22
       last:22
-    }
+    },
     {
       first: 80
       last: 80
-    }
+    },
     {
       first: 8000
       last: 9000


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
Add support for allowed_ports field to the workstation config.
```
