### PR TITLE
Add new field enable_dataplex_integration to google_sql_database_instance settings

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.erb
@@ -402,6 +402,11 @@ is set to true. Defaults to ZONAL.`,
 							Optional:         true,
 							Description:      `Enables Vertex AI Integration.`,
 						},
+						"enable_dataplex_integration": {
+							Type:             schema.TypeBool,
+							Optional:         true,
+							Description:      `Enables Dataplex Integration.`,
+						},
 						"disk_size": {
 							Type:     schema.TypeInt,
 							Optional: true,
@@ -1274,7 +1279,7 @@ func expandSqlDatabaseInstanceSettings(configured []interface{}, databaseVersion
 		Tier:                       _settings["tier"].(string),
 		Edition:                    _settings["edition"].(string),
 		AdvancedMachineFeatures:    expandSqlServerAdvancedMachineFeatures(_settings["advanced_machine_features"].([]interface{})),
-		ForceSendFields:            []string{"StorageAutoResize", "EnableGoogleMlIntegration"},
+		ForceSendFields:            []string{"StorageAutoResize", "EnableGoogleMlIntegration", "EnableDataplexIntegration"},
 		ActivationPolicy:           _settings["activation_policy"].(string),
 		ActiveDirectoryConfig:      expandActiveDirectoryConfig(_settings["active_directory_config"].([]interface{})),
 		DenyMaintenancePeriods:	    expandDenyMaintenancePeriod(_settings["deny_maintenance_period"].([]interface{})),
@@ -1288,6 +1293,7 @@ func expandSqlDatabaseInstanceSettings(configured []interface{}, databaseVersion
 		PricingPlan:                _settings["pricing_plan"].(string),
 		DeletionProtectionEnabled:  _settings["deletion_protection_enabled"].(bool),
 		EnableGoogleMlIntegration:  _settings["enable_google_ml_integration"].(bool),
+		EnableDataplexIntegration:  _settings["enable_dataplex_integration"].(bool),
 		UserLabels:                 tpgresource.ConvertStringMap(_settings["user_labels"].(map[string]interface{})),
 		BackupConfiguration:        expandBackupConfiguration(_settings["backup_configuration"].([]interface{})),
 		DatabaseFlags:              expandDatabaseFlags(_settings["database_flags"].(*schema.Set).List()),
@@ -2113,6 +2119,7 @@ func flattenSettings(settings *sqladmin.Settings, d *schema.ResourceData) []map[
 	data["disk_autoresize_limit"] = settings.StorageAutoResizeLimit
 
 	data["enable_google_ml_integration"] = settings.EnableGoogleMlIntegration
+	data["enable_dataplex_integration"] = settings.EnableDataplexIntegration
 
 	if settings.UserLabels != nil {
 		data["user_labels"] = settings.UserLabels

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -1419,6 +1419,38 @@ func TestAccSqlDatabaseInstance_EnableGoogleMlIntegration(t *testing.T) {
 	})
 }
 
+func TestAccSqlDatabaseInstance_EnableGoogleDataplexIntegration(t *testing.T) {
+	t.Parallel()
+
+	masterID := acctest.RandInt(t)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleSqlDatabaseInstance_EnableDataplexIntegration(masterID, true),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "root_password"},
+			},
+			{
+				Config: testGoogleSqlDatabaseInstance_EnableDataplexIntegration(masterID, false),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "root_password"},
+			},
+		},
+	})
+}
+
 func TestAccSqlDatabaseInstance_insights(t *testing.T) {
 	t.Parallel()
 
@@ -3956,6 +3988,22 @@ resource "google_sql_database_instance" "instance" {
   }
 }
 `, masterID, dbVersion, masterID, tier, enableGoogleMlIntegration)
+}
+
+func testGoogleSqlDatabaseInstance_EnableDataplexIntegration(masterID int, enableDataplexIntegration bool) string {
+	return fmt.Sprintf(`
+resource "google_sql_database_instance" "instance" {
+  name                = "tf-test-%d"
+  region              = "us-central1"
+  database_version    = "MYSQL_8_0"
+  deletion_protection = false
+  root_password		  = "rand-pwd-%d"
+  settings {
+    tier = "db-custom-2-10240"
+	enable_dataplex_integration = %t
+  }
+}
+`, masterID, masterID, enableDataplexIntegration)
 }
 
 func testGoogleSqlDatabaseInstance_BackupRetention(masterID int) string {

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -292,6 +292,8 @@ The `settings` block supports:
 
 * `enable_google_ml_integration` - (Optional) Enables [Cloud SQL instances to connect to Vertex AI](https://cloud.google.com/sql/docs/postgres/integrate-cloud-sql-with-vertex-ai) and pass requests for real-time predictions and insights. Defaults to `false`.
 
+* `enable_dataplex_integration` - (Optional) Enables [Cloud SQL instance integration with Dataplex](https://cloud.google.com/sql/docs/mysql/dataplex-catalog-integration). MySQL, Postgres and SQL Server instances are supported for this feature. Defaults to `false`.
+
 * `disk_autoresize` - (Optional) Enables auto-resizing of the storage size. Defaults to `true`.
 
 * `disk_autoresize_limit` - (Optional) The maximum size to which storage capacity can be automatically increased. The default value is 0, which specifies that there is no limit.


### PR DESCRIPTION
This PR adds the new field enable_dataplex_integration to google_sql_database_instance settings. This new field is only available for google.golang.org/api v0.186.0 or after, hence updated the dependency. Added Acctests for this field and they passed. All of the existing unit tests are passing.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
sql: added `enable_dataplex_integration` field to `google_sql_database_instance` resource
```
