### PR TITLE
Update description of `resourceTypeSelector` KeyHandle field

### DIFF
--- a/mmv1/products/kms/KeyHandle.yaml
+++ b/mmv1/products/kms/KeyHandle.yaml
@@ -84,6 +84,6 @@ properties:
     name: 'resourceTypeSelector'
     description: |
       Selector of the resource type where we want to protect resources.
-      For example, `storage.googleapis.com/Bucket OR compute.googleapis.com/*`
+      For example, `storage.googleapis.com/Bucket`.
     required: true
     immutable: true


### PR DESCRIPTION
Star expressions are not allowed.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Minor description update, no release notes needed because this was never allowed by the API.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
