### PR TITLE
feat: optional sql server change tables and transaction logs

### DIFF
--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -1023,8 +1023,7 @@ properties:
             name: 'transactionLogs'
             allow_empty_object: true
             send_empty_value: true
-            exactly_one_of:
-              - source_config.0.sql_server_source_config.transaction_logs
+            conflicts:
               - source_config.0.sql_server_source_config.change_tables
             description: |
               CDC reader reads from transaction logs.
@@ -1033,9 +1032,8 @@ properties:
             name: 'changeTables'
             allow_empty_object: true
             send_empty_value: true
-            exactly_one_of:
+            conflicts:
               - source_config.0.sql_server_source_config.transaction_logs
-              - source_config.0.sql_server_source_config.change_tables
             description: |
               CDC reader reads from change tables.
             properties: []

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -124,6 +124,23 @@ examples:
     test_vars_overrides:
       deletion_protection: 'false'
   - !ruby/object:Provider::Terraform::Examples
+    name: 'datastream_stream_sql_server_change_tables'
+    primary_resource_id: 'default'
+    # Requires SQLServer Configuration
+    skip_test: true
+    vars:
+      database_name: 'db'
+      database_password: 'password'
+      database_user: 'user'
+      deletion_protection: 'true'
+      destination_connection_profile_id: 'destination-profile'
+      source_connection_profile_id: 'source-profile'
+      sql_server_name: 'sql-server'
+      sql_server_root_password: 'root-password'
+      stream_id: 'stream'
+    test_vars_overrides:
+      deletion_protection: 'false'
+  - !ruby/object:Provider::Terraform::Examples
     name: 'datastream_stream_postgresql_bigquery_dataset_id'
     primary_resource_id: 'default'
     vars:

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -1010,7 +1010,7 @@ properties:
               - source_config.0.sql_server_source_config.transaction_logs
               - source_config.0.sql_server_source_config.change_tables
             description: |
-              CDC reader reads from change tables.
+              CDC reader reads from transaction logs.
             properties: []
           - !ruby/object:Api::Type::NestedObject
             name: 'changeTables'

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -1002,6 +1002,26 @@ properties:
             default_from_api: true
             validation: !ruby/object:Provider::Terraform::Validation
               function: 'validation.IntAtLeast(0)'
+          - !ruby/object:Api::Type::NestedObject
+            name: 'transactionLogs'
+            allow_empty_object: true
+            send_empty_value: true
+            exactly_one_of:
+              - source_config.0.sql_server_source_config.transaction_logs
+              - source_config.0.sql_server_source_config.change_tables
+            description: |
+              CDC reader reads from change tables.
+            properties: []
+          - !ruby/object:Api::Type::NestedObject
+            name: 'changeTables'
+            allow_empty_object: true
+            send_empty_value: true
+            exactly_one_of:
+              - source_config.0.sql_server_source_config.transaction_logs
+              - source_config.0.sql_server_source_config.change_tables
+            description: |
+              CDC reader reads from change tables.
+            properties: []
   - !ruby/object:Api::Type::NestedObject
     name: 'destinationConfig'
     required: true

--- a/mmv1/templates/terraform/examples/datastream_stream_sql_server.tf.erb
+++ b/mmv1/templates/terraform/examples/datastream_stream_sql_server.tf.erb
@@ -83,6 +83,7 @@ resource "google_datastream_stream" "default" {
                     }
                 }
             }
+            change_tables {}
         }
     }
 

--- a/mmv1/templates/terraform/examples/datastream_stream_sql_server_change_tables.tf.erb
+++ b/mmv1/templates/terraform/examples/datastream_stream_sql_server_change_tables.tf.erb
@@ -83,7 +83,7 @@ resource "google_datastream_stream" "default" {
                     }
                 }
             }
-            transaction_logs {}
+            change_tables {}
         }
     }
 

--- a/mmv1/templates/terraform/examples/go/datastream_stream_sql_server.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/datastream_stream_sql_server.tf.tmpl
@@ -83,6 +83,7 @@ resource "google_datastream_stream" "default" {
                     }
                 }
             }
+            change_tables {}
         }
     }
 

--- a/mmv1/templates/terraform/examples/go/datastream_stream_sql_server.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/datastream_stream_sql_server.tf.tmpl
@@ -83,7 +83,7 @@ resource "google_datastream_stream" "default" {
                     }
                 }
             }
-            change_tables {}
+            transaction_logs {}
         }
     }
 

--- a/mmv1/templates/terraform/examples/go/datastream_stream_sql_server_change_tables.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/datastream_stream_sql_server_change_tables.tf.tmpl
@@ -1,9 +1,9 @@
 resource "google_sql_database_instance" "instance" {
-    name                = "<%= ctx[:vars]['sql_server_name'] %>"
+    name                = "{{index $.Vars "sql_server_name"}}"
     database_version    = "SQLSERVER_2019_STANDARD"
     region              = "us-central1"
-    root_password       = "<%= ctx[:vars]['sql_server_root_password'] %>"
-    deletion_protection = "<%= ctx[:vars]['deletion_protection'] %>"
+    root_password       = "{{index $.Vars "sql_server_root_password"}}"
+    deletion_protection = "{{index $.Vars "deletion_protection"}}"
 
     settings {
         tier = "db-custom-2-4096"
@@ -34,21 +34,21 @@ resource "google_sql_database_instance" "instance" {
 }
 
 resource "google_sql_database" "db" {
-    name       = "<%= ctx[:vars]['database_name'] %>"
+    name       = "{{index $.Vars "database_name"}}"
     instance   = google_sql_database_instance.instance.name
     depends_on = [google_sql_user.user]
 }
 
 resource "google_sql_user" "user" {
-    name     = "<%= ctx[:vars]['database_user'] %>"
+    name     = "{{index $.Vars "database_user"}}"
     instance = google_sql_database_instance.instance.name
-    password = "<%= ctx[:vars]['database_password'] %>"
+    password = "{{index $.Vars "database_password"}}"
 }
 
 resource "google_datastream_connection_profile" "source" {
     display_name          = "SQL Server Source"
     location              = "us-central1"
-    connection_profile_id = "<%= ctx[:vars]['source_connection_profile_id'] %>"
+    connection_profile_id = "{{index $.Vars "source_connection_profile_id"}}"
 
     sql_server_profile {
         hostname = google_sql_database_instance.instance.public_ip_address
@@ -62,7 +62,7 @@ resource "google_datastream_connection_profile" "source" {
 resource "google_datastream_connection_profile" "destination" {
     display_name          = "BigQuery Destination"
     location              = "us-central1"
-    connection_profile_id = "<%= ctx[:vars]['destination_connection_profile_id'] %>"
+    connection_profile_id = "{{index $.Vars "destination_connection_profile_id"}}"
 
     bigquery_profile {}
 }
@@ -70,7 +70,7 @@ resource "google_datastream_connection_profile" "destination" {
 resource "google_datastream_stream" "default" {
     display_name = "SQL Server to BigQuery"
     location     = "us-central1"
-    stream_id    = "<%= ctx[:vars]['stream_id'] %>"
+    stream_id    = "{{index $.Vars "stream_id"}}"
 
     source_config {
         source_connection_profile = google_datastream_connection_profile.source.id
@@ -83,7 +83,7 @@ resource "google_datastream_stream" "default" {
                     }
                 }
             }
-            transaction_logs {}
+            change_tables {}
         }
     }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds optional blocks for `transaction_logs` and `change_tables` to the `sql_server_source_config`.
Fixes https://github.com/hashicorp/terraform-provider-google/issues/18836

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
datastream: added `transaction_logs` and `change_tables` to the `datastream_stream` resource
```
