### PR TITLE
Update max threshold permitted in ServiceLevelObjectives

### DIFF
--- a/mmv1/templates/terraform/constants/monitoring_slo.go.erb
+++ b/mmv1/templates/terraform/constants/monitoring_slo.go.erb
@@ -1,7 +1,7 @@
 func validateMonitoringSloGoal(v interface{}, k string) (warnings []string, errors []error) {
 	goal := v.(float64)
-	if goal <= 0 || goal > 0.999 {
-		errors = append(errors, fmt.Errorf("goal %f must be > 0 and <= 0.999", goal))
+	if goal <= 0 || goal > 0.9999 {
+		errors = append(errors, fmt.Errorf("goal %f must be > 0 and <= 0.9999", goal))
 	}
 	return
 }


### PR DESCRIPTION
https://cloud.google.com/monitoring/api/ref_v3/rest/v3/services.serviceLevelObjectives#resource:-servicelevelobjective indicate that the threshold can now be .9999

Fixes https://github.com/hashicorp/terraform-provider-google/issues/18556

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
monitoring: updated max threshold permitted in google_monitoring_slo to 0.9999
```
