### PR TITLE
Add accessMode support for compute disk

### DIFF
--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -521,5 +521,6 @@ properties:
       * READ_WRITE_SINGLE
       * READ_WRITE_MANY
       * READ_ONLY_SINGLE
-    diff_suppress_func: 'tpgresource.CompareResourceNames'
-    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
+    default_from_api: true
+    update_verb: :PATCH
+    update_url: 'projects/{{project}}/zones/{{zone}}/disks/{{name}}?paths=accessMode'

--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -511,3 +511,15 @@ properties:
       * /projects/{project}/zones/{zone}/storagePools/{storagePool}
     diff_suppress_func: 'tpgresource.CompareResourceNames'
     custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
+  - !ruby/object:Api::Type::String
+    name: 'accessMode'
+    required: false
+    immutable: false
+    description: |
+      The accessMode of the disk.
+      For example:
+      * READ_WRITE_SINGLE
+      * READ_WRITE_MANY
+      * READ_ONLY_SINGLE
+    diff_suppress_func: 'tpgresource.CompareResourceNames'
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'

--- a/mmv1/templates/terraform/update_encoder/hyper_disk.go.erb
+++ b/mmv1/templates/terraform/update_encoder/hyper_disk.go.erb
@@ -1,5 +1,5 @@
 
-if (d.HasChange("provisioned_iops") && strings.Contains(d.Get("type").(string), "hyperdisk")) || (d.HasChange("provisioned_throughput") && strings.Contains(d.Get("type").(string), "hyperdisk")) {
+if (d.HasChange("provisioned_iops") && strings.Contains(d.Get("type").(string), "hyperdisk")) || (d.HasChange("provisioned_throughput") && strings.Contains(d.Get("type").(string), "hyperdisk")) || (d.HasChange("access_mode") && strings.Contains(d.Get("type").(string), "hyperdisk")) {
     nameProp := d.Get("name")
     if v, ok := d.GetOkExists("name"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, nameProp)) {
         obj["name"] = nameProp

--- a/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.erb
@@ -1725,16 +1725,29 @@ func TestAccComputeDisk_accessModeSpecified(t *testing.T) {
 	t.Parallel()
 
 	diskName := fmt.Sprintf("tf-test-disk-accessmode-%s", acctest.RandString(t, 10))
-	accessMode := "READ_ONLY_MANY"
-
+	accessModeForCreate := "READ_WRITE_SINGLE"
+        accessModeForUpdate := "READ_ONLY_MANY"
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
+			// Create disk with Access Mode
 			{
-				Config:    testAccComputeDisk_accessModeSpecified(diskName, accessMode),
+				Config:    testAccComputeDisk_accessModeSpecified(diskName, accessModeForCreate),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("google_compute_disk.foobar", "access_mode", accessMode),
+					resource.TestCheckResourceAttr("google_compute_disk.foobar", "access_mode", accessModeForCreate),
+				),
+			},
+			{
+				ResourceName:      "google_compute_disk.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+                        // Update Access Mode
+			{       
+				Config: testAccComputeDisk_accessModeSpecified(diskName, accessModeForUpdate),
+                               	Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_compute_disk.foobar", "access_mode", accessModeForUpdate),
 				),
 			},
 			{
@@ -1744,7 +1757,6 @@ func TestAccComputeDisk_accessModeSpecified(t *testing.T) {
 			},
 		},
 	})
-
 }
 
 func testAccComputeDisk_accessModeSpecified(diskName, accessMode string) string {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

```release-note:enhancement
compute: added `access_mode` field to `google_compute_disk` resource
```
