### PR TITLE
Switched quickstart to use a different set of tests

### DIFF
--- a/docs/content/get-started/generate-providers.md
+++ b/docs/content/get-started/generate-providers.md
@@ -79,10 +79,10 @@ If you are familiar with Docker or Podman, you may want to use the experimental 
 
 ## Generate a provider change
 
-1. In your cloned magic-modules repository, edit `mmv1/products/pubsub/Topic.yaml` to change the description for the schemaSettings field:
+1. In your cloned magic-modules repository, edit `mmv1/products/bigqueryanalyticshub/DataExchange.yaml` to change the description for the `displayName` field:
    ```yaml
    - !ruby/object:Api::Type::NestedObject
-     name: 'schemaSettings'
+     name: 'displayName'
      description: |
        UPDATED_DESCRIPTION
    ```
@@ -94,11 +94,11 @@ If you are familiar with Docker or Podman, you may want to use the experimental 
    ```
 1. Generate changes for the `google` provider
    ```bash
-   make provider VERSION=ga OUTPUT_PATH="$GOPATH/src/github.com/hashicorp/terraform-provider-google" PRODUCT=pubsub
+   make provider VERSION=ga OUTPUT_PATH="$GOPATH/src/github.com/hashicorp/terraform-provider-google" PRODUCT=bigqueryanalyticshub
    ```
 1. Generate changes for the `google-beta` provider
    ```bash
-   make provider VERSION=beta OUTPUT_PATH="$GOPATH/src/github.com/hashicorp/terraform-provider-google-beta" PRODUCT=pubsub
+   make provider VERSION=beta OUTPUT_PATH="$GOPATH/src/github.com/hashicorp/terraform-provider-google-beta" PRODUCT=bigqueryanalyticshub
    ```
 1. Confirm that the expected changes were generated
    ```bash
@@ -111,17 +111,17 @@ If you are familiar with Docker or Podman, you may want to use the experimental 
    In both cases, the changes should include:
 
    ```diff
-   diff --git a/google-beta/resource_pubsub_topic.go b/google-beta/resource_pubsub_topic.go
-   --- a/google-beta/resource_pubsub_topic.go
-   +++ b/google-beta/resource_pubsub_topic.go
-   @@ -115 +115 @@ and is not a valid configuration.`,
-   -                               Description: `Settings for validating messages published against a schema.`,
+   diff --git a/google/services/bigqueryanalyticshub/resource_bigquery_analytics_hudiff --git a/google/services/bigqueryanalyticshub/resource_bigquery_analytics_hub_data_exchange.go b/google/services/bigqueryanalyticshub/resource_bigquery_analytics_hub_data_exchange.go
+   --- a/google/services/bigqueryanalyticshub/resource_bigquery_analytics_hub_data_exchange.go
+   +++ b/google/services/bigqueryanalyticshub/resource_bigquery_analytics_hub_data_exchange.go
+   @@ -66 +66 @@ func ResourceBigqueryAnalyticsHubDataExchange() *schema.Resource {
+   -                               Description: `Human-readable display name of the data exchange. The display name must contain only Unicode letters, numbers (0-9), underscores (_), dashes (-), spaces ( ), and must not start or end with spaces.`,
    +                               Description: `UPDATED_DESCRIPTION`,
-   diff --git a/website/docs/r/pubsub_topic.html.markdown b/website/docs/r/pubsub_topic.html.markdown
-   --- a/website/docs/r/pubsub_topic.html.markdown
-   +++ b/website/docs/r/pubsub_topic.html.markdown
-   @@ -146 +146 @@ The following arguments are supported:
-   -  Settings for validating messages published against a schema.
+   diff --git a/website/docs/r/bigquery_analytics_hub_data_exchange.html.markdown b/website/docs/r/bigquery_analytics_hub_data_exchange.html.markdown
+   --- a/website/docs/r/bigquery_analytics_hub_data_exchange.html.markdown
+   +++ b/website/docs/r/bigquery_analytics_hub_data_exchange.html.markdown
+   @@ -63 +63 @@ The following arguments are supported:
+   -  Human-readable display name of the data exchange. The display name must contain only Unicode letters, numbers (0-9), underscores (_), dashes (-), spaces ( ), and must not start or end with spaces.
    +  UPDATED_DESCRIPTION
    ```
 
@@ -148,8 +148,7 @@ If you are familiar with Docker or Podman, you may want to use the experimental 
 1. Enable required APIs
    ```bash
    gcloud config set project $GOOGLE_PROJECT
-   gcloud services enable pubsub.googleapis.com
-   gcloud services enable cloudkms.googleapis.com
+   gcloud services enable analyticshub.googleapis.com
    ```
 1. Run all linters
    ```bash
@@ -165,13 +164,13 @@ If you are familiar with Docker or Podman, you may want to use the experimental 
    cd $GOPATH/src/github.com/hashicorp/terraform-provider-google-beta
    make test
    ```
-1. Run acceptance tests for Pub/Sub Topic
+1. Run acceptance tests for BigqueryAnalyticsHub DataExchange
 
    ```bash
    cd $GOPATH/src/github.com/hashicorp/terraform-provider-google
-   make testacc TEST=./google/services/pubsub TESTARGS='-run=TestAccPubsubTopic_'
+   make testacc TEST=./google/services/bigqueryanalyticshub TESTARGS='-run=TestAccBigqueryAnalyticsHubDataExchange_'
    cd $GOPATH/src/github.com/hashicorp/terraform-provider-google-beta
-   make testacc TEST=./google-beta/services/pubsub TESTARGS='-run=TestAccPubsubTopic_'
+   make testacc TEST=./google-beta/services/bigqueryanalyticshub TESTARGS='-run=TestAccBigqueryAnalyticsHubDataExchange_'
    ```
 
 ## Troubleshoot


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
The pubsub topic tests were initially chosen because they were "simple" but they turn out to have a bunch of edge cases that confuse users. Bigquery Analytics Hub seems potentially safer at the moment.

yaqs/3976147406851932160
yaqs/4786742563220488192
yaqs/7980362047026102272

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
