### PR TITLE
Permadiff fix: advertised_ip_ranges in cloud router

### DIFF
--- a/mmv1/templates/terraform/custom_flatten/compute_router_range.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/compute_router_range.go.erb
@@ -30,7 +30,7 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d 
 		})
 	}
 	configData := []map[string]interface{}{}
-	if v, ok := d.GetOk("advertised_ip_ranges"); ok {
+	if v, ok := d.GetOk("bgp.0.advertised_ip_ranges"); ok {
 		for _, item := range v.([]interface{}) {
 			configData = append(configData, item.(map[string]interface{}))
 		}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_test.go.erb
@@ -78,6 +78,29 @@ func TestAccComputeRouter_full(t *testing.T) {
 	})
 }
 
+func TestAccComputeRouter_advertisedIpRangesOrder(t *testing.T) {
+	t.Parallel()
+
+	testId := acctest.RandString(t, 10)
+	routerName := fmt.Sprintf("tf-test-router-%s", testId)
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRouterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRouterAdvertisedIpRangesOrder(routerName),
+			},
+			{
+				ResourceName:      "google_compute_router.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"bgp.0.advertised_ip_ranges.0.range", "bgp.0.advertised_ip_ranges.1.range"},
+			},
+		},
+	})
+}
+
 func TestAccComputeRouter_update(t *testing.T) {
 	t.Parallel()
 
@@ -257,6 +280,32 @@ resource "google_compute_router" "foobar" {
     }
     advertised_ip_ranges {
       range = "6.7.0.0/16"
+    }
+    keepalive_interval = 25
+  }
+}
+`, routerName, routerName)
+}
+
+func testAccComputeRouterAdvertisedIpRangesOrder(routerName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  name                    = "%s-net"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_router" "foobar" {
+  name    = "%s"
+  network = google_compute_network.foobar.name
+  bgp {
+    asn               = 64514
+    advertise_mode    = "CUSTOM"
+    advertised_groups = ["ALL_SUBNETS"]
+	advertised_ip_ranges {
+      range = "6.7.0.0/16"
+    }
+    advertised_ip_ranges {
+      range = "1.2.3.4"
     }
     keepalive_interval = 25
   }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
https://github.com/hashicorp/terraform-provider-google/issues/18472

sorting in flatten was not working as expected because configData was empty because of the wrong query of schema resourcedata

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed perma-diff in `google_compute_router`
```
