### PR TITLE
Add ingress_from documentation for VPC Service Controls resources for using networks as an incoming source.

### DIFF
--- a/mmv1/products/accesscontextmanager/ServicePerimeter.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeter.yaml
@@ -265,7 +265,10 @@ properties:
                         description: |
                           A Google Cloud resource that is allowed to ingress the perimeter.
                           Requests from these resources will be allowed to access perimeter data.
-                          Currently only projects are allowed. Format `projects/{project_number}`
+                          Currently only projects and VPCs are allowed.
+                          Project format: `projects/{projectNumber}`
+                          VPC network format: 
+                          `//compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NAME}`.
                           The project may be in any Google Cloud organization, not just the
                           organization that the perimeter is defined in. `*` is not allowed, the case
                           of allowing all Google Cloud resources only is not supported.

--- a/mmv1/products/accesscontextmanager/ServicePerimeter.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeter.yaml
@@ -267,7 +267,7 @@ properties:
                           Requests from these resources will be allowed to access perimeter data.
                           Currently only projects and VPCs are allowed.
                           Project format: `projects/{projectNumber}`
-                          VPC network format: 
+                          VPC network format:
                           `//compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NAME}`.
                           The project may be in any Google Cloud organization, not just the
                           organization that the perimeter is defined in. `*` is not allowed, the case

--- a/mmv1/products/accesscontextmanager/ServicePerimeterIngressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterIngressPolicy.yaml
@@ -113,7 +113,7 @@ properties:
                 Requests from these resources will be allowed to access perimeter data.
                 Currently only projects and VPCs are allowed.
                 Project format: `projects/{projectNumber}`
-                VPC network format: 
+                VPC network format:
                 `//compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NAME}`.
                 The project may be in any Google Cloud organization, not just the
                 organization that the perimeter is defined in. `*` is not allowed, the case

--- a/mmv1/products/accesscontextmanager/ServicePerimeterIngressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterIngressPolicy.yaml
@@ -111,7 +111,10 @@ properties:
               description: |
                 A Google Cloud resource that is allowed to ingress the perimeter.
                 Requests from these resources will be allowed to access perimeter data.
-                Currently only projects are allowed. Format `projects/{project_number}`
+                Currently only projects and VPCs are allowed.
+                Project format: `projects/{projectNumber}`
+                VPC network format: 
+                `//compute.googleapis.com/projects/{PROJECT_ID}/global/networks/{NAME}`.
                 The project may be in any Google Cloud organization, not just the
                 organization that the perimeter is defined in. `*` is not allowed, the case
                 of allowing all Google Cloud resources only is not supported.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This change addresses the issue at https://github.com/hashicorp/terraform-provider-google/issues/18142.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
