### PR TITLE
Add separate error message for not supported operation on min_cpu_platform

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -2539,36 +2539,43 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			}
 		}
 
-		if d.HasChange("min_cpu_platform") {
-			minCpuPlatform := d.Get("min_cpu_platform")
-			req := &compute.InstancesSetMinCpuPlatformRequest{
-				MinCpuPlatform: minCpuPlatform.(string),
-			}
-			op, err := config.NewComputeClient(userAgent).Instances.SetMinCpuPlatform(project, zone, instance.Name, req).Do()
-			if err != nil {
-				return err
-			}
-			opErr := ComputeOperationWaitTime(config, op, project, "updating min cpu platform", userAgent, d.Timeout(schema.TimeoutUpdate))
-			if opErr != nil {
-				return opErr
-			}
-		}
+		if d.HasChange("min_cpu_platform") || d.HasChange("machine_type") {
+			err = transport_tpg.Retry(transport_tpg.RetryOptions{
+				RetryFunc: func() error {
+					instance, err := config.NewComputeClient(userAgent).Instances.Get(project, zone, instance.Name).Do() //fetch instance for fingerprints
+					if err != nil {
+						return fmt.Errorf("Error retrieving instance: %s", err)
+					}
+					instanceFromConfig, err := expandComputeInstance(project, d, config) //need raw disk encryption keys from config for the Instaces.Update() call
+					if err != nil {
+						return fmt.Errorf("Error retrieving instance config: %s", err)
+					}
+					for _, disk := range instanceFromConfig.Disks {
+						disk.InitializeParams = nil //cannot have both `initialize_params` and source `specified`
+					}
+					mcp := d.Get("min_cpu_platform")
+					mt, err := tpgresource.ParseMachineTypesFieldValue(d.Get("machine_type").(string), d, config)
+					if err != nil {
+						return fmt.Errorf("Error retrieving instance's machine_type: %s", err)
+					}
 
-		if d.HasChange("machine_type") {
-			mt, err := tpgresource.ParseMachineTypesFieldValue(d.Get("machine_type").(string), d, config)
+					instance.Disks = instanceFromConfig.Disks
+					instance.MinCpuPlatform = mcp.(string)
+					instance.MachineType = mt.RelativeLink()
+
+					op, err := config.NewComputeClient(userAgent).Instances.Update(project, zone, instance.Name, instance).Do()
+					if err != nil {
+						return fmt.Errorf("Error updating instance: %s", err)
+					}
+					opErr := ComputeOperationWaitTime(config, op, project, "updating instance", userAgent, d.Timeout(schema.TimeoutUpdate))
+					if opErr != nil {
+						return opErr
+					}
+					return nil
+				},
+			})
 			if err != nil {
 				return err
-			}
-			req := &compute.InstancesSetMachineTypeRequest{
-				MachineType: mt.RelativeLink(),
-			}
-			op, err := config.NewComputeClient(userAgent).Instances.SetMachineType(project, zone, instance.Name, req).Do()
-			if err != nil {
-				return err
-			}
-			opErr := ComputeOperationWaitTime(config, op, project, "updating machinetype", userAgent, d.Timeout(schema.TimeoutUpdate))
-			if opErr != nil {
-				return opErr
 			}
 		}
 


### PR DESCRIPTION
Resolves [issue #15471](https://github.com/hashicorp/terraform-provider-google/issues/15471)

Refactor how machine_type and min_cpu_platform are updated

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: `min_cpu_platform` and `machine_type` are no longer changed separately resolving cases where values needed to be set to `AUTOMATIC`
```
