### PR TITLE
Add support for the management field in ConfigManagement Fleet-level default config

### DIFF
--- a/mmv1/products/gkehub2/Feature.yaml
+++ b/mmv1/products/gkehub2/Feature.yaml
@@ -279,6 +279,13 @@ properties:
           - !ruby/object:Api::Type::String
             name: version
             description: 'Version of ACM installed'
+          - !ruby/object:Api::Type::Enum
+            name: management
+            description: 'Set this field to MANAGEMENT_AUTOMATIC to enable Config Sync auto-upgrades, and set this field to MANAGEMENT_MANUAL or MANAGEMENT_UNSPECIFIED to disable Config Sync auto-upgrades.'
+            values:
+              - :MANAGEMENT_UNSPECIFIED
+              - :MANAGEMENT_AUTOMATIC
+              - :MANAGEMENT_MANUAL
           - !ruby/object:Api::Type::NestedObject
             name: configSync
             description: 'ConfigSync configuration for the cluster'

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go.erb
@@ -492,8 +492,51 @@ func TestAccGKEHubFeature_FleetDefaultMemberConfigConfigManagement(t *testing.T)
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+      {
+				Config: testAccGKEHubFeature_FleetDefaultMemberConfigConfigManagementEnableAutomaticManagementUpdate(context),
+			},
+			{
+				ResourceName:      "google_gke_hub_feature.feature",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+      {
+				Config: testAccGKEHubFeature_FleetDefaultMemberConfigConfigManagementRemovalUpdate(context),
+			},
+			{
+				ResourceName:      "google_gke_hub_feature.feature",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+      {
+				Config: testAccGKEHubFeature_FleetDefaultMemberConfigConfigManagementAutomaticManagement(context),
+			},
+			{
+				ResourceName:      "google_gke_hub_feature.feature",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
+}
+
+func testAccGKEHubFeature_FleetDefaultMemberConfigConfigManagementAutomaticManagement(context map[string]interface{}) string {
+	return gkeHubFeatureProjectSetupForGA(context) + acctest.Nprintf(`
+resource "google_gke_hub_feature" "feature" {
+  name = "configmanagement"
+  location = "global"
+  fleet_default_member_config {
+    configmanagement {
+      management = "MANAGEMENT_AUTOMATIC"
+      config_sync {
+        enabled = true
+      }
+    }
+  }
+  depends_on = [google_project_service.anthos, google_project_service.gkehub, google_project_service.acm]
+  project = google_project.project.project_id
+}
+`, context)
 }
 
 func testAccGKEHubFeature_FleetDefaultMemberConfigConfigManagement(context map[string]interface{}) string {
@@ -531,6 +574,7 @@ resource "google_gke_hub_feature" "feature" {
   fleet_default_member_config {
     configmanagement {
       version = "1.16.1"
+      management = "MANAGEMENT_MANUAL"
       config_sync {
         enabled = true
         prevent_drift = true
@@ -545,6 +589,45 @@ resource "google_gke_hub_feature" "feature" {
       }
     }
   }
+  depends_on = [google_project_service.anthos, google_project_service.gkehub, google_project_service.acm]
+  project = google_project.project.project_id
+}
+`, context)
+}
+
+func testAccGKEHubFeature_FleetDefaultMemberConfigConfigManagementEnableAutomaticManagementUpdate(context map[string]interface{}) string {
+	return gkeHubFeatureProjectSetupForGA(context) + acctest.Nprintf(`
+resource "google_gke_hub_feature" "feature" {
+  name = "configmanagement"
+  location = "global"
+  fleet_default_member_config {
+    configmanagement {
+      version = "1.16.1"
+      management = "MANAGEMENT_AUTOMATIC"
+      config_sync {
+        prevent_drift = true
+        source_format = "unstructured"
+        oci {
+          sync_repo = "us-central1-docker.pkg.dev/corp-gke-build-artifacts/acm/configs:latest"
+          policy_dir = "/acm/nonprod-root/"
+          secret_type = "gcpserviceaccount"
+          sync_wait_secs = "15"
+          gcp_service_account_email = "gke-cluster@gke-foo-nonprod.iam.gserviceaccount.com"
+        }
+      }
+    }
+  }
+  depends_on = [google_project_service.anthos, google_project_service.gkehub, google_project_service.acm]
+  project = google_project.project.project_id
+}
+`, context)
+}
+
+func testAccGKEHubFeature_FleetDefaultMemberConfigConfigManagementRemovalUpdate(context map[string]interface{}) string {
+	return gkeHubFeatureProjectSetupForGA(context) + acctest.Nprintf(`
+resource "google_gke_hub_feature" "feature" {
+  name = "configmanagement"
+  location = "global"
   depends_on = [google_project_service.anthos, google_project_service.gkehub, google_project_service.acm]
   project = google_project.project.project_id
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add support for the management field in ConfigManagement Fleet-level default config. Note this field is already supported in Pantheon UI and gcloud.


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
gkehub: added `management` field to ConfigManagement `fleet_default_member_config`
```
