### PR TITLE
Change datastream stream merge and append_only to conflicts with

### DIFF
--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -1140,7 +1140,6 @@ properties:
             allow_empty_object: true
             immutable: true
             conflicts:
-              - destination_config.0.bigquery_destination_config.0.merge
               - destination_config.0.bigquery_destination_config.0.append_only
             description: |
               Merge mode defines that all changes to a table will be merged at the destination Google BigQuery
@@ -1154,7 +1153,6 @@ properties:
             immutable: true
             conflicts:
               - destination_config.0.bigquery_destination_config.0.merge
-              - destination_config.0.bigquery_destination_config.0.append_only
             description: |
               AppendOnly mode defines that the stream of changes (INSERT, UPDATE-INSERT, UPDATE-DELETE and DELETE
               events) to a source table will be written to the destination Google BigQuery table, retaining the

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -1139,7 +1139,7 @@ properties:
             send_empty_value: true
             allow_empty_object: true
             immutable: true
-            exactly_one_of:
+            conflicts:
               - destination_config.0.bigquery_destination_config.0.merge
               - destination_config.0.bigquery_destination_config.0.append_only
             description: |
@@ -1152,7 +1152,7 @@ properties:
             send_empty_value: true
             allow_empty_object: true
             immutable: true
-            exactly_one_of:
+            conflicts:
               - destination_config.0.bigquery_destination_config.0.merge
               - destination_config.0.bigquery_destination_config.0.append_only
             description: |

--- a/mmv1/templates/terraform/examples/datastream_stream_bigquery.tf.erb
+++ b/mmv1/templates/terraform/examples/datastream_stream_bigquery.tf.erb
@@ -106,7 +106,6 @@ resource "google_datastream_stream" "<%= ctx[:primary_resource_id] %>" {
                     kms_key_name = "<%= ctx[:vars]['bigquery_destination_table_kms_key_name'] %>"
                 }
             }
-            merge {}
         }
     }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fix-forward part of https://github.com/hashicorp/terraform-provider-google/issues/18890 

manual confirmation: 
error recreation: gpaste/6276707390849024
after fix: gpaste/5739342071070720

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
datastream: removed a breaking change in `google_datastream_stream` that made one of `destination_config.0.bigquery_destination_config.0.merge` or `destination_config.0.bigquery_destination_config.0.append_only` required
```
