### PR TITLE
Fix static resource name in acceptance test TestAccVmwareengineNetworkPolicy_vmwareEngineNetworkPolicyFullExample

### DIFF
--- a/mmv1/products/vmwareengine/NetworkPolicy.yaml
+++ b/mmv1/products/vmwareengine/NetworkPolicy.yaml
@@ -50,14 +50,16 @@ examples:
     name: "vmware_engine_network_policy_basic"
     primary_resource_id: "vmw-engine-network-policy"
     vars:
-      name: "sample-network-policy"
+      network_name: 'sample-network-policy'
+      network_policy_name: 'sample-network-policy'
     test_env_vars:
       region: :REGION
   - !ruby/object:Provider::Terraform::Examples
     name: "vmware_engine_network_policy_full"
     primary_resource_id: "vmw-engine-network-policy"
     vars:
-      name: "sample-network-policy-full"
+      network_name: 'sample-network-policy'
+      network_policy_name: 'sample-network-policy'
     test_env_vars:
       region: :REGION
 

--- a/mmv1/products/vmwareengine/NetworkPolicy.yaml
+++ b/mmv1/products/vmwareengine/NetworkPolicy.yaml
@@ -50,7 +50,7 @@ examples:
     name: "vmware_engine_network_policy_basic"
     primary_resource_id: "vmw-engine-network-policy"
     vars:
-      network_name: 'sample-network-policy'
+      network_name: 'sample-network'
       network_policy_name: 'sample-network-policy'
     test_env_vars:
       region: :REGION
@@ -58,7 +58,7 @@ examples:
     name: "vmware_engine_network_policy_full"
     primary_resource_id: "vmw-engine-network-policy"
     vars:
-      network_name: 'sample-network-policy'
+      network_name: 'sample-network'
       network_policy_name: 'sample-network-policy'
     test_env_vars:
       region: :REGION

--- a/mmv1/products/vmwareengine/go_NetworkPolicy.yaml
+++ b/mmv1/products/vmwareengine/go_NetworkPolicy.yaml
@@ -53,7 +53,8 @@ examples:
   - name: 'vmware_engine_network_policy_basic'
     primary_resource_id: 'vmw-engine-network-policy'
     vars:
-      name: 'sample-network-policy'
+      network_name: 'sample-network-policy'
+      network_policy_name: 'sample-network-policy'
     test_env_vars:
       region: 'REGION'
   - name: 'vmware_engine_network_policy_full'

--- a/mmv1/products/vmwareengine/go_NetworkPolicy.yaml
+++ b/mmv1/products/vmwareengine/go_NetworkPolicy.yaml
@@ -60,7 +60,8 @@ examples:
   - name: 'vmware_engine_network_policy_full'
     primary_resource_id: 'vmw-engine-network-policy'
     vars:
-      name: 'sample-network-policy-full'
+      network_name: 'sample-network-policy'
+      network_policy_name: 'sample-network-policy'
     test_env_vars:
       region: 'REGION'
 parameters:

--- a/mmv1/products/vmwareengine/go_NetworkPolicy.yaml
+++ b/mmv1/products/vmwareengine/go_NetworkPolicy.yaml
@@ -53,14 +53,14 @@ examples:
   - name: 'vmware_engine_network_policy_basic'
     primary_resource_id: 'vmw-engine-network-policy'
     vars:
-      network_name: 'sample-network-policy'
+      network_name: 'sample-network'
       network_policy_name: 'sample-network-policy'
     test_env_vars:
       region: 'REGION'
   - name: 'vmware_engine_network_policy_full'
     primary_resource_id: 'vmw-engine-network-policy'
     vars:
-      network_name: 'sample-network-policy'
+      network_name: 'sample-network'
       network_policy_name: 'sample-network-policy'
     test_env_vars:
       region: 'REGION'

--- a/mmv1/templates/terraform/examples/go/vmware_engine_network_policy_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/vmware_engine_network_policy_full.tf.tmpl
@@ -1,5 +1,5 @@
 resource "google_vmwareengine_network" "network-policy-nw" {
-    name              = "standard-full-nw"
+    name              = "{{index $.Vars "network_name"}}"
     location          = "global" 
     type              = "STANDARD"
     description       = "VMwareEngine standard network sample"
@@ -7,7 +7,7 @@ resource "google_vmwareengine_network" "network-policy-nw" {
 
 resource "google_vmwareengine_network_policy" "{{$.PrimaryResourceId}}" {
     location = "{{index $.TestEnvVars "region"}}"
-    name = "{{index $.Vars "name"}}"
+    name = "{{index $.Vars "network_policy_name"}}"
     edge_services_cidr = "192.168.30.0/26"
     vmware_engine_network = google_vmwareengine_network.network-policy-nw.id
     description = "Sample Network Policy"

--- a/mmv1/templates/terraform/examples/vmware_engine_network_policy_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/vmware_engine_network_policy_basic.tf.erb
@@ -1,5 +1,5 @@
 resource "google_vmwareengine_network" "network-policy-nw" {
-    name              = "standard-nw"
+    name              = "<%= ctx[:vars]['network_name'] %>"
     location          = "global" 
     type              = "STANDARD"
     description       = "VMwareEngine standard network sample"
@@ -7,7 +7,7 @@ resource "google_vmwareengine_network" "network-policy-nw" {
 
 resource "google_vmwareengine_network_policy" "<%= ctx[:primary_resource_id] %>" {
     location = "<%= ctx[:test_env_vars]['region'] %>"
-    name = "<%= ctx[:vars]['name'] %>"
+    name = "<%= ctx[:vars]['network_policy_name'] %>"
     edge_services_cidr = "192.168.30.0/26"
     vmware_engine_network = google_vmwareengine_network.network-policy-nw.id
 }

--- a/mmv1/templates/terraform/examples/vmware_engine_network_policy_full.tf.erb
+++ b/mmv1/templates/terraform/examples/vmware_engine_network_policy_full.tf.erb
@@ -1,5 +1,5 @@
 resource "google_vmwareengine_network" "network-policy-nw" {
-    name              = "standard-full-nw"
+    name              = "<%= ctx[:vars]['network_name'] %>"
     location          = "global" 
     type              = "STANDARD"
     description       = "VMwareEngine standard network sample"
@@ -7,7 +7,7 @@ resource "google_vmwareengine_network" "network-policy-nw" {
 
 resource "google_vmwareengine_network_policy" "<%= ctx[:primary_resource_id] %>" {
     location = "<%= ctx[:test_env_vars]['region'] %>"
-    name = "<%= ctx[:vars]['name'] %>"
+    name = "<%= ctx[:vars]['network_policy_name'] %>"
     edge_services_cidr = "192.168.30.0/26"
     vmware_engine_network = google_vmwareengine_network.network-policy-nw.id
     description = "Sample Network Policy"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Addresses this problem in the tests:

```
------- Stdout: -------
=== RUN   TestAccVmwareengineNetworkPolicy_vmwareEngineNetworkPolicyFullExample
=== PAUSE TestAccVmwareengineNetworkPolicy_vmwareEngineNetworkPolicyFullExample
=== CONT  TestAccVmwareengineNetworkPolicy_vmwareEngineNetworkPolicyFullExample
    vcr_utils.go:152: Step 1/2 error: Error running apply: exit status 1
        Error: Error creating Network: googleapi: Error 409: Resource 'projects/PROJECTID/locations/global/vmwareEngineNetworks/standard-full-nw' already exists
        Details:
        [
          {
            "@type": "type.googleapis.com/google.rpc.ResourceInfo",
            "resourceName": "projects/PROJECTID/locations/global/vmwareEngineNetworks/standard-full-nw"
          }
        ]
          with google_vmwareengine_network.network-policy-nw,
          on terraform_plugin_test.tf line 2, in resource "google_vmwareengine_network" "network-policy-nw":
           2: resource "google_vmwareengine_network" "network-policy-nw" {
--- FAIL: TestAccVmwareengineNetworkPolicy_vmwareEngineNetworkPolicyFullExample (2.82s)
FAIL
```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
