### PR TITLE
Make TestAccAppEngineFlexibleAppVersion_update beta-only; contains beta-only field

### DIFF
--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.erb
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.erb
@@ -1,4 +1,7 @@
+<% autogen_exception -%>
 package appengine_test
+
+<% unless version == 'ga' -%>
 
 import (
 	"testing"
@@ -19,7 +22,7 @@ func TestAccAppEngineFlexibleAppVersion_update(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 		CheckDestroy:             testAccCheckAppEngineFlexibleAppVersionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -47,6 +50,7 @@ func TestAccAppEngineFlexibleAppVersion_update(t *testing.T) {
 func testAccAppEngineFlexibleAppVersion_python(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_project" "my_project" {
+  provider = google-beta
   name = "tf-test-appeng-flex%{random_suffix}"
   project_id = "tf-test-appeng-flex%{random_suffix}"
   org_id = "%{org_id}"
@@ -54,6 +58,7 @@ resource "google_project" "my_project" {
 }
 
 resource "google_project_service" "compute" {
+  provider = google-beta
   project = google_project.my_project.project_id
   service = "compute.googleapis.com"
 
@@ -61,6 +66,7 @@ resource "google_project_service" "compute" {
 }
 
 resource "google_project_service" "appengineflex" {
+  provider = google-beta
   project = google_project.my_project.project_id
   service = "appengineflex.googleapis.com"
 
@@ -69,12 +75,14 @@ resource "google_project_service" "appengineflex" {
 }
 
 resource "google_compute_network" "network" {
+  provider = google-beta
   project                 = google_project_service.compute.project
   name                    = "custom"
   auto_create_subnetworks = "false"
 }
 
 resource "google_compute_subnetwork" "subnetwork" {
+  provider = google-beta
   project                  = google_project_service.compute.project
   name                     = "custom"
   region                   = "us-central1"
@@ -84,17 +92,20 @@ resource "google_compute_subnetwork" "subnetwork" {
 }
 
 resource "google_app_engine_application" "app" {
+  provider = google-beta
   project     = google_project.my_project.project_id
   location_id = "us-central"
 }
 
 resource "google_project_iam_member" "gae_api" {
+  provider = google-beta
   project = google_project_service.appengineflex.project
   role    = "roles/compute.networkUser"
   member  = "serviceAccount:service-${google_project.my_project.number}@gae-api-prod.google.com.iam.gserviceaccount.com"
 }
 
 resource "google_app_engine_standard_app_version" "foo" {
+  provider = google-beta
   project    = google_project_iam_member.gae_api.project
   version_id = "v1"
   service    = "default"
@@ -124,6 +135,7 @@ resource "google_app_engine_standard_app_version" "foo" {
 }
 
 resource "google_app_engine_flexible_app_version" "foo" {
+  provider = google-beta
   project    = google_project_iam_member.gae_api.project
   version_id = "v1"
   service    = "custom"
@@ -193,24 +205,28 @@ resource "google_app_engine_flexible_app_version" "foo" {
 }
 
 resource "google_storage_bucket" "bucket" {
+  provider = google-beta
   project  = google_project.my_project.project_id
   name     = "tf-test-%{random_suffix}-flex-ae-bucket"
   location = "US"
 }
 
 resource "google_storage_bucket_object" "yaml" {
+  provider = google-beta
   name   = "app.yaml"
   bucket = google_storage_bucket.bucket.name
   source = "./test-fixtures/hello-world-flask/app.yaml"
 }
 
 resource "google_storage_bucket_object" "requirements" {
+  provider = google-beta
   name   = "requirements.txt"
   bucket = google_storage_bucket.bucket.name
   source = "./test-fixtures/hello-world-flask/requirements.txt"
 }
 
 resource "google_storage_bucket_object" "main" {
+  provider = google-beta
   name   = "main.py"
   bucket = google_storage_bucket.bucket.name
   source = "./test-fixtures/hello-world-flask/main.py"
@@ -220,6 +236,7 @@ resource "google_storage_bucket_object" "main" {
 func testAccAppEngineFlexibleAppVersion_pythonUpdate(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_project" "my_project" {
+  provider = google-beta
   name = "tf-test-appeng-flex%{random_suffix}"
   project_id = "tf-test-appeng-flex%{random_suffix}"
   org_id = "%{org_id}"
@@ -227,6 +244,7 @@ resource "google_project" "my_project" {
 }
 
 resource "google_project_service" "compute" {
+  provider = google-beta
   project = google_project.my_project.project_id
   service = "compute.googleapis.com"
 
@@ -234,6 +252,7 @@ resource "google_project_service" "compute" {
 }
 
 resource "google_project_service" "appengineflex" {
+  provider = google-beta
   project = google_project.my_project.project_id
   service = "appengineflex.googleapis.com"
 
@@ -242,12 +261,14 @@ resource "google_project_service" "appengineflex" {
 }
 
 resource "google_compute_network" "network" {
+  provider = google-beta
   project                 = google_project_service.compute.project
   name                    = "custom"
   auto_create_subnetworks = "false"
 }
 
 resource "google_compute_subnetwork" "subnetwork" {
+  provider = google-beta
   project                  = google_project_service.compute.project
   name                     = "custom"
   region                   = "us-central1"
@@ -257,17 +278,20 @@ resource "google_compute_subnetwork" "subnetwork" {
 }
 
 resource "google_app_engine_application" "app" {
+  provider = google-beta
   project     = google_project.my_project.project_id
   location_id = "us-central"
 }
 
 resource "google_project_iam_member" "gae_api" {
+  provider = google-beta
   project = google_project_service.appengineflex.project
   role    = "roles/compute.networkUser"
   member  = "serviceAccount:service-${google_project.my_project.number}@gae-api-prod.google.com.iam.gserviceaccount.com"
 }
 
 resource "google_app_engine_standard_app_version" "foo" {
+  provider = google-beta
   project    = google_project_iam_member.gae_api.project
   version_id = "v1"
   service    = "default"
@@ -297,6 +321,7 @@ resource "google_app_engine_standard_app_version" "foo" {
 }
 
 resource "google_app_engine_flexible_app_version" "foo" {
+  provider = google-beta
   project    = google_project_iam_member.gae_api.project
   version_id = "v1"
   service    = "custom"
@@ -366,26 +391,32 @@ resource "google_app_engine_flexible_app_version" "foo" {
 }
 
 resource "google_storage_bucket" "bucket" {
+  provider = google-beta
   project  = google_project.my_project.project_id
   name     = "tf-test-%{random_suffix}-flex-ae-bucket"
   location = "US"
 }
 
 resource "google_storage_bucket_object" "yaml" {
+  provider = google-beta
   name   = "app.yaml"
   bucket = google_storage_bucket.bucket.name
   source = "./test-fixtures/hello-world-flask/app.yaml"
 }
 
 resource "google_storage_bucket_object" "requirements" {
+  provider = google-beta
   name   = "requirements.txt"
   bucket = google_storage_bucket.bucket.name
   source = "./test-fixtures/hello-world-flask/requirements.txt"
 }
 
 resource "google_storage_bucket_object" "main" {
+  provider = google-beta
   name   = "main.py"
   bucket = google_storage_bucket.bucket.name
   source = "./test-fixtures/hello-world-flask/main.py"
 }`, context)
 }
+
+<% end -%>

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.erb
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.erb
@@ -22,7 +22,7 @@ func TestAccAppEngineFlexibleAppVersion_update(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckAppEngineFlexibleAppVersionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This test fails in the nightlies due to using the GA provider but the config [contains a Beta-only field](https://github.com/GoogleCloudPlatform/magic-modules/pull/10326#issuecomment-2115766195)

```
------- Stdout: -------
=== RUN   TestAccAppEngineFlexibleAppVersion_update
=== PAUSE TestAccAppEngineFlexibleAppVersion_update
=== CONT  TestAccAppEngineFlexibleAppVersion_update
    vcr_utils.go:152: Step 1/4 error: Error running pre-apply refresh: exit status 1
        Error: Unsupported argument
          on terraform_plugin_test.tf line 134, in resource "google_app_engine_flexible_app_version" "foo":
         134:     instance_ip_mode = "EXTERNAL"
        An argument named "instance_ip_mode" is not expected here.
--- FAIL: TestAccAppEngineFlexibleAppVersion_update (0.73s)
FAIL

```


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
