### PR TITLE
Add Beta support for allowedPorts field for Cloud Workstations configurations

### DIFF
--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -658,6 +658,7 @@ properties:
     min_version: 'beta'
   - name: 'allowedPorts'
     type: Array
+    default_from_api: true
     description: |
       A list of port ranges specifying single ports or ranges of ports that are externally accessible in the workstation. Allowed ports must be one of 22, 80, or within range 1024-65535. If not specified defaults to ports 22, 80, and ports 1024-65535.
     min_version: 'beta'

--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -670,13 +670,11 @@ properties:
           description: |
             Starting port number for the current range of ports. Valid ports are 22, 80, and ports within the range 1024-65535.
           min_version: 'beta'
-          required: true
         - name: 'last'
           type: Integer
           description: |
             Ending port number for the current range of ports. Valid ports are 22, 80, and ports within the range 1024-65535.
           min_version: 'beta'
-          required: true
   - name: 'conditions'
     type: Array
     description: |-

--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -119,6 +119,12 @@ examples:
       account_id: 'my-account'
       workstation_cluster_name: 'workstation-cluster'
       workstation_config_name: 'workstation-config'
+  - name: 'workstation_config_allowed_ports'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      workstation_cluster_name: 'workstation-cluster'
+      workstation_config_name: 'workstation-config'
 parameters:
   - name: 'workstationConfigId'
     type: String
@@ -650,6 +656,26 @@ properties:
     description: |
       Disables support for plain TCP connections in the workstation. By default the service supports TCP connections via a websocket relay. Setting this option to true disables that relay, which prevents the usage of services that require plain tcp connections, such as ssh. When enabled, all communication must occur over https or wss.
     min_version: 'beta'
+  - name: 'allowedPorts'
+    type: Array
+    description: |
+      A list of port ranges specifying single ports or ranges of ports that are externally accessible in the workstation. Allowed ports must be one of 22, 80, or within range 1024-65535. If not specified defaults to ports 22, 80, and ports 1024-65535.
+    min_version: 'beta'
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'first'
+          type: Integer
+          description: |
+            Starting port number for the current range of ports. Valid ports are 22, 80, and ports within the range 1024-65535.
+          min_version: 'beta'
+          required: true
+        - name: 'last'
+          type: Integer
+          description: |
+            Ending port number for the current range of ports. Valid ports are 22, 80, and ports within the range 1024-65535.
+          min_version: 'beta'
+          required: true
   - name: 'conditions'
     type: Array
     description: |-

--- a/mmv1/templates/terraform/examples/workstation_config_allowed_ports.tf.tmpl
+++ b/mmv1/templates/terraform/examples/workstation_config_allowed_ports.tf.tmpl
@@ -1,0 +1,62 @@
+resource "google_compute_network" "default" {
+  provider                = google-beta
+  name                    = "{{index $.Vars "workstation_cluster_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  provider      = google-beta
+  name          = "{{index $.Vars "workstation_cluster_name"}}"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.default.name
+}
+
+resource "google_workstations_workstation_cluster" "{{$.PrimaryResourceId}}" {
+  provider               = google-beta
+  workstation_cluster_id = "{{index $.Vars "workstation_cluster_name"}}"
+  network                = google_compute_network.default.id
+  subnetwork             = google_compute_subnetwork.default.id
+  location               = "us-central1"
+  
+  labels = {
+    "label" = "key"
+  }
+
+  annotations = {
+    label-one = "value-one"
+  }
+}
+
+resource "google_workstations_workstation_config" "{{$.PrimaryResourceId}}" {
+  provider               = google-beta
+  workstation_config_id  = "{{index $.Vars "workstation_config_name"}}"
+  workstation_cluster_id = google_workstations_workstation_cluster.{{$.PrimaryResourceId}}.workstation_cluster_id
+  location               = "us-central1"
+
+  host {
+    gce_instance {
+      machine_type                = "e2-standard-4"
+      boot_disk_size_gb           = 35
+      disable_public_ip_addresses = true
+    }
+  }
+
+  # Allow only port 80 (HTTP)
+  allowed_ports {
+    first = 80
+    last  = 80
+  }
+
+  # Allow only port 22 (SSH)
+  allowed_ports {
+    first = 22
+    last  = 22
+  }
+
+  # Allow port range 1024-65535
+  allowed_ports {
+    first = 1024
+    last  = 65535
+  }
+}

--- a/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.tmpl
@@ -1397,4 +1397,159 @@ resource "google_workstations_workstation_config" "default" {
 `, context)
 }
 
-{{ end }}
+func TestAccWorkstationsWorkstationConfig_workstationConfigAllowedPortsUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckWorkstationsWorkstationConfigDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkstationsWorkstationConfig_workstationConfigAllowedPorts(context),
+			},
+			{
+				ResourceName:            "google_workstations_workstation_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "enable_audit_agent", "labels", "location", "terraform_labels", "workstation_cluster_id", "workstation_config_id"},
+			},
+			{
+				Config: testAccWorkstationsWorkstationConfig_workstationConfigAllowedPortsUpdate(context),
+			},
+			{
+				ResourceName:            "google_workstations_workstation_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "enable_audit_agent", "labels", "location", "terraform_labels", "workstation_cluster_id", "workstation_config_id"},
+			},
+		},
+	})
+}
+
+func testAccWorkstationsWorkstationConfig_workstationConfigAllowedPorts(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "default" {
+  provider                = google-beta
+  name                    = "tf-test-workstation-cluster%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  provider      = google-beta
+  name          = "tf-test-workstation-cluster%{random_suffix}"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.default.name
+}
+
+resource "google_workstations_workstation_cluster" "default" {
+  provider               = google-beta
+  workstation_cluster_id = "tf-test-workstation-cluster%{random_suffix}"
+  network                = google_compute_network.default.id
+  subnetwork             = google_compute_subnetwork.default.id
+  location               = "us-central1"
+
+  labels = {
+    "label" = "key"
+  }
+
+  annotations = {
+    label-one = "value-one"
+  }
+}
+
+resource "google_workstations_workstation_config" "default" {
+  provider               = google-beta
+  workstation_config_id  = "tf-test-workstation-config%{random_suffix}"
+  workstation_cluster_id = google_workstations_workstation_cluster.default.workstation_cluster_id
+  location               = "us-central1"
+
+  host {
+    gce_instance {
+      machine_type                = "e2-standard-4"
+      boot_disk_size_gb           = 35
+      disable_public_ip_addresses = true
+    }
+  }
+
+  # Allow only port 80 (HTTP)
+  allowed_ports {
+    first = 80
+    last  = 80
+  }
+}
+`, context)
+}
+
+func testAccWorkstationsWorkstationConfig_workstationConfigAllowedPortsUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "default" {
+  provider                = google-beta
+  name                    = "tf-test-workstation-cluster%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  provider      = google-beta
+  name          = "tf-test-workstation-cluster%{random_suffix}"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.default.name
+}
+
+resource "google_workstations_workstation_cluster" "default" {
+  provider               = google-beta
+  workstation_cluster_id = "tf-test-workstation-cluster%{random_suffix}"
+  network                = google_compute_network.default.id
+  subnetwork             = google_compute_subnetwork.default.id
+  location               = "us-central1"
+
+  labels = {
+    "label" = "key"
+  }
+
+  annotations = {
+    label-one = "value-one"
+  }
+}
+
+resource "google_workstations_workstation_config" "default" {
+  provider               = google-beta
+  workstation_config_id  = "tf-test-workstation-config%{random_suffix}"
+  workstation_cluster_id = google_workstations_workstation_cluster.default.workstation_cluster_id
+  location               = "us-central1"
+
+  host {
+    gce_instance {
+      machine_type                = "e2-standard-4"
+      boot_disk_size_gb           = 35
+      disable_public_ip_addresses = true
+    }
+  }
+
+  # Allow only port 80 (HTTP)
+  allowed_ports {
+    first = 80
+    last  = 80
+  }
+
+  # Allow only port 22 (SSH)
+  allowed_ports {
+    first = 22
+    last  = 22
+  }
+
+  # Allow port range 1024-65535
+  allowed_ports {
+    first = 1024
+    last  = 65535
+  }
+}
+`, context)
+}
+{{- end }}


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/18859

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
workstations: added field `allowedPorts` to `google_workstations_workstation_config`
```
