### PR TITLE
Apply labels model

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -541,7 +541,7 @@ func (r *Resource) addLabelsFields(props []*Type, parent *Type, labels *Type) []
 	if parent == nil || parent.FlattenObject {
 		r.CustomDiff = append(r.CustomDiff, "tpgresource.SetLabelsDiff")
 	} else if parent.Name == "metadata" {
-		r.CustomDiff = append(r.CustomDiff, "tpgresource.SetMetadataLabelsDiff")
+		r.CustomDiff = append(r.CustomDiff, `tpgresource.SetNestedLabelsDiff("metadata", "labels")`)
 	}
 
 	terraformLabelsField := buildTerraformLabelsField("labels", parent, labels)

--- a/mmv1/api/resource.rb
+++ b/mmv1/api/resource.rb
@@ -477,7 +477,7 @@ module Api
       if parent.nil? || parent.flatten_object
         @custom_diff.append('tpgresource.SetLabelsDiff')
       elsif parent.name == 'metadata'
-        @custom_diff.append('tpgresource.SetMetadataLabelsDiff')
+        @custom_diff.append('tpgresource.SetNestedLabelsDiff("metadata", "labels")')
       end
 
       props << build_terraform_labels_field('labels', parent, labels)

--- a/mmv1/api/type.rb
+++ b/mmv1/api/type.rb
@@ -762,12 +762,6 @@ module Api
              # The "labels" field has type Array, so skip this resource
              !(product_name == 'DeploymentManager' && resource_name == 'Deployment') &&
 
-             # https://github.com/hashicorp/terraform-provider-google/issues/16219
-             !(product_name == 'Edgenetwork' && resource_name == 'Network') &&
-
-             # https://github.com/hashicorp/terraform-provider-google/issues/16219
-             !(product_name == 'Edgenetwork' && resource_name == 'Subnet') &&
-
              # "userLabels" is the resource labels field
              !(product_name == 'Monitoring' && resource_name == 'NotificationChannel') &&
 

--- a/mmv1/products/edgenetwork/Network.yaml
+++ b/mmv1/products/edgenetwork/Network.yaml
@@ -66,7 +66,7 @@ properties:
     description: |
       The canonical name of this resource, with format
       `projects/{{project}}/locations/{{location}}/zones/{{zone}}/networks/{{network_id}}`
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     required: false
     description: |

--- a/mmv1/products/edgenetwork/Subnet.yaml
+++ b/mmv1/products/edgenetwork/Subnet.yaml
@@ -77,7 +77,7 @@ properties:
     description: |
       The canonical name of this resource, with format
       `projects/{{project}}/locations/{{location}}/zones/{{zone}}/subnets/{{subnet_id}}`
-  - !ruby/object:Api::Type::KeyValuePairs
+  - !ruby/object:Api::Type::KeyValueLabels
     name: 'labels'
     required: false
     description: |

--- a/mmv1/templates/terraform/yaml_conversion.erb
+++ b/mmv1/templates/terraform/yaml_conversion.erb
@@ -409,7 +409,7 @@ custom_code:
 <%  end -%>
 <% 
 custom_diff = object.custom_diff.reject {
-  |cdiff| cdiff == "tpgresource.SetLabelsDiff" || cdiff == "tpgresource.SetMetadataLabelsDiff" || cdiff == "tpgresource.SetAnnotationsDiff" || cdiff == "tpgresource.SetMetadataAnnotationsDiff"
+  |cdiff| cdiff == "tpgresource.SetLabelsDiff" || cdiff.include?("tpgresource.SetNestedLabelsDiff") || cdiff == "tpgresource.SetAnnotationsDiff" || cdiff == "tpgresource.SetMetadataAnnotationsDiff"
 }
 -%>
 <%  unless custom_diff.empty? -%>

--- a/mmv1/third_party/terraform/services/container/go/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/go/resource_container_cluster_test.go.tmpl
@@ -148,7 +148,7 @@ func TestAccContainerCluster_misc(t *testing.T) {
 				ResourceName:            "google_container_cluster.primary",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"remove_default_node_pool", "deletion_protection"},
+				ImportStateVerifyIgnore: []string{"remove_default_node_pool", "deletion_protection", "resource_labels", "terraform_labels"},
 			},
 			{
 				Config: testAccContainerCluster_misc_update(clusterName, networkName, subnetworkName),
@@ -157,7 +157,7 @@ func TestAccContainerCluster_misc(t *testing.T) {
 				ResourceName:            "google_container_cluster.primary",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"remove_default_node_pool", "deletion_protection"},
+				ImportStateVerifyIgnore: []string{"remove_default_node_pool", "deletion_protection", "resource_labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -217,6 +217,7 @@ func ResourceContainerCluster() *schema.Resource {
 			containerClusterSurgeSettingsCustomizeDiff,
 			containerClusterEnableK8sBetaApisCustomizeDiff,
 			containerClusterNodeVersionCustomizeDiff,
+			tpgresource.SetDiffForLabelsWithCustomizedName("resource_labels"),
 		),
 
 		Timeouts: &schema.ResourceTimeout{
@@ -1768,7 +1769,22 @@ func ResourceContainerCluster() *schema.Resource {
 				Type:        schema.TypeMap,
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
-				Description: `The GCE resource labels (a map of key/value pairs) to be applied to the cluster.`,
+				Description: `The GCE resource labels (a map of key/value pairs) to be applied to the cluster.
+
+				**Note**: This field is non-authoritative, and will only manage the labels present in your configuration.
+				Please refer to the field 'effective_labels' for all of the labels present on the resource.`,
+			},
+			"terraform_labels": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: `The combination of labels configured directly on the resource and default labels configured on the provider.`,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"effective_labels": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: `All of labels (key/value pairs) present on the resource in GCP, including the labels configured through Terraform, other clients and services.`,
+				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 
 			"label_fingerprint": {
@@ -2333,7 +2349,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		MasterAuth:     expandMasterAuth(d.Get("master_auth")),
 		NotificationConfig: expandNotificationConfig(d.Get("notification_config")),
 		ConfidentialNodes: expandConfidentialNodes(d.Get("confidential_nodes")),
-		ResourceLabels: tpgresource.ExpandStringMap(d, "resource_labels"),
+		ResourceLabels: tpgresource.ExpandStringMap(d, "effective_labels"),
 		NodePoolAutoConfig: expandNodePoolAutoConfig(d.Get("node_pool_auto_config")),
 <% unless version == 'ga' -%>
 		ProtectConfig: expandProtectConfig(d.Get("protect_config")),
@@ -2951,8 +2967,14 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	}
 <% end -%>
 
-	if err := d.Set("resource_labels", cluster.ResourceLabels); err != nil {
-		return fmt.Errorf("Error setting resource_labels: %s", err)
+	if err := tpgresource.SetLabels(cluster.ResourceLabels, d, "resource_labels"); err != nil {
+		return fmt.Errorf("Error setting labels: %s", err)
+	}
+	if err := tpgresource.SetLabels(cluster.ResourceLabels, d, "terraform_labels"); err != nil {
+		return fmt.Errorf("Error setting terraform_labels: %s", err)
+	}
+	if err := d.Set("effective_labels", cluster.ResourceLabels); err != nil {
+		return fmt.Errorf("Error setting effective_labels: %s", err)
 	}
 	if err := d.Set("label_fingerprint", cluster.LabelFingerprint); err != nil {
 		return fmt.Errorf("Error setting label_fingerprint: %s", err)
@@ -4044,8 +4066,8 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		log.Printf("[INFO] GKE cluster %s monitoring config has been updated", d.Id())
 	}
 
-	if d.HasChange("resource_labels") {
-		resourceLabels := d.Get("resource_labels").(map[string]interface{})
+	if d.HasChange("effective_labels") {
+		resourceLabels := d.Get("effective_labels").(map[string]interface{})
 		labelFingerprint := d.Get("label_fingerprint").(string)
 		req := &container.SetLabelsRequest{
 			ResourceLabels:   tpgresource.ConvertStringMap(resourceLabels),

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -11080,3 +11080,158 @@ resource "google_container_cluster" "primary" {
 }
 `, secretID, clusterName, networkName, subnetworkName)
 }
+
+func TestAccContainerCluster_withProviderDefaultLabels(t *testing.T) {
+	// The test failed if VCR testing is enabled, because the cached provider config is used.
+	// With the cached provider config, any changes in the provider default labels will not be applied.
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withProviderDefaultLabels(clusterName, networkName, subnetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "resource_labels.%", "1"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "resource_labels.created-by", "terraform"),
+
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.%", "2"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.default_key1", "default_value1"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.created-by", "terraform"),
+
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "effective_labels.%", "2"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"remove_default_node_pool", "deletion_protection", "resource_labels", "terraform_labels"},
+			},
+			{
+				Config: testAccContainerCluster_resourceLabelsOverridesProviderDefaultLabels(clusterName, networkName, subnetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "resource_labels.%", "2"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "resource_labels.created-by", "terraform"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.default_key1", "value1"),
+
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.%", "2"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.default_key1", "value1"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.created-by", "terraform"),
+
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "effective_labels.%", "2"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"remove_default_node_pool", "deletion_protection", "resource_labels", "terraform_labels"},
+			},
+			{
+				Config: testAccContainerCluster_moveResourceLabelToProviderDefaultLabels(clusterName, networkName, subnetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "resource_labels.%", "0"),
+
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.%", "2"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.default_key1", "default_value1"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.created-by", "terraform"),
+
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "effective_labels.%", "2"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"remove_default_node_pool", "deletion_protection", "resource_labels", "terraform_labels"},
+			},
+			{
+				Config: testAccContainerCluster_basic(clusterName, networkName, subnetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "resource_labels.%", "0"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.%", "0"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "effective_labels.%", "0"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"remove_default_node_pool", "deletion_protection", "resource_labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccContainerCluster_withProviderDefaultLabels(name, networkName, subnetworkName string) string {
+	return fmt.Sprintf(`
+provider "google" {
+  default_labels = {
+    default_key1 = "default_value1"
+  }
+}
+
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  deletion_protection = false
+  network    = "%s"
+  subnetwork    = "%s"
+  resource_labels = {
+    created-by = "terraform"
+  }
+}
+`, name, networkName, subnetworkName)
+}
+
+func testAccContainerCluster_resourceLabelsOverridesProviderDefaultLabels(name, networkName, subnetworkName string) string {
+	return fmt.Sprintf(`
+provider "google" {
+  default_labels = {
+    default_key1 = "default_value1"
+  }
+}
+
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  deletion_protection = false
+  network    = "%s"
+  subnetwork    = "%s"
+  resource_labels = {
+    created-by = "terraform"
+	default_key1 = "value1"
+  }
+}
+`, name, networkName, subnetworkName)
+}
+
+func testAccContainerCluster_moveResourceLabelToProviderDefaultLabels(name, networkName, subnetworkName string) string {
+	return fmt.Sprintf(`
+provider "google" {
+  default_labels = {
+    default_key1 = "default_value1"
+	created-by   = "terraform"
+  }
+}
+
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  deletion_protection = false
+  network    = "%s"
+  subnetwork    = "%s"
+}
+`, name, networkName, subnetworkName)
+}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -149,7 +149,7 @@ func TestAccContainerCluster_misc(t *testing.T) {
 				ResourceName:            "google_container_cluster.primary",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"remove_default_node_pool", "deletion_protection"},
+				ImportStateVerifyIgnore: []string{"remove_default_node_pool", "deletion_protection", "resource_labels", "terraform_labels"},
 			},
 			{
 				Config: testAccContainerCluster_misc_update(clusterName, networkName, subnetworkName),
@@ -158,7 +158,7 @@ func TestAccContainerCluster_misc(t *testing.T) {
 				ResourceName:            "google_container_cluster.primary",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"remove_default_node_pool", "deletion_protection"},
+				ImportStateVerifyIgnore: []string{"remove_default_node_pool", "deletion_protection", "resource_labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.erb
@@ -2128,9 +2128,7 @@ func flattenSettings(settings *sqladmin.Settings, d *schema.ResourceData) []map[
 
 	data["enable_google_ml_integration"] = settings.EnableGoogleMlIntegration
 
-	if settings.UserLabels != nil {
-		data["user_labels"] = flattenSettingsLabels("settings.0.user_labels", settings.UserLabels, d)
-	}
+	data["user_labels"] = flattenSettingsLabels("settings.0.user_labels", settings.UserLabels, d)
 	data["terraform_labels"] = flattenSettingsLabels("settings.0.terraform_labels", settings.UserLabels, d)
 	data["effective_labels"] = settings.UserLabels
 

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.erb
@@ -141,6 +141,7 @@ func ResourceSqlDatabaseInstance() *schema.Resource {
 			customdiff.IfValueChange("instance_type", isReplicaPromoteRequested, checkPromoteConfigurationsAndUpdateDiff),
 			privateNetworkCustomizeDiff,
 			pitrSupportDbCustomizeDiff,
+			tpgresource.SetNestedLabelsDiff("settings", "user_labels"),
 		),
 
 		Schema: map[string]*schema.Schema{
@@ -565,9 +566,23 @@ is set to true. Defaults to ZONAL.`,
 						"user_labels": {
 							Type:        schema.TypeMap,
 							Optional:    true,
-							Computed:    true,
 							Elem:        &schema.Schema{Type: schema.TypeString},
-							Description: `A set of key/value user label pairs to assign to the instance.`,
+							Description: `A set of key/value user label pairs to assign to the instance.
+
+							**Note**: This field is non-authoritative, and will only manage the labels present in your configuration.
+							Please refer to the field 'effective_labels' for all of the labels present on the resource.`,
+						},
+						"terraform_labels": {
+							Type:        schema.TypeMap,
+							Computed:    true,
+							Description: `The combination of labels configured directly on the resource and default labels configured on the provider.`,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+						},
+						"effective_labels": {
+							Type:        schema.TypeMap,
+							Computed:    true,
+							Description: `All of labels (key/value pairs) present on the resource in GCP, including the labels configured through Terraform, other clients and services.`,
+							Elem:        &schema.Schema{Type: schema.TypeString},
 						},
 						"insights_config": {
 							Type:     schema.TypeList,
@@ -1288,7 +1303,7 @@ func expandSqlDatabaseInstanceSettings(configured []interface{}, databaseVersion
 		PricingPlan:                _settings["pricing_plan"].(string),
 		DeletionProtectionEnabled:  _settings["deletion_protection_enabled"].(bool),
 		EnableGoogleMlIntegration:  _settings["enable_google_ml_integration"].(bool),
-		UserLabels:                 tpgresource.ConvertStringMap(_settings["user_labels"].(map[string]interface{})),
+		UserLabels:                 tpgresource.ConvertStringMap(_settings["effective_labels"].(map[string]interface{})),
 		BackupConfiguration:        expandBackupConfiguration(_settings["backup_configuration"].([]interface{})),
 		DatabaseFlags:              expandDatabaseFlags(_settings["database_flags"].(*schema.Set).List()),
 		IpConfiguration:            expandIpConfiguration(_settings["ip_configuration"].([]interface{}), databaseVersion),
@@ -2067,7 +2082,6 @@ func flattenSettings(settings *sqladmin.Settings, d *schema.ResourceData) []map[
 		"disk_type":                    settings.DataDiskType,
 		"disk_size":                    settings.DataDiskSizeGb,
 		"pricing_plan":                 settings.PricingPlan,
-		"user_labels":                  settings.UserLabels,
 		"password_validation_policy":   settings.PasswordValidationPolicy,
 		"time_zone":                    settings.TimeZone,
 		"deletion_protection_enabled":  settings.DeletionProtectionEnabled,
@@ -2115,8 +2129,10 @@ func flattenSettings(settings *sqladmin.Settings, d *schema.ResourceData) []map[
 	data["enable_google_ml_integration"] = settings.EnableGoogleMlIntegration
 
 	if settings.UserLabels != nil {
-		data["user_labels"] = settings.UserLabels
+		data["user_labels"] = flattenSettingsLabels("settings.0.user_labels", settings.UserLabels, d)
 	}
+	data["terraform_labels"] = flattenSettingsLabels("settings.0.terraform_labels", settings.UserLabels, d)
+	data["effective_labels"] = settings.UserLabels
 
 	if settings.PasswordValidationPolicy != nil {
 		data["password_validation_policy"] = flattenPasswordValidationPolicy(settings.PasswordValidationPolicy)
@@ -2131,6 +2147,21 @@ func flattenSettings(settings *sqladmin.Settings, d *schema.ResourceData) []map[
 	}
 
 	return []map[string]interface{}{data}
+}
+
+func flattenSettingsLabels(lineage string, v interface{}, d *schema.ResourceData) interface{} {
+	if v == nil {
+		return v
+	}
+
+	transformed := make(map[string]string)
+	if l, ok := d.GetOkExists(lineage); ok {
+		for k := range l.(map[string]interface{}) {
+			transformed[k] = v.(map[string]string)[k]
+		}
+	}
+
+	return transformed
 }
 
 func flattenDataCacheConfig(d *sqladmin.DataCacheConfig) []map[string]interface{} {

--- a/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
@@ -114,6 +114,15 @@ A `view` can no longer be created when `schema` contains required fields
 
 Removed in favor of field `settings.ip_configuration.ssl_mode`.
 
+### Three label-related fields are now present
+
+* `settings.user_labels` field is non-authoritative and only manages the labels defined by
+the users on the resource through Terraform.
+* The new output-only `settings.terraform_labels` field merges the labels defined by the users
+on the resource through Terraform and the default labels configured on the provider.
+* The new output-only `settings.effective_labels` field lists all of labels present on the resource
+in GCP, including the labels configured through Terraform, the system, and other clients.
+
 ## Resource: `google_pubsub_topic`
 
 ### `schema_settings` no longer has a default value
@@ -172,3 +181,36 @@ Users will need to check their configuration for any `google_vpc_access_connecto
 resource blocks that contain both fields in a conflicting pair, and remove one of those fields.
 The fields that are removed from the configuration will still have Computed values,
 that are derived from the API.
+
+## Resource: `google_container_cluster`
+
+### Three label-related fields are now present
+
+* `resource_labels` field is non-authoritative and only manages the labels defined by
+the users on the resource through Terraform.
+* The new output-only `terraform_labels` field merges the labels defined by the users
+on the resource through Terraform and the default labels configured on the provider.
+* The new output-only `effective_labels` field lists all of labels present on the resource
+in GCP, including the labels configured through Terraform, the system, and other clients.
+
+## Resource: `google_edgenetwork_network`
+
+### Three label-related fields are now present
+
+* `labels` field is non-authoritative and only manages the labels defined by
+the users on the resource through Terraform.
+* The new output-only `terraform_labels` field merges the labels defined by the users
+on the resource through Terraform and the default labels configured on the provider.
+* The new output-only `effective_labels` field lists all of labels present on the resource
+in GCP, including the labels configured through Terraform, the system, and other clients.
+
+## Resource: `google_edgenetwork_subnet`
+
+### Three label-related fields are now present
+
+* `labels` field is non-authoritative and only manages the labels defined by
+the users on the resource through Terraform.
+* The new output-only `terraform_labels` field merges the labels defined by the users
+on the resource through Terraform and the default labels configured on the provider.
+* The new output-only `effective_labels` field lists all of labels present on the resource
+in GCP, including the labels configured through Terraform, the system, and other clients.

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -328,6 +328,15 @@ channel. Structure is [documented below](#nested_release_channel).
 
 * `resource_labels` - (Optional) The GCE resource labels (a map of key/value pairs) to be applied to the cluster.
 
+    **Note**: This field is non-authoritative, and will only manage the labels present in your configuration.
+    Please refer to the field 'effective_labels' for all of the labels present on the resource.
+
+* `terraform_labels` -
+  The combination of labels configured directly on the resource and default labels configured on the provider.
+
+* `effective_labels` -
+  All of labels (key/value pairs) present on the resource in GCP, including the labels configured through Terraform, other clients and services.
+
 * `cost_management_config` - (Optional) Configuration for the
     [Cost Allocation](https://cloud.google.com/kubernetes-engine/docs/how-to/cost-allocations) feature.
     Structure is [documented below](#nested_cost_management_config).

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -274,6 +274,15 @@ The `settings` block supports:
 
 * `user_labels` - (Optional) A set of key/value user label pairs to assign to the instance.
 
+    **Note**: This field is non-authoritative, and will only manage the labels present in your configuration.
+    Please refer to the field 'effective_labels' for all of the labels present on the resource.
+
+* `terraform_labels` -
+  The combination of labels configured directly on the resource and default labels configured on the provider.
+
+* `effective_labels` -
+  All of labels (key/value pairs) present on the resource in GCP, including the labels configured through Terraform, other clients and services.
+
 * `activation_policy` - (Optional) This specifies when the instance should be
     active. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`.
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
container: three label-related fields are now in `google_container_cluster` resource. `resource_labels` field is non-authoritative and only manages the labels defined by the users on the resource through Terraform. The new output-only `terraform_labels` field merges the labels defined by the users on the resource through Terraform and the default labels configured on the provider. The new output-only `effective_labels` field lists all of labels present on the resource in GCP, including the labels configured through Terraform, the system, and other clients.
```
```release-note:breaking-change
edgenetwork: three label-related fields are now in `google_edgenetwork_network ` and `google_edgenetwork_subnet` resources. `labels` field is non-authoritative and only manages the labels defined by the users on the resource through Terraform. The new output-only `terraform_labels` field merges the labels defined by the users on the resource through Terraform and the default labels configured on the provider. The new output-only `effective_labels` field lists all of labels present on the resource in GCP, including the labels configured through Terraform, the system, and other clients.
```
```release-note:breaking-change
sql: three label-related fields are now in `google_sql_database_instance` resource. `settings.user_labels` field is non-authoritative and only manages the labels defined by the users on the resource through Terraform. The new output-only `settings.terraform_labels` field merges the labels defined by the users on the resource through Terraform and the default labels configured on the provider. The new output-only `settings.effective_labels` field lists all of labels present on the resource in GCP, including the labels configured through Terraform, the system, and other clients.
```
