### PR TITLE
add deletion_protection to v2 service and jobs

### DIFF
--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -50,6 +50,17 @@ iam_policy: !ruby/object:Api::Resource::IamPolicy
 id_format: 'projects/{{project}}/locations/{{location}}/jobs/{{name}}'
 import_format: ['projects/{{project}}/locations/{{location}}/jobs/{{name}}']
 autogen_async: true
+virtual_fields:
+  - !ruby/object:Api::Type::Boolean
+    name: 'deletion_protection'
+    default_value: true
+    description: |
+      Whether Terraform will be prevented from destroying the job. Defaults to true.
+      When a`terraform destroy` or `terraform apply` would delete the job,
+      the command will fail if this field is not set to false in Terraform state.
+      When the field is set to true or unset in Terraform state, a `terraform apply`
+      or `terraform destroy` that would delete the job will fail.
+      When the field is set to false, deleting the job is allowed.
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'cloudrunv2_job_basic'

--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -61,6 +61,9 @@ virtual_fields:
       When the field is set to true or unset in Terraform state, a `terraform apply`
       or `terraform destroy` that would delete the job will fail.
       When the field is set to false, deleting the job is allowed.
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  custom_import: templates/terraform/custom_import/self_link_as_name.erb
+  pre_delete: 'templates/terraform/pre_delete/cloudrunv2_job_deletion_policy.go.erb'
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'cloudrunv2_job_basic'

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -49,6 +49,17 @@ async: !ruby/object:Api::OpAsync
 id_format: 'projects/{{project}}/locations/{{location}}/services/{{name}}'
 import_format: ['projects/{{project}}/locations/{{location}}/services/{{name}}']
 autogen_async: true
+virtual_fields:
+  - !ruby/object:Api::Type::Boolean
+    name: 'deletion_protection'
+    default_value: true
+    description: |
+      Whether Terraform will be prevented from destroying the service. Defaults to true.
+      When a`terraform destroy` or `terraform apply` would delete the service,
+      the command will fail if this field is not set to false in Terraform state.
+      When the field is set to true or unset in Terraform state, a `terraform apply`
+      or `terraform destroy` that would delete the service will fail.
+      When the field is set to false, deleting the service is allowed.
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'cloudrunv2_service_basic'

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -60,6 +60,9 @@ virtual_fields:
       When the field is set to true or unset in Terraform state, a `terraform apply`
       or `terraform destroy` that would delete the service will fail.
       When the field is set to false, deleting the service is allowed.
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  custom_import: templates/terraform/custom_import/self_link_as_name.erb
+  pre_delete: 'templates/terraform/pre_delete/cloudrunv2_service_deletion_policy.go.erb'
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'cloudrunv2_service_basic'

--- a/mmv1/templates/terraform/pre_delete/cloudrunv2_job_deletion_policy.go.erb
+++ b/mmv1/templates/terraform/pre_delete/cloudrunv2_job_deletion_policy.go.erb
@@ -1,0 +1,3 @@
+if d.Get("deletion_protection").(bool) {
+    return fmt.Errorf("cannot destroy job without setting deletion_protection=false and running `terraform apply`")
+}

--- a/mmv1/templates/terraform/pre_delete/cloudrunv2_service_deletion_policy.go.erb
+++ b/mmv1/templates/terraform/pre_delete/cloudrunv2_service_deletion_policy.go.erb
@@ -1,0 +1,3 @@
+if d.Get("deletion_protection").(bool) {
+    return fmt.Errorf("cannot destroy service without setting deletion_protection=false and running `terraform apply`")
+}

--- a/mmv1/third_party/terraform/services/cloudrunv2/data_source_google_cloud_run_v2_job_test.go
+++ b/mmv1/third_party/terraform/services/cloudrunv2/data_source_google_cloud_run_v2_job_test.go
@@ -39,6 +39,7 @@ func testAccDataSourceGoogleCloudRunV2Job_basic(name, location string) string {
 resource "google_cloud_run_v2_job" "hello" {
   name     = "%s"
   location = "%s"
+  deletion_protection = false
 
   template {
     template {
@@ -100,6 +101,7 @@ func testAccDataSourceGoogleCloudRunV2Job_bindIAMPermission(name, location strin
 resource "google_cloud_run_v2_job" "hello" {
   name     = "%s"
   location = "%s"
+  deletion_protection = false
 
   template {
     template {

--- a/mmv1/third_party/terraform/services/cloudrunv2/data_source_google_cloud_run_v2_service_test.go
+++ b/mmv1/third_party/terraform/services/cloudrunv2/data_source_google_cloud_run_v2_service_test.go
@@ -39,6 +39,7 @@ func testAccDataSourceGoogleCloudRunV2Service_basic(name, location string) strin
 resource "google_cloud_run_v2_service" "hello" {
   name     = "%s"
   location = "%s"
+  deletion_protection = false
   ingress  = "INGRESS_TRAFFIC_ALL"
   
   template {
@@ -93,6 +94,7 @@ func testAccDataSourceGoogleCloudRunV2Service_bindIAMPermission(name, location s
 resource "google_cloud_run_v2_service" "hello" {
   name     = "%s"
   location = "%s"
+  deletion_protection = false
   ingress  = "INGRESS_TRAFFIC_ALL"
   
   template {

--- a/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
@@ -122,7 +122,31 @@ An empty value means the setting should be cleared.
 
 ## Resource: `google_cloud_run_v2_service`
 
+### Service deletion now prevented by default with `deletion_protection`
+
+The field `deletion_protection` has been added with a default value of `true`. This field prevents
+Terraform from destroying or recreating the Service. In 6.0.0, existing services will have
+`deletion_protection` set to `true` during the next refresh unless otherwise set in configuration.
+
+**`deletion_protection` does NOT prevent deletion outside of Terraform.**
+
+To disable deletion protection, explicitly set this field to `false` in configuration
+and then run `terraform apply` to apply the change.
+
 ### `liveness_probe` no longer defaults from API
 
 Cloud Run does not provide a default value for liveness probe. Now removing this field
 will remove the liveness probe from the Cloud Run service.
+
+## Resource: `google_cloud_run_v2_job`
+
+### Job deletion now prevented by default with `deletion_protection`
+
+The field `deletion_protection` has been added with a default value of `true`. This field prevents
+Terraform from destroying or recreating the Job. In 6.0.0, existing jobs will have
+`deletion_protection` set to `true` during the next refresh unless otherwise set in configuration.
+
+**`deletion_protection` does NOT prevent deletion outside of Terraform.**
+
+To disable deletion protection, explicitly set this field to `false` in configuration
+and then run `terraform apply` to apply the change.


### PR DESCRIPTION
Add deletion_protection to Cloud Run v2 service and job resources.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change

```
