### PR TITLE
Remove `multi_region_auxiliary` from `google_bigquery_reservation`

### DIFF
--- a/mmv1/products/bigqueryreservation/Reservation.yaml
+++ b/mmv1/products/bigqueryreservation/Reservation.yaml
@@ -65,12 +65,6 @@ properties:
     default_value: 0
     description: |
       Maximum number of queries that are allowed to run concurrently in this reservation. This is a soft limit due to asynchronous nature of the system and various optimizations for small queries. Default value is 0 which means that concurrency will be automatically set based on the reservation size.
-  - !ruby/object:Api::Type::Boolean
-    name: 'multiRegionAuxiliary'
-    description: |
-      Applicable only for reservations located within one of the BigQuery multi-regions (US or EU).
-      If set to true, this reservation is placed in the organization's secondary region which is designated for disaster recovery purposes. If false, this reservation is placed in the organization's default region.
-    deprecation_message: "`multi_region_auxiliary` is deprecated and will be removed in a future major release. This field is no longer supported by the BigQuery Reservation API."
   - !ruby/object:Api::Type::String
     name: 'edition'
     immutable: true

--- a/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
@@ -108,6 +108,12 @@ Description of the change and how users should adjust their configuration (if ne
 
 A `view` can no longer be created when `schema` contains required fields
 
+## Resource: `google_bigquery_reservation`
+
+### `multi_region_auxiliary` is now removed
+
+This field is no longer supported by the BigQuery Reservation API.
+
 ## Resource: `google_sql_database_instance`
 
 ### `settings.ip_configuration.require_ssl` is now removed


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Remove `multi_region_auxiliary` from `google_bigquery_reservation` as this field is no longer supported

b/350571636

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
bigqueryreservation: remove `multi_region_auxiliary` from `google_bigquery_reservation`
```
