### PR TITLE
google_container_cluster: add Node auto-provisioning locations

### DIFF
--- a/mmv1/third_party/terraform/services/container/go/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/go/resource_container_cluster.go.tmpl
@@ -846,6 +846,13 @@ func ResourceContainerCluster() *schema.Resource {
 								},
 							},
 						},
+						"auto_provisioning_locations": {
+							Type:             schema.TypeList,
+							Optional:         true,
+							Computed:         true,
+							Elem:             &schema.Schema{Type: schema.TypeString},
+							Description:      `The list of Google Compute Engine zones in which the NodePool's nodes can be created by NAP.`,
+						},
 						"autoscaling_profile": {
 							Type:             schema.TypeString,
 							Default:          "BALANCED",

--- a/mmv1/third_party/terraform/services/container/go/resource_container_cluster_migratev1.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/go/resource_container_cluster_migratev1.go.tmpl
@@ -559,6 +559,13 @@ func resourceContainerClusterResourceV1() *schema.Resource {
 								},
 							},
 						},
+						"auto_provisioning_locations": {
+							Type:             schema.TypeList,
+							Optional:         true,
+							Computed:         true,
+							Elem:             &schema.Schema{Type: schema.TypeString},
+							Description:      `The list of Google Compute Engine zones in which the NodePool's nodes can be created by NAP.`,
+						},
 						{{- if ne $.TargetVersionName "ga" }}
 						"autoscaling_profile": {
 							Type:             schema.TypeString,

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -847,6 +847,13 @@ func ResourceContainerCluster() *schema.Resource {
 								},
 							},
 						},
+						"auto_provisioning_locations": {
+							Type:             schema.TypeList,
+							Optional:         true,
+							Computed:         true,
+							Elem:             &schema.Schema{Type: schema.TypeString},
+							Description:      `The list of Google Compute Engine zones in which the NodePool's nodes can be created by NAP.`,
+						},
 						"autoscaling_profile": {
 							Type:             schema.TypeString,
 							Default:          "BALANCED",
@@ -4872,6 +4879,7 @@ func expandClusterAutoscaling(configured interface{}, d *schema.ResourceData) *c
 		ResourceLimits:             resourceLimits,
 		AutoscalingProfile: config["autoscaling_profile"].(string),
 		AutoprovisioningNodePoolDefaults: expandAutoProvisioningDefaults(config["auto_provisioning_defaults"], d),
+		AutoprovisioningLocations: 	tpgresource.ConvertStringArr(config["auto_provisioning_locations"].([]interface{})),
 	}
 }
 
@@ -6184,6 +6192,7 @@ func flattenClusterAutoscaling(a *container.ClusterAutoscaling) []map[string]int
 		r["resource_limits"] = resourceLimits
 		r["enabled"] = true
 		r["auto_provisioning_defaults"] = flattenAutoProvisioningDefaults(a.AutoprovisioningNodePoolDefaults)
+		r["auto_provisioning_locations"] = a.AutoprovisioningLocations
 	} else {
 		r["enabled"] = false
 	}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_migratev1.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_migratev1.go.erb
@@ -560,6 +560,13 @@ func resourceContainerClusterResourceV1() *schema.Resource {
 								},
 							},
 						},
+						"auto_provisioning_locations": {
+							Type:             schema.TypeList,
+							Optional:         true,
+							Computed:         true,
+							Elem:             &schema.Schema{Type: schema.TypeString},
+							Description:      `The list of Google Compute Engine zones in which the NodePool's nodes can be created by NAP.`,
+						},
 						<% unless version == 'ga' -%>
 						"autoscaling_profile": {
 							Type:             schema.TypeString,

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -3962,6 +3962,42 @@ func TestAccContainerCluster_autoprovisioningDefaultsManagement(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_autoprovisioningLocations(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+	locations := []string{"us-central1-a", "us-central1-f"}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_autoprovisioningLocations(clusterName, networkName, subnetworkName, locations),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.with_autoprovisioning_locations",
+						"cluster_autoscaling.0.enabled", "true"),
+					
+					resource.TestCheckResourceAttr("google_container_cluster.with_autoprovisioning_locations",
+						"cluster_autoscaling.0.auto_provisioning_locations.0", locations[0]),
+					
+					resource.TestCheckResourceAttr("google_container_cluster.with_autoprovisioning_locations",
+						"cluster_autoscaling.0.auto_provisioning_locations.1", locations[1]),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_autoprovisioning_locations",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
+			},
+		},
+	})
+}
+
 // This resource originally cleaned up the dangling cluster directly, but now
 // taints it, having Terraform clean it up during the next apply. This test
 // name is now inexact, but is being preserved to maintain the test history.
@@ -6955,6 +6991,46 @@ resource "google_container_cluster" "with_autoprovisioning_management" {
   subnetwork    = "%s"
 }
 `, clusterName, autoUpgrade, autoRepair, networkName, subnetworkName)
+}
+
+func testAccContainerCluster_autoprovisioningLocations(clusterName, networkName, subnetworkName string, locations []string) string {
+	var autoprovisionLocationsStr string
+	for i := 0; i < len(locations); i++ {
+		autoprovisionLocationsStr += fmt.Sprintf("\"%s\",", locations[i])
+	}
+	var apl string
+	if len(autoprovisionLocationsStr) > 0 {
+		apl = fmt.Sprintf(`
+			auto_provisioning_locations = [%s]
+		`, autoprovisionLocationsStr)
+	}
+
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_autoprovisioning_locations" {
+  name               = "%s"
+  location           = "us-central1-f"
+  initial_node_count = 1
+
+  cluster_autoscaling {
+    enabled = true
+
+	resource_limits {
+	  resource_type = "cpu"
+	  maximum       = 2
+	}
+
+	resource_limits {
+	  resource_type = "memory"
+	  maximum       = 2048
+	}
+
+    %s
+  }
+  deletion_protection = false
+  network    = "%s"
+  subnetwork    = "%s"
+}
+`, clusterName, apl, networkName, subnetworkName)
 }
 
 func testAccContainerCluster_backendRef(cluster, networkName, subnetworkName string) string {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -3968,7 +3968,6 @@ func TestAccContainerCluster_autoprovisioningLocations(t *testing.T) {
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
 	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
 	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
-	locations := []string{"us-central1-a", "us-central1-f"}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.AccTestPreCheck(t) },
@@ -3976,16 +3975,35 @@ func TestAccContainerCluster_autoprovisioningLocations(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_autoprovisioningLocations(clusterName, networkName, subnetworkName, locations),
+				Config: testAccContainerCluster_autoprovisioningLocations(clusterName, networkName, subnetworkName, []string{"us-central1-a", "us-central1-f"}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.with_autoprovisioning_locations",
 						"cluster_autoscaling.0.enabled", "true"),
 					
 					resource.TestCheckResourceAttr("google_container_cluster.with_autoprovisioning_locations",
-						"cluster_autoscaling.0.auto_provisioning_locations.0", locations[0]),
+						"cluster_autoscaling.0.auto_provisioning_locations.0", "us-central1-a"),
 					
 					resource.TestCheckResourceAttr("google_container_cluster.with_autoprovisioning_locations",
-						"cluster_autoscaling.0.auto_provisioning_locations.1", locations[1]),
+						"cluster_autoscaling.0.auto_provisioning_locations.1", "us-central1-f"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_autoprovisioning_locations",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_autoprovisioningLocations(clusterName, networkName, subnetworkName, []string{"us-central1-b", "us-central1-c"}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.with_autoprovisioning_locations",
+						"cluster_autoscaling.0.enabled", "true"),
+					
+					resource.TestCheckResourceAttr("google_container_cluster.with_autoprovisioning_locations",
+						"cluster_autoscaling.0.auto_provisioning_locations.0", "us-central1-b"),
+					
+					resource.TestCheckResourceAttr("google_container_cluster.with_autoprovisioning_locations",
+						"cluster_autoscaling.0.auto_provisioning_locations.1", "us-central1-c"),
 				),
 			},
 			{

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -543,6 +543,10 @@ in addition to node auto-provisioning. Structure is [documented below](#nested_r
 GKE Autopilot clusters.
 Structure is [documented below](#nested_auto_provisioning_defaults).
 
+* `auto_provisioning_locations` - (Optional) The list of Google Compute Engine 
+[zones](https://cloud.google.com/compute/docs/zones#available) in which the 
+NodePool's nodes can be created by NAP.
+
 * `autoscaling_profile` - (Optional) Configuration
 options for the [Autoscaling profile](https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-autoscaler#autoscaling_profiles)
 feature, which lets you choose whether the cluster autoscaler should optimize for resource utilization or resource availability


### PR DESCRIPTION
When Node auto-provisioning is enabled, the terraform provider currently cannot be used to define node auto-provisioning locations. This configuration is, as of today, presently limited to the UI, gcloud, or API.

Tests for google_container_cluster were already successfully executed locally

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added `auto_provisioning_locations` field to `google_container_cluster`
```
