### PR TITLE
Logging view iam

### DIFF
--- a/mmv1/products/logging/LogView.yaml
+++ b/mmv1/products/logging/LogView.yaml
@@ -35,7 +35,6 @@ iam_policy: !ruby/object:Api::Resource::IamPolicy
   method_name_separator: ':'
   fetch_iam_policy_verb: :POST
   iam_conditions_request_type: :REQUEST_BODY
-
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'logging_log_view_basic'

--- a/mmv1/products/logging/LogView.yaml
+++ b/mmv1/products/logging/LogView.yaml
@@ -11,42 +11,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
---- !ruby/object:Api::Resource
+---
+!ruby/object:Api::Resource
 name: LogView
-base_url: '{{parent}}/locations/{{location}}/buckets/{{bucket}}/views'
-create_url: '{{parent}}/locations/{{location}}/buckets/{{bucket}}/views?viewId={{name}}'
-self_link: '{{parent}}/locations/{{location}}/buckets/{{bucket}}/views/{{name}}'
+base_url: "{{parent}}/locations/{{location}}/buckets/{{bucket}}/views"
+create_url: "{{parent}}/locations/{{location}}/buckets/{{bucket}}/views?viewId={{name}}"
+self_link: "{{parent}}/locations/{{location}}/buckets/{{bucket}}/views/{{name}}"
 import_format:
-  ['{{%parent}}/locations/{{location}}/buckets/{{bucket}}/views/{{name}}']
+  ["{{%parent}}/locations/{{location}}/buckets/{{bucket}}/views/{{name}}"]
 update_verb: :PATCH
 update_mask: true
 references: !ruby/object:Api::Resource::ReferenceLinks
   guides:
-    'Official Documentation': 'https://cloud.google.com/logging/docs/apis'
-  api: 'https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.locations.buckets.views'
+    "Official Documentation": "https://cloud.google.com/logging/docs/apis"
+  api: "https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.locations.buckets.views"
 # Skipping sweeper since this is a child resource.
 skip_sweeper: true
-description: 'Describes a view over log entries in a bucket.'
+description: "Describes a view over log entries in a bucket."
 iam_policy: !ruby/object:Api::Resource::IamPolicy
   skip_import_test: true
-  parent_resource_attribute: 'name'
-  import_format: ['{{%parent}}/locations/{{location}}/buckets/{{bucket}}/views/{{name}}', '{{name}}']
-  allowed_iam_role: 'roles/logging.admin'
-  method_name_separator: ':'
+  parent_resource_attribute: "name"
+  import_format:
+    [
+      "{{%parent}}/locations/{{location}}/buckets/{{bucket}}/views/{{name}}",
+      "{{name}}",
+    ]
+  allowed_iam_role: "roles/logging.admin"
+  method_name_separator: ":"
   fetch_iam_policy_verb: :POST
   iam_conditions_request_type: :REQUEST_BODY
-  min_version: beta
 examples:
   - !ruby/object:Provider::Terraform::Examples
-    name: 'logging_log_view_basic'
-    primary_resource_id: 'logging_log_view'
+    name: "logging_log_view_basic"
+    primary_resource_id: "logging_log_view"
     vars:
-      log_view_name: 'my-view'
+      log_view_name: "my-view"
     test_env_vars:
       project: :PROJECT_NAME
   - !ruby/object:Provider::Terraform::Examples
-    name: 'logging_log_view_long_name'
-    primary_resource_id: 'logging_log_view'
+    name: "logging_log_view_long_name"
+    primary_resource_id: "logging_log_view"
     test_env_vars:
       project: :PROJECT_NAME
     skip_docs: true
@@ -60,32 +64,31 @@ parameters:
     url_param_only: true
     immutable: true
     default_from_api: true
-    diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+    diff_suppress_func: "tpgresource.CompareSelfLinkOrResourceName"
   - !ruby/object:Api::Type::String
     name: location
     description:
-      'The location of the resource. The supported locations are: global,
-      us-central1, us-east1, us-west1, asia-east1, europe-west1.'
+      "The location of the resource. The supported locations are: global,
+      us-central1, us-east1, us-west1, asia-east1, europe-west1."
     url_param_only: true
     immutable: true
     default_from_api: true
-  - !ruby/object:Api::Type::String  # Make this a String for now since we don't have a good way to reference multiple resources.
+  - !ruby/object:Api::Type::String # Make this a String for now since we don't have a good way to reference multiple resources.
     name: bucket
     description: The bucket of the resource
     url_param_only: true
     required: true
     immutable: true
-    diff_suppress_func: 'tpgresource.CompareResourceNames'
+    diff_suppress_func: "tpgresource.CompareResourceNames"
 properties:
   - !ruby/object:Api::Type::String
     name: name
-    description:
-      'The resource name of the view. For example:
+    description: 'The resource name of the view. For example:
       \`projects/my-project/locations/global/buckets/my-bucket/views/my-view\`'
     required: true
     immutable: true
     ignore_read: true
-    diff_suppress_func: 'tpgresource.CompareResourceNames'
+    diff_suppress_func: "tpgresource.CompareResourceNames"
   - !ruby/object:Api::Type::String
     name: description
     description: Describes this view.

--- a/mmv1/products/logging/LogView.yaml
+++ b/mmv1/products/logging/LogView.yaml
@@ -11,46 +11,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
----
-!ruby/object:Api::Resource
+--- !ruby/object:Api::Resource
 name: LogView
-base_url: "{{parent}}/locations/{{location}}/buckets/{{bucket}}/views"
-create_url: "{{parent}}/locations/{{location}}/buckets/{{bucket}}/views?viewId={{name}}"
-self_link: "{{parent}}/locations/{{location}}/buckets/{{bucket}}/views/{{name}}"
+base_url: '{{parent}}/locations/{{location}}/buckets/{{bucket}}/views'
+create_url: '{{parent}}/locations/{{location}}/buckets/{{bucket}}/views?viewId={{name}}'
+self_link: '{{parent}}/locations/{{location}}/buckets/{{bucket}}/views/{{name}}'
 import_format:
-  ["{{%parent}}/locations/{{location}}/buckets/{{bucket}}/views/{{name}}"]
+  ['{{%parent}}/locations/{{location}}/buckets/{{bucket}}/views/{{name}}']
 update_verb: :PATCH
 update_mask: true
 references: !ruby/object:Api::Resource::ReferenceLinks
   guides:
-    "Official Documentation": "https://cloud.google.com/logging/docs/apis"
-  api: "https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.locations.buckets.views"
+    'Official Documentation': 'https://cloud.google.com/logging/docs/apis'
+  api: 'https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.locations.buckets.views'
 # Skipping sweeper since this is a child resource.
 skip_sweeper: true
-description: "Describes a view over log entries in a bucket."
+description: 'Describes a view over log entries in a bucket.'
 iam_policy: !ruby/object:Api::Resource::IamPolicy
   skip_import_test: true
-  parent_resource_attribute: "name"
-  import_format:
-    [
-      "{{%parent}}/locations/{{location}}/buckets/{{bucket}}/views/{{name}}",
-      "{{name}}",
-    ]
-  allowed_iam_role: "roles/logging.admin"
-  method_name_separator: ":"
+  parent_resource_attribute: 'name'
+  import_format: ['{{%parent}}/locations/{{location}}/buckets/{{bucket}}/views/{{name}}', '{{name}}']
+  allowed_iam_role: 'roles/logging.admin'
+  method_name_separator: ':'
   fetch_iam_policy_verb: :POST
   iam_conditions_request_type: :REQUEST_BODY
+
 examples:
   - !ruby/object:Provider::Terraform::Examples
-    name: "logging_log_view_basic"
-    primary_resource_id: "logging_log_view"
+    name: 'logging_log_view_basic'
+    primary_resource_id: 'logging_log_view'
     vars:
-      log_view_name: "my-view"
+      log_view_name: 'my-view'
     test_env_vars:
       project: :PROJECT_NAME
   - !ruby/object:Provider::Terraform::Examples
-    name: "logging_log_view_long_name"
-    primary_resource_id: "logging_log_view"
+    name: 'logging_log_view_long_name'
+    primary_resource_id: 'logging_log_view'
     test_env_vars:
       project: :PROJECT_NAME
     skip_docs: true
@@ -64,31 +60,32 @@ parameters:
     url_param_only: true
     immutable: true
     default_from_api: true
-    diff_suppress_func: "tpgresource.CompareSelfLinkOrResourceName"
+    diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
   - !ruby/object:Api::Type::String
     name: location
     description:
-      "The location of the resource. The supported locations are: global,
-      us-central1, us-east1, us-west1, asia-east1, europe-west1."
+      'The location of the resource. The supported locations are: global,
+      us-central1, us-east1, us-west1, asia-east1, europe-west1.'
     url_param_only: true
     immutable: true
     default_from_api: true
-  - !ruby/object:Api::Type::String # Make this a String for now since we don't have a good way to reference multiple resources.
+  - !ruby/object:Api::Type::String  # Make this a String for now since we don't have a good way to reference multiple resources.
     name: bucket
     description: The bucket of the resource
     url_param_only: true
     required: true
     immutable: true
-    diff_suppress_func: "tpgresource.CompareResourceNames"
+    diff_suppress_func: 'tpgresource.CompareResourceNames'
 properties:
   - !ruby/object:Api::Type::String
     name: name
-    description: 'The resource name of the view. For example:
+    description:
+      'The resource name of the view. For example:
       \`projects/my-project/locations/global/buckets/my-bucket/views/my-view\`'
     required: true
     immutable: true
     ignore_read: true
-    diff_suppress_func: "tpgresource.CompareResourceNames"
+    diff_suppress_func: 'tpgresource.CompareResourceNames'
   - !ruby/object:Api::Type::String
     name: description
     description: Describes this view.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Promote Logging `google_logging_log_view_iam` resources to GA
CloudLogging GA API does have[ LogView IAM ](https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.locations.buckets.views/setIamPolicy)support 
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
logging: promoted `google_logging_log_view_iam` resources from beta to GA
```
