### PR TITLE
Ignore fingerprint during import in TestAccComputeInstanceSettings_update, as it often changes

### DIFF
--- a/mmv1/third_party/terraform/services/compute/go/resource_compute_instance_settings_test.go
+++ b/mmv1/third_party/terraform/services/compute/go/resource_compute_instance_settings_test.go
@@ -12,7 +12,7 @@ func TestAccComputeInstanceSettings_update(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"random_suffix":   acctest.RandString(t, 10),
+		"random_suffix": acctest.RandString(t, 10),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -27,7 +27,7 @@ func TestAccComputeInstanceSettings_update(t *testing.T) {
 				ResourceName:            "google_compute_instance_settings.gce_instance_settings",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"zone"},
+				ImportStateVerifyIgnore: []string{"zone", "fingerprint"},
 			},
 			{
 				Config: testAccComputeInstanceSettings_update(context),
@@ -36,7 +36,7 @@ func TestAccComputeInstanceSettings_update(t *testing.T) {
 				ResourceName:            "google_compute_instance_settings.gce_instance_settings",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"zone"},
+				ImportStateVerifyIgnore: []string{"zone", "fingerprint"},
 			},
 			{
 				Config: testAccComputeInstanceSettings_delete(context),
@@ -45,7 +45,7 @@ func TestAccComputeInstanceSettings_update(t *testing.T) {
 				ResourceName:            "google_compute_instance_settings.gce_instance_settings",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"zone"},
+				ImportStateVerifyIgnore: []string{"zone", "fingerprint"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_settings_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_settings_test.go.erb
@@ -28,7 +28,7 @@ func TestAccComputeInstanceSettings_update(t *testing.T) {
 				ResourceName:            "google_compute_instance_settings.gce_instance_settings",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"zone"},
+				ImportStateVerifyIgnore: []string{"zone", "fingerprint"},
 			},
 			{
 				Config: testAccComputeInstanceSettings_update(context),
@@ -37,7 +37,7 @@ func TestAccComputeInstanceSettings_update(t *testing.T) {
 				ResourceName:            "google_compute_instance_settings.gce_instance_settings",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"zone"},
+				ImportStateVerifyIgnore: []string{"zone", "fingerprint"},
 			},
 			{
 				Config: testAccComputeInstanceSettings_delete(context),
@@ -46,7 +46,7 @@ func TestAccComputeInstanceSettings_update(t *testing.T) {
 				ResourceName:            "google_compute_instance_settings.gce_instance_settings",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"zone"},
+				ImportStateVerifyIgnore: []string{"zone", "fingerprint"},
 			},
 		},
 	})


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Addresses a [flaky test with ~50% failure rate](https://hashicorp.teamcity.com/test/4946789655298649883?currentProjectId=TerraformProviders_GoogleCloud_GOOGLE_BETA_NIGHTLYTESTS&expandTestHistoryChartSection=true)

```
------- Stdout: -------
=== RUN   TestAccComputeInstanceSettings_update
=== PAUSE TestAccComputeInstanceSettings_update
=== CONT  TestAccComputeInstanceSettings_update
    vcr_utils.go:152: Step 2/6 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
          map[string]string{
        -   "fingerprint":          "wQH2_MqU01c=",
        +   "fingerprint":          "TyiC4TGN8NA=",
        -   "metadata.#":           "1",
        -   "metadata.0.%":         "1",
        -   "metadata.0.items.%":   "1",
        -   "metadata.0.items.foo": "baz",
          }
--- FAIL: TestAccComputeInstanceSettings_update (71.24s)
FAIL
```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
