### PR TITLE
Fix `Error: Inconsistent dependency lock file` error in test

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service_test.go.erb
@@ -368,12 +368,14 @@ resource "google_project_service" "test" {
 func testAccProjectService_checkUsage(service string, pid, org string, checkIfServiceHasUsage string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
+  provider = google-beta
   project_id = "%s"
   name       = "%s"
   org_id     = "%s"
 }
 
 resource "google_project_service" "test" {
+  provider = google-beta
   project = google_project.acceptance.project_id
   service = "%s"
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This test has [100% failure rate](https://hashicorp.teamcity.com/test/8863425902380288891?currentProjectId=TerraformProviders_GoogleCloud_GOOGLE_BETA_NIGHTLYTESTS&expandTestHistoryChartSection=true) in TPGB nightlies

```
------- Stdout: -------
=== RUN   TestAccProjectService_checkUsageOfServices
=== PAUSE TestAccProjectService_checkUsageOfServices
=== CONT  TestAccProjectService_checkUsageOfServices
    vcr_utils.go:152: Step 1/3 error: Error running pre-apply refresh: exit status 1
        Error: Inconsistent dependency lock file
        The following dependency selections recorded in the lock file are
        inconsistent with the current configuration:
          - provider registry.terraform.io/hashicorp/google: required by this configuration but no version is selected
        To make the initial dependency selections that will initialize the dependency
        lock file, run:
          terraform init
--- FAIL: TestAccProjectService_checkUsageOfServices (0.26s)
FAIL

```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
