### PR TITLE
Remove change to state migrate function that was not touched

### DIFF
--- a/mmv1/third_party/terraform/services/container/go/resource_container_cluster_migratev1.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/go/resource_container_cluster_migratev1.go.tmpl
@@ -559,13 +559,6 @@ func resourceContainerClusterResourceV1() *schema.Resource {
 								},
 							},
 						},
-						"auto_provisioning_locations": {
-							Type:             schema.TypeList,
-							Optional:         true,
-							Computed:         true,
-							Elem:             &schema.Schema{Type: schema.TypeString},
-							Description:      `The list of Google Compute Engine zones in which the NodePool's nodes can be created by NAP.`,
-						},
 						{{- if ne $.TargetVersionName "ga" }}
 						"autoscaling_profile": {
 							Type:             schema.TypeString,


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
No changes, this isn't currently being used to generate. Follow-up to my miss of this being added in https://github.com/GoogleCloudPlatform/magic-modules/pull/11305

I think this should be removed, as we don't add new schema values to old state migrate functions

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
