### PR TITLE
Make resource have sweepable, unique name in TestAccIntegrationsClient_integrationsClientBasicExample

### DIFF
--- a/mmv1/products/integrations/Client.yaml
+++ b/mmv1/products/integrations/Client.yaml
@@ -128,6 +128,7 @@ examples:
     skip_vcr: true
     vars:
       key_ring_name: my-keyring
+      service_account_id: my-service-acc
   - !ruby/object:Provider::Terraform::Examples
     name: "integrations_client_deprecated_fields"
     primary_resource_id: "example"

--- a/mmv1/products/integrations/go_Client.yaml
+++ b/mmv1/products/integrations/go_Client.yaml
@@ -45,6 +45,7 @@ examples:
     primary_resource_id: 'example'
     vars:
       key_ring_name: 'my-keyring'
+      service_account_id: my-service-acc
     skip_vcr: true
   - name: 'integrations_client_deprecated_fields'
     primary_resource_id: 'example'

--- a/mmv1/templates/terraform/examples/integrations_client_full.tf.erb
+++ b/mmv1/templates/terraform/examples/integrations_client_full.tf.erb
@@ -17,7 +17,7 @@ resource "google_kms_crypto_key_version" "test_key" {
 }
 
 resource "google_service_account" "service_account" {
-  account_id   = "service-account-id"
+  account_id   = "<%= ctx[:vars]['service_account_id'] %>"
   display_name = "Service Account"
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Addresses error in nightly tests

> Error: Error creating service account: googleapi: Error 409: Service account service-account-id already exists

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
