### PR TITLE
Add missing Storage Object Viewer permission to TestAccCloudFunctionsFunction_buildServiceAccount

### DIFF
--- a/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function_test.go.erb
@@ -1363,34 +1363,41 @@ resource "google_service_account" "cloud_function_build_account_%[3]s" {
 }
 
 resource "google_project_iam_member" "storage_object_admin_%[3]s" {
-	project = data.google_project.project.project_id
+  project = data.google_project.project.project_id
   role      = "roles/storage.objectAdmin"
   member    = "serviceAccount:${google_service_account.cloud_function_build_account_%[3]s.email}"
 }
 
 resource "google_project_iam_member" "artifact_registry_writer_%[3]s" {
-	project = data.google_project.project.project_id
+  project = data.google_project.project.project_id
   role      = "roles/artifactregistry.writer"
   member    = "serviceAccount:${google_service_account.cloud_function_build_account_%[3]s.email}"
 }
 
 resource "google_project_iam_member" "log_writer_%[3]s" {
-	project = data.google_project.project.project_id
+  project = data.google_project.project.project_id
   role      = "roles/logging.logWriter"
+  member    = "serviceAccount:${google_service_account.cloud_function_build_account_%[3]s.email}"
+}
+
+resource "google_project_iam_member" "object_viewer_%[3]s" {
+  project = data.google_project.project.project_id
+  role      = "roles/storage.objectViewer"
   member    = "serviceAccount:${google_service_account.cloud_function_build_account_%[3]s.email}"
 }
 
 resource "time_sleep" "wait_iam_roles_%[3]s" {
   depends_on       = [
-		google_project_iam_member.storage_object_admin_%[3]s,
-		google_project_iam_member.artifact_registry_writer_%[3]s,
-		google_project_iam_member.log_writer_%[3]s,
-	]
-	create_duration  = "60s"
+    google_project_iam_member.storage_object_admin_%[3]s,
+    google_project_iam_member.artifact_registry_writer_%[3]s,
+    google_project_iam_member.log_writer_%[3]s,
+    google_project_iam_member.object_viewer_%[3]s,
+  ]
+  create_duration  = "60s"
 }
 
 resource "google_cloudfunctions_function" "function" {
-	depends_on = [time_sleep.wait_iam_roles_%[3]s]
+  depends_on = [time_sleep.wait_iam_roles_%[3]s]
   name    = "%[5]s"
   runtime = "nodejs10"
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Addresses test failure:

```
------- Stdout: -------
=== RUN   TestAccCloudFunctionsFunction_buildServiceAccount
=== PAUSE TestAccCloudFunctionsFunction_buildServiceAccount
=== CONT  TestAccCloudFunctionsFunction_buildServiceAccount
    vcr_utils.go:152: Step 1/4 error: Error running apply: exit status 1
        Error: Error waiting for Creating CloudFunctions Function: Error code 3, message: Build failed: failed to Fetch: failed to download archive gs://gcf-sources-653407317329-us-central1/tf-test-zi89ai0x2i-9123a416-18d1-4c1e-9908-b7cc44c2e07a/version-1/function-source.zip: Access to bucket gcf-sources-653407317329-us-central1 denied. You must grant Storage Object Viewer permission to tf-test-build1-feri8bfna7@ci-test-project-nightly-beta.iam.gserviceaccount.com. If you are using VPC Service Controls, you must also grant it access to your service perimeter.
          with google_cloudfunctions_function.function,
          on terraform_plugin_test.tf line 49, in resource "google_cloudfunctions_function" "function":
          49: resource "google_cloudfunctions_function" "function" {
--- FAIL: TestAccCloudFunctionsFunction_buildServiceAccount (126.12s)
FAIL
```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
