### PR TITLE
Fix dependencies for TestAccAppEngineFlexibleAppVersion_update

### DIFF
--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.erb
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.erb
@@ -22,7 +22,7 @@ func TestAccAppEngineFlexibleAppVersion_update(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 		CheckDestroy:             testAccCheckAppEngineFlexibleAppVersionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fix following the last minute changes in https://github.com/GoogleCloudPlatform/magic-modules/pull/11296

Changing the provider factory caused this error:

```
------- Stdout: -------
=== RUN   TestAccAppEngineFlexibleAppVersion_update
=== PAUSE TestAccAppEngineFlexibleAppVersion_update
=== CONT  TestAccAppEngineFlexibleAppVersion_update
    vcr_utils.go:152: Step 1/4 error: Error running pre-apply refresh: exit status 1
        Error: Inconsistent dependency lock file
        The following dependency selections recorded in the lock file are
        inconsistent with the current configuration:
          - provider registry.terraform.io/hashicorp/google-beta: required by this configuration but no version is selected
        To make the initial dependency selections that will initialize the dependency
        lock file, run:
          terraform init
--- FAIL: TestAccAppEngineFlexibleAppVersion_update (0.23s)
FAIL
```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
