### PR TITLE
Add GAE default service account to binding for roles/editor to address TestAccAppEngineStandardAppVersion_update failure

### DIFF
--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_standard_app_version_test.go
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_standard_app_version_test.go
@@ -65,16 +65,34 @@ resource "google_project" "my_project" {
   billing_account = "%{billing_account}"
 }
 
-resource "google_app_engine_application" "app" {
-  project     = google_project.my_project.project_id
-  location_id = "us-central"
-}
-
 resource "google_project_service" "project" {
   project = google_project.my_project.project_id
   service = "appengine.googleapis.com"
 
   disable_dependent_services = false
+}
+
+resource "google_app_engine_application" "app" {
+  project     = google_project.my_project.project_id
+  location_id = "us-central"
+}
+
+data "google_app_engine_default_service_account" "default" {
+  depends_on = [
+    google_app_engine_application.app
+  ]
+}
+
+resource "google_project_iam_member" "app_eng_sa_bucket_permissions" {
+  project = google_project.my_project.project_id
+  role    = "roles/editor"
+  member  = "serviceAccount:${data.google_app_engine_default_service_account.default.email}"
+}
+
+resource "time_sleep" "wait_for_appengine_permissions_propagate" {
+  depends_on = [google_project_iam_member.app_eng_sa_bucket_permissions]
+
+  create_duration = "60s"
 }
 
 resource "google_app_engine_standard_app_version" "foo" {
@@ -121,6 +139,7 @@ resource "google_app_engine_standard_app_version" "foo" {
     }
   }
 
+  depends_on = [ time_sleep.wait_for_appengine_permissions_propagate ]
   noop_on_destroy = true
 }
 
@@ -152,16 +171,34 @@ resource "google_project" "my_project" {
   billing_account = "%{billing_account}"
 }
 
-resource "google_app_engine_application" "app" {
-  project     = google_project.my_project.project_id
-  location_id = "us-central"
-}
-
 resource "google_project_service" "project" {
   project = google_project.my_project.project_id
   service = "appengine.googleapis.com"
 
   disable_dependent_services = false
+}
+
+resource "google_app_engine_application" "app" {
+  project     = google_project.my_project.project_id
+  location_id = "us-central"
+}
+
+data "google_app_engine_default_service_account" "default" {
+  depends_on = [
+    google_app_engine_application.app
+  ]
+}
+
+resource "google_project_iam_member" "app_eng_sa_bucket_permissions" {
+  project = google_project.my_project.project_id
+  role    = "roles/editor"
+  member  = "serviceAccount:${data.google_app_engine_default_service_account.default.email}"
+}
+
+resource "time_sleep" "wait_for_appengine_permissions_propagate" {
+  depends_on = [google_project_iam_member.app_eng_sa_bucket_permissions]
+
+  create_duration = "60s"
 }
 
 resource "time_sleep" "wait_60_seconds" {
@@ -240,6 +277,7 @@ resource "google_app_engine_standard_app_version" "foo" {
     }
   }
 
+  depends_on = [ time_sleep.wait_for_appengine_permissions_propagate ]
   noop_on_destroy = true
 }
 
@@ -271,16 +309,34 @@ resource "google_project" "my_project" {
   billing_account = "%{billing_account}"
 }
 
-resource "google_app_engine_application" "app" {
-  project     = google_project.my_project.project_id
-  location_id = "us-central"
-}
-
 resource "google_project_service" "project" {
   project = google_project.my_project.project_id
   service = "appengine.googleapis.com"
 
   disable_dependent_services = false
+}
+
+resource "google_app_engine_application" "app" {
+  project     = google_project.my_project.project_id
+  location_id = "us-central"
+}
+
+data "google_app_engine_default_service_account" "default" {
+  depends_on = [
+    google_app_engine_application.app
+  ]
+}
+
+resource "google_project_iam_member" "app_eng_sa_bucket_permissions" {
+  project = google_project.my_project.project_id
+  role    = "roles/editor"
+  member  = "serviceAccount:${data.google_app_engine_default_service_account.default.email}"
+}
+
+resource "time_sleep" "wait_for_appengine_permissions_propagate" {
+  depends_on = [google_project_iam_member.app_eng_sa_bucket_permissions]
+
+  create_duration = "60s"
 }
 
 resource "google_app_engine_standard_app_version" "foo" {
@@ -317,6 +373,7 @@ resource "google_app_engine_standard_app_version" "foo" {
     max_instances = 5
   }
 
+  depends_on = [ time_sleep.wait_for_appengine_permissions_propagate ]
   noop_on_destroy = true
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR is exploring solutions for https://github.com/hashicorp/terraform-provider-google/issues/18936, as I've experienced the permissions error even when the permission is supplied ok.


There's another test failing due to permissions for accessing buckets being reportedly missing but definitely being supplied in the test: https://github.com/GoogleCloudPlatform/magic-modules/pull/11324

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
