### PR TITLE
Documented how to add client-side fields

### DIFF
--- a/docs/content/best-practices/_index.md
+++ b/docs/content/best-practices/_index.md
@@ -19,7 +19,7 @@ Some fields or resources may be possible to update in place, but only under spec
 
 In complex cases, it is better to mark the field `ForceNew` to ensure that users can apply their configurations successfully.
 
-### Mitigating data loss risk via deletion_protection
+### Mitigating data loss risk via deletion_protection {#deletion_protection}
 
 Some resources, such as databases, have a significant risk of unrecoverable data loss if the resource is accidentally deleted due to a change to a ForceNew field. For these resources, the best practice is to add a `deletion_protection` field that defaults to `true`, which prevents the resource from being deleted if enabled. Although it is a small breaking change, for users, the benefits of `deletion_protection` defaulting to `true` outweigh the cost.
 
@@ -30,17 +30,19 @@ A resource can have up to two `deletion_protection` fields (with different names
 
 Resources that do not have a significant risk of unrecoverable data loss or similar critical concern will not be given `deletion_protection` fields.
 
+See [Client-side fields]({{< ref "/develop/client-side-fields" >}}) for information about adding `deletion_protection` fields.
+
 {{< hint info >}}
 **Note:** The previous best practice was a field called `force_delete` that defaulted to `false`. This is still present on some resources for backwards-compatibility reasons, but `deletion_protection` is preferred going forward.
 {{< /hint >}}
 
-## Deletion policy
+## Deletion policy {#deletion_policy}
 
 Some resources need to let users control the actions taken add deletion time. For these resources, the best practice is to add a `deletion_policy` enum field that defaults to an empty string and allows special values that control the deletion behavior.
 
 One common example is `ABANDON`, which is useful if the resource is safe to delete from Terraform but could cause problems if deleted from the API - for example, `google_bigtable_gc_policy` deletion can fail in replicated instances. `ABANDON` indicates that attempts to delete the resource should remove it from state without actually deleting it.
 
-See [magic-modules#13107](https://github.com/hashicorp/terraform-provider-google/pull/13107) for an example of adding a `deletion_policy` field to an existing resource.
+See [Client-side fields]({{< ref "/develop/client-side-fields" >}}) for information about adding `deletion_policy` fields.
 
 ## Add labels and annotations support
 

--- a/docs/content/develop/client-side-fields.md
+++ b/docs/content/develop/client-side-fields.md
@@ -1,0 +1,92 @@
+---
+title: "Client-side fields"
+weight: 400
+---
+
+# Client-side fields
+
+Client-side fields are most often used as flags to modify the behavior of a Terraform resource. Because they don't correspond to an API field, there are some additional considerations in terms of how to implement them.
+
+Common client-side fields include:
+
+- [`deletion_protection`]({{< ref "/best-practices#deletion_protection" >}})
+- [`deletion_policy`]({{< ref "/best-practices#deletion_policy" >}})
+
+{{< tabs "schema" >}}
+{{< tab "MMv1" >}}
+## Add to the schema
+
+Instead of adding the field in `parameters` or `properties`, use a section called `virtual_fields`.
+
+Example:
+```yaml
+virtual_fields:
+  - !ruby/object:Api::Type::Boolean
+    name: 'deletion_protection'
+    default_value: true
+    description: |
+      Whether Terraform will be prevented from destroying the CertificateAuthority.
+      When the field is set to true or unset in Terraform state, a `terraform apply`
+      or `terraform destroy` that would delete the CertificateAuthority will fail.
+      When the field is set to false, deleting the CertificateAuthority is allowed.
+```
+
+This will automatically ensure that the field works as users expect.
+{{< /tab >}}
+{{< tab "Handwritten" >}}
+## Add to the schema
+
+Add the field to the schema as usual.
+
+Example:
+
+```go
+"deletion_protection": {
+	Type:        schema.TypeBool,
+	Optional:    true,
+	Default:     true,
+	Description: `Whether Terraform will be prevented from destroying the instance. When the field is set to true or unset in Terraform state, a terraform apply or terraform destroy that would delete the table will fail. When the field is set to false, deleting the table is allowed.`,
+},
+```
+## Set on read
+
+For fields with default values, you need to explicitly set client-side fields in the Read function to avoid a diff that "sets" the field to its default value when users upgrade to the version that contains the new field.
+
+Example:
+
+```go
+// Explicitly set client-side fields to default values if unset
+if _, ok := d.GetOkExists("deletion_protection"); !ok {
+	if err := d.Set("deletion_protection", true); err != nil {
+		return fmt.Errorf("Error setting deletion_protection: %s", err)
+	}
+}
+```
+
+## Short-circuit updates if only client-side fields were modified
+
+Client-side fields can always be updated in-place. However, if the resource is otherwise immutable, you will need to ensure that an Update function is present for the resource. Terraform automatically updates the state based on the plan; this does not need to happen in the Update function unless the value for a field might have changed (for example, based on an API response, which doesn't apply to client-side fields).
+
+If only client-side fields were modified, you can short-circuit the Update function to avoid sending an API request. This is important because the update request will be empty (which causes errors for some APIs.) This can go at the top of the Update function:
+
+```go
+clientSideFields := map[string]bool{"deletion_protection": true}
+clientSideOnly := true
+for field := range ResourceSpannerInstance().Schema {
+	if d.HasChange(field) && !clientSideFields[field] {
+		clientSideOnly = false
+		break
+	}
+}
+if clientSideOnly {
+	return nil
+}
+```
+
+Replace `ResourceSpannerInstance` with the appropriate resource function.
+{{< /tab >}}
+{{< /tabs >}}
+
+## Implement logic
+
+At this point, you should be ready to implement your logic!

--- a/docs/content/develop/custom-code.md
+++ b/docs/content/develop/custom-code.md
@@ -160,7 +160,7 @@ The parameters the function receives are:
 
 The function returns a final value that will be stored in Terraform state for the field, which will be compared with the user's configuration to determine if there is a diff.
 
-## Inject code before / after CRUD operations and Import
+## Inject code before / after CRUD operations and Import {#pre_post_injection}
 
 ```yaml
 custom_code: !ruby/object:Provider::Terraform::CustomCode


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Clarifies the best practices for implementing client-side fields like deletion_protection.

Also related to https://github.com/hashicorp/terraform-provider-google/issues/13820
![localhost_1313_magic-modules_develop_client-side-fields_ (2)](https://github.com/user-attachments/assets/4043046b-c774-4c77-8f88-73708f9b2c97)
![localhost_1313_magic-modules_develop_client-side-fields_ (3)](https://github.com/user-attachments/assets/6e8741e0-659d-4305-ab50-58373eba2bc0)


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
