### PR TITLE
fix permadiff issue in google_cloudfunctions2_function service_config.environment_variables

### DIFF
--- a/mmv1/products/cloudfunctions2/Function.yaml
+++ b/mmv1/products/cloudfunctions2/Function.yaml
@@ -560,6 +560,7 @@ properties:
         description:
           'Environment variables that shall be available during function
           execution.'
+        default_from_api: true
         diff_suppress_func: 'environmentVariablesDiffSuppress'
       - !ruby/object:Api::Type::Integer
         name: 'maxInstanceCount'

--- a/mmv1/products/cloudfunctions2/go_Function.yaml
+++ b/mmv1/products/cloudfunctions2/go_Function.yaml
@@ -511,6 +511,7 @@ properties:
         description:
           'Environment variables that shall be available during function
           execution.'
+        default_from_api: true
         diff_suppress_func: 'environmentVariablesDiffSuppress'
       - name: 'maxInstanceCount'
         type: Integer

--- a/mmv1/templates/terraform/examples/cloudfunctions2_full.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudfunctions2_full.tf.erb
@@ -50,7 +50,8 @@ resource "google_cloudfunctions2_function" "<%= ctx[:primary_resource_id] %>" {
     max_instance_request_concurrency = 80
     available_cpu = "4"
     environment_variables = {
-        SERVICE_CONFIG_TEST = "config_test"
+        SERVICE_CONFIG_TEST      = "config_test"
+        SERVICE_CONFIG_DIFF_TEST = google_service_account.account.email
     }
     ingress_settings = "ALLOW_INTERNAL_ONLY"
     all_traffic_on_latest_revision = true


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fix permadiff issue in google_cloudfunctions2_function service_config.environment_variables https://github.com/hashicorp/terraform-provider-google/issues/18747

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
cloudfunctions2: fixed a "Provider produced inconsistent final plan" bug affecting the `service_config.environment_variables` field in `google_cloudfunctions2_function` resource
```
