### PR TITLE
extend data storage_bucket_object with generation

### DIFF
--- a/mmv1/third_party/terraform/services/storage/data_source_google_storage_bucket_object.go
+++ b/mmv1/third_party/terraform/services/storage/data_source_google_storage_bucket_object.go
@@ -89,6 +89,9 @@ func dataSourceGoogleStorageBucketObjectRead(d *schema.ResourceData, meta interf
 	if err := d.Set("metadata", res["metadata"]); err != nil {
 		return fmt.Errorf("Error setting metadata: %s", err)
 	}
+	if err := d.Set("generation", res["generation"]); err != nil {
+		return fmt.Errorf("Error setting generation: %s", err)
+	}
 
 	d.SetId(bucket + "-" + name)
 

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
@@ -95,6 +95,12 @@ func ResourceStorageBucketObject() *schema.Resource {
 				Description:  `Data as string to be uploaded. Must be defined if source is not. Note: The content field is marked as sensitive. To view the raw contents of the object, please define an output.`,
 			},
 
+			"generation": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The content generation of this object. Used for object versioning and soft delete.`,
+			},
+
 			"crc32c": {
 				Type:        schema.TypeString,
 				Computed:    true,

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
@@ -96,7 +96,7 @@ func ResourceStorageBucketObject() *schema.Resource {
 			},
 
 			"generation": {
-				Type:        schema.TypeString,
+				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: `The content generation of this object. Used for object versioning and soft delete.`,
 			},

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
@@ -460,6 +460,9 @@ func resourceStorageBucketObjectRead(d *schema.ResourceData, meta interface{}) e
 	if err := d.Set("detect_md5hash", res.Md5Hash); err != nil {
 		return fmt.Errorf("Error setting detect_md5hash: %s", err)
 	}
+	if err := d.Set("generation", res.Generation); err != nil {
+		return fmt.Errorf("Error setting generation: %s", err)
+	}
 	if err := d.Set("crc32c", res.Crc32c); err != nil {
 		return fmt.Errorf("Error setting crc32c: %s", err)
 	}

--- a/mmv1/third_party/terraform/website/docs/d/storage_bucket_object.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/storage_bucket_object.html.markdown
@@ -47,6 +47,8 @@ The following attributes are exported:
 
 * `content_type` - (Computed) [Content-Type](https://tools.ietf.org/html/rfc7231#section-3.1.1.5) of the object data. Defaults to "application/octet-stream" or "text/plain; charset=utf-8".
 
+* `generation` - (Computed) The content generation of this object. Used for object [versioning](https://cloud.google.com/storage/docs/object-versioning) and [soft delete](https://cloud.google.com/storage/docs/soft-delete).
+
 * `crc32c` - (Computed) Base 64 CRC32 hash of the uploaded data.
 
 * `md5hash` - (Computed) Base 64 MD5 hash of the uploaded data.

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
@@ -104,6 +104,8 @@ One of the following is required:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
+* `generation` - (Computed) The content generation of this object. Used for object [versioning](https://cloud.google.com/storage/docs/object-versioning) and [soft delete](https://cloud.google.com/storage/docs/soft-delete).
+
 * `crc32c` - (Computed) Base 64 CRC32 hash of the uploaded data.
 
 * `md5hash` - (Computed) Base 64 MD5 hash of the uploaded data.


### PR DESCRIPTION
This change extends the `google_storage_bucket_object` resource and data source with the `generation` output. This will help to reference the `generation`-id in `google_cloudfunctions2_function.build_config.source.storage_source.generation`.

See #11287 
Fixes [#14117](https://github.com/hashicorp/terraform-provider-google/issues/14117)

cc @gleichda 

 

```release-note:enhancement
storage: added `generation` field to `storage_bucket_object` resource
```
