### PR TITLE
Don't send labels in POST request to create PSC forwarding rules

### DIFF
--- a/mmv1/products/compute/ForwardingRule.yaml
+++ b/mmv1/products/compute/ForwardingRule.yaml
@@ -215,6 +215,7 @@ examples:
       - "port_range"
       - "target"
 custom_code: !ruby/object:Provider::Terraform::CustomCode
+  pre_create: templates/terraform/pre_create/compute_forwarding_rule.go.erb
   post_create: templates/terraform/post_create/labels.erb
   constants: 'templates/terraform/constants/compute_forwarding_rule.go.erb'
 custom_diff: [

--- a/mmv1/products/compute/go_ForwardingRule.yaml
+++ b/mmv1/products/compute/go_ForwardingRule.yaml
@@ -47,6 +47,7 @@ async:
     message: 'message'
 collection_url_key: 'items'
 custom_code:
+  pre_create: templates/terraform/pre_create/compute_forwarding_rule.go.tmpl
   constants: 'templates/terraform/constants/go/compute_forwarding_rule.go.tmpl'
   post_create: 'templates/terraform/post_create/go/labels.tmpl'
 custom_diff:

--- a/mmv1/templates/terraform/pre_create/compute_forwarding_rule.go.erb
+++ b/mmv1/templates/terraform/pre_create/compute_forwarding_rule.go.erb
@@ -1,0 +1,6 @@
+// Labels cannot be set in a create for PSC forwarding rules, so remove it from the CREATE request.
+if targetProp != nil && strings.Contains(targetProp.(string), "/serviceAttachments/") {
+  if _, ok := obj["labels"]; ok {
+    delete(obj, "labels")
+  }
+}

--- a/mmv1/templates/terraform/pre_create/go/compute_forwarding_rule.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/go/compute_forwarding_rule.go.tmpl
@@ -1,0 +1,6 @@
+// Labels cannot be set in a create for PSC forwarding rules, so remove it from the CREATE request.
+if targetProp != nil && strings.Contains(targetProp.(string), "/serviceAttachments/") {
+  if _, ok := obj["labels"]; ok {
+    delete(obj, "labels")
+  }
+}

--- a/mmv1/third_party/terraform/services/compute/go/resource_compute_forwarding_rule_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/go/resource_compute_forwarding_rule_test.go.tmpl
@@ -191,6 +191,7 @@ func TestAccComputeForwardingRule_forwardingRuleVpcPscExampleUpdate(t *testing.T
 				ResourceName:      "google_compute_forwarding_rule.default",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			{
 				Config: testAccComputeForwardingRule_forwardingRuleVpcPscExampleUpdate(context, false),
@@ -199,6 +200,7 @@ func TestAccComputeForwardingRule_forwardingRuleVpcPscExampleUpdate(t *testing.T
 				ResourceName:      "google_compute_forwarding_rule.default",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 		},
 	})
@@ -648,6 +650,9 @@ resource "google_compute_forwarding_rule" "default" {
   ip_address              = google_compute_address.consumer_address.id
   allow_psc_global_access = false
   %{lifecycle_block}
+  labels = {
+    "foo" = "bar"
+  }
 }
 
 // Consumer service endpoint

--- a/mmv1/third_party/terraform/services/compute/resource_compute_forwarding_rule_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_forwarding_rule_test.go.erb
@@ -649,6 +649,9 @@ resource "google_compute_forwarding_rule" "default" {
   ip_address              = google_compute_address.consumer_address.id
   allow_psc_global_access = false
   %{lifecycle_block}
+  labels = {
+    "foo" = "bar"
+  }
 }
 
 // Consumer service endpoint

--- a/mmv1/third_party/terraform/services/compute/resource_compute_forwarding_rule_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_forwarding_rule_test.go.erb
@@ -192,6 +192,7 @@ func TestAccComputeForwardingRule_forwardingRuleVpcPscExampleUpdate(t *testing.T
 				ResourceName:      "google_compute_forwarding_rule.default",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			{
 				Config: testAccComputeForwardingRule_forwardingRuleVpcPscExampleUpdate(context, false),
@@ -200,6 +201,7 @@ func TestAccComputeForwardingRule_forwardingRuleVpcPscExampleUpdate(t *testing.T
 				ResourceName:      "google_compute_forwarding_rule.default",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 		},
 	})


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Don't send labels in POST request to create PSC forwarding rules. labels will be set in a separate request after the POST request is complete.

fixes https://github.com/hashicorp/terraform-provider-google/issues/17334

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed the bug that creation of PSC forwarding rules fails in `google_compute_forwarding_rule` resource when provider default labels are set
```
