### PR TITLE
adding storage.us-central1 as the network connectivity regional  endp…

### DIFF
--- a/mmv1/templates/terraform/examples/go/network_connectivity_regional_endpoint_global_access.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/network_connectivity_regional_endpoint_global_access.tf.tmpl
@@ -13,7 +13,7 @@ resource "google_compute_subnetwork" "my_subnetwork" {
 resource "google_network_connectivity_regional_endpoint" "{{$.PrimaryResourceId}}" {
   name              = "{{index $.Vars "rep_name"}}"
   location          = "us-central1"
-  target_google_api = "boqcodelabjaimin-pa.us-central1.p.rep.googleapis.com"
+  target_google_api = "storage.us-central1.p.rep.googleapis.com"
   access_type       = "GLOBAL"
   address           = "192.168.0.4"
   network           = google_compute_network.my_network.id

--- a/mmv1/templates/terraform/examples/go/network_connectivity_regional_endpoint_regional_access.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/network_connectivity_regional_endpoint_regional_access.tf.tmpl
@@ -13,11 +13,11 @@ resource "google_compute_subnetwork" "my_subnetwork" {
 resource "google_network_connectivity_regional_endpoint" "{{$.PrimaryResourceId}}" {
   name              = "{{index $.Vars "rep_name"}}"
   location          = "us-central1"
-  target_google_api = "boqcodelabjaimin-pa.us-central1.p.rep.googleapis.com"
+  target_google_api = "storage.us-central1.p.rep.googleapis.com"
   access_type       = "REGIONAL"
   address           = "192.168.0.5"
   network           = google_compute_network.my_network.id
   subnetwork        = google_compute_subnetwork.my_subnetwork.id
-  description       = "My RegionalEndpoint targeting Google API boqcodelabjaimin-pa.us-central1.p.rep.googleapis.com"
+  description       = "My RegionalEndpoint targeting Google API storage.us-central1.p.rep.googleapis.com"
   labels            = {env = "default"}
 }

--- a/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_global_access.tf.erb
+++ b/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_global_access.tf.erb
@@ -13,7 +13,7 @@ resource "google_compute_subnetwork" "my_subnetwork" {
 resource "google_network_connectivity_regional_endpoint" "<%= ctx[:primary_resource_id] %>" {
   name              = "<%= ctx[:vars]['rep_name'] %>"
   location          = "us-central1"
-  target_google_api = "boqcodelabjaimin-pa.us-central1.p.rep.googleapis.com"
+  target_google_api = "storage.us-central1.p.rep.googleapis.com"
   access_type       = "GLOBAL"
   address           = "192.168.0.4"
   network           = google_compute_network.my_network.id

--- a/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.erb
+++ b/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.erb
@@ -13,11 +13,11 @@ resource "google_compute_subnetwork" "my_subnetwork" {
 resource "google_network_connectivity_regional_endpoint" "<%= ctx[:primary_resource_id] %>" {
   name              = "<%= ctx[:vars]['rep_name'] %>"
   location          = "us-central1"
-  target_google_api = "boqcodelabjaimin-pa.us-central1.p.rep.googleapis.com"
+  target_google_api = "storage.us-central1.p.rep.googleapis.com"
   access_type       = "REGIONAL"
   address           = "192.168.0.5"
   network           = google_compute_network.my_network.id
   subnetwork        = google_compute_subnetwork.my_subnetwork.id
-  description       = "My RegionalEndpoint targeting Google API boqcodelabjaimin-pa.us-central1.p.rep.googleapis.com"
+  description       = "My RegionalEndpoint targeting Google API storage.us-central1.p.rep.googleapis.com"
   labels            = {env = "default"}
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/18979

replacing boqcodelabjaimin with globally accessible API example such as storage.us-central1 for the network connectivity regional endpoints example.

```release-note:none
```
