### PR TITLE
Change ExpectedError in TestAccComputeInstanceNetworkIntefaceWithSecurityPolicy

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -3345,11 +3345,7 @@ func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfi
 			},
 			{
 				Config: testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateTwoPoliciesRemoveAccessConfig(suffix, policyName, policyName2, instanceName, "google_compute_region_security_policy.policyforinstance.self_link", "google_compute_region_security_policy.policyforinstance.self_link"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(
-						t, "google_compute_instance.foobar", &instance),
-					testAccCheckComputeInstanceNicAccessConfigHasSecurityPolicy(&instance, policyName),
-				),
+				ExpectError: regexp.MustCompile(`.* Cannot delete an access config with a security policy set. Please remove the security policy first. .*`),
 			},
 			{
 				ResourceName:      "google_compute_instance.foobar",
@@ -3455,11 +3451,7 @@ func testAccComputeInstance_nic_securityPolicyCreateWithAccessConfigUpdateAccess
 			},
 			{
 				Config: testAccComputeInstance_nic_securityPolicyCreateWithTwoAccessConfigsUpdateAccessConfig(suffix, policyName, instanceName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(
-						t, "google_compute_instance.foobar", &instance),
-					testAccCheckComputeInstanceNicAccessConfigHasSecurityPolicy(&instance, policyName),
-				),
+				ExpectError: regexp.MustCompile(`.* Cannot delete an access config with a security policy set. Please remove the security policy first. .*`),
 			},
 			{
 				ResourceName:      "google_compute_instance.foobar",
@@ -3468,7 +3460,7 @@ func testAccComputeInstance_nic_securityPolicyCreateWithAccessConfigUpdateAccess
 			},
 			{
 				Config:      testAccComputeInstance_nic_securityPolicyCreateWithTwoAccessConfigsRemoveAccessConfig(suffix, policyName, instanceName),
-				ExpectError: regexp.MustCompile(`.* Cannot delete an access config with a security policy set. Please remove the security policy first. .*`),
+				ExpectError: regexp.MustCompile("Error setting security policy to the instance since at least one access config must exist"),
 			},
 		},
 	})
@@ -3486,7 +3478,7 @@ func testAccComputeInstance_nic_securityPolicyCreateWithoutAccessConfig(t *testi
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccComputeInstance_nic_securityPolicyCreateWithTwoAccessConfigsRemoveAccessConfig(suffix, policyName, instanceName),
-				ExpectError: regexp.MustCompile(`.* Cannot delete an access config with a security policy set. Please remove the security policy first. .*`),
+				ExpectError: regexp.MustCompile("Error setting security policy to the instance since at least one access config must exist"),
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -3160,6 +3160,8 @@ func TestAccComputeInstance_proactiveAttributionLabel(t *testing.T) {
 }
 
 <% unless version == 'ga' -%>
+const errorDeleteAccessConfigWithSecPolicy = "Cannot delete an access config with a security policy set. Please remove the security policy first"
+
 // The tests related to security_policy use network_edge_security_service resource
 // which can only exist one per region. Because of that, all the following tests must run serially.
 func TestAccComputeInstanceNetworkIntefaceWithSecurityPolicy(t *testing.T) {
@@ -3345,7 +3347,7 @@ func testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfi
 			},
 			{
 				Config: testAccComputeInstance_nic_securityPolicyCreateWithTwoNicsAndTwoAccessConfigsUpdateTwoPoliciesRemoveAccessConfig(suffix, policyName, policyName2, instanceName, "google_compute_region_security_policy.policyforinstance.self_link", "google_compute_region_security_policy.policyforinstance.self_link"),
-				ExpectError: regexp.MustCompile(`.* Cannot delete an access config with a security policy set. Please remove the security policy first. .*`),
+				ExpectError: regexp.MustCompile(errorDeleteAccessConfigWithSecPolicy),
 			},
 			{
 				ResourceName:      "google_compute_instance.foobar",
@@ -3451,7 +3453,7 @@ func testAccComputeInstance_nic_securityPolicyCreateWithAccessConfigUpdateAccess
 			},
 			{
 				Config: testAccComputeInstance_nic_securityPolicyCreateWithTwoAccessConfigsUpdateAccessConfig(suffix, policyName, instanceName),
-				ExpectError: regexp.MustCompile(`.* Cannot delete an access config with a security policy set. Please remove the security policy first. .*`),
+				ExpectError: regexp.MustCompile(errorDeleteAccessConfigWithSecPolicy),
 			},
 			{
 				ResourceName:      "google_compute_instance.foobar",

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -3163,8 +3163,6 @@ func TestAccComputeInstance_proactiveAttributionLabel(t *testing.T) {
 // The tests related to security_policy use network_edge_security_service resource
 // which can only exist one per region. Because of that, all the following tests must run serially.
 func TestAccComputeInstanceNetworkIntefaceWithSecurityPolicy(t *testing.T) {
-	// Consistently failing - https://github.com/hashicorp/terraform-provider-google/issues/17838
-	acctest.SkipIfVcr(t)
 	testCases := map[string]func(t *testing.T){
 		"two_access_config": testAccComputeInstance_nic_securityPolicyCreateWithTwoAccessConfigs,
 		"two_nics_access_config_with_empty_nil_security_policy":   testAccComputeInstance_nic_securityPolicyCreateWithEmptyAndNullSecurityPolicies,
@@ -3470,7 +3468,7 @@ func testAccComputeInstance_nic_securityPolicyCreateWithAccessConfigUpdateAccess
 			},
 			{
 				Config:      testAccComputeInstance_nic_securityPolicyCreateWithTwoAccessConfigsRemoveAccessConfig(suffix, policyName, instanceName),
-				ExpectError: regexp.MustCompile("Error setting security policy to the instance since at least one access config must exist"),
+				ExpectError: regexp.MustCompile(`.* Cannot delete an access config with a security policy set. Please remove the security policy first. .*`),
 			},
 		},
 	})
@@ -3488,7 +3486,7 @@ func testAccComputeInstance_nic_securityPolicyCreateWithoutAccessConfig(t *testi
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccComputeInstance_nic_securityPolicyCreateWithTwoAccessConfigsRemoveAccessConfig(suffix, policyName, instanceName),
-				ExpectError: regexp.MustCompile("Error setting security policy to the instance since at least one access config must exist"),
+				ExpectError: regexp.MustCompile(`.* Cannot delete an access config with a security policy set. Please remove the security policy first. .*`),
 			},
 		},
 	})


### PR DESCRIPTION
References [issue #17838](https://github.com/hashicorp/terraform-provider-google/issues/17838)

The tests expects a wrong error in config. The error isn't thrown by the Security Policy code but rather by the AccessConfig code

Didn't have an environment to test this so testing it in PR

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
