### PR TITLE
Removes `no_age` from `google_storage_bucket` resource.

### DIFF
--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
@@ -227,12 +227,6 @@ func ResourceStorageBucket() *schema.Resource {
 										Optional:    true,
 										Description: `Creation date of an object in RFC 3339 (e.g. 2017-06-13) to satisfy this condition.`,
 									},
-									"no_age": {
-										Type:        schema.TypeBool,
-										Deprecated:  "`no_age` is deprecated and will be removed in a future major release. Use `send_age_if_zero` instead.",
-										Optional:    true,
-										Description: `While set true, age value will be omitted.Required to set true when age is unset in the config file.`,
-									},
 									"with_state": {
 										Type:         schema.TypeString,
 										Computed:     true,
@@ -266,7 +260,6 @@ func ResourceStorageBucket() *schema.Resource {
 									"send_age_if_zero": {
 										Type:        schema.TypeBool,
 										Optional:    true,
-										Default:     true,
 										Description: `While set true, age value will be sent in the request even for zero value of the field. This field is only useful for setting 0 value to the age field. It can be used alone or together with age.`,
 									},
 									"send_days_since_noncurrent_time_if_zero": {
@@ -1407,14 +1400,12 @@ func flattenBucketLifecycleRuleCondition(index int, d *schema.ResourceData, cond
 	// are already present otherwise setting them to individual default values.
 	if v, ok := d.GetOk(fmt.Sprintf("lifecycle_rule.%d.condition",index)); ok{
 		state_condition := v.(*schema.Set).List()[0].(map[string]interface{})
-		ruleCondition["no_age"] = state_condition["no_age"].(bool)
 		ruleCondition["send_days_since_noncurrent_time_if_zero"] = state_condition["send_days_since_noncurrent_time_if_zero"].(bool)
 		ruleCondition["send_days_since_custom_time_if_zero"] = state_condition["send_days_since_custom_time_if_zero"].(bool)
 		ruleCondition["send_num_newer_versions_if_zero"] = state_condition["send_num_newer_versions_if_zero"].(bool)
 		ruleCondition["send_age_if_zero"] = state_condition["send_age_if_zero"].(bool)
 	}  else {
-		ruleCondition["no_age"] = false
-		ruleCondition["send_age_if_zero"] = true
+		ruleCondition["send_age_if_zero"] = false
 		ruleCondition["send_days_since_noncurrent_time_if_zero"] = false
 		ruleCondition["send_days_since_custom_time_if_zero"] = false
 		ruleCondition["send_num_newer_versions_if_zero"] = false
@@ -1567,15 +1558,10 @@ func expandStorageBucketLifecycleRuleCondition(v interface{}) (*storage.BucketLi
 
 	condition := conditions[0].(map[string]interface{})
 	transformed := &storage.BucketLifecycleRuleCondition{}
-	// Setting high precedence of no_age over age and send_age_if_zero.
-	// Only sets age value when no_age is not present or no_age is present and has false value
-	if v, ok := condition["no_age"]; !ok || !(v.(bool)) {
-		if v, ok := condition["age"]; ok {
-			age := int64(v.(int))
-			u, ok := condition["send_age_if_zero"]
-			if age > 0 || (ok && u.(bool)) {
-				transformed.Age = &age
-			}
+	if v, ok := condition["age"]; ok {
+		age := int64(v.(int))
+		if u, ok := condition["send_age_if_zero"]; age > 0 || (ok && u.(bool)) {
+			transformed.Age = &age
 		}
 	}
 
@@ -1686,15 +1672,8 @@ func resourceGCSBucketLifecycleRuleConditionHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 
-	if v, ok := m["no_age"]; ok && v.(bool){
-		buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
-	} else {
-		if v, ok := m["send_age_if_zero"]; ok {
-			buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
-		}
-		if v, ok := m["age"]; ok {
-			buf.WriteString(fmt.Sprintf("%d-", v.(int)))
-		}
+	if v, ok := m["age"]; ok {
+		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
 	}
 
 	if v, ok := m["days_since_custom_time"]; ok {
@@ -1736,6 +1715,10 @@ func resourceGCSBucketLifecycleRuleConditionHash(v interface{}) int {
 
 	if v, ok := m["num_newer_versions"]; ok {
 		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
+	}
+
+	if v, ok := m["send_age_if_zero"]; ok {
+		buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
 	}
 
 	if v, ok := m["send_days_since_noncurrent_time_if_zero"]; ok {
@@ -1860,8 +1843,7 @@ func setStorageBucket(d *schema.ResourceData, config *transport_tpg.Config, res 
 	if err := d.Set("autoclass", flattenBucketAutoclass(res.Autoclass)); err != nil {
 		return fmt.Errorf("Error setting autoclass: %s", err)
 	}
-	// lifecycle_rule contains terraform only variable no_age.
-	// Passing config("d") to flattener function to set no_age separately.
+	// Passing config("d") to flattener function to set virtual fields separately.
 	if err := d.Set("lifecycle_rule", flattenBucketLifecycle(d, res.Lifecycle)); err != nil {
 		return fmt.Errorf("Error setting lifecycle_rule: %s", err)
 	}

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
@@ -656,14 +656,13 @@ func TestAccStorageBucket_lifecycleRulesVirtualFields(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy", "lifecycle_rule.1.condition.0.no_age", "lifecycle_rule.1.condition.0.send_days_since_noncurrent_time_if_zero", "lifecycle_rule.2.condition.0.send_days_since_noncurrent_time_if_zero", "lifecycle_rule.1.condition.0.send_days_since_custom_time_if_zero", "lifecycle_rule.2.condition.0.send_days_since_custom_time_if_zero", "lifecycle_rule.1.condition.0.send_num_newer_versions_if_zero", "lifecycle_rule.2.condition.0.send_num_newer_versions_if_zero", "lifecycle_rule.1.condition.0.send_age_if_zero"},
+				ImportStateVerifyIgnore: []string{"force_destroy", "lifecycle_rule.1.condition.0.send_days_since_noncurrent_time_if_zero", "lifecycle_rule.2.condition.0.send_days_since_noncurrent_time_if_zero", "lifecycle_rule.1.condition.0.send_days_since_custom_time_if_zero", "lifecycle_rule.2.condition.0.send_days_since_custom_time_if_zero", "lifecycle_rule.1.condition.0.send_num_newer_versions_if_zero", "lifecycle_rule.2.condition.0.send_num_newer_versions_if_zero", "lifecycle_rule.1.condition.0.send_age_if_zero", "lifecycle_rule.2.condition.0.send_age_if_zero"},
 			},
 			{
 				Config: testAccStorageBucket_customAttributes_withLifecycleVirtualFieldsUpdate2(bucketName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStorageBucketExists(
 						t, "google_storage_bucket.bucket", bucketName, &bucket),
-					testAccCheckStorageBucketLifecycleConditionNoAge(nil, &bucket, 1),
 					testAccCheckStorageBucketLifecycleConditionNoAge(nil, &bucket, 2),
 				),
 			},
@@ -671,7 +670,7 @@ func TestAccStorageBucket_lifecycleRulesVirtualFields(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy", "lifecycle_rule.1.condition.0.no_age", "lifecycle_rule.0.condition.0.send_days_since_noncurrent_time_if_zero", "lifecycle_rule.0.condition.0.send_days_since_custom_time_if_zero", "lifecycle_rule.0.condition.0.send_num_newer_versions_if_zero", "lifecycle_rule.0.condition.0.send_age_if_zero", "lifecycle_rule.1.condition.0.send_age_if_zero", "lifecycle_rule.2.condition.0.send_age_if_zero"},
+				ImportStateVerifyIgnore: []string{"force_destroy", "lifecycle_rule.0.condition.0.send_days_since_noncurrent_time_if_zero", "lifecycle_rule.0.condition.0.send_days_since_custom_time_if_zero", "lifecycle_rule.0.condition.0.send_num_newer_versions_if_zero", "lifecycle_rule.0.condition.0.send_age_if_zero", "lifecycle_rule.1.condition.0.send_age_if_zero", "lifecycle_rule.2.condition.0.send_age_if_zero"},
 			},
 			{
 				Config: testAccStorageBucket_customAttributes_withLifecycle1(bucketName),
@@ -1916,7 +1915,6 @@ resource "google_storage_bucket" "bucket" {
      }
      condition {
       age = 10
-      no_age = false
       days_since_noncurrent_time = 0
       send_days_since_noncurrent_time_if_zero = false
       days_since_custom_time = 0
@@ -1930,7 +1928,6 @@ resource "google_storage_bucket" "bucket" {
       type = "Delete"
     }
     condition {
-      no_age = true
       days_since_noncurrent_time = 0
       send_days_since_noncurrent_time_if_zero = true
       days_since_custom_time = 0
@@ -1944,6 +1941,7 @@ resource "google_storage_bucket" "bucket" {
       type = "Delete"
     }
     condition {
+      send_age_if_zero = true
       send_days_since_noncurrent_time_if_zero = true
       send_days_since_custom_time_if_zero = true
       send_num_newer_versions_if_zero = true
@@ -1965,7 +1963,6 @@ resource "google_storage_bucket" "bucket" {
      }
      condition {
       age = 10
-      no_age = false
       days_since_noncurrent_time = 0
       send_days_since_noncurrent_time_if_zero = true
       days_since_custom_time = 0
@@ -1980,7 +1977,6 @@ resource "google_storage_bucket" "bucket" {
     }
     condition {
       age = 10
-      no_age = true
       send_age_if_zero = false
       custom_time_before = "2022-09-01"
       days_since_noncurrent_time = 0

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
@@ -1868,6 +1868,7 @@ resource "google_storage_bucket" "bucket" {
       type = "Delete"
     }
     condition {
+      send_age_if_zero = true
       age = 0
     }
   }

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -171,9 +171,7 @@ The following arguments are supported:
 
 <a name="nested_condition"></a>The `condition` block supports the following elements, and requires at least one to be defined. If you specify multiple conditions in a rule, an object has to match all of the conditions for the action to be taken:
 
-* `age` - (Optional) Minimum age of an object in days to satisfy this condition. If not supplied alongside another condition and without setting `no_age` to `true`, a default `age` of 0 will be set.
-
-* `no_age` - (Optional, Deprecated) While set `true`, `age` value will be omitted from requests. This prevents a default age of `0` from being applied, and if you do not have an `age` value set, setting this to `true` is strongly recommended. When unset and other conditions are set to zero values, this can result in a rule that applies your action to all files in the bucket. `no_age` is deprecated and will be removed in a future major release. Use `send_age_if_zero` instead.
+* `age` - (Optional) Minimum age of an object in days to satisfy this condition. **Note** To set `0` value of `age`, `send_age_if_zero` should be set `true` otherwise `0` value of `age` field will be ignored.
 
 * `created_before` - (Optional) A date in the RFC 3339 format YYYY-MM-DD. This condition is satisfied when an object is created before midnight of the specified date in UTC.
 
@@ -193,7 +191,7 @@ The following arguments are supported:
 
 * `days_since_custom_time` - (Optional)	Days since the date set in the `customTime` metadata for the object. This condition is satisfied when the current date and time is at least the specified number of days after the `customTime`. Due to a current bug you are unable to set this value to `0` within Terraform. When set to `0` it will be ignored, and your state will treat it as though you supplied no `days_since_custom_time` condition.
 
-* `send_age_if_zero` - (Optional, Default: true) While set true, `age` value will be sent in the request even for zero value of the field. This field is only useful and required for setting 0 value to the `age` field. It can be used alone or together with `age` attribute. **NOTE** `age` attibute with `0` value will be ommitted from the API request if `send_age_if_zero` field is having `false` value.
+* `send_age_if_zero` - (Optional) While set true, `age` value will be sent in the request even for zero value of the field. This field is only useful and required for setting 0 value to the `age` field. It can be used alone or together with `age` attribute. **NOTE** `age` attibute with `0` value will be ommitted from the API request if `send_age_if_zero` field is having `false` value.
 
 * `send_days_since_custom_time_if_zero` - (Optional) While set true, `days_since_custom_time` value will be sent in the request even for zero value of the field. This field is only useful for setting 0 value to the `days_since_custom_time` field. It can be used alone or together with `days_since_custom_time`.
 


### PR DESCRIPTION
This PR removes `no_age` field from `lifecycle_rule.condition` of `google_storage_bucket` resource as this VF(Virtual Field) is no longer supported and removes default value of `send_age_if_zero` to keep it align with other `lifecycle_rule.condition` virtual fields.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
storage: removed `no_age` field from  `lifecycle_rule.condition` in the `google_storage_bucket` resource
```
