### PR TITLE
Add deletion_policy field to Project resource

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_project_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_project_test.go
@@ -28,6 +28,7 @@ func TestAccDataSourceGoogleProject_basic(t *testing.T) {
 							// Virtual fields
 							"auto_create_network": {},
 							"skip_delete":         {},
+							"deletion_policy":     {},
 						}),
 				),
 			},

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
 	tpgserviceusage "github.com/hashicorp/terraform-provider-google/google/services/serviceusage"
@@ -72,6 +73,14 @@ func ResourceGoogleProject() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Description: `If true, the Terraform resource can be deleted without deleting the Project via the Google API.`,
+			},
+			"deletion_policy": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "NONE",
+				Description: `The deletion policy for the Project. Setting PREVENT will protect the project against any destroy actions caused by a terraform apply or terraform destroy. Setting ABANDON allows the resource
+				to be abandoned rather than deleted. Possible values are: "PREVENT", "ABANDON", "NONE"`,
+				ValidateFunc: validation.StringInSlice([]string{"PREVENT", "ABANDON", "NONE"}, false),
 			},
 			"auto_create_network": {
 				Type:        schema.TypeBool,
@@ -499,8 +508,16 @@ func resourceGoogleProjectDelete(d *schema.ResourceData, meta interface{}) error
 	if err != nil {
 		return err
 	}
-	// Only delete projects if skip_delete isn't set
-	if !d.Get("skip_delete").(bool) {
+	deletionPolicy := d.Get("deletion_policy").(string)
+
+	if deletionPolicy == "PREVENT" {
+		return fmt.Errorf("Cannot destroy project as deletion_policy is set to PREVENT.")
+	} else if deletionPolicy == "ABANDON" {
+		log.Printf("[WARN] The project has been abandoned as deletion_policy set to ABANDON.")
+		d.SetId("")
+		return nil
+	} else {
+		// Only delete projects if deletion_policy isn't PREVENT or ABANDON
 		parts := strings.Split(d.Id(), "/")
 		pid := parts[len(parts)-1]
 		if err := transport_tpg.Retry(transport_tpg.RetryOptions{

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
@@ -77,10 +77,10 @@ func ResourceGoogleProject() *schema.Resource {
 			"deletion_policy": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "NONE",
+				Default:  "DELETE",
 				Description: `The deletion policy for the Project. Setting PREVENT will protect the project against any destroy actions caused by a terraform apply or terraform destroy. Setting ABANDON allows the resource
-				to be abandoned rather than deleted. Possible values are: "PREVENT", "ABANDON", "NONE"`,
-				ValidateFunc: validation.StringInSlice([]string{"PREVENT", "ABANDON", "NONE"}, false),
+				to be abandoned rather than deleted. Possible values are: "PREVENT", "ABANDON", "DELETE"`,
+				ValidateFunc: validation.StringInSlice([]string{"PREVENT", "ABANDON", "DELETE"}, false),
 			},
 			"auto_create_network": {
 				Type:        schema.TypeBool,
@@ -316,7 +316,7 @@ func resourceGoogleProjectRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	// Explicitly set client-side fields to default values if unset
 	if _, ok := d.GetOkExists("deletion_policy"); !ok {
-		if err := d.Set("deletion_policy", "NONE"); err != nil {
+		if err := d.Set("deletion_policy", "DELETE"); err != nil {
 			return fmt.Errorf("Error setting deletion_policy: %s", err)
 		}
 	}

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
@@ -314,7 +314,12 @@ func resourceGoogleProjectRead(d *schema.ResourceData, meta interface{}) error {
 		d.SetId("")
 		return nil
 	}
-
+	// Explicitly set client-side fields to default values if unset
+	if _, ok := d.GetOkExists("deletion_policy"); !ok {
+		if err := d.Set("deletion_policy", "NONE"); err != nil {
+			return fmt.Errorf("Error setting deletion_policy: %s", err)
+		}
+	}
 	if err := d.Set("project_id", pid); err != nil {
 		return fmt.Errorf("Error setting project_id: %s", err)
 	}

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_test.go
@@ -375,7 +375,7 @@ func TestAccProject_noAllowDestroy(t *testing.T) {
 				ExpectError: regexp.MustCompile("deletion_policy"),
 			},
 			{
-				Config: testAccProject(pid, org),
+				Config: testAccProject_create(pid, org),
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -95,7 +96,7 @@ func TestAccProject_billing(t *testing.T) {
 				ResourceName:            "google_project.acceptance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"skip_delete"},
+				ImportStateVerifyIgnore: []string{"skip_delete", "deletion_policy"},
 			},
 			// Update to a different  billing account
 			{
@@ -136,7 +137,7 @@ func TestAccProject_labels(t *testing.T) {
 				ResourceName:            "google_project.acceptance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"skip_delete", "labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"skip_delete", "labels", "terraform_labels", "deletion_policy"},
 			},
 			// update project with labels
 			{
@@ -209,7 +210,7 @@ func TestAccProject_migrateParent(t *testing.T) {
 				ResourceName:            "google_project.acceptance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"skip_delete"},
+				ImportStateVerifyIgnore: []string{"skip_delete", "deletion_policy"},
 			},
 			{
 				Config: testAccProject_migrateParentOrg(pid, folderDisplayName, org),
@@ -218,7 +219,7 @@ func TestAccProject_migrateParent(t *testing.T) {
 				ResourceName:            "google_project.acceptance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"skip_delete"},
+				ImportStateVerifyIgnore: []string{"skip_delete", "deletion_policy"},
 			},
 			{
 				Config: testAccProject_migrateParentFolder(pid, folderDisplayName, org),
@@ -227,7 +228,7 @@ func TestAccProject_migrateParent(t *testing.T) {
 				ResourceName:            "google_project.acceptance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"skip_delete"},
+				ImportStateVerifyIgnore: []string{"skip_delete", "deletion_policy"},
 			},
 		},
 	})
@@ -350,6 +351,65 @@ func testAccCheckGoogleProjectHasNoLabels(t *testing.T, r, pid string) resource.
 	}
 }
 
+func TestAccProject_noAllowDestroy(t *testing.T) {
+	t.Parallel()
+
+	org := envvar.GetTestOrgFromEnv(t)
+	pid := fmt.Sprintf("%s-%d", TestPrefix, acctest.RandInt(t))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProject_noAllowDestroy(pid, org),
+			},
+			{
+				ResourceName:            "google_project.acceptance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_delete", "deletion_policy"},
+			},
+			{
+				Config:      testAccProject_noAllowDestroy(pid, org),
+				Destroy:     true,
+				ExpectError: regexp.MustCompile("deletion_policy"),
+			},
+			{
+				Config: testAccProject(pid, org),
+			},
+		},
+	})
+}
+
+func TestAccProject_abandon(t *testing.T) {
+	t.Parallel()
+
+	org := envvar.GetTestOrgFromEnv(t)
+	pid := fmt.Sprintf("%s-%d", TestPrefix, acctest.RandInt(t))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProject_abandon(pid, org),
+			},
+			{
+				ResourceName:            "google_project.acceptance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_policy"},
+			},
+			{
+				Config:  testAccProject_abandon(pid, org),
+				Destroy: true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
+				),
+			},
+		},
+	})
+}
+
 func testAccProject_createWithoutOrg(pid string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
@@ -357,6 +417,28 @@ resource "google_project" "acceptance" {
   name       = "%s"
 }
 `, pid, pid)
+}
+
+func testAccProject_noAllowDestroy(pid, org string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+  project_id = "%s"
+  name       = "%s"
+  org_id = "%s"
+  deletion_policy = "PREVENT"
+}
+`, pid, pid, org)
+}
+
+func testAccProject_abandon(pid, org string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+  project_id = "%s"
+  name       = "%s"
+  org_id = "%s"
+  deletion_policy = "ABANDON"
+}
+`, pid, pid, org)
 }
 
 func testAccProject_createBilling(pid, org, billing string) string {

--- a/mmv1/third_party/terraform/website/docs/r/google_project.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project.html.markdown
@@ -98,6 +98,11 @@ The following arguments are supported:
     `false`. Note that when `false`, Terraform enables `compute.googleapis.com` on the project to interact
     with the GCE API and currently leaves it enabled.
 
+* `deletion_policy` -  (Optional) The deletion policy for the Project. Setting PREVENT will protect the project
+   against any destroy actions caused by a terraform apply or terraform destroy. Setting ABANDON allows the resource 
+   to be abandoned rather than deleted, i.e., the Terraform resource can be deleted without deleting the Project via 
+   the Google API. Possible values are: "PREVENT", "ABANDON", "NONE". Default value is `NONE`.
+
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are

--- a/mmv1/third_party/terraform/website/docs/r/google_project.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project.html.markdown
@@ -101,7 +101,7 @@ The following arguments are supported:
 * `deletion_policy` -  (Optional) The deletion policy for the Project. Setting PREVENT will protect the project
    against any destroy actions caused by a terraform apply or terraform destroy. Setting ABANDON allows the resource 
    to be abandoned rather than deleted, i.e., the Terraform resource can be deleted without deleting the Project via 
-   the Google API. Possible values are: "PREVENT", "ABANDON", "NONE". Default value is `NONE`.
+   the Google API. Possible values are: "PREVENT", "ABANDON", "DELETE". Default value is `DELETE`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add deletion_policy field to make deletion actions require an explicit intent.
Part of b/330143705

Part of  https://github.com/hashicorp/terraform-provider-google/issues/18775
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**
```release-note:enhancement
resourcemanager: added `deletion_policy` field to replace `skip_delete` field in `google_project` resource. Setting `deletion_policy` to `PREVENT` will protect the project against any destroy actions caused by a terraform apply or terraform destroy. Setting `deletion_policy` to `ABANDON` allows the resource to be abandoned rather than deleted and it behaves the same with `skip_delete = true`. Default value is `DELETE`.
```
