### PR TITLE
Fixed TestAccWorkbenchInstance_removeGpu

### DIFF
--- a/mmv1/third_party/terraform/services/workbench/go/resource_workbench_instance_test.go
+++ b/mmv1/third_party/terraform/services/workbench/go/resource_workbench_instance_test.go
@@ -213,7 +213,7 @@ func TestAccWorkbenchInstance_removeGpu(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"name", "instance_owners", "location", "instance_id", "request_id", "labels", "terraform_labels"},
 			},
       		{
-				Config: testAccWorkbenchInstance_updateGpu(context),
+				Config: testAccWorkbenchInstance_removeGpu(context),
 				Check: resource.ComposeTestCheckFunc(
                     	resource.TestCheckResourceAttr(
                         		"google_workbench_instance.instance", "state", "ACTIVE"),

--- a/mmv1/third_party/terraform/services/workbench/resource_workbench_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/workbench/resource_workbench_instance_test.go.erb
@@ -214,7 +214,7 @@ func TestAccWorkbenchInstance_removeGpu(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"name", "instance_owners", "location", "instance_id", "request_id", "labels", "terraform_labels"},
 			},
       		{
-				Config: testAccWorkbenchInstance_updateGpu(context),
+				Config: testAccWorkbenchInstance_removeGpu(context),
 				Check: resource.ComposeTestCheckFunc(
                     	resource.TestCheckResourceAttr(
                         		"google_workbench_instance.instance", "state", "ACTIVE"),


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
The test was previously referencing the testAccWorkbenchInstance_updateGpu (which upgrades the GPU instead of removing it). The low quota on P4 GPUs was getting hit regularly as a result.

Fixed https://github.com/hashicorp/terraform-provider-google/issues/18952

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
