### PR TITLE
Add a flag to use patch when creating a service networking connection fails

### DIFF
--- a/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
@@ -69,6 +69,11 @@ func ResourceServiceNetworkingConnection() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"update_on_creation_fail": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `When set to true, enforce an update of the reserved peering ranges on the existing service networking connection in case of a new connection creation failure.`,
+			},
 		},
 		UseJSONNumber: true,
 	}
@@ -118,7 +123,21 @@ func resourceServiceNetworkingConnectionCreate(d *schema.ResourceData, meta inte
 	}
 
 	if err := ServiceNetworkingOperationWaitTimeHW(config, op, "Create Service Networking Connection", userAgent, project, d.Timeout(schema.TimeoutCreate)); err != nil {
-		return err
+		if strings.Contains(err.Error(), "Cannot modify allocated ranges in CreateConnection.") && d.Get("update_on_creation_fail").(bool) {
+			patchCall := config.NewServiceNetworkingClient(userAgent).Services.Connections.Patch(parentService+"/connections/-", connection).UpdateMask("reservedPeeringRanges").Force(true)
+			if config.UserProjectOverride {
+				patchCall.Header().Add("X-Goog-User-Project", project)
+			}
+			op, err := patchCall.Do()
+			if err != nil {
+				return err
+			}
+			if err := ServiceNetworkingOperationWaitTimeHW(config, op, "Update Service Networking Connection", userAgent, project, d.Timeout(schema.TimeoutUpdate)); err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
 	}
 
 	connectionId := &connectionId{

--- a/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection_test.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection_test.go
@@ -2,6 +2,7 @@ package servicenetworking_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -60,6 +61,38 @@ func TestAccServiceNetworkingConnection_abandon(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccServiceNetworkingConnection_updateOnCreationFail(t *testing.T) {
+	t.Parallel()
+
+	network := fmt.Sprintf("tf-test-service-networking-connection-update-%s", acctest.RandString(t, 10))
+	addr1 := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	addr2 := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	service := "servicenetworking.googleapis.com"
+	org_id := envvar.GetTestOrgFromEnv(t)
+	billing_account := envvar.GetTestBillingAccountFromEnv(t)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testServiceNetworkingConnectionDestroy(t, service, network),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccServiceNetworkingConnections(network, addr1, addr2, "servicenetworking.googleapis.com", org_id, billing_account, false),
+				ExpectError: regexp.MustCompile("Cannot modify allocated ranges in CreateConnection. Please use UpdateConnection"),
+			},
+			{
+				Config: testAccServiceNetworkingConnections(network, addr1, addr2, "servicenetworking.googleapis.com", org_id, billing_account, true),
+				// google_service_networking_connection.foobar and google_service_networking_connection.foobar1 are the same service networking connection
+				// as they have the same network and service. When update_on_creation_fail is set to true, the service networking connection is updated
+				// with peering range google_compute_global_address.foobar1 successfully through google_service_networking_connection.foobar1.
+				// After refresh, google_service_networking_connection.foobar will also have the updated peering range google_compute_global_address.foobar1, so the plan is not empty.
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+
 }
 
 func TestAccServiceNetworkingConnection_update(t *testing.T) {
@@ -181,6 +214,61 @@ resource "google_service_networking_connection" "foobar" {
   depends_on = [google_project_service.servicenetworking]
 }
 `, addressRangeName, addressRangeName, org_id, billing_account, networkName, addressRangeName, serviceName)
+}
+
+func testAccServiceNetworkingConnections(networkName, addressRangeName, addressRangeName1, serviceName, org_id, billing_account string, update_on_creation_fail bool) string {
+	return fmt.Sprintf(`
+resource "google_project" "project" {
+  project_id      = "%s"
+  name            = "%s"
+  org_id          = "%s"
+  billing_account = "%s"
+}
+
+resource "google_project_service" "servicenetworking" {
+  project = google_project.project.project_id
+  service = "servicenetworking.googleapis.com"
+}
+
+resource "google_compute_network" "servicenet" {
+  name = "%s"
+  depends_on = [google_project_service.servicenetworking]
+}
+
+resource "google_compute_global_address" "foobar" {
+  name          = "%s"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.servicenet.self_link
+  depends_on = [google_project_service.servicenetworking]
+}
+
+resource "google_compute_global_address" "foobar1" {
+  name          = "%s"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.servicenet.self_link
+  depends_on = [google_project_service.servicenetworking]
+}
+
+resource "google_service_networking_connection" "foobar" {
+  network                 = google_compute_network.servicenet.self_link
+  service                 = "%s"
+  reserved_peering_ranges = [google_compute_global_address.foobar.name]
+  deletion_policy         = "ABANDON"
+  depends_on = [google_project_service.servicenetworking]
+}
+
+resource "google_service_networking_connection" "foobar1" {
+  network                 = google_compute_network.servicenet.self_link
+  service                 = "%s"
+  reserved_peering_ranges = [google_compute_global_address.foobar1.name]
+  update_on_creation_fail = "%t"
+  depends_on = [google_service_networking_connection.foobar]
+}
+`, addressRangeName, addressRangeName, org_id, billing_account, networkName, addressRangeName, addressRangeName1, serviceName, serviceName, update_on_creation_fail)
 }
 
 func testAccServiceNetworkingConnectionToBeAbandoned(networkName, addressRangeName, serviceName, org_id, billing_account string) string {

--- a/mmv1/third_party/terraform/website/docs/r/service_networking_connection.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/service_networking_connection.html.markdown
@@ -61,6 +61,8 @@ The following arguments are supported:
 
 * `deletion_policy` - (Optional) The deletion policy for the service networking connection. Setting to ABANDON allows the resource to be abandoned rather than deleted. This will enable a successful terraform destroy when destroying CloudSQL instances. Use with care as it can lead to dangling resources.
 
+* `update_on_creation_fail` - (Optional) When set to true, enforce an update of the reserved peering ranges on the existing service networking connection in case of a new connection creation failure.
+
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are exported:


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-google/issues/16697

In provider 4.x, resource `google_service_networking_connection` is soft deleted with `removePeering` method. 
After upgrading to 5.x, creating the resource `google_service_networking_connection` in the same network and different peering ranges fails.  When the field `update_on_creation_fail` is set to true, the creation will succeed by calling PATCH method after creation fails.

one pager doc is [here](https://docs.google.com/document/d/1Rp_1TYGWVPSL608idB6H9yA0Syk4G0EmmBdJERX14f4/edit?tab=t.0) 

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
servicenetworking: added `update_on_creation_fail` field to `google_service_networking_connection` resource. When it is set to true, enforce an update of the reserved peering ranges on the existing service networking connection in case of a new connection creation failure.
```
