### PR TITLE
Removed cloud armor tests that modify the default test project

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_project_cloud_armor_tier_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_project_cloud_armor_tier_test.go
@@ -10,62 +10,6 @@ import (
 )
 
 func TestAccComputeProjectCloudArmorTier_basic(t *testing.T) {
-	acctest.SkipIfVcr(t)
-	t.Parallel()
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccComputeProject_cloudArmorTier_standard(),
-			},
-			{
-				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier_config",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccComputeProjectCloudArmorTier_modify(t *testing.T) {
-	acctest.SkipIfVcr(t)
-	t.Parallel()
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccComputeProject_cloudArmorTier_standard(),
-			},
-			{
-				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier_config",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccComputeProject_cloudArmorTier_enterprise_paygo(),
-			},
-			{
-				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier_config",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccComputeProject_cloudArmorTier_standard(),
-			},
-			{
-				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier_config",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccComputeProjectCloudArmorTier_withProjectSet(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
@@ -79,23 +23,7 @@ func TestAccComputeProjectCloudArmorTier_withProjectSet(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeProject_cloudArmorTier_withProjectSet_standard(context),
-			},
-			{
-				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier_config",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccComputeProject_cloudArmorTier_withProjectSet_enterprise_paygo(context),
-			},
-			{
-				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier_config",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccComputeProject_cloudArmorTier_withProjectSet_standard(context),
+				Config: testAccComputeProject_cloudArmorTier_standard(context),
 			},
 			{
 				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier_config",
@@ -106,21 +34,48 @@ func TestAccComputeProjectCloudArmorTier_withProjectSet(t *testing.T) {
 	})
 }
 
-func testAccComputeProject_cloudArmorTier_enterprise_paygo() string {
-	return fmt.Sprintln(`
-resource "google_compute_project_cloud_armor_tier" "cloud_armor_tier_config" {
-  cloud_armor_tier = "CA_ENTERPRISE_PAYGO"
-}`)
+func TestAccComputeProjectCloudArmorTier_modify(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org":       envvar.GetTestOrgFromEnv(t),
+		"billingId": envvar.GetTestBillingAccountFromEnv(t),
+		"projectID": fmt.Sprintf("tf-test-%d", acctest.RandInt(t)),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeProject_cloudArmorTier_standard(context),
+			},
+			{
+				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier_config",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeProject_cloudArmorTier_enterprise_paygo(context),
+			},
+			{
+				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier_config",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeProject_cloudArmorTier_standard(context),
+			},
+			{
+				ResourceName:      "google_compute_project_cloud_armor_tier.cloud_armor_tier_config",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
 }
 
-func testAccComputeProject_cloudArmorTier_standard() string {
-	return fmt.Sprintln(`
-resource "google_compute_project_cloud_armor_tier" "cloud_armor_tier_config" {
-	cloud_armor_tier = "CA_STANDARD"
-}`)
-}
-
-func testAccComputeProject_cloudArmorTier_withProjectSet_enterprise_paygo(context map[string]interface{}) string {
+func testAccComputeProject_cloudArmorTier_enterprise_paygo(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_project" "project" {
   project_id      = "%{projectID}"
@@ -142,7 +97,7 @@ resource "google_compute_project_cloud_armor_tier" "cloud_armor_tier_config" {
 `, context)
 }
 
-func testAccComputeProject_cloudArmorTier_withProjectSet_standard(context map[string]interface{}) string {
+func testAccComputeProject_cloudArmorTier_standard(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_project" "project" {
   project_id      = "%{projectID}"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixed https://github.com/hashicorp/terraform-provider-google/issues/18659.

It turns out that these tests modify the global project in a way that is incompatible with other tests (https://github.com/hashicorp/terraform-provider-google/issues/18950). We shouldn't actually need tests for the project being unset, since we're just trying to test the API behavior (which is already tested by the tests which set the project.)

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
