### PR TITLE
add `google_kms_crypto_key_version_latest`

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
@@ -137,6 +137,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_kms_crypto_key":                            kms.DataSourceGoogleKmsCryptoKey(),
 	"google_kms_crypto_keys":                           kms.DataSourceGoogleKmsCryptoKeys(),
 	"google_kms_crypto_key_version":                    kms.DataSourceGoogleKmsCryptoKeyVersion(),
+	"google_kms_crypto_key_version_latest":				kms.DataSourceGoogleLatestKmsCryptoKeyVersionLatest(),
 	"google_kms_key_ring":                              kms.DataSourceGoogleKmsKeyRing(),
 	"google_kms_key_rings":                              kms.DataSourceGoogleKmsKeyRings(),
 	"google_kms_secret":                                kms.DataSourceGoogleKmsSecret(),

--- a/mmv1/third_party/terraform/services/kms/data_source_google_kms_crypto_key_version_latest.go
+++ b/mmv1/third_party/terraform/services/kms/data_source_google_kms_crypto_key_version_latest.go
@@ -67,7 +67,7 @@ func dataSourceGoogleLatestKmsCryptoKeyVersionLatestRead(d *schema.ResourceData,
 		return err
 	}
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{KMSBasePath}}{{crypto_key}}/cryptoKeyVersions")
+	url, err := tpgresource.ReplaceVars(d, config, "{{KMSBasePath}}{{crypto_key}}/cryptoKeyVersions?filter=state=ENABLED")
 	if err != nil {
 		return err
 	}

--- a/mmv1/third_party/terraform/services/kms/data_source_google_kms_crypto_key_version_latest.go
+++ b/mmv1/third_party/terraform/services/kms/data_source_google_kms_crypto_key_version_latest.go
@@ -1,0 +1,218 @@
+package kms
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func DataSourceGoogleLatestKmsCryptoKeyVersionLatest() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGoogleLatestKmsCryptoKeyVersionLatestRead,
+		Schema: map[string]*schema.Schema{
+			"crypto_key": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"algorithm": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"protection_level": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"public_key": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"algorithm": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"pem": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGoogleLatestKmsCryptoKeyVersionLatestRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	url, err := tpgresource.ReplaceVars(d, config, "{{KMSBasePath}}{{crypto_key}}/cryptoKeyVersions")
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Getting list of cryptoKeyVersions from cryptoKey: {{crypto_key}}")
+
+	cryptoKeyId, err := ParseKmsCryptoKeyId(d.Get("crypto_key").(string), config)
+	if err != nil {
+		return err
+	}
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   cryptoKeyId.KeyRingId.Project,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
+	if err != nil {
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("KmsCryptoKeyVersion %q", d.Id()), url)
+	}
+
+	v, err := flattenKmsCryptoKeyVersionLatest(res["cryptoKeyVersions"].([]interface{}), d, config, cryptoKeyId.CryptoKeyId())
+	if err != nil {
+		return fmt.Errorf("Error getting latest CryptoKeyVersion from crypto key: %s", cryptoKeyId)
+	}
+	latestVersion := v.(map[string]interface{})
+
+	if err := d.Set("version", latestVersion["version"].(int64)); err != nil {
+		return fmt.Errorf("Error setting CryptoKeyVersion: %s", err)
+	}
+	if err := d.Set("name", latestVersion["name"].(string)); err != nil {
+		return fmt.Errorf("Error setting CryptoKeyVersion: %s", err)
+	}
+	if err := d.Set("state", latestVersion["state"]); err != nil {
+		return fmt.Errorf("Error setting CryptoKeyVersion: %s", err)
+	}
+	if err := d.Set("protection_level", latestVersion["protectionLevel"]); err != nil {
+		return fmt.Errorf("Error setting CryptoKeyVersion: %s", err)
+	}
+	if err := d.Set("algorithm", latestVersion["algorithm"]); err != nil {
+		return fmt.Errorf("Error setting CryptoKeyVersion: %s", err)
+	}
+
+	url, err = tpgresource.ReplaceVars(d, config, "{{KMSBasePath}}{{crypto_key}}")
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Getting purpose of CryptoKey: %#v", url)
+	res, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   cryptoKeyId.KeyRingId.Project,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
+	if err != nil {
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("KmsCryptoKey %q", d.Id()), url)
+	}
+
+	if res["purpose"] == "ASYMMETRIC_SIGN" || res["purpose"] == "ASYMMETRIC_DECRYPT" {
+		url, err = tpgresource.ReplaceVars(d, config, "{{KMSBasePath}}{{crypto_key}}/cryptoKeyVersions/{{version}}/publicKey")
+		if err != nil {
+			return err
+		}
+		log.Printf("[DEBUG] Getting public key of CryptoKeyVersion: %#v", url)
+
+		res, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:               config,
+			Method:               "GET",
+			Project:              cryptoKeyId.KeyRingId.Project,
+			RawURL:               url,
+			UserAgent:            userAgent,
+			Timeout:              d.Timeout(schema.TimeoutRead),
+			ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{transport_tpg.IsCryptoKeyVersionsPendingGeneration},
+		})
+
+		if err != nil {
+			log.Printf("Error generating public key: %s", err)
+			return err
+		}
+
+		if err := d.Set("public_key", flattenKmsCryptoKeyVersionPublicKey(res, d)); err != nil {
+			return fmt.Errorf("Error setting CryptoKeyVersion public key: %s", err)
+		}
+	}
+	d.SetId(fmt.Sprintf("//cloudkms.googleapis.com/v1/%s/cryptoKeyVersions/%d", d.Get("crypto_key"), d.Get("version")))
+
+	return nil
+}
+
+func flattenKmsCryptoKeyVersionVersionLatest(v interface{}, d *schema.ResourceData) interface{} {
+	parts := strings.Split(v.(string), "/")
+	version := parts[len(parts)-1]
+	// Handles the string fixed64 format
+	if intVal, err := tpgresource.StringToFixed64(version); err == nil {
+		return intVal
+	} // let terraform core handle it if we can't convert the string to an int.
+	return v
+}
+
+func flattenKmsCryptoKeyVersionNameLatest(v interface{}, d *schema.ResourceData) interface{} {
+	return v
+}
+
+func flattenKmsCryptoKeyVersionStateLatest(v interface{}, d *schema.ResourceData) interface{} {
+	return v
+}
+
+func flattenKmsCryptoKeyVersionProtectionLevelLatest(v interface{}, d *schema.ResourceData) interface{} {
+	return v
+}
+
+func flattenKmsCryptoKeyVersionAlgorithmLatest(v interface{}, d *schema.ResourceData) interface{} {
+	return v
+}
+
+func flattenKmsCryptoKeyVersionLatest(versionsList []interface{}, d *schema.ResourceData, config *transport_tpg.Config, cryptoKeyId string) (interface{}, error) {
+	latestVersion := versionsList[len(versionsList)-1].(map[string]interface{})
+	parsedId, err := parseKmsCryptoKeyVersionId(latestVersion["name"].(string), config)
+	if err != nil {
+		return nil, err
+	}
+
+	data := map[string]interface{}{}
+	// The google_kms_crypto_key resource and dataset set
+	// id as the value of name (projects/{{project}}/locations/{{location}}/keyRings/{{keyRing}}/cryptoKeys/{{name}})
+	// and set name is set as just {{name}}.
+	data["id"] = latestVersion["name"]
+	data["name"] = parsedId.Name
+	data["crypto_key"] = cryptoKeyId
+
+	// fields can be found in `data_source_google_kms_crypto_key_version.go`
+	data["version"] = flattenKmsCryptoKeyVersionVersion(latestVersion["name"], d)
+	data["algorithm"] = flattenKmsCryptoKeyVersionAlgorithm(latestVersion["algorithm"], d)
+	data["protection_level"] = flattenKmsCryptoKeyVersionProtectionLevel(latestVersion["protectionLevel"], d)
+	data["state"] = flattenKmsCryptoKeyVersionState(latestVersion["state"], d)
+	data["public_key"] = flattenKmsCryptoKeyVersionPublicKey(latestVersion["publicKey"], d)
+
+	return data, nil
+}
+func flattenKmsCryptoKeyVersionPublicKeyPemLatest(v interface{}, d *schema.ResourceData) interface{} {
+	return v
+}
+
+func flattenKmsCryptoKeyVersionPublicKeyAlgorithmLatest(v interface{}, d *schema.ResourceData) interface{} {
+	return v
+}

--- a/mmv1/third_party/terraform/services/kms/data_source_google_kms_crypto_key_version_latest_test.go
+++ b/mmv1/third_party/terraform/services/kms/data_source_google_kms_crypto_key_version_latest_test.go
@@ -1,0 +1,53 @@
+package kms_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccDataSourceGoogleKmsCryptoKeyVersionLatest_basic(t *testing.T) {
+	asymSignKey := acctest.BootstrapKMSKeyWithPurpose(t, "ASYMMETRIC_SIGN")
+	asymDecrKey := acctest.BootstrapKMSKeyWithPurpose(t, "ASYMMETRIC_DECRYPT")
+	symKey := acctest.BootstrapKMSKey(t)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleKmsCryptoKeyVersionLatest_basic(asymSignKey.CryptoKey.Name),
+				Check:  resource.TestCheckResourceAttr("data.google_kms_crypto_key_version_latest.version_latest", "version", "2"),
+			},
+			// Asymmetric keys should have a public key
+			{
+				Config: testAccDataSourceGoogleKmsCryptoKeyVersionLatest_basic(asymSignKey.CryptoKey.Name),
+				Check:  resource.TestCheckResourceAttr("data.google_kms_crypto_key_version_latest.version_latest", "public_key.#", "1"),
+			},
+			{
+				Config: testAccDataSourceGoogleKmsCryptoKeyVersionLatest_basic(asymDecrKey.CryptoKey.Name),
+				Check:  resource.TestCheckResourceAttr("data.google_kms_crypto_key_version_latest.version_latest", "public_key.#", "1"),
+			},
+			// Symmetric key should have no public key
+			{
+				Config: testAccDataSourceGoogleKmsCryptoKeyVersionLatest_basic(symKey.CryptoKey.Name),
+				Check:  resource.TestCheckResourceAttr("data.google_kms_crypto_key_version_latest.version_latest", "public_key.#", "0"),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleKmsCryptoKeyVersionLatest_basic(kmsKey string) string {
+	return fmt.Sprintf(`
+resource "google_kms_crypto_key_version" "version" {
+	crypto_key = "%s"
+	state = "ENABLED"
+  }
+
+data "google_kms_crypto_key_version_latest" "version_latest" {
+  crypto_key = "%s"
+}
+`, kmsKey, kmsKey)
+}

--- a/mmv1/third_party/terraform/services/kms/data_source_google_kms_crypto_key_version_latest_test.go
+++ b/mmv1/third_party/terraform/services/kms/data_source_google_kms_crypto_key_version_latest_test.go
@@ -43,7 +43,6 @@ func testAccDataSourceGoogleKmsCryptoKeyVersionLatest_basic(kmsKey string) strin
 	return fmt.Sprintf(`
 resource "google_kms_crypto_key_version" "version" {
 	crypto_key = "%s"
-	state = "ENABLED"
   }
 
 data "google_kms_crypto_key_version_latest" "version_latest" {

--- a/mmv1/third_party/terraform/services/kms/data_source_google_kms_crypto_key_version_latest_test.go
+++ b/mmv1/third_party/terraform/services/kms/data_source_google_kms_crypto_key_version_latest_test.go
@@ -44,5 +44,5 @@ func testAccDataSourceGoogleKmsCryptoKeyVersionLatest_basic(kmsKey string) strin
 data "google_kms_crypto_key_version_latest" "version_latest" {
   crypto_key = "%s"
 }
-`, kmsKey, kmsKey)
+`, kmsKey)
 }

--- a/mmv1/third_party/terraform/services/kms/data_source_google_kms_crypto_key_version_latest_test.go
+++ b/mmv1/third_party/terraform/services/kms/data_source_google_kms_crypto_key_version_latest_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceGoogleKmsCryptoKeyVersionLatest_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceGoogleKmsCryptoKeyVersionLatest_basic(asymSignKey.CryptoKey.Name),
-				Check:  resource.TestCheckResourceAttr("data.google_kms_crypto_key_version_latest.version_latest", "version", "2"),
+				Check:  resource.TestCheckResourceAttr("data.google_kms_crypto_key_version_latest.version_latest", "version", "3"),
 			},
 			// Asymmetric keys should have a public key
 			{
@@ -41,10 +41,6 @@ func TestAccDataSourceGoogleKmsCryptoKeyVersionLatest_basic(t *testing.T) {
 
 func testAccDataSourceGoogleKmsCryptoKeyVersionLatest_basic(kmsKey string) string {
 	return fmt.Sprintf(`
-resource "google_kms_crypto_key_version" "version" {
-	crypto_key = "%s"
-  }
-
 data "google_kms_crypto_key_version_latest" "version_latest" {
   crypto_key = "%s"
 }

--- a/mmv1/third_party/terraform/website/docs/d/kms_crypto_key_version_latest.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/kms_crypto_key_version_latest.html.markdown
@@ -1,0 +1,65 @@
+---
+subcategory: "Cloud Key Management Service"
+description: |-
+ Provides access to the latest KMS key version data with Google Cloud KMS.
+---
+
+# google_kms_crypto_key_version_latest
+
+Provides access to a Google Cloud Platform KMS Latest CryptoKeyVersion. For more information see
+[the official documentation](https://cloud.google.com/kms/docs/object-hierarchy#key_version)
+and
+[API](https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys.cryptoKeyVersions).
+
+A CryptoKeyVersion represents an individual cryptographic key, and the associated key material. Multiple CryptoKeyVersions can
+exist within one CryptoKey. This data source allows the ability to use the latest CryptoVersion from a specified CryptoKey.
+
+## Example Usage
+
+```hcl
+data "google_kms_key_ring" "my_key_ring" {
+  name     = "my-key-ring"
+  location = "us-central1"
+}
+
+data "google_kms_crypto_key" "my_crypto_key" {
+  name     = "my-crypto-key"
+  key_ring = data.google_kms_key_ring.my_key_ring.id
+}
+
+data "google_kms_crypto_key_version_latest" "my_crypto_key_version_latest" {
+  crypto_key = data.google_kms_crypto_key.my_key.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `crypto_key` - (Required) The `id` of the Google Cloud Platform CryptoKey to which the key version belongs. This is also the `id` field of the 
+`google_kms_crypto_key` resource/datasource.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `id` - an identifier for the resource with format `//cloudkms.googleapis.com/v1/{{crypto_key}}/cryptoKeyVersions/{{version}}`
+
+* `name` - The resource name for this CryptoKeyVersion in the format `projects/*/locations/*/keyRings/*/cryptoKeys/*/cryptoKeyVersions/*`
+
+* `state` - The current state of the CryptoKeyVersion. See the [state reference](https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys.cryptoKeyVersions#CryptoKeyVersion.CryptoKeyVersionState) for possible outputs.
+
+* `protection_level` - The ProtectionLevel describing how crypto operations are performed with this CryptoKeyVersion. See the [protection_level reference](https://cloud.google.com/kms/docs/reference/rest/v1/ProtectionLevel) for possible outputs.
+
+* `algorithm` - The CryptoKeyVersionAlgorithm that this CryptoKeyVersion supports. See the [algorithm reference](https://cloud.google.com/kms/docs/reference/rest/v1/CryptoKeyVersionAlgorithm) for possible outputs.
+
+* `public_key` -  If the enclosing CryptoKey has purpose `ASYMMETRIC_SIGN` or `ASYMMETRIC_DECRYPT`, this block contains details about the public key associated to this CryptoKeyVersion. Structure is [documented below](#nested_public_key).
+
+<a name="nested_public_key"></a>The `public_key` block, if present, contains:
+
+* `pem` - The public key, encoded in PEM format. For more information, see the RFC 7468 sections for General Considerations and Textual Encoding of Subject Public Key Info.
+
+* `algorithm` - The CryptoKeyVersionAlgorithm that this CryptoKeyVersion supports.
+
+


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Currently their is no way for users to grab the latest crypto key version without needing to use a separate resource that can perform a get of `cryptoKeyVersions` in order to grab the latest version from a latest.

This PR addes a `crypto_key_version` data source that takes in a `crypto_key` id in order to output the latest cryptoVersion for the specified crypto_key

`simple tfconfig`:
```hcl
resource "google_kms_key_ring" "key_ring" {
  project  = "<INSERT-PROJECT>"
  name     = "<INSERT-KEY-RING>"
  location = "us-central1"
}

resource "google_kms_crypto_key" "crypto_key" {
  name     = "<INSERT-CRYPTO-KEY>"
  key_ring = google_kms_key_ring.key_ring.id
  purpose  = "ASYMMETRIC_SIGN"

  version_template {
    algorithm = "EC_SIGN_P256_SHA256"
  }
}

data "google_kms_crypto_key_version_latest" "latest_version_data_source" {
  crypto_key = google_kms_crypto_key.crypto_key.id
}

output "latest_version" {
  value = data.google_kms_crypto_key_version_latest.latest_version_data_source.version
}
```

The `GET` request of cryptoVersions:
```hcl
 ---[ REQUEST ]---------------------------------------
 GET /v1/projects/hc-terraform-testing/locations/us-central1/keyRings/mau-latest-test/cryptoKeys/mau-crypto-key-test/cryptoKeyVersions?alt=json HTTP/1.1
 Host: cloudkms.googleapis.com
 User-Agent: Terraform/1.8.0-alpha20240131 (+https://www.terraform.io) Terraform-Plugin-SDK/2.33.0 terraform-provider-google/dev
 Content-Type: application/json
 Accept-Encoding: gzip


 -----------------------------------------------------
 2024/08/06 15:27:21 [DEBUG] Google API Response Details:
 ---[ RESPONSE ]--------------------------------------
 HTTP/2.0 200 OK
 Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
 Cache-Control: private
 Content-Type: application/json; charset=UTF-8
 Date: Tue, 06 Aug 2024 22:27:21 GMT
 Server: ESF
 Vary: Origin
 Vary: X-Origin
 Vary: Referer
 X-Content-Type-Options: nosniff
 X-Frame-Options: SAMEORIGIN
 X-Xss-Protection: 0

 {
   "cryptoKeyVersions": [
     {
       "name": "projects/hc-terraform-testing/locations/us-central1/keyRings/mau-latest-test/cryptoKeys/mau-crypto-key-test/cryptoKeyVersions/1",
       "state": "DESTROY_SCHEDULED",
       "createTime": "2024-08-01T22:50:13.684360401Z",
       "destroyTime": "2024-08-31T23:07:49.100169Z",
       "protectionLevel": "SOFTWARE",
       "algorithm": "EC_SIGN_P256_SHA256",
       "generateTime": "2024-08-01T22:50:13.757083972Z"
     },
     {
       "name": "projects/hc-terraform-testing/locations/us-central1/keyRings/mau-latest-test/cryptoKeys/mau-crypto-key-test/cryptoKeyVersions/2",
       "state": "ENABLED",
       "createTime": "2024-08-06T20:20:32.503393705Z",
       "protectionLevel": "SOFTWARE",
       "algorithm": "EC_SIGN_P256_SHA256",
       "generateTime": "2024-08-06T20:20:32.539700895Z"
     },
     {
       "name": "projects/hc-terraform-testing/locations/us-central1/keyRings/mau-latest-test/cryptoKeys/mau-crypto-key-test/cryptoKeyVersions/3",
       "state": "ENABLED",
       "createTime": "2024-08-06T20:20:35.716831348Z",
       "protectionLevel": "SOFTWARE",
       "algorithm": "EC_SIGN_P256_SHA256",
       "generateTime": "2024-08-06T20:20:35.753066470Z"
     },
     {
       "name": "projects/hc-terraform-testing/locations/us-central1/keyRings/mau-latest-test/cryptoKeys/mau-crypto-key-test/cryptoKeyVersions/4",
       "state": "ENABLED",
       "createTime": "2024-08-06T20:20:38.344795186Z",
       "protectionLevel": "SOFTWARE",
       "algorithm": "EC_SIGN_P256_SHA256",
       "generateTime": "2024-08-06T20:20:38.376814820Z"
     }
   ],
   "totalSize": 4
 }
```

The output from the tfconfig confirms the latest version by outputting version 4 which can be found in the GET request above:
```hcl
Outputs:

latest_version = 4
latest_version_crypto_key = "projects/hc-terraform-testing/locations/us-central1/keyRings/mau-latest-test/cryptoKeys/mau-crypto-key-test"
latest_version_name = "projects/hc-terraform-testing/locations/us-central1/keyRings/mau-latest-test/cryptoKeys/mau-crypto-key-test/cryptoKeyVersions/4"
```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
`google_kms_crypto_key_version_latest`
```
