### PR TITLE
ancestrymanager: Prefer to use the project number

### DIFF
--- a/mmv1/third_party/tgc/ancestrymanager/ancestrymanager.go
+++ b/mmv1/third_party/tgc/ancestrymanager/ancestrymanager.go
@@ -18,6 +18,13 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	projectPrefix = "projects/"
+	folderPrefix  = "folders/"
+	orgPrefix     = "organizations/"
+	unknownOrg    = orgPrefix + "unknown"
+)
+
 // AncestryManager is the interface that fetch ancestors for a resource.
 type AncestryManager interface {
 	// Ancestors returns a list of ancestors.
@@ -73,8 +80,11 @@ func (m *manager) initAncestryCache(entries map[string]string) error {
 			if err != nil {
 				return err
 			}
-			// ancestry path should include the item itself
-			if ancestors[0] != key {
+			// The ancestry path should include the item itself, unless both the key and ancestor
+			// have the projects/ prefix, indicating the key is a project ID and the ancestry is
+			// project number. CAI ancestors use the project number, so that is preferred if it
+			// is available.
+			if ancestors[0] != key && !(strings.HasPrefix(key, projectPrefix) && strings.HasPrefix(ancestors[0], projectPrefix)) {
 				ancestors = append([]string{key}, ancestors...)
 			}
 			m.store(key, ancestors)
@@ -88,7 +98,7 @@ func parseAncestryKey(val string) (string, error) {
 	ix := strings.LastIndex(key, "/")
 	if ix == -1 {
 		// If not containing /, then treat it as a project.
-		return fmt.Sprintf("projects/%s", key), nil
+		return projectPrefix + key, nil
 	} else {
 		k := key[:ix]
 		if k == "projects" || k == "folders" || k == "organizations" {
@@ -127,24 +137,15 @@ func (m *manager) fetchAncestors(config *transport_tpg.Config, tfData tpgresourc
 
 	orgID, orgOK := getOrganizationFromResource(tfData)
 	if orgOK {
-		orgKey = orgID
-		if !strings.HasPrefix(orgKey, "organizations/") {
-			orgKey = fmt.Sprintf("organizations/%s", orgKey)
-		}
+		orgKey = ensurePrefix(orgID, orgPrefix)
 	}
 	folderID, folderOK := getFolderFromResource(tfData)
 	if folderOK {
-		folderKey = folderID
-		if !strings.HasPrefix(folderKey, "folders/") {
-			folderKey = fmt.Sprintf("folders/%s", folderKey)
-		}
+		folderKey = ensurePrefix(folderID, folderPrefix)
 	}
 	project, _ := m.getProjectFromResource(tfData, config, cai)
 	if project != "" {
-		projectKey = project
-		if !strings.HasPrefix(projectKey, "projects/") {
-			projectKey = fmt.Sprintf("projects/%s", project)
-		}
+		projectKey = ensurePrefix(project, projectPrefix)
 	}
 
 	switch cai.Type {
@@ -154,7 +155,7 @@ func (m *manager) fetchAncestors(config *transport_tpg.Config, tfData tpgresourc
 		} else if orgOK {
 			key = orgKey
 		} else {
-			return []string{"organizations/unknown"}, nil
+			return []string{unknownOrg}, nil
 		}
 	case "cloudresourcemanager.googleapis.com/Organization":
 		if !orgOK {
@@ -168,7 +169,7 @@ func (m *manager) fetchAncestors(config *transport_tpg.Config, tfData tpgresourc
 		} else if projectKey != "" {
 			key = projectKey
 		} else {
-			return []string{"organizations/unknown"}, nil
+			return []string{unknownOrg}, nil
 		}
 	case "cloudresourcemanager.googleapis.com/Project", "cloudbilling.googleapis.com/ProjectBillingInfo":
 		// for google_project and google_project_iam resources
@@ -183,7 +184,7 @@ func (m *manager) fetchAncestors(config *transport_tpg.Config, tfData tpgresourc
 		// only folder_id or org_id is allowed for google_project
 		if orgOK {
 			// no need to use API to fetch ancestors
-			ancestors = append(ancestors, fmt.Sprintf("organizations/%s", orgID))
+			ancestors = append(ancestors, orgPrefix+orgID)
 			return ancestors, nil
 		}
 		if folderOK {
@@ -199,13 +200,13 @@ func (m *manager) fetchAncestors(config *transport_tpg.Config, tfData tpgresourc
 
 		// neither folder_id nor org_id is specified
 		if projectKey == "" {
-			return []string{"organizations/unknown"}, nil
+			return []string{unknownOrg}, nil
 		}
 		key = projectKey
 
 	default:
 		if projectKey == "" {
-			return []string{"organizations/unknown"}, nil
+			return []string{unknownOrg}, nil
 		}
 		key = projectKey
 	}
@@ -220,16 +221,16 @@ func (m *manager) getAncestorsWithCache(key string) ([]string, error) {
 			ancestors = append(ancestors, cachedAncestors...)
 			break
 		}
-		if strings.HasPrefix(cur, "organizations/") {
+		if strings.HasPrefix(cur, orgPrefix) {
 			ancestors = append(ancestors, cur)
 			break
 		}
 		if m.resourceManagerV3 == nil || m.resourceManagerV1 == nil {
 			return nil, fmt.Errorf("resourceManager required to fetch ancestry for %s from the API", cur)
 		}
-		if strings.HasPrefix(cur, "projects") {
+		if strings.HasPrefix(cur, projectPrefix) {
 			// fall back to use v1 API GetAncestry to avoid requiring extra folder permission
-			projectID := strings.TrimPrefix(cur, "projects/")
+			projectID := strings.TrimPrefix(cur, projectPrefix)
 			var resp *crmv1.GetAncestryResponse
 			var err error
 			err = transport_tpg.Retry(transport_tpg.RetryOptions{
@@ -325,9 +326,9 @@ func normalizeAncestry(val string) string {
 		old string
 		new string
 	}{
-		{"organization/", "organizations/"},
-		{"folder/", "folders/"},
-		{"project/", "projects/"},
+		{"organization/", orgPrefix},
+		{"folder/", folderPrefix},
+		{"project/", projectPrefix},
 	} {
 		val = strings.ReplaceAll(val, r.old, r.new)
 	}
@@ -382,4 +383,11 @@ type NoOpAncestryManager struct{}
 
 func (*NoOpAncestryManager) Ancestors(config *transport_tpg.Config, tfData tpgresource.TerraformResourceData, cai *resources.Asset) ([]string, string, error) {
 	return nil, "", nil
+}
+
+func ensurePrefix(s, pre string) string {
+	if strings.HasPrefix(s, pre) {
+		return s
+	}
+	return pre + s
 }

--- a/mmv1/third_party/tgc/ancestrymanager/ancestrymanager_test.go
+++ b/mmv1/third_party/tgc/ancestrymanager/ancestrymanager_test.go
@@ -1032,6 +1032,8 @@ func TestParseAncestryPath_Fail(t *testing.T) {
 }
 
 func TestInitAncestryCache(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		entries map[string]string
@@ -1082,9 +1084,23 @@ func TestInitAncestryCache(t *testing.T) {
 				"organizations/123":  {"organizations/123"},
 			},
 		},
+		{
+			name: "project id key with project number ancestry",
+			entries: map[string]string{
+				"projects/test-proj": "organizations/456/projects/123",
+			},
+			want: map[string][]string{
+				"projects/test-proj": {"projects/123", "organizations/456"},
+				"projects/123":       {"projects/123", "organizations/456"},
+				"organizations/456":  {"organizations/456"},
+			},
+		},
 	}
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			m := &manager{
 				ancestorCache: make(map[string][]string),
 			}


### PR DESCRIPTION
In CAI exports, the ancestors list always uses the project number and never the project ID. The converter uses the project ID for the lookup, as many Terraform resources accept the project ID rather than the number.

To work around this, users of the library may supply ancestry cache that is keyed on the project ID, but uses the project number in the ancestor list. Previously, the library would insert the project ID into the ancestors list which is incorrect behavior when the ancestors list already contains the project number.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
ancestrymanager: Prefer project number over project id to align with CAI format.
```
