### PR TITLE
Get generated service account name under 28 chars

### DIFF
--- a/mmv1/products/integrations/Client.yaml
+++ b/mmv1/products/integrations/Client.yaml
@@ -128,7 +128,7 @@ examples:
     skip_vcr: true
     vars:
       key_ring_name: my-keyring
-      service_account_id: my-service-acc
+      service_account_id: service-acc
   - !ruby/object:Provider::Terraform::Examples
     name: "integrations_client_deprecated_fields"
     primary_resource_id: "example"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes errors like below, accidentally introduced in https://github.com/GoogleCloudPlatform/magic-modules/pull/11322:

```
Error: "account_id" ("tf-test-my-service-acczbofubzx87") doesn't match regexp "^[a-z](?:[-a-z0-9]{4,28}[a-z0-9])$"
```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
