### PR TITLE
Promote Firestore database cmek support to GA

### DIFF
--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -80,7 +80,6 @@ examples:
       - deletion_policy
   - !ruby/object:Provider::Terraform::Examples
     name: 'firestore_cmek_database'
-    min_version: beta
     primary_resource_id: 'database'
     vars:
       database_id: "cmek-database-id"
@@ -121,7 +120,6 @@ examples:
       - deletion_policy
   - !ruby/object:Provider::Terraform::Examples
     name: 'firestore_cmek_database_in_datastore_mode'
-    min_version: beta
     primary_resource_id: 'database'
     vars:
       database_id: "cmek-database-id"
@@ -270,7 +268,6 @@ properties:
     output: true
   - !ruby/object:Api::Type::NestedObject
     name: cmekConfig
-    min_version: beta
     immutable: true
     description: |
        The CMEK (Customer Managed Encryption Key) configuration for a Firestore

--- a/mmv1/templates/terraform/examples/firestore_cmek_database.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_cmek_database.tf.erb
@@ -1,10 +1,7 @@
 data "google_project" "project" {
-  provider = google-beta
 }
 
 resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
-
   project                           = "<%= ctx[:test_env_vars]['project_id'] %>"
   name                              = "<%= ctx[:vars]['database_id']%>"
   location_id                       = "nam5"
@@ -24,23 +21,17 @@ resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
 }
 
 resource "google_kms_crypto_key" "crypto_key" {
-  provider = google-beta
-
   name     = "<%= ctx[:vars]['kms_key_name'] %>"
   key_ring = google_kms_key_ring.key_ring.id
   purpose  = "ENCRYPT_DECRYPT"
 }
 
 resource "google_kms_key_ring" "key_ring" {
-  provider = google-beta
-
   name     = "<%= ctx[:vars]['kms_key_ring_name'] %>"
   location = "us"
 }
 
 resource "google_kms_crypto_key_iam_binding" "firestore_cmek_keyuser" {
-  provider = google-beta
-
   crypto_key_id = google_kms_crypto_key.crypto_key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 

--- a/mmv1/templates/terraform/examples/firestore_cmek_database_in_datastore_mode.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_cmek_database_in_datastore_mode.tf.erb
@@ -1,10 +1,7 @@
 data "google_project" "project" {
-  provider = google-beta
 }
 
 resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
-
   project                           = "<%= ctx[:test_env_vars]['project_id'] %>"
   name                              = "<%= ctx[:vars]['database_id']%>"
   location_id                       = "nam5"
@@ -24,23 +21,17 @@ resource "google_firestore_database" "<%= ctx[:primary_resource_id] %>" {
 }
 
 resource "google_kms_crypto_key" "crypto_key" {
-  provider = google-beta
-
   name     = "<%= ctx[:vars]['kms_key_name'] %>"
   key_ring = google_kms_key_ring.key_ring.id
   purpose  = "ENCRYPT_DECRYPT"
 }
 
 resource "google_kms_key_ring" "key_ring" {
-  provider = google-beta
-
   name     = "<%= ctx[:vars]['kms_key_ring_name'] %>"
   location = "us"
 }
 
 resource "google_kms_crypto_key_iam_binding" "firestore_cmek_keyuser" {
-  provider = google-beta
-
   crypto_key_id = google_kms_crypto_key.crypto_key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Promote Firestore database cmek support to GA:
- Adds the new field `cmek_config` to `google_firestore_database` to support creating a Firestore CMEK database.


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->
Self check:
  
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [make test and make lint](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
firestore: added `cmek_config` field to `google_firestore_database` resource (GA)
```
