### PR TITLE
Remove allow_resource_tags_on_deletion from google_bigquery_table

### DIFF
--- a/mmv1/products/bigquery/Table.yaml
+++ b/mmv1/products/bigquery/Table.yaml
@@ -43,16 +43,6 @@ examples:
     vars:
       dataset_id: 'dataset_id'
       table_id: 'table_id'
-virtual_fields:
-  - !ruby/object:Api::Type::Boolean
-    name: 'allow_resource_tags_on_deletion'
-    description: |
-      If set to true, it allows table deletion when there are still resource tags attached.
-    deprecation_message: |
-      `allow_resource_tags_on_deletion` is deprecated and will be removed in a future major
-      release. The default behavior will be allowing the presence of resource tags on
-      deletion after the next major release.
-    default_value: false
 parameters:
   # TODO(alexstephen): Remove once we have support for placing
   # nested object fields in URL

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go
@@ -1250,14 +1250,6 @@ func ResourceBigQueryTable() *schema.Resource {
 				Description: `Whether Terraform will be prevented from destroying the instance. When the field is set to true or unset in Terraform state, a terraform apply or terraform destroy that would delete the table will fail. When the field is set to false, deleting the table is allowed.`,
 			},
 
-			"allow_resource_tags_on_deletion": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
-				Description: `**Deprecated** Whether or not to allow table deletion when there are still resource tags attached.`,
-				Deprecated:  `This field is deprecated and will be removed in a future major release. The default behavior will be allowing the presence of resource tags on deletion after the next major release.`,
-			},
-
 			// TableConstraints: [Optional] Defines the primary key and foreign keys.
 			"table_constraints": {
 				Type:        schema.TypeList,
@@ -1929,17 +1921,6 @@ func resourceBigQueryTableColumnDrop(config *transport_tpg.Config, userAgent str
 func resourceBigQueryTableDelete(d *schema.ResourceData, meta interface{}) error {
 	if d.Get("deletion_protection").(bool) {
 		return fmt.Errorf("cannot destroy table %v without setting deletion_protection=false and running `terraform apply`", d.Id())
-	}
-	if v, ok := d.GetOk("resource_tags"); ok {
-		if !d.Get("allow_resource_tags_on_deletion").(bool) {
-			var resourceTags []string
-
-			for k, v := range v.(map[string]interface{}) {
-				resourceTags = append(resourceTags, fmt.Sprintf("%s:%s", k, v.(string)))
-			}
-
-			return fmt.Errorf("cannot destroy table %v without unsetting the following resource tags or setting allow_resource_tags_on_deletion=true: %v", d.Id(), resourceTags)
-		}
 	}
 
 	config := meta.(*transport_tpg.Config)
@@ -2946,9 +2927,6 @@ func resourceBigQueryTableImport(d *schema.ResourceData, meta interface{}) ([]*s
 	// Explicitly set virtual fields to default values on import
 	if err := d.Set("deletion_protection", true); err != nil {
 		return nil, fmt.Errorf("Error setting deletion_protection: %s", err)
-	}
-	if err := d.Set("allow_resource_tags_on_deletion", false); err != nil {
-		return nil, fmt.Errorf("Error setting allow_resource_tags_on_deletion: %s", err)
 	}
 
 	// Replace import id for the resource id

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
@@ -1645,7 +1645,7 @@ func TestAccBigQueryTable_ResourceTags(t *testing.T) {
 				ResourceName:            "google_bigquery_table.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"deletion_protection", "allow_resource_tags_on_deletion"},
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
 				Config: testAccBigQueryTableWithResourceTagsUpdate(context),
@@ -1654,7 +1654,7 @@ func TestAccBigQueryTable_ResourceTags(t *testing.T) {
 				ResourceName:            "google_bigquery_table.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"deletion_protection", "allow_resource_tags_on_deletion"},
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			// testAccBigQueryTableWithResourceTagsDestroy must be called at the end of this test to clear the resource tag bindings of the table before deletion.
 			{
@@ -1664,7 +1664,7 @@ func TestAccBigQueryTable_ResourceTags(t *testing.T) {
 				ResourceName:            "google_bigquery_table.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"deletion_protection", "allow_resource_tags_on_deletion"},
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
 	})
@@ -4202,7 +4202,6 @@ resource "google_bigquery_dataset" "test" {
 
 resource "google_bigquery_table" "test" {
   deletion_protection = false
-  allow_resource_tags_on_deletion = true
   dataset_id = "${google_bigquery_dataset.test.dataset_id}"
   table_id   = "%{table_id}"
   resource_tags = {
@@ -4240,7 +4239,6 @@ resource "google_bigquery_dataset" "test" {
 
 resource "google_bigquery_table" "test" {
   deletion_protection = false
-  allow_resource_tags_on_deletion = true
   dataset_id = "${google_bigquery_dataset.test.dataset_id}"
   table_id   = "%{table_id}"
   resource_tags = {
@@ -4279,7 +4277,6 @@ resource "google_bigquery_dataset" "test" {
 
 resource "google_bigquery_table" "test" {
   deletion_protection = false
-  allow_resource_tags_on_deletion = true
   dataset_id = "${google_bigquery_dataset.test.dataset_id}"
   table_id   = "%{table_id}"
   resource_tags = {}

--- a/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
@@ -108,6 +108,10 @@ Description of the change and how users should adjust their configuration (if ne
 
 A `view` can no longer be created when `schema` contains required fields
 
+### `allow_resource_tags_on_deletion` is now removed
+
+Resource tags are now always allowed on table deletion.
+
 ## Resource: `google_bigquery_reservation`
 
 ### `multi_region_auxiliary` is now removed


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Remove `allow_resource_tags_on_deletion` from `google_bigquery_table`. A follow-up to https://github.com/GoogleCloudPlatform/magic-modules/pull/10568.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
bigquery: removed `allow_resource_tags_on_deletion` from `google_bigquery_table`. Resource tags are now always allowed on table deletion.
```
