### PR TITLE
Fix Datastream private connection resource destruction

### DIFF
--- a/mmv1/products/datastream/PrivateConnection.yaml
+++ b/mmv1/products/datastream/PrivateConnection.yaml
@@ -43,6 +43,7 @@ custom_code: !ruby/object:Provider::Terraform::CustomCode
   constants: templates/terraform/constants/private_connection.go.erb
   post_create: templates/terraform/post_create/private_connection.go.erb
   post_import: templates/terraform/post_import/private_connection.go.erb
+  pre_delete: templates/terraform/pre_delete/private_connection.go.erb
 parameters:
   - !ruby/object:Api::Type::String
     name: privateConnectionId

--- a/mmv1/templates/terraform/pre_delete/private_connection.go.erb
+++ b/mmv1/templates/terraform/pre_delete/private_connection.go.erb
@@ -1,0 +1,5 @@
+// Add force=true query param to force deletion of private connection sub resources like Routes
+url, err = transport_tpg.AddQueryParams(url, map[string]string{"force": strconv.FormatBool(true)})
+if err != nil {
+return err
+}


### PR DESCRIPTION
Fix Datastream private connection resource destruction. The current private connection resource deletion fails as a result of sub resource existence.
This fix will always force the resource deletion, as the sub resources deletion is taking care the the API anyway.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/17290 
https://github.com/hashicorp/terraform-provider-google/issues/13054

```release-note:bug
compute:  fixed issue where sub-resources managed by `google_compute_forwarding_rule` prevented resource deletion
```
