### PR TITLE
docs: fix inaccurate docs for Cloud Run environment variables

### DIFF
--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -338,7 +338,7 @@ properties:
                       - !ruby/object:Api::Type::String
                         name: 'value'
                         description: |-
-                          Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any route environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "", and the maximum length is 32768 bytes
+                          Literal value of the environment variable. Defaults to "" and the maximum allowed length is 32768 characters. Variable references are not supported in Cloud Run.
                         # exactly_one_of:
                         #   - template.0.template.0.containers.0.env.0.value
                         #   - template.0.template.0.containers.0.env.0.valueSource

--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -322,7 +322,7 @@ properties:
                 - !ruby/object:Api::Type::Array
                   name: 'args'
                   description: |-
-                    Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                    Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references are not supported in Cloud Run.
                   item_type: Api::Type::String
                 - !ruby/object:Api::Type::Array
                   name: 'env'

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -399,7 +399,7 @@ properties:
             - !ruby/object:Api::Type::Array
               name: 'args'
               description: |-
-                Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references are not supported in Cloud Run.
               item_type: Api::Type::String
             - !ruby/object:Api::Type::Array
               name: 'env'

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -411,11 +411,11 @@ properties:
                     name: 'name'
                     required: true
                     description: |-
-                      Name of the environment variable. Must be a C_IDENTIFIER, and mnay not exceed 32768 characters.
+                      Name of the environment variable. Must be a C_IDENTIFIER, and may not exceed 32768 characters.
                   - !ruby/object:Api::Type::String
                     name: 'value'
                     description: |-
-                      Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any route environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "", and the maximum length is 32768 bytes
+                      Literal value of the environment variable. Defaults to "" and the maximum allowed length is 32768 characters. Variable references are not supported in Cloud Run.
                     # exactly_one_of:
                     #   - template.0.containers.0.env.0.value
                     #   - template.0.containers.0.env.0.valueSource


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
fix inaccurate docs for Cloud Run environment variables.

Cloud Run doesn't support variable substitution for environment variables.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
