### PR TITLE
Add a new example for Firestore documents that shows how to make fields of different types

### DIFF
--- a/mmv1/products/firestore/Document.yaml
+++ b/mmv1/products/firestore/Document.yaml
@@ -55,6 +55,16 @@ examples:
       document_id: 'my-doc-id'
       project_id: 'project-id'
     external_providers: ["random", "time"]
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'firestore_document_various_types'
+    primary_resource_id: 'mydoc'
+    test_env_vars:
+      org_id: :ORG_ID
+    vars:
+      document_id: 'my-doc-id'
+      project_id: 'project-id'
+      other_document_id: 'other-doc-id'
+    external_providers: ["random", "time"]
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_import: templates/terraform/custom_import/firestore_document.go.erb
   decoder: templates/terraform/decoders/firestore_document.go.erb

--- a/mmv1/templates/terraform/examples/firestore_document_various_types.tf.erb
+++ b/mmv1/templates/terraform/examples/firestore_document_various_types.tf.erb
@@ -1,0 +1,79 @@
+resource "google_project" "project" {
+  project_id = "<%= ctx[:vars]['project_id'] %>"
+  name       = "<%= ctx[:vars]['project_id'] %>"
+  org_id     = "<%= ctx[:test_env_vars]['org_id'] %>"
+}
+
+resource "time_sleep" "wait_60_seconds" {
+  depends_on = [google_project.project]
+
+  create_duration = "60s"
+}
+
+resource "google_project_service" "firestore" {
+  project = google_project.project.project_id
+  service = "firestore.googleapis.com"
+
+  # Needed for CI tests for permissions to propagate, should not be needed for actual usage
+  depends_on = [time_sleep.wait_60_seconds]
+}
+
+resource "google_firestore_database" "database" {
+  project     = google_project.project.project_id
+  name        = "(default)"
+  location_id = "nam5"
+  type        = "FIRESTORE_NATIVE"
+
+  depends_on = [google_project_service.firestore]
+}
+
+resource "google_firestore_document" "some_other_document" {
+  project     = google_project.project.project_id
+  database    = google_firestore_database.database.name
+  collection  = "somenewcollection"
+  document_id = "<%= ctx[:vars]['other_document_id'] %>"
+
+  fields = jsonencode({
+    f = { stringValue = "a field value" }
+  })
+}
+
+resource "google_firestore_document" "<%= ctx[:primary_resource_id] %>" {
+  project     = google_project.project.project_id
+  database    = google_firestore_database.database.name
+  collection  = "somenewcollection"
+  document_id = "<%= ctx[:vars]['document_id'] %>"
+  # See https://firebase.google.com/docs/firestore/reference/rpc/google.firestore.v1#google.firestore.v1.Value 
+  fields = jsonencode({
+    a_string_field = { stringValue = "a_string_value" }
+    an_integer_field = { integerValue = "54321" }
+    a_double_field = { doubleValue = 2.71828 }
+    a_bool_field = { booleanValue = true }
+    an_array_field = {
+        arrayValue = {
+            values: [
+                { stringValue = "an_array_entry" },
+                { stringValue = "another_array_entry" }
+            ]
+        }
+    }
+    a_map_field = {
+        mapValue = {
+            fields: {
+                key1 = { stringValue = "a_map_value_of_type_string" }
+                key2 = { integerValue = "2000" }
+            }
+        }
+    }
+    a_null_field = { nullValue = null }
+    a_latlng_field = {
+      geoPointValue = {
+        latitude = 12.0
+        longitude = 34.0
+      }
+    }
+    a_reference_field = {
+      referenceValue = resource.google_firestore_document.some_other_document.name
+    }
+  })
+}


### PR DESCRIPTION
b/331386622

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
