### PR TITLE
Revert "Add send_age_if_zero field and deprecate no_age. (#11098)"

### DIFF
--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
@@ -229,7 +229,6 @@ func ResourceStorageBucket() *schema.Resource {
 									},
 									"no_age": {
 										Type:        schema.TypeBool,
-										Deprecated:  "`no_age` is deprecated and will be removed in a future major release. Use `send_age_if_zero` instead.",
 										Optional:    true,
 										Description: `While set true, age value will be omitted.Required to set true when age is unset in the config file.`,
 									},
@@ -262,12 +261,6 @@ func ResourceStorageBucket() *schema.Resource {
 										Optional:    true,
 										Elem:        &schema.Schema{Type: schema.TypeString},
 										Description: `One or more matching name suffixes to satisfy this condition.`,
-									},
-									"send_age_if_zero": {
-										Type:        schema.TypeBool,
-										Optional:    true,
-										Default:     true,
-										Description: `While set true, age value will be sent in the request even for zero value of the field. This field is only useful for setting 0 value to the age field. It can be used alone or together with age.`,
 									},
 									"send_days_since_noncurrent_time_if_zero": {
 										Type:        schema.TypeBool,
@@ -1403,21 +1396,13 @@ func flattenBucketLifecycleRuleCondition(index int, d *schema.ResourceData, cond
 			ruleCondition["with_state"] = "ARCHIVED"
 		}
 	}
-	// Setting the lifecycle condition virtual fields from the state file if they
-	// are already present otherwise setting them to individual default values.
+  // setting no_age value from state config since it is terraform only variable and not getting value from backend.
 	if v, ok := d.GetOk(fmt.Sprintf("lifecycle_rule.%d.condition",index)); ok{
 		state_condition := v.(*schema.Set).List()[0].(map[string]interface{})
 		ruleCondition["no_age"] = state_condition["no_age"].(bool)
 		ruleCondition["send_days_since_noncurrent_time_if_zero"] = state_condition["send_days_since_noncurrent_time_if_zero"].(bool)
 		ruleCondition["send_days_since_custom_time_if_zero"] = state_condition["send_days_since_custom_time_if_zero"].(bool)
 		ruleCondition["send_num_newer_versions_if_zero"] = state_condition["send_num_newer_versions_if_zero"].(bool)
-		ruleCondition["send_age_if_zero"] = state_condition["send_age_if_zero"].(bool)
-	}  else {
-		ruleCondition["no_age"] = false
-		ruleCondition["send_age_if_zero"] = true
-		ruleCondition["send_days_since_noncurrent_time_if_zero"] = false
-		ruleCondition["send_days_since_custom_time_if_zero"] = false
-		ruleCondition["send_num_newer_versions_if_zero"] = false
 	}
 
 	return ruleCondition
@@ -1567,15 +1552,13 @@ func expandStorageBucketLifecycleRuleCondition(v interface{}) (*storage.BucketLi
 
 	condition := conditions[0].(map[string]interface{})
 	transformed := &storage.BucketLifecycleRuleCondition{}
-	// Setting high precedence of no_age over age and send_age_if_zero.
+	// Setting high precedence of no_age over age when both used together.
 	// Only sets age value when no_age is not present or no_age is present and has false value
 	if v, ok := condition["no_age"]; !ok || !(v.(bool)) {
 		if v, ok := condition["age"]; ok {
 			age := int64(v.(int))
-			u, ok := condition["send_age_if_zero"]
-			if age > 0 || (ok && u.(bool)) {
-				transformed.Age = &age
-			}
+			transformed.Age = &age
+			transformed.ForceSendFields = append(transformed.ForceSendFields, "Age")
 		}
 	}
 
@@ -1689,9 +1672,6 @@ func resourceGCSBucketLifecycleRuleConditionHash(v interface{}) int {
 	if v, ok := m["no_age"]; ok && v.(bool){
 		buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
 	} else {
-		if v, ok := m["send_age_if_zero"]; ok {
-			buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
-		}
 		if v, ok := m["age"]; ok {
 			buf.WriteString(fmt.Sprintf("%d-", v.(int)))
 		}

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
@@ -461,7 +461,7 @@ func TestAccStorageBucket_lifecycleRulesMultiple(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.send_age_if_zero","lifecycle_rule.1.condition.0.send_age_if_zero","lifecycle_rule.2.condition.0.send_age_if_zero","lifecycle_rule.3.condition.0.send_age_if_zero","lifecycle_rule.4.condition.0.send_age_if_zero","lifecycle_rule.5.condition.0.send_age_if_zero","lifecycle_rule.6.condition.0.send_age_if_zero","lifecycle_rule.7.condition.0.send_age_if_zero","lifecycle_rule.8.condition.0.send_age_if_zero","lifecycle_rule.9.condition.0.send_age_if_zero"},
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
 				Config: testAccStorageBucket_lifecycleRulesMultiple_update(bucketName),
@@ -470,7 +470,7 @@ func TestAccStorageBucket_lifecycleRulesMultiple(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.send_age_if_zero","lifecycle_rule.1.condition.0.send_age_if_zero","lifecycle_rule.2.condition.0.send_age_if_zero","lifecycle_rule.3.condition.0.send_age_if_zero","lifecycle_rule.4.condition.0.send_age_if_zero","lifecycle_rule.5.condition.0.send_age_if_zero","lifecycle_rule.6.condition.0.send_age_if_zero","lifecycle_rule.7.condition.0.send_age_if_zero","lifecycle_rule.8.condition.0.send_age_if_zero","lifecycle_rule.9.condition.0.send_age_if_zero"},
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 		},
 	})
@@ -499,7 +499,7 @@ func TestAccStorageBucket_lifecycleRuleStateLive(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.send_age_if_zero","lifecycle_rule.1.condition.0.send_age_if_zero"},
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 		},
 	})
@@ -528,7 +528,7 @@ func TestAccStorageBucket_lifecycleRuleStateArchived(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.send_age_if_zero"},
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
 				Config: testAccStorageBucket_lifecycleRule_withStateArchived(bucketName),
@@ -542,7 +542,7 @@ func TestAccStorageBucket_lifecycleRuleStateArchived(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.send_age_if_zero"},
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 		},
 	})
@@ -571,7 +571,7 @@ func TestAccStorageBucket_lifecycleRuleStateAny(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.send_age_if_zero"},
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
 				Config: testAccStorageBucket_lifecycleRule_withStateLive(bucketName),
@@ -585,7 +585,7 @@ func TestAccStorageBucket_lifecycleRuleStateAny(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.send_age_if_zero","lifecycle_rule.1.condition.0.send_age_if_zero"},
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
 				Config: testAccStorageBucket_lifecycleRule_withStateAny(bucketName),
@@ -599,7 +599,7 @@ func TestAccStorageBucket_lifecycleRuleStateAny(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.send_age_if_zero"},
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
 				Config: testAccStorageBucket_lifecycleRule_withStateArchived(bucketName),
@@ -613,7 +613,7 @@ func TestAccStorageBucket_lifecycleRuleStateAny(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.send_age_if_zero"},
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 		},
 	})
@@ -622,7 +622,6 @@ func TestAccStorageBucket_lifecycleRuleStateAny(t *testing.T) {
 func TestAccStorageBucket_lifecycleRulesVirtualFields(t *testing.T) {
 	t.Parallel()
 	var bucket storage.Bucket
-	zero_age := int64(0)
 	bucketName := acctest.TestBucketName(t)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -648,30 +647,28 @@ func TestAccStorageBucket_lifecycleRulesVirtualFields(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStorageBucketExists(
 						t, "google_storage_bucket.bucket", bucketName, &bucket),
-					testAccCheckStorageBucketLifecycleConditionNoAge(nil, &bucket, 1),
-					testAccCheckStorageBucketLifecycleConditionNoAge(&zero_age, &bucket, 2),
+					testAccCheckStorageBucketLifecycleConditionNoAge(nil, &bucket),
 				),
 			},
 			{
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy", "lifecycle_rule.1.condition.0.no_age", "lifecycle_rule.1.condition.0.send_days_since_noncurrent_time_if_zero", "lifecycle_rule.2.condition.0.send_days_since_noncurrent_time_if_zero", "lifecycle_rule.1.condition.0.send_days_since_custom_time_if_zero", "lifecycle_rule.2.condition.0.send_days_since_custom_time_if_zero", "lifecycle_rule.1.condition.0.send_num_newer_versions_if_zero", "lifecycle_rule.2.condition.0.send_num_newer_versions_if_zero", "lifecycle_rule.1.condition.0.send_age_if_zero"},
+				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.1.condition.0.no_age","lifecycle_rule.1.condition.0.send_days_since_noncurrent_time_if_zero","lifecycle_rule.2.condition.0.send_days_since_noncurrent_time_if_zero","lifecycle_rule.1.condition.0.send_days_since_custom_time_if_zero","lifecycle_rule.2.condition.0.send_days_since_custom_time_if_zero","lifecycle_rule.1.condition.0.send_num_newer_versions_if_zero","lifecycle_rule.2.condition.0.send_num_newer_versions_if_zero"},
 			},
 			{
 				Config: testAccStorageBucket_customAttributes_withLifecycleVirtualFieldsUpdate2(bucketName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStorageBucketExists(
 						t, "google_storage_bucket.bucket", bucketName, &bucket),
-					testAccCheckStorageBucketLifecycleConditionNoAge(nil, &bucket, 1),
-					testAccCheckStorageBucketLifecycleConditionNoAge(nil, &bucket, 2),
+					testAccCheckStorageBucketLifecycleConditionNoAge(nil, &bucket),
 				),
 			},
 			{
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy", "lifecycle_rule.1.condition.0.no_age", "lifecycle_rule.0.condition.0.send_days_since_noncurrent_time_if_zero", "lifecycle_rule.0.condition.0.send_days_since_custom_time_if_zero", "lifecycle_rule.0.condition.0.send_num_newer_versions_if_zero", "lifecycle_rule.0.condition.0.send_age_if_zero", "lifecycle_rule.1.condition.0.send_age_if_zero", "lifecycle_rule.2.condition.0.send_age_if_zero"},
+				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.1.condition.0.no_age","lifecycle_rule.0.condition.0.send_days_since_noncurrent_time_if_zero","lifecycle_rule.0.condition.0.send_days_since_custom_time_if_zero","lifecycle_rule.0.condition.0.send_num_newer_versions_if_zero"},
 			},
 			{
 				Config: testAccStorageBucket_customAttributes_withLifecycle1(bucketName),
@@ -850,7 +847,7 @@ func TestAccStorageBucket_update(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.send_age_if_zero"},
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
 				Config: testAccStorageBucket_customAttributes_withLifecycle2(bucketName),
@@ -866,7 +863,7 @@ func TestAccStorageBucket_update(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.send_age_if_zero","lifecycle_rule.1.condition.0.send_age_if_zero"},
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
 				Config: testAccStorageBucket_customAttributes_withLifecycle1Update(bucketName),
@@ -882,7 +879,7 @@ func TestAccStorageBucket_update(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.send_age_if_zero"},
+				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
 				Config: testAccStorageBucket_customAttributes(bucketName),
@@ -1684,10 +1681,10 @@ func testAccCheckStorageBucketLifecycleConditionState(expected *bool, b *storage
 	}
 }
 
-func testAccCheckStorageBucketLifecycleConditionNoAge(expected *int64, b *storage.Bucket, index int) resource.TestCheckFunc {
+func testAccCheckStorageBucketLifecycleConditionNoAge(expected *int64, b *storage.Bucket) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		actual := b.Lifecycle.Rule[index].Condition.Age
-		if expected == nil && b.Lifecycle.Rule[index].Condition.Age == nil {
+		actual := b.Lifecycle.Rule[1].Condition.Age
+		if expected == nil && b.Lifecycle.Rule[1].Condition.Age == nil {
 			return nil
 		}
 		if expected == nil {
@@ -1981,7 +1978,6 @@ resource "google_storage_bucket" "bucket" {
     condition {
       age = 10
       no_age = true
-      send_age_if_zero = false
       custom_time_before = "2022-09-01"
       days_since_noncurrent_time = 0
       send_days_since_noncurrent_time_if_zero = false
@@ -1996,7 +1992,6 @@ resource "google_storage_bucket" "bucket" {
       type = "Delete"
     }
     condition {
-      send_age_if_zero= false
       custom_time_before = "2022-09-01"
       send_days_since_noncurrent_time_if_zero = false
       send_days_since_custom_time_if_zero = false

--- a/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
@@ -153,6 +153,7 @@ If you were relying on accessing an individual environment variable by index (fo
 
 Cloud Run does not provide a default value for liveness probe. Now removing this field
 will remove the liveness probe from the Cloud Run service.
+<<<<<<< HEAD
 
 ### retyped `containers.env` to SET from ARRAY
 
@@ -204,16 +205,6 @@ Users will need to check their configuration for any `google_vpc_access_connecto
 resource blocks that contain both fields in a conflicting pair, and remove one of those fields.
 The fields that are removed from the configuration will still have Computed values,
 that are derived from the API.
-
-## Resource: `google_storage_bucket`
-
-### `lifecycle_rule.condition.no_age` is now removed
-
-Previously `lifecycle_rule.condition.age` attirbute was being set zero value by default and `lifecycle_rule.condition.no_age` was introduced to prevent that.
-Now `lifecycle_rule.condition.no_age` is no longer supported and `lifecycle_rule.condition.age` won't set a zero value by default.
-Removed in favor of the field `lifecycle_rule.condition.send_age_if_zero` which can be used to set zero value for `lifecycle_rule.condition.age` attribute. 
-
-For a seamless update, if your state today uses `no_age=true`, update it to remove `no_age` and set `send_age_if_zero=false`. If you do not use `no_age=true`, you will need to add `send_age_if_zero=true` to your state to avoid any changes after updating to 6.0.0. 
 
 ## Removals
 

--- a/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
@@ -153,7 +153,6 @@ If you were relying on accessing an individual environment variable by index (fo
 
 Cloud Run does not provide a default value for liveness probe. Now removing this field
 will remove the liveness probe from the Cloud Run service.
-<<<<<<< HEAD
 
 ### retyped `containers.env` to SET from ARRAY
 

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -69,8 +69,8 @@ resource "google_storage_bucket" "auto-expire" {
 }
 ```
 
-## Example Usage - Life cycle settings for storage bucket objects with `send_age_if_zero` disabled
-When creating a life cycle condition that does not also include an `age` field, a default `age` of 0 will be set. Set the `send_age_if_zero` flag to `false` to prevent this and avoid any potentially unintended interactions.
+## Example Usage - Life cycle settings for storage bucket objects with `no_age` enabled
+When creating a life cycle condition that does not also include an `age` field, a default `age` of 0 will be set. Set the `no_age` flag to `true` to prevent this and avoid any potentially unintended interactions.
 
 ```hcl
 resource "google_storage_bucket" "no-age-enabled" {
@@ -85,7 +85,7 @@ resource "google_storage_bucket" "no-age-enabled" {
     }
     condition {
       days_since_noncurrent_time = 3
-      send_age_if_zero = false
+      no_age = true
     }
   }
 }
@@ -173,7 +173,7 @@ The following arguments are supported:
 
 * `age` - (Optional) Minimum age of an object in days to satisfy this condition. If not supplied alongside another condition and without setting `no_age` to `true`, a default `age` of 0 will be set.
 
-* `no_age` - (Optional, Deprecated) While set `true`, `age` value will be omitted from requests. This prevents a default age of `0` from being applied, and if you do not have an `age` value set, setting this to `true` is strongly recommended. When unset and other conditions are set to zero values, this can result in a rule that applies your action to all files in the bucket. `no_age` is deprecated and will be removed in a future major release. Use `send_age_if_zero` instead.
+* `no_age` - (Optional) While set `true`, `age` value will be omitted from requests. This prevents a default age of `0` from being applied, and if you do not have an `age` value set, setting this to `true` is strongly recommended. When unset and other conditions are set to zero values, this can result in a rule that applies your action to all files in the bucket.
 
 * `created_before` - (Optional) A date in the RFC 3339 format YYYY-MM-DD. This condition is satisfied when an object is created before midnight of the specified date in UTC.
 
@@ -192,8 +192,6 @@ The following arguments are supported:
 * `custom_time_before` - (Optional) A date in the RFC 3339 format YYYY-MM-DD. This condition is satisfied when the customTime metadata for the object is set to an earlier date than the date used in this lifecycle condition.
 
 * `days_since_custom_time` - (Optional)	Days since the date set in the `customTime` metadata for the object. This condition is satisfied when the current date and time is at least the specified number of days after the `customTime`. Due to a current bug you are unable to set this value to `0` within Terraform. When set to `0` it will be ignored, and your state will treat it as though you supplied no `days_since_custom_time` condition.
-
-* `send_age_if_zero` - (Optional, Default: true) While set true, `age` value will be sent in the request even for zero value of the field. This field is only useful and required for setting 0 value to the `age` field. It can be used alone or together with `age` attribute. **NOTE** `age` attibute with `0` value will be ommitted from the API request if `send_age_if_zero` field is having `false` value.
 
 * `send_days_since_custom_time_if_zero` - (Optional) While set true, `days_since_custom_time` value will be sent in the request even for zero value of the field. This field is only useful for setting 0 value to the `days_since_custom_time` field. It can be used alone or together with `days_since_custom_time`.
 


### PR DESCRIPTION
This reverts commit 2b005430b0cf15ddc5d04aa1f0df998f34aa2f3f.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
storage: added `send_age_if_zero` field with default value `true` and deprecated `no_age` field. (revert)
```
