### PR TITLE
Add IPv6 support for PAP and PDPs.

### DIFF
--- a/mmv1/products/compute/PublicAdvertisedPrefix.yaml
+++ b/mmv1/products/compute/PublicAdvertisedPrefix.yaml
@@ -51,6 +51,16 @@ examples:
       prefixes_name: 'my-prefix'
     test_env_vars:
       desc: :PAP_DESCRIPTION
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'public_advertised_prefixes_ipv6'
+    primary_resource_id: 'prefixes'
+    # PAPs have very low quota limits and a shared testing range so serialized tests exist in:
+    # resource_compute_public_advertised_prefix_test.go
+    skip_test: true
+    vars:
+      prefixes_name: 'my-prefix'
+    test_env_vars:
+      desc: :PAP_DESCRIPTION
 properties:
   - !ruby/object:Api::Type::String
     name: 'description'
@@ -72,11 +82,23 @@ properties:
   - !ruby/object:Api::Type::String
     name: 'ipCidrRange'
     description:
-      The IPv4 address range, in CIDR format, represented by this public
-      advertised prefix.
+      The address range, in CIDR format, represented by this public advertised
+      prefix.
     required: true
   - !ruby/object:Api::Type::String
     name: 'sharedSecret'
     output: true
     description: |
       Output Only. The shared secret to be used for reverse DNS verification.
+  - !ruby/object:Api::Type::Enum
+    name: 'pdpScope'
+    description: |
+      Specifies how child public delegated prefix will be scoped. It could be one of following values:
+
+      REGIONAL: The public delegated prefix is regional only. The provisioning will take a few minutes.
+      GLOBAL: The public delegated prefix is global only. The provisioning will take ~4 weeks.
+      GLOBAL_AND_REGIONAL [output only]: The public delegated prefixes is BYOIP V1 legacy prefix. This is output only value and no longer supported in BYOIP V2.
+    values:
+      - :REGIONAL
+      - :GLOBAL
+      - :GLOBAL_AND_REGIONAL

--- a/mmv1/products/compute/PublicDelegatedPrefix.yaml
+++ b/mmv1/products/compute/PublicDelegatedPrefix.yaml
@@ -51,6 +51,16 @@ examples:
       prefixes_name: 'my-prefix'
     test_env_vars:
       desc: :PAP_DESCRIPTION
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'public_delegated_prefixes_ipv6'
+    primary_resource_id: 'prefixes'
+    # PAPs have very low quota limits and a shared testing range so serialized tests exist in:
+    # resource_compute_public_advertised_prefix_test.go
+    skip_test: true
+    vars:
+      prefixes_name: 'my-prefix'
+    test_env_vars:
+      desc: :PAP_DESCRIPTION
 properties:
   - !ruby/object:Api::Type::String
     name: 'region'
@@ -83,6 +93,13 @@ properties:
   - !ruby/object:Api::Type::String
     name: 'ipCidrRange'
     description:
-      The IPv4 address range, in CIDR format, represented by this public
-      advertised prefix.
+      The IP address range, in CIDR format, represented by this public
+      delegated prefix.
     required: true
+  - !ruby/object:Api::Type::Enum
+    name: 'mode'
+    description:
+      The public delegated prefix mode for IPv6 only.
+    values:
+      - :DELEGATION
+      - :EXTERNAL_IPV6_FORWARDING_RULE_CREATION

--- a/mmv1/templates/terraform/examples/go/public_advertised_prefixes_ipv6.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/public_advertised_prefixes_ipv6.tf.tmpl
@@ -1,0 +1,7 @@
+resource "google_compute_public_advertised_prefix" "{{$.PrimaryResourceId}}" {
+  name                = "{{index $.Vars "prefixes_name"}}"
+  description         = "{{index $.TestEnvVars "desc"}}"
+  dns_verification_ip = "2001:db8::55"
+  ip_cidr_range       = "2001:db8::/40"
+  pdp_scope           = "REGIONAL"
+}

--- a/mmv1/templates/terraform/examples/go/public_delegated_prefixes_ipv6.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/public_delegated_prefixes_ipv6.tf.tmpl
@@ -1,0 +1,15 @@
+resource "google_compute_public_advertised_prefix" "advertised" {
+  name                = "{{index $.Vars "prefixes_name"}}"
+  description         = "{{index $.TestEnvVars "desc"}}"
+  dns_verification_ip = "2001:db8::55"
+  ip_cidr_range       = "2001:db8::/40"
+}
+
+resource "google_compute_public_delegated_prefix" "{{$.PrimaryResourceId}}" {
+  name          = "{{index $.Vars "prefixes_name"}}"
+  region        = "us-central1"
+  description   = "my description"
+  ip_cidr_range = "2001:db8::/48"
+  mode          = "EXTERNAL_IPV6_FORWARDING_RULE_CREATION"
+  parent_prefix = google_compute_public_advertised_prefix.advertised.id
+}

--- a/mmv1/templates/terraform/examples/public_advertised_prefixes_ipv6.tf.erb
+++ b/mmv1/templates/terraform/examples/public_advertised_prefixes_ipv6.tf.erb
@@ -1,0 +1,7 @@
+resource "google_compute_public_advertised_prefix" "<%= ctx[:primary_resource_id] %>" {
+  name                = "<%= ctx[:vars]['prefixes_name'] %>"
+  description         = "<%= ctx[:test_env_vars]['desc'] %>"
+  dns_verification_ip = "2001:db8::55"
+  ip_cidr_range       = "2001:db8::/40"
+  pdp_scope           = "REGIONAL"
+}

--- a/mmv1/templates/terraform/examples/public_delegated_prefixes_ipv6.tf.erb
+++ b/mmv1/templates/terraform/examples/public_delegated_prefixes_ipv6.tf.erb
@@ -1,0 +1,14 @@
+resource "google_compute_public_advertised_prefix" "advertised" {
+  name                = "<%= ctx[:vars]['prefixes_name'] %>"
+  description         = "<%= ctx[:test_env_vars]['desc'] %>"
+  dns_verification_ip = "2001:db8::55"
+  ip_cidr_range       = "2001:db8::/40"
+}
+
+resource "google_compute_public_delegated_prefix" "<%= ctx[:primary_resource_id] %>" {
+  name          = "<%= ctx[:vars]['prefixes_name'] %>"
+  region        = "us-central1"
+  description   = "my description"
+  ip_cidr_range = "2001:db8::/48"
+  parent_prefix = google_compute_public_advertised_prefix.advertised.id
+}


### PR DESCRIPTION
Adds IPv6 support for google_compute_public_advertised_prefix and google_compute_public_delegated_prefix.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement 
compute: Add `pdp_scope` field to `google_compute_public_delegated_prefix` resource
```
```release-note:enhancement 
compute: Add `mode` field to `google_compute_public_advertised_prefix` resource
```