### PR TITLE
Remove default_from_api from certificateId field

### DIFF
--- a/mmv1/products/compute/ManagedSslCertificate.yaml
+++ b/mmv1/products/compute/ManagedSslCertificate.yaml
@@ -107,7 +107,6 @@ properties:
     api_name: 'id'
     description: 'The unique identifier for the resource.'
     output: true
-    default_from_api: true
   - !ruby/object:Api::Type::String
     name: 'name'
     description: |


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Remove `default_from_api=true` property from `certificateId` field in `ManagedSslCertificate` resource

The field is marked as `default_from_api=true` and `output=true` at the same time. [default_from_api property takes precedence](https://github.com/GoogleCloudPlatform/magic-modules/blob/2b6e2fac92b47dca3c9f5b6e86cfac64923d9a36/mmv1/templates/terraform/schema_property.erb#L26) and hence the field is marked as `Optional` + `Computed` which is not correct as the field shouldn't be optional. 

This issue has a small impact in TF behavior because it will probably allow customers to modify the field, but the impact should be minor as probably the API will reject modifying an output only field + I don't believe customers will modify it anyways. 

Also according to [#15585](https://github.com/hashicorp/terraform-provider-google/issues/15585), setting `default_from_api=true` made config connector position the field in `spec` section (which should contain only modifiable fields), though I see that the field currently is [placed properly](https://github.com/GoogleCloudPlatform/k8s-config-connector/blob/master/crds/compute_v1beta1_computemanagedsslcertificate.yaml#L170).

Anyways, as long as this is a breaking change, we would prefer to fix it now to avoid any future hassle.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/15585
b/312432901

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
compute: stopped the `certifcate_id` field in `google_compute_managed_ssl_certificate` resource being incorrectly marked as a user-configurable value when it should just be an output.
```
