### PR TITLE
add send_secondary_ip_range_if_empty

### DIFF
--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -130,7 +130,7 @@ virtual_fields:
     name: 'send_secondary_ip_range_if_empty'
     description: |
       Controls the removal behavior of secondary_ip_range.
-      When false, removing secondary_ip_range from config will not produce a diff as 
+      When false, removing secondary_ip_range from config will not produce a diff as
       the provider will default to the API's value.
       When true, the provider will treat removing secondary_ip_range as sending an
       empty list of secondary IP ranges to the API.

--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -71,8 +71,10 @@ iam_policy: !ruby/object:Api::Resource::IamPolicy
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   constants: templates/terraform/constants/subnetwork.erb
   extra_schema_entry: templates/terraform/extra_schema_entry/subnetwork.erb
+  post_update: templates/terraform/post_update/compute_subnetwork.go.erb
 custom_diff: [
   'customdiff.ForceNewIfChange("ip_cidr_range", IsShrinkageIpCidr)',
+  'sendSecondaryIpRangeIfEmptyDiff',
 ]
 examples:
   - !ruby/object:Provider::Terraform::Examples
@@ -123,6 +125,16 @@ examples:
     vars:
       subnetwork_name: 'subnet-cidr-overlap'
       network_name: 'net-cidr-overlap'
+virtual_fields:
+  - !ruby/object:Api::Type::Boolean
+    name: 'send_secondary_ip_range_if_empty'
+    description: |
+      Controls the removal behavior of secondary_ip_range.
+      When false, removing secondary_ip_range from config will not produce a diff as 
+      the provider will default to the API's value.
+      When true, the provider will treat removing secondary_ip_range as sending an
+      empty list of secondary IP ranges to the API.
+      Defaults to false.
 properties:
   - !ruby/object:Api::Type::Time
     name: 'creationTimestamp'
@@ -215,11 +227,7 @@ properties:
       to the primary ipCidrRange of the subnetwork. The alias IPs may belong
       to either primary or secondary ranges.
 
-      **Note**: This field uses [attr-as-block mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html) to avoid
-      breaking users during the 0.12 upgrade. To explicitly send a list
-      of zero objects you must use the following syntax:
-      `example=[]`
-      For more details about this behavior, see [this section](https://www.terraform.io/docs/configuration/attr-as-blocks.html#defining-a-fixed-object-collection-value).
+      **Note**: To explicitly send a list of zero objects, set `send_secondary_ip_range_if_empty = true`
     update_verb: :PATCH
     update_url: projects/{{project}}/regions/{{region}}/subnetworks/{{name}}
     update_id: 'secondaryIpRanges'

--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -227,7 +227,9 @@ properties:
       to the primary ipCidrRange of the subnetwork. The alias IPs may belong
       to either primary or secondary ranges.
 
-      **Note**: To explicitly send a list of zero objects, set `send_secondary_ip_range_if_empty = true`
+      **Note**: This field uses [attr-as-block mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html) to avoid
+      breaking users during the 0.12 upgrade. To explicitly send a list of zero objects,
+      set `send_secondary_ip_range_if_empty = true`
     update_verb: :PATCH
     update_url: projects/{{project}}/regions/{{region}}/subnetworks/{{name}}
     update_id: 'secondaryIpRanges'

--- a/mmv1/templates/terraform/constants/subnetwork.erb
+++ b/mmv1/templates/terraform/constants/subnetwork.erb
@@ -19,24 +19,26 @@ func IsShrinkageIpCidr(_ context.Context, old, new, _ interface{}) bool {
 }
 
 func sendSecondaryIpRangeIfEmptyDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+	if diff.Id() == "" {
+		return nil
+	}
+
 	sendZero := diff.Get("send_secondary_ip_range_if_empty").(bool)
 	if !sendZero {
 		return nil
 	}
 
-	configValueIsEmpty := false
 	configSecondaryIpRange := diff.GetRawConfig().GetAttr("secondary_ip_range")
-
-	// IsNull check can be deleted when SchemaConfigModeAttr is removed
-	if configSecondaryIpRange.IsNull() {
-		configValueIsEmpty = true
-	} else {
-		configSlice := configSecondaryIpRange.AsValueSlice()
-		configValueIsEmpty = len(configSlice) == 0
+	if !configSecondaryIpRange.IsKnown() {
+		return nil
 	}
+	configValueIsEmpty := configSecondaryIpRange.IsNull() || configSecondaryIpRange.LengthInt() == 0
 
-	stateSecondaryIpRange, ok := diff.GetOk("secondary_ip_range")
-	stateValueIsEmpty := !ok || len(stateSecondaryIpRange.([]interface{})) == 0
+	stateSecondaryIpRange := diff.GetRawState().GetAttr("secondary_ip_range")
+	if !stateSecondaryIpRange.IsKnown() {
+		return nil
+	}
+	stateValueIsEmpty := stateSecondaryIpRange.IsNull() || stateSecondaryIpRange.LengthInt() == 0
 
 	if configValueIsEmpty && !stateValueIsEmpty {
 		log.Printf("[DEBUG] setting secondary_ip_range to newly empty")

--- a/mmv1/templates/terraform/constants/subnetwork.erb
+++ b/mmv1/templates/terraform/constants/subnetwork.erb
@@ -17,3 +17,31 @@ func IsShrinkageIpCidr(_ context.Context, old, new, _ interface{}) bool {
 
 	return true
 }
+
+func sendSecondaryIpRangeIfEmptyDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+	sendZero := diff.Get("send_secondary_ip_range_if_empty").(bool)
+	if !sendZero {
+		return nil
+	}
+
+	configValueIsEmpty := false
+	configSecondaryIpRange := diff.GetRawConfig().GetAttr("secondary_ip_range")
+
+	// IsNull check can be deleted when SchemaConfigModeAttr is removed
+	if configSecondaryIpRange.IsNull() {
+		configValueIsEmpty = true
+	} else {
+		configSlice := configSecondaryIpRange.AsValueSlice()
+		configValueIsEmpty = len(configSlice) == 0
+	}
+
+	stateSecondaryIpRange, ok := diff.GetOk("secondary_ip_range")
+	stateValueIsEmpty := !ok || len(stateSecondaryIpRange.([]interface{})) == 0
+
+	if configValueIsEmpty && !stateValueIsEmpty {
+		log.Printf("[DEBUG] setting secondary_ip_range to newly empty")
+		diff.SetNew("secondary_ip_range", make([]interface{}, 0))
+	}
+
+	return nil
+}

--- a/mmv1/templates/terraform/constants/subnetwork.erb
+++ b/mmv1/templates/terraform/constants/subnetwork.erb
@@ -19,6 +19,7 @@ func IsShrinkageIpCidr(_ context.Context, old, new, _ interface{}) bool {
 }
 
 func sendSecondaryIpRangeIfEmptyDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+	// on create, return immediately as we don't need to determine if the value is empty or not
 	if diff.Id() == "" {
 		return nil
 	}

--- a/mmv1/templates/terraform/post_update/compute_subnetwork.go.erb
+++ b/mmv1/templates/terraform/post_update/compute_subnetwork.go.erb
@@ -1,8 +1,8 @@
 if v, ok := d.GetOk("send_secondary_ip_range_if_empty"); ok && v.(bool) {
 	if sv, ok := d.GetOk("secondary_ip_range"); ok {
-		configValue := d.GetRawConfig().GetAttr("secondary_ip_range").AsValueSlice()
+		configValue := d.GetRawConfig().GetAttr("secondary_ip_range")
 		stateValue := sv.([]interface{})
-		if len(configValue) == 0 && len(stateValue) != 0 {
+		if configValue.LengthInt() == 0 && len(stateValue) != 0 {
 			log.Printf("[DEBUG] Sending empty secondary_ip_range in update")
 			obj := make(map[string]interface{})
 			obj["secondaryIpRanges"] = make([]interface{}, 0)

--- a/mmv1/templates/terraform/post_update/compute_subnetwork.go.erb
+++ b/mmv1/templates/terraform/post_update/compute_subnetwork.go.erb
@@ -1,0 +1,72 @@
+if v, ok := d.GetOk("send_secondary_ip_range_if_empty"); ok && v.(bool) {
+	if sv, ok := d.GetOk("secondary_ip_range"); ok {
+		configValue := d.GetRawConfig().GetAttr("secondary_ip_range").AsValueSlice()
+		stateValue := sv.([]interface{})
+		if len(configValue) == 0 && len(stateValue) != 0 {
+			log.Printf("[DEBUG] Sending empty secondary_ip_range in update")
+			obj := make(map[string]interface{})
+			obj["secondaryIpRanges"] = make([]interface{}, 0)
+
+			// The rest is the same as the secondary_ip_range generated update code
+			// without the secondaryIpRangesProp logic
+
+			getUrl, err := tpgresource.ReplaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/subnetworks/{{name}}")
+			if err != nil {
+				return err
+			}
+
+			// err == nil indicates that the billing_project value was found
+			if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+				billingProject = bp
+			}
+
+			getRes, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				Project:   billingProject,
+				RawURL:    getUrl,
+				UserAgent: userAgent,
+			})
+			if err != nil {
+				return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("ComputeSubnetwork %q", d.Id()))
+			}
+
+			obj["fingerprint"] = getRes["fingerprint"]
+
+			url, err := tpgresource.ReplaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/subnetworks/{{name}}")
+			if err != nil {
+				return err
+			}
+
+			headers := make(http.Header)
+
+			// err == nil indicates that the billing_project value was found
+			if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+				billingProject = bp
+			}
+
+			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "PATCH",
+				Project:   billingProject,
+				RawURL:    url,
+				UserAgent: userAgent,
+				Body:      obj,
+				Timeout:   d.Timeout(schema.TimeoutUpdate),
+				Headers:   headers,
+			})
+			if err != nil {
+				return fmt.Errorf("Error updating Subnetwork %q: %s", d.Id(), err)
+			} else {
+				log.Printf("[DEBUG] Finished updating Subnetwork %q: %#v", d.Id(), res)
+			}
+
+			err = ComputeOperationWaitTime(
+				config, res, project, "Updating Subnetwork", userAgent,
+				d.Timeout(schema.TimeoutUpdate))
+			if err != nil {
+				return err
+			}
+		}
+	}
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_subnetwork_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_subnetwork_test.go.erb
@@ -208,6 +208,92 @@ func TestAccComputeSubnetwork_secondaryIpRanges(t *testing.T) {
 	})
 }
 
+func TestAccComputeSubnetwork_secondaryIpRanges_sendEmpty(t *testing.T) {
+	t.Parallel()
+
+	var subnetwork compute.Subnetwork
+
+	cnName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	subnetworkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeSubnetworkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			// Start without secondary_ip_range at all
+			{
+				Config: testAccComputeSubnetwork_sendEmpty_removed(cnName, subnetworkName, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeSubnetworkExists(t, "google_compute_subnetwork.network-with-private-secondary-ip-ranges", &subnetwork),
+				),
+			},
+			// Add one secondary_ip_range
+			{
+				Config: testAccComputeSubnetwork_sendEmpty_single(cnName, subnetworkName, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeSubnetworkExists(t, "google_compute_subnetwork.network-with-private-secondary-ip-ranges", &subnetwork),
+					testAccCheckComputeSubnetworkHasSecondaryIpRange(&subnetwork, "tf-test-secondary-range-update1", "192.168.10.0/24"),
+				),
+			},
+			// Remove it with send_secondary_ip_range_if_empty = true
+			{
+				Config: testAccComputeSubnetwork_sendEmpty_removed(cnName, subnetworkName, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeSubnetworkExists(t, "google_compute_subnetwork.network-with-private-secondary-ip-ranges", &subnetwork),
+					testAccCheckComputeSubnetworkHasNotSecondaryIpRange(&subnetwork, "tf-test-secondary-range-update1", "192.168.10.0/24"),
+				),
+			},
+			// Check that empty block secondary_ip_range = [] is not different
+			{
+				Config:             testAccComputeSubnetwork_sendEmpty_emptyBlock(cnName, subnetworkName, "true"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// Apply two secondary_ip_range
+			{
+				Config: testAccComputeSubnetwork_sendEmpty_double(cnName, subnetworkName, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeSubnetworkExists(t, "google_compute_subnetwork.network-with-private-secondary-ip-ranges", &subnetwork),
+					testAccCheckComputeSubnetworkHasSecondaryIpRange(&subnetwork, "tf-test-secondary-range-update1", "192.168.10.0/24"),
+					testAccCheckComputeSubnetworkHasSecondaryIpRange(&subnetwork, "tf-test-secondary-range-update2", "192.168.11.0/24"),
+				),
+			},
+			// Remove both with send_secondary_ip_range_if_empty = true
+			{
+				Config: testAccComputeSubnetwork_sendEmpty_removed(cnName, subnetworkName, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeSubnetworkExists(t, "google_compute_subnetwork.network-with-private-secondary-ip-ranges", &subnetwork),
+					testAccCheckComputeSubnetworkHasNotSecondaryIpRange(&subnetwork, "tf-test-secondary-range-update1", "192.168.10.0/24"),
+					testAccCheckComputeSubnetworkHasNotSecondaryIpRange(&subnetwork, "tf-test-secondary-range-update2", "192.168.11.0/24"),
+				),
+			},
+			// Apply one secondary_ip_range
+			{
+				Config: testAccComputeSubnetwork_sendEmpty_single(cnName, subnetworkName, "false"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeSubnetworkExists(t, "google_compute_subnetwork.network-with-private-secondary-ip-ranges", &subnetwork),
+					testAccCheckComputeSubnetworkHasSecondaryIpRange(&subnetwork, "tf-test-secondary-range-update1", "192.168.10.0/24"),
+				),
+			},
+			// Check removing without send_secondary_ip_range_if_empty produces no diff (normal computed behavior)
+			{
+				Config:             testAccComputeSubnetwork_sendEmpty_removed(cnName, subnetworkName, "false"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// Remove with empty block []
+			{
+				Config: testAccComputeSubnetwork_sendEmpty_emptyBlock(cnName, subnetworkName, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeSubnetworkExists(t, "google_compute_subnetwork.network-with-private-secondary-ip-ranges", &subnetwork),
+					testAccCheckComputeSubnetworkHasNotSecondaryIpRange(&subnetwork, "tf-test-secondary-range-update1", "192.168.10.0/24"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccComputeSubnetwork_flowLogs(t *testing.T) {
 	t.Parallel()
 
@@ -620,6 +706,91 @@ resource "google_compute_subnetwork" "network-with-private-secondary-ip-ranges" 
   secondary_ip_range = []
 }
 `, cnName, subnetworkName)
+}
+
+func testAccComputeSubnetwork_sendEmpty_removed(cnName, subnetworkName, sendEmpty string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "custom-test" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "network-with-private-secondary-ip-ranges" {
+  name               = "%s"
+  ip_cidr_range      = "10.2.0.0/16"
+  region             = "us-central1"
+  network            = google_compute_network.custom-test.self_link
+  send_secondary_ip_range_if_empty = "%s"
+}
+`, cnName, subnetworkName, sendEmpty)
+}
+
+func testAccComputeSubnetwork_sendEmpty_emptyBlock(cnName, subnetworkName, sendEmpty string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "custom-test" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "network-with-private-secondary-ip-ranges" {
+  name               = "%s"
+  ip_cidr_range      = "10.2.0.0/16"
+  region             = "us-central1"
+  network            = google_compute_network.custom-test.self_link
+  secondary_ip_range = []
+  send_secondary_ip_range_if_empty = "%s"
+}
+`, cnName, subnetworkName, sendEmpty)
+}
+
+func testAccComputeSubnetwork_sendEmpty_single(cnName, subnetworkName, sendEmpty string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "custom-test" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "network-with-private-secondary-ip-ranges" {
+  name               = "%s"
+  ip_cidr_range      = "10.2.0.0/16"
+  region             = "us-central1"
+  network            = google_compute_network.custom-test.self_link
+  secondary_ip_range {
+    range_name    = "tf-test-secondary-range-update2"
+    ip_cidr_range = "192.168.11.0/24"
+  }
+  secondary_ip_range {
+    range_name    = "tf-test-secondary-range-update1"
+    ip_cidr_range = "192.168.10.0/24"
+  }
+  send_secondary_ip_range_if_empty = "%s"
+}
+`, cnName, subnetworkName, sendEmpty)
+}
+
+func testAccComputeSubnetwork_sendEmpty_double(cnName, subnetworkName, sendEmpty string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "custom-test" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "network-with-private-secondary-ip-ranges" {
+  name               = "%s"
+  ip_cidr_range      = "10.2.0.0/16"
+  region             = "us-central1"
+  network            = google_compute_network.custom-test.self_link
+  secondary_ip_range {
+    range_name    = "tf-test-secondary-range-update2"
+    ip_cidr_range = "192.168.11.0/24"
+  }
+  secondary_ip_range {
+    range_name    = "tf-test-secondary-range-update1"
+    ip_cidr_range = "192.168.10.0/24"
+  }
+  send_secondary_ip_range_if_empty = "%s"
+}
+`, cnName, subnetworkName, sendEmpty)
 }
 
 func testAccComputeSubnetwork_flowLogs(cnName, subnetworkName string) string {

--- a/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
@@ -160,6 +160,16 @@ Previously, `containers.env` was a list, making it order-dependent. It is now a 
 
 If you were relying on accessing an individual environment variable by index (for example, `google_cloud_run_v2_service.template.containers.0.env.0.name`), then that will now need to by hash (for example, `google_cloud_run_v2_service.template.containers.0.env.<some-hash>.name`).
 
+## Resource: `google_compute_subnetwork`
+
+### `secondary_ip_range = []` is no longer valid configuration
+
+To explicitly set an empty list of objects, use `send_secondary_ip_range_if_empty = true` and completely remove `secondary_ip_range` from config.
+
+Previously, to explicitly set `secondary_ip_range` as an empty list of objects, the specific configuration `secondary_ip_range = []` was necessary.
+This was to maintain compatability in behavior between Terraform versions 0.11 and 0.12 using a special setting ["attributes as blocks"](https://developer.hashicorp.com/terraform/language/attr-as-blocks).
+This special setting causes other breakages so it is now removed, with `send_secondary_ip_range_if_empty` available instead.
+
 ## Resource: `google_compute_backend_service`
 
 ## Resource: `google_compute_region_backend_service`


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

part of https://github.com/hashicorp/terraform-provider-google/issues/12824 and https://github.com/hashicorp/terraform-provider-google/issues/17881

adds a virtual field to replace the need to set `secondary_ip_range = []` to remove `secondary_ip_range` explicitly. The virtual field in combination with `GetRawConfig().GetAttr("secondary_ip_range")` can let us detect when the user has intent to set to an empty list vs intending to let the backend manage the field.

Normally, when removing an Optional+Computed field from config, Terraform will not produce a diff. The `sendSecondaryIpRangeIfEmptyDiff` checks if the new flag is set and then compares the config value with the state value using `GetRawConfig()` and `GetOk` respectively.

The actual update call is handled in a post_update custom code block.

This logic works **with and without SchemaConfigModeAttr**, allowing an upgrade path in 5.x before removing SchemaConfigModeAttr from `secondary_ip_range` in 6.0


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:deprecation
compute: setting `google_compute_subnetwork.secondary_ip_range = []` to explicitly set a list of empty objects is deprecated and will produce an error in the upcoming major release. Use `send_secondary_ip_range_if_empty` while removing `secondary_ip_range` from config instead.
```

```release-note:enhancement
compute: added `send_secondary_ip_range_if_empty` to `google_compute_subnetwork`
```
