### PR TITLE
Update Managed Kafka service name

### DIFF
--- a/mmv1/products/managedkafka/Cluster.yaml
+++ b/mmv1/products/managedkafka/Cluster.yaml
@@ -19,7 +19,7 @@ id_format: projects/{{project}}/locations/{{location}}/clusters/{{cluster_id}}
 import_format:
   - projects/{{project}}/locations/{{location}}/clusters/{{cluster_id}}
 name: Cluster
-description: An Apache Kafka for BigQuery cluster. Apache Kafka is a trademark owned by the Apache Software Foundation.
+description: A Managed Service for Apache Kafka cluster. Apache Kafka is a trademark owned by the Apache Software Foundation.
 min_version: beta
 update_verb: :PATCH
 update_mask: true
@@ -67,7 +67,7 @@ async: !ruby/object:Api::OpAsync
 parameters:
   - !ruby/object:Api::Type::String
     name: location
-    description: "ID of the location of the Apache Kafka for BigQuery resource. See
+    description: "ID of the location of the Kafka resource. See
       https://cloud.google.com/managed-kafka/docs/locations for a list of
       supported locations."
     url_param_only: true

--- a/mmv1/products/managedkafka/Topic.yaml
+++ b/mmv1/products/managedkafka/Topic.yaml
@@ -19,7 +19,7 @@ id_format: projects/{{project}}/locations/{{location}}/clusters/{{cluster}}/topi
 import_format:
   - projects/{{project}}/locations/{{location}}/clusters/{{cluster}}/topics/{{topic_id}}
 name: Topic
-description: An Apache Kafka for BigQuery topic. Apache Kafka is a trademark owned by the Apache Software Foundation.
+description: A Managed Service for Apache Kafka topic. Apache Kafka is a trademark owned by the Apache Software Foundation.
 min_version: beta
 update_verb: :PATCH
 update_mask: true
@@ -34,7 +34,7 @@ examples:
 parameters:
   - !ruby/object:Api::Type::String
     name: location
-    description: "ID of the location of the Apache Kafka for BigQuery resource. See
+    description: "ID of the location of the Kafka resource. See
       https://cloud.google.com/managed-kafka/docs/locations for a list of
       supported locations."
     url_param_only: true

--- a/mmv1/products/managedkafka/go_Cluster.yaml
+++ b/mmv1/products/managedkafka/go_Cluster.yaml
@@ -14,7 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'Cluster'
-description: An Apache Kafka for BigQuery cluster. Apache Kafka is a trademark owned by the Apache Software Foundation.
+description: A Managed Service for Apache Kafka cluster. Apache Kafka is a trademark owned by the Apache Software Foundation.
 min_version: 'beta'
 docs:
 id_format: 'projects/{{project}}/locations/{{location}}/clusters/{{cluster_id}}'
@@ -63,7 +63,7 @@ examples:
 parameters:
   - name: 'location'
     type: String
-    description: "ID of the location of the Apache Kafka for BigQuery resource. See
+    description: "ID of the location of the Kafka resource. See
       https://cloud.google.com/managed-kafka/docs/locations for a list of
       supported locations."
     min_version: 'beta'

--- a/mmv1/products/managedkafka/go_Topic.yaml
+++ b/mmv1/products/managedkafka/go_Topic.yaml
@@ -14,7 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'Topic'
-description: An Apache Kafka for BigQuery topic. Apache Kafka is a trademark owned by the Apache Software Foundation.
+description: A Managed Service for Apache Kafka topic. Apache Kafka is a trademark owned by the Apache Software Foundation.
 min_version: 'beta'
 docs:
 id_format: 'projects/{{project}}/locations/{{location}}/clusters/{{cluster}}/topics/{{topic_id}}'
@@ -40,7 +40,7 @@ examples:
 parameters:
   - name: 'location'
     type: String
-    description: "ID of the location of the Apache Kafka for BigQuery resource. See
+    description: "ID of the location of the Kafka resource. See
       https://cloud.google.com/managed-kafka/docs/locations for a list of
       supported locations."
     min_version: 'beta'


### PR DESCRIPTION
The name of our service has been updated to "Managed Service for Apache Kafka", and we would like our terraform documentation to reflect this for our Cluster and Topic resource.

Issue: https://b.corp.google.com/issues/358588110

```release-note:none
```
