### PR TITLE
Fix subnet documentation for Managed Kafka

### DIFF
--- a/mmv1/products/managedkafka/Cluster.yaml
+++ b/mmv1/products/managedkafka/Cluster.yaml
@@ -95,9 +95,10 @@ properties:
         properties:
           - !ruby/object:Api::Type::Array
             name: networkConfigs
-            description: "Virtual Private Cloud (VPC) networks that must be granted
-              direct access to the Kafka cluster. Minimum of 1 network is required. Maximum
-              of 10 networks can be specified."
+            description: "Virtual Private Cloud (VPC) subnets where IP addresses for the Kafka
+              cluster are allocated. To make the cluster available in a VPC, you must specify at least
+              one subnet per network. You must specify between 1 and 10 subnets.
+              Additional subnets may be specified with additional `network_configs` blocks."
             required: true
             item_type: !ruby/object:Api::Type::NestedObject
               properties:
@@ -106,8 +107,7 @@ properties:
                   description: "Name of the VPC subnet from which the cluster is accessible. Both broker and
                     bootstrap server IP addresses and DNS entries are automatically created
                     in the subnet. The subnet must be located in the same region as the
-                    cluster. The project may differ. A minimum of 1 subnet is required.
-                    A maximum of 10 subnets can be specified. The name of the subnet must be
+                    cluster. The project may differ. The name of the subnet must be
                     in the format `projects/PROJECT_ID/regions/REGION/subnetworks/SUBNET`."
                   required: true
                   diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'


### PR DESCRIPTION
Documentation on how to specify multiple subnets has been confusing to customers. This PR addresses this confusion.

Issue: b/353952791

```release-note:none
managedkafka: fix subnet documentation (beta) (no release note for documentation-only changes)
```
