### PR TITLE
Support full resource names in autokey_config.folder

### DIFF
--- a/mmv1/products/kms/AutokeyConfig.yaml
+++ b/mmv1/products/kms/AutokeyConfig.yaml
@@ -39,6 +39,8 @@ references: !ruby/object:Api::Resource::ReferenceLinks
 id_format: 'folders/{{folder}}/autokeyConfig'
 import_format: ['folders/{{folder}}/autokeyConfig']
 min_version: beta
+# Using a handwritten sweeper because of pre_delete.
+skip_sweeper: true
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   constants: templates/terraform/constants/autokey_config_folder_diff.go.erb
   pre_create: templates/terraform/pre_create/kms_autokey_config_folder.go.erb

--- a/mmv1/products/kms/AutokeyConfig.yaml
+++ b/mmv1/products/kms/AutokeyConfig.yaml
@@ -40,6 +40,11 @@ id_format: 'folders/{{folder}}/autokeyConfig'
 import_format: ['folders/{{folder}}/autokeyConfig']
 min_version: beta
 custom_code: !ruby/object:Provider::Terraform::CustomCode
+  constants: templates/terraform/constants/autokey_config_folder_diff.go.erb
+  pre_create: templates/terraform/pre_create/kms_autokey_config_folder.go.erb
+  pre_delete: templates/terraform/pre_delete/kms_autokey_config_folder.go.erb
+  pre_read: templates/terraform/pre_read/kms_autokey_config_folder.go.erb
+  pre_update: templates/terraform/pre_update/kms_autokey_config_folder.go.erb
   test_check_destroy: templates/terraform/custom_check_destroy/kms_autokey_config.go.erb
 examples:
   - !ruby/object:Provider::Terraform::Examples
@@ -63,6 +68,7 @@ parameters:
     required: true
     immutable: true
     url_param_only: true
+    diff_suppress_func: 'folderPrefixSuppress'
     description: |
       The folder for which to retrieve config.
 properties:

--- a/mmv1/templates/terraform/constants/autokey_config_folder_diff.go.erb
+++ b/mmv1/templates/terraform/constants/autokey_config_folder_diff.go.erb
@@ -1,0 +1,4 @@
+func folderPrefixSuppress(_, old, new string, d *schema.ResourceData) bool {
+	prefix := "folders/"
+	return prefix+old == new || prefix+new == old
+}

--- a/mmv1/templates/terraform/constants/go/autokey_config_folder_diff.go.tmpl
+++ b/mmv1/templates/terraform/constants/go/autokey_config_folder_diff.go.tmpl
@@ -1,0 +1,4 @@
+func folderPrefixSuppress(_, old, new string, d *schema.ResourceData) bool {
+	prefix := "folders/"
+	return prefix+old == new || prefix+new == old
+}

--- a/mmv1/templates/terraform/custom_check_destroy/kms_autokey_config.go.erb
+++ b/mmv1/templates/terraform/custom_check_destroy/kms_autokey_config.go.erb
@@ -1,6 +1,7 @@
 config := acctest.GoogleProviderConfig(t)
 
 url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{KMSBasePath}}folders/{{folder}}/autokeyConfig")
+url = strings.Replace(url, "folders/folders/", "folders/", 1)
 if err != nil {
   return err
 }

--- a/mmv1/templates/terraform/examples/kms_autokey_config_all.tf.erb
+++ b/mmv1/templates/terraform/examples/kms_autokey_config_all.tf.erb
@@ -70,6 +70,6 @@ resource "google_kms_autokey_config" "<%= ctx[:primary_resource_id] %>" {
 # Wait delay after setting AutokeyConfig, to prevent diffs on reapply,
 # because setting the config takes a little to fully propagate.
 resource "time_sleep" "wait_autokey_propagation" {
-  create_duration = "15s"
+  create_duration = "30s"
   depends_on      = [google_kms_autokey_config.<%= ctx[:primary_resource_id] %>]
 }

--- a/mmv1/templates/terraform/examples/kms_autokey_config_all.tf.erb
+++ b/mmv1/templates/terraform/examples/kms_autokey_config_all.tf.erb
@@ -62,7 +62,14 @@ resource "time_sleep" "wait_srv_acc_permissions" {
 
 resource "google_kms_autokey_config" "<%= ctx[:primary_resource_id] %>" {
   provider    = google-beta
-  folder      = google_folder.autokms_folder.folder_id
+  folder      = google_folder.autokms_folder.id
   key_project = "projects/${google_project.key_project.project_id}"
   depends_on  = [time_sleep.wait_srv_acc_permissions]
+}
+
+# Wait delay after setting AutokeyConfig, to prevent diffs on reapply,
+# because setting the config takes a little to fully propagate.
+resource "time_sleep" "wait_autokey_propagation" {
+  create_duration = "15s"
+  depends_on      = [google_kms_autokey_config.<%= ctx[:primary_resource_id] %>]
 }

--- a/mmv1/templates/terraform/post_create/kms_autokey_config_folder.go.erb
+++ b/mmv1/templates/terraform/post_create/kms_autokey_config_folder.go.erb
@@ -1,0 +1,2 @@
+id = strings.Replace(id, "folders/folders/", "folders/", 1)
+d.SetId(id)

--- a/mmv1/templates/terraform/pre_create/kms_autokey_config_folder.go.erb
+++ b/mmv1/templates/terraform/pre_create/kms_autokey_config_folder.go.erb
@@ -1,0 +1,4 @@
+url = strings.Replace(url, "folders/folders/", "folders/", 1)
+folderValue := d.Get("folder").(string)
+folderValue = strings.Replace(folderValue, "folders/", "", 1)
+d.Set("folder", folderValue)

--- a/mmv1/templates/terraform/pre_create/kms_autokey_config_folder.go.erb
+++ b/mmv1/templates/terraform/pre_create/kms_autokey_config_folder.go.erb
@@ -1,1 +1,4 @@
 url = strings.Replace(url, "folders/folders/", "folders/", 1)
+folderValue := d.Get("folder").(string)
+folderValue = strings.Replace(folderValue, "folders/", "", 1)
+d.Set("folder", folderValue)

--- a/mmv1/templates/terraform/pre_create/kms_autokey_config_folder.go.erb
+++ b/mmv1/templates/terraform/pre_create/kms_autokey_config_folder.go.erb
@@ -1,4 +1,1 @@
 url = strings.Replace(url, "folders/folders/", "folders/", 1)
-folderValue := d.Get("folder").(string)
-folderValue = strings.Replace(folderValue, "folders/", "", 1)
-d.Set("folder", folderValue)

--- a/mmv1/templates/terraform/pre_delete/kms_autokey_config_folder.go.erb
+++ b/mmv1/templates/terraform/pre_delete/kms_autokey_config_folder.go.erb
@@ -1,0 +1,1 @@
+url = strings.Replace(url, "folders/folders/", "folders/", 1)

--- a/mmv1/templates/terraform/pre_read/kms_autokey_config_folder.go.erb
+++ b/mmv1/templates/terraform/pre_read/kms_autokey_config_folder.go.erb
@@ -1,0 +1,1 @@
+url = strings.Replace(url, "folders/folders/", "folders/", 1)

--- a/mmv1/templates/terraform/pre_update/kms_autokey_config_folder.go.erb
+++ b/mmv1/templates/terraform/pre_update/kms_autokey_config_folder.go.erb
@@ -1,0 +1,4 @@
+url = strings.Replace(url, "folders/folders/", "folders/", 1)
+folderValue := d.Get("folder").(string)
+folderValue = strings.Replace(folderValue, "folders/", "", 1)
+d.Set("folder", folderValue)

--- a/mmv1/templates/terraform/pre_update/kms_autokey_config_folder.go.erb
+++ b/mmv1/templates/terraform/pre_update/kms_autokey_config_folder.go.erb
@@ -1,4 +1,1 @@
 url = strings.Replace(url, "folders/folders/", "folders/", 1)
-folderValue := d.Get("folder").(string)
-folderValue = strings.Replace(folderValue, "folders/", "", 1)
-d.Set("folder", folderValue)

--- a/mmv1/third_party/terraform/services/kms/resource_kms_autokey_config_sweeper.go
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_autokey_config_sweeper.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-google-beta/google-beta/envvar"
-	"github.com/hashicorp/terraform-provider-google-beta/google-beta/sweeper"
-	"github.com/hashicorp/terraform-provider-google-beta/google-beta/tpgresource"
-	transport_tpg "github.com/hashicorp/terraform-provider-google-beta/google-beta/transport"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/sweeper"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 func init() {

--- a/mmv1/third_party/terraform/services/kms/resource_kms_autokey_config_sweeper.go
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_autokey_config_sweeper.go
@@ -1,0 +1,124 @@
+package kms
+
+import (
+	"context"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-google-beta/google-beta/envvar"
+	"github.com/hashicorp/terraform-provider-google-beta/google-beta/sweeper"
+	"github.com/hashicorp/terraform-provider-google-beta/google-beta/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google-beta/google-beta/transport"
+)
+
+func init() {
+	sweeper.AddTestSweepers("KMSAutokeyConfig", testSweepKMSAutokeyConfig)
+}
+
+// At the time of writing, the CI only passes us-central1 as the region
+func testSweepKMSAutokeyConfig(region string) error {
+	resourceName := "KMSAutokeyConfig"
+	log.Printf("[INFO][SWEEPER_LOG] Starting sweeper for %s", resourceName)
+
+	config, err := sweeper.SharedConfigForRegion(region)
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error getting shared config for region: %s", err)
+		return err
+	}
+
+	err = config.LoadAndValidate(context.Background())
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error loading: %s", err)
+		return err
+	}
+
+	t := &testing.T{}
+	billingId := envvar.GetTestBillingAccountFromEnv(t)
+
+	// Setup variables to replace in list template
+	d := &tpgresource.ResourceDataMock{
+		FieldsInSchema: map[string]interface{}{
+			"project":         config.Project,
+			"region":          region,
+			"location":        region,
+			"zone":            "-",
+			"billing_account": billingId,
+		},
+	}
+
+	listTemplate := strings.Split("https://cloudkms.googleapis.com/v1/folders/{{folder}}/autokeyConfig", "?")[0]
+	listUrl, err := tpgresource.ReplaceVars(d, config, listTemplate)
+	listUrl = strings.Replace(listUrl, "folders/folders/", "folders/", 1)
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error preparing sweeper list url: %s", err)
+		return nil
+	}
+
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   config.Project,
+		RawURL:    listUrl,
+		UserAgent: config.UserAgent,
+	})
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)
+		return nil
+	}
+
+	resourceList, ok := res["autokeyConfigs"]
+	if !ok {
+		log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
+		return nil
+	}
+
+	rl := resourceList.([]interface{})
+
+	log.Printf("[INFO][SWEEPER_LOG] Found %d items in %s list response.", len(rl), resourceName)
+	// Keep count of items that aren't sweepable for logging.
+	nonPrefixCount := 0
+	for _, ri := range rl {
+		obj := ri.(map[string]interface{})
+		if obj["name"] == nil {
+			log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
+			return nil
+		}
+
+		name := tpgresource.GetResourceNameFromSelfLink(obj["name"].(string))
+		// Skip resources that shouldn't be sweeped
+		if !sweeper.IsSweepableTestResource(name) {
+			nonPrefixCount++
+			continue
+		}
+
+		deleteTemplate := "https://cloudkms.googleapis.com/v1/folders/{{folder}}/autokeyConfig?updateMask=keyProject"
+		deleteUrl, err := tpgresource.ReplaceVars(d, config, deleteTemplate)
+		if err != nil {
+			log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
+			return nil
+		}
+		deleteUrl = deleteUrl + name
+		deleteUrl = strings.Replace(deleteUrl, "folders/folders/", "folders/", 1)
+
+		// Don't wait on operations as we may have a lot to delete
+		_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "DELETE",
+			Project:   config.Project,
+			RawURL:    deleteUrl,
+			UserAgent: config.UserAgent,
+		})
+		if err != nil {
+			log.Printf("[INFO][SWEEPER_LOG] Error deleting for url %s : %s", deleteUrl, err)
+		} else {
+			log.Printf("[INFO][SWEEPER_LOG] Sent delete request for %s resource: %s", resourceName, name)
+		}
+	}
+
+	if nonPrefixCount > 0 {
+		log.Printf("[INFO][SWEEPER_LOG] %d items were non-sweepable and skipped.", nonPrefixCount)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Add pre_* custom code to drop the 'folders/' prefix from API requests, as well as a diff suppressor for the same reason. The ID also needs to be adjusted on post_create.

Side change: add a time delay after setting the autokey_config in the basic example, to try to address test flakiness (#18935)

NOTE: looking at the debug logs, I see the following error:
```
2024-08-09T16:37:55.977Z [WARN]  Provider "provider[\"registry.terraform.io/hashicorp/google-beta\"]" produced an unexpected new value for google_kms_autokey_config.example-autokeyconfig, but we are tolerating it because it is using the legacy plugin SDK.
    The following problems may be the cause of any confusing errors from downstream operations:
      - .folder: was cty.StringVal("folders/966201355962"), but now cty.StringVal("966201355962")
```
looking for guidance on whether my current approach is fine, or if this should be addressed in a different way.

Thank you!

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
kms: updated the `google_kms_autokey_config` resource's `folder` field to accept values that are either full resource names (`folders/{folder_id}`) or just the folder id (`{folder_id}` only)
```
