### PR TITLE
Revert "Sweep up Firestore (default) databases to prevent errant ALREADY_EXISTS errors"

### DIFF
--- a/mmv1/third_party/terraform/services/firestore/resource_firestore_database_sweeper.go
+++ b/mmv1/third_party/terraform/services/firestore/resource_firestore_database_sweeper.go
@@ -17,9 +17,7 @@ func init() {
 }
 
 // At the time of writing, the CI only passes us-central1 as the region
-// But all Firestore examples use nam5, so we will force that instead
 func testSweepFirestoreDatabase(region string) error {
-	actualRegion := "nam5"
 	resourceName := "FirestoreDatabase"
 	log.Printf("[INFO][SWEEPER_LOG] Starting sweeper for %s", resourceName)
 
@@ -38,12 +36,12 @@ func testSweepFirestoreDatabase(region string) error {
 	t := &testing.T{}
 	billingId := envvar.GetTestBillingAccountFromEnv(t)
 
-	// Set up variables to replace in list template
+	// Setup variables to replace in list template
 	d := &tpgresource.ResourceDataMock{
 		FieldsInSchema: map[string]interface{}{
 			"project":         config.Project,
-			"region":          actualRegion,
-			"location":        actualRegion,
+			"region":          region,
+			"location":        region,
 			"zone":            "-",
 			"billing_account": billingId,
 		},
@@ -88,7 +86,7 @@ func testSweepFirestoreDatabase(region string) error {
 
 		name := tpgresource.GetResourceNameFromSelfLink(obj["name"].(string))
 		// Skip resources that shouldn't be sweeped
-		if !sweeper.IsSweepableTestResource(name) && name != "(default)" {
+		if !sweeper.IsSweepableTestResource(name) {
 			nonPrefixCount++
 			continue
 		}


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#10930.

This sweeping breaks TestAccCloudFunctionsFunction_firestore - see https://github.com/hashicorp/terraform-provider-google/issues/18072 for details. The datastore index test should instead use an isolated project (instead of running in the default test project.)

Attn @rwhogg as the original PR author.