### PR TITLE
Run CryptoKey key_access_justification test only in beta

### DIFF
--- a/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go
@@ -317,6 +317,7 @@ func TestAccKmsCryptoKey_destroyDuration(t *testing.T) {
 	})
 }
 
+<% unless version == "ga" -%>
 func TestAccKmsCryptoKey_keyAccessJustificationsPolicy(t *testing.T) {
 	t.Parallel()
 
@@ -363,6 +364,7 @@ func TestAccKmsCryptoKey_keyAccessJustificationsPolicy(t *testing.T) {
 		},
 	})
 }
+<% end -%>
 
 func TestAccKmsCryptoKey_importOnly(t *testing.T) {
 	t.Parallel()
@@ -836,6 +838,7 @@ resource "google_kms_crypto_key" "crypto_key" {
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
 }
 
+<% unless version == "ga" -%>
 func testGoogleKmsCryptoKey_keyAccessJustificationsPolicy(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, allowed_access_reason string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
@@ -868,6 +871,7 @@ resource "google_kms_crypto_key" "crypto_key" {
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, allowed_access_reason)
 }
+<% end -%>
 
 func testGoogleKmsCryptoKey_importOnly(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go.erb
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go.erb
@@ -843,6 +843,7 @@ resource "google_kms_crypto_key" "crypto_key" {
 func testGoogleKmsCryptoKey_keyAccessJustificationsPolicy(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, allowed_access_reason string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
+  provider = google-beta
   name            = "%s"
   project_id      = "%s"
   org_id          = "%s"
@@ -850,11 +851,13 @@ resource "google_project" "acceptance" {
 }
 
 resource "google_project_service" "acceptance" {
+  provider = google-beta
   project = google_project.acceptance.project_id
   service = "cloudkms.googleapis.com"
 }
 
 resource "google_kms_key_ring" "key_ring" {
+  provider = google-beta
   project  = google_project_service.acceptance.project
   name     = "%s"
   location = "us-central1"

--- a/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go.erb
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package kms_test
 
 import (

--- a/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go.erb
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go.erb
@@ -318,7 +318,7 @@ func TestAccKmsCryptoKey_destroyDuration(t *testing.T) {
 	})
 }
 
-<% unless version == "ga" -%>
+<% unless version == 'ga' -%>
 func TestAccKmsCryptoKey_keyAccessJustificationsPolicy(t *testing.T) {
 	t.Parallel()
 
@@ -355,7 +355,7 @@ func TestAccKmsCryptoKey_keyAccessJustificationsPolicy(t *testing.T) {
 			},
 			// Use a separate TestStep rather than a CheckDestroy because we need the project to still exist.
 			{
-				Config: testGoogleKmsCryptoKey_removed(projectId, projectOrg, projectBillingAccount, keyRingName),
+				Config: testGoogleKmsCryptoKey_removedBeta(projectId, projectOrg, projectBillingAccount, keyRingName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleKmsCryptoKeyWasRemovedFromState("google_kms_crypto_key.crypto_key"),
 					testAccCheckGoogleKmsCryptoKeyVersionsDestroyed(t, projectId, location, keyRingName, cryptoKeyName),
@@ -808,6 +808,31 @@ resource "google_kms_key_ring" "key_ring" {
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName)
 }
 
+func testGoogleKmsCryptoKey_removedBeta(projectId, projectOrg, projectBillingAccount, keyRingName string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+  provider        = google-beta
+  name            = "%s"
+  project_id      = "%s"
+  org_id          = "%s"
+  billing_account = "%s"
+}
+
+resource "google_project_service" "acceptance" {
+  provider = google-beta
+  project  = google_project.acceptance.project_id
+  service  = "cloudkms.googleapis.com"
+}
+
+resource "google_kms_key_ring" "key_ring" {
+  provider = google-beta
+  project  = google_project_service.acceptance.project
+  name     = "%s"
+  location = "us-central1"
+}
+`, projectId, projectId, projectOrg, projectBillingAccount, keyRingName)
+}
+
 func testGoogleKmsCryptoKey_destroyDuration(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
@@ -839,11 +864,11 @@ resource "google_kms_crypto_key" "crypto_key" {
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
 }
 
-<% unless version == "ga" -%>
+<% unless version == 'ga' -%>
 func testGoogleKmsCryptoKey_keyAccessJustificationsPolicy(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, allowed_access_reason string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
-  provider = google-beta
+  provider        = google-beta
   name            = "%s"
   project_id      = "%s"
   org_id          = "%s"
@@ -852,8 +877,8 @@ resource "google_project" "acceptance" {
 
 resource "google_project_service" "acceptance" {
   provider = google-beta
-  project = google_project.acceptance.project_id
-  service = "cloudkms.googleapis.com"
+  project  = google_project.acceptance.project_id
+  service  = "cloudkms.googleapis.com"
 }
 
 resource "google_kms_key_ring" "key_ring" {

--- a/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go.erb
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go.erb
@@ -808,6 +808,7 @@ resource "google_kms_key_ring" "key_ring" {
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName)
 }
 
+<% unless version == 'ga' -%>
 func testGoogleKmsCryptoKey_removedBeta(projectId, projectOrg, projectBillingAccount, keyRingName string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
@@ -832,6 +833,7 @@ resource "google_kms_key_ring" "key_ring" {
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName)
 }
+<% end -%>
 
 func testGoogleKmsCryptoKey_destroyDuration(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go.erb
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go.erb
@@ -332,7 +332,7 @@ func TestAccKmsCryptoKey_keyAccessJustificationsPolicy(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testGoogleKmsCryptoKey_keyAccessJustificationsPolicy(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, allowedAccessReason),
@@ -860,6 +860,7 @@ resource "google_kms_key_ring" "key_ring" {
 }
 
 resource "google_kms_crypto_key" "crypto_key" {
+  provider = google-beta
   name     = "%s"
   key_ring = google_kms_key_ring.key_ring.id
   labels = {


### PR DESCRIPTION
The field is beta-only. The change in this PR is based on the instructions on how to add beta-only tests.

Fixed https://github.com/hashicorp/terraform-provider-google/issues/19083

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
kms: restrict beta-only field test to beta environment
```
