### PR TITLE
add restrictedFields functionality

### DIFF
--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config.go
@@ -36,6 +36,14 @@ var loggingBucketConfigSchema = map[string]*schema.Schema{
 		Computed:    true,
 		Description: `An optional description for this bucket.`,
 	},
+	"restricted_fields": {
+		Type:        schema.TypeList,
+		Optional:    true,
+		Description: `Optional fields to configure with field-level access`,
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+	},
 	"retention_days": {
 		Type:        schema.TypeInt,
 		Optional:    true,
@@ -205,7 +213,7 @@ func resourceLoggingBucketConfigAcquireOrCreate(parentType string, iDFunc loggin
 				UserAgent: userAgent,
 			})
 			if res == nil {
-				log.Printf("[DEGUG] Loggin Bucket not exist %s", id)
+				log.Printf("[DEGUG] Logging Bucket does not exist %s", id)
 				// we need to pass the id in here because we don't want to set it in state
 				// until we know there won't be any errors on create
 				return resourceLoggingBucketConfigCreate(d, meta, id)
@@ -228,6 +236,7 @@ func resourceLoggingBucketConfigCreate(d *schema.ResourceData, meta interface{},
 	obj := make(map[string]interface{})
 	obj["name"] = d.Get("name")
 	obj["description"] = d.Get("description")
+	obj["restrictedFields"] = d.Get("restricted_fields")
 	obj["retentionDays"] = d.Get("retention_days")
 	obj["cmekSettings"] = expandCmekSettings(d.Get("cmek_settings"))
 	obj["indexConfigs"] = expandIndexConfigs(d.Get("index_configs"))
@@ -304,6 +313,9 @@ func resourceLoggingBucketConfigRead(d *schema.ResourceData, meta interface{}) e
 	if err := d.Set("description", res["description"]); err != nil {
 		return fmt.Errorf("Error setting description: %s", err)
 	}
+	if err := d.Set("restricted_fields", res["restrictedFields"]); err != nil {
+		return fmt.Errorf("Error setting restricted_fields: %s", err)
+	}
 	if err := d.Set("lifecycle_state", res["lifecycleState"]); err != nil {
 		return fmt.Errorf("Error setting lifecycle_state: %s", err)
 	}
@@ -338,6 +350,7 @@ func resourceLoggingBucketConfigUpdate(d *schema.ResourceData, meta interface{})
 
 	obj["retentionDays"] = d.Get("retention_days")
 	obj["description"] = d.Get("description")
+	obj["restrictedFields"] = d.Get("restricted_fields")
 	obj["cmekSettings"] = expandCmekSettings(d.Get("cmek_settings"))
 	obj["indexConfigs"] = expandIndexConfigs(d.Get("index_configs"))
 
@@ -347,6 +360,9 @@ func resourceLoggingBucketConfigUpdate(d *schema.ResourceData, meta interface{})
 	}
 	if d.HasChange("description") {
 		updateMask = append(updateMask, "description")
+	}
+	if d.HasChange("restricted_fields") {
+		updateMask = append(updateMask, "restrictedFields")
 	}
 	if d.HasChange("cmek_settings") {
 		updateMask = append(updateMask, "cmekSettings")

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_bucket_config.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_bucket_config.go
@@ -42,6 +42,14 @@ var loggingProjectBucketConfigSchema = map[string]*schema.Schema{
 		Computed:    true,
 		Description: `An optional description for this bucket.`,
 	},
+	"restricted_fields": {
+		Type:        schema.TypeList,
+		Optional:    true,
+		Description: `Optional fields to configure with field-level access`,
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+	},
 	"locked": {
 		Type:        schema.TypeBool,
 		Optional:    true,
@@ -210,6 +218,7 @@ func resourceLoggingProjectBucketConfigCreate(d *schema.ResourceData, meta inter
 	obj := make(map[string]interface{})
 	obj["name"] = d.Get("name")
 	obj["description"] = d.Get("description")
+	obj["restrictedFields"] = d.Get("restricted_fields")
 	obj["locked"] = d.Get("locked")
 	obj["retentionDays"] = d.Get("retention_days")
 	// Only set analyticsEnabled if it has been explicitly preferenced.
@@ -299,6 +308,9 @@ func resourceLoggingProjectBucketConfigRead(d *schema.ResourceData, meta interfa
 	if err := d.Set("description", res["description"]); err != nil {
 		return fmt.Errorf("Error setting description: %s", err)
 	}
+	if err := d.Set("restricted_fields", res["restrictedFields"]); err != nil {
+		return fmt.Errorf("Error setting restricted_fields: %s", err)
+	}
 	if err := d.Set("locked", res["locked"]); err != nil {
 		return fmt.Errorf("Error setting locked: %s", err)
 	}
@@ -367,6 +379,7 @@ func resourceLoggingProjectBucketConfigUpdate(d *schema.ResourceData, meta inter
 
 	obj["retentionDays"] = d.Get("retention_days")
 	obj["description"] = d.Get("description")
+	obj["restrictedFields"] = d.Get("restricted_fields")
 	obj["cmekSettings"] = expandCmekSettings(d.Get("cmek_settings"))
 	obj["indexConfigs"] = expandIndexConfigs(d.Get("index_configs"))
 
@@ -376,6 +389,9 @@ func resourceLoggingProjectBucketConfigUpdate(d *schema.ResourceData, meta inter
 	}
 	if d.HasChange("description") {
 		updateMask = append(updateMask, "description")
+	}
+	if d.HasChange("restricted_fields") {
+		updateMask = append(updateMask, "restrictedFields")
 	}
 	if d.HasChange("cmek_settings") {
 		updateMask = append(updateMask, "cmekSettings")

--- a/mmv1/third_party/terraform/website/docs/r/logging_folder_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_folder_bucket_config.html.markdown
@@ -30,6 +30,11 @@ resource "google_logging_folder_bucket_config" "basic" {
     field_path = "jsonPayload.request.status"
     type       = "INDEX_TYPE_STRING"
   }
+
+  restricted_fields = [
+    "jsonPayload.url",
+    "jsonPayload.data"
+  ]
 }
 ```
 
@@ -55,6 +60,8 @@ The following arguments are supported:
   Note that some paths are automatically indexed, and other paths are not eligible for indexing. See [indexing documentation](https://cloud.google.com/logging/docs/analyze/custom-index) for details.
 
 * `type` - The type of data in this index. Allowed types include `INDEX_TYPE_UNSPECIFIED`, `INDEX_TYPE_STRING` and `INDEX_TYPE_INTEGER`.
+
+* `restricted_fields` - (Optional) A list of restricted fields requiring `logging.fields.access` permission to view. See [field-level access documentation](https://cloud.google.com/logging/docs/field-level-acl)
 
 ## Attributes Reference
 

--- a/mmv1/third_party/terraform/website/docs/r/logging_organization_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_organization_bucket_config.html.markdown
@@ -29,6 +29,11 @@ resource "google_logging_organization_bucket_config" "basic" {
     field_path = "jsonPayload.request.status"
     type       = "INDEX_TYPE_STRING"
   }
+
+  restricted_fields = [
+    "jsonPayload.url",
+    "jsonPayload.data"
+  ]
 }
 ```
 
@@ -54,6 +59,8 @@ The following arguments are supported:
   Note that some paths are automatically indexed, and other paths are not eligible for indexing. See [indexing documentation](https://cloud.google.com/logging/docs/analyze/custom-index) for details.
 
 * `type` - The type of data in this index. Allowed types include `INDEX_TYPE_UNSPECIFIED`, `INDEX_TYPE_STRING` and `INDEX_TYPE_INTEGER`.
+
+* `restricted_fields` - (Optional) A list of restricted fields requiring `logging.fields.access` permission to view. See [field-level access documentation](https://cloud.google.com/logging/docs/field-level-acl)
 
 ## Attributes Reference
 

--- a/mmv1/third_party/terraform/website/docs/r/logging_project_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_project_bucket_config.html.markdown
@@ -109,6 +109,22 @@ resource "google_logging_project_bucket_config" "example-project-bucket-index-co
 }
 ```
 
+Create logging bucket with field-level access
+
+```hcl
+resource "google_logging_project_bucket_config" "example-project-bucket-restricted-fields" {
+  project          = "project_id"
+  location         = "global"
+  retention_days   = 30
+  bucket_id        = "custom-bucket"
+
+  restricted_fields = [
+    "jsonPayload.url",
+    "jsonPayload.data"
+  ]
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -130,6 +146,8 @@ The following arguments are supported:
 * `cmek_settings` - (Optional) The CMEK settings of the log bucket. If present, new log entries written to this log bucket are encrypted using the CMEK key provided in this configuration. If a log bucket has CMEK settings, the CMEK settings cannot be disabled later by updating the log bucket. Changing the KMS key is allowed. Structure is [documented below](#nested_cmek_settings).
 
 * `index_configs` - (Optional) A list of indexed fields and related configuration data. Structure is [documented below](#nested_index_configs).
+
+* `restricted_fields` - (Optional) A list of restricted fields requiring `logging.fields.access` permission to view. See [field-level access documentation](https://cloud.google.com/logging/docs/field-level-acl)
 
 <a name="nested_cmek_settings"></a>The `cmek_settings` block supports:
 


### PR DESCRIPTION
This adds a `restricted_fields` list to the following resources:
- google_logging_project_bucket_config
- google_logging_folder_bucket_config
- google_logging_organization_bucket_config

Resolves [#10142](https://github.com/hashicorp/terraform-provider-google/issues/10142)

I've run though the contributing steps, however didn't have access to an organisation so the go tests were skipped when I ran them. However I have tested locally:

```hcl
resource "google_logging_project_bucket_config" "basic" {
    project    = var.project
    location  = "global"
    retention_days = 30
    bucket_id = "test-logs-bucket"
    restricted_fields = ["jsonPayload.url","jsonPayload.data"]
}
```

Results in with `terraform apply`:

```
Terraform will perform the following actions:

  # google_logging_project_bucket_config.basic will be created
  + resource "google_logging_project_bucket_config" "basic" {
      + bucket_id         = "test-logs-bucket"
      + description       = (known after apply)
      + id                = (known after apply)
      + lifecycle_state   = (known after apply)
      + location          = "global"
      + name              = (known after apply)
      + project           = "sandbox-385820"
      + restricted_fields = [
          + "jsonPayload.url",
          + "jsonPayload.data",
        ]
      + retention_days    = 30
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

google_logging_project_bucket_config.basic: Creating...
google_logging_project_bucket_config.basic: Creation complete after 2s [id=projects/sandbox-385820/locations/global/buckets/test-logs-bucket]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

`terraform show `
```hcl
# google_logging_project_bucket_config.basic:
resource "google_logging_project_bucket_config" "basic" {
    bucket_id         = "test-logs-bucket"
    enable_analytics  = false
    id                = "projects/sandbox-385820/locations/global/buckets/test-logs-bucket"
    lifecycle_state   = "ACTIVE"
    location          = "global"
    locked            = false
    name              = "projects/sandbox-385820/locations/global/buckets/test-logs-bucket"
    project           = "sandbox-385820"
    restricted_fields = [
        "jsonPayload.url",
        "jsonPayload.data",
    ]
    retention_days    = 30
}
```

Verifying that terraform isn't lying with:

```
LOCATION  BUCKET_ID         RETENTION_DAYS  CMEK  RESTRICTED_FIELDS                        INDEX_CONFIGS  LIFECYCLE_STATE   LOCKED  CREATE_TIME
global    test-logs-bucket  30                    ['jsonPayload.url', 'jsonPayload.data']                 ACTIVE                    2024-08-10T22:19:36.485466430Z  2024-08-10T23:02:08.506788736Z
```

Let me know if I've missed anything

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
logging: Added `restricted_fields` to `google_logging_project_bucket_config`, `google_logging_folder_bucket_config`, `google_logging_organization_bucket_config` resources
```
