### PR TITLE
Remove hardcoded values that are handled by the API

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
@@ -1207,9 +1207,6 @@ func buildDisks(d *schema.ResourceData, config *transport_tpg.Config) ([]*comput
 
 		// Build the disk
 		var disk compute.AttachedDisk
-		disk.Type = "PERSISTENT"
-		disk.Mode = "READ_WRITE"
-		disk.Interface = "SCSI"
 		disk.Boot = i == 0
 		disk.AutoDelete = d.Get(prefix + ".auto_delete").(bool)
 
@@ -1620,10 +1617,6 @@ func reorderDisks(configDisks []interface{}, apiDisks []map[string]interface{}) 
 			disksByDeviceName[v.(string)] = i
 		} else if v := disk["type"]; v.(string) == "SCRATCH" {
 			iface := disk["interface"].(string)
-			if iface == "" {
-				// apply-time default
-				iface = "SCSI"
-			}
 			scratchDisksByInterface[iface] = append(scratchDisksByInterface[iface], i)
 		} else if v := disk["source"]; v.(string) != "" {
 			attachedDisksBySource[v.(string)] = i

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_internal_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_internal_test.go.tmpl
@@ -22,8 +22,9 @@ func TestComputeRegionInstanceTemplate_reorderDisks(t *testing.T) {
 	cDeviceName := map[string]interface{}{
 		"device_name": "disk-1",
 	}
-	cScratch := map[string]interface{}{
+	cScratchScsi := map[string]interface{}{
 		"type": "SCRATCH",
+		"interface": "SCSI",
 	}
 	cSource := map[string]interface{}{
 		"source": "disk-source",
@@ -81,7 +82,7 @@ func TestComputeRegionInstanceTemplate_reorderDisks(t *testing.T) {
 				aBoot, aScratchNvme, aSource, aScratchScsi, aFallThrough, aDeviceName,
 			},
 			ConfigDisks: []interface{}{
-				cBoot, cFallThrough, cDeviceName, cScratch, cSource, cScratchNvme,
+				cBoot, cFallThrough, cDeviceName, cScratchScsi, cSource, cScratchNvme,
 			},
 			ExpectedResult: []map[string]interface{}{
 				aBoot, aFallThrough, aDeviceName, aScratchScsi, aSource, aScratchNvme,
@@ -92,7 +93,7 @@ func TestComputeRegionInstanceTemplate_reorderDisks(t *testing.T) {
 				aBoot, aNoMatch, aScratchNvme, aScratchScsi, aFallThrough, aDeviceName,
 			},
 			ConfigDisks: []interface{}{
-				cBoot, cFallThrough, cDeviceName, cScratch, cSource, cScratchNvme,
+				cBoot, cFallThrough, cDeviceName, cScratchScsi, cSource, cScratchNvme,
 			},
 			ExpectedResult: []map[string]interface{}{
 				aBoot, aFallThrough, aDeviceName, aScratchScsi, aScratchNvme, aNoMatch,
@@ -103,7 +104,7 @@ func TestComputeRegionInstanceTemplate_reorderDisks(t *testing.T) {
 				aBoot, aScratchNvme, aFallThrough, aSource, aScratchScsi, aFallThrough2, aDeviceName,
 			},
 			ConfigDisks: []interface{}{
-				cBoot, cFallThrough, cDeviceName, cScratch, cFallThrough, cSource, cScratchNvme,
+				cBoot, cFallThrough, cDeviceName, cScratchScsi, cFallThrough, cSource, cScratchNvme,
 			},
 			ExpectedResult: []map[string]interface{}{
 				aBoot, aFallThrough, aDeviceName, aScratchScsi, aFallThrough2, aSource, aScratchNvme,


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Resolves [Issue #5295](https://github.com/hashicorp/terraform-provider-google/issues/5295)

- removing hardcoded values from `buildDisks()` for instance_templates

Setting this to defaults is handled by the instance.Insert() API method already
```
--- PASS: TestAccComputeInstanceTemplate_disksInvalid (9.81s)
--- PASS: TestAccComputeInstanceTemplate_disks (28.82s)
```
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:note
compute: instance_template and region_instance_template no longer have predefined values on their disks on the provider-side 
```
