### PR TITLE
Add `tags` field to Folder resource

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_folder.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_folder.go
@@ -93,7 +93,7 @@ func resourceGoogleFolderCreate(d *schema.ResourceData, meta interface{}) error 
 	displayName := d.Get("display_name").(string)
 	parent := d.Get("parent").(string)
 
-	folder := &cloudresourcemanager.Folder{
+	folder := &resourceManagerV3.Folder{
 		DisplayName: displayName,
 		Parent:      parent,
 	}

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_folder.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_folder.go
@@ -65,6 +65,12 @@ func ResourceGoogleFolder() *schema.Resource {
 				Computed:    true,
 				Description: `Timestamp when the Folder was created. Assigned by the server. A timestamp in RFC3339 UTC "Zulu" format, accurate to nanoseconds. Example: "2014-10-02T15:01:23.045123456Z".`,
 			},
+			"deletion_protection": {
+				Type:        schema.TypeBool,
+				Optional:    true
+				Default:     true,
+				Description: `When the field is set to true or unset in Terraform state, a terraform apply or terraform destroy that would delete the instance will fail. When the field is set to false, deleting the instance is allowed.`,
+			},
 			"tags": {
 				Type:        schema.TypeMap,
 				Optional:    true,
@@ -152,6 +158,13 @@ func resourceGoogleFolderRead(d *schema.ResourceData, meta interface{}) error {
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Folder Not Found : %s", d.Id()))
 	}
 
+	// Explicitly set client-side fields to default values if unset
+	if _, ok := d.GetOkExists("deletion_protection"); !ok {
+		if err := d.Set("deletion_protection", true); err != nil {
+			return fmt.Errorf("Error setting deletion_protection: %s", err)
+		}
+	}
+
 	if err := d.Set("name", folder.Name); err != nil {
 		return fmt.Errorf("Error setting name: %s", err)
 	}
@@ -181,6 +194,19 @@ func resourceGoogleFolderUpdate(d *schema.ResourceData, meta interface{}) error 
 	if err != nil {
 		return err
 	}
+
+	clientSideFields := map[string]bool{"deletion_protection": true}
+	clientSideOnly := true
+	for field := range ResourceGoogleFolder().Schema {
+		if d.HasChange(field) && !clientSideFields[field] {
+			clientSideOnly = false
+			break
+		}
+	}
+	if clientSideOnly {
+		return nil
+	}
+
 	displayName := d.Get("display_name").(string)
 
 	d.Partial(true)
@@ -237,6 +263,11 @@ func resourceGoogleFolderDelete(d *schema.ResourceData, meta interface{}) error 
 	if err != nil {
 		return err
 	}
+
+	if d.Get("deletion_protection").(bool) {
+		return fmt.Errorf("cannot destroy folder without setting deletion_protection=false and running `terraform apply`")
+	}
+
 	displayName := d.Get("display_name").(string)
 
 	var op *resourceManagerV3.Operation

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_folder.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_folder.go
@@ -67,7 +67,7 @@ func ResourceGoogleFolder() *schema.Resource {
 			},
 			"deletion_protection": {
 				Type:        schema.TypeBool,
-				Optional:    true
+				Optional:    true,
 				Default:     true,
 				Description: `When the field is set to true or unset in Terraform state, a terraform apply or terraform destroy that would delete the instance will fail. When the field is set to false, deleting the instance is allowed.`,
 			},
@@ -105,10 +105,7 @@ func resourceGoogleFolderCreate(d *schema.ResourceData, meta interface{}) error 
 	err = transport_tpg.Retry(transport_tpg.RetryOptions{
 		RetryFunc: func() error {
 			var reqErr error
-			op, reqErr = config.NewResourceManagerV3Client(userAgent).Folders.Create(&resourceManagerV3.Folder{
-				DisplayName: displayName,
-				Parent:      parent,
-			}).Do()
+			op, reqErr = config.NewResourceManagerV3Client(userAgent).Folders.Create(folder).Do()
 			return reqErr
 		},
 		Timeout: d.Timeout(schema.TimeoutCreate),
@@ -157,14 +154,12 @@ func resourceGoogleFolderRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Folder Not Found : %s", d.Id()))
 	}
-
 	// Explicitly set client-side fields to default values if unset
 	if _, ok := d.GetOkExists("deletion_protection"); !ok {
 		if err := d.Set("deletion_protection", true); err != nil {
 			return fmt.Errorf("Error setting deletion_protection: %s", err)
 		}
 	}
-
 	if err := d.Set("name", folder.Name); err != nil {
 		return fmt.Errorf("Error setting name: %s", err)
 	}

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_folder_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_folder_test.go
@@ -116,13 +116,13 @@ func TestAccFolder_tags(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"tags", "deletion_protection"}, // we don't read tags back
 			},
-			// Update tags tries to replace project but fails due to deletion protection
+			// Update tags tries to replace the folder but fails due to deletion protection
 			{
-				Config:      testAccFolder_tags(folderDisplayName, org, map[string]string{org + "/env": "staging"}),
+				Config:      testAccFolder_tags(folderDisplayName, org, map[string]string{}),
 				ExpectError: regexp.MustCompile("deletion_protection"),
 			},
 			{
-				Config: testAccFolder_tagsAllowDestroy(folderDisplayName, parent, map[string]string{org + "/env": "test"}),
+				Config: testAccFolder_tagsAllowDestroy(folderDisplayName, parent, map[string]string{org + "/" + tagKey: tagValue}),
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_folder_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_folder_test.go
@@ -89,7 +89,7 @@ func TestAccFolder_moveParent(t *testing.T) {
 	})
 }
 
-// Test that a Project resource can be created with tags
+// Test that a Folder resource can be created with tags
 func TestAccFolder_tags(t *testing.T) {
 	t.Parallel()
 

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_folder_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_folder_test.go
@@ -96,13 +96,15 @@ func TestAccFolder_tags(t *testing.T) {
 	org := envvar.GetTestOrgFromEnv(t)
 	parent := "organizations/" + org
 	folderDisplayName := "tf-test-" + acctest.RandString(t, 10)
+	tagKey := acctest.BootstrapSharedTestTagKey(t, "crm-folder-tagkey")
+	tagValue := acctest.BootstrapSharedTestTagValue(t, "crm-folder-tagvalue", tagKey)
 	folder_tags := resourceManagerV3.Folder{}
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFolder_tags(folderDisplayName, parent, map[string]string{org + "/env": "test"}),
+				Config: testAccFolder_tags(folderDisplayName, parent, map[string]string{org + "/" + tagKey: tagValue}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleFolderExists(t, "google_folder.folder_tags", &folder_tags),
 				),

--- a/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
@@ -231,10 +231,19 @@ These were never intended to be set this way. Removing the fields from configura
 ### `secondary_ip_range = []` is no longer valid configuration
 
 To explicitly set an empty list of objects, use `send_secondary_ip_range_if_empty = true` and completely remove `secondary_ip_range` from config.
-
 Previously, to explicitly set `secondary_ip_range` as an empty list of objects, the specific configuration `secondary_ip_range = []` was necessary.
 This was to maintain compatability in behavior between Terraform versions 0.11 and 0.12 using a special setting ["attributes as blocks"](https://developer.hashicorp.com/terraform/language/attr-as-blocks).
 This special setting causes other breakages so it is now removed, with `send_secondary_ip_range_if_empty` available instead.
+
+## Resource: `google_storage_bucket`
+
+### `lifecycle_rule.condition.no_age` is now removed
+
+Previously `lifecycle_rule.condition.age` attirbute was being set zero value by default and `lifecycle_rule.condition.no_age` was introduced to prevent that.
+Now `lifecycle_rule.condition.no_age` is no longer supported and `lifecycle_rule.condition.age` won't set a zero value by default.
+Removed in favor of the field `lifecycle_rule.condition.send_age_if_zero` which can be used to set zero value for `lifecycle_rule.condition.age` attribute.
+
+For a seamless update, if your state today uses `no_age=true`, update it to remove `no_age` and set `send_age_if_zero=false`. If you do not use `no_age=true`, you will need to add `send_age_if_zero=true` to your state to avoid any changes after updating to 6.0.0.
 
 ## Resource: `google_container_cluster`
 

--- a/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
@@ -231,19 +231,10 @@ These were never intended to be set this way. Removing the fields from configura
 ### `secondary_ip_range = []` is no longer valid configuration
 
 To explicitly set an empty list of objects, use `send_secondary_ip_range_if_empty = true` and completely remove `secondary_ip_range` from config.
+
 Previously, to explicitly set `secondary_ip_range` as an empty list of objects, the specific configuration `secondary_ip_range = []` was necessary.
 This was to maintain compatability in behavior between Terraform versions 0.11 and 0.12 using a special setting ["attributes as blocks"](https://developer.hashicorp.com/terraform/language/attr-as-blocks).
 This special setting causes other breakages so it is now removed, with `send_secondary_ip_range_if_empty` available instead.
-
-## Resource: `google_storage_bucket`
-
-### `lifecycle_rule.condition.no_age` is now removed
-
-Previously `lifecycle_rule.condition.age` attirbute was being set zero value by default and `lifecycle_rule.condition.no_age` was introduced to prevent that.
-Now `lifecycle_rule.condition.no_age` is no longer supported and `lifecycle_rule.condition.age` won't set a zero value by default.
-Removed in favor of the field `lifecycle_rule.condition.send_age_if_zero` which can be used to set zero value for `lifecycle_rule.condition.age` attribute.
-
-For a seamless update, if your state today uses `no_age=true`, update it to remove `no_age` and set `send_age_if_zero=false`. If you do not use `no_age=true`, you will need to add `send_age_if_zero=true` to your state to avoid any changes after updating to 6.0.0.
 
 ## Resource: `google_container_cluster`
 

--- a/mmv1/third_party/terraform/website/docs/r/google_folder.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_folder.html.markdown
@@ -20,6 +20,8 @@ resource must have `roles/resourcemanager.folderCreator`. See the
 [Access Control for Folders Using IAM](https://cloud.google.com/resource-manager/docs/access-control-folders)
 doc for more information.
 
+~> It may take a while for the attached tag bindings to be deleted after the folder is scheduled to be deleted. 
+
 ## Example Usage
 
 ```hcl
@@ -33,6 +35,13 @@ resource "google_folder" "department1" {
 resource "google_folder" "team-abc" {
   display_name = "Team ABC"
   parent       = google_folder.department1.name
+}
+
+# Folder with a tag
+resource "google_folder" "department1" {
+  display_name = "Department 1"
+  parent       = "organizations/1234567"
+  tags = {"1234567/env":"staging"}
 }
 ```
 

--- a/mmv1/third_party/terraform/website/docs/r/google_folder.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_folder.html.markdown
@@ -46,6 +46,8 @@ The following arguments are supported:
 * `parent` - (Required) The resource name of the parent Folder or Organization.
     Must be of the form `folders/{folder_id}` or `organizations/{org_id}`.
 
+* `tags` - (Optional) A map of resource manager tags. Resource manager tag keys and values have the same definition as resource manager tags. Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456. The field is ignored when empty. The field is immutable and causes resource replacement when  mutated.
+
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add tags field to folder resource to allow setting tags on folder resources at creation time. 
Part of b/330143705

Part of  https://github.com/hashicorp/terraform-provider-google/issues/18904
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**
```release-note:enhancement
resourcemanager: added `tags` field to `google_folder` to allow setting tags for folders at creation time
```
