### PR TITLE
Prepare removal of guest_accelerator ConfigModeAttr

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -1741,6 +1741,20 @@ func TestAccComputeInstance_guestAcceleratorSkip(t *testing.T) {
 					testAccCheckComputeInstanceLacksGuestAccelerator(&instance),
 				),
 			},
+			// Recreate with guest_accelerator = []
+			{
+				Config: testAccComputeInstance_guestAcceleratorEmptyBlock(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceLacksGuestAccelerator(&instance),
+				),
+			},
+			// Check that count = 0 is the same as empty block []
+			{
+				Config:             testAccComputeInstance_guestAccelerator(instanceName, 0),
+				ExpectNonEmptyPlan: false,
+				PlanOnly:           true,
+			},
 		},
 	})
 
@@ -7096,6 +7110,38 @@ resource "google_compute_instance" "foobar" {
   }
 }
 `, instance, count)
+}
+
+func testAccComputeInstance_guestAcceleratorEmptyBlock(instance string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%s"
+  machine_type = "n1-standard-1"   // can't be e2 because of guest_accelerator
+  zone         = "us-east1-d"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+    # Instances with guest accelerators do not support live migration.
+    on_host_maintenance = "TERMINATE"
+  }
+
+  guest_accelerator = []
+}
+`, instance)
 }
 
 func testAccComputeInstance_minCpuPlatform(instance string) string {

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -1322,6 +1322,12 @@ func TestAccContainerNodePool_012_ConfigModeAttr(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 			},
+			{
+				// Test guest_accelerator.count = 0 is the same as guest_accelerator = []
+				Config:             testAccContainerNodePool_EmptyGuestAccelerator(cluster, np, networkName, subnetworkName),
+				ExpectNonEmptyPlan: false,
+				PlanOnly:           true,
+			},
 		},
 	})
 }
@@ -3800,6 +3806,7 @@ resource "google_container_node_pool" "np" {
 
   node_config {
     guest_accelerator = []
+	machine_type = "n1-highmem-4"
   }
 }
 `, cluster, networkName, subnetworkName, np)

--- a/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
@@ -126,6 +126,20 @@ Removed in favor of field `settings.ip_configuration.ssl_mode`.
 
 An empty value means the setting should be cleared.
 
+## Resources: `google_container_cluster`, `google_container_node_pool`, and `google_compute_instance`
+
+### `guest_accelerator = []` is no longer valid configuration
+
+To explicitly set an empty list of objects, set `guest_accelerator.count = 0`.
+
+Previously, to explicitly set `guest_accelerator` as an empty list of objects, the specific configuration `guest_accelerator = []` was necessary.
+This was to maintain compatability in behavior between Terraform versions 0.11 and 0.12 using a special setting ["attributes as blocks"](https://developer.hashicorp.com/terraform/language/attr-as-blocks).
+This special setting causes other breakages so it is now removed, with setting `guest_accelerator.count = 0` available as an alternative form of empty `guest_accelerator` object.
+
+### `guest_accelerator.gpu_driver_installation_config = []` and `guest_accelerator.gpu_sharing_config = []` are no longer valid configuration
+
+These were never intended to be set this way. Removing the fields from configuration should not produce a diff.
+
 ## Resource: `google_domain`
 
 ### Domain deletion now prevented by default with `deletion_protection`


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

part of https://github.com/hashicorp/terraform-provider-google/issues/12824

`guest_accelerator`'s ConfigModeAttr can be directly removed in 6.0 because:
1. [existing logic](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb#L2247) to make `guest_accelerator.count = 0` count as an empty entry, therefore an alternative way to send an empty list
2. The field is `ForceNew`, meaning we don't need update functionality

I've manually tested that there is no difference between `count = 0` and `guest_accelerator = []` for `google_container_cluster`, `google_container_node_pool`, and `google_compute_instance`, and have added tests for them as well.


The child fields `guest_accelerator.gpu_driver_installation_config` and `guest_accelerator.gpu_sharing_config` have been added AFTER the 0.11->0.12 upgrade and look to have just copied the ConfigModeAttr attribute mistakenly: https://github.com/GoogleCloudPlatform/magic-modules/pull/8348/files#diff-058ffca5a3cb3663c791422e055902e433e8f27f44fd144c667cfe5ed95556eeR117 and https://github.com/GoogleCloudPlatform/magic-modules/pull/6628/files#diff-542bf08ccbb9e20a2abbf127fde6d38f61c83124b05370a5e53d3e4caa3512f4R110
In the rare chance a user has somehow utilized the empty block configuration `[]` for these, just removing the fields entirely will not produce a diff due to O+C.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
