### PR TITLE
Explicitly state breaking modules as a concern with making settable fields read-only

### DIFF
--- a/docs/content/develop/breaking-changes/breaking-changes.md
+++ b/docs/content/develop/breaking-changes/breaking-changes.md
@@ -63,6 +63,8 @@ For more information, see
 * <a name="field-becoming-computed"></a> Making a settable field read-only
   * For MMv1 resources, adding `output: true` to an existing field.
   * For handwritten resources, adding `Computed: true` to a field that does not have `Optional: true` set.
+  * Even if there is no valid scenario where a field can be set, changing it to read-only may be a breaking change for
+    modules that depend on the provider.
 * <a name="field-oc-to-c"></a> Removing support for API-side defaults
   * For MMv1 resources, removing `default_from_api: true`.
   * For handwritten resources, altering a field schema with `Computed: true` + `Optional: true`


### PR DESCRIPTION


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
