### PR TITLE
Fixes tests TestAccDataSourceGoogleFirebaseAndroidAppConfig

### DIFF
--- a/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_android_app_config_test.go.erb
+++ b/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_android_app_config_test.go.erb
@@ -17,7 +17,7 @@ func TestAccDataSourceGoogleFirebaseAndroidAppConfig(t *testing.T) {
 
 	context := map[string]interface{}{
 		"project_id":   envvar.GetTestProjectFromEnv(),
-		"package_name":    "android.app." + acctest.RandString(t, 5),
+		"package_name": "android.package.app" + acctest.RandString(t, 5),
 		"display_name": "tf-test Display Name AndroidAppConfig DataSource",
 	}
 

--- a/mmv1/third_party/terraform/services/firebase/go/data_source_google_firebase_android_app_config_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebase/go/data_source_google_firebase_android_app_config_test.go.tmpl
@@ -16,7 +16,7 @@ func TestAccDataSourceGoogleFirebaseAndroidAppConfig(t *testing.T) {
 
 	context := map[string]interface{}{
 		"project_id":   envvar.GetTestProjectFromEnv(),
-		"package_name":    "android.app." + acctest.RandString(t, 5),
+		"package_name":    "android.package.app" + acctest.RandString(t, 5),
 		"display_name": "tf-test Display Name AndroidAppConfig DataSource",
 	}
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/19090

Each segment of an Android package name should start with a letter, but the randomString() generator doesn't know about that, which is why it fails only occasionally. This is test only. Real users aren't be affected because Play won't allow them to publish an Android app with an invalid package name.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
Test only changes
```
