### PR TITLE
Add handwritten sweeper for google_data_loss_prevention_discovery_config

### DIFF
--- a/mmv1/products/dlp/DiscoveryConfig.yaml
+++ b/mmv1/products/dlp/DiscoveryConfig.yaml
@@ -29,6 +29,7 @@ references: !ruby/object:Api::Resource::ReferenceLinks
     'Schedule inspection scan': 'https://cloud.google.com/dlp/docs/schedule-inspection-scan'
   api: 'https://cloud.google.com/dlp/docs/reference/rest/v2/projects.locations.discoveryConfigs'
 id_format: '{{parent}}/discoveryConfigs/{{name}}'
+skip_sweeper: true
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'dlp_discovery_config_basic'

--- a/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_discovery_config_sweeper.go
+++ b/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_discovery_config_sweeper.go
@@ -1,0 +1,106 @@
+package datalossprevention
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-provider-google/google/sweeper"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func init() {
+	sweeper.AddTestSweepers("DataLossPreventionDiscoveryConfig", testSweepDataLossPreventionDiscoveryConfig)
+}
+
+// At the time of writing, the CI only passes us-central1 as the region
+func testSweepDataLossPreventionDiscoveryConfig(region string) error {
+	resourceName := "DataLossPreventionDiscoveryConfig"
+	log.Printf("[INFO][SWEEPER_LOG] Starting sweeper for %s", resourceName)
+
+	config, err := sweeper.SharedConfigForRegion(region)
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error getting shared config for region: %s", err)
+		return err
+	}
+
+	err = config.LoadAndValidate(context.Background())
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error loading: %s", err)
+		return err
+	}
+
+	// Setup variables to replace in list template
+	d := &tpgresource.ResourceDataMock{
+		FieldsInSchema: map[string]interface{}{
+			"project":  config.Project,
+			"region":   region,
+			"location": region,
+			"zone":     "-",
+		},
+	}
+
+	listTemplate := strings.Split("https://dlp.googleapis.com/v2/projects/{{project}}/locations/{{location}}/discoveryConfigs", "?")[0]
+	listUrl, err := tpgresource.ReplaceVars(d, config, listTemplate)
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error preparing sweeper list url: %s", err)
+		return nil
+	}
+
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   config.Project,
+		RawURL:    listUrl,
+		UserAgent: config.UserAgent,
+	})
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)
+		return nil
+	}
+
+	resourceList, ok := res["discoveryConfigs"]
+	if !ok {
+		log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
+		return nil
+	}
+
+	rl := resourceList.([]interface{})
+
+	log.Printf("[INFO][SWEEPER_LOG] Found %d items in %s list response.", len(rl), resourceName)
+	for _, ri := range rl {
+		obj := ri.(map[string]interface{})
+		if obj["name"] == nil {
+			log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
+			return nil
+		}
+
+		// Note that we do not check for a sweepable prefix here.
+		// We can have at most 1 DiscoveryConfig for a storage type in the same project/location, so ensure we delete everything.
+		name := tpgresource.GetResourceNameFromSelfLink(obj["name"].(string))
+
+		deleteTemplate := "https://dlp.googleapis.com/v2/projects/{{project}}/locations/{{location}}/discoveryConfigs/{{name}}"
+		deleteUrl, err := tpgresource.ReplaceVars(d, config, deleteTemplate)
+		if err != nil {
+			log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
+			return nil
+		}
+		deleteUrl = deleteUrl + name
+
+		// Don't wait on operations as we may have a lot to delete
+		_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "DELETE",
+			Project:   config.Project,
+			RawURL:    deleteUrl,
+			UserAgent: config.UserAgent,
+		})
+		if err != nil {
+			log.Printf("[INFO][SWEEPER_LOG] Error deleting for url %s : %s", deleteUrl, err)
+		} else {
+			log.Printf("[INFO][SWEEPER_LOG] Sent delete request for %s resource: %s", resourceName, name)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Addresses https://github.com/hashicorp/terraform-provider-google/issues/19089.

This PR:

- Adds a new sweeper to remove DiscoveryConfigs in the location passed by the sweeper (us-central1)
- Creates a sweeper that **does not** check for unsweepable resources, as there should be only one DiscoveryConfig of each storage type per location per project, so we must delete all DiscoveryConfigs in this location and project to avoid impacting CI tests
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
