### PR TITLE
logging_project_bucket_config: support "no preference" for enable_analytics setting.

### DIFF
--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_bucket_config.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_bucket_config.go
@@ -170,7 +170,6 @@ func resourceLoggingProjectBucketConfigAcquireOrCreate(parentType string, iDFunc
 		if err != nil {
 			return err
 		}
-
 		if parentType == "project" {
 			//logging bucket can be created only at the project level, in future api may allow for folder, org and other parent resources
 
@@ -187,7 +186,7 @@ func resourceLoggingProjectBucketConfigAcquireOrCreate(parentType string, iDFunc
 				UserAgent: userAgent,
 			})
 			if res == nil {
-				log.Printf("[DEGUG] Loggin Bucket not exist %s", id)
+				log.Printf("[DEBUG] Logging Bucket does not exist %s", id)
 				// we need to pass the id in here because we don't want to set it in state
 				// until we know there won't be any errors on create
 				return resourceLoggingProjectBucketConfigCreate(d, meta, id)
@@ -212,7 +211,11 @@ func resourceLoggingProjectBucketConfigCreate(d *schema.ResourceData, meta inter
 	obj["description"] = d.Get("description")
 	obj["locked"] = d.Get("locked")
 	obj["retentionDays"] = d.Get("retention_days")
-	obj["analyticsEnabled"] = d.Get("enable_analytics")
+	// Only set analyticsEnabled if it has been explicitly preferenced.
+	analyticsRawValue := d.GetRawConfig().GetAttr("enable_analytics")
+	if !analyticsRawValue.IsNull() {
+		obj["analyticsEnabled"] = analyticsRawValue.True()
+	}
 	obj["cmekSettings"] = expandCmekSettings(d.Get("cmek_settings"))
 	obj["indexConfigs"] = expandIndexConfigs(d.Get("index_configs"))
 

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_bucket_config.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_bucket_config.go
@@ -170,6 +170,7 @@ func resourceLoggingProjectBucketConfigAcquireOrCreate(parentType string, iDFunc
 		if err != nil {
 			return err
 		}
+
 		if parentType == "project" {
 			//logging bucket can be created only at the project level, in future api may allow for folder, org and other parent resources
 


### PR DESCRIPTION
Addresses https://github.com/hashicorp/terraform-provider-google/issues/19099

Before this change, omitting the `enable_analytics` option was interpreted as a desire to specifically disable analytics during logging bucket creation. This updates the behavior to omit the field in the creation if the user didn't specify it, better reflecting user intent.

For existing and new templates, this has no practical effect -- omitting the field will still create a bucket without analytics, but this provides more context in the creation request to the Logging API.

Also fixed typos in an existing log statement.

```release-note:enhancement
logging: changed enable_analytics parsing to "no preference" in analytics if omitted, instead of explicitly disabling analytics.
```
