### PR TITLE
Add send_age_if_zero field and deprecate no_age

### DIFF
--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
@@ -229,6 +229,7 @@ func ResourceStorageBucket() *schema.Resource {
 									},
 									"no_age": {
 										Type:        schema.TypeBool,
+										Deprecated:  "`no_age` is deprecated and will be removed in a future major release. Use `send_age_if_zero` instead.",
 										Optional:    true,
 										Description: `While set true, age value will be omitted.Required to set true when age is unset in the config file.`,
 									},
@@ -261,6 +262,12 @@ func ResourceStorageBucket() *schema.Resource {
 										Optional:    true,
 										Elem:        &schema.Schema{Type: schema.TypeString},
 										Description: `One or more matching name suffixes to satisfy this condition.`,
+									},
+									"send_age_if_zero": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Default:     true,
+										Description: `While set true, age value will be sent in the request even for zero value of the field. This field is only useful for setting 0 value to the age field. It can be used alone or together with age.`,
 									},
 									"send_days_since_noncurrent_time_if_zero": {
 										Type:        schema.TypeBool,
@@ -1396,13 +1403,21 @@ func flattenBucketLifecycleRuleCondition(index int, d *schema.ResourceData, cond
 			ruleCondition["with_state"] = "ARCHIVED"
 		}
 	}
-  // setting no_age value from state config since it is terraform only variable and not getting value from backend.
+	// Setting the lifecycle condition virtual fields from the state file if they
+	// are already present otherwise setting them to individual default values.
 	if v, ok := d.GetOk(fmt.Sprintf("lifecycle_rule.%d.condition",index)); ok{
 		state_condition := v.(*schema.Set).List()[0].(map[string]interface{})
 		ruleCondition["no_age"] = state_condition["no_age"].(bool)
 		ruleCondition["send_days_since_noncurrent_time_if_zero"] = state_condition["send_days_since_noncurrent_time_if_zero"].(bool)
 		ruleCondition["send_days_since_custom_time_if_zero"] = state_condition["send_days_since_custom_time_if_zero"].(bool)
 		ruleCondition["send_num_newer_versions_if_zero"] = state_condition["send_num_newer_versions_if_zero"].(bool)
+		ruleCondition["send_age_if_zero"] = state_condition["send_age_if_zero"].(bool)
+	}  else {
+		ruleCondition["no_age"] = false
+		ruleCondition["send_age_if_zero"] = true
+		ruleCondition["send_days_since_noncurrent_time_if_zero"] = false
+		ruleCondition["send_days_since_custom_time_if_zero"] = false
+		ruleCondition["send_num_newer_versions_if_zero"] = false
 	}
 
 	return ruleCondition
@@ -1552,13 +1567,15 @@ func expandStorageBucketLifecycleRuleCondition(v interface{}) (*storage.BucketLi
 
 	condition := conditions[0].(map[string]interface{})
 	transformed := &storage.BucketLifecycleRuleCondition{}
-	// Setting high precedence of no_age over age when both used together.
+	// Setting high precedence of no_age over age and send_age_if_zero.
 	// Only sets age value when no_age is not present or no_age is present and has false value
 	if v, ok := condition["no_age"]; !ok || !(v.(bool)) {
 		if v, ok := condition["age"]; ok {
 			age := int64(v.(int))
-			transformed.Age = &age
-			transformed.ForceSendFields = append(transformed.ForceSendFields, "Age")
+			u, ok := condition["send_age_if_zero"]
+			if age > 0 || (ok && u.(bool)) {
+				transformed.Age = &age
+			}
 		}
 	}
 
@@ -1672,6 +1689,9 @@ func resourceGCSBucketLifecycleRuleConditionHash(v interface{}) int {
 	if v, ok := m["no_age"]; ok && v.(bool){
 		buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
 	} else {
+		if v, ok := m["send_age_if_zero"]; ok {
+			buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
+		}
 		if v, ok := m["age"]; ok {
 			buf.WriteString(fmt.Sprintf("%d-", v.(int)))
 		}

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb
@@ -48,12 +48,17 @@ func ResourceStorageBucket() *schema.Resource {
 			Read:   schema.DefaultTimeout(4 * time.Minute),
 		},
 
-		SchemaVersion: 1,
+		SchemaVersion: 2,
 		StateUpgraders: []schema.StateUpgrader{
 			{
 				Type:    resourceStorageBucketV0().CoreConfigSchema().ImpliedType(),
 				Upgrade: ResourceStorageBucketStateUpgradeV0,
 				Version: 0,
+			},
+			{
+				Type:    resourceStorageBucketV1().CoreConfigSchema().ImpliedType(),
+				Upgrade: ResourceStorageBucketStateUpgradeV1,
+				Version: 1,
 			},
 		},
 

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_600_migration.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_600_migration.go
@@ -1,5 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
 package storage
 
 import (

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_600_migration.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_600_migration.go
@@ -1,0 +1,531 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+package storage
+
+import (
+	"context"
+	"log"
+	"math"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/hashicorp/terraform-provider-google/google/verify"
+)
+
+func resourceStorageBucketV1() *schema.Resource {
+	return &schema.Resource{
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    resourceStorageBucketV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: ResourceStorageBucketStateUpgradeV0,
+				Version: 0,
+			},
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  `The name of the bucket.`,
+				ValidateFunc: verify.ValidateGCSName,
+			},
+
+			"encryption": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"default_kms_key_name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `A Cloud KMS key that will be used to encrypt objects inserted into this bucket, if no encryption method is specified. You must pay attention to whether the crypto key is available in the location that this bucket is created in. See the docs for more details.`,
+						},
+					},
+				},
+				Description: `The bucket's encryption configuration.`,
+			},
+
+			"requester_pays": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Enables Requester Pays on a storage bucket.`,
+			},
+
+			"force_destroy": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: `When deleting a bucket, this boolean option will delete all contained objects. If you try to delete a bucket that contains objects, Terraform will fail that run.`,
+			},
+
+			"labels": {
+				Type:         schema.TypeMap,
+				ValidateFunc: labelKeyValidator,
+				Optional:     true,
+				Elem:         &schema.Schema{Type: schema.TypeString},
+				Description:  `A set of key/value label pairs to assign to the bucket.`,
+			},
+
+			"terraform_labels": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: `The combination of labels configured directly on the resource and default labels configured on the provider.`,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+
+			"effective_labels": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: `All of labels (key/value pairs) present on the resource in GCP, including the labels configured through Terraform, other clients and services.`,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+
+			"location": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				StateFunc: func(s interface{}) string {
+					return strings.ToUpper(s.(string))
+				},
+				Description: `The Google Cloud Storage location`,
+			},
+
+			"project": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The ID of the project in which the resource belongs. If it is not provided, the provider project is used.`,
+			},
+
+			"project_number": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The project number of the project in which the resource belongs.`,
+			},
+
+			"self_link": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The URI of the created resource.`,
+			},
+
+			"url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The base URL of the bucket, in the format gs://<bucket-name>.`,
+			},
+
+			"storage_class": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "STANDARD",
+				Description: `The Storage Class of the new bucket. Supported values include: STANDARD, MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE.`,
+			},
+
+			"lifecycle_rule": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 100,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"action": {
+							Type:     schema.TypeSet,
+							Required: true,
+							MinItems: 1,
+							MaxItems: 1,
+							Set:      resourceGCSBucketLifecycleRuleActionHash,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: `The type of the action of this Lifecycle Rule. Supported values include: Delete, SetStorageClass and AbortIncompleteMultipartUpload.`,
+									},
+									"storage_class": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: `The target Storage Class of objects affected by this Lifecycle Rule. Supported values include: MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE.`,
+									},
+								},
+							},
+							Description: `The Lifecycle Rule's action configuration. A single block of this type is supported.`,
+						},
+						"condition": {
+							Type:     schema.TypeSet,
+							Required: true,
+							MinItems: 1,
+							MaxItems: 1,
+							Set:      resourceGCSBucketLifecycleRuleConditionHash,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"age": {
+										Type:        schema.TypeInt,
+										Optional:    true,
+										Description: `Minimum age of an object in days to satisfy this condition.`,
+									},
+									"created_before": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: `Creation date of an object in RFC 3339 (e.g. 2017-06-13) to satisfy this condition.`,
+									},
+									"custom_time_before": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: `Creation date of an object in RFC 3339 (e.g. 2017-06-13) to satisfy this condition.`,
+									},
+									"days_since_custom_time": {
+										Type:        schema.TypeInt,
+										Optional:    true,
+										Description: `Number of days elapsed since the user-specified timestamp set on an object.`,
+									},
+									"days_since_noncurrent_time": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										Description: `Number of days elapsed since the noncurrent timestamp of an object. This
+										condition is relevant only for versioned objects.`,
+									},
+									"noncurrent_time_before": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: `Creation date of an object in RFC 3339 (e.g. 2017-06-13) to satisfy this condition.`,
+									},
+									"no_age": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Description: `While set true, age value will be omitted.Required to set true when age is unset in the config file.`,
+									},
+									"with_state": {
+										Type:         schema.TypeString,
+										Computed:     true,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice([]string{"LIVE", "ARCHIVED", "ANY", ""}, false),
+										Description:  `Match to live and/or archived objects. Unversioned buckets have only live objects. Supported values include: "LIVE", "ARCHIVED", "ANY".`,
+									},
+									"matches_storage_class": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Description: `Storage Class of objects to satisfy this condition. Supported values include: MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE, STANDARD, DURABLE_REDUCED_AVAILABILITY.`,
+									},
+									"num_newer_versions": {
+										Type:        schema.TypeInt,
+										Optional:    true,
+										Description: `Relevant only for versioned objects. The number of newer versions of an object to satisfy this condition.`,
+									},
+									"matches_prefix": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Description: `One or more matching name prefixes to satisfy this condition.`,
+									},
+									"matches_suffix": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Description: `One or more matching name suffixes to satisfy this condition.`,
+									},
+									"send_days_since_noncurrent_time_if_zero": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Description: `While set true, days_since_noncurrent_time value will be sent in the request even for zero value of the field. This field is only useful for setting 0 value to the days_since_noncurrent_time field. It can be used alone or together with days_since_noncurrent_time.`,
+									},
+									"send_days_since_custom_time_if_zero": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Description: `While set true, days_since_custom_time value will be sent in the request even for zero value of the field. This field is only useful for setting 0 value to the days_since_custom_time field. It can be used alone or together with days_since_custom_time.`,
+									},
+									"send_num_newer_versions_if_zero": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Description: `While set true, num_newer_versions value will be sent in the request even for zero value of the field. This field is only useful for setting 0 value to the num_newer_versions field. It can be used alone or together with num_newer_versions.`,
+									},
+								},
+							},
+							Description: `The Lifecycle Rule's condition configuration.`,
+						},
+					},
+				},
+				Description: `The bucket's Lifecycle Rules configuration.`,
+			},
+
+			"enable_object_retention": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Enables each object in the bucket to have its own retention policy, which prevents deletion until stored for a specific length of time.`,
+			},
+
+			"versioning": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:        schema.TypeBool,
+							Required:    true,
+							Description: `While set to true, versioning is fully enabled for this bucket.`,
+						},
+					},
+				},
+				Description: `The bucket's Versioning configuration.`,
+			},
+
+			"autoclass": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:        schema.TypeBool,
+							Required:    true,
+							Description: `While set to true, autoclass automatically transitions objects in your bucket to appropriate storage classes based on each object's access pattern.`,
+						},
+						"terminal_storage_class": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: `The storage class that objects in the bucket eventually transition to if they are not read for a certain length of time. Supported values include: NEARLINE, ARCHIVE.`,
+						},
+					},
+				},
+				Description: `The bucket's autoclass configuration.`,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					_, n := d.GetChange(strings.TrimSuffix(k, ".#"))
+					if !strings.HasSuffix(k, ".#") {
+						return false
+					}
+					var l []interface{}
+					if new == "1" && old == "0" {
+						l = n.([]interface{})
+						contents, ok := l[0].(map[string]interface{})
+						if !ok {
+							return false
+						}
+						if contents["enabled"] == false {
+							return true
+						}
+					}
+					if new == "0" && old == "1" {
+						n := d.Get(strings.TrimSuffix(k, ".#"))
+						l = n.([]interface{})
+						contents := l[0].(map[string]interface{})
+						if contents["enabled"] == false {
+							return true
+						}
+					}
+					return false
+				},
+			},
+			"website": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"main_page_suffix": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							AtLeastOneOf: []string{"website.0.not_found_page", "website.0.main_page_suffix"},
+							Description:  `Behaves as the bucket's directory index where missing objects are treated as potential directories.`,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								return old != "" && new == ""
+							},
+						},
+						"not_found_page": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							AtLeastOneOf: []string{"website.0.main_page_suffix", "website.0.not_found_page"},
+							Description:  `The custom object to return when a requested resource is not found.`,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								return old != "" && new == ""
+							},
+						},
+					},
+				},
+				Description: `Configuration if the bucket acts as a website.`,
+			},
+
+			"retention_policy": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"is_locked": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: `If set to true, the bucket will be locked and permanently restrict edits to the bucket's retention policy.  Caution: Locking a bucket is an irreversible action.`,
+						},
+						"retention_period": {
+							Type:         schema.TypeInt,
+							Required:     true,
+							ValidateFunc: validation.IntBetween(1, math.MaxInt32),
+							Description:  `The period of time, in seconds, that objects in the bucket must be retained and cannot be deleted, overwritten, or archived. The value must be less than 3,155,760,000 seconds.`,
+						},
+					},
+				},
+				Description: `Configuration of the bucket's data retention policy for how long objects in the bucket should be retained.`,
+			},
+
+			"cors": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"origin": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+							Description: `The list of Origins eligible to receive CORS response headers. Note: "*" is permitted in the list of origins, and means "any Origin".`,
+						},
+						"method": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+							Description: `The list of HTTP methods on which to include CORS response headers, (GET, OPTIONS, POST, etc) Note: "*" is permitted in the list of methods, and means "any method".`,
+						},
+						"response_header": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+							Description: `The list of HTTP headers other than the simple response headers to give permission for the user-agent to share across domains.`,
+						},
+						"max_age_seconds": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: `The value, in seconds, to return in the Access-Control-Max-Age header used in preflight responses.`,
+						},
+					},
+				},
+				Description: `The bucket's Cross-Origin Resource Sharing (CORS) configuration.`,
+			},
+
+			"default_event_based_hold": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether or not to automatically apply an eventBasedHold to new objects added to the bucket.`,
+			},
+
+			"logging": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"log_bucket": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The bucket that will receive log objects.`,
+						},
+						"log_object_prefix": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: `The object prefix for log objects. If it's not provided, by default Google Cloud Storage sets this to this bucket's name.`,
+						},
+					},
+				},
+				Description: `The bucket's Access & Storage Logs configuration.`,
+			},
+			"uniform_bucket_level_access": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: `Enables uniform bucket-level access on a bucket.`,
+			},
+			"custom_placement_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"data_locations": {
+							Type:     schema.TypeSet,
+							Required: true,
+							ForceNew: true,
+							MaxItems: 2,
+							MinItems: 2,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								StateFunc: func(s interface{}) string {
+									return strings.ToUpper(s.(string))
+								},
+							},
+							Description: `The list of individual regions that comprise a dual-region bucket. See the docs for a list of acceptable regions. Note: If any of the data_locations changes, it will recreate the bucket.`,
+						},
+					},
+				},
+				Description: `The bucket's custom location configuration, which specifies the individual regions that comprise a dual-region bucket. If the bucket is designated a single or multi-region, the parameters are empty.`,
+			},
+			"rpo": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the RPO setting of bucket. If set 'ASYNC_TURBO', The Turbo Replication will be enabled for the dual-region bucket. Value 'DEFAULT' will set RPO setting to default. Turbo Replication is only for buckets in dual-regions.See the docs for more details.`,
+			},
+			"public_access_prevention": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Prevents public access to a bucket.`,
+			},
+			"soft_delete_policy": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Computed:    true,
+				Description: `The bucket's soft delete policy, which defines the period of time that soft-deleted objects will be retained, and cannot be permanently deleted. If it is not provided, by default Google Cloud Storage sets this to default soft delete policy`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"retention_duration_seconds": {
+							Type:        schema.TypeInt,
+							Default:     604800,
+							Optional:    true,
+							Description: `The duration in seconds that soft-deleted objects in the bucket will be retained and cannot be permanently deleted. Default value is 604800.`,
+						},
+						"effective_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Server-determined value that indicates the time from which the policy, or one with a greater retention, was effective. This value is in RFC 3339 format.`,
+						},
+					},
+				},
+			},
+		},
+		UseJSONNumber: true,
+	}
+}
+
+func ResourceStorageBucketStateUpgradeV1(_ context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	log.Printf("[DEBUG] Attributes before migration: %#v", rawState)
+	if rawState["lifecycle_rule"] != nil {
+		rawRules := rawState["lifecycle_rule"].([]interface{})
+		for i, r := range rawRules {
+			newRule := r.(map[string]interface{})
+			if newRule["condition"] != nil {
+				newCondition := newRule["condition"].([]interface{})[0].(map[string]interface{})
+				newCondition["send_age_if_zero"] = true
+				newRule["condition"].([]interface{})[0] = newCondition
+			}
+			rawState["lifecycle_rule"].([]interface{})[i] = newRule
+		}
+	}
+	log.Printf("[DEBUG] Attributes after migration: %#v", rawState)
+	return rawState, nil
+}

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.erb
@@ -461,7 +461,7 @@ func TestAccStorageBucket_lifecycleRulesMultiple(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy"},
+				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.send_age_if_zero","lifecycle_rule.1.condition.0.send_age_if_zero","lifecycle_rule.2.condition.0.send_age_if_zero","lifecycle_rule.3.condition.0.send_age_if_zero","lifecycle_rule.4.condition.0.send_age_if_zero","lifecycle_rule.5.condition.0.send_age_if_zero","lifecycle_rule.6.condition.0.send_age_if_zero","lifecycle_rule.7.condition.0.send_age_if_zero","lifecycle_rule.8.condition.0.send_age_if_zero","lifecycle_rule.9.condition.0.send_age_if_zero"},
 			},
 			{
 				Config: testAccStorageBucket_lifecycleRulesMultiple_update(bucketName),
@@ -470,7 +470,7 @@ func TestAccStorageBucket_lifecycleRulesMultiple(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy"},
+				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.send_age_if_zero","lifecycle_rule.1.condition.0.send_age_if_zero","lifecycle_rule.2.condition.0.send_age_if_zero","lifecycle_rule.3.condition.0.send_age_if_zero","lifecycle_rule.4.condition.0.send_age_if_zero","lifecycle_rule.5.condition.0.send_age_if_zero","lifecycle_rule.6.condition.0.send_age_if_zero","lifecycle_rule.7.condition.0.send_age_if_zero","lifecycle_rule.8.condition.0.send_age_if_zero","lifecycle_rule.9.condition.0.send_age_if_zero"},
 			},
 		},
 	})
@@ -499,7 +499,7 @@ func TestAccStorageBucket_lifecycleRuleStateLive(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy"},
+				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.send_age_if_zero","lifecycle_rule.1.condition.0.send_age_if_zero"},
 			},
 		},
 	})
@@ -528,7 +528,7 @@ func TestAccStorageBucket_lifecycleRuleStateArchived(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy"},
+				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.send_age_if_zero"},
 			},
 			{
 				Config: testAccStorageBucket_lifecycleRule_withStateArchived(bucketName),
@@ -542,7 +542,7 @@ func TestAccStorageBucket_lifecycleRuleStateArchived(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy"},
+				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.send_age_if_zero"},
 			},
 		},
 	})
@@ -571,7 +571,7 @@ func TestAccStorageBucket_lifecycleRuleStateAny(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy"},
+				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.send_age_if_zero"},
 			},
 			{
 				Config: testAccStorageBucket_lifecycleRule_withStateLive(bucketName),
@@ -585,7 +585,7 @@ func TestAccStorageBucket_lifecycleRuleStateAny(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy"},
+				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.send_age_if_zero","lifecycle_rule.1.condition.0.send_age_if_zero"},
 			},
 			{
 				Config: testAccStorageBucket_lifecycleRule_withStateAny(bucketName),
@@ -599,7 +599,7 @@ func TestAccStorageBucket_lifecycleRuleStateAny(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy"},
+				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.send_age_if_zero"},
 			},
 			{
 				Config: testAccStorageBucket_lifecycleRule_withStateArchived(bucketName),
@@ -613,7 +613,7 @@ func TestAccStorageBucket_lifecycleRuleStateAny(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy"},
+				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.send_age_if_zero"},
 			},
 		},
 	})
@@ -622,6 +622,7 @@ func TestAccStorageBucket_lifecycleRuleStateAny(t *testing.T) {
 func TestAccStorageBucket_lifecycleRulesVirtualFields(t *testing.T) {
 	t.Parallel()
 	var bucket storage.Bucket
+	zero_age := int64(0)
 	bucketName := acctest.TestBucketName(t)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -647,28 +648,30 @@ func TestAccStorageBucket_lifecycleRulesVirtualFields(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStorageBucketExists(
 						t, "google_storage_bucket.bucket", bucketName, &bucket),
-					testAccCheckStorageBucketLifecycleConditionNoAge(nil, &bucket),
+					testAccCheckStorageBucketLifecycleConditionNoAge(nil, &bucket, 1),
+					testAccCheckStorageBucketLifecycleConditionNoAge(&zero_age, &bucket, 2),
 				),
 			},
 			{
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.1.condition.0.no_age","lifecycle_rule.1.condition.0.send_days_since_noncurrent_time_if_zero","lifecycle_rule.2.condition.0.send_days_since_noncurrent_time_if_zero","lifecycle_rule.1.condition.0.send_days_since_custom_time_if_zero","lifecycle_rule.2.condition.0.send_days_since_custom_time_if_zero","lifecycle_rule.1.condition.0.send_num_newer_versions_if_zero","lifecycle_rule.2.condition.0.send_num_newer_versions_if_zero"},
+				ImportStateVerifyIgnore: []string{"force_destroy", "lifecycle_rule.1.condition.0.no_age", "lifecycle_rule.1.condition.0.send_days_since_noncurrent_time_if_zero", "lifecycle_rule.2.condition.0.send_days_since_noncurrent_time_if_zero", "lifecycle_rule.1.condition.0.send_days_since_custom_time_if_zero", "lifecycle_rule.2.condition.0.send_days_since_custom_time_if_zero", "lifecycle_rule.1.condition.0.send_num_newer_versions_if_zero", "lifecycle_rule.2.condition.0.send_num_newer_versions_if_zero", "lifecycle_rule.1.condition.0.send_age_if_zero"},
 			},
 			{
 				Config: testAccStorageBucket_customAttributes_withLifecycleVirtualFieldsUpdate2(bucketName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStorageBucketExists(
 						t, "google_storage_bucket.bucket", bucketName, &bucket),
-					testAccCheckStorageBucketLifecycleConditionNoAge(nil, &bucket),
+					testAccCheckStorageBucketLifecycleConditionNoAge(nil, &bucket, 1),
+					testAccCheckStorageBucketLifecycleConditionNoAge(nil, &bucket, 2),
 				),
 			},
 			{
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.1.condition.0.no_age","lifecycle_rule.0.condition.0.send_days_since_noncurrent_time_if_zero","lifecycle_rule.0.condition.0.send_days_since_custom_time_if_zero","lifecycle_rule.0.condition.0.send_num_newer_versions_if_zero"},
+				ImportStateVerifyIgnore: []string{"force_destroy", "lifecycle_rule.1.condition.0.no_age", "lifecycle_rule.0.condition.0.send_days_since_noncurrent_time_if_zero", "lifecycle_rule.0.condition.0.send_days_since_custom_time_if_zero", "lifecycle_rule.0.condition.0.send_num_newer_versions_if_zero", "lifecycle_rule.0.condition.0.send_age_if_zero", "lifecycle_rule.1.condition.0.send_age_if_zero", "lifecycle_rule.2.condition.0.send_age_if_zero"},
 			},
 			{
 				Config: testAccStorageBucket_customAttributes_withLifecycle1(bucketName),
@@ -847,7 +850,7 @@ func TestAccStorageBucket_update(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy"},
+				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.send_age_if_zero"},
 			},
 			{
 				Config: testAccStorageBucket_customAttributes_withLifecycle2(bucketName),
@@ -863,7 +866,7 @@ func TestAccStorageBucket_update(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy"},
+				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.send_age_if_zero","lifecycle_rule.1.condition.0.send_age_if_zero"},
 			},
 			{
 				Config: testAccStorageBucket_customAttributes_withLifecycle1Update(bucketName),
@@ -879,7 +882,7 @@ func TestAccStorageBucket_update(t *testing.T) {
 				ResourceName:            "google_storage_bucket.bucket",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy"},
+				ImportStateVerifyIgnore: []string{"force_destroy","lifecycle_rule.0.condition.0.send_age_if_zero"},
 			},
 			{
 				Config: testAccStorageBucket_customAttributes(bucketName),
@@ -1681,10 +1684,10 @@ func testAccCheckStorageBucketLifecycleConditionState(expected *bool, b *storage
 	}
 }
 
-func testAccCheckStorageBucketLifecycleConditionNoAge(expected *int64, b *storage.Bucket) resource.TestCheckFunc {
+func testAccCheckStorageBucketLifecycleConditionNoAge(expected *int64, b *storage.Bucket, index int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		actual := b.Lifecycle.Rule[1].Condition.Age
-		if expected == nil && b.Lifecycle.Rule[1].Condition.Age == nil {
+		actual := b.Lifecycle.Rule[index].Condition.Age
+		if expected == nil && b.Lifecycle.Rule[index].Condition.Age == nil {
 			return nil
 		}
 		if expected == nil {
@@ -1978,6 +1981,7 @@ resource "google_storage_bucket" "bucket" {
     condition {
       age = 10
       no_age = true
+      send_age_if_zero = false
       custom_time_before = "2022-09-01"
       days_since_noncurrent_time = 0
       send_days_since_noncurrent_time_if_zero = false
@@ -1992,6 +1996,7 @@ resource "google_storage_bucket" "bucket" {
       type = "Delete"
     }
     condition {
+      send_age_if_zero= false
       custom_time_before = "2022-09-01"
       send_days_since_noncurrent_time_if_zero = false
       send_days_since_custom_time_if_zero = false

--- a/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
@@ -215,7 +215,7 @@ that are derived from the API.
 
 ### `lifecycle_rule.condition.no_age` is now removed
 
-Previously `lifecycle_rule.condition.age` attirbute was being set zero value by default and `lifecycle_rule.condition.no_age` was introduced to prevent that.
+Previously `lifecycle_rule.condition.age` attribute was being set to zero by default and `lifecycle_rule.condition.no_age` was introduced to prevent that.
 Now `lifecycle_rule.condition.no_age` is no longer supported and `lifecycle_rule.condition.age` won't set a zero value by default.
 Removed in favor of the field `lifecycle_rule.condition.send_age_if_zero` which can be used to set zero value for `lifecycle_rule.condition.age` attribute. 
 

--- a/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
@@ -210,3 +210,13 @@ that are derived from the API.
 ### Resource: `google_identity_platform_project_default_config` is now removed
 
 `google_identity_platform_project_default_config` is removed in favor of `google_identity_platform_project_config`
+
+## Resource: `google_storage_bucket`
+
+### `lifecycle_rule.condition.no_age` is now removed
+
+Previously `lifecycle_rule.condition.age` attirbute was being set zero value by default and `lifecycle_rule.condition.no_age` was introduced to prevent that.
+Now `lifecycle_rule.condition.no_age` is no longer supported and `lifecycle_rule.condition.age` won't set a zero value by default.
+Removed in favor of the field `lifecycle_rule.condition.send_age_if_zero` which can be used to set zero value for `lifecycle_rule.condition.age` attribute. 
+
+For a seamless update, if your state today uses `no_age=true`, update it to remove `no_age` and set `send_age_if_zero=false`. If you do not use `no_age=true`, you will need to add `send_age_if_zero=true` to your state to avoid any changes after updating to 6.0.0. 

--- a/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
@@ -216,7 +216,9 @@ that are derived from the API.
 ### `lifecycle_rule.condition.no_age` is now removed
 
 Previously `lifecycle_rule.condition.age` attribute was being set to zero by default and `lifecycle_rule.condition.no_age` was introduced to prevent that.
-Now `lifecycle_rule.condition.no_age` is no longer supported and `lifecycle_rule.condition.age` won't set a zero value by default.
-Removed in favor of the field `lifecycle_rule.condition.send_age_if_zero` which can be used to set zero value for `lifecycle_rule.condition.age` attribute. 
+Now `lifecycle_rule.condition.no_age` is no longer supported and `lifecycle_rule.condition.age` won't be set to zero by default.
+Removed in favor of the field `lifecycle_rule.condition.send_age_if_zero` which can be used to set a zero value for the `lifecycle_rule.condition.age` attribute. 
 
-For a seamless update, if your state today uses `no_age=true`, update it to remove `no_age` and set `send_age_if_zero=false`. If you do not use `no_age=true`, you will need to add `send_age_if_zero=true` to your state to avoid any changes after updating to 6.0.0. 
+For a seamless update, if your state today uses `no_age=true`, update it to remove `no_age` and set `send_age_if_zero=false`. If you do not use `no_age=true` and desire to continue creating rules with an `age=0` condition, you will need to add `send_age_if_zero=true` to your state to avoid any changes after updating to 6.0.0. 
+
+With the 6.0.0 update, `send_age_if_zero` will be set to `false` by default unless declared explicitly `true`, and `age=0` conditions will be removed from existing buckets next time your `lifecycle_rule.condition` configuration is updated.

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -69,8 +69,8 @@ resource "google_storage_bucket" "auto-expire" {
 }
 ```
 
-## Example Usage - Life cycle settings for storage bucket objects with `no_age` enabled
-When creating a life cycle condition that does not also include an `age` field, a default `age` of 0 will be set. Set the `no_age` flag to `true` to prevent this and avoid any potentially unintended interactions.
+## Example Usage - Life cycle settings for storage bucket objects with `send_age_if_zero` disabled
+When creating a life cycle condition that does not also include an `age` field, a default `age` of 0 will be set. Set the `send_age_if_zero` flag to `false` to prevent this and avoid any potentially unintended interactions.
 
 ```hcl
 resource "google_storage_bucket" "no-age-enabled" {
@@ -85,7 +85,7 @@ resource "google_storage_bucket" "no-age-enabled" {
     }
     condition {
       days_since_noncurrent_time = 3
-      no_age = true
+      send_age_if_zero = false
     }
   }
 }
@@ -173,7 +173,7 @@ The following arguments are supported:
 
 * `age` - (Optional) Minimum age of an object in days to satisfy this condition. If not supplied alongside another condition and without setting `no_age` to `true`, a default `age` of 0 will be set.
 
-* `no_age` - (Optional) While set `true`, `age` value will be omitted from requests. This prevents a default age of `0` from being applied, and if you do not have an `age` value set, setting this to `true` is strongly recommended. When unset and other conditions are set to zero values, this can result in a rule that applies your action to all files in the bucket.
+* `no_age` - (Optional, Deprecated) While set `true`, `age` value will be omitted from requests. This prevents a default age of `0` from being applied, and if you do not have an `age` value set, setting this to `true` is strongly recommended. When unset and other conditions are set to zero values, this can result in a rule that applies your action to all files in the bucket. `no_age` is deprecated and will be removed in a future major release. Use `send_age_if_zero` instead.
 
 * `created_before` - (Optional) A date in the RFC 3339 format YYYY-MM-DD. This condition is satisfied when an object is created before midnight of the specified date in UTC.
 
@@ -192,6 +192,8 @@ The following arguments are supported:
 * `custom_time_before` - (Optional) A date in the RFC 3339 format YYYY-MM-DD. This condition is satisfied when the customTime metadata for the object is set to an earlier date than the date used in this lifecycle condition.
 
 * `days_since_custom_time` - (Optional)	Days since the date set in the `customTime` metadata for the object. This condition is satisfied when the current date and time is at least the specified number of days after the `customTime`. Due to a current bug you are unable to set this value to `0` within Terraform. When set to `0` it will be ignored, and your state will treat it as though you supplied no `days_since_custom_time` condition.
+
+* `send_age_if_zero` - (Optional, Default: true) While set true, `age` value will be sent in the request even for zero value of the field. This field is only useful and required for setting 0 value to the `age` field. It can be used alone or together with `age` attribute. **NOTE** `age` attibute with `0` value will be ommitted from the API request if `send_age_if_zero` field is having `false` value.
 
 * `send_days_since_custom_time_if_zero` - (Optional) While set true, `days_since_custom_time` value will be sent in the request even for zero value of the field. This field is only useful for setting 0 value to the `days_since_custom_time` field. It can be used alone or together with `days_since_custom_time`.
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Redo of https://github.com/GoogleCloudPlatform/magic-modules/pull/11098

Further details: only changes from the above pr are within the `mmv1/third_party/terraform/services/storage/resource_storage_bucket_600_migration.go` file, and adding the schema version/state upgraders to the top of `mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.erb` (i.e. [this commit](https://github.com/GoogleCloudPlatform/magic-modules/pull/11431/commits/a80468e9302f031f123b64f573f072dc9fbf07c3))

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:deprecation
storage: deprecated `lifecycle_rule.condition.no_age` field in `google_storage_bucket`. Use the new `lifecycle_rule.condition.send_age_if_zero` field instead.
```
