### PR TITLE
Improve comment about how plugin-framework provider is configured

### DIFF
--- a/mmv1/third_party/terraform/fwprovider/framework_provider.go.erb
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider.go.erb
@@ -259,9 +259,10 @@ func (p *FrameworkProvider) Configure(ctx context.Context, req provider.Configur
         return
     }
 
-    // Example client configuration for data sources and resources
-    resp.DataSourceData = &p.FrameworkProviderConfig
-    resp.ResourceData = &p.FrameworkProviderConfig
+	// This is how we make provider configuration info (configured clients, default project, etc) available to resources and data sources
+	// implemented using the plugin-framework. The resources' Configure functions receive this data in the ConfigureRequest argument. 
+	resp.DataSourceData = &p.FrameworkProviderConfig
+	resp.ResourceData = &p.FrameworkProviderConfig
 }
 
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

I'm starting to look into fixing the muxing of the provider, and I anticipate a large PR in the future. To minimise that, I'm going to pull out any small improvements into separate PRs.

This PR replaces [a comment that is unchanged from the hashicorp/terraform-provider-scaffolding-framework repo](https://github.com/hashicorp/terraform-provider-scaffolding-framework/blob/ca67c18913bf8a40400d8a2bd03c1efa86fc258c/internal/provider/provider.go#L63) with something more informative

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
