### PR TITLE
Add missing 'global' to serverTlsPolicy update_url on `google_compute_target_https_proxy`

### DIFF
--- a/mmv1/products/compute/TargetHttpsProxy.yaml
+++ b/mmv1/products/compute/TargetHttpsProxy.yaml
@@ -221,7 +221,7 @@ properties:
       load balancer (classic), this option is not available publicly.
   - !ruby/object:Api::Type::ResourceRef
     name: 'serverTlsPolicy'
-    resource: 'SslPolicy'
+    resource: 'ServerSslPolicy'
     imports: 'selfLink'
     description: |
       A URL referring to a networksecurity.ServerTlsPolicy
@@ -234,4 +234,5 @@ properties:
       loadBalancingScheme consult ServerTlsPolicy documentation.
       If left blank, communications are not encrypted.
     update_verb: :PATCH
-    update_url: 'projects/{{project}}/targetHttpsProxies/{{name}}/setServerTlsPolicy'
+    update_url: 'projects/{{project}}/global/targetHttpsProxies/{{name}}'
+    fingerprint_name: 'fingerprint'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_target_https_proxy_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_target_https_proxy_test.go.erb
@@ -52,6 +52,7 @@ func TestAccComputeTargetHttpsProxy_update(t *testing.T) {
 					testAccComputeTargetHttpsProxyDescription("Resource created for Terraform acceptance testing", &proxy),
 					testAccComputeTargetHttpsProxyHasSslCertificate(t, "tf-test-httpsproxy-cert1-"+resourceSuffix, &proxy),
 					testAccComputeTargetHttpsProxyHasSslCertificate(t, "tf-test-httpsproxy-cert2-"+resourceSuffix, &proxy),
+					testAccComputeTargetHttpsProxyHasNullServerTlsPolicy(t, &proxy),
 				),
 			},
 		},
@@ -76,6 +77,37 @@ func TestAccComputeTargetHttpsProxy_certificateMap(t *testing.T) {
                         t, "google_compute_target_https_proxy.foobar", &proxy),
                     testAccComputeTargetHttpsProxyDescription("Resource created for Terraform acceptance testing", &proxy),
                     testAccComputeTargetHttpsProxyHasCertificateMap(t, "tf-test-certmap-"+resourceSuffix, &proxy),
+                ),
+            },
+        },
+    })
+}
+
+func TestAccComputeTargetHttpsProxyServerTlsPolicy_update(t *testing.T) {
+	t.Parallel()
+
+	var proxy compute.TargetHttpsProxy
+	resourceSuffix := acctest.RandString(t, 10)
+
+    acctest.VcrTest(t, resource.TestCase{
+        PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+        ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+        CheckDestroy:             testAccCheckComputeTargetHttpsProxyDestroyProducer(t),
+        Steps: []resource.TestStep{
+            {
+                Config: testAccComputeTargetHttpsProxyServerTlsPolicy_full(resourceSuffix),
+                Check: resource.ComposeTestCheckFunc(
+                    testAccCheckComputeTargetHttpsProxyExists(
+                        t, "google_compute_target_https_proxy.foobar", &proxy),
+										testAccComputeTargetHttpsProxyHasNullServerTlsPolicy(t, &proxy),
+                ),
+            },
+            {
+                Config: testAccComputeTargetHttpsProxyServerTlsPolicy_update(resourceSuffix),
+                Check: resource.ComposeTestCheckFunc(
+                    testAccCheckComputeTargetHttpsProxyExists(
+                        t, "google_compute_target_https_proxy.foobar", &proxy),
+										testAccComputeTargetHttpsProxyHasServerTlsPolicy(t, "tf-test-server-tls-policy-"+resourceSuffix, &proxy),
                 ),
             },
         },
@@ -117,6 +149,7 @@ func testAccComputeTargetHttpsProxyDescription(description string, proxy *comput
 		if proxy.Description != description {
 			return fmt.Errorf("Wrong description: expected '%s' got '%s'", description, proxy.Description)
 		}
+
 		return nil
 	}
 }
@@ -146,6 +179,16 @@ func testAccComputeTargetHttpsProxyHasServerTlsPolicy(t *testing.T, policy strin
 		}
 
 		return fmt.Errorf("Server Tls Policy not found: expected '%s'", serverTlsPolicyUrl)
+	}
+}
+
+func testAccComputeTargetHttpsProxyHasNullServerTlsPolicy(t *testing.T, proxy *compute.TargetHttpsProxy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if proxy.ServerTlsPolicy != "" {
+			return fmt.Errorf("Server Tls Policy found: expected 'null'")
+		}
+
+		return nil
 	}
 }
 
@@ -260,8 +303,9 @@ resource "google_compute_target_https_proxy" "foobar" {
     google_compute_ssl_certificate.foobar1.self_link,
     google_compute_ssl_certificate.foobar2.self_link,
   ]
-  quic_override  = "ENABLE"
-  tls_early_data = "STRICT"
+  quic_override     = "ENABLE"
+  tls_early_data    = "STRICT"
+  server_tls_policy = null
 }
 
 resource "google_compute_backend_service" "foobar" {
@@ -376,4 +420,116 @@ resource "google_certificate_manager_dns_authorization" "instance" {
   domain = "mysite.com"
 }
 `, id, id, id, id, id, id, id, id)
+}
+
+func testAccComputeTargetHttpsProxyServerTlsPolicy_full(id string) string {
+	return fmt.Sprintf(`
+data "google_project" "project" {}
+
+resource "google_compute_target_https_proxy" "foobar" {
+  description       = "Resource created for Terraform acceptance testing"
+  name              = "tf-test-httpsproxy-%s"
+	url_map           = google_compute_url_map.foobar.self_link
+	ssl_certificates  = [google_compute_ssl_certificate.foobar.self_link]
+  server_tls_policy = null
+}
+
+resource "google_compute_backend_service" "foobar" {
+  name          = "tf-test-httpsproxy-backend-%s"
+  health_checks = [google_compute_http_health_check.zero.self_link]
+}
+
+resource "google_compute_http_health_check" "zero" {
+  name               = "tf-test-httpsproxy-check-%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+resource "google_compute_url_map" "foobar" {
+  name            = "tf-test-httpsproxy-urlmap-%s"
+  default_service = google_compute_backend_service.foobar.self_link
+}
+
+resource "google_compute_ssl_certificate" "foobar" {
+  name        = "tf-test-httpsproxy-cert-%s"
+  description = "very descriptive"
+  private_key = file("test-fixtures/test.key")
+  certificate = file("test-fixtures/test.crt")
+}
+
+resource "google_certificate_manager_trust_config" "trust_config" {
+  name     = "tf-test-trust-config-%s"
+  location = "global"
+
+  allowlisted_certificates  {
+    pem_certificate = file("test-fixtures/cert.pem")
+  }
+}
+
+resource "google_network_security_server_tls_policy" "server_tls_policy" {
+  name = "tf-test-server-tls-policy-%s"
+
+  mtls_policy {
+    client_validation_trust_config = "projects/${data.google_project.project.number}/locations/global/trustConfigs/${google_certificate_manager_trust_config.trust_config.name}"
+    client_validation_mode         = "ALLOW_INVALID_OR_MISSING_CLIENT_CERT"
+  }
+}
+`, id, id, id, id, id, id, id)
+}
+
+func testAccComputeTargetHttpsProxyServerTlsPolicy_update(id string) string {
+	return fmt.Sprintf(`
+data "google_project" "project" {}
+
+resource "google_compute_target_https_proxy" "foobar" {
+  description       = "Resource created for Terraform acceptance testing"
+  name              = "tf-test-httpsproxy-%s"
+	url_map           = google_compute_url_map.foobar.self_link
+	ssl_certificates  = [google_compute_ssl_certificate.foobar.self_link]
+  server_tls_policy = google_network_security_server_tls_policy.server_tls_policy.id
+}
+
+resource "google_compute_backend_service" "foobar" {
+  name          = "tf-test-httpsproxy-backend-%s"
+  health_checks = [google_compute_http_health_check.zero.self_link]
+}
+
+resource "google_compute_http_health_check" "zero" {
+  name               = "tf-test-httpsproxy-check-%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+resource "google_compute_url_map" "foobar" {
+  name            = "tf-test-httpsproxy-urlmap-%s"
+  default_service = google_compute_backend_service.foobar.self_link
+}
+
+resource "google_compute_ssl_certificate" "foobar" {
+  name        = "tf-test-httpsproxy-cert-%s"
+  description = "very descriptive"
+  private_key = file("test-fixtures/test.key")
+  certificate = file("test-fixtures/test.crt")
+}
+
+resource "google_certificate_manager_trust_config" "trust_config" {
+  name     = "tf-test-trust-config-%s"
+  location = "global"
+
+  allowlisted_certificates  {
+    pem_certificate = file("test-fixtures/cert.pem")
+  }
+}
+
+resource "google_network_security_server_tls_policy" "server_tls_policy" {
+  name = "tf-test-server-tls-policy-%s"
+
+  mtls_policy {
+    client_validation_trust_config = "projects/${data.google_project.project.number}/locations/global/trustConfigs/${google_certificate_manager_trust_config.trust_config.name}"
+    client_validation_mode         = "ALLOW_INVALID_OR_MISSING_CLIENT_CERT"
+  }
+}
+`, id, id, id, id, id, id, id)
 }


### PR DESCRIPTION
This PR adds the missing `global` to the `TargetHttpsProxy` update_url of the property `serverTlsPolicy` while using the `PATCH` method.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed a malformed URL that affected updating the `server_tls_policy` property on `google_compute_target_https_proxy` resources
```
