### PR TITLE
alloydb: make psc_instance_config O+C in google_alloydb_instance

### DIFF
--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -109,6 +109,17 @@ examples:
       - 'reconciling'
       - 'update_time'
     skip_docs: true
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'alloydb_instance_psc_test'
+    primary_resource_id: 'default'
+    vars:
+      alloydb_cluster_name: 'alloydb-cluster'
+      alloydb_instance_name: 'alloydb-instance'
+      network_name: 'alloydb-network'
+    ignore_read_extra:
+      - 'reconciling'
+      - 'update_time'
+    skip_docs: true
 parameters:
   - !ruby/object:Api::Type::ResourceRef
     name: 'cluster'
@@ -310,6 +321,7 @@ properties:
               - :ALLOW_UNENCRYPTED_AND_ENCRYPTED
   - !ruby/object:Api::Type::NestedObject
     name: 'pscInstanceConfig'
+    default_from_api: true
     description: |
       Configuration for Private Service Connect (PSC) for the instance.
     properties:

--- a/mmv1/templates/terraform/examples/alloydb_instance_psc_test.tf.erb
+++ b/mmv1/templates/terraform/examples/alloydb_instance_psc_test.tf.erb
@@ -1,0 +1,21 @@
+resource "google_alloydb_instance" "<%= ctx[:primary_resource_id] %>" {
+  cluster       = google_alloydb_cluster.<%= ctx[:primary_resource_id] %>.name
+  instance_id   = "<%= ctx[:vars]['alloydb_instance_name'] %>"
+  instance_type = "PRIMARY"
+
+  machine_config {
+    cpu_count = 2
+  }
+}
+
+resource "google_alloydb_cluster" "<%= ctx[:primary_resource_id] %>" {
+  cluster_id = "<%= ctx[:vars]['alloydb_cluster_name'] %>"
+  location   = "us-central1"
+
+  initial_user {
+    password = "<%= ctx[:vars]['alloydb_cluster_name'] %>"
+  }
+  psc_config {
+    psc_enabled = true
+  }
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Suppress permadiff for psc_enabled = true
https://github.com/hashicorp/terraform-provider-google/issues/19113

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
alloydb: fixed a permadiff on `psc_instance_config` in `google_alloydb_instance` resource
```
