### PR TITLE
Add server-side identifier to Forwarding_Rule

### DIFF
--- a/mmv1/products/compute/ForwardingRule.yaml
+++ b/mmv1/products/compute/ForwardingRule.yaml
@@ -255,6 +255,12 @@ properties:
 
       This can only be set to true for load balancers that have their
       `loadBalancingScheme` set to `INTERNAL`.
+  - !ruby/object:Api::Type::Integer
+    name: 'forwardingRuleId'
+    description: |
+      The unique identifier number for the resource. This identifier is defined by the server.
+    api_name: id
+    output: true
   - !ruby/object:Api::Type::String
     name: 'pscConnectionId'
     description: 'The PSC connection id of the PSC Forwarding Rule.'

--- a/mmv1/third_party/terraform/services/compute/go/resource_compute_forwarding_rule_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/go/resource_compute_forwarding_rule_test.go.tmpl
@@ -91,6 +91,10 @@ func TestAccComputeForwardingRule_internalTcpUdpLbWithMigBackendExampleUpdate(t 
 		Steps: []resource.TestStep{
 			{
 				Config: testAccComputeForwardingRule_internalTcpUdpLbWithMigBackendExample(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"google_compute_forwarding_rule.google_compute_forwarding_rule", "forwarding_rule_id"),
+				),
 			},
 			{
 				ResourceName:            "google_compute_forwarding_rule.google_compute_forwarding_rule",

--- a/mmv1/third_party/terraform/services/compute/resource_compute_forwarding_rule_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_forwarding_rule_test.go.erb
@@ -300,6 +300,10 @@ func TestAccComputeForwardingRule_forwardingRuleIpAddressIpv6(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccComputeForwardingRule_forwardingRuleIpAddressIpv6(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"google_compute_forwarding_rule.external", "forwarding_rule_id"),
+				),
 			},
 			{
 				ResourceName:            "google_compute_forwarding_rule.external",


### PR DESCRIPTION
Helps with https://yaqs.corp.google.com/eng/q/8810620869345804288?team_name=1426779064760270848

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: expose service side id for as new output field `forwarding_rule_id` on resource `google_compute_forwarding_rule`
```
