### PR TITLE
Add default_labels to data source google_client_config

### DIFF
--- a/mmv1/third_party/terraform/fwtransport/framework_config.go.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config.go.erb
@@ -48,6 +48,7 @@ type FrameworkProviderConfig struct {
 	UniverseDomain             types.String
 	UserAgent                  string
 	UserProjectOverride        types.Bool
+	DefaultLabels              types.Map
 
 	// paths for client setup
 	<% products.each do |product| -%>
@@ -98,13 +99,13 @@ func (p *FrameworkProviderConfig) LoadAndValidateFramework(ctx context.Context, 
 
 	p.Context = ctx
 	p.BillingProject = data.BillingProject
+	p.DefaultLabels = data.DefaultLabels
 	p.Project = data.Project
 	p.Region = GetRegionFromRegionSelfLink(data.Region)
 	p.Scopes = data.Scopes
 	p.Zone = data.Zone
 	p.UserProjectOverride = data.UserProjectOverride
 	p.PollInterval = 10 * time.Second
-	p.Project = data.Project
 	p.UniverseDomain = data.UniverseDomain
 	p.RequestBatcherServiceUsage = transport_tpg.NewRequestBatcher("Service Usage", ctx, batchingConfig)
 	p.RequestBatcherIam = transport_tpg.NewRequestBatcher("IAM", ctx, batchingConfig)

--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_client_config.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_client_config.go
@@ -31,11 +31,12 @@ type GoogleClientConfigDataSource struct {
 type GoogleClientConfigModel struct {
 	// Id could/should be removed in future as it's not necessary in the plugin framework
 	// https://github.com/hashicorp/terraform-plugin-testing/issues/84
-	Id          types.String `tfsdk:"id"`
-	Project     types.String `tfsdk:"project"`
-	Region      types.String `tfsdk:"region"`
-	Zone        types.String `tfsdk:"zone"`
-	AccessToken types.String `tfsdk:"access_token"`
+	Id            types.String `tfsdk:"id"`
+	Project       types.String `tfsdk:"project"`
+	Region        types.String `tfsdk:"region"`
+	Zone          types.String `tfsdk:"zone"`
+	AccessToken   types.String `tfsdk:"access_token"`
+	DefaultLabels types.Map    `tfsdk:"default_labels"`
 }
 
 func (m *GoogleClientConfigModel) GetLocationDescription(providerConfig *fwtransport.FrameworkProviderConfig) fwresource.LocationDescription {
@@ -86,6 +87,12 @@ func (d *GoogleClientConfigDataSource) Schema(ctx context.Context, req datasourc
 				Computed:            true,
 				Sensitive:           true,
 			},
+			"default_labels": schema.MapAttribute{
+				Description:         "The default labels configured on the provider.",
+				MarkdownDescription: "The default labels configured on the provider.",
+				Computed:            true,
+				ElementType:         types.StringType,
+			},
 		},
 	}
 }
@@ -134,6 +141,7 @@ func (d *GoogleClientConfigDataSource) Read(ctx context.Context, req datasource.
 	data.Project = d.providerConfig.Project
 	data.Region = region
 	data.Zone = zone
+	data.DefaultLabels = d.providerConfig.DefaultLabels
 
 	token, err := d.providerConfig.TokenSource.Token()
 	if err != nil {

--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_client_config_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_client_config_test.go
@@ -23,6 +23,8 @@ func TestAccDataSourceGoogleClientConfig_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "region"),
 					resource.TestCheckResourceAttrSet(resourceName, "zone"),
 					resource.TestCheckResourceAttrSet(resourceName, "access_token"),
+					resource.TestCheckResourceAttr("data.google_client_config.current", "default_labels.%", "1"),
+					resource.TestCheckResourceAttr("data.google_client_config.current", "default_labels.default_key", "default_value"),
 				),
 			},
 		},
@@ -43,6 +45,8 @@ func TestAccDataSourceGoogleClientConfig_omitLocation(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "project"),
 					resource.TestCheckResourceAttrSet(resourceName, "access_token"),
+					resource.TestCheckResourceAttr("data.google_client_config.current", "default_labels.%", "1"),
+					resource.TestCheckResourceAttr("data.google_client_config.current", "default_labels.default_key", "default_value"),
 				),
 			},
 		},
@@ -50,5 +54,11 @@ func TestAccDataSourceGoogleClientConfig_omitLocation(t *testing.T) {
 }
 
 const testAccCheckGoogleClientConfig_basic = `
+provider "google" {
+  default_labels = {
+    default_key = "default_value"
+  }
+}
+
 data "google_client_config" "current" { }
 `

--- a/mmv1/third_party/terraform/website/docs/d/client_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/client_config.html.markdown
@@ -57,3 +57,5 @@ In addition to the arguments listed above, the following attributes are exported
 * `zone` - The zone to operate under.
 
 * `access_token` - The OAuth2 access token used by the client to authenticate against the Google Cloud API.
+
+* `default_labels` - The default labels configured on the provider.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
fixes https://github.com/hashicorp/terraform-provider-google/issues/19140

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
resourcemanager: added `default_labels` field to `google_client_config` data source
```
