### PR TITLE
remove deprecated integration client fields

### DIFF
--- a/mmv1/products/integrations/Client.yaml
+++ b/mmv1/products/integrations/Client.yaml
@@ -84,34 +84,12 @@ properties:
           the kms key is stored at the same project as customer's project and ecrypted
           with CMEK, otherwise, the kms key is stored in the tenant project and
           encrypted with GMEK.
-    conflicts:
-      - provision_gmek
-  - !ruby/object:Api::Type::Boolean
-    name: 'createSampleWorkflows'
-    description: |
-      Indicates if sample workflow should be created along with provisioning.
-    immutable: true
-    ignore_read: true
-    deprecation_message: "`create_sample_workflows` is deprecated and will be removed in a future major release. Use `create_sample_integrations` instead."
-    conflicts:
-      - create_sample_integrations
   - !ruby/object:Api::Type::Boolean
     name: 'createSampleIntegrations'
     description: |
       Indicates if sample integrations should be created along with provisioning.
     immutable: true
     ignore_read: true
-    conflicts:
-      - create_sample_workflows
-  - !ruby/object:Api::Type::Boolean
-    name: 'provisionGmek'
-    description: |
-      Indicates provision with GMEK or CMEK.
-    deprecation_message: "`provision_gmek` is deprecated and will be removed in a future major release. Client would be provisioned as gmek if `cloud_kms_config` is not given."
-    immutable: true
-    ignore_read: true
-    conflicts:
-      - cloud_kms_config
   - !ruby/object:Api::Type::String
     name: 'runAsServiceAccount'
     description: |
@@ -129,7 +107,3 @@ examples:
     vars:
       key_ring_name: my-keyring
       service_account_id: service-acc
-  - !ruby/object:Provider::Terraform::Examples
-    name: "integrations_client_deprecated_fields"
-    primary_resource_id: "example"
-    skip_docs: true

--- a/mmv1/templates/terraform/examples/integrations_client_deprecated_fields.tf.erb
+++ b/mmv1/templates/terraform/examples/integrations_client_deprecated_fields.tf.erb
@@ -1,5 +1,0 @@
-resource "google_integrations_client" "<%= ctx[:primary_resource_id] %>" {
-  location = "asia-south1"
-  provision_gmek = true
-  create_sample_workflows = true
-}

--- a/mmv1/third_party/terraform/services/integrations/resource_integrations_auth_config_test.go
+++ b/mmv1/third_party/terraform/services/integrations/resource_integrations_auth_config_test.go
@@ -46,7 +46,7 @@ func testAccIntegrationsAuthConfig_full(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_integrations_client" "client" {
 	location = "southamerica-west1"
-	provision_gmek = true
+	create_sample_integrations = true
 }
 
 resource "google_integrations_auth_config" "update_example" {
@@ -72,7 +72,7 @@ func testAccIntegrationsAuthConfig_update(context map[string]interface{}) string
 	return acctest.Nprintf(`
 resource "google_integrations_client" "client" {
 	location = "southamerica-west1"
-	provision_gmek = true
+	create_sample_integrations = true
 }
 
 resource "google_integrations_auth_config" "update_example" {

--- a/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
@@ -334,6 +334,12 @@ in GCP, including the labels configured through Terraform, the system, and other
 
 `google_identity_platform_project_default_config` is removed in favor of `google_identity_platform_project_config`
 
+## Resource: `google_integrations_client`
+
+### `create_sample_worklfows` and `provision_gmek` is now removed
+
+`create_sample_worklfows` and `provision_gmek` is now removed in favor of `create_sample_integrations`
+
 ## Resource: `google_project`
 
 ### Project deletion now prevented by default with `deletion_policy`


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fixes https://github.com/hashicorp/terraform-provider-google/issues/17928


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
integrations: `create_sample_workflows` and `provision_gmek` are removed from `google_integrations_client`
```
