### PR TITLE
Revert "Switch nightly ci to use the golang version of vcr_cassette_update"

### DIFF
--- a/.ci/gcb-vcr-nightly.yml
+++ b/.ci/gcb-vcr-nightly.yml
@@ -2,15 +2,10 @@
 steps:
     - name: 'gcr.io/graphite-docker-images/go-plus'
       id: gcb-vcr-nightly
-      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
-      secretEnv: ["GOOGLE_BILLING_ACCOUNT", "GOOGLE_CUST_ID", "GOOGLE_IDENTITY_USER", "GOOGLE_MASTER_BILLING_ACCOUNT", "GOOGLE_ORG", "GOOGLE_ORG_2", "GOOGLE_ORG_DOMAIN", "GOOGLE_PROJECT", "GOOGLE_PROJECT_NUMBER", "GOOGLE_SERVICE_ACCOUNT", "SA_KEY", "GOOGLE_PUBLIC_AVERTISED_PREFIX_DESCRIPTION", "GITHUB_TOKEN_CLASSIC"]
-      env:
-        - "GOOGLE_REGION=us-central1"
-        - "GOOGLE_ZONE=us-central1-a"
-        - "USER=magician"
+      entrypoint: '/workspace/.ci/scripts/go-plus/vcr-cassette-update/vcr_cassette_update.sh'
+      secretEnv: ["GOOGLE_BILLING_ACCOUNT", "GOOGLE_CUST_ID", "GOOGLE_IDENTITY_USER", "GOOGLE_MASTER_BILLING_ACCOUNT", "GOOGLE_ORG", "GOOGLE_ORG_2", "GOOGLE_ORG_DOMAIN", "GOOGLE_PROJECT", "GOOGLE_PROJECT_NUMBER", "GOOGLE_SERVICE_ACCOUNT", "SA_KEY", "GOOGLE_PUBLIC_AVERTISED_PREFIX_DESCRIPTION"]
       args:
-        - 'vcr-cassette-update'
-        - $BUILD_ID
+          - $BUILD_ID
 
 # Long timeout to enable waiting on VCR test
 timeout: 20000s
@@ -44,5 +39,3 @@ availableSecrets:
       env: SA_KEY
     - versionName: projects/673497134629/secrets/ci-test-public-advertised-prefix-description/versions/latest
       env: GOOGLE_PUBLIC_AVERTISED_PREFIX_DESCRIPTION
-    - versionName: projects/673497134629/secrets/github-classic--repo-workflow/versions/latest
-      env: GITHUB_TOKEN_CLASSIC


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#11148

[vcr-nightly](https://pantheon.corp.google.com/cloud-build/builds/e9676603-1717-4e3b-92df-fce83709a31d?project=graphite-docker-images&e=-13802955&mods=logs_tg_staging&invt=AbZZpQ&inv=1) failed last night. Let's revert this change for now.

```release-note:none

```