### PR TITLE
Mark VcrTest() as a test helper function

### DIFF
--- a/mmv1/third_party/terraform/acctest/vcr_utils.go
+++ b/mmv1/third_party/terraform/acctest/vcr_utils.go
@@ -142,6 +142,8 @@ func vcrFileName(name string) string {
 // VcrTest is a wrapper for resource.Test to swap out providers for VCR providers and handle VCR specific things
 // Can be called when VCR is not enabled, and it will behave as normal
 func VcrTest(t *testing.T, c resource.TestCase) {
+	t.Helper()
+
 	if IsVcrEnabled() {
 		defer closeRecorder(t)
 	} else if isReleaseDiffEnabled() {


### PR DESCRIPTION
This is just a small quality of life improvement for developers. Currently when an acceptance test fails it reports `vcr_utils.go` as the location of the failing test a la:

```
vcr_utils.go:152: Step 1/10 error: Check failed: Check 4/9 error: yada yada yada
--- FAIL: TestAccClouddeployTarget_withProviderDefaultLabels (5.23s)
```

With this change the location of the failing test is reported:

```
resource_clouddeploy_target_test.go:26: Step 1/10 error: Check failed: Check 4/9 error: yada yada yada
--- FAIL: TestAccClouddeployTarget_withProviderDefaultLabels (5.23s)
```

The line number doesn't point to the exact point of failure, but it at least it gets you into the actual test (the line containing the call to `VcrTest()`, FWIW).

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
