### PR TITLE
Adds the IdleTimeout parameter to the RouteAction section of the TcpRoute resource.

### DIFF
--- a/mmv1/products/networkservices/TcpRoute.yaml
+++ b/mmv1/products/networkservices/TcpRoute.yaml
@@ -184,6 +184,8 @@ properties:
             - !ruby/object:Api::Type::String
               name: idleTimeout
               description: |
-                Specifies the idle timeout for the selected route. The idle timeout is defined as the period in which there are no bytes sent or received on either the upstream or downstream connection.
+                Specifies the idle timeout for the selected route. The idle timeout is defined as the period in which there are no bytes sent or received on either the upstream or downstream connection. If not set, the default idle timeout is 30 seconds. If set to 0s, the timeout will be disabled.
+
+                A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.5s".
               validation: !ruby/object:Provider::Terraform::Validation
                 regex: '^(0|[1-9][0-9]*)(\.[0-9]{1,9})?s$'

--- a/mmv1/products/networkservices/TcpRoute.yaml
+++ b/mmv1/products/networkservices/TcpRoute.yaml
@@ -181,3 +181,9 @@ properties:
               name: originalDestination
               description: |
                 If true, Router will use the destination IP and port of the original connection as the destination of the request.
+            - !ruby/object:Api::Type::String
+              name: idleTimeout
+              description: |
+                Specifies the idle timeout for the selected route. The idle timeout is defined as the period in which there are no bytes sent or received on either the upstream or downstream connection.
+              validation: !ruby/object:Provider::Terraform::Validation
+                regex: '^(0|[1-9][0-9]*)(\.[0-9]{1,9})?s$'

--- a/mmv1/templates/terraform/examples/network_services_tcp_route_actions.tf.erb
+++ b/mmv1/templates/terraform/examples/network_services_tcp_route_actions.tf.erb
@@ -26,6 +26,7 @@ resource "google_network_services_tcp_route" "<%= ctx[:primary_resource_id] %>" 
         weight = 1
       }
       original_destination = false
+      idle_timeout = "60s"
     }
   }
 }

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_tcp_route_test.go.erb
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_tcp_route_test.go.erb
@@ -75,6 +75,7 @@ resource "google_network_services_tcp_route" "foobar" {
         weight = 1
       }
       original_destination = false
+      idle_timeout = "60s"
     }
   }
 }
@@ -112,6 +113,7 @@ resource "google_network_services_tcp_route" "foobar" {
         weight = 1
       }
       original_destination = false
+      idle_timeout = "120s"
     }
   }
 }


### PR DESCRIPTION
https://cloud.google.com/service-mesh/docs/reference/network-services/rest/v1/projects.locations.tcpRoutes#routeaction


**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
networkservices: added `idle_timeout` field to the `google_network_services_tcp_route` resource (beta)
```