### PR TITLE
Remove project dependency from TestAccApikeysKey_*

### DIFF
--- a/tpgtools/api/apikeys/samples/android.key.json
+++ b/tpgtools/api/apikeys/samples/android.key.json
@@ -1,6 +1,5 @@
 {
  "name": "{{key}}",
- "project": "{{ref:basic.cloudresourcemanager.project.json:name}}",
  "displayName": "sample-key",
  "restrictions": {
    "androidKeyRestrictions": {

--- a/tpgtools/api/apikeys/samples/android_key.yaml
+++ b/tpgtools/api/apikeys/samples/android_key.yaml
@@ -17,12 +17,8 @@ type: key
 versions:
 - ga
 resource: samples/android.key.json
-dependencies:
-- samples/basic.cloudresourcemanager.project.json
 updates:
 - resource: samples/android_update.key.json
-  dependencies:
-  - samples/basic.cloudresourcemanager.project.json
 variables:
 - name: app
   type: resource_name

--- a/tpgtools/api/apikeys/samples/android_update.key.json
+++ b/tpgtools/api/apikeys/samples/android_update.key.json
@@ -1,6 +1,5 @@
 {
  "name": "{{key}}",
- "project": "{{ref:basic.cloudresourcemanager.project.json:name}}",
  "displayName": "sample-key",
  "restrictions": {
    "androidKeyRestrictions": {

--- a/tpgtools/api/apikeys/samples/apikeys.serviceusage.service.json
+++ b/tpgtools/api/apikeys/samples/apikeys.serviceusage.service.json
@@ -1,5 +1,4 @@
 {
   "name": "apikeys.googleapis.com",
-  "project": "{{ref:basic.cloudresourcemanager.project.json:name}}",
   "state": "ENABLED"
 }

--- a/tpgtools/api/apikeys/samples/basic.cloudbilling.project_billing_info.json
+++ b/tpgtools/api/apikeys/samples/basic.cloudbilling.project_billing_info.json
@@ -1,4 +1,0 @@
-{
-  "name": "{{ref:basic.cloudresourcemanager.project.json:name}}",
-  "billingAccountName": "{{billing_account}}"
-}

--- a/tpgtools/api/apikeys/samples/basic.cloudresourcemanager.project.json
+++ b/tpgtools/api/apikeys/samples/basic.cloudresourcemanager.project.json
@@ -1,4 +1,0 @@
-{
-  "name": "{{app}}",
-  "parent": "organizations/{{org_id}}"
-}

--- a/tpgtools/api/apikeys/samples/basic.key.json
+++ b/tpgtools/api/apikeys/samples/basic.key.json
@@ -1,6 +1,5 @@
 {
  "name": "{{key}}",
- "project": "{{ref:basic.cloudresourcemanager.project.json:name}}",
  "displayName": "sample-key",
  "restrictions": {
    "browserKeyRestrictions": {

--- a/tpgtools/api/apikeys/samples/basic_key.yaml
+++ b/tpgtools/api/apikeys/samples/basic_key.yaml
@@ -17,12 +17,8 @@ type: key
 versions:
 - ga
 resource: samples/basic.key.json
-dependencies:
-- samples/basic.cloudresourcemanager.project.json
 updates:
 - resource: samples/update.key.json
-  dependencies:
-  - samples/basic.cloudresourcemanager.project.json
 variables:
 - name: app
   type: resource_name

--- a/tpgtools/api/apikeys/samples/ios.key.json
+++ b/tpgtools/api/apikeys/samples/ios.key.json
@@ -1,6 +1,5 @@
 {
  "name": "{{key}}",
- "project": "{{ref:basic.cloudresourcemanager.project.json:name}}",
  "displayName": "sample-key",
  "restrictions": {
    "iosKeyRestrictions": {

--- a/tpgtools/api/apikeys/samples/ios_key.yaml
+++ b/tpgtools/api/apikeys/samples/ios_key.yaml
@@ -17,12 +17,8 @@ type: key
 versions:
 - ga
 resource: samples/ios.key.json
-dependencies:
-- samples/basic.cloudresourcemanager.project.json
 updates:
 - resource: samples/ios_update.key.json
-  dependencies:
-  - samples/basic.cloudresourcemanager.project.json
 variables:
 - name: app
   type: resource_name

--- a/tpgtools/api/apikeys/samples/ios_update.key.json
+++ b/tpgtools/api/apikeys/samples/ios_update.key.json
@@ -1,6 +1,5 @@
 {
  "name": "{{key}}",
- "project": "{{ref:basic.cloudresourcemanager.project.json:name}}",
  "displayName": "sample-key",
  "restrictions": {
    "iosKeyRestrictions": {

--- a/tpgtools/api/apikeys/samples/minimal.key.json
+++ b/tpgtools/api/apikeys/samples/minimal.key.json
@@ -1,5 +1,4 @@
 {
  "name": "{{key}}",
- "project": "{{ref:basic.cloudresourcemanager.project.json:name}}",
  "displayName": "sample-key"
 }

--- a/tpgtools/api/apikeys/samples/minimal_key.yaml
+++ b/tpgtools/api/apikeys/samples/minimal_key.yaml
@@ -17,8 +17,6 @@ type: key
 versions:
 - ga
 resource: samples/minimal.key.json
-dependencies:
-- samples/basic.cloudresourcemanager.project.json
 variables:
 - name: app
   type: resource_name

--- a/tpgtools/api/apikeys/samples/server.key.json
+++ b/tpgtools/api/apikeys/samples/server.key.json
@@ -1,6 +1,5 @@
 {
  "name": "{{key}}",
- "project": "{{ref:basic.cloudresourcemanager.project.json:name}}",
  "displayName": "sample-key",
  "restrictions": {
    "serverKeyRestrictions": {

--- a/tpgtools/api/apikeys/samples/server_key.yaml
+++ b/tpgtools/api/apikeys/samples/server_key.yaml
@@ -17,12 +17,8 @@ type: key
 versions:
 - ga
 resource: samples/server.key.json
-dependencies:
-- samples/basic.cloudresourcemanager.project.json
 updates:
 - resource: samples/server_update.key.json
-  dependencies:
-  - samples/basic.cloudresourcemanager.project.json
 variables:
 - name: app
   type: resource_name

--- a/tpgtools/api/apikeys/samples/server_update.key.json
+++ b/tpgtools/api/apikeys/samples/server_update.key.json
@@ -1,6 +1,5 @@
 {
  "name": "{{key}}",
- "project": "{{ref:basic.cloudresourcemanager.project.json:name}}",
  "displayName": "sample-key",
  "restrictions": {
    "serverKeyRestrictions": {

--- a/tpgtools/api/apikeys/samples/update.key.json
+++ b/tpgtools/api/apikeys/samples/update.key.json
@@ -1,6 +1,5 @@
 {
  "name":"{{key}}",
- "project": "{{ref:basic.cloudresourcemanager.project.json:name}}",
  "displayName": "sample-key-update",
  "restrictions": {
    "browserKeyRestrictions": {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
After `deletion_policy` is defaulted to `PREVENT` in `google_project` resource in https://github.com/GoogleCloudPlatform/magic-modules/pull/11255, the tests `TestAccApikeysKey_*` started failing as the projects are prevented to be deleted by default. 

[Nightly testing results
](https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_GoogleCloud_FEATUREBRANCHMAJORRELEASE6_0_0_GA_NIGHTLYTESTS_GOOGLE_PACKAGE_APIKEYS/218928?hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildTestsSection=true&expandBuildDeploymentsSection=false&expandBuildChangesSection=true)
I don't think it's necessary to create a new project in these tests, so remove the project dependency to fix the tests.


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
