### PR TITLE
Fix how `data.google_client_config` handles errors from invalid credentials

### DIFF
--- a/mmv1/third_party/terraform/acctest/go/test_utils.go.tmpl
+++ b/mmv1/third_party/terraform/acctest/go/test_utils.go.tmpl
@@ -266,3 +266,11 @@ func GenerateFakeCredentialsJson(testId string) string {
 	json := fmt.Sprintf(`{"private_key_id": "foo","private_key": "bar","client_email": "%s@example.com","client_id": "id@foo.com","type": "service_account"}`, testId)
 	return json
 }
+
+// Returns a fake credentials JSON string with the client_email set to a test-specific value
+// Escaping the quotes here allows you to use this value as an argument in a provider block
+// in the config of an acceptance test
+func GenerateEscapedFakeCredentialsJson(testId string) string {
+	json := fmt.Sprintf(`{\"private_key_id\": \"foo\",\"private_key\": \"bar\",\"client_email\": \"%s@example.com\",\"client_id\": \"id@foo.com\",\"type\": \"service_account\"}`, testId)
+	return json
+}

--- a/mmv1/third_party/terraform/acctest/go/test_utils.go.tmpl
+++ b/mmv1/third_party/terraform/acctest/go/test_utils.go.tmpl
@@ -266,11 +266,3 @@ func GenerateFakeCredentialsJson(testId string) string {
 	json := fmt.Sprintf(`{"private_key_id": "foo","private_key": "bar","client_email": "%s@example.com","client_id": "id@foo.com","type": "service_account"}`, testId)
 	return json
 }
-
-// Returns a fake credentials JSON string with the client_email set to a test-specific value
-// Escaping the quotes here allows you to use this value as an argument in a provider block
-// in the config of an acceptance test
-func GenerateEscapedFakeCredentialsJson(testId string) string {
-	json := fmt.Sprintf(`{\"private_key_id\": \"foo\",\"private_key\": \"bar\",\"client_email\": \"%s@example.com\",\"client_id\": \"id@foo.com\",\"type\": \"service_account\"}`, testId)
-	return json
-}

--- a/mmv1/third_party/terraform/acctest/test_utils.go.erb
+++ b/mmv1/third_party/terraform/acctest/test_utils.go.erb
@@ -267,3 +267,11 @@ func GenerateFakeCredentialsJson(testId string) string {
 	json := fmt.Sprintf(`{"private_key_id": "foo","private_key": "bar","client_email": "%s@example.com","client_id": "id@foo.com","type": "service_account"}`, testId)
 	return json
 }
+
+// Returns a fake credentials JSON string with the client_email set to a test-specific value
+// Escaping the quotes here allows you to use this value as an argument in a provider block
+// in the config of an acceptance test
+func GenerateEscapedFakeCredentialsJson(testId string) string {
+	json := fmt.Sprintf(`{\"private_key_id\": \"foo\",\"private_key\": \"bar\",\"client_email\": \"%s@example.com\",\"client_id\": \"id@foo.com\",\"type\": \"service_account\"}`, testId)
+	return json
+}

--- a/mmv1/third_party/terraform/acctest/test_utils.go.erb
+++ b/mmv1/third_party/terraform/acctest/test_utils.go.erb
@@ -267,11 +267,3 @@ func GenerateFakeCredentialsJson(testId string) string {
 	json := fmt.Sprintf(`{"private_key_id": "foo","private_key": "bar","client_email": "%s@example.com","client_id": "id@foo.com","type": "service_account"}`, testId)
 	return json
 }
-
-// Returns a fake credentials JSON string with the client_email set to a test-specific value
-// Escaping the quotes here allows you to use this value as an argument in a provider block
-// in the config of an acceptance test
-func GenerateEscapedFakeCredentialsJson(testId string) string {
-	json := fmt.Sprintf(`{\"private_key_id\": \"foo\",\"private_key\": \"bar\",\"client_email\": \"%s@example.com\",\"client_id\": \"id@foo.com\",\"type\": \"service_account\"}`, testId)
-	return json
-}

--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_client_config.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_client_config.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-google/google/fwmodels"
 	"github.com/hashicorp/terraform-provider-google/google/fwresource"
@@ -112,7 +111,6 @@ func (d *GoogleClientConfigDataSource) Configure(ctx context.Context, req dataso
 func (d *GoogleClientConfigDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var data GoogleClientConfigModel
 	var metaData *fwmodels.ProviderMetaModel
-	var diags diag.Diagnostics
 
 	// Read Provider meta into the meta model
 	resp.Diagnostics.Append(req.ProviderMeta.Get(ctx, &metaData)...)
@@ -137,7 +135,7 @@ func (d *GoogleClientConfigDataSource) Read(ctx context.Context, req datasource.
 
 	token, err := d.providerConfig.TokenSource.Token()
 	if err != nil {
-		diags.AddError("Error setting access_token", err.Error())
+		resp.Diagnostics.AddError("Error setting access_token", err.Error())
 		return
 	}
 	data.AccessToken = types.StringValue(token.AccessToken)

--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_client_config_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_client_config_test.go
@@ -63,7 +63,7 @@ func TestAccDataSourceGoogleClientConfig_invalidCredentials(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccCheckGoogleClientConfig_credentialsInProviderConfig(),
+				Config:      testAccCheckGoogleClientConfig_basic,
 				ExpectError: regexp.MustCompile("Error setting access_token"),
 			},
 		},
@@ -73,7 +73,3 @@ func TestAccDataSourceGoogleClientConfig_invalidCredentials(t *testing.T) {
 const testAccCheckGoogleClientConfig_basic = `
 data "google_client_config" "current" { }
 `
-
-func testAccCheckGoogleClientConfig_credentialsInProviderConfig() string {
-	return `data "google_client_config" "current" {}`
-}

--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_client_config_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_client_config_test.go
@@ -1,10 +1,12 @@
 package resourcemanager_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestAccDataSourceGoogleClientConfig_basic(t *testing.T) {
@@ -49,6 +51,47 @@ func TestAccDataSourceGoogleClientConfig_omitLocation(t *testing.T) {
 	})
 }
 
+// Test checks how the data source behaves when credentials are set in the provider block,
+// including when the credentials are valid and not valid
+func TestAccDataSourceGoogleClientConfig_credentialsInProviderConfig(t *testing.T) {
+	// t.Parallel() - Cannot use as we change ENVs
+
+	goodCreds := envvar.GetTestCredsFromEnv()
+	t.Setenv("GOOGLE_CREDENTIALS", "")
+
+	badCreds := acctest.GenerateEscapedFakeCredentialsJson("test") // Need to double escape quotes
+
+	resourceName := "data.google_client_config.current"
+
+	acctest.VcrTest(t, resource.TestCase{
+		// PreCheck cannot be set as usual, as test has GOOGLE_CREDENTIALS unset
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckGoogleClientConfig_credentialsInProviderConfig(goodCreds),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "access_token"),
+				),
+			},
+			{
+				Config: testAccCheckGoogleClientConfig_credentialsInProviderConfig(badCreds),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "access_token"),
+				),
+			},
+		},
+	})
+}
+
 const testAccCheckGoogleClientConfig_basic = `
 data "google_client_config" "current" { }
 `
+
+func testAccCheckGoogleClientConfig_credentialsInProviderConfig(creds string) string {
+	return fmt.Sprintf(`
+provider "google" {
+  credentials = "%s"
+}
+
+data "google_client_config" "current" {}`, creds)
+}

--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_client_config_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_client_config_test.go
@@ -1,13 +1,11 @@
 package resourcemanager_test
 
 import (
-	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestAccDataSourceGoogleClientConfig_basic(t *testing.T) {
@@ -52,31 +50,20 @@ func TestAccDataSourceGoogleClientConfig_omitLocation(t *testing.T) {
 	})
 }
 
-// Test checks how the data source behaves when credentials are set in the provider block,
-// including when the credentials are valid and not valid
-func TestAccDataSourceGoogleClientConfig_credentialsInProviderConfig(t *testing.T) {
+// Test checks how the data source behaves when invalid credentials are used
+// This test sets them as an ENV
+func TestAccDataSourceGoogleClientConfig_invalidCredentials(t *testing.T) {
 	// t.Parallel() - Cannot use as we change ENVs
 
-	goodCreds := envvar.GetTestCredsFromEnv()
-	t.Setenv("GOOGLE_CREDENTIALS", "")
-
-	badCreds := acctest.GenerateEscapedFakeCredentialsJson("test") // Need to double escape quotes
-
-	resourceName := "data.google_client_config.current"
+	badCreds := acctest.GenerateFakeCredentialsJson("test")
+	t.Setenv("GOOGLE_CREDENTIALS", badCreds)
 
 	acctest.VcrTest(t, resource.TestCase{
 		// PreCheck cannot be set as usual, as test has GOOGLE_CREDENTIALS unset
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckGoogleClientConfig_credentialsInProviderConfig(goodCreds),
-				Check: resource.ComposeTestCheckFunc(
-					// This field is set when credentials are valid
-					resource.TestCheckResourceAttrSet(resourceName, "access_token"),
-				),
-			},
-			{
-				Config:      testAccCheckGoogleClientConfig_credentialsInProviderConfig(badCreds),
+				Config:      testAccCheckGoogleClientConfig_credentialsInProviderConfig(),
 				ExpectError: regexp.MustCompile("Error setting access_token"),
 			},
 		},
@@ -87,11 +74,6 @@ const testAccCheckGoogleClientConfig_basic = `
 data "google_client_config" "current" { }
 `
 
-func testAccCheckGoogleClientConfig_credentialsInProviderConfig(creds string) string {
-	return fmt.Sprintf(`
-provider "google" {
-  credentials = "%s"
-}
-
-data "google_client_config" "current" {}`, creds)
+func testAccCheckGoogleClientConfig_credentialsInProviderConfig() string {
+	return `data "google_client_config" "current" {}`
 }

--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_client_config_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_client_config_test.go
@@ -2,6 +2,7 @@ package resourcemanager_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -70,14 +71,13 @@ func TestAccDataSourceGoogleClientConfig_credentialsInProviderConfig(t *testing.
 			{
 				Config: testAccCheckGoogleClientConfig_credentialsInProviderConfig(goodCreds),
 				Check: resource.ComposeTestCheckFunc(
+					// This field is set when credentials are valid
 					resource.TestCheckResourceAttrSet(resourceName, "access_token"),
 				),
 			},
 			{
-				Config: testAccCheckGoogleClientConfig_credentialsInProviderConfig(badCreds),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(resourceName, "access_token"),
-				),
+				Config:      testAccCheckGoogleClientConfig_credentialsInProviderConfig(badCreds),
+				ExpectError: regexp.MustCompile("Error setting access_token"),
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_client_config_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_client_config_test.go
@@ -50,16 +50,12 @@ func TestAccDataSourceGoogleClientConfig_omitLocation(t *testing.T) {
 	})
 }
 
-// Test checks how the data source behaves when invalid credentials are used
-// This test sets them as an ENV
 func TestAccDataSourceGoogleClientConfig_invalidCredentials(t *testing.T) {
-	// t.Parallel() - Cannot use as we change ENVs
-
 	badCreds := acctest.GenerateFakeCredentialsJson("test")
 	t.Setenv("GOOGLE_CREDENTIALS", badCreds)
 
 	acctest.VcrTest(t, resource.TestCase{
-		// PreCheck cannot be set as usual, as test has GOOGLE_CREDENTIALS unset
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

Related to https://github.com/hashicorp/terraform-provider-google/issues/18774

```release-note:bug
resourcemanager: fixed a bug where data.google_client_config failed silently when inadequate credentials were used to configure the provider
```
