### PR TITLE
Don't require -o arg when running autogen

### DIFF
--- a/mmv1/compiler.rb
+++ b/mmv1/compiler.rb
@@ -105,7 +105,8 @@ raise 'Cannot use -p/--products and -a/--all simultaneously' \
   if products_to_generate && all_products
 raise 'Either -p/--products OR -a/--all must be present' \
   if products_to_generate.nil? && !all_products
-raise 'Option -o/--output is a required parameter' if output_path.nil?
+raise 'Option -o/--output is a required parameter' \
+  if output_path.nil? && !openapi_generate
 raise 'Option -e/--engine is a required parameter' if provider_name.nil?
 
 if openapi_generate

--- a/mmv1/openapi_generate/parser.rb
+++ b/mmv1/openapi_generate/parser.rb
@@ -25,7 +25,9 @@ module OpenAPIGenerate
     end
 
     def run
-      Dir[@folder].each do |openapi_file|
+      openapi_dir = Dir[@folder]
+      raise "No OpenAPI files found in #{@folder}" if openapi_dir.empty?
+      openapi_dir.each do |openapi_file|
         write_yaml(openapi_file, @output)
       end
     end
@@ -287,10 +289,12 @@ module OpenAPIGenerate
     def write_yaml(spec_path, output)
       resource_paths = find_resources(spec_path)
       product_path = build_product(spec_path, output)
+      Google::LOGGER.info "Generated product '#{product_path}/product.yaml'"
       resource_paths.each do |path_array|
         resource = build_resource(spec_path, path_array[0], path_array[1])
         file_path = File.join(product_path, "#{resource.name}.yaml")
         File.write(file_path, resource.to_yaml)
+        Google::LOGGER.info "Generated resource '#{file_path}'"
       end
     end
   end

--- a/mmv1/openapi_generate/parser.rb
+++ b/mmv1/openapi_generate/parser.rb
@@ -27,6 +27,7 @@ module OpenAPIGenerate
     def run
       openapi_dir = Dir[@folder]
       raise "No OpenAPI files found in #{@folder}" if openapi_dir.empty?
+
       openapi_dir.each do |openapi_file|
         write_yaml(openapi_file, @output)
       end


### PR DESCRIPTION
Also complain if there's no JSON file(s) to generate from and log what files are generated to hopefully avoid future support questions.

```release-note:none
```
