### PR TITLE
redis_cluster 6.0.0 documentation updates

### DIFF
--- a/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
@@ -203,6 +203,12 @@ An empty value now means 300.
 ### `balancing_mode` default value changed
 
 An empty value now means UTILIZATION.
+
+## Resource: `google_redis_cluster`
+
+### `deletion_protection_enabled` field with default value added
+
+Support for the deletionProtectionEnabled field has been added. Redis clusters will now be created with a `deletion_protection_enabled = true` value by default. 
  
 ## Resource: `google_vpc_access_connector`
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Documentation for the change located here: https://github.com/GoogleCloudPlatform/magic-modules/pull/10367

Field is using the actual `deletion_protection_enabled` [field from the API,](https://cloud.google.com/memorystore/docs/cluster/reference/rest/v1/projects.locations.clusters) so it is introducing a real breaking change as opposed to a virtual field that could be handled in a separate fashion.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
