### PR TITLE
Handle email casing in google_bigquery_dataset_access

### DIFF
--- a/mmv1/products/bigquery/DatasetAccess.yaml
+++ b/mmv1/products/bigquery/DatasetAccess.yaml
@@ -125,6 +125,7 @@ properties:
       - view
       - dataset
       - routine
+    custom_expand: 'templates/terraform/custom_expand/string_to_lower_case.go.erb'
     diff_suppress_func: resourceBigQueryDatasetAccessIamMemberDiffSuppress
   - !ruby/object:Api::Type::String
     name: 'groupByEmail'
@@ -138,6 +139,7 @@ properties:
       - view
       - dataset
       - routine
+    custom_expand: 'templates/terraform/custom_expand/string_to_lower_case.go.erb'
     diff_suppress_func: resourceBigQueryDatasetAccessIamMemberDiffSuppress
   - !ruby/object:Api::Type::String
     name: 'domain'

--- a/mmv1/templates/terraform/constants/bigquery_dataset_access.go.erb
+++ b/mmv1/templates/terraform/constants/bigquery_dataset_access.go.erb
@@ -27,20 +27,28 @@ func resourceBigQueryDatasetAccessIamMemberDiffSuppress(k, old, new string, d *s
 		}
 
 		if memberInState := d.Get("user_by_email").(string); memberInState != "" {
-			return strings.ToUpper(memberInState) == strings.ToUpper(strippedIamMember)
+			return strings.ToLower(memberInState) == strings.ToLower(strippedIamMember)
 		}
 
 		if memberInState := d.Get("group_by_email").(string); memberInState != "" {
-			return strings.ToUpper(memberInState) == strings.ToUpper(strippedIamMember)
+			return strings.ToLower(memberInState) == strings.ToLower(strippedIamMember)
 		}
 
 		if memberInState := d.Get("domain").(string); memberInState != "" {
-			return strings.ToUpper(memberInState) == strings.ToUpper(strippedIamMember)
+			return strings.ToLower(memberInState) == strings.ToLower(strippedIamMember)
 		}
 
 		if memberInState := d.Get("special_group").(string); memberInState != "" {
-			return strings.ToUpper(memberInState) == strings.ToUpper(strippedIamMember)
+			return strings.ToLower(memberInState) == strings.ToLower(strippedIamMember)
 		}
+	}
+
+	if memberInState := d.Get("user_by_email").(string); memberInState != "" {
+		return strings.ToLower(old) == strings.ToLower(new)
+	}
+
+	if memberInState := d.Get("group_by_email").(string); memberInState != "" {
+		return strings.ToLower(old) == strings.ToLower(new)
 	}
 
 	return false

--- a/mmv1/templates/terraform/custom_expand/string_to_lower_case.go.erb
+++ b/mmv1/templates/terraform/custom_expand/string_to_lower_case.go.erb
@@ -1,0 +1,21 @@
+<%- # the license inside this block applies to this file
+	# Copyright 2024 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+  if v == nil {
+    return nil, nil
+  }
+
+  return strings.ToLower(v.(string)), nil
+}

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_dataset_access_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_dataset_access_test.go
@@ -276,6 +276,38 @@ func TestAccBigQueryDatasetAccess_allAuthenticatedUsers(t *testing.T) {
 	})
 }
 
+func TestAccBigQueryDatasetAccess_userByEmailWithMixedCase(t *testing.T) {
+	t.Parallel()
+
+	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryDatasetAccess_mixedCaseEmail(datasetID, "user_by_email", "alicE@google.COM"),
+			},
+		},
+	})
+}
+
+func TestAccBigQueryDatasetAccess_groupByEmailWithMixedCase(t *testing.T) {
+	t.Parallel()
+
+	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryDatasetAccess_mixedCaseEmail(datasetID, "group_by_email", "MAGIC-MODULES@gOOgle.com"),
+			},
+		},
+	})
+}
+
 func testAccCheckBigQueryDatasetAccessPresent(t *testing.T, n string, expected map[string]interface{}) resource.TestCheckFunc {
 	return testAccCheckBigQueryDatasetAccess(t, n, expected, true)
 }
@@ -528,4 +560,18 @@ resource "google_bigquery_dataset" "dataset" {
   dataset_id    = "%s"
 }
 `, datasetID)
+}
+
+func testAccBigQueryDatasetAccess_mixedCaseEmail(datasetID, accessType, email string) string {
+	return fmt.Sprintf(`
+resource "google_bigquery_dataset_access" "mixed_case_email" {
+  dataset_id    = google_bigquery_dataset.dataset.dataset_id
+  role          = "roles/bigquery.dataEditor"
+  %s = "%s"
+}
+
+resource "google_bigquery_dataset" "dataset" {
+  dataset_id = "%s"
+}
+`, accessType, email, datasetID)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/17994.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigquery: fixed an error which could occur with email field values containing non-lower-case characters in `google_bigquery_dataset_access`
```
