### PR TITLE
Support Undelete for Vmwareengine Private Cloud

### DIFF
--- a/mmv1/products/vmwareengine/PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/PrivateCloud.yaml
@@ -47,6 +47,7 @@ autogen_async: true
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   constants: templates/terraform/constants/vmwareengine_private_cloud.go.erb
   decoder: "templates/terraform/decoders/private_cloud.go.erb"
+  pre_create: templates/terraform/pre_create/vmwareengine_private_cloud.go.erb
   pre_delete: templates/terraform/pre_delete/vmwareengine_private_cloud.go.erb
   post_delete: "templates/terraform/post_delete/private_cloud.go.erb"
   post_update: "templates/terraform/post_update/private_cloud.go.erb"

--- a/mmv1/templates/terraform/constants/vmwareengine_private_cloud.go.erb
+++ b/mmv1/templates/terraform/constants/vmwareengine_private_cloud.go.erb
@@ -31,3 +31,49 @@ func isMultiNodePrivateCloud(d *schema.ResourceData) bool {
     }
     return false
 }
+
+func isPrivateCloudInDeletedState(config *transport_tpg.Config, d *schema.ResourceData, billingProject string, userAgent string) (bool, error) {
+    baseurl, err := tpgresource.ReplaceVars(d, config, "{{<%=object.__product.name-%>BasePath}}<%=object.self_link_uri-%>")
+    if err != nil {
+        return false, err
+    }
+    res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+        Config: config,
+        Method: "GET",
+        Project: billingProject,
+        RawURL: baseurl,
+        UserAgent: userAgent,
+    })
+    if err != nil {
+        if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[DEBUG] No existing private cloud found")
+			return false, nil
+		} 
+        return false, err
+    }
+    // if resource exists but is marked for deletion
+    v, ok := res["state"]
+    if ok && v.(string) == "DELETED" {
+        log.Printf("[DEBUG] The Private cloud exists and is marked for deletion.")
+        return true, nil
+    }
+    return false, nil
+}
+
+// Check if private cloud is absent or if it exists in a deleted state.
+func pollCheckForPrivateCloudAbsence(resp map[string]interface{}, respErr error) transport_tpg.PollResult {
+    if respErr != nil {
+        if transport_tpg.IsGoogleApiErrorWithCode(respErr, 404) {
+            return transport_tpg.SuccessPollResult()
+        }
+        return transport_tpg.ErrorPollResult(respErr)
+    }
+    // if resource exists but is marked for deletion
+    log.Printf("[DEBUG] Fetching state of the private cloud.")
+    v, ok := resp["state"]
+    if ok && v.(string) == "DELETED" {
+        log.Printf("[DEBUG] The Private cloud has been successfully marked for delayed deletion.")
+        return transport_tpg.SuccessPollResult()
+    }
+    return transport_tpg.PendingStatusPollResult("found")
+}

--- a/mmv1/templates/terraform/post_delete/private_cloud.go.erb
+++ b/mmv1/templates/terraform/post_delete/private_cloud.go.erb
@@ -29,18 +29,11 @@ privateCloudPollRead := func(d *schema.ResourceData, meta interface{}) transport
             if err != nil {
                 return res, err
             }
-            // if resource exists but is marked for deletion
-            log.Printf("[DEBUG] Fetching state of the private cloud.")
-            v, ok := res["state"]
-            if ok && v.(string) == "DELETED" {
-                log.Printf("[DEBUG] The Private cloud has been successfully marked for delayed deletion.")
-                return nil, nil
-            }
             return res, nil
         }
     }
 
-err = transport_tpg.PollingWaitTime(privateCloudPollRead(d, meta), transport_tpg.PollCheckForAbsence, "Deleting <%= object.name -%>", d.Timeout(schema.TimeoutDelete), 10)
+err = transport_tpg.PollingWaitTime(privateCloudPollRead(d, meta), pollCheckForPrivateCloudAbsence, "Deleting <%= object.name -%>", d.Timeout(schema.TimeoutDelete), 10)
 if err != nil {
     return fmt.Errorf("Error waiting to delete PrivateCloud: %s", err)
 }

--- a/mmv1/templates/terraform/pre_create/vmwareengine_private_cloud.go.erb
+++ b/mmv1/templates/terraform/pre_create/vmwareengine_private_cloud.go.erb
@@ -1,0 +1,15 @@
+// Check if the project exists in a deleted state
+pcMarkedForDeletion, err := isPrivateCloudInDeletedState(config, d, billingProject, userAgent)
+if err != nil {
+        return fmt.Errorf("Error checking if Private Cloud exists and is marked for deletion: %s", err)
+}
+if pcMarkedForDeletion {
+    log.Printf("[DEBUG] Private Cloud exists and is marked for deletion. Triggering UNDELETE of the Private Cloud.\n")
+    url, err = tpgresource.ReplaceVars(d, config, "{{VmwareengineBasePath}}projects/{{project}}/locations/{{location}}/privateClouds/{{name}}:undelete")
+	if err != nil {
+		return err
+	}
+    obj = make(map[string]interface{})
+} else {
+    log.Printf("[DEBUG] Private Cloud is not found to be marked for deletion. Triggering CREATE of the Private Cloud.\n")
+}

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
@@ -47,13 +47,13 @@ func TestAccVmwareenginePrivateCloud_vmwareEnginePrivateCloudUpdate(t *testing.T
 					testAccCheckGoogleVmwareengineVcenterCredentialsMeta("data.google_vmwareengine_vcenter_credentials.vcenter-ds"),
 				),
 			},
-
 			{
 				ResourceName:            "google_vmwareengine_private_cloud.vmw-engine-pc",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"location", "name", "update_time", "type", "deletion_delay_hours", "send_deletion_delay_hours_if_zero"},
 			},
+
 			{
 				Config: testVmwareenginePrivateCloudUpdateConfig(context),
 				Check: resource.ComposeTestCheckFunc(
@@ -67,13 +67,43 @@ func TestAccVmwareenginePrivateCloud_vmwareEnginePrivateCloudUpdate(t *testing.T
 						}),
 				),
 			},
-
 			{
 				ResourceName:            "google_vmwareengine_private_cloud.vmw-engine-pc",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"location", "name", "update_time", "type", "deletion_delay_hours", "send_deletion_delay_hours_if_zero"},
 			},
+
+			{
+				Config: testVmwareenginePrivateCloudDelayedDeleteConfig(context),
+			},
+			{
+				ResourceName:            "google_vmwareengine_network.vmw-engine-nw",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "name"},
+			},
+
+			{
+				Config: testVmwareenginePrivateCloudUndeleteConfig(context),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores(
+						"data.google_vmwareengine_private_cloud.ds",
+						"google_vmwareengine_private_cloud.vmw-engine-pc",
+						map[string]struct{}{
+							"type":                              {},
+							"deletion_delay_hours":              {},
+							"send_deletion_delay_hours_if_zero": {},
+						}),
+				),
+			},
+			{
+				ResourceName:            "google_vmwareengine_private_cloud.vmw-engine-pc",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "name", "update_time", "type", "deletion_delay_hours", "send_deletion_delay_hours_if_zero"},
+			},
+
 			{
 				Config: testVmwareengineSubnetImportConfig(context),
 				Check: resource.ComposeTestCheckFunc(
@@ -86,6 +116,7 @@ func TestAccVmwareenginePrivateCloud_vmwareEnginePrivateCloudUpdate(t *testing.T
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"parent", "name"},
 			},
+
 			{
 				Config: testVmwareengineSubnetUpdateConfig(context),
 			},
@@ -104,6 +135,14 @@ func testVmwareenginePrivateCloudCreateConfig(context map[string]interface{}) st
 }
 
 func testVmwareenginePrivateCloudUpdateConfig(context map[string]interface{}) string {
+	return testVmwareenginePrivateCloudConfig(context, "sample updated description", "STANDARD", 3, 8) + testVmwareengineVcenterNSXCredentailsConfig(context)
+}
+
+func testVmwareenginePrivateCloudDelayedDeleteConfig(context map[string]interface{}) string {
+	return testVmwareenginePrivateCloudDeletedConfig(context)
+}
+
+func testVmwareenginePrivateCloudUndeleteConfig(context map[string]interface{}) string {
 	return testVmwareenginePrivateCloudConfig(context, "sample updated description", "STANDARD", 3, 0) + testVmwareengineVcenterNSXCredentailsConfig(context)
 }
 
@@ -121,7 +160,7 @@ func testVmwareenginePrivateCloudConfig(context map[string]interface{}, descript
 	context["description"] = description
 	context["type"] = pcType
 	return acctest.Nprintf(`
-resource "google_vmwareengine_network" "default-nw" {
+resource "google_vmwareengine_network" "vmw-engine-nw" {
   name              = "tf-test-pc-nw-%{random_suffix}"
   location          = "global"
   type              = "STANDARD"
@@ -137,7 +176,7 @@ resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
   send_deletion_delay_hours_if_zero = true
   network_config {
     management_cidr = "192.168.0.0/24"
-    vmware_engine_network = google_vmwareengine_network.default-nw.id
+    vmware_engine_network = google_vmwareengine_network.vmw-engine-nw.id
   }
   management_cluster {
     cluster_id = "tf-test-sample-mgmt-cluster-custom-core-count%{random_suffix}"
@@ -155,6 +194,17 @@ data "google_vmwareengine_private_cloud" "ds" {
 	depends_on = [
    	google_vmwareengine_private_cloud.vmw-engine-pc,
   ]
+}
+`, context)
+}
+
+func testVmwareenginePrivateCloudDeletedConfig(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_vmwareengine_network" "vmw-engine-nw" {
+  name              = "tf-test-pc-nw-%{random_suffix}"
+  location          = "global"
+  type              = "STANDARD"
+  description       = "PC network description."
 }
 `, context)
 }


### PR DESCRIPTION
Support undelete of the Private Cloud if it exists in the 'marked for deletion' state.

Private Cloud Acceptance Tests pass at gpaste/4841587882590208

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
vmwareengine: Added PC undelete support in `google_vmwareengine_private_cloud`
```
