### PR TITLE
Add regex for time format to `resource_compute_resource_policies`

### DIFF
--- a/mmv1/products/compute/ResourcePolicy.yaml
+++ b/mmv1/products/compute/ResourcePolicy.yaml
@@ -142,7 +142,7 @@ properties:
                   where HH : [00-23] and MM : [00] GMT. eg: 21:00
                 required: true
                 validation: !ruby/object:Provider::Terraform::Validation
-                  function: 'verify.ValidateHourlyOnly'
+                  regex: '^([01][0-9]|2[0-3]):00$'
           - !ruby/object:Api::Type::NestedObject
             name: 'dailySchedule'
             description: |
@@ -165,7 +165,7 @@ properties:
                   both 13:00-5 and 08:00 are valid.
                 required: true
                 validation: !ruby/object:Provider::Terraform::Validation
-                  function: 'verify.ValidateHourlyOnly'
+                  regex: '^([01][0-9]|2[0-3]):00$'
           - !ruby/object:Api::Type::NestedObject
             name: 'weeklySchedule'
             description: |


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
closes [issue #8460](https://github.com/hashicorp/terraform-provider-google/issues/8460)

This is probably a breaking change because some `terraform apply` commands won't go through if they have a wrong format. The regex will throw an error. But it also ensures that it's the correct format for the API.

Will write a test case for this into the PR if it's an approved solution.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
compute: `resource_policies` now have a regex on their time format that will allow for correct calls to the API
```
