### PR TITLE
Stop passing version as an argument when making a new PF provider

### DIFF
--- a/mmv1/third_party/terraform/fwprovider/framework_provider.go.erb
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider.go.erb
@@ -19,6 +19,7 @@ import (
     "github.com/hashicorp/terraform-provider-google/google/fwmodels"
     "github.com/hashicorp/terraform-provider-google/google/fwtransport"
     "github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
+	"github.com/hashicorp/terraform-provider-google/version"
     <% unless version == 'ga' -%>
     "github.com/hashicorp/terraform-provider-google/google/services/firebase"
     <% end -%>
@@ -33,9 +34,9 @@ var (
 )
 
 // New is a helper function to simplify provider server and testing implementation.
-func New(version string) provider.ProviderWithMetaSchema {
+func New() provider.ProviderWithMetaSchema {
     return &FrameworkProvider{
-        Version: version,
+        Version: version.ProviderVersion,
     }
 }
 

--- a/mmv1/third_party/terraform/fwprovider/framework_provider_internal_test.go
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider_internal_test.go
@@ -9,12 +9,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 func TestFrameworkProvider_impl(t *testing.T) {
-	var _ provider.ProviderWithMetaSchema = New("test")
+	primary := &schema.Provider{}
+	var _ provider.ProviderWithMetaSchema = New(primary)
 }
 
 func TestFrameworkProvider_CredentialsValidator(t *testing.T) {

--- a/mmv1/third_party/terraform/fwprovider/framework_provider_internal_test.go
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider_internal_test.go
@@ -9,14 +9,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 func TestFrameworkProvider_impl(t *testing.T) {
-	primary := &schema.Provider{}
-	var _ provider.ProviderWithMetaSchema = New(primary)
+	var _ provider.ProviderWithMetaSchema = New()
 }
 
 func TestFrameworkProvider_CredentialsValidator(t *testing.T) {

--- a/mmv1/third_party/terraform/go/main.go.tmpl
+++ b/mmv1/third_party/terraform/go/main.go.tmpl
@@ -32,8 +32,8 @@ func main() {
 
 	// concat with sdkv2 provider
 	providers := []func() tfprotov5.ProviderServer{
-		providerserver.NewProtocol5(fwprovider.New(version)), // framework provider
-		provider.Provider().GRPCProvider,                   // sdk provider
+		providerserver.NewProtocol5(fwprovider.New()), // framework provider
+		provider.Provider().GRPCProvider,              // sdk provider
 	}
 
 	// use the muxer

--- a/mmv1/third_party/terraform/main.go.erb
+++ b/mmv1/third_party/terraform/main.go.erb
@@ -13,7 +13,6 @@ import (
 
 	"github.com/hashicorp/terraform-provider-google/google/fwprovider"
 	"github.com/hashicorp/terraform-provider-google/google/provider"
-	ver "github.com/hashicorp/terraform-provider-google/version"
 )
 
 func main() {

--- a/mmv1/third_party/terraform/main.go.erb
+++ b/mmv1/third_party/terraform/main.go.erb
@@ -16,15 +16,6 @@ import (
 	ver "github.com/hashicorp/terraform-provider-google/version"
 )
 
-var (
-	// these will be set by the goreleaser configuration
-	// to appropriate values for the compiled binary
-	version string = ver.ProviderVersion
-
-	// goreleaser can also pass the specific commit if you want
-	// commit  string = ""
-)
-
 func main() {
 	var debug bool
 
@@ -33,8 +24,8 @@ func main() {
 
 	// concat with sdkv2 provider
 	providers := []func() tfprotov5.ProviderServer{
-		providerserver.NewProtocol5(fwprovider.New(version)), // framework provider
-		provider.Provider().GRPCProvider,                   // sdk provider
+		providerserver.NewProtocol5(fwprovider.New()), // framework provider
+		provider.Provider().GRPCProvider,              // sdk provider
 	}
 
 	// use the muxer


### PR DESCRIPTION
# Context

The version variable comes from the version package, here: [version.ProviderVersion](https://github.com/hashicorp/terraform-provider-google/blob/924af2bcae221ec3c65d027b617dbcd0b7b2605f/version/version.go#L7)

When we release a new version of the provider that string is overwritten via `ldflags` with the semver version of the new release ([via GoReleaser, here](https://github.com/hashicorp/terraform-provider-google/blob/924af2bcae221ec3c65d027b617dbcd0b7b2605f/.goreleaser.yml#L32-L33)), and when we run acceptance tests "dev" is replaced with "acc" ([see Makefile command here](https://github.com/hashicorp/terraform-provider-google/blob/924af2bcae221ec3c65d027b617dbcd0b7b2605f/GNUmakefile#L18)).

The provider only uses this version number to create a UserAgent string that includes the version of the provider.
- [SDK creation of UserAgent when configuring the provider](https://github.com/hashicorp/terraform-provider-google/blob/924af2bcae221ec3c65d027b617dbcd0b7b2605f/google/provider/provider.go#L828) - note that version.ProviderVersion is used directly
- [PF creation of UserAgent when configuring the provider](https://github.com/hashicorp/terraform-provider-google/blob/924af2bcae221ec3c65d027b617dbcd0b7b2605f/google/fwtransport/framework_config.go#L191)

# This PR

This PR refactors how the provider version is passed into the code that returns an instance of a plugin-framework implemented provider.

This PR is part of breaking [a large future PR](https://github.com/SarahFrench/terraform-provider-google/pull/9) into smaller chunks! There will be future changes to the `New` function, so removing this argument is a first step. When that work is complete we'll actually be removing the parallel user agent creation code completely and only have it implemented in one place.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
