### PR TITLE
Add PUPI import and export to google_compute_network_peering_routes_config

### DIFF
--- a/mmv1/products/compute/NetworkPeeringRoutesConfig.yaml
+++ b/mmv1/products/compute/NetworkPeeringRoutesConfig.yaml
@@ -118,7 +118,7 @@ properties:
       IPv4 special-use ranges are always exported to peers and
       are not controlled by this field.
     send_empty_value: true
-    required: true
+    default_from_api: true
   - !ruby/object:Api::Type::Boolean
     name: 'importSubnetRoutesWithPublicIp'
     description: |
@@ -126,4 +126,4 @@ properties:
       IPv4 special-use ranges are always imported from peers and
       are not controlled by this field.
     send_empty_value: true
-    required: true
+    default_from_api: true

--- a/mmv1/products/compute/NetworkPeeringRoutesConfig.yaml
+++ b/mmv1/products/compute/NetworkPeeringRoutesConfig.yaml
@@ -115,7 +115,7 @@ properties:
     name: 'exportSubnetRoutesWithPublicIp'
     description: |
       Whether subnet routes with public IP range are exported.
-      The default value is true, all subnet routes are exported.
+      All subnet routes are exported.
       IPv4 special-use ranges are always exported to peers and
       are not controlled by this field.
     send_empty_value: true
@@ -124,7 +124,6 @@ properties:
     name: 'importSubnetRoutesWithPublicIp'
     description: |
       Whether subnet routes with public IP range are imported.
-      The default value is false.
       IPv4 special-use ranges are always imported from peers and
       are not controlled by this field.
     send_empty_value: true

--- a/mmv1/products/compute/NetworkPeeringRoutesConfig.yaml
+++ b/mmv1/products/compute/NetworkPeeringRoutesConfig.yaml
@@ -115,7 +115,6 @@ properties:
     name: 'exportSubnetRoutesWithPublicIp'
     description: |
       Whether subnet routes with public IP range are exported.
-      All subnet routes are exported.
       IPv4 special-use ranges are always exported to peers and
       are not controlled by this field.
     send_empty_value: true

--- a/mmv1/products/compute/NetworkPeeringRoutesConfig.yaml
+++ b/mmv1/products/compute/NetworkPeeringRoutesConfig.yaml
@@ -111,3 +111,21 @@ properties:
     description: |
       Whether to import the custom routes to the peer network.
     send_empty_value: true
+  - !ruby/object:Api::Type::Boolean
+    name: 'exportSubnetRoutesWithPublicIp'
+    description: |
+      Whether subnet routes with public IP range are exported.
+      The default value is true, all subnet routes are exported.
+      IPv4 special-use ranges are always exported to peers and
+      are not controlled by this field.
+    send_empty_value: true
+    required: true
+  - !ruby/object:Api::Type::Boolean
+    name: 'importSubnetRoutesWithPublicIp'
+    description: |
+      Whether subnet routes with public IP range are imported.
+      The default value is false.
+      IPv4 special-use ranges are always imported from peers and
+      are not controlled by this field.
+    send_empty_value: true
+    required: true

--- a/mmv1/templates/terraform/examples/network_peering_routes_config_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/network_peering_routes_config_basic.tf.erb
@@ -4,6 +4,8 @@ resource "google_compute_network_peering_routes_config" "<%= ctx[:primary_resour
 
   import_custom_routes = true
   export_custom_routes = true
+  import_subnet_routes_with_public_ip = true
+  export_subnet_routes_with_public_ip = true
 }
 
 resource "google_compute_network_peering" "peering_primary" {


### PR DESCRIPTION
This PR adds the `import_subnet_routes_with_public_ip` and `export_subnet_routes_with_public_ip` fields to the compute resource `google_compute_network_peering_routes_config`.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/11573

Although there is an API side default, I set these fields as required without defaults as people may have this resource already in state, and it is undesirable to change without explicitly choosing to. 

This mirrors the approach of `import_custom_routes` and `export_custom_routes`. Please let me know if there is a better approach.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `import_subnet_routes_with_public_ip` and `export_subnet_routes_with_public_ip` fields to `google_compute_network_peering_routes_config` resource
```