### PR TITLE
Update data_source_artifact_registry_docker_image_test.go

### DIFF
--- a/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_docker_image_test.go
+++ b/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_docker_image_test.go
@@ -28,25 +28,12 @@ func TestAccDataSourceArtifactRegistryDockerImage(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName+"Tag", "image_size_bytes"),
 					validateTimeStamps(resourceName+"Tag"),
 
-					// Data source using a digest
-					checkDigestDataSources(
-						resourceName+"Digest",
-						"projects/cloudrun/locations/us/repositories/container/dockerImages/hello@sha256:7a6e0dfb0142464ce0ba14a2cfcac75e383e36f39f47539c870132c826314ad6",
-						"us-docker.pkg.dev/cloudrun/container/hello@sha256:7a6e0dfb0142464ce0ba14a2cfcac75e383e36f39f47539c870132c826314ad6",
-					),
 					resource.TestCheckResourceAttrSet(resourceName+"Digest", "image_size_bytes"),
 					validateTimeStamps(resourceName+"Digest"),
 
 					// url safe docker name using a tag
 					checkTaggedDataSources(resourceName+"UrlTag", "latest"),
-
-					// url safe docker name using a digest
-					checkDigestDataSources(
-						resourceName+"UrlDigest",
-						"projects/go-containerregistry/locations/us/repositories/gcr.io/dockerImages/krane%2Fdebug@sha256:26903bf659994649af0b8ccb2675b76318b2bc3b2c85feea9a1f9d5b98eff363",
-						"us-docker.pkg.dev/go-containerregistry/gcr.io/krane/debug@sha256:26903bf659994649af0b8ccb2675b76318b2bc3b2c85feea9a1f9d5b98eff363",
-					),
-
+					
 					// Data source using no tag or digest
 					resource.TestCheckResourceAttrSet(resourceName+"None", "repository_id"),
 					resource.TestCheckResourceAttrSet(resourceName+"None", "image_name"),
@@ -70,25 +57,11 @@ data "google_artifact_registry_docker_image" "testTag" {
 	image_name    = "hello:latest"
 }
 
-data "google_artifact_registry_docker_image" "testDigest" {
-	project       = "cloudrun"
-	location      = "us"
-	repository_id = "container"
-	image_name    = "hello@sha256:7a6e0dfb0142464ce0ba14a2cfcac75e383e36f39f47539c870132c826314ad6"
-}
-
 data "google_artifact_registry_docker_image" "testUrlTag" {
 	project       = "go-containerregistry"
 	location      = "us"
 	repository_id = "gcr.io"
 	image_name    = "krane/debug:latest"
-}
-
-data "google_artifact_registry_docker_image" "testUrlDigest" {
-	project       = "go-containerregistry"
-	location      = "us"
-	repository_id = "gcr.io"
-	image_name    = "krane/debug@sha256:26903bf659994649af0b8ccb2675b76318b2bc3b2c85feea9a1f9d5b98eff363"
 }
 
 data "google_artifact_registry_docker_image" "testNone" {

--- a/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_docker_image_test.go
+++ b/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_docker_image_test.go
@@ -33,7 +33,7 @@ func TestAccDataSourceArtifactRegistryDockerImage(t *testing.T) {
 
 					// url safe docker name using a tag
 					checkTaggedDataSources(resourceName+"UrlTag", "latest"),
-					
+
 					// Data source using no tag or digest
 					resource.TestCheckResourceAttrSet(resourceName+"None", "repository_id"),
 					resource.TestCheckResourceAttrSet(resourceName+"None", "image_name"),


### PR DESCRIPTION
Removing hard-coded values for tests. These are not created or owned by this test and cannot be assured to work 100%

```release-note:bug
artifactregistry: Fixed https://github.com/hashicorp/terraform-provider-google/issues/18955
```
