### PR TITLE
Adding Preference field and test for BackendService

### DIFF
--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -271,6 +271,16 @@ properties:
           description: |
             Used when balancingMode is UTILIZATION. This ratio defines the
             CPU utilization target for the group. Valid range is [0.0, 1.0].
+        - !ruby/object:Api::Type::Enum
+          name: 'preference'
+          default_from_api: true
+          description: |
+            Indicates whether this backend should be fully utilized before 
+            sending traffic to backends with default preference. The possible 
+            values are PREFERRED and DEFAULT.
+          values:
+            - :PREFERRED
+            - :DEFAULT
   - !ruby/object:Api::Type::NestedObject
     name: 'circuitBreakers'
     description: |

--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -275,8 +275,8 @@ properties:
           name: 'preference'
           default_from_api: true
           description: |
-            Indicates whether this backend should be fully utilized before 
-            sending traffic to backends with default preference. The possible 
+            Indicates whether this backend should be fully utilized before
+            sending traffic to backends with default preference. The possible
             values are PREFERRED and DEFAULT.
           values:
             - :PREFERRED

--- a/mmv1/third_party/terraform/services/compute/go/resource_compute_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/go/resource_compute_backend_service_test.go.tmpl
@@ -113,6 +113,44 @@ func TestAccComputeBackendService_withBackendAndMaxUtilization(t *testing.T) {
 	})
 }
 
+func TestAccComputeBackendService_withBackendPreference(t *testing.T) {
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	igName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	itName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeBackendService_withBackend(
+					serviceName, igName, itName, checkName, 10),
+			},
+			{
+				ResourceName:            "google_compute_backend_service.lipsum",
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
+			{
+				Config: testAccComputeBackendService_withBackendPreference(
+					serviceName, igName, itName, checkName, 10),
+				PlanOnly: true,
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccComputeBackendService_withBackendPreference(
+					serviceName, igName, itName, checkName, 10),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccComputeBackendService_withBackendAndIAP(t *testing.T) {
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	igName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
@@ -1306,6 +1344,64 @@ resource "google_compute_http_health_check" "default" {
 }
 `, serviceName, timeout, igName, itName, checkName)
 }
+
+func testAccComputeBackendService_withBackendPreference(
+	serviceName, igName, itName, checkName string, timeout int64) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_backend_service" "lipsum" {
+  name        = "%s"
+  description = "Hello World 1234"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = %v
+
+  backend {
+    group           = google_compute_instance_group_manager.foobar.instance_group
+    preference      = "PREFERRED"
+  }
+
+
+  health_checks = [google_compute_http_health_check.default.self_link]
+}
+
+resource "google_compute_instance_group_manager" "foobar" {
+  name = "%s"
+  version {
+    instance_template = google_compute_instance_template.foobar.self_link
+    name              = "primary"
+  }
+  base_instance_name = "tf-test-foobar"
+  zone               = "us-central1-f"
+  target_size        = 1
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+
+  network_interface {
+    network = "default"
+  }
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+}
+
+resource "google_compute_http_health_check" "default" {
+  name               = "%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+`, serviceName, timeout, igName, itName, checkName)
 
 func testAccComputeBackendService_withBackendAndIAP(
 	serviceName, igName, itName, checkName string, timeout int64) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.erb
@@ -114,6 +114,44 @@ func TestAccComputeBackendService_withBackendAndMaxUtilization(t *testing.T) {
 	})
 }
 
+func TestAccComputeBackendService_withBackendPreference(t *testing.T) {
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	igName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	itName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeBackendService_withBackend(
+					serviceName, igName, itName, checkName, 10),
+			},
+			{
+				ResourceName:            "google_compute_backend_service.lipsum",
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
+			{
+				Config: testAccComputeBackendService_withBackendPreference(
+					serviceName, igName, itName, checkName, 10),
+				PlanOnly: true,
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccComputeBackendService_withBackendPreference(
+					serviceName, igName, itName, checkName, 10),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccComputeBackendService_withBackendAndIAP(t *testing.T) {
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	igName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
@@ -1268,6 +1306,64 @@ resource "google_compute_backend_service" "lipsum" {
   backend {
     group           = google_compute_instance_group_manager.foobar.instance_group
     max_utilization = 1.0
+  }
+
+  health_checks = [google_compute_http_health_check.default.self_link]
+}
+
+resource "google_compute_instance_group_manager" "foobar" {
+  name = "%s"
+  version {
+    instance_template = google_compute_instance_template.foobar.self_link
+    name              = "primary"
+  }
+  base_instance_name = "tf-test-foobar"
+  zone               = "us-central1-f"
+  target_size        = 1
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+
+  network_interface {
+    network = "default"
+  }
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+}
+
+resource "google_compute_http_health_check" "default" {
+  name               = "%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+`, serviceName, timeout, igName, itName, checkName)
+}
+
+func testAccComputeBackendService_withBackendPreference(
+	serviceName, igName, itName, checkName string, timeout int64) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_backend_service" "lipsum" {
+  name        = "%s"
+  description = "Hello World 1234"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = %v
+
+  backend {
+    group           = google_compute_instance_group_manager.foobar.instance_group
+    preference      = "PREFERRED"
   }
 
   health_checks = [google_compute_http_health_check.default.self_link]


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This PR adds the `backends[].preference` field to the `google_compute_backend_service` resource to allow certain backends to be preferred in the backend service.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `backends[].preference` field to `google_compute_backend_service` resource
```
