### PR TITLE
Improve handling when enabling/disabling server TLS policy in global target HTTPS proxies

### DIFF
--- a/mmv1/products/compute/TargetHttpsProxy.yaml
+++ b/mmv1/products/compute/TargetHttpsProxy.yaml
@@ -221,7 +221,7 @@ properties:
       load balancer (classic), this option is not available publicly.
   - !ruby/object:Api::Type::ResourceRef
     name: 'serverTlsPolicy'
-    resource: 'ServerSslPolicy'
+    resource: 'ServerTlsPolicy'
     imports: 'selfLink'
     description: |
       A URL referring to a networksecurity.ServerTlsPolicy
@@ -233,6 +233,11 @@ properties:
       INTERNAL_SELF_MANAGED and which with EXTERNAL, EXTERNAL_MANAGED
       loadBalancingScheme consult ServerTlsPolicy documentation.
       If left blank, communications are not encrypted.
+
+      If you remove this field from your configuration at the same time as
+      deleting or recreating a referenced ServerTlsPolicy resource, you will
+      receive a resourceInUseByAnotherResource error. Use lifecycle.create_before_destroy
+      within the ServerTlsPolicy resource to avoid this.
     update_verb: :PATCH
     update_url: 'projects/{{project}}/global/targetHttpsProxies/{{name}}'
     fingerprint_name: 'fingerprint'

--- a/mmv1/templates/terraform/encoders/compute_target_https_proxy.go.erb
+++ b/mmv1/templates/terraform/encoders/compute_target_https_proxy.go.erb
@@ -12,7 +12,7 @@ if _, ok := obj["certificateManagerCertificates"]; ok {
 // in the "PATCH" payload so if you were to remove a server TLS policy from a target HTTPS proxy, it would NOT remove
 // the association.
 if _, ok := obj["serverTlsPolicy"]; !ok {
-        obj["serverTlsPolicy"] = nil
+	obj["serverTlsPolicy"] = nil
 }
 
 return obj, nil

--- a/mmv1/templates/terraform/encoders/compute_target_https_proxy.go.erb
+++ b/mmv1/templates/terraform/encoders/compute_target_https_proxy.go.erb
@@ -7,4 +7,12 @@ if _, ok := obj["certificateManagerCertificates"]; ok {
 	obj["sslCertificates"] = obj["certificateManagerCertificates"]
 	delete(obj, "certificateManagerCertificates")
 }
+
+// Send null if serverTlsPolicy is not set. Without this, Terraform would not send any value for `serverTlsPolicy`
+// in the "PATCH" payload so if you were to remove a server TLS policy from a target HTTPS proxy, it would NOT remove
+// the association.
+if _, ok := obj["serverTlsPolicy"]; !ok {
+        obj["serverTlsPolicy"] = nil
+}
+
 return obj, nil

--- a/mmv1/third_party/terraform/services/compute/resource_compute_target_https_proxy_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_target_https_proxy_test.go.erb
@@ -95,7 +95,7 @@ func TestAccComputeTargetHttpsProxyServerTlsPolicy_update(t *testing.T) {
         CheckDestroy:             testAccCheckComputeTargetHttpsProxyDestroyProducer(t),
         Steps: []resource.TestStep{
             {
-                Config: testAccComputeTargetHttpsProxyServerTlsPolicy_full(resourceSuffix),
+                Config: testAccComputeTargetHttpsProxyWithoutServerTlsPolicy(resourceSuffix),
                 Check: resource.ComposeTestCheckFunc(
                     testAccCheckComputeTargetHttpsProxyExists(
                         t, "google_compute_target_https_proxy.foobar", &proxy),
@@ -103,11 +103,19 @@ func TestAccComputeTargetHttpsProxyServerTlsPolicy_update(t *testing.T) {
                 ),
             },
             {
-                Config: testAccComputeTargetHttpsProxyServerTlsPolicy_update(resourceSuffix),
+                Config: testAccComputeTargetHttpsProxyWithServerTlsPolicy(resourceSuffix),
                 Check: resource.ComposeTestCheckFunc(
                     testAccCheckComputeTargetHttpsProxyExists(
                         t, "google_compute_target_https_proxy.foobar", &proxy),
 										testAccComputeTargetHttpsProxyHasServerTlsPolicy(t, "tf-test-server-tls-policy-"+resourceSuffix, &proxy),
+                ),
+            },
+            {
+                Config: testAccComputeTargetHttpsProxyWithoutServerTlsPolicy(resourceSuffix),
+                Check: resource.ComposeTestCheckFunc(
+                    testAccCheckComputeTargetHttpsProxyExists(
+                        t, "google_compute_target_https_proxy.foobar", &proxy),
+										testAccComputeTargetHttpsProxyHasNullServerTlsPolicy(t, &proxy),
                 ),
             },
         },
@@ -422,7 +430,7 @@ resource "google_certificate_manager_dns_authorization" "instance" {
 `, id, id, id, id, id, id, id, id)
 }
 
-func testAccComputeTargetHttpsProxyServerTlsPolicy_full(id string) string {
+func testAccComputeTargetHttpsProxyWithoutServerTlsPolicy(id string) string {
 	return fmt.Sprintf(`
 data "google_project" "project" {}
 
@@ -431,7 +439,6 @@ resource "google_compute_target_https_proxy" "foobar" {
   name              = "tf-test-httpsproxy-%s"
 	url_map           = google_compute_url_map.foobar.self_link
 	ssl_certificates  = [google_compute_ssl_certificate.foobar.self_link]
-  server_tls_policy = null
 }
 
 resource "google_compute_backend_service" "foobar" {
@@ -457,28 +464,10 @@ resource "google_compute_ssl_certificate" "foobar" {
   private_key = file("test-fixtures/test.key")
   certificate = file("test-fixtures/test.crt")
 }
-
-resource "google_certificate_manager_trust_config" "trust_config" {
-  name     = "tf-test-trust-config-%s"
-  location = "global"
-
-  allowlisted_certificates  {
-    pem_certificate = file("test-fixtures/cert.pem")
-  }
+`, id, id, id, id, id)
 }
 
-resource "google_network_security_server_tls_policy" "server_tls_policy" {
-  name = "tf-test-server-tls-policy-%s"
-
-  mtls_policy {
-    client_validation_trust_config = "projects/${data.google_project.project.number}/locations/global/trustConfigs/${google_certificate_manager_trust_config.trust_config.name}"
-    client_validation_mode         = "ALLOW_INVALID_OR_MISSING_CLIENT_CERT"
-  }
-}
-`, id, id, id, id, id, id, id)
-}
-
-func testAccComputeTargetHttpsProxyServerTlsPolicy_update(id string) string {
+func testAccComputeTargetHttpsProxyWithServerTlsPolicy(id string) string {
 	return fmt.Sprintf(`
 data "google_project" "project" {}
 
@@ -529,6 +518,10 @@ resource "google_network_security_server_tls_policy" "server_tls_policy" {
   mtls_policy {
     client_validation_trust_config = "projects/${data.google_project.project.number}/locations/global/trustConfigs/${google_certificate_manager_trust_config.trust_config.name}"
     client_validation_mode         = "ALLOW_INVALID_OR_MISSING_CLIENT_CERT"
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 `, id, id, id, id, id, id, id)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR implements similar behavior as in https://github.com/GoogleCloudPlatform/magic-modules/pull/11184 but for **global** target HTTPS proxies.

Prior to this PR, you could enable a server TLS policy on a global HTTPS proxy, but disabling it would not work as removing `server_tls_policy` removes it from the `PATCH` payload entirely, so Google simply leaves the server TLS policy as is. What we actually need to do is send `serverTlsPolicy = null` if it's not set, which is what this PR does.

We're also adding a note about having to add the `create_before_destroy = true` lifecycle on `google_network_security_server_tls_policy` as removing the resource would make Terraform destroy the resource first _before_ creating/updating other resources, and that would result in a "resource already in use" error. This lifecycle rule means Terraform will create/update resources (in this case it would update `google_compute_target_https_proxy` first and remove the association with the `google_network_security_server_tls_policy` resource) before destroying the resource.

I've updated the tests so that it creates the resources _without_ a server TLS policy, then it adds the `server_tls_policy` and related resources, and then it removes them again. This is to ensure that we can successfully enable & disable mTLS.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: allowed disabling 'server_tls_policy' during update in 'google_compute_target_https_proxy' resources
```
