### PR TITLE
Add service mesh field to Cloud Run v2 Service

### DIFF
--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -168,7 +168,7 @@ examples:
     primary_resource_name: "fmt.Sprintf(\"tf-test-cloudrun-service-%s\", context[\"random_suffix\"])"
     vars:
       cloud_run_service_name: 'cloudrun-service'
-      mesh_name: 'mesh'
+      mesh_name: 'network-services-mesh'
     ignore_read_extra:
       - 'deletion_protection'
 

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -169,6 +169,8 @@ examples:
     vars:
       cloud_run_service_name: 'cloudrun-service'
       mesh_name: 'mesh'
+    ignore_read_extra:
+      - 'deletion_protection'
 
 parameters:
   - !ruby/object:Api::Type::String

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -160,6 +160,15 @@ examples:
     ignore_read_extra:
       - 'deletion_protection'
 
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'cloudrunv2_service_mesh'
+    min_version: 'beta'
+    primary_resource_id: 'default'
+    primary_resource_name: "fmt.Sprintf(\"tf-test-cloudrun-service-%s\", context[\"random_suffix\"])"
+    vars:
+      cloud_run_service_name: 'cloudrun-service'
+      mesh_name: 'mesh'
+
 parameters:
   - !ruby/object:Api::Type::String
     name: 'location'
@@ -877,6 +886,16 @@ properties:
         name: 'sessionAffinity'
         description: |-
           Enables session affinity. For more information, go to https://cloud.google.com/run/docs/configuring/session-affinity
+      - !ruby/object:Api::Type::NestedObject
+        name: 'serviceMesh'
+        min_version: beta
+        description: |-
+          Enables Cloud Service Mesh for this Revision.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'mesh'
+            description: |-
+              The Mesh resource name. For more information see https://cloud.google.com/service-mesh/docs/reference/network-services/rest/v1/projects.locations.meshes#resource:-mesh.
   - !ruby/object:Api::Type::Array
     name: 'traffic'
     description: |-

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -163,6 +163,7 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'cloudrunv2_service_mesh'
     min_version: 'beta'
+    external_providers: ['time']
     primary_resource_id: 'default'
     primary_resource_name: "fmt.Sprintf(\"tf-test-cloudrun-service-%s\", context[\"random_suffix\"])"
     vars:

--- a/mmv1/templates/terraform/examples/cloudrunv2_service_mesh.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_mesh.tf.erb
@@ -1,6 +1,7 @@
 resource "google_cloud_run_v2_service" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
   name     = "<%= ctx[:vars]['cloud_run_service_name'] %>"
+  depends_on = [time_sleep.wait_for_mesh]
 
   location     = "us-central1"
   launch_stage = "BETA"
@@ -13,6 +14,12 @@ resource "google_cloud_run_v2_service" "<%= ctx[:primary_resource_id] %>" {
       mesh = google_network_services_mesh.mesh.id
     }
   }
+}
+
+resource "time_sleep" "wait_for_mesh" {
+  depends_on = [google_network_services_mesh.mesh]
+
+  create_duration = "1m"
 }
 
 resource "google_network_services_mesh" "mesh" {

--- a/mmv1/templates/terraform/examples/cloudrunv2_service_mesh.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_mesh.tf.erb
@@ -2,6 +2,7 @@ resource "google_cloud_run_v2_service" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
   name     = "<%= ctx[:vars]['cloud_run_service_name'] %>"
   depends_on = [time_sleep.wait_for_mesh]
+  deletion_protection = false
 
   location     = "us-central1"
   launch_stage = "BETA"

--- a/mmv1/templates/terraform/examples/cloudrunv2_service_mesh.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_mesh.tf.erb
@@ -1,0 +1,21 @@
+resource "google_cloud_run_v2_service" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+  name     = "<%= ctx[:vars]['cloud_run_service_name'] %>"
+
+  location     = "us-central1"
+  launch_stage = "BETA"
+
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+    service_mesh {
+      mesh = google_network_services_mesh.mesh.id
+    }
+  }
+}
+
+resource "google_network_services_mesh" "mesh" {
+  provider = google-beta
+  name     = "<%= ctx[:vars]['mesh_name'] %>"
+}

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.erb
@@ -1076,3 +1076,124 @@ resource "google_cloud_run_v2_service" "default" {
 `, context)
 }
 <% end -%>
+
+<% unless version == 'ga' -%>
+func TestAccCloudRunV2Service_cloudrunv2ServiceMeshUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy:             testAccCheckCloudRunV2ServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudRunV2Service_cloudrunv2ServiceMesh(context),
+			},
+			{
+				ResourceName:            "google_cloud_run_v2_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "launch_stage", "deletion_protection"},
+                        },
+			{
+				Config: testAccCloudRunV2Service_cloudrunv2ServiceMeshUpdate(context),
+			},
+			{
+				ResourceName:            "google_cloud_run_v2_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "launch_stage", "deletion_protection"},
+                        },
+              },
+	})
+}
+
+func testAccCloudRunV2Service_cloudrunv2ServiceMesh(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_cloud_run_v2_service" "default" {
+  provider = google-beta
+  name     = "tf-test-cloudrun-service%{random_suffix}"
+  location = "us-central1"
+  deletion_protection = false
+  depends_on = [time_sleep.wait_for_mesh]
+  launch_stage = "BETA"
+  template {
+    containers {
+      name = "container-1"
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+    service_mesh {
+      mesh = google_network_services_mesh.mesh.id
+    }
+  }
+}
+
+resource "time_sleep" "wait_for_mesh" {
+  depends_on = [
+    google_network_services_mesh.mesh,
+    google_network_services_mesh.new_mesh,
+  ]
+
+  create_duration = "1m"
+}
+
+resource "google_network_services_mesh" "mesh" {
+  provider = google-beta
+  name     = "tf-test-mesh%{random_suffix}"
+}
+
+resource "google_network_services_mesh" "new_mesh" {
+  provider = google-beta
+  name     = "tf-test-new-mesh%{random_suffix}"
+}
+`, context)
+}
+
+func testAccCloudRunV2Service_cloudrunv2ServiceMeshUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_cloud_run_v2_service" "default" {
+  provider = google-beta
+  name     = "tf-test-cloudrun-service%{random_suffix}"
+  location = "us-central1"
+  deletion_protection = false
+  depends_on = [time_sleep.wait_for_mesh]
+  launch_stage = "BETA"
+  template {
+    containers {
+      name = "container-1"
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+    service_mesh {
+      mesh = google_network_services_mesh.new_mesh.id
+    }
+  }
+}
+
+resource "time_sleep" "wait_for_mesh" {
+  depends_on = [
+    google_network_services_mesh.mesh,
+    google_network_services_mesh.new_mesh,
+  ]
+
+  create_duration = "1m"
+}
+
+resource "google_network_services_mesh" "mesh" {
+  provider = google-beta
+  name     = "tf-test-mesh%{random_suffix}"
+}
+
+resource "google_network_services_mesh" "new_mesh" {
+  provider = google-beta
+  name     = "tf-test-new-mesh%{random_suffix}"
+}
+`, context)
+}
+<% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds support for Cloud Service Mesh configuration in Cloud Run v2 Services.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudrunv2: added `template.service_mesh` to `google_cloud_run_v2_service` (beta)
```
