### PR TITLE
Promoted labelFingerprint field to GA

### DIFF
--- a/mmv1/products/compute/GlobalAddress.yaml
+++ b/mmv1/products/compute/GlobalAddress.yaml
@@ -100,7 +100,6 @@ properties:
       internally during updates.
     update_url: 'projects/{{project}}/global/addresses/{{name}}/setLabels'
     update_verb: :POST
-    min_version: beta
   - !ruby/object:Api::Type::Enum
     name: 'ipVersion'
     description: |

--- a/mmv1/third_party/terraform/acctest/resource_test_utils.go
+++ b/mmv1/third_party/terraform/acctest/resource_test_utils.go
@@ -1,16 +1,39 @@
 package acctest
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+    "github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	tfjson "github.com/hashicorp/terraform-json"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 // General test utils
+
+var _ plancheck.PlanCheck = expectNoDelete{}
+
+type expectNoDelete struct{}
+
+func (e expectNoDelete) CheckPlan(ctx context.Context, req plancheck.CheckPlanRequest, resp *plancheck.CheckPlanResponse) {
+	var result error
+	for _, rc := range req.Plan.ResourceChanges {
+		if slices.Contains(rc.Change.Actions, tfjson.ActionDelete) {
+			result = errors.Join(result, fmt.Errorf("expected no deletion of resources, but %s has planned deletion", rc.Address))
+		}
+	}
+	resp.Error = result
+}
+
+func ExpectNoDelete() plancheck.PlanCheck {
+	return expectNoDelete{}
+}
 
 // TestExtractResourceAttr navigates a test's state to find the specified resource (or data source) attribute and makes the value
 // accessible via the attributeValue string pointer.

--- a/mmv1/third_party/terraform/acctest/resource_test_utils.go
+++ b/mmv1/third_party/terraform/acctest/resource_test_utils.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-    "github.com/hashicorp/terraform-plugin-testing/plancheck"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_global_address_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_global_address_test.go.erb
@@ -7,7 +7,47 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
+
+func TestAccComputeGlobalAddress_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeGlobalAddressDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeGlobalAddress_update1(context),
+			},
+			{
+				ResourceName:      "google_compute_global_address.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccComputeGlobalAddress_update2(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						acctest.ExpectNoDelete(),
+					},
+				},
+			},
+			{
+				ResourceName:      "google_compute_global_address.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
 
 func TestAccComputeGlobalAddress_ipv6(t *testing.T) {
 	t.Parallel()
@@ -74,4 +114,48 @@ resource "google_compute_global_address" "foobar" {
   network       = google_compute_network.foobar.self_link
 }
 `, networkName, addressName)
+}
+
+func testAccComputeGlobalAddress_update1(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "foobar" {
+  name = "tf-test-address-%{random_suffix}"
+}
+
+resource "google_compute_global_address" "foobar" {
+  address       = "172.20.181.0"
+  description   = "Description"
+  name          = "tf-test-address-%{random_suffix}"
+  labels        = {
+  	foo = "bar"
+  }
+  ip_version     = "IPV4"
+  prefix_length = 24
+  address_type  = "INTERNAL"
+  purpose       = "VPC_PEERING"
+  network       = google_compute_network.foobar.self_link
+}
+`, context)
+}
+
+func testAccComputeGlobalAddress_update2(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "foobar" {
+  name = "tf-test-address-%{random_suffix}"
+}
+
+resource "google_compute_global_address" "foobar" {
+  address       = "172.20.181.0"
+  description   = "Description2"
+  name          = "tf-test-address-%{random_suffix}"
+  labels        = {
+  	foo = "baz"
+  }
+  ip_version     = "IPV4"
+  prefix_length = 24
+  address_type  = "INTERNAL"
+  purpose       = "VPC_PEERING"
+  network       = google_compute_network.foobar.self_link
+}
+`, context)
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_global_address_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_global_address_test.go.erb
@@ -146,7 +146,7 @@ resource "google_compute_network" "foobar" {
 
 resource "google_compute_global_address" "foobar" {
   address       = "172.20.181.0"
-  description   = "Description2"
+  description   = "Description"
   name          = "tf-test-address-%{random_suffix}"
   labels        = {
   	foo = "baz"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixed https://github.com/hashicorp/terraform-provider-google/issues/18739.

This required writing a new Update test, so I implemented a PlanCheck to verify there was no deletion as described in https://github.com/hashicorp/terraform-provider-google/issues/12428#issuecomment-1548573984 The first commit intentionally forces recreate of the resource to show the PlanCheck works.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `label_fingerprint` field to `google_compute_global_address` resource (ga)
```

```release-note:bug
compute: fixed bug where the `labels` field could not be updated on `google_compute_global_address` (ga)
```
