### PR TITLE
Remove SchemaConfigModeAttr

### DIFF
--- a/docs/content/develop/breaking-changes/breaking-changes.md
+++ b/docs/content/develop/breaking-changes/breaking-changes.md
@@ -84,9 +84,6 @@ For more information, see
 * <a name="field-removing-diff-suppress"></a> Removing diff suppression from a field.
   * For MMv1 resources, removing `diff_suppress_func` from a field.
   * For handwritten resources, removing `DiffSuppressFunc` from a field.
-* <a name="field-adding-subfield-to-config-mode-attr"></a> Adding a subfield to
-  a SchemaConfigModeAttr field.
-  * Subfields of SchemaConfigModeAttr fields are treated as required even if the schema says they are optional.
 * Removing update support from a field.
 
 ### Making validation more strict

--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -242,7 +242,6 @@ properties:
     api_name: secondaryIpRanges
     unordered_list: true
     default_from_api: true
-    schema_config_mode_attr: true
     send_empty_value: true
     description: |
       An array of configurations for secondary IP ranges for VM instances

--- a/mmv1/templates/terraform/schema_property.erb
+++ b/mmv1/templates/terraform/schema_property.erb
@@ -26,9 +26,6 @@
 <% if property.default_from_api -%>
 	Computed: true,
 	Optional: true,
-	<% if property.schema_config_mode_attr -%>
-	ConfigMode: schema.SchemaConfigModeAttr,
-	<% end -%>
 <% elsif property.required -%>
   Required: true,
 <% elsif property.output -%>

--- a/mmv1/templates/terraform/schema_property.go.tmpl
+++ b/mmv1/templates/terraform/schema_property.go.tmpl
@@ -27,9 +27,6 @@
 {{ if .DefaultFromApi -}}
 	Computed: true,
 	Optional: true,
-	{{ if .SchemaConfigModeAttr -}}
-	ConfigMode: schema.SchemaConfigModeAttr,
-	{{ end -}}
 {{ else if .Required -}}
   Required: true,
 {{ else if .Output -}}

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -338,7 +338,6 @@ func ResourceComposerEnvironment() *schema.Resource {
 										Optional:    true,
 										Computed:    true,
 										ForceNew:    true,
-										ConfigMode:  schema.SchemaConfigModeAttr,
 										MaxItems:    1,
 										Description: `Configuration for controlling how IPs are allocated in the GKE cluster. Cannot be updated.`,
 										Elem: &schema.Resource{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
@@ -668,7 +668,6 @@ func ResourceComputeInstance() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				ForceNew:    true,
-				ConfigMode:  schema.SchemaConfigModeAttr,
 				Description: `List of the type and count of accelerator cards attached to the instance.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image.go.erb
@@ -47,17 +47,6 @@ func computeInstanceFromMachineImageSchema() map[string]*schema.Schema {
 		s[field].Optional = true
 	}
 
-	// schema.SchemaConfigModeAttr allows these fields to be removed in Terraform 0.12.
-	// Passing field_name = [] in this mode differentiates between an intentionally empty
-	// block vs an ignored computed block.
-	nic := s["network_interface"].Elem.(*schema.Resource)
-	nic.Schema["alias_ip_range"].ConfigMode = schema.SchemaConfigModeAttr
-	nic.Schema["access_config"].ConfigMode = schema.SchemaConfigModeAttr
-
-	for _, field := range []string{"attached_disk", "guest_accelerator", "service_account", "scratch_disk"} {
-		s[field].ConfigMode = schema.SchemaConfigModeAttr
-	}
-
 	recurseOnSchema(s, func(field *schema.Schema) {
 		// We don't want to accidentally use default values to override the instance
 		// machine image, so remove defaults.

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template.go.erb
@@ -51,17 +51,6 @@ func computeInstanceFromTemplateSchema() map[string]*schema.Schema {
 		s[field].Optional = true
 	}
 
-	// schema.SchemaConfigModeAttr allows these fields to be removed in Terraform 0.12.
-	// Passing field_name = [] in this mode differentiates between an intentionally empty
-	// block vs an ignored computed block.
-	nic := s["network_interface"].Elem.(*schema.Resource)
-	nic.Schema["alias_ip_range"].ConfigMode = schema.SchemaConfigModeAttr
-	nic.Schema["access_config"].ConfigMode = schema.SchemaConfigModeAttr
-
-	for _, field := range []string{"attached_disk", "guest_accelerator", "service_account", "scratch_disk"} {
-		s[field].ConfigMode = schema.SchemaConfigModeAttr
-	}
-
 	// Remove deprecated/removed fields that are never d.Set. We can't
 	// programmatically remove all of them, because some of them still have d.Set
 	// calls.

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_test.go.erb
@@ -378,49 +378,6 @@ func TestAccComputeInstanceFromTemplate_overrideScheduling(t *testing.T) {
 	})
 }
 
-func TestAccComputeInstanceFromTemplate_012_removableFields(t *testing.T) {
-	t.Parallel()
-
-	var instance compute.Instance
-	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
-	templateName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
-	resourceName := "google_compute_instance_from_template.inst"
-
-	// First config is a basic instance from template, second tests the empty list syntax
-	config1 := testAccComputeInstanceFromTemplate_012_removableFieldsTpl(templateName) +
-		testAccComputeInstanceFromTemplate_012_removableFields1(instanceName)
-	config2 := testAccComputeInstanceFromTemplate_012_removableFieldsTpl(templateName) +
-		testAccComputeInstanceFromTemplate_012_removableFields2(instanceName)
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckComputeInstanceFromTemplateDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: config1,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(t, resourceName, &instance),
-
-					resource.TestCheckResourceAttr(resourceName, "service_account.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "service_account.0.scopes.#", "3"),
-				),
-			},
-			{
-				Config: config2,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(t, resourceName, &instance),
-
-					// Check that fields were able to be removed
-					resource.TestCheckResourceAttr(resourceName, "scratch_disk.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "attached_disk.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "network_interface.0.alias_ip_range.#", "0"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccComputeInstanceFromTemplate_overrideMetadataDotStartupScript(t *testing.T) {
 	var instance compute.Instance
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
@@ -1494,84 +1451,6 @@ resource "google_compute_instance_from_template" "inst" {
   source_instance_template = google_compute_instance_template.foobar.self_link
 }
 `, templateDisk, template, instance)
-}
-
-func testAccComputeInstanceFromTemplate_012_removableFieldsTpl(template string) string {
-
-	return fmt.Sprintf(`
-data "google_compute_image" "my_image" {
-  family  = "debian-11"
-  project = "debian-cloud"
-}
-
-resource "google_compute_instance_template" "foobar" {
-  name         = "%s"
-  machine_type = "e2-medium"
-
-  disk {
-    source_image = data.google_compute_image.my_image.self_link
-    auto_delete  = true
-    disk_size_gb = 20
-    boot         = true
-  }
-
-  network_interface {
-    network = "default"
-  }
-
-  metadata = {
-    foo = "bar"
-  }
-
-  service_account {
-    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
-  }
-
-  can_ip_forward = true
-}
-`, template)
-}
-
-func testAccComputeInstanceFromTemplate_012_removableFields1(instance string) string {
-	return fmt.Sprintf(`
-resource "google_compute_instance_from_template" "inst" {
-  name = "%s"
-  zone = "us-central1-a"
-
-  allow_stopping_for_update = true
-
-  source_instance_template = google_compute_instance_template.foobar.self_link
-}
-`, instance)
-}
-
-func testAccComputeInstanceFromTemplate_012_removableFields2(instance string) string {
-	return fmt.Sprintf(`
-resource "google_compute_instance_from_template" "inst" {
-  name = "%s"
-  zone = "us-central1-a"
-
-  allow_stopping_for_update = true
-
-  source_instance_template = google_compute_instance_template.foobar.self_link
-
-  // Overrides
-  network_interface {
-    alias_ip_range = []
-  }
-
-  service_account = []
-
-  scratch_disk = []
-
-  attached_disk = []
-
-  timeouts {
-    create = "10m"
-    update = "10m"
-  }
-}
-`, instance)
 }
 
 func testAccComputeInstanceFromTemplate_overrideMetadataDotStartupScript(instance, template string) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -1741,20 +1741,6 @@ func TestAccComputeInstance_guestAcceleratorSkip(t *testing.T) {
 					testAccCheckComputeInstanceLacksGuestAccelerator(&instance),
 				),
 			},
-			// Recreate with guest_accelerator = []
-			{
-				Config: testAccComputeInstance_guestAcceleratorEmptyBlock(instanceName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
-					testAccCheckComputeInstanceLacksGuestAccelerator(&instance),
-				),
-			},
-			// Check that count = 0 is the same as empty block []
-			{
-				Config:             testAccComputeInstance_guestAccelerator(instanceName, 0),
-				ExpectNonEmptyPlan: false,
-				PlanOnly:           true,
-			},
 		},
 	})
 
@@ -7152,38 +7138,6 @@ resource "google_compute_instance" "foobar" {
   }
 }
 `, instance, count)
-}
-
-func testAccComputeInstance_guestAcceleratorEmptyBlock(instance string) string {
-	return fmt.Sprintf(`
-data "google_compute_image" "my_image" {
-  family  = "debian-11"
-  project = "debian-cloud"
-}
-
-resource "google_compute_instance" "foobar" {
-  name         = "%s"
-  machine_type = "n1-standard-1"   // can't be e2 because of guest_accelerator
-  zone         = "us-east1-d"
-
-  boot_disk {
-    initialize_params {
-      image = data.google_compute_image.my_image.self_link
-    }
-  }
-
-  network_interface {
-    network = "default"
-  }
-
-  scheduling {
-    # Instances with guest accelerators do not support live migration.
-    on_host_maintenance = "TERMINATE"
-  }
-
-  guest_accelerator = []
-}
-`, instance)
 }
 
 func testAccComputeInstance_minCpuPlatform(instance string) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_subnetwork_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_subnetwork_test.go.erb
@@ -189,14 +189,6 @@ func TestAccComputeSubnetwork_secondaryIpRanges(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccComputeSubnetwork_secondaryIpRanges_update4(cnName, subnetworkName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeSubnetworkExists(t, "google_compute_subnetwork.network-with-private-secondary-ip-ranges", &subnetwork),
-					testAccCheckComputeSubnetworkHasNotSecondaryIpRange(&subnetwork, "tf-test-secondary-range-update1", "192.168.10.0/24"),
-					testAccCheckComputeSubnetworkHasNotSecondaryIpRange(&subnetwork, "tf-test-secondary-range-update2", "192.168.11.0/24"),
-				),
-			},
-			{
 				Config: testAccComputeSubnetwork_secondaryIpRanges_update1(cnName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeSubnetworkExists(t, "google_compute_subnetwork.network-with-private-secondary-ip-ranges", &subnetwork),
@@ -244,12 +236,6 @@ func TestAccComputeSubnetwork_secondaryIpRanges_sendEmpty(t *testing.T) {
 					testAccCheckComputeSubnetworkHasNotSecondaryIpRange(&subnetwork, "tf-test-secondary-range-update1", "192.168.10.0/24"),
 				),
 			},
-			// Check that empty block secondary_ip_range = [] is not different
-			{
-				Config:             testAccComputeSubnetwork_sendEmpty_emptyBlock(cnName, subnetworkName, "true"),
-				PlanOnly:           true,
-				ExpectNonEmptyPlan: false,
-			},
 			// Apply two secondary_ip_range
 			{
 				Config: testAccComputeSubnetwork_sendEmpty_double(cnName, subnetworkName, "true"),
@@ -281,14 +267,6 @@ func TestAccComputeSubnetwork_secondaryIpRanges_sendEmpty(t *testing.T) {
 				Config:             testAccComputeSubnetwork_sendEmpty_removed(cnName, subnetworkName, "false"),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
-			},
-			// Remove with empty block []
-			{
-				Config: testAccComputeSubnetwork_sendEmpty_emptyBlock(cnName, subnetworkName, "true"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeSubnetworkExists(t, "google_compute_subnetwork.network-with-private-secondary-ip-ranges", &subnetwork),
-					testAccCheckComputeSubnetworkHasNotSecondaryIpRange(&subnetwork, "tf-test-secondary-range-update1", "192.168.10.0/24"),
-				),
 			},
 		},
 	})
@@ -691,23 +669,6 @@ resource "google_compute_subnetwork" "network-with-private-secondary-ip-ranges" 
 `, cnName, subnetworkName)
 }
 
-func testAccComputeSubnetwork_secondaryIpRanges_update4(cnName, subnetworkName string) string {
-	return fmt.Sprintf(`
-resource "google_compute_network" "custom-test" {
-  name                    = "%s"
-  auto_create_subnetworks = false
-}
-
-resource "google_compute_subnetwork" "network-with-private-secondary-ip-ranges" {
-  name               = "%s"
-  ip_cidr_range      = "10.2.0.0/16"
-  region             = "us-central1"
-  network            = google_compute_network.custom-test.self_link
-  secondary_ip_range = []
-}
-`, cnName, subnetworkName)
-}
-
 func testAccComputeSubnetwork_sendEmpty_removed(cnName, subnetworkName, sendEmpty string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "custom-test" {
@@ -720,24 +681,6 @@ resource "google_compute_subnetwork" "network-with-private-secondary-ip-ranges" 
   ip_cidr_range      = "10.2.0.0/16"
   region             = "us-central1"
   network            = google_compute_network.custom-test.self_link
-  send_secondary_ip_range_if_empty = "%s"
-}
-`, cnName, subnetworkName, sendEmpty)
-}
-
-func testAccComputeSubnetwork_sendEmpty_emptyBlock(cnName, subnetworkName, sendEmpty string) string {
-	return fmt.Sprintf(`
-resource "google_compute_network" "custom-test" {
-  name                    = "%s"
-  auto_create_subnetworks = false
-}
-
-resource "google_compute_subnetwork" "network-with-private-secondary-ip-ranges" {
-  name               = "%s"
-  ip_cidr_range      = "10.2.0.0/16"
-  region             = "us-central1"
-  network            = google_compute_network.custom-test.self_link
-  secondary_ip_range = []
   send_secondary_ip_range_if_empty = "%s"
 }
 `, cnName, subnetworkName, sendEmpty)

--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -139,9 +139,6 @@ func schemaNodeConfig() *schema.Schema {
 					Optional: true,
 					Computed: true,
 					ForceNew: true,
-					// Legacy config mode allows removing GPU's from an existing resource
-					// See https://www.terraform.io/docs/configuration/attr-as-blocks.html
-					ConfigMode: schema.SchemaConfigModeAttr,
 					Description: `List of the type and count of accelerator cards attached to the instance.`,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
@@ -164,7 +161,6 @@ func schemaNodeConfig() *schema.Schema {
 								Optional:     true,
 								Computed:     true,
 								ForceNew:     true,
-								ConfigMode: schema.SchemaConfigModeAttr,
 								Description:  `Configuration for auto installation of GPU driver.`,
 								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
@@ -189,7 +185,6 @@ func schemaNodeConfig() *schema.Schema {
 								MaxItems:     1,
 								Optional:     true,
 								ForceNew:     true,
-								ConfigMode: schema.SchemaConfigModeAttr,
 								Description:  `Configuration for GPU sharing.`,
 								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -2244,12 +2244,6 @@ func ResourceContainerCluster() *schema.Resource {
 // One quirk with this approach is that configs with mixed count=0 and count>0 accelerator blocks will
 // show a confusing diff if one of there are config changes that result in a legitimate diff as the count=0
 // blocks will not be in state.
-//
-// This could also be modelled by setting `guest_accelerator = []` in the config. However since the
-// previous syntax requires that schema.SchemaConfigModeAttr is set on the field it is advisable that
-// we have a work around for removing guest accelerators. Also Terraform 0.11 cannot use dynamic blocks
-// so this isn't a solution for module authors who want to dynamically omit guest accelerators
-// See https://github.com/hashicorp/terraform-provider-google/issues/3786
 func resourceNodeConfigEmptyGuestAccelerator(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
 	old, new := diff.GetChange("node_config.0.guest_accelerator")
 	oList := old.([]interface{})

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -1293,45 +1293,6 @@ func TestAccContainerNodePool_regionalClusters(t *testing.T) {
 	})
 }
 
-func TestAccContainerNodePool_012_ConfigModeAttr(t *testing.T) {
-	t.Parallel()
-
-	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
-	np := fmt.Sprintf("tf-test-nodepool-%s", acctest.RandString(t, 10))
-	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccContainerNodePool_012_ConfigModeAttr1(cluster, np, networkName, subnetworkName),
-			},
-			{
-				ResourceName:            "google_container_node_pool.np",
-				ImportState:             true,
-				ImportStateVerify:       true,
-			},
-			{
-				Config: testAccContainerNodePool_012_ConfigModeAttr2(cluster, np, networkName, subnetworkName),
-			},
-			{
-				ResourceName:            "google_container_node_pool.np",
-				ImportState:             true,
-				ImportStateVerify:       true,
-			},
-			{
-				// Test guest_accelerator.count = 0 is the same as guest_accelerator = []
-				Config:             testAccContainerNodePool_EmptyGuestAccelerator(cluster, np, networkName, subnetworkName),
-				ExpectNonEmptyPlan: false,
-				PlanOnly:           true,
-			},
-		},
-	})
-}
-
 func TestAccContainerNodePool_EmptyGuestAccelerator(t *testing.T) {
 	t.Parallel()
 
@@ -3755,59 +3716,6 @@ resource "google_container_node_pool" "np" {
   initial_node_count = 1
 
   version = data.google_container_engine_versions.central1a.valid_node_versions[0]
-}
-`, cluster, networkName, subnetworkName, np)
-}
-
-func testAccContainerNodePool_012_ConfigModeAttr1(cluster, np, networkName, subnetworkName string) string {
-	return fmt.Sprintf(`
-resource "google_container_cluster" "cluster" {
-  name               = "%s"
-  location           = "us-central1-f"
-  initial_node_count = 3
-  deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
-}
-
-resource "google_container_node_pool" "np" {
-  name               = "%s"
-  location           = "us-central1-f"
-  cluster            = google_container_cluster.cluster.name
-  initial_node_count = 1
-
-  node_config {
-    guest_accelerator {
-      count = 1
-      type  = "nvidia-tesla-t4"
-    }
-	machine_type = "n1-highmem-4"
-  }
-}
-`, cluster, networkName, subnetworkName, np)
-}
-
-func testAccContainerNodePool_012_ConfigModeAttr2(cluster, np, networkName, subnetworkName string) string {
-	return fmt.Sprintf(`
-resource "google_container_cluster" "cluster" {
-  name               = "%s"
-  location           = "us-central1-f"
-  initial_node_count = 3
-  deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
-}
-
-resource "google_container_node_pool" "np" {
-  name               = "%s"
-  location           = "us-central1-f"
-  cluster            = google_container_cluster.cluster.name
-  initial_node_count = 1
-
-  node_config {
-    guest_accelerator = []
-	machine_type = "n1-highmem-4"
-  }
 }
 `, cluster, networkName, subnetworkName, np)
 }

--- a/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
@@ -220,6 +220,18 @@ Previously, `containers.env` was a list, making it order-dependent. It is now a 
 
 If you were relying on accessing an individual environment variable by index (for example, `google_cloud_run_v2_service.template.containers.0.env.0.name`), then that will now need to by hash (for example, `google_cloud_run_v2_service.template.containers.0.env.<some-hash>.name`).
 
+## Resource: `google_composer_environment`
+
+### `ip_allocation_policy = []` is no longer valid configuration
+
+There was no functional difference between setting `ip_allocation_policy = []` and not setting `ip_allocation_policy` at all. Removing the field from configuration should not produce a diff.
+
+## Resources: `google_compute_instance_from_template` and `google_compute_instance_from_machine_image`
+
+### `network_interface.alias_ip_range, network_interface.access_config, attached_disk, guest_accelerator, service_account, scratch_disk` can no longer be set to an empty block `[]`
+
+`field = []` is no longer valid configuration for these fields. Removing the fields from configuration should not produce a diff.
+
 ## Resource: `google_compute_subnetwork`
 
 ### `secondary_ip_range = []` is no longer valid configuration


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fixes https://github.com/hashicorp/terraform-provider-google/issues/12824

Compute subnetwork preparation change: https://github.com/GoogleCloudPlatform/magic-modules/pull/11410
Guest Accelerator preparation change: https://github.com/GoogleCloudPlatform/magic-modules/pull/11425

Composer's `ip_allocation_policy` did not actually send an empty list when specifying an empty block, and it is create-only. Therefore removing configModeAttr doesn't make a difference


`google_compute_instance_from_template` and `google_compute_instance_from_machine_image` functionality for empty blocks is being removed to prevent accidental breaking changes for new subfields from the parent `google_compute_instance`


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
composer: `ip_allocation_policy = []` in `google_composer_environment` is no longer valid configuration. Removing the field from configuration should not produce a diff.
```

```release-note:breaking-change
compute: `secondary_ip_ranges = []` in `google_compute_subnetwork` is no longer valid configuration. To set an explicitly empty list, use `send_secondary_ip_range_if_empty` and completely remove `secondary_ip_range` from config.
```

```release-note:breaking-change
compute: `guest_accelerator = []` is no longer valid configuration in `google_compute_instance`. To explicitly set an empty list of objects, set guest_accelerator.count = 0.
```

```release-note:breaking-change
compute: `google_compute_instance_from_template` and `google_compute_instance_from_machine_image` `network_interface.alias_ip_range, network_interface.access_config, attached_disk, guest_accelerator, service_account, scratch_disk` can no longer be set to an empty block `[]`. Removing the fields from configuration should not produce a diff.
```

```release-note:breaking-change
container: `guest_accelerator = []` is no longer valid configuration in `google_container_cluster` and `google_container_node_pool`. To explicitly set an empty list of objects, set guest_accelerator.count = 0.
```

```release-note:breaking-change
container: `guest_accelerator.gpu_driver_installation_config = []` and `guest_accelerator.gpu_sharing_config = []` are no longer valid configuration in `google_container_cluster` and `google_container_node_pool`. Removing the fields from configuration should not produce a diff.
```