### PR TITLE
Add InspectTemplateModifiedCadence to BigQueryTarget and CloudSqlTarg…

### DIFF
--- a/mmv1/products/dlp/DiscoveryConfig.yaml
+++ b/mmv1/products/dlp/DiscoveryConfig.yaml
@@ -206,6 +206,49 @@ properties:
               values:
                 - :TABLE_PROFILE
                 - :RESOURCE_NAME
+        - !ruby/object:Api::Type::NestedObject
+          name: tagResources
+          description: Publish a message into the Pub/Sub topic.
+          properties:
+            - !ruby/object:Api::Type::Array
+              name: tagConditions
+              description: The tags to associate with different conditions.
+              item_type: !ruby/object:Api::Type::NestedObject
+                properties:
+                  - !ruby/object:Api::Type::NestedObject
+                    name: tag
+                    description: The tag value to attach to resources.
+                    properties:
+                      - !ruby/object:Api::Type::String
+                        name: namespacedValue
+                        description: The namespaced name for the tag value to attach to resources. Must be in the format `{parent_id}/{tag_key_short_name}/{short_name}`, for example, "123456/environment/prod".
+                  - !ruby/object:Api::Type::NestedObject
+                    name: sensitivityScore
+                    description: Conditions attaching the tag to a resource on its profile having this sensitivity score.
+                    properties:
+                      - !ruby/object:Api::Type::Enum
+                        name: 'score'
+                        required: true
+                        description: |
+                          The sensitivity score applied to the resource.
+                        values:
+                          - :SENSITIVITY_LOW
+                          - :SENSITIVITY_MODERATE
+                          - :SENSITIVITY_HIGH
+            - !ruby/object:Api::Type::Array
+              name: profileGenerationsToTag
+              description: The profile generations for which the tag should be attached to resources. If you attach a tag to only new profiles, then if the sensitivity score of a profile subsequently changes, its tag doesn't change. By default, this field includes only new profiles. To include both new and updated profiles for tagging, this field should explicitly include both `PROFILE_GENERATION_NEW` and `PROFILE_GENERATION_UPDATE`.
+              item_type: !ruby/object:Api::Type::Enum
+                name: 'undefined'
+                description: |
+                  This field only has a name and description because of MM
+                  limitations. It should not appear in downstreams.
+                values:
+                  - :PROFILE_GENERATION_NEW
+                  - :PROFILE_GENERATION_UPDATE
+            - !ruby/object:Api::Type::Boolean
+              name: lowerDataRiskToLow
+              description: Whether applying a tag to a resource should lower the risk of the profile for that resource. For example, in conjunction with an [IAM deny policy](https://cloud.google.com/iam/docs/deny-overview), you can deny all principals a permission if a tag value is present, mitigating the risk of the resource. This also lowers the data risk of resources at the lower levels of the resource hierarchy. For example, reducing the data risk of a table data profile also reduces the data risk of the constituent column data profiles.
   - !ruby/object:Api::Type::Array
     name: 'targets'
     description: Target to match against for determining what to scan and how frequently
@@ -346,6 +389,17 @@ properties:
                         - :UPDATE_FREQUENCY_NEVER
                         - :UPDATE_FREQUENCY_DAILY
                         - :UPDATE_FREQUENCY_MONTHLY
+                - !ruby/object:Api::Type::NestedObject
+                  name: inspectTemplateModifiedCadence
+                  description: Governs when to update data profiles when the inspection rules defined by the `InspectTemplate` change. If not set, changing the template will not cause a data profile to update.
+                  properties:
+                    - !ruby/object:Api::Type::Enum
+                      name: 'frequency'
+                      description: How frequently data profiles can be updated when the template is modified. Defaults to never.
+                      values:
+                        - :UPDATE_FREQUENCY_NEVER
+                        - :UPDATE_FREQUENCY_DAILY
+                        - :UPDATE_FREQUENCY_MONTHLY
             - !ruby/object:Api::Type::NestedObject
               name: disabled
               description: 'Tables that match this filter will not have profiles created.'
@@ -475,6 +529,18 @@ properties:
                     - :UPDATE_FREQUENCY_NEVER
                     - :UPDATE_FREQUENCY_DAILY
                     - :UPDATE_FREQUENCY_MONTHLY
+                - !ruby/object:Api::Type::NestedObject
+                  name: inspectTemplateModifiedCadence
+                  description: Governs when to update data profiles when the inspection rules defined by the `InspectTemplate` change. If not set, changing the template will not cause a data profile to update.
+                  properties:
+                    - !ruby/object:Api::Type::Enum
+                      name: 'frequency'
+                      description: How frequently data profiles can be updated when the template is modified. Defaults to never.
+                      required: true
+                      values:
+                        - :UPDATE_FREQUENCY_NEVER
+                        - :UPDATE_FREQUENCY_DAILY
+                        - :UPDATE_FREQUENCY_MONTHLY
             - !ruby/object:Api::Type::NestedObject
               name: disabled
               description: 'Disable profiling for database resources that match this filter.'

--- a/mmv1/templates/terraform/examples/dlp_discovery_config_actions.tf.erb
+++ b/mmv1/templates/terraform/examples/dlp_discovery_config_actions.tf.erb
@@ -34,6 +34,28 @@ resource "google_data_loss_prevention_discovery_config" "<%= ctx[:primary_resour
             detail_of_message = "TABLE_PROFILE"
         }
     }
+    actions {
+        tag_resources {
+            tag_conditions {
+                tag {
+                    namespaced_value = "123456/environment/prod"
+                }
+                sensitivity_score {
+                    score = "SENSITIVITY_HIGH"
+                }
+            }
+            tag_conditions {
+                tag {
+                    namespaced_value = "123456/environment/test"
+                }
+                sensitivity_score {
+                    score = "SENSITIVITY_LOW"
+                }
+            }
+            profile_generations_to_tag = ["PROFILE_GENERATION_NEW", "PROFILE_GENERATION_UPDATE"]
+            lower_data_risk_to_low = true
+        }
+    }
     inspect_templates = ["projects/%{project}/inspectTemplates/${google_data_loss_prevention_inspect_template.basic.name}"] 
 }
 
@@ -51,4 +73,24 @@ resource "google_data_loss_prevention_inspect_template" "basic" {
 			name = "EMAIL_ADDRESS"
 		}
     }
+}
+
+data "google_project" "project" {
+	project_id = "%{project}"
+}
+
+resource "google_tags_tag_key" "tag_key" {
+	parent = "projects/${data.google_project.project.number}"
+	short_name = "environment"
+}
+
+resource "google_tags_tag_value" "tag_value" {
+	parent = "tagKeys/${google_tags_tag_key.tag_key.name}"
+	short_name = "prod"
+}
+
+resource "google_project_iam_member" "tag_role" {
+    project = "%{project}"
+    role    = "roles/resourcemanager.tagUser"
+    member = "serviceAccount:service-${data.google_project.project.number}@dlp-api.iam.gserviceaccount.com"
 }

--- a/mmv1/templates/terraform/examples/dlp_discovery_config_conditions_cadence.tf.erb
+++ b/mmv1/templates/terraform/examples/dlp_discovery_config_conditions_cadence.tf.erb
@@ -20,6 +20,9 @@ resource "google_data_loss_prevention_discovery_config" "<%= ctx[:primary_resour
                     types = ["TABLE_MODIFIED_TIMESTAMP"]
                     frequency = "UPDATE_FREQUENCY_DAILY"
                 }
+                inspect_template_modified_cadence {
+                    frequency = "UPDATE_FREQUENCY_DAILY"
+                }
             }
         }
     }

--- a/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_discovery_config_test.go
+++ b/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_discovery_config_test.go
@@ -511,6 +511,20 @@ resource "google_data_loss_prevention_discovery_config" "basic" {
 
 func testAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigActions(context map[string]interface{}) string {
 	return acctest.Nprintf(`
+data "google_project" "project" {
+	project_id = "%{project}"
+}
+
+resource "google_tags_tag_key" "tag_key" {
+	parent = "projects/${data.google_project.project.number}"
+	short_name = "environment"
+}
+
+resource "google_tags_tag_value" "tag_value" {
+	parent = "tagKeys/${google_tags_tag_key.tag_key.name}"
+	short_name = "prod"
+}
+
 resource "google_data_loss_prevention_inspect_template" "basic" {
 	parent = "projects/%{project}"
 	description = "Description"
@@ -525,6 +539,12 @@ resource "google_data_loss_prevention_inspect_template" "basic" {
 
 resource "google_pubsub_topic" "basic" {
 	name = "test-topic"
+}
+
+resource "google_project_iam_member" "tag_role" {
+    project = "%{project}"
+    role    = "roles/resourcemanager.tagUser"
+    member = "serviceAccount:service-${data.google_project.project.number}@dlp-api.iam.gserviceaccount.com"
 }
 
 resource "google_data_loss_prevention_discovery_config" "basic" {
@@ -563,7 +583,26 @@ resource "google_data_loss_prevention_discovery_config" "basic" {
 			detail_of_message = "TABLE_PROFILE"
 		}
     }
+	actions {
+        tag_resources {
+            tag_conditions {
+                tag {
+                    namespaced_value = "%{project}/environment/prod"
+                }
+                sensitivity_score {
+                    score = "SENSITIVITY_HIGH"
+                }
+            }
+            profile_generations_to_tag = ["PROFILE_GENERATION_NEW", "PROFILE_GENERATION_UPDATE"]
+            lower_data_risk_to_low = true
+        }
+    }
     inspect_templates = ["projects/%{project}/inspectTemplates/${google_data_loss_prevention_inspect_template.basic.name}"]
+	depends_on = [
+		google_project_iam_member.tag_role,
+		google_tags_tag_key.tag_key,
+		google_tags_tag_value.tag_value,
+	]
 }
 `, context)
 }
@@ -721,26 +760,29 @@ resource "google_data_loss_prevention_discovery_config" "basic" {
 	status = "RUNNING"
 
 	targets {
-        big_query_target {
-            filter {
-                other_tables {}
-            }
-            conditions {
-                type_collection = "BIG_QUERY_COLLECTION_ALL_TYPES"
-            }
-            cadence {
-                schema_modified_cadence {
-                    types = ["SCHEMA_NEW_COLUMNS"]
-                    frequency = "UPDATE_FREQUENCY_DAILY"
-                }
-                table_modified_cadence {
-                    types = ["TABLE_MODIFIED_TIMESTAMP"]
-                    frequency = "UPDATE_FREQUENCY_DAILY"
-                }
-            }
-        }
-    }
-    inspect_templates = ["projects/%{project}/inspectTemplates/${google_data_loss_prevention_inspect_template.basic.name}"]
+		big_query_target {
+			filter {
+				other_tables {}
+			}
+			conditions {
+				type_collection = "BIG_QUERY_COLLECTION_ALL_TYPES"
+			}
+			cadence {
+				schema_modified_cadence {
+					types = ["SCHEMA_NEW_COLUMNS"]
+					frequency = "UPDATE_FREQUENCY_DAILY"
+				}
+				table_modified_cadence {
+					types = ["TABLE_MODIFIED_TIMESTAMP"]
+					frequency = "UPDATE_FREQUENCY_DAILY"
+				}
+				inspect_template_modified_cadence {
+					frequency = "UPDATE_FREQUENCY_DAILY"
+				}
+			}
+		}
+	}
+	inspect_templates = ["projects/%{project}/inspectTemplates/${google_data_loss_prevention_inspect_template.basic.name}"]
 }
 `, context)
 }
@@ -897,6 +939,9 @@ resource "google_data_loss_prevention_discovery_config" "basic" {
                     frequency = "UPDATE_FREQUENCY_DAILY"
                 }
                 refresh_frequency = "UPDATE_FREQUENCY_MONTHLY"
+                inspect_template_modified_cadence {
+                    frequency = "UPDATE_FREQUENCY_DAILY"
+                }
             }
         }
     }


### PR DESCRIPTION
…et in DiscoveryConfig. Add TagResources action to DiscoveryConfig.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Added new feature fields (InspectTemplateModifiedCadence and TagResources action) to DiscoveryConfig resource. Modify the update tests to support new fields. 

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dlp: added `inspect_template_modified_cadence` field to `big_query_target` and `cloud_sql_target` in `google_data_loss_prevention_discovery_config`
```

```release-note:enhancement
dlp: added `tag_resources` field to `google_data_loss_prevention_discovery_config`.
```
