### PR TITLE
Adding accelerators[] for NodeTemplate

### DIFF
--- a/mmv1/products/compute/NodeTemplate.yaml
+++ b/mmv1/products/compute/NodeTemplate.yaml
@@ -162,8 +162,6 @@ properties:
           description: |
             The number of the guest accelerator cards exposed to this
             node template.
-        # TODO(alexstephen): Change to ResourceRef once AcceleratorType is
-        # created.
         - !ruby/object:Api::Type::String
           name: 'acceleratorType'
           description: |

--- a/mmv1/products/compute/NodeTemplate.yaml
+++ b/mmv1/products/compute/NodeTemplate.yaml
@@ -55,6 +55,11 @@ examples:
     primary_resource_id: 'template'
     vars:
       template_name: 'soletenant-with-licenses'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'node_template_accelerators'
+    primary_resource_id: 'template'
+    vars:
+      template_name: 'soletenant-with-accelerators'
 parameters:
   - !ruby/object:Api::Type::ResourceRef
     name: 'region'
@@ -145,6 +150,25 @@ properties:
         values:
           - :RESTART_NODE_ON_ANY_SERVER
           - :RESTART_NODE_ON_MINIMAL_SERVERS
+  - !ruby/object:Api::Type::Array
+    name: 'accelerators'
+    description: |
+      List of the type and count of accelerator cards attached to the
+      node template 
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties:
+        - !ruby/object:Api::Type::Integer
+          name: 'acceleratorCount'
+          description: |
+            The number of the guest accelerator cards exposed to this
+            node template.
+        # TODO(alexstephen): Change to ResourceRef once AcceleratorType is
+        # created.
+        - !ruby/object:Api::Type::String
+          name: 'acceleratorType'
+          description: |
+            Full or partial URL of the accelerator type resource to expose
+            to this node template.
   - !ruby/object:Api::Type::Enum
     name: 'cpuOvercommitType'
     description: |

--- a/mmv1/products/compute/NodeTemplate.yaml
+++ b/mmv1/products/compute/NodeTemplate.yaml
@@ -154,7 +154,7 @@ properties:
     name: 'accelerators'
     description: |
       List of the type and count of accelerator cards attached to the
-      node template 
+      node template
     item_type: !ruby/object:Api::Type::NestedObject
       properties:
         - !ruby/object:Api::Type::Integer

--- a/mmv1/templates/terraform/examples/node_template_accelerators.tf.erb
+++ b/mmv1/templates/terraform/examples/node_template_accelerators.tf.erb
@@ -1,0 +1,15 @@
+data "google_compute_node_types" "central1a" {
+  zone     = "us-central1-a"
+}
+
+resource "google_compute_node_template" "<%= ctx[:primary_resource_id] %>" {
+  name      = "<%= ctx[:vars]['template_name'] %>"
+  region    = "us-central1"
+  node_type = "n1-node-96-624"
+
+  accelerators {
+    accelerator_type  = "nvidia-tesla-t4"
+    accelerator_count = 4
+  }
+}
+


### PR DESCRIPTION
Adds accelerators[] field for NodeTemplate to support GPU accelerators in sole tenant node templates

Fixes https://github.com/hashicorp/terraform-provider-google/issues/19201

```release-note:enhancement
compute: added `accelerators` field to `google_compute_node_template` resource
```