### PR TITLE
container: add oauth scope to private registry test

### DIFF
--- a/mmv1/third_party/terraform/services/container/go/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/go/resource_container_cluster_test.go.tmpl
@@ -10972,6 +10972,11 @@ resource "google_container_cluster" "primary" {
   network    = "%s"
   subnetwork    = "%s"
 
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+    ]
+  }
   node_pool_defaults {
     node_config_defaults {
       containerd_config {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -11052,6 +11052,11 @@ resource "google_container_cluster" "primary" {
   network    = "%s"
   subnetwork    = "%s"
 
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+    ]
+  }
   node_pool_defaults {
     node_config_defaults {
       containerd_config {


### PR DESCRIPTION
Add oauth scopes in `node_config` for `TestAccContainerCluster_privateRegistry` (required to avoid an API level error).

Test only change; doesn't affect behavior

Without this change:

```
2024/08/21 10:45:48 [DEBUG] Retry Transport: Returning after 1 attempts
    vcr_utils.go:152: Step 1/7 error: Error running apply: exit status 1
        
        Error: googleapi: Error 400: Private_registry_access_config requires scope 'cloud-platform' in order to pull certificates. The following node-pools are lacking such scope: [default-pool].
        Details:
        [
          {
            "@type": "type.googleapis.com/google.rpc.RequestInfo",
            "requestId": "0x9bda853dba747e59"
          }
        ]
        , badRequest
        
          with google_container_cluster.primary,
          on terraform_plugin_test.tf line 28, in resource "google_container_cluster" "primary":
          28: resource "google_container_cluster" "primary" {
        
--- FAIL: TestAccContainerCluster_privateRegistry (19.16s)
```

With it:
```
--- PASS: TestAccContainerCluster_privateRegistry (1375.74s)
PASS
ok  	github.com/hashicorp/terraform-provider-google/google/services/container	1376.747s
```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->


**Release Note Template for Downstream PRs (will be copied)**
```release-note:none

```