### PR TITLE
Fix 6.0-related VCR failures and skip previously failing ones

### DIFF
--- a/mmv1/products/networksecurity/ServerTlsPolicy.yaml
+++ b/mmv1/products/networksecurity/ServerTlsPolicy.yaml
@@ -49,6 +49,7 @@ examples:
   - !ruby/object:Provider::Terraform::Examples
     min_version: beta
     name: 'network_security_server_tls_policy_basic'
+    skip_vcr: true
     primary_resource_id: 'default'
     vars:
       resource_name: 'my-server-tls-policy'

--- a/mmv1/products/networksecurity/go_ServerTlsPolicy.yaml
+++ b/mmv1/products/networksecurity/go_ServerTlsPolicy.yaml
@@ -53,6 +53,7 @@ custom_code:
 examples:
   - name: 'network_security_server_tls_policy_basic'
     primary_resource_id: 'default'
+    skip_vcr: true
     min_version: 'beta'
     vars:
       resource_name: 'my-server-tls-policy'

--- a/mmv1/products/networksecurity/go_ServerTlsPolicy.yaml
+++ b/mmv1/products/networksecurity/go_ServerTlsPolicy.yaml
@@ -53,7 +53,6 @@ custom_code:
 examples:
   - name: 'network_security_server_tls_policy_basic'
     primary_resource_id: 'default'
-    skip_vcr: true
     min_version: 'beta'
     vars:
       resource_name: 'my-server-tls-policy'

--- a/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function_test.go.erb
@@ -332,6 +332,8 @@ func TestAccCloudFunctionsFunction_cmek(t *testing.T) {
 <% end -%>
 
 func TestAccCloudFunctionsFunction_firestore(t *testing.T) {
+	// Currently failing
+	acctest.SkipIfVcr(t)
 	t.Parallel()
 	funcResourceName := "google_cloudfunctions_function.function"
 	functionName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))

--- a/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.erb
@@ -1615,6 +1615,8 @@ resource "google_compute_disk" "foobar" {
 }
 
 func TestAccComputeDisk_storagePoolSpecified(t *testing.T) {
+	// Currently failing
+	acctest.SkipIfVcr(t)
 	t.Parallel()
 
 	storagePoolName := fmt.Sprintf("tf-test-storage-pool-%s", acctest.RandString(t, 10))

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -2041,6 +2041,8 @@ func TestAccComputeInstanceConfidentialInstanceConfigMain(t *testing.T) {
 }
 
 func TestAccComputeInstance_confidentialHyperDiskBootDisk(t *testing.T) {
+	// Currently failing
+	acctest.SkipIfVcr(t)
 	t.Parallel()
 	kms := acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-bootstrap-hyperdisk-key1")
 
@@ -10201,6 +10203,8 @@ resource "google_compute_instance" "foobar" {
 }
 
 func TestAccComputeInstance_bootDisk_storagePoolSpecified(t *testing.T) {
+	// Currently failing
+	acctest.SkipIfVcr(t)
 	t.Parallel()
 
 	instanceName := fmt.Sprintf("tf-test-instance-%s", acctest.RandString(t, 10))

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_firewall_policy_rule_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_firewall_policy_rule_test.go.erb
@@ -67,6 +67,8 @@ func TestAccComputeNetworkFirewallPolicyRule_update(t *testing.T) {
 }
 
 func TestAccComputeNetworkFirewallPolicyRule_multipleRules(t *testing.T) {
+	// Currently failing
+	acctest.SkipIfVcr(t)
   t.Parallel()
 
   context := map[string]interface{}{

--- a/mmv1/third_party/terraform/services/container/data_source_google_container_cluster_test.go
+++ b/mmv1/third_party/terraform/services/container/data_source_google_container_cluster_test.go
@@ -60,7 +60,7 @@ func TestAccContainerClusterDatasource_regional(t *testing.T) {
 							"enable_tpu":                   {},
 							"pod_security_policy_config.#": {},
 							"deletion_protection":          {},
-							"resource_labels":              {},
+							"resource_labels.%":            {},
 						},
 					),
 				),

--- a/mmv1/third_party/terraform/services/dataform/resource_dataform_repository_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataform/resource_dataform_repository_test.go.erb
@@ -95,7 +95,7 @@ resource "google_sourcerepo_repository" "git_repository" {
 
 resource "google_secret_manager_secret" "secret" {
   provider = google-beta
-  secret_id = "secret"
+  secret_id = "tf-test-secret%{random_suffix}"
 
   replication {
     auto {}

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
@@ -106,6 +106,8 @@ func TestAccDataprocCluster_basic(t *testing.T) {
 }
 
 func TestAccDataprocVirtualCluster_basic(t *testing.T) {
+	// Currently failing
+	acctest.SkipIfVcr(t)
 	t.Parallel()
 
 	var cluster dataproc.Cluster

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_membership_binding_test.go
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_membership_binding_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestAccGKEHub2MembershipBinding_gkehubMembershipBindingBasicExample_update(t *testing.T) {
+	// Currently failing
+	acctest.SkipIfVcr(t)
 	t.Parallel()
 
 	context := map[string]interface{}{

--- a/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go.erb
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go.erb
@@ -822,6 +822,7 @@ resource "google_project" "acceptance" {
   project_id      = "%s"
   org_id          = "%s"
   billing_account = "%s"
+  deletion_policy = "DELETE"
 }
 
 resource "google_project_service" "acceptance" {

--- a/mmv1/third_party/terraform/services/securitycenter/resource_scc_folder_notification_config_test.go
+++ b/mmv1/third_party/terraform/services/securitycenter/resource_scc_folder_notification_config_test.go
@@ -64,6 +64,7 @@ func testAccSecurityCenterFolderNotificationConfig_basic(context map[string]inte
 resource "google_folder" "folder" {
   parent       = "organizations/%{org_id}"
   display_name = "tf-test-folder-name%{random_suffix}"
+  deletion_protection = false
 }
 
 resource "time_sleep" "wait_1_minute" {
@@ -97,6 +98,7 @@ func testAccSecurityCenterFolderNotificationConfig_update(context map[string]int
 resource "google_folder" "folder" {
   parent       = "organizations/%{org_id}"
   display_name = "tf-test-folder-name%{random_suffix}"
+  deletion_protection = false
 }
 
 resource "google_pubsub_topic" "scc_folder_notification_config" {

--- a/mmv1/third_party/terraform/services/securitycenterv2/resource_scc_v2_folder_notification_config_test.go
+++ b/mmv1/third_party/terraform/services/securitycenterv2/resource_scc_v2_folder_notification_config_test.go
@@ -64,6 +64,7 @@ func testAccSecurityCenterV2FolderNotificationConfig_basic(context map[string]in
 resource "google_folder" "folder" {
   parent       = "organizations/%{org_id}"
   display_name = "tf-test-folder-name%{random_suffix}"
+  deletion_protection = false
 }
 
 resource "time_sleep" "wait_1_minute" {
@@ -98,6 +99,7 @@ func testAccSecurityCenterV2FolderNotificationConfig_update(context map[string]i
 resource "google_folder" "folder" {
   parent       = "organizations/%{org_id}"
   display_name = "tf-test-folder-name%{random_suffix}"
+  deletion_protection = false
 }
 
 resource "google_pubsub_topic" "scc_v2_folder_notification_config" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fixes https://github.com/hashicorp/terraform-provider-google/issues/19209

Test failures sourced from https://github.com/GoogleCloudPlatform/magic-modules/pull/11513#issuecomment-2302896864

- Looks like `TestAccCloudFunctionsFunction_firestore` was already investigated: https://github.com/hashicorp/terraform-provider-google/issues/18072#issuecomment-2278540970
- `TestAccComputeDisk_storagePoolSpecified`,  `TestAccComputeInstance_bootDisk_storagePoolSpecified` : https://github.com/hashicorp/terraform-provider-google/issues/19199
- `TestAccComputeInstance_confidentialHyperDiskBootDisk`: https://github.com/hashicorp/terraform-provider-google/issues/19217
- `TestAccComputeNetworkFirewallPolicyRule_multipleRules` : https://github.com/hashicorp/terraform-provider-google/issues/19218
- `TestAccDataprocVirtualCluster_basic`: https://github.com/hashicorp/terraform-provider-google/issues/19076
- `TestAccGKEHub2MembershipBinding_gkehubMembershipBindingBasicExample_update `: https://github.com/hashicorp/terraform-provider-google/issues/18007
- `TestAccNetworkSecurityServerTlsPolicy_networkSecurityServerTlsPolicyBasicExample`: https://github.com/hashicorp/terraform-provider-google/issues/18103

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
