### PR TITLE
google_sql_user: Fixed import where host is an IPv4 CIDR

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_user.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user.go
@@ -570,6 +570,19 @@ func resourceSqlUserImporter(d *schema.ResourceData, meta interface{}) ([]*schem
 		if err := d.Set("name", parts[3]); err != nil {
 			return nil, fmt.Errorf("Error setting name: %s", err)
 		}
+	} else if len(parts) == 5 {
+		if err := d.Set("project", parts[0]); err != nil {
+			return nil, fmt.Errorf("Error setting project: %s", err)
+		}
+		if err := d.Set("instance", parts[1]); err != nil {
+			return nil, fmt.Errorf("Error setting instance: %s", err)
+		}
+		if err := d.Set("host", fmt.Sprintf("%s/%s", parts[2], parts[3])); err != nil {
+			return nil, fmt.Errorf("Error setting host: %s", err)
+		}
+		if err := d.Set("name", parts[4]); err != nil {
+			return nil, fmt.Errorf("Error setting name: %s", err)
+		}
 	} else {
 		return nil, fmt.Errorf("Invalid specifier. Expecting {project}/{instance}/{name} for postgres instance and {project}/{instance}/{host}/{name} for MySQL instance")
 	}

--- a/mmv1/third_party/terraform/services/sql/resource_sql_user_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user_test.go
@@ -34,11 +34,19 @@ func TestAccSqlUser_mysql(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleSqlUserExists(t, "google_sql_user.user1"),
 					testAccCheckGoogleSqlUserExists(t, "google_sql_user.user2"),
+					testAccCheckGoogleSqlUserExists(t, "google_sql_user.user3"),
 				),
 			},
 			{
 				ResourceName:            "google_sql_user.user2",
 				ImportStateId:           fmt.Sprintf("%s/%s/gmail.com/admin", envvar.GetTestProjectFromEnv(), instance),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+			{
+				ResourceName:            "google_sql_user.user3",
+				ImportStateId:           fmt.Sprintf("%s/%s/10.0.0.0/24/admin", envvar.GetTestProjectFromEnv(), instance),
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"password"},
@@ -340,6 +348,13 @@ resource "google_sql_user" "user2" {
   instance = google_sql_database_instance.instance.name
   host     = "gmail.com"
   password = "hunter2"
+}
+
+resource "google_sql_user" "user3" {
+  name     = "admin"
+  instance = google_sql_database_instance.instance.name
+  host     = "10.0.0.0/24"
+  password = "hunter3"
 }
 `, instance, password)
 }


### PR DESCRIPTION
Previously it was not possible to import _CloudSQL users for MySQL_ with `host` set to an IPv4 CIDR. The parsing of `ID` failed if `host` was a CIDR since it expected it to be on the form `{project}/{instance}/{host}/{name}` and an error was returned if there where more than three slashes in the `ID`.

With this fix if there are four slashes in the `ID` the third is considered part of the `host` argument.

```release-note: bug
sql: fixed importing `google_sql_user` where `host` is an IPv4 CIDR
```

Acceptance test run:
```
$ make testacc TEST=./google/services/sql TESTARGS='-run=TestAccSqlUser_mysql' 
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/sql -v -run=TestAccSqlUser_mysql -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccSqlUser_mysql
=== PAUSE TestAccSqlUser_mysql
=== RUN   TestAccSqlUser_mysqlPasswordPolicy
=== PAUSE TestAccSqlUser_mysqlPasswordPolicy
=== CONT  TestAccSqlUser_mysql
=== CONT  TestAccSqlUser_mysqlPasswordPolicy
--- PASS: TestAccSqlUser_mysql (770.89s)
--- PASS: TestAccSqlUser_mysqlPasswordPolicy (950.89s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/sql      952.219s
```

Previously a import would fail with the message shown bellow. After the change this import succeeds with `host` set to `10.0.0.0/24`.

```
$ terraform import google_sql_user.admin my-project/my-instance/10.0.0.0/24/admin 
[...]
        Error: Invalid specifier. Expecting {project}/{instance}/{name} for postgres instance and {project}/{instance}/{host}/{name} for MySQL instance
```