### PR TITLE
Add disk resource policies field to the compute instance

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
@@ -74,6 +74,7 @@ var (
 		"boot_disk.0.initialize_params.0.provisioned_throughput",
 		"boot_disk.0.initialize_params.0.enable_confidential_compute",
 		"boot_disk.0.initialize_params.0.storage_pool",
+		"boot_disk.0.initialize_params.0.resource_policies",
 	}
 
 	schedulingKeys = []string{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
@@ -280,6 +280,17 @@ func ResourceComputeInstance() *schema.Resource {
 										Description:  `A map of resource manager tags. Resource manager tag keys and values have the same definition as resource manager tags. Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456. The field is ignored (both PUT & PATCH) when empty.`,
 									},
 
+									"resource_policies": {
+										Type:             schema.TypeList,
+										Elem:             &schema.Schema{Type: schema.TypeString},
+										Optional:         true,
+										ForceNew:         true,
+										AtLeastOneOf:     initializeParamsKeys,
+										DiffSuppressFunc: tpgresource.CompareSelfLinkRelativePaths,
+										MaxItems:         1,
+										Description:      `A list of self_links of resource policies to attach to the instance's boot disk. Modifying this list will cause the instance to recreate. Currently a max of 1 resource policy is supported.`,
+									},
+
 									"provisioned_iops": {
 										Type:         schema.TypeInt,
 										Optional:     true,
@@ -3018,6 +3029,10 @@ func expandBootDisk(d *schema.ResourceData, config *transport_tpg.Config, projec
 			disk.InitializeParams.ResourceManagerTags = tpgresource.ExpandStringMap(d, "boot_disk.0.initialize_params.0.resource_manager_tags")
 		}
 
+		if _, ok := d.GetOk("boot_disk.0.initialize_params.0.resource_policies"); ok {
+			disk.InitializeParams.ResourcePolicies = tpgresource.ConvertStringArr(d.Get("boot_disk.0.initialize_params.0.resource_policies").([]interface{}))
+		}
+
 		if v, ok := d.GetOk("boot_disk.0.initialize_params.0.storage_pool"); ok {
 			disk.InitializeParams.StoragePool = v.(string)
 		}
@@ -3063,6 +3078,7 @@ func flattenBootDisk(d *schema.ResourceData, disk *compute.AttachedDisk, config 
 			"size":   diskDetails.SizeGb,
 			"labels": diskDetails.Labels,
 			"resource_manager_tags": d.Get("boot_disk.0.initialize_params.0.resource_manager_tags"),
+			"resource_policies": diskDetails.ResourcePolicies,
 			"provisioned_iops": diskDetails.ProvisionedIops,
 			"provisioned_throughput": diskDetails.ProvisionedThroughput,
 			"enable_confidential_compute": diskDetails.EnableConfidentialCompute,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template.go.erb
@@ -251,6 +251,15 @@ func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *transport_t
 						// only have the name (since they're global).
 						disk.InitializeParams.DiskType = fmt.Sprintf("zones/%s/diskTypes/%s", zone.Name, dt)
 					}
+					if rp := disk.InitializeParams.ResourcePolicies; len(rp) > 0 {
+						// Instances need a URL for the resource policy, but instance templates
+						// only have the name (since they're global).
+						for i := range rp {
+							rp[i], _ = parseUniqueId(rp[i]) // in some cases the API translation doesn't work and returns entire url when only name is provided. And allows for id to be passed as well
+							rp[i] = fmt.Sprintf("projects/%s/regions/%s/resourcePolicies/%s", project, regionFromUrl(zone.Region), rp[i])
+						}
+						disk.InitializeParams.ResourcePolicies = rp
+					}
 				}
 				disks = append(disks, disk)
 				break

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_test.go.erb
@@ -169,6 +169,38 @@ func TestAccComputeInstanceFromTemplateWithOverride_localSsdRecoveryTimeout(t *t
 	})
 }
 
+func TestAccComputeInstanceFromTemplate_diskResourcePolicies(t *testing.T) {
+	t.Parallel()
+
+	var instance compute.Instance
+	templateName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	suffix := acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceFromTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceFromTemplate_diskResourcePoliciesCreate(suffix, templateName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance_from_template.foobar", &instance),
+				),
+			},
+			{
+				Config: testAccComputeInstanceFromTemplate_diskResourcePoliciesUpdate(suffix, templateName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance_from_template.foobar", &instance),
+				),
+			},
+			{
+				Config:      testAccComputeInstanceFromTemplate_diskResourcePoliciesTwoPolicies(suffix, templateName),
+				ExpectError: regexp.MustCompile("Too many list items"),
+			},
+		},
+	})
+}
+
 <% unless version == 'ga' -%>
 func TestAccComputeInstanceFromTemplate_partnerMetadata(t *testing.T) {
 	t.Parallel()
@@ -1856,4 +1888,160 @@ resource "google_compute_instance_from_template" "foobar" {
   }
 }
 `, template, instance, template, instance)
+}
+
+func testAccComputeInstanceFromTemplate_diskResourcePoliciesCreate(suffix, template string) string {
+	return fmt.Sprintf(`
+resource "google_compute_resource_policy" "test-snapshot-policy" {
+  name    = "test-policy-%s"
+  snapshot_schedule_policy {
+    schedule {
+      hourly_schedule {
+        hours_in_cycle = 1
+        start_time     = "11:00"
+      }
+    }
+  }
+}
+
+resource "google_compute_resource_policy" "test-snapshot-policy2" {
+  name    = "test-policy2-%s"
+  snapshot_schedule_policy {
+    schedule {
+      hourly_schedule {
+        hours_in_cycle = 1
+        start_time     = "22:00"
+      }
+    }
+  }
+}
+
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+  
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "%s"
+  region = "us-central1"
+  machine_type = "n1-standard-1"
+  disk {
+    resource_policies = [ google_compute_resource_policy.test-snapshot-policy.name ]
+    source_image = data.google_compute_image.my_image.self_link
+  }
+  network_interface {
+      network = "default"
+  }
+}
+  
+resource "google_compute_instance_from_template" "foobar" {
+  name = "%s"
+  zone = "us-central1-a"
+  source_instance_template = google_compute_region_instance_template.foobar.id
+}
+`, suffix, suffix, template, template)
+}
+
+func testAccComputeInstanceFromTemplate_diskResourcePoliciesUpdate(suffix, template string) string {
+	return fmt.Sprintf(`
+resource "google_compute_resource_policy" "test-snapshot-policy" {
+  name    = "test-policy-%s"
+  snapshot_schedule_policy {
+    schedule {
+      hourly_schedule {
+        hours_in_cycle = 1
+        start_time     = "11:00"
+      }
+    }
+  }
+}
+
+resource "google_compute_resource_policy" "test-snapshot-policy2" {
+  name    = "test-policy2-%s"
+  snapshot_schedule_policy {
+    schedule {
+      hourly_schedule {
+        hours_in_cycle = 1
+        start_time     = "22:00"
+      }
+    }
+  }
+}
+
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+  
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "%s"
+  region = "us-central1"
+  machine_type = "n1-standard-1" 
+  disk {
+    resource_policies = [ google_compute_resource_policy.test-snapshot-policy2.name ]
+    source_image = data.google_compute_image.my_image.self_link
+  }
+  network_interface {
+      network = "default"
+  }
+}
+  
+resource "google_compute_instance_from_template" "foobar" {
+  name = "%s"
+  zone = "us-central1-a"
+  source_instance_template = google_compute_region_instance_template.foobar.id
+}
+`, suffix, suffix, template, template)
+}
+
+func testAccComputeInstanceFromTemplate_diskResourcePoliciesTwoPolicies(suffix, template string) string {
+	return fmt.Sprintf(`
+resource "google_compute_resource_policy" "test-snapshot-policy" {
+  name    = "test-policy-%s"
+  snapshot_schedule_policy {
+    schedule {
+      hourly_schedule {
+        hours_in_cycle = 1
+        start_time     = "11:00"
+      }
+    }
+  }
+}
+
+resource "google_compute_resource_policy" "test-snapshot-policy2" {
+  name    = "test-policy2-%s"
+  snapshot_schedule_policy {
+    schedule {
+      hourly_schedule {
+        hours_in_cycle = 1
+        start_time     = "22:00"
+      }
+    }
+  }
+}
+
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+  
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "%s"
+  region = "us-central1"
+  machine_type = "n1-standard-1" 
+  disk {
+    resource_policies = [ google_compute_resource_policy.test-snapshot-policy.name, google_compute_resource_policy.test-snapshot-policy2.name ]
+    source_image = data.google_compute_image.my_image.self_link
+  }
+  network_interface {
+      network = "default"
+  }
+}
+  
+resource "google_compute_instance_from_template" "foobar" {
+  name = "%s"
+  zone = "us-central1-a"
+  source_instance_template = google_compute_region_instance_template.foobar.id
+}
+  `, suffix, suffix, template, template)
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -339,6 +339,42 @@ func TestAccComputeInstance_resourceManagerTags(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstance_diskResourcePolicies(t *testing.T) {
+	t.Parallel()
+
+	var instance compute.Instance
+	var instanceName = fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	context := map[string]interface{}{
+		"project":       envvar.GetTestProjectFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+		"instance_name": instanceName,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_diskResourcePoliciesOnePolicy(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+				),
+			},
+			{
+				Config: testAccComputeInstance_diskResourcePoliciesOnePolicyUpdate(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+				),
+			},
+			{
+				Config:      testAccComputeInstance_diskResourcePoliciesTwoPolicies(context),
+				ExpectError: regexp.MustCompile("Too many list items"),
+			},
+		},
+	})
+}
+
 func TestAccComputeInstance_machineTypeUrl(t *testing.T) {
 	t.Parallel()
 
@@ -4958,6 +4994,156 @@ resource "google_compute_instance" "foobar" {
     resource_manager_tags = {
       "tagKeys/${google_tags_tag_key.key.name}"     = "tagValues/${google_tags_tag_value.value.name}"
       "tagKeys/${google_tags_tag_key.key_new.name}" = "tagValues/${google_tags_tag_value.value_new.name}"
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+`, context)
+}
+
+func testAccComputeInstance_diskResourcePoliciesOnePolicy(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_resource_policy" "test-snapshot-policy" {
+  name    = "test-policy-%{random_suffix}"
+  snapshot_schedule_policy {
+    schedule {
+      hourly_schedule {
+        hours_in_cycle = 1
+        start_time     = "11:00"
+      }
+    }
+  }
+}
+
+resource "google_compute_resource_policy" "test-snapshot-policy2" {
+  name    = "test-policy2-%{random_suffix}"
+  snapshot_schedule_policy {
+    schedule {
+      hourly_schedule {
+        hours_in_cycle = 1
+        start_time     = "22:00"
+      }
+    }
+  }
+}
+
+resource "google_compute_instance" "foobar" {
+  name           = "%{instance_name}"
+  machine_type   = "e2-medium"
+  zone           = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+	  resource_policies = [google_compute_resource_policy.test-snapshot-policy.id]
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+`, context)
+}
+
+func testAccComputeInstance_diskResourcePoliciesOnePolicyUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_resource_policy" "test-snapshot-policy" {
+  name    = "test-policy-%{random_suffix}"
+  snapshot_schedule_policy {
+    schedule {
+      hourly_schedule {
+        hours_in_cycle = 1
+        start_time     = "11:00"
+      }
+    }
+  }
+}
+
+resource "google_compute_resource_policy" "test-snapshot-policy2" {
+  name    = "test-policy2-%{random_suffix}"
+  snapshot_schedule_policy {
+    schedule {
+      hourly_schedule {
+        hours_in_cycle = 1
+        start_time     = "22:00"
+      }
+    }
+  }
+}
+
+resource "google_compute_instance" "foobar" {
+  name           = "%{instance_name}"
+  machine_type   = "e2-medium"
+  zone           = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+	  resource_policies = [google_compute_resource_policy.test-snapshot-policy2.id]
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+`, context)
+}
+
+func testAccComputeInstance_diskResourcePoliciesTwoPolicies(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_resource_policy" "test-snapshot-policy" {
+  name    = "test-policy-%{random_suffix}"
+  snapshot_schedule_policy {
+    schedule {
+      hourly_schedule {
+        hours_in_cycle = 1
+        start_time     = "11:00"
+      }
+    }
+  }
+}
+
+resource "google_compute_resource_policy" "test-snapshot-policy2" {
+  name    = "test-policy2-%{random_suffix}"
+  snapshot_schedule_policy {
+    schedule {
+      hourly_schedule {
+        hours_in_cycle = 1
+        start_time     = "22:00"
+      }
+    }
+  }
+}
+
+resource "google_compute_instance" "foobar" {
+  name           = "%{instance_name}"
+  machine_type   = "e2-medium"
+  zone           = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+	  resource_policies = [google_compute_resource_policy.test-snapshot-policy2.id, google_compute_resource_policy.test-snapshot-policy.id]
+      image = data.google_compute_image.my_image.self_link
     }
   }
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance.html.markdown
@@ -131,7 +131,7 @@ The following arguments are supported:
 
 * `labels` - A set of key/value label pairs assigned to the disk.
 
-* `resource_policies` - A self_link of a resource policy attached to the disk
+* `resource_policies` - A list of self_links to resource policies attached to the selected `boot_disk`
 
 <a name="nested_scratch_disk"></a>The `scratch_disk` block supports:
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance.html.markdown
@@ -131,6 +131,8 @@ The following arguments are supported:
 
 * `labels` - A set of key/value label pairs assigned to the disk.
 
+* `resource_policies` - A self_link of a resource policy attached to the disk
+
 <a name="nested_scratch_disk"></a>The `scratch_disk` block supports:
 
 * `interface` - The disk interface used for attaching this disk. One of `SCSI` or `NVME`.

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -302,6 +302,8 @@ is desired, you will need to modify your state file manually using
 
 * `resource_manager_tags` - (Optional) A tag is a key-value pair that can be attached to a Google Cloud resource. You can use tags to conditionally allow or deny policies based on whether a resource has a specific tag. This value is not returned by the API. In Terraform, this value cannot be updated and changing it will recreate the resource.
 
+* `resource_policies` - (Optional) A list of self_links of resource policies to attach to the instance's boot disk. Modifying this list will cause the instance to recreate. Currently a max of 1 resource policy is supported.
+
 * `provisioned_iops` - (Optional) Indicates how many IOPS to provision for the disk.
     This sets the number of I/O operations per second that the disk can handle.
     For more details,see the [Hyperdisk documentation](https://cloud.google.com/compute/docs/disks/hyperdisks).


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
closes https://github.com/hashicorp/terraform-provider-google/issues/8963
closes https://github.com/hashicorp/terraform-provider-google/issues/9260

This adds boot_disk -> initialize_params -> resource_policies

- Added the field into `google_compute_instance`
- Added data_source support
- Added tests for the new field
- Doc changes
- Added translation in `instance_from_template` that will support this change and resolve [this issue](https://github.com/hashicorp/terraform-provider-google/issues/9260)

If there are any more files that i need to update please LMK
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added support for `boot_disk.initialize_params.resource_policies` in `google_compute_instance` and `google_instance_template`
```
