### PR TITLE
Fix TestAccSecurityCenterV2OrganizationBigQueryExportConfig_basic

### DIFF
--- a/mmv1/products/securitycenterv2/OrganizationSccBigQueryExports.yaml
+++ b/mmv1/products/securitycenterv2/OrganizationSccBigQueryExports.yaml
@@ -42,7 +42,6 @@ examples:
     vars:
       big_query_export_id: 'my-export'
       dataset: 'my-dataset'
-      dataset_id: 'my_dataset_id'
       name: 'my-export'
     test_env_vars:
       org_id: :ORG_ID

--- a/mmv1/templates/terraform/examples/scc_v2_organization_big_query_export_config_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/scc_v2_organization_big_query_export_config_basic.tf.erb
@@ -19,7 +19,7 @@ resource "google_scc_v2_organization_scc_big_query_exports" "<%= ctx[:primary_re
   name         = "<%= ctx[:vars]['name'] %>"
   big_query_export_id    = "<%= ctx[:vars]['big_query_export_id'] %>"
   organization = "<%= ctx[:test_env_vars]['org_id'] %>"
-  dataset      = "<%= ctx[:vars]['dataset'] %>"
+  dataset      = google_bigquery_dataset.default.id
   location     = "global"
   description  = "Cloud Security Command Center Findings Big Query Export Config"
   filter       = "state=\"ACTIVE\" AND NOT mute=\"MUTED\""

--- a/mmv1/third_party/terraform/services/securitycenterv2/resource_scc_v2_organization_big_query_export_config_test.go
+++ b/mmv1/third_party/terraform/services/securitycenterv2/resource_scc_v2_organization_big_query_export_config_test.go
@@ -17,11 +17,9 @@ func TestAccSecurityCenterV2OrganizationBigQueryExportConfig_basic(t *testing.T)
 	orgID := envvar.GetTestOrgFromEnv(t)
 
 	context := map[string]interface{}{
-		"org_id":        orgID,
-		"random_suffix": randomSuffix,
-		"dataset_id":    dataset_id,
-		"dataset": fmt.Sprintf("projects/%s/datasets/%s",
-			envvar.GetTestProjectFromEnv(), dataset_id),
+		"org_id":              orgID,
+		"random_suffix":       randomSuffix,
+		"dataset_id":          dataset_id,
 		"big_query_export_id": "tf-test-export-" + randomSuffix,
 		"name": fmt.Sprintf("organizations/%s/locations/global/bigQueryExports/%s",
 			orgID, "tf-test-export-"+randomSuffix),
@@ -86,7 +84,7 @@ resource "google_scc_v2_organization_scc_big_query_exports" "default" {
   name		   = "%{name}"
   big_query_export_id    = "%{big_query_export_id}"
   organization = "%{org_id}"
-  dataset      = "%{dataset}"
+  dataset      = google_bigquery_dataset.default.id
   location     = "global"
   description  = "Cloud Security Command Center Findings Big Query Export Config"
   filter       = "state=\"ACTIVE\" AND NOT mute=\"MUTED\""
@@ -125,7 +123,7 @@ resource "google_scc_v2_organization_scc_big_query_exports" "default" {
   name		   = "%{name}"
   big_query_export_id    = "%{big_query_export_id}"
   organization = "%{org_id}"
-  dataset      = "%{dataset}"
+  dataset      = google_bigquery_dataset.default.id
   location     = "global"
   description  = "SCC Findings Big Query Export Update"
   filter       = "state=\"ACTIVE\" AND NOT mute=\"MUTED\""


### PR DESCRIPTION
These resources didn't have a proper resource dependency relationship. Fixing so resource order is deleted as we desire.

https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_GoogleCloud_GOOGLE_BETA_NIGHTLYTESTS_GOOGLEBETA_PACKAGE_SECURITYCENTERV2/222279?buildTab=overview&expandBuildDeploymentsSection=false&hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildTestsSection=true&expandBuildChangesSection=true

```
=== RUN   TestAccSecurityCenterV2OrganizationBigQueryExportConfig_basic
=== PAUSE TestAccSecurityCenterV2OrganizationBigQueryExportConfig_basic
=== CONT  TestAccSecurityCenterV2OrganizationBigQueryExportConfig_basic
    testing_new.go:90: Error running post-test destroy, there may be dangling resources: exit status 1
        Error: Error when reading or editing Dataset: googleapi: Error 400: Dataset some-project:tf_test_78i3eei6rd is still in use, resourceInUse
--- FAIL: TestAccSecurityCenterV2OrganizationBigQueryExportConfig_basic (391.49s)

```

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
