### PR TITLE
Made virtual fields get generated with the same template as non-virtual fields

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -329,6 +329,12 @@ func (r *Resource) UnmarshalYAML(n *yaml.Node) error {
 		r.CollectionUrlKey = google.Camelize(google.Plural(r.Name), "lower")
 	}
 
+	if len(r.VirtualFields) > 0 {
+		for _, f := range r.VirtualFields {
+			f.ClientSide = true
+		}
+	}
+
 	return nil
 }
 

--- a/mmv1/api/resource.rb
+++ b/mmv1/api/resource.rb
@@ -321,6 +321,10 @@ module Api
             type: Array,
             default: []
 
+      if !@virtual_fields.nil?
+        @virtual_fields.each { |field| field.client_side = true }
+      end
+
       check :custom_code, type: Provider::Terraform::CustomCode,
                           default: Provider::Terraform::CustomCode.new
       check :sweeper, type: Provider::Terraform::Sweeper, default: Provider::Terraform::Sweeper.new

--- a/mmv1/api/resource.rb
+++ b/mmv1/api/resource.rb
@@ -321,9 +321,7 @@ module Api
             type: Array,
             default: []
 
-      if !@virtual_fields.nil?
-        @virtual_fields.each { |field| field.client_side = true }
-      end
+      @virtual_fields&.each { |field| field.client_side = true }
 
       check :custom_code, type: Provider::Terraform::CustomCode,
                           default: Provider::Terraform::CustomCode.new

--- a/mmv1/api/type.rb
+++ b/mmv1/api/type.rb
@@ -49,6 +49,9 @@ module Api
       # behavior.
       attr_accessor :immutable
 
+      # Indicates that this field is client-side only (aka virtual.)
+      attr_accessor :client_side
+
       # url_param_only will not send the field in the resource body and will
       # not attempt to read the field from the API response.
       # NOTE - this doesn't work for nested fields
@@ -228,6 +231,7 @@ module Api
       check :url_param_only, type: :boolean
       check :read_query_params, type: ::String
       check :immutable, type: :boolean
+      check :client_side, type: :boolean
 
       raise 'Property cannot be output and required at the same time.' \
         if @output && @required

--- a/mmv1/products/alloydb/Cluster.yaml
+++ b/mmv1/products/alloydb/Cluster.yaml
@@ -114,16 +114,14 @@ custom_code: !ruby/object:Provider::Terraform::CustomCode
   pre_update: templates/terraform/pre_update/alloydb_cluster.go.erb
   pre_delete: templates/terraform/pre_delete/alloydb_cluster.go.erb
 virtual_fields:
-  - !ruby/object:Api::Type::Enum
+  - !ruby/object:Api::Type::String
     name: 'deletion_policy'
     description: |
       Policy to determine if the cluster should be deleted forcefully.
       Deleting a cluster forcefully, deletes the cluster and all its associated instances within the cluster.
       Deleting a Secondary cluster with a secondary instance REQUIRES setting deletion_policy = "FORCE" otherwise an error is returned. This is needed as there is no support to delete just the secondary instance, and the only way to delete secondary instance is to delete the associated secondary cluster forcefully which also deletes the secondary instance.
-    values:
-      - :DEFAULT
-      - :FORCE
-    default_value: :DEFAULT
+      Possible values: DEFAULT, FORCE
+    default_value: DEFAULT
 parameters:
   - !ruby/object:Api::Type::String
     name: 'clusterId'

--- a/mmv1/products/alloydb/go_Cluster.yaml
+++ b/mmv1/products/alloydb/go_Cluster.yaml
@@ -113,7 +113,8 @@ virtual_fields:
       Policy to determine if the cluster should be deleted forcefully.
       Deleting a cluster forcefully, deletes the cluster and all its associated instances within the cluster.
       Deleting a Secondary cluster with a secondary instance REQUIRES setting deletion_policy = "FORCE" otherwise an error is returned. This is needed as there is no support to delete just the secondary instance, and the only way to delete secondary instance is to delete the associated secondary cluster forcefully which also deletes the secondary instance.
-    type: Enum
+      Possible values: DEFAULT, FORCE
+    type: String
     default_value: "DEFAULT"
 parameters:
   - name: 'clusterId'

--- a/mmv1/products/compute/PerInstanceConfig.yaml
+++ b/mmv1/products/compute/PerInstanceConfig.yaml
@@ -70,7 +70,7 @@ examples:
       igm_name: 'my-igm'
       disk_name: 'my-disk-name'
 virtual_fields:
-  - !ruby/object:Api::Type::Enum
+  - !ruby/object:Api::Type::String
     name: 'minimal_action'
     description: |
       The minimal action to perform on the instance during an update.
@@ -79,13 +79,8 @@ virtual_fields:
       * RESTART
       * REFRESH
       * NONE
-    values:
-      - :REPLACE
-      - :RESTART
-      - :REFRESH
-      - :NONE
-    default_value: :NONE
-  - !ruby/object:Api::Type::Enum
+    default_value: NONE
+  - !ruby/object:Api::Type::String
     name: 'most_disruptive_allowed_action'
     description: |
       The most disruptive action to perform on the instance during an update.
@@ -94,12 +89,7 @@ virtual_fields:
       * RESTART
       * REFRESH
       * NONE
-    values:
-      - :REPLACE
-      - :RESTART
-      - :REFRESH
-      - :NONE
-    default_value: :REPLACE
+    default_value: REPLACE
   - !ruby/object:Api::Type::Boolean
     name: 'remove_instance_on_destroy'
     conflicts:

--- a/mmv1/products/compute/RegionPerInstanceConfig.yaml
+++ b/mmv1/products/compute/RegionPerInstanceConfig.yaml
@@ -71,7 +71,7 @@ examples:
       igm_name: 'my-rigm'
       disk_name: 'my-disk-name'
 virtual_fields:
-  - !ruby/object:Api::Type::Enum
+  - !ruby/object:Api::Type::String
     name: 'minimal_action'
     description: |
       The minimal action to perform on the instance during an update.
@@ -80,13 +80,8 @@ virtual_fields:
       * RESTART
       * REFRESH
       * NONE
-    values:
-      - :REPLACE
-      - :RESTART
-      - :REFRESH
-      - :NONE
-    default_value: :NONE
-  - !ruby/object:Api::Type::Enum
+    default_value: NONE
+  - !ruby/object:Api::Type::String
     name: 'most_disruptive_allowed_action'
     description: |
       The most disruptive action to perform on the instance during an update.
@@ -95,12 +90,7 @@ virtual_fields:
       * RESTART
       * REFRESH
       * NONE
-    values:
-      - :REPLACE
-      - :RESTART
-      - :REFRESH
-      - :NONE
-    default_value: :REPLACE
+    default_value: REPLACE
   - !ruby/object:Api::Type::Boolean
     name: 'remove_instance_on_destroy'
     conflicts:

--- a/mmv1/products/compute/go_PerInstanceConfig.yaml
+++ b/mmv1/products/compute/go_PerInstanceConfig.yaml
@@ -80,7 +80,7 @@ virtual_fields:
       * RESTART
       * REFRESH
       * NONE
-    type: Enum
+    type: String
     default_value: "NONE"
   - name: 'most_disruptive_allowed_action'
     description: |
@@ -90,7 +90,7 @@ virtual_fields:
       * RESTART
       * REFRESH
       * NONE
-    type: Enum
+    type: String
     default_value: "REPLACE"
   - name: 'remove_instance_on_destroy'
     description: |

--- a/mmv1/products/compute/go_RegionPerInstanceConfig.yaml
+++ b/mmv1/products/compute/go_RegionPerInstanceConfig.yaml
@@ -81,7 +81,7 @@ virtual_fields:
       * RESTART
       * REFRESH
       * NONE
-    type: Enum
+    type: String
     default_value: "NONE"
   - name: 'most_disruptive_allowed_action'
     description: |
@@ -91,7 +91,7 @@ virtual_fields:
       * RESTART
       * REFRESH
       * NONE
-    type: Enum
+    type: String
     default_value: "REPLACE"
   - name: 'remove_instance_on_destroy'
     description: |

--- a/mmv1/products/containerattached/Cluster.yaml
+++ b/mmv1/products/containerattached/Cluster.yaml
@@ -75,13 +75,10 @@ custom_code: !ruby/object:Provider::Terraform::CustomCode
   pre_update: templates/terraform/pre_update/containerattached_update.go.erb
   pre_delete: templates/terraform/pre_delete/container_attached_deletion_policy.go.erb
 virtual_fields:
-  - !ruby/object:Api::Type::Enum
+  - !ruby/object:Api::Type::String
     name: 'deletion_policy'
-    description: 'Policy to determine what flags to send on delete.'
-    values:
-      - :DELETE
-      - :DELETE_IGNORE_ERRORS
-    default_value: :DELETE
+    description: 'Policy to determine what flags to send on delete. Possible values: DELETE, DELETE_IGNORE_ERRORS'
+    default_value: DELETE
 properties:
   - !ruby/object:Api::Type::String
     name: location

--- a/mmv1/products/containerattached/go_Cluster.yaml
+++ b/mmv1/products/containerattached/go_Cluster.yaml
@@ -73,8 +73,8 @@ examples:
       - 'deletion_policy'
 virtual_fields:
   - name: 'deletion_policy'
-    description: 'Policy to determine what flags to send on delete.'
-    type: Enum
+    description: 'Policy to determine what flags to send on delete. Possible values: DELETE, DELETE_IGNORE_ERRORS'
+    type: String
     default_value: "DELETE"
 parameters:
 properties:

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -28,15 +28,12 @@ id_format: projects/{{project}}/locations/{{location}}/streams/{{stream_id}}
 import_format:
   ['projects/{{project}}/locations/{{location}}/streams/{{stream_id}}']
 virtual_fields:
-  - !ruby/object:Api::Type::Enum
+  - !ruby/object:Api::Type::String
     name: 'desired_state'
     description: |
       Desired state of the Stream. Set this field to `RUNNING` to start the stream, and `PAUSED` to pause the stream.
-    values:
-      - :NOT_STARTED
-      - :RUNNING
-      - :PAUSED
-    default_value: :NOT_STARTED
+      Possible values: NOT_STARTED, RUNNING_PAUSED. Default: NOT_STARTED
+    default_value: NOT_STARTED
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   constants: 'templates/terraform/constants/datastream_stream.go.erb'
   post_create: 'templates/terraform/post_create/datastream_stream.go.erb'

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -32,7 +32,7 @@ virtual_fields:
     name: 'desired_state'
     description: |
       Desired state of the Stream. Set this field to `RUNNING` to start the stream, and `PAUSED` to pause the stream.
-      Possible values: NOT_STARTED, RUNNING_PAUSED. Default: NOT_STARTED
+      Possible values: NOT_STARTED, RUNNING, PAUSED. Default: NOT_STARTED
     default_value: NOT_STARTED
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   constants: 'templates/terraform/constants/datastream_stream.go.erb'

--- a/mmv1/products/datastream/go_Stream.yaml
+++ b/mmv1/products/datastream/go_Stream.yaml
@@ -163,7 +163,7 @@ virtual_fields:
   - name: 'desired_state'
     description: |
       Desired state of the Stream. Set this field to `RUNNING` to start the stream, and `PAUSED` to pause the stream.
-      Possible values: NOT_STARTED, RUNNING_PAUSED. Default: NOT_STARTED
+      Possible values: NOT_STARTED, RUNNING, PAUSED. Default: NOT_STARTED
     type: String
     default_value: "NOT_STARTED"
 parameters:

--- a/mmv1/products/datastream/go_Stream.yaml
+++ b/mmv1/products/datastream/go_Stream.yaml
@@ -163,7 +163,8 @@ virtual_fields:
   - name: 'desired_state'
     description: |
       Desired state of the Stream. Set this field to `RUNNING` to start the stream, and `PAUSED` to pause the stream.
-    type: Enum
+      Possible values: NOT_STARTED, RUNNING_PAUSED. Default: NOT_STARTED
+    type: String
     default_value: "NOT_STARTED"
 parameters:
   - name: 'streamId'

--- a/mmv1/products/firebase/AndroidApp.yaml
+++ b/mmv1/products/firebase/AndroidApp.yaml
@@ -90,16 +90,13 @@ examples:
       - project
       - deletion_policy
 virtual_fields:
-  - !ruby/object:Api::Type::Enum
+  - !ruby/object:Api::Type::String
     name: 'deletion_policy'
     description: |
       (Optional) Set to `ABANDON` to allow the AndroidApp to be untracked from terraform state
       rather than deleted upon `terraform destroy`. This is useful because the AndroidApp may be
       serving traffic. Set to `DELETE` to delete the AndroidApp. Defaults to `DELETE`.
-    default_value: :DELETE
-    values:
-      - :DELETE
-      - :ABANDON
+    default_value: DELETE
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_delete: templates/terraform/custom_delete/firebase_app_deletion_policy.erb
 properties:

--- a/mmv1/products/firebase/AppleApp.yaml
+++ b/mmv1/products/firebase/AppleApp.yaml
@@ -89,16 +89,13 @@ examples:
       - project
       - deletion_policy
 virtual_fields:
-  - !ruby/object:Api::Type::Enum
+  - !ruby/object:Api::Type::String
     name: 'deletion_policy'
     description: |
       (Optional) Set to `ABANDON` to allow the Apple to be untracked from terraform state
       rather than deleted upon `terraform destroy`. This is useful because the Apple may be
       serving traffic. Set to `DELETE` to delete the Apple. Defaults to `DELETE`.
-    default_value: :DELETE
-    values:
-      - :DELETE
-      - :ABANDON
+    default_value: DELETE
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_delete: templates/terraform/custom_delete/firebase_app_deletion_policy.erb
 properties:

--- a/mmv1/products/firebase/WebApp.yaml
+++ b/mmv1/products/firebase/WebApp.yaml
@@ -86,16 +86,13 @@ examples:
       - project
       - deletion_policy
 virtual_fields:
-  - !ruby/object:Api::Type::Enum
+  - !ruby/object:Api::Type::String
     name: 'deletion_policy'
     description: |
       Set to `ABANDON` to allow the WebApp to be untracked from terraform state
       rather than deleted upon `terraform destroy`. This is useful becaue the WebApp may be
       serving traffic. Set to `DELETE` to delete the WebApp. Default to `DELETE`
-    default_value: :DELETE
-    values:
-      - :DELETE
-      - :ABANDON
+    default_value: DELETE
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   custom_delete: templates/terraform/custom_delete/firebase_app_deletion_policy.erb
 properties:

--- a/mmv1/products/firebase/go_AndroidApp.yaml
+++ b/mmv1/products/firebase/go_AndroidApp.yaml
@@ -93,7 +93,7 @@ virtual_fields:
       (Optional) Set to `ABANDON` to allow the AndroidApp to be untracked from terraform state
       rather than deleted upon `terraform destroy`. This is useful because the AndroidApp may be
       serving traffic. Set to `DELETE` to delete the AndroidApp. Defaults to `DELETE`.
-    type: Enum
+    type: String
     default_value: "DELETE"
 parameters:
 properties:

--- a/mmv1/products/firebase/go_AppleApp.yaml
+++ b/mmv1/products/firebase/go_AppleApp.yaml
@@ -92,7 +92,7 @@ virtual_fields:
       (Optional) Set to `ABANDON` to allow the Apple to be untracked from terraform state
       rather than deleted upon `terraform destroy`. This is useful because the Apple may be
       serving traffic. Set to `DELETE` to delete the Apple. Defaults to `DELETE`.
-    type: Enum
+    type: String
     default_value: "DELETE"
 parameters:
 properties:

--- a/mmv1/products/firebase/go_WebApp.yaml
+++ b/mmv1/products/firebase/go_WebApp.yaml
@@ -89,7 +89,7 @@ virtual_fields:
       Set to `ABANDON` to allow the WebApp to be untracked from terraform state
       rather than deleted upon `terraform destroy`. This is useful becaue the WebApp may be
       serving traffic. Set to `DELETE` to delete the WebApp. Default to `DELETE`
-    type: Enum
+    type: String
     default_value: "DELETE"
 parameters:
 properties:

--- a/mmv1/products/firebasedatabase/Instance.yaml
+++ b/mmv1/products/firebasedatabase/Instance.yaml
@@ -55,13 +55,11 @@ examples:
     test_env_vars:
       org_id: :ORG_ID
 virtual_fields:
-  - !ruby/object:Api::Type::Enum
+  - !ruby/object:Api::Type::String
     name: desired_state
-    description: The intended database state.
-    values:
-      - :ACTIVE
-      - :DISABLED
-    default_value: :ACTIVE
+    description: |
+      The intended database state. Possible values: ACTIVE, DISABLED.
+    default_value: ACTIVE
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   constants: 'templates/terraform/constants/firebase_database_instance.go.erb'
   decoder: templates/terraform/decoders/firebase_database_instance.go.erb

--- a/mmv1/products/firebasedatabase/go_Instance.yaml
+++ b/mmv1/products/firebasedatabase/go_Instance.yaml
@@ -64,8 +64,9 @@ examples:
       org_id: 'ORG_ID'
 virtual_fields:
   - name: 'desired_state'
-    description: The intended database state.
-    type: Enum
+    description: |
+      The intended database state. Possible values: ACTIVE, DISABLED.
+    type: String
     default_value: "ACTIVE"
 parameters:
   - name: 'region'

--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -135,7 +135,7 @@ examples:
       - etag
       - deletion_policy
 virtual_fields:
-  - !ruby/object:Api::Type::Enum
+  - !ruby/object:Api::Type::String
     name: 'deletion_policy'
     description: |
       Deletion behavior for this database.
@@ -143,10 +143,7 @@ virtual_fields:
       If the deletion policy is `DELETE`, the database will both be removed from Terraform state and deleted from Google Cloud upon destruction.
       The default value is `ABANDON`.
       See also `delete_protection`.
-    values:
-      - :ABANDON
-      - :DELETE
-    default_value: :ABANDON
+    default_value: ABANDON
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   pre_delete: templates/terraform/pre_delete/firestore_database.go.erb
 properties:

--- a/mmv1/products/firestore/go_Database.yaml
+++ b/mmv1/products/firestore/go_Database.yaml
@@ -141,7 +141,7 @@ virtual_fields:
       If the deletion policy is `DELETE`, the database will both be removed from Terraform state and deleted from Google Cloud upon destruction.
       The default value is `ABANDON`.
       See also `delete_protection`.
-    type: Enum
+    type: String
     default_value: "ABANDON"
 parameters:
 properties:

--- a/mmv1/products/netapp/go_Volume.yaml
+++ b/mmv1/products/netapp/go_Volume.yaml
@@ -66,7 +66,8 @@ virtual_fields:
       Policy to determine if the volume should be deleted forcefully.
       Volumes may have nested snapshot resources. Deleting such a volume will fail.
       Setting this parameter to FORCE will delete volumes including nested snapshots.
-    type: Enum
+      Possible values: DEFAULT, FORCE.
+    type: String
     default_value: "DEFAULT"
 parameters:
   - name: 'location'

--- a/mmv1/products/netapp/volume.yaml
+++ b/mmv1/products/netapp/volume.yaml
@@ -51,16 +51,14 @@ examples:
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   pre_delete: templates/terraform/pre_delete/netapp_volume_force_delete.go.erb
 virtual_fields:
-  - !ruby/object:Api::Type::Enum
+  - !ruby/object:Api::Type::String
     name: 'deletion_policy'
     description: |
       Policy to determine if the volume should be deleted forcefully.
       Volumes may have nested snapshot resources. Deleting such a volume will fail.
       Setting this parameter to FORCE will delete volumes including nested snapshots.
-    values:
-      - :DEFAULT
-      - :FORCE
-    default_value: :DEFAULT
+      Possible values: DEFAULT, FORCE.
+    default_value: DEFAULT
 parameters:
   - !ruby/object:Api::Type::String
     name: 'location'

--- a/mmv1/products/notebooks/Instance.yaml
+++ b/mmv1/products/notebooks/Instance.yaml
@@ -99,14 +99,11 @@ examples:
     test_env_vars:
       service_account: :SERVICE_ACCT
 virtual_fields:
-  - !ruby/object:Api::Type::Enum
+  - !ruby/object:Api::Type::String
     name: desired_state
     description: |
       Desired state of the Notebook Instance. Set this field to `ACTIVE` to start the Instance, and `STOPPED` to stop the Instance.
-    values:
-      - :ACTIVE
-      - :STOPPED
-    default_value: :ACTIVE
+    default_value: ACTIVE
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   constants: templates/terraform/constants/notebooks_instance.go.erb
   update_encoder: templates/terraform/update_encoder/notebooks_instance.go.erb

--- a/mmv1/products/notebooks/go_Instance.yaml
+++ b/mmv1/products/notebooks/go_Instance.yaml
@@ -106,7 +106,7 @@ virtual_fields:
   - name: 'desired_state'
     description: |
       Desired state of the Notebook Instance. Set this field to `ACTIVE` to start the Instance, and `STOPPED` to stop the Instance.
-    type: Enum
+    type: String
     default_value: "ACTIVE"
 parameters:
   - name: 'location'

--- a/mmv1/products/privateca/CertificateAuthority.yaml
+++ b/mmv1/products/privateca/CertificateAuthority.yaml
@@ -140,14 +140,11 @@ virtual_fields:
       When the field is set to true or unset in Terraform state, a `terraform apply`
       or `terraform destroy` that would delete the CertificateAuthority will fail.
       When the field is set to false, deleting the CertificateAuthority is allowed.
-  - !ruby/object:Api::Type::Enum
+  - !ruby/object:Api::Type::String
     name: 'desired_state'
     description: |
       Desired state of the CertificateAuthority. Set this field to `STAGED` to create a `STAGED` root CA.
-    values:
-      - :ENABLED
-      - :DISABLED
-      - :STAGED
+      Possible values: ENABLED, DISABLED, STAGED.
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   constants: 'templates/terraform/constants/privateca_certificate_authority.go.erb'
   decoder: templates/terraform/decoders/treat_deleted_state_as_gone.go.erb

--- a/mmv1/products/privateca/go_CertificateAuthority.yaml
+++ b/mmv1/products/privateca/go_CertificateAuthority.yaml
@@ -137,7 +137,8 @@ virtual_fields:
   - name: 'desired_state'
     description: |
       Desired state of the CertificateAuthority. Set this field to `STAGED` to create a `STAGED` root CA.
-    type: Enum
+      Possible values: ENABLED, DISABLED, STAGED.
+    type: String
 parameters:
 properties:
   - name: 'pem_ca_certificate'

--- a/mmv1/products/secretmanager/SecretVersion.yaml
+++ b/mmv1/products/secretmanager/SecretVersion.yaml
@@ -69,7 +69,7 @@ docs: !ruby/object:Provider::Terraform::Docs
   optional_properties: |
     * `is_secret_data_base64` - (Optional) If set to 'true', the secret data is expected to be base64-encoded string and would be sent as is.
 virtual_fields:
-  - !ruby/object:Api::Type::Enum
+  - !ruby/object:Api::Type::String
     name: 'deletion_policy'
     description: |
       The deletion policy for the secret version. Setting `ABANDON` allows the resource
@@ -78,11 +78,7 @@ virtual_fields:
         * DELETE
         * DISABLE
         * ABANDON
-    values:
-      - :DELETE
-      - :DISABLE
-      - :ABANDON
-    default_value: :DELETE
+    default_value: DELETE
 parameters:
   - !ruby/object:Api::Type::ResourceRef
     name: secret

--- a/mmv1/products/workbench/Instance.yaml
+++ b/mmv1/products/workbench/Instance.yaml
@@ -106,14 +106,11 @@ custom_code: !ruby/object:Provider::Terraform::CustomCode
   pre_update: templates/terraform/pre_update/workbench_instance.go.erb
   post_update: templates/terraform/post_update/workbench_instance.go.erb
 virtual_fields:
-  - !ruby/object:Api::Type::Enum
+  - !ruby/object:Api::Type::String
     name: desired_state
     description: |
       Desired state of the Workbench Instance. Set this field to `ACTIVE` to start the Instance, and `STOPPED` to stop the Instance.
-    values:
-      - :ACTIVE
-      - :STOPPED
-    default_value: :ACTIVE
+    default_value: ACTIVE
 parameters:
   - !ruby/object:Api::Type::String
     name: location

--- a/mmv1/products/workbench/go_Instance.yaml
+++ b/mmv1/products/workbench/go_Instance.yaml
@@ -108,7 +108,7 @@ virtual_fields:
   - name: 'desired_state'
     description: |
       Desired state of the Workbench Instance. Set this field to `ACTIVE` to start the Instance, and `STOPPED` to stop the Instance.
-    type: Enum
+    type: String
     default_value: "ACTIVE"
 parameters:
   - name: 'location'

--- a/mmv1/provider/terraform.rb
+++ b/mmv1/provider/terraform.rb
@@ -563,10 +563,9 @@ module Provider
 
     def force_new?(property, resource)
       # Client-side fields don't inherit immutability
-      if property.client_side
-        return property.immutable
-      end
-      return (
+      return property.immutable if property.client_side
+
+      (
         (!property.output || property.is_a?(Api::Type::KeyValueEffectiveLabels)) &&
         (property.immutable ||
           (resource.immutable && property.update_url.nil? && property.immutable.nil? &&
@@ -577,10 +576,10 @@ module Provider
             )
           )
         )
-      ) ||
-        (property.is_a?(Api::Type::KeyValueTerraformLabels) &&
-          !updatable?(resource, resource.all_user_properties) && !resource.root_labels?
-        )
+      ) || (
+        property.is_a?(Api::Type::KeyValueTerraformLabels) &&
+        !updatable?(resource, resource.all_user_properties) && !resource.root_labels?
+      )
     end
 
     # Returns tuples of (fieldName, list of update masks) for

--- a/mmv1/provider/terraform.rb
+++ b/mmv1/provider/terraform.rb
@@ -562,7 +562,11 @@ module Provider
     end
 
     def force_new?(property, resource)
-      (
+      # Client-side fields don't inherit immutability
+      if property.client_side
+        return property.immutable
+      end
+      return (
         (!property.output || property.is_a?(Api::Type::KeyValueEffectiveLabels)) &&
         (property.immutable ||
           (resource.immutable && property.update_url.nil? && property.immutable.nil? &&

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -131,18 +131,8 @@ func Resource<%= object.resource_name -%>() *schema.Resource {
 <%=       lines(build_schema_property(prop, object, pwd)) -%>
 <%  end -%>
 <%- unless object.virtual_fields.empty? -%>
-<%-   object.virtual_fields.each do |field| -%>
-            "<%= field.name -%>": {
-                Type: <%= tf_type(field) -%>,
-                Optional: true,
-<%       if field.immutable -%>
-                ForceNew: true,
-<%       end -%>
-<%       unless field.default_value.nil? -%>
-                Default:  <%= go_literal(field.default_value) -%>,
-<%       end -%>
-                Description: `<%= field.description.strip.gsub("`", "'") -%>`,
-            },
+<%-   object.virtual_fields.each do |prop| -%>
+<%=       lines(build_schema_property(prop, object, pwd)) -%>
 <%     end -%>
 <%   end -%>
 <%= lines(compile(pwd + '/' + object.custom_code.extra_schema_entry)) if object.custom_code.extra_schema_entry -%>

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -138,21 +138,9 @@ func Resource{{ $.ResourceName -}}() *schema.Resource {
 			{{- range $prop := $.OrderProperties $.AllUserProperties }}
 {{template "SchemaFields" $prop -}}
 			{{- end }}
-{{- if $.VirtualFields -}}
-{{-   range $field := $.VirtualFields }}
-            "{{ $field.Name -}}": {
-                Type: {{ $field.TFType $field.Type -}},
-                Optional: true,
-{{-      if $field.Immutable }}
-                ForceNew: true,
-{{-     end}}
-{{-      if not (eq $field.DefaultValue nil) }}
-                Default:  {{ $field.GoLiteral $field.DefaultValue -}},
-{{-     end}}
-                Description: `{{ replace $field.GetDescription "`" "'" -1 -}}`,
-            },
-{{-   end}}
-{{- end}}
+            {{- range $prop := $.VirtualFields }}
+{{template "SchemaFields" $prop -}}
+            {{- end }}
 {{- if $.CustomCode.ExtraSchemaEntry }} 
     {{ $.CustomTemplate $.CustomCode.ExtraSchemaEntry false -}}
 {{- end}}


### PR DESCRIPTION
This allows users to use more complex field types as virtual fields.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/19245. See yaqs/986109097998811136 for additional context.

Note that I had to remove "Enum" status from all virtual fields, because they were not actually being honored previously (and adding new validatefuncs would be a breaking change.)

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
