### PR TITLE
Add http_target field to google_cloud_tasks_queue

### DIFF
--- a/mmv1/products/cloudtasks/Queue.yaml
+++ b/mmv1/products/cloudtasks/Queue.yaml
@@ -45,6 +45,16 @@ examples:
       - 'app_engine_routing_override.0.instance'
     vars:
       name: 'instance-name'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'cloud_tasks_queue_http_target_oidc'
+    primary_resource_id: 'http_target_oidc'
+    vars:
+      name: 'cloud-tasks-queue-http-target-oidc'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'cloud_tasks_queue_http_target_oauth'
+    primary_resource_id: 'http_target_oauth'
+    vars:
+      name: 'cloud-tasks-queue-http-target-oauth'
 parameters:
   - !ruby/object:Api::Type::String
     name: 'location'
@@ -195,3 +205,167 @@ properties:
           Specifies the fraction of operations to write to Stackdriver Logging.
           This field may contain any value between 0.0 and 1.0, inclusive. 0.0 is the
           default and means that no operations are logged.
+  - !ruby/object:Api::Type::NestedObject
+    name: 'httpTarget'
+    description: Modifies HTTP target for HTTP tasks.
+    properties:
+      - !ruby/object:Api::Type::Enum
+        name: 'httpMethod'
+        description: |
+          The HTTP method to use for the request.
+
+          When specified, it overrides HttpRequest for the task.
+          Note that if the value is set to GET the body of the task will be ignored at execution time.
+        values:
+          - HTTP_METHOD_UNSPECIFIED
+          - POST
+          - GET
+          - HEAD
+          - PUT
+          - DELETE
+          - PATCH
+          - OPTIONS
+        default_from_api: true
+      - !ruby/object:Api::Type::NestedObject
+        name: 'uriOverride'
+        description: |
+          URI override.
+
+          When specified, overrides the execution URI for all the tasks in the queue.
+        properties:
+          - !ruby/object:Api::Type::Enum
+            name: 'scheme'
+            description: |
+              Scheme override.
+
+              When specified, the task URI scheme is replaced by the provided value (HTTP or HTTPS).
+            values:
+              - 'HTTP'
+              - 'HTTPS'
+            default_from_api: true
+          - !ruby/object:Api::Type::String
+            name: 'host'
+            description: |
+              Host override.
+
+              When specified, replaces the host part of the task URL.
+              For example, if the task URL is "https://www.google.com", and host value
+              is set to "example.net", the overridden URI will be changed to "https://example.net".
+              Host value cannot be an empty string (INVALID_ARGUMENT).
+          - !ruby/object:Api::Type::String
+            name: 'port'
+            description: |
+              Port override.
+
+              When specified, replaces the port part of the task URI.
+              For instance, for a URI http://www.google.com/foo and port=123, the overridden URI becomes http://www.google.com:123/foo.
+              Note that the port value must be a positive integer.
+              Setting the port to 0 (Zero) clears the URI port.
+          - !ruby/object:Api::Type::NestedObject
+            name: 'pathOverride'
+            description: |
+              URI path.
+
+              When specified, replaces the existing path of the task URL.
+              Setting the path value to an empty string clears the URI path segment.
+            properties:
+              - !ruby/object:Api::Type::String
+                name: 'path'
+                description: The URI path (e.g., /users/1234). Default is an empty string.
+                default_from_api: true
+          - !ruby/object:Api::Type::NestedObject
+            name: 'queryOverride'
+            description: |
+              URI query.
+
+              When specified, replaces the query part of the task URI. Setting the query value to an empty string clears the URI query segment.
+            properties:
+              - !ruby/object:Api::Type::String
+                name: 'queryParams'
+                description: The query parameters (e.g., qparam1=123&qparam2=456). Default is an empty string.
+                default_from_api: true
+          - !ruby/object:Api::Type::Enum
+            name: 'uriOverrideEnforceMode'
+            description: |
+              URI Override Enforce Mode
+
+              When specified, determines the Target UriOverride mode. If not specified, it defaults to ALWAYS.
+            values:
+              - ALWAYS
+              - IF_NOT_EXISTS
+            default_from_api: true
+      - !ruby/object:Api::Type::Array
+        name: 'headerOverrides'
+        description: |
+          HTTP target headers.
+
+          This map contains the header field names and values.
+          Headers will be set when running the CreateTask and/or BufferTask.
+
+          These headers represent a subset of the headers that will be configured for the task's HTTP request.
+          Some HTTP request headers will be ignored or replaced.
+
+          Headers which can have multiple values (according to RFC2616) can be specified using comma-separated values.
+
+          The size of the headers must be less than 80KB. Queue-level headers to override headers of all the tasks in the queue.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::NestedObject
+              name: 'header'
+              description: |
+                Header embodying a key and a value.
+              required: true
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: 'key'
+                  required: true
+                  description: The Key of the header.
+                - !ruby/object:Api::Type::String
+                  name: 'value'
+                  required: true
+                  description: The Value of the header.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'oauthToken'
+        description: |
+          If specified, an OAuth token is generated and attached as the Authorization header in the HTTP request.
+
+          This type of authorization should generally be used only when calling Google APIs hosted on *.googleapis.com.
+          Note that both the service account email and the scope MUST be specified when using the queue-level authorization override.
+        conflicts:
+          - 'oidcToken'
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'serviceAccountEmail'
+            description: |
+              Service account email to be used for generating OAuth token.
+              The service account must be within the same project as the queue.
+              The caller must have iam.serviceAccounts.actAs permission for the service account.
+            required: true
+          - !ruby/object:Api::Type::String
+            name: 'scope'
+            description: |
+              OAuth scope to be used for generating OAuth access token.
+              If not specified, "https://www.googleapis.com/auth/cloud-platform" will be used.
+            default_from_api: true
+      - !ruby/object:Api::Type::NestedObject
+        name: 'oidcToken'
+        description: |
+          If specified, an OIDC token is generated and attached as an Authorization header in the HTTP request.
+
+          This type of authorization can be used for many scenarios, including calling Cloud Run, or endpoints where you intend to validate the token yourself.
+          Note that both the service account email and the audience MUST be specified when using the queue-level authorization override.
+        conflicts:
+          - 'oauthToken'
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'serviceAccountEmail'
+            description: |
+              Service account email to be used for generating OIDC token.
+              The service account must be within the same project as the queue.
+              The caller must have iam.serviceAccounts.actAs permission for the service account.
+            required: true
+          - !ruby/object:Api::Type::String
+            name: 'audience'
+            description: |
+              Audience to be used when generating OIDC token. If not specified, the URI specified in target will be used.
+            default_from_api: true

--- a/mmv1/templates/terraform/examples/cloud_tasks_queue_http_target_oauth.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_tasks_queue_http_target_oauth.tf.erb
@@ -1,0 +1,40 @@
+resource "google_cloud_tasks_queue" "<%= ctx[:primary_resource_id] %>" {
+  name     = "<%= ctx[:vars]["name"] %>"
+  location = "us-central1"
+
+  http_target {
+    http_method = "POST"
+    uri_override {
+      scheme = "HTTPS"
+      host   = "oauth.example.com"
+      port   = 8443
+      path_override {
+        path = "/users/1234"
+      }
+      query_override {
+        query_params = "qparam1=123&qparam2=456"
+      }
+    }
+    header_overrides {
+      header {
+        key   = "AddSomethingElse"
+        value = "MyOtherValue"
+      }
+    }
+    header_overrides {
+      header {
+        key   = "AddMe"
+        value = "MyValue"
+      }
+    }
+    oauth_token {
+      service_account_email = google_service_account.oauth_service_account.email
+      scope                 = "openid https://www.googleapis.com/auth/userinfo.email"
+    }
+  }
+}
+
+resource "google_service_account" "oauth_service_account" {
+  account_id   = "example-oauth"
+  display_name = "Tasks Queue OAuth Service Account"
+}

--- a/mmv1/templates/terraform/examples/cloud_tasks_queue_http_target_oauth.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_tasks_queue_http_target_oauth.tf.erb
@@ -14,6 +14,7 @@ resource "google_cloud_tasks_queue" "<%= ctx[:primary_resource_id] %>" {
       query_override {
         query_params = "qparam1=123&qparam2=456"
       }
+      uri_override_enforce_mode = "IF_NOT_EXISTS"
     }
     header_overrides {
       header {

--- a/mmv1/templates/terraform/examples/cloud_tasks_queue_http_target_oidc.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_tasks_queue_http_target_oidc.tf.erb
@@ -1,0 +1,40 @@
+resource "google_cloud_tasks_queue" "<%= ctx[:primary_resource_id] %>" {
+  name     = "<%= ctx[:vars]["name"] %>"
+  location = "us-central1"
+
+  http_target {
+    http_method = "POST"
+    uri_override {
+      scheme = "HTTPS"
+      host   = "oidc.example.com"
+      port   = 8443
+      path_override {
+        path = "/users/1234"
+      }
+      query_override {
+        query_params = "qparam1=123&qparam2=456"
+      }
+    }
+    header_overrides {
+      header {
+        key   = "AddSomethingElse"
+        value = "MyOtherValue"
+      }
+    }
+    header_overrides {
+      header {
+        key   = "AddMe"
+        value = "MyValue"
+      }
+    }
+    oidc_token {
+      service_account_email = google_service_account.oidc_service_account.email
+      audience              = "https://oidc.example.com"
+    }
+  }
+}
+
+resource "google_service_account" "oidc_service_account" {
+  account_id   = "example-oidc"
+  display_name = "Tasks Queue OIDC Service Account"
+}

--- a/mmv1/templates/terraform/examples/cloud_tasks_queue_http_target_oidc.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_tasks_queue_http_target_oidc.tf.erb
@@ -14,6 +14,7 @@ resource "google_cloud_tasks_queue" "<%= ctx[:primary_resource_id] %>" {
       query_override {
         query_params = "qparam1=123&qparam2=456"
       }
+      uri_override_enforce_mode = "IF_NOT_EXISTS"
     }
     header_overrides {
       header {

--- a/mmv1/third_party/terraform/services/cloudtasks/resource_cloud_tasks_queue_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudtasks/resource_cloud_tasks_queue_test.go.erb
@@ -114,6 +114,66 @@ func TestAccCloudTasksQueue_TimeUnitDiff(t *testing.T) {
 	})
 }
 
+func TestAccCloudTasksQueue_HttpTargetOIDC_update(t *testing.T) {
+	t.Parallel()
+
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	serviceAccountID := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudTasksQueue_HttpTargetOIDC(name, serviceAccountID),
+			},
+			{
+				ResourceName:            "google_cloud_tasks_queue.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
+			{
+				Config: testAccCloudTasksQueue_basic(name),
+			},
+			{
+				ResourceName:            "google_cloud_tasks_queue.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
+		},
+	})
+}
+
+func TestAccCloudTasksQueue_HttpTargetOAuth_update(t *testing.T) {
+	t.Parallel()
+
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	serviceAccountID := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudTasksQueue_HttpTargetOAuth(name, serviceAccountID),
+			},
+			{
+				ResourceName:            "google_cloud_tasks_queue.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
+			{
+				Config: testAccCloudTasksQueue_basic(name),
+			},
+			{
+				ResourceName:            "google_cloud_tasks_queue.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
+		},
+	})
+}
+
 func testAccCloudTasksQueue_basic(name string) string {
 	return fmt.Sprintf(`
 resource "google_cloud_tasks_queue" "default" {
@@ -224,4 +284,97 @@ resource "google_cloud_tasks_queue" "default" {
   }
 }
 `, cloudTaskName)
+}
+
+func testAccCloudTasksQueue_HttpTargetOIDC(name, serviceAccountID string) string {
+	return fmt.Sprintf(`
+resource "google_cloud_tasks_queue" "default" {
+  name     = "%s"
+  location = "us-central1"
+
+  http_target {
+    http_method = "POST"
+    uri_override {
+      scheme = "HTTPS"
+      host   = "oidc.example.com"
+      port   = 8443
+      path_override {
+        path = "/users/1234"
+      }
+      query_override {
+        query_params = "qparam1=123&qparam2=456"
+      }
+    }
+    header_overrides {
+      header {
+        key   = "AddSomethingElse"
+        value = "MyOtherValue"
+      }
+    }
+    header_overrides {
+      header {
+        key   = "AddMe"
+        value = "MyValue"
+      }
+    }
+    oidc_token {
+      service_account_email = google_service_account.test.email
+      audience              = "https://oidc.example.com"
+    }
+  }
+}
+
+resource "google_service_account" "test" {
+  account_id   = "%s"
+  display_name = "Tasks Queue OIDC Service Account"
+}
+
+`, name, serviceAccountID)
+}
+
+
+func testAccCloudTasksQueue_HttpTargetOAuth(name, serviceAccountID string) string {
+	return fmt.Sprintf(`
+resource "google_cloud_tasks_queue" "default" {
+  name     = "%s"
+  location = "us-central1"
+
+  http_target {
+    http_method = "POST"
+    uri_override {
+      scheme = "HTTPS"
+      host   = "oidc.example.com"
+      port   = 8443
+      path_override {
+        path = "/users/1234"
+      }
+      query_override {
+        query_params = "qparam1=123&qparam2=456"
+      }
+    }
+    header_overrides {
+      header {
+        key   = "AddSomethingElse"
+        value = "MyOtherValue"
+      }
+    }
+    header_overrides {
+      header {
+        key   = "AddMe"
+        value = "MyValue"
+      }
+    }
+    oauth_token {
+      service_account_email = google_service_account.test.email
+      scope                 = "openid https://www.googleapis.com/auth/userinfo.email"
+    }
+  }
+}
+
+resource "google_service_account" "test" {
+  account_id   = "%s"
+  display_name = "Tasks Queue OAuth Service Account"
+}
+
+`, name, serviceAccountID)
 }

--- a/mmv1/third_party/terraform/services/cloudtasks/resource_cloud_tasks_queue_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudtasks/resource_cloud_tasks_queue_test.go.erb
@@ -304,6 +304,7 @@ resource "google_cloud_tasks_queue" "default" {
       query_override {
         query_params = "qparam1=123&qparam2=456"
       }
+      uri_override_enforce_mode = "IF_NOT_EXISTS"
     }
     header_overrides {
       header {
@@ -351,6 +352,7 @@ resource "google_cloud_tasks_queue" "default" {
       query_override {
         query_params = "qparam1=123&qparam2=456"
       }
+      uri_override_enforce_mode = "IF_NOT_EXISTS"
     }
     header_overrides {
       header {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR adds support for queue-level routing in Cloud Tasks.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/15022.

[The doc of REST Resource: projects.locations.queues](https://cloud.google.com/tasks/docs/reference/rest/v2/projects.locations.queues) describes httpTarget property in Queue resource.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudtasks: added `http_target` field to `google_cloud_tasks_queue` resource
```
