### PR TITLE
container: bump `additive_vpc_scope_dns_domain` to GA

### DIFF
--- a/mmv1/third_party/terraform/services/container/go/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/go/resource_container_cluster.go.tmpl
@@ -2126,13 +2126,11 @@ func ResourceContainerCluster() *schema.Resource {
 				Description: `Configuration for Cloud DNS for Kubernetes Engine.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						{{- if ne $.TargetVersionName "ga" }}
 						"additive_vpc_scope_dns_domain": {
 							Type:         schema.TypeString,
 							Description:  `Enable additive VPC scope DNS in a GKE cluster.`,
 							Optional:     true,
 						},
-						{{- end }}
 						"cluster_dns": {
 							Type:         schema.TypeString,
 							Default:      "PROVIDER_UNSPECIFIED",
@@ -5488,9 +5486,7 @@ func expandDnsConfig(configured interface{}) *container.DNSConfig {
 
 	config := l[0].(map[string]interface{})
 	return &container.DNSConfig{
-{{- if ne $.TargetVersionName "ga" }}
 		AdditiveVpcScopeDnsDomain: 	config["additive_vpc_scope_dns_domain"].(string),
-{{- end }}
 		ClusterDns:       			config["cluster_dns"].(string),
 		ClusterDnsScope:  			config["cluster_dns_scope"].(string),
 		ClusterDnsDomain: 			config["cluster_dns_domain"].(string),
@@ -6401,9 +6397,7 @@ func flattenDnsConfig(c *container.DNSConfig) []map[string]interface{} {
 	}
 	return []map[string]interface{}{
 		{
-{{- if ne $.TargetVersionName "ga" }}
 			"additive_vpc_scope_dns_domain": 	c.AdditiveVpcScopeDnsDomain,
-{{- end }}
 			"cluster_dns":        				c.ClusterDns,
 			"cluster_dns_scope":  				c.ClusterDnsScope,
 			"cluster_dns_domain": 				c.ClusterDnsDomain,

--- a/mmv1/third_party/terraform/services/container/go/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/go/resource_container_cluster_test.go.tmpl
@@ -488,7 +488,6 @@ func TestAccContainerCluster_withFQDNNetworkPolicy(t *testing.T) {
 }
 {{- end }}
 
-{{ if ne $.TargetVersionName `ga` -}}
 func TestAccContainerCluster_withAdditiveVPC(t *testing.T) {
 	t.Parallel()
 
@@ -511,7 +510,6 @@ func TestAccContainerCluster_withAdditiveVPC(t *testing.T) {
 		},
 	})
 }
-{{- end }}
 
 func TestAccContainerCluster_withMasterAuthConfig_NoCert(t *testing.T) {
 	t.Parallel()
@@ -699,7 +697,6 @@ resource "google_container_cluster" "cluster" {
 `, clusterName, clusterName)
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func testAccContainerCluster_withAdditiveVPC(clusterName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
@@ -716,7 +713,6 @@ resource "google_container_cluster" "cluster" {
 }
 `, clusterName)
 }
-{{- end }}
 
 {{ if ne $.TargetVersionName `ga` -}}
 func testAccContainerCluster_withFQDNNetworkPolicy(clusterName string, enabled bool) string {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -2133,13 +2133,11 @@ func ResourceContainerCluster() *schema.Resource {
 				Description: `Configuration for Cloud DNS for Kubernetes Engine.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						<% unless version == 'ga' -%>
 						"additive_vpc_scope_dns_domain": {
 							Type:         schema.TypeString,
 							Description:  `Enable additive VPC scope DNS in a GKE cluster.`,
 							Optional:     true,
 						},
-						<% end -%>
 						"cluster_dns": {
 							Type:         schema.TypeString,
 							Default:      "PROVIDER_UNSPECIFIED",
@@ -5496,9 +5494,7 @@ func expandDnsConfig(configured interface{}) *container.DNSConfig {
 
 	config := l[0].(map[string]interface{})
 	return &container.DNSConfig{
-<% unless version == 'ga' -%>
 		AdditiveVpcScopeDnsDomain: 	config["additive_vpc_scope_dns_domain"].(string),
-<% end -%>
 		ClusterDns:       			config["cluster_dns"].(string),
 		ClusterDnsScope:  			config["cluster_dns_scope"].(string),
 		ClusterDnsDomain: 			config["cluster_dns_domain"].(string),
@@ -6399,9 +6395,7 @@ func flattenDnsConfig(c *container.DNSConfig) []map[string]interface{} {
 	}
 	return []map[string]interface{}{
 		{
-<% unless version == 'ga' -%>
 			"additive_vpc_scope_dns_domain": 	c.AdditiveVpcScopeDnsDomain,
-<% end -%>
 			"cluster_dns":        				c.ClusterDns,
 			"cluster_dns_scope":  				c.ClusterDnsScope,
 			"cluster_dns_domain": 				c.ClusterDnsDomain,

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -489,7 +489,6 @@ func TestAccContainerCluster_withFQDNNetworkPolicy(t *testing.T) {
 }
 <% end -%>
 
-<% unless version == 'ga' -%>
 func TestAccContainerCluster_withAdditiveVPC(t *testing.T) {
 	t.Parallel()
 
@@ -512,7 +511,6 @@ func TestAccContainerCluster_withAdditiveVPC(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func TestAccContainerCluster_withMasterAuthConfig_NoCert(t *testing.T) {
 	t.Parallel()
@@ -700,7 +698,6 @@ resource "google_container_cluster" "cluster" {
 `, clusterName, clusterName)
 }
 
-<% unless version == 'ga' -%>
 func testAccContainerCluster_withAdditiveVPC(clusterName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
@@ -717,7 +714,6 @@ resource "google_container_cluster" "cluster" {
 }
 `, clusterName)
 }
-<% end -%>
 
 <% unless version == 'ga' -%>
 func testAccContainerCluster_withFQDNNetworkPolicy(clusterName string, enabled bool) string {

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1346,7 +1346,7 @@ linux_node_config {
 
 <a name="nested_dns_config"></a>The `dns_config` block supports:
 
-* `additive_vpc_scope_dns_domain` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) This will enable Cloud DNS additive VPC scope. Must provide a domain name that is unique within the VPC. For this to work `cluster_dns = "CLOUD_DNS"` and `cluster_dns_scope = "CLUSTER_SCOPE"` must both be set as well.
+* `additive_vpc_scope_dns_domain` - (Optional) This will enable Cloud DNS additive VPC scope. Must provide a domain name that is unique within the VPC. For this to work `cluster_dns = "CLOUD_DNS"` and `cluster_dns_scope = "CLUSTER_SCOPE"` must both be set as well.
 
 * `cluster_dns` - (Optional) Which in-cluster DNS provider should be used. `PROVIDER_UNSPECIFIED` (default) or `PLATFORM_DEFAULT` or `CLOUD_DNS`.
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: promoted the `additive_vpc_scope_dns_domain` field on the `google_container_cluster` resource to GA
```