### PR TITLE
Update docs for `google_compute_firewall` resource - Remove quotes for numbers in the list

### DIFF
--- a/mmv1/products/compute/Firewall.yaml
+++ b/mmv1/products/compute/Firewall.yaml
@@ -120,7 +120,7 @@ properties:
             either an integer or a range. If not specified, this rule
             applies to connections through any port.
 
-            Example inputs include: ["22"], ["80","443"], and
+            Example inputs include: [22], [80, 443], and
             ["12345-12349"].
   - !ruby/object:Api::Type::Time
     name: 'creationTimestamp'
@@ -160,7 +160,7 @@ properties:
             either an integer or a range. If not specified, this rule
             applies to connections through any port.
 
-            Example inputs include: ["22"], ["80","443"], and
+            Example inputs include: [22], [80, 443], and
             ["12345-12349"].
   - !ruby/object:Api::Type::String
     name: 'description'


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This is a follow up of the closed PR (https://github.com/hashicorp/terraform-provider-google/pull/19251) and it adds cosmetic change to reflect more appropriately Terraform type [list](https://developer.hashicorp.com/terraform/language/expressions/types#lists-tuples) for [`google_compute_firewall`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) resource
```diff
+ [22], [80, 443]
- ["22"], ["80","443"]
```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
