### PR TITLE
Remove require_ssl

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.erb
@@ -442,13 +442,6 @@ is set to true. Defaults to ZONAL.`,
 										AtLeastOneOf: ipConfigurationKeys,
 										Description:  `Whether this Cloud SQL instance should be assigned a public IPV4 address. At least ipv4_enabled must be enabled or a private_network must be configured.`,
 									},
-									"require_ssl": {
-										Type:         schema.TypeBool,
-										Optional:     true,
-										AtLeastOneOf: ipConfigurationKeys,
-										Description:  `Whether SSL connections over IP are enforced or not. To change this field, also set the corresponding value in ssl_mode if it has been set too.`,
-										Deprecated:   "`require_ssl` will be fully deprecated in a future major release. For now, please use `ssl_mode` with a compatible `require_ssl` value instead.",
-									},
 									"private_network": {
 										Type:             schema.TypeString,
 										Optional:         true,
@@ -497,7 +490,7 @@ is set to true. Defaults to ZONAL.`,
 										Optional:     true,
 										Computed:     true,
 										ValidateFunc: validation.StringInSlice([]string{"ALLOW_UNENCRYPTED_AND_ENCRYPTED", "ENCRYPTED_ONLY", "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"}, false),
-										Description:  `Specify how SSL connection should be enforced in DB connections. This field provides more SSL enforcement options compared to require_ssl. To change this field, also set the correspoding value in require_ssl until next major release.`,
+										Description:  `Specify how SSL connection should be enforced in DB connections.`,
 										AtLeastOneOf: ipConfigurationKeys,
 									},
                                                                         "server_ca_mode": {
@@ -2268,11 +2261,6 @@ func flattenIpConfiguration(ipConfiguration *sqladmin.IpConfiguration, d *schema
 
 	if ipConfiguration.PscConfig != nil {
 		data["psc_config"] = flattenPscConfigs(ipConfiguration.PscConfig)
-	}
-
-	// We store the ssl_mode value only if the customer already uses `ssl_mode`.
-	if _, ok := d.GetOk("settings.0.ip_configuration.0.ssl_mode"); ok {
-		data["ssl_mode"] = ipConfiguration.SslMode
 	}
 
 	return []map[string]interface{}{data}

--- a/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
@@ -369,9 +369,9 @@ Support for the deletionProtectionEnabled field has been added. Redis clusters w
 
 ## Resource: `google_sql_database_instance`
 
-### `settings.ip_configuration.require_ssl` is now removed
+### `settings.ip_configuration.require_ssl` is now removed (in 6.0.1)
 
-Removed in favor of field `settings.ip_configuration.ssl_mode`.
+Removed in favor of field `settings.ip_configuration.ssl_mode`. `settings.ip_configuration.require_ssl` was intended to be removed in 6.0.0, but is removed in 6.0.1 instead.
 
 ## Resource: `google_storage_bucket`
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

b/362297432

Reapplies the changes in https://github.com/GoogleCloudPlatform/magic-modules/pull/11154 that were accidentally reverted in the merge commit from 6.0.0 into main

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
sql: removed `settings.ip_configuration.require_ssl` from `google_sql_database_instance` in favor of `settings.ip_configuration.ssl_mode`. This field was intended to be removed in 6.0.0.
```
