### PR TITLE
feat: Remove force replacement from gcfs_config

### DIFF
--- a/mmv1/third_party/terraform/services/container/go/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/go/node_config.go.tmpl
@@ -87,13 +87,12 @@ func schemaLoggingVariant() *schema.Schema {
 	}
 }
 
-func schemaGcfsConfig(forceNew bool) *schema.Schema {
+func schemaGcfsConfig() *schema.Schema {
         return &schema.Schema{
                 Type:     schema.TypeList,
 		Optional: true,
 		MaxItems: 1,
 		Description: `GCFS configuration for this node.`,
-		ForceNew: forceNew,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"enabled": {
@@ -332,7 +331,7 @@ func schemaNodeConfig() *schema.Schema {
 					},
 				},
 
-				"gcfs_config": schemaGcfsConfig(true),
+				"gcfs_config": schemaGcfsConfig(),
 
 				"gvnic": {
 					Type:     schema.TypeList,

--- a/mmv1/third_party/terraform/services/container/go/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/go/resource_container_cluster.go.tmpl
@@ -159,7 +159,7 @@ func clusterSchemaNodePoolDefaults() *schema.Schema {
 						Schema: map[string]*schema.Schema{
 							"containerd_config": schemaContainerdConfig(),
 {{- if ne $.TargetVersionName "ga" }}
-							"gcfs_config": schemaGcfsConfig(false),
+							"gcfs_config": schemaGcfsConfig(),
 {{- end }}
 							"logging_variant": schemaLoggingVariant(),
 						},

--- a/mmv1/third_party/terraform/services/container/go/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/go/resource_container_node_pool_test.go.tmpl
@@ -1736,7 +1736,11 @@ func TestAccContainerNodePool_gcfsConfig(t *testing.T) {
 		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerNodePool_gcfsConfig(cluster, np, networkName, subnetworkName),
+				Config: testAccContainerNodePool_gcfsConfig(cluster, np, networkName, subnetworkName, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_node_pool.np",
+						"node_config.0.gcfs_config.0.enabled", "true"),
+				),
 			},
 			{
 				ResourceName:            "google_container_node_pool.np",
@@ -1747,7 +1751,7 @@ func TestAccContainerNodePool_gcfsConfig(t *testing.T) {
 	})
 }
 
-func testAccContainerNodePool_gcfsConfig(cluster, np, networkName, subnetworkName string) string {
+func testAccContainerNodePool_gcfsConfig(cluster, np, networkName, subnetworkName string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
   name               = "%s"
@@ -1768,11 +1772,11 @@ resource "google_container_node_pool" "np" {
     machine_type = "n1-standard-8"
     image_type = "COS_CONTAINERD"
     gcfs_config {
-      enabled = true
+      enabled = %t
     }
   }
 }
-`, cluster, networkName, subnetworkName, np)
+`, cluster, networkName, subnetworkName, np, enabled)
 }
 
 func TestAccContainerNodePool_gvnic(t *testing.T) {
@@ -4803,30 +4807,30 @@ func TestAccContainerNodePool_privateRegistry(t *testing.T) {
 
 func testAccContainerNodePool_privateRegistryEnabled(secretID, cluster, nodepool, network, subnetwork string) string {
 	return fmt.Sprintf(`
-data "google_project" "test_project" { 
+data "google_project" "test_project" {
 	}
 
-resource "google_secret_manager_secret" "secret-basic" { 
-	secret_id     = "%s" 
-	replication { 
-		user_managed { 
-		replicas { 
-			location = "us-central1" 
-		} 
-		} 
-	} 
+resource "google_secret_manager_secret" "secret-basic" {
+	secret_id     = "%s"
+	replication {
+		user_managed {
+		replicas {
+			location = "us-central1"
+		}
+		}
+	}
 }
 
-resource "google_secret_manager_secret_version" "secret-version-basic" { 
-	secret = google_secret_manager_secret.secret-basic.id 
-	secret_data = "dummypassword" 
-  } 
-   
-resource "google_secret_manager_secret_iam_member" "secret_iam" { 
-	secret_id  = google_secret_manager_secret.secret-basic.id 
-	role       = "roles/secretmanager.admin" 
-	member     = "serviceAccount:${data.google_project.test_project.number}-compute@developer.gserviceaccount.com" 
-	depends_on = [google_secret_manager_secret_version.secret-version-basic] 
+resource "google_secret_manager_secret_version" "secret-version-basic" {
+	secret = google_secret_manager_secret.secret-basic.id
+	secret_data = "dummypassword"
+  }
+
+resource "google_secret_manager_secret_iam_member" "secret_iam" {
+	secret_id  = google_secret_manager_secret.secret-basic.id
+	role       = "roles/secretmanager.admin"
+	member     = "serviceAccount:${data.google_project.test_project.number}-compute@developer.gserviceaccount.com"
+	depends_on = [google_secret_manager_secret_version.secret-version-basic]
   }
 
 resource "google_container_cluster" "cluster" {
@@ -4837,13 +4841,13 @@ resource "google_container_cluster" "cluster" {
   network    = "%s"
   subnetwork    = "%s"
 }
-	
+
 resource "google_container_node_pool" "np" {
   name               = "%s"
   location           = "us-central1-a"
   cluster            = google_container_cluster.cluster.name
   initial_node_count = 1
-	
+
   node_config {
 	oauth_scopes = [
       "https://www.googleapis.com/auth/cloud-platform",

--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -100,19 +100,17 @@ func schemaLoggingVariant() *schema.Schema {
 	}
 }
 
-func schemaGcfsConfig(forceNew bool) *schema.Schema {
+func schemaGcfsConfig() *schema.Schema {
         return &schema.Schema{
                 Type:     schema.TypeList,
 		Optional: true,
 		MaxItems: 1,
 		Description: `GCFS configuration for this node.`,
-		ForceNew: forceNew,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"enabled": {
 					Type:        schema.TypeBool,
 					Required:    true,
-					ForceNew:    forceNew,
 					Description: `Whether or not GCFS is enabled`,
 				},
 			},
@@ -340,7 +338,7 @@ func schemaNodeConfig() *schema.Schema {
 					},
 				},
 
-				"gcfs_config": schemaGcfsConfig(true),
+				"gcfs_config": schemaGcfsConfig(),
 
 				"gvnic": {
 					Type:     schema.TypeList,

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -160,7 +160,7 @@ func clusterSchemaNodePoolDefaults() *schema.Schema {
 						Schema: map[string]*schema.Schema{
 							"containerd_config": schemaContainerdConfig(),
 <% unless version == 'ga' -%>
-							"gcfs_config": schemaGcfsConfig(false),
+							"gcfs_config": schemaGcfsConfig(),
 <% end -%>
 							"insecure_kubelet_readonly_port_enabled": schemaInsecureKubeletReadonlyPortEnabled(),
 							"logging_variant": schemaLoggingVariant(),

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -1719,7 +1719,11 @@ func TestAccContainerNodePool_gcfsConfig(t *testing.T) {
 		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerNodePool_gcfsConfig(cluster, np, networkName, subnetworkName),
+				Config: testAccContainerNodePool_gcfsConfig(cluster, np, networkName, subnetworkName, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_node_pool.np",
+						"node_config.0.gcfs_config.0.enabled", "true"),
+				),
 			},
 			{
 				ResourceName:            "google_container_node_pool.np",
@@ -1730,7 +1734,7 @@ func TestAccContainerNodePool_gcfsConfig(t *testing.T) {
 	})
 }
 
-func testAccContainerNodePool_gcfsConfig(cluster, np, networkName, subnetworkName string) string {
+func testAccContainerNodePool_gcfsConfig(cluster, np, networkName, subnetworkName string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
   name               = "%s"
@@ -1751,11 +1755,11 @@ resource "google_container_node_pool" "np" {
     machine_type = "n1-standard-8"
     image_type = "COS_CONTAINERD"
     gcfs_config {
-      enabled = true
+      enabled = %t
     }
   }
 }
-`, cluster, networkName, subnetworkName, np)
+`, cluster, networkName, subnetworkName, np, enabled)
 }
 
 func TestAccContainerNodePool_gvnic(t *testing.T) {
@@ -4735,30 +4739,30 @@ func TestAccContainerNodePool_privateRegistry(t *testing.T) {
 
 func testAccContainerNodePool_privateRegistryEnabled(secretID, cluster, nodepool, network, subnetwork string) string {
 	return fmt.Sprintf(`
-data "google_project" "test_project" { 
+data "google_project" "test_project" {
 	}
 
-resource "google_secret_manager_secret" "secret-basic" { 
-	secret_id     = "%s" 
-	replication { 
-		user_managed { 
-		replicas { 
-			location = "us-central1" 
-		} 
-		} 
-	} 
+resource "google_secret_manager_secret" "secret-basic" {
+	secret_id     = "%s"
+	replication {
+		user_managed {
+		replicas {
+			location = "us-central1"
+		}
+		}
+	}
 }
 
-resource "google_secret_manager_secret_version" "secret-version-basic" { 
-	secret = google_secret_manager_secret.secret-basic.id 
-	secret_data = "dummypassword" 
-  } 
-   
-resource "google_secret_manager_secret_iam_member" "secret_iam" { 
-	secret_id  = google_secret_manager_secret.secret-basic.id 
-	role       = "roles/secretmanager.admin" 
-	member     = "serviceAccount:${data.google_project.test_project.number}-compute@developer.gserviceaccount.com" 
-	depends_on = [google_secret_manager_secret_version.secret-version-basic] 
+resource "google_secret_manager_secret_version" "secret-version-basic" {
+	secret = google_secret_manager_secret.secret-basic.id
+	secret_data = "dummypassword"
+  }
+
+resource "google_secret_manager_secret_iam_member" "secret_iam" {
+	secret_id  = google_secret_manager_secret.secret-basic.id
+	role       = "roles/secretmanager.admin"
+	member     = "serviceAccount:${data.google_project.test_project.number}-compute@developer.gserviceaccount.com"
+	depends_on = [google_secret_manager_secret_version.secret-version-basic]
   }
 
 resource "google_container_cluster" "cluster" {
@@ -4769,13 +4773,13 @@ resource "google_container_cluster" "cluster" {
   network    = "%s"
   subnetwork    = "%s"
 }
-	
+
 resource "google_container_node_pool" "np" {
   name               = "%s"
   location           = "us-central1-a"
   cluster            = google_container_cluster.cluster.name
   initial_node_count = 1
-	
+
   node_config {
 	oauth_scopes = [
       "https://www.googleapis.com/auth/cloud-platform",


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->
Gcfsconfig changes do not require to re-create node pools hence there is no point to ForceNew on each gcfsconfig change, gcfs can be enabled and disabled via GUI or gcloud CLI without recreating node pools, examples:
https://cloud.google.com/kubernetes-engine/docs/how-to/image-streaming#disable

https://cloud.google.com/kubernetes-engine/docs/how-to/image-streaming#enable_on_node_pools

Also, same issue noted here https://github.com/hashicorp/terraform-provider-google/issues/18417

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: removed unnecessary force replacement in `gcfs_config`
```
