### PR TITLE
`pubsub`: allow empty filter definition

### DIFF
--- a/mmv1/products/pubsub/Subscription.yaml
+++ b/mmv1/products/pubsub/Subscription.yaml
@@ -388,7 +388,7 @@ properties:
     name: 'filter'
     required: false
     validation: !ruby/object:Provider::Terraform::Validation
-      regex: '^.{1,256}$'
+      regex: '^.{0,256}$'
     description: |
       The subscription only delivers the messages that match the filter.
       Pub/Sub automatically acknowledges the messages that don't match the filter. You can filter messages

--- a/mmv1/third_party/terraform/services/pubsub/resource_pubsub_subscription_test.go
+++ b/mmv1/third_party/terraform/services/pubsub/resource_pubsub_subscription_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
 package pubsub_test
 
 import (
@@ -398,6 +400,47 @@ func TestUnitPubsubSubscription_IgnoreMissingKeyInMap(t *testing.T) {
 	}
 }
 
+func TestAccPubsubSubscription_filter(t *testing.T) {
+	t.Parallel()
+
+	topic := fmt.Sprintf("tf-test-topic-%s", acctest.RandString(t, 10))
+	subscriptionShort := fmt.Sprintf("tf-test-sub-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckPubsubSubscriptionDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPubsubSubscription_filter(topic, subscriptionShort, "attributes.foo = \\\"bar\\\""),
+				Check: resource.ComposeTestCheckFunc(
+					// Test schema
+					resource.TestCheckResourceAttr("google_pubsub_subscription.foo", "filter", "attributes.foo = \"bar\""),
+				),
+			},
+			{
+				ResourceName:      "google_pubsub_subscription.foo",
+				ImportStateId:     subscriptionShort,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccPubsubSubscription_filter(topic, subscriptionShort, ""),
+				Check: resource.ComposeTestCheckFunc(
+					// Test schema
+					resource.TestCheckResourceAttr("google_pubsub_subscription.foo", "filter", ""),
+				),
+			},
+			{
+				ResourceName:      "google_pubsub_subscription.foo",
+				ImportStateId:     subscriptionShort,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccPubsubSubscription_emptyTTL(topic, subscription string) string {
 	return fmt.Sprintf(`
 resource "google_pubsub_topic" "foo" {
@@ -795,4 +838,18 @@ func testAccCheckPubsubSubscriptionCache404(t *testing.T, subName string) resour
 		}
 		return nil
 	}
+}
+
+func testAccPubsubSubscription_filter(topic, subscription, filter string) string {
+	return fmt.Sprintf(`
+resource "google_pubsub_topic" "foo" {
+  name = "%s"
+}
+
+resource "google_pubsub_subscription" "foo" {
+  name   = "%s"
+  topic  = google_pubsub_topic.foo.id
+  filter = "%s"
+}
+`, topic, subscription, filter)
 }

--- a/mmv1/third_party/terraform/services/pubsub/resource_pubsub_subscription_test.go
+++ b/mmv1/third_party/terraform/services/pubsub/resource_pubsub_subscription_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
 package pubsub_test
 
 import (


### PR DESCRIPTION
This PR allows to define an empty filter definition, as we do for our API. The implementation is due to PR #11421, which prohibits this.

Tests added and passed.


Fixes [#19269](https://github.com/hashicorp/terraform-provider-google/issues/19269)

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
pubsub: fixed a validation bug that didn't allow empty filter definitions for `google_pubsub_subscription` resources
```
