### PR TITLE
Update docs and tests for google_compute_firewall resource - Remove quotes for numbers in the list

### DIFF
--- a/mmv1/templates/terraform/examples/firewall_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/firewall_basic.tf.erb
@@ -8,7 +8,7 @@ resource "google_compute_firewall" "default" {
 
   allow {
     protocol = "tcp"
-    ports    = ["80", "8080", "1000-2000"]
+    ports    = [80, 8080, "1000-2000"]
   }
 
   source_tags = ["web"]

--- a/mmv1/templates/terraform/examples/firewall_with_target_tags.tf.erb
+++ b/mmv1/templates/terraform/examples/firewall_with_target_tags.tf.erb
@@ -6,7 +6,7 @@ resource "google_compute_firewall" "<%= ctx[:primary_resource_id] %>" {
 
   allow {
     protocol  = "tcp"
-    ports     = ["80", "8080", "1000-2000"]
+    ports     = [80, 8080, "1000-2000"]
   }
 
   source_tags = ["foo"]

--- a/mmv1/templates/terraform/examples/go/firewall_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/firewall_basic.tf.tmpl
@@ -8,7 +8,7 @@ resource "google_compute_firewall" "default" {
 
   allow {
     protocol = "tcp"
-    ports    = ["80", "8080", "1000-2000"]
+    ports    = [80, 8080, "1000-2000"]
   }
 
   source_tags = ["web"]

--- a/mmv1/templates/terraform/examples/go/firewall_with_target_tags.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/firewall_with_target_tags.tf.tmpl
@@ -6,7 +6,7 @@ resource "google_compute_firewall" "{{$.PrimaryResourceId}}" {
 
   allow {
     protocol  = "tcp"
-    ports     = ["80", "8080", "1000-2000"]
+    ports     = [80, 8080, "1000-2000"]
   }
 
   source_tags = ["foo"]

--- a/mmv1/third_party/tgc/tests/data/example_compute_firewall.tf
+++ b/mmv1/third_party/tgc/tests/data/example_compute_firewall.tf
@@ -37,7 +37,7 @@ resource "google_compute_firewall" "default" {
 
   allow {
     protocol = "tcp"
-    ports    = ["80", "8080", "1000-2000"]
+    ports    = [80, 8080, "1000-2000"]
   }
 
   source_tags = ["web"]

--- a/mmv1/third_party/tgc/tests/data/firewall.tf
+++ b/mmv1/third_party/tgc/tests/data/firewall.tf
@@ -37,7 +37,7 @@ resource "google_compute_firewall" "my-test-firewall" {
 
   allow {
     protocol = "tcp"
-    ports    = ["80", "8080", "1000-2000"]
+    ports    = [80, 8080, "1000-2000"]
   }
 
   source_tags = ["web"]

--- a/mmv1/third_party/tgc/tests/data/full_compute_firewall.tf
+++ b/mmv1/third_party/tgc/tests/data/full_compute_firewall.tf
@@ -36,7 +36,7 @@ resource "google_compute_firewall" "full_list_default_1" {
   }
   allow {
     protocol = "tcp"
-    ports    = ["80", "8080", "1000-2000"]
+    ports    = [80, 8080, "1000-2000"]
   }
   description        = "test-description"
   destination_ranges = ["192.168.0.42/32", "192.168.0.43/32"]
@@ -58,7 +58,7 @@ resource "google_compute_firewall" "full_list_default_2" {
   }
   deny {
     protocol = "tcp"
-    ports    = ["80", "8080", "1000-2000"]
+    ports    = [80, 8080, "1000-2000"]
   }
   source_ranges           = ["192.168.0.44/32", "192.168.0.45/32"]
   source_service_accounts = ["test-source_service_account1", "test-source_service_account2"]


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This is a follow up of the #11548 and adds similar changes to the lists in the tests and templates, to reflect more appropriately Terraform type [list](https://developer.hashicorp.com/terraform/language/expressions/types#lists-tuples) for [`google_compute_firewall`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) resource
```diff
+ [80, 8080, "1000-2000"]
- ["80", "8080", "1000-2000"]
```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
