### PR TITLE
Update resource_container_cluster.go.erb

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -113,7 +113,7 @@ var (
 
 	suppressDiffForAutopilot = schema.SchemaDiffSuppressFunc(func(k, oldValue, newValue string, d *schema.ResourceData) bool {
 		if v, _ := d.Get("enable_autopilot").(bool); v {
-			/ If there is an ID we can safely assume the cluster already exists and return true.
+			// If there is an ID we can safely assume the cluster already exists and return true.
 			// If there is no ID we don't need to supress any diffs and return false.
 			return d.Id() != ""
 		}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -113,7 +113,9 @@ var (
 
 	suppressDiffForAutopilot = schema.SchemaDiffSuppressFunc(func(k, oldValue, newValue string, d *schema.ResourceData) bool {
 		if v, _ := d.Get("enable_autopilot").(bool); v {
-			return true
+			/ If there is an ID we can safely assume the cluster already exists and return true.
+			// If there is no ID we don't need to supress any diffs and return false.
+			return d.Id() != ""
 		}
 		return false
 	})


### PR DESCRIPTION
Fix autopilot diff suppression func.
We only need a diff if a cluster already exists.

This will fix https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/2042 and other similar issues 


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
Fix autopilot diff suppression func.
We only need a diff if a cluster already exists.

This will fix https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/2042 and other similar issues 
```
