### PR TITLE
Fix google_compute_interconnect to support the correct feature values

### DIFF
--- a/mmv1/products/compute/Interconnect.yaml
+++ b/mmv1/products/compute/Interconnect.yaml
@@ -372,16 +372,18 @@ properties:
   - !ruby/object:Api::Type::Array
     name: 'requestedFeatures'
     description: |
-      interconnects.list of features requested for this Interconnect connection. Options: MACSEC (
+      interconnects.list of features requested for this Interconnect connection. Options: IF_MACSEC (
       If specified then the connection is created on MACsec capable hardware ports. If not
       specified, the default value is false, which allocates non-MACsec capable ports first if
-      available).
+      available). Note that MACSEC is still technically allowed for compatibility reasons, but it
+      does not work with the API, and will be removed in an upcoming major version.
     item_type: !ruby/object:Api::Type::Enum
       name: 'requestedFeatures'
       description: |
         interconnects.list of features requested for this Interconnect connection
       values:
         - :MACSEC
+        - :IF_MACSEC
   - !ruby/object:Api::Type::Array
     name: 'availableFeatures'
     description: |
@@ -390,9 +392,4 @@ properties:
       ports. If not present then the Interconnect connection is provisioned on non-MACsec capable
       ports and MACsec isn't supported and enabling MACsec fails).
     output: true
-    item_type: !ruby/object:Api::Type::Enum
-      name: 'availableFeatures'
-      description: |
-        interconnects.list of features available for this Interconnect connection,
-      values:
-        - :MACSEC
+    item_type: Api::Type::String


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/19300

`MACSEC` is not a valid option, which causes an API error. This change adds the correct option (`IF_MACSEC`) so that it can be used instead, but we plan to keep the old option until the next major release to be safe.


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fix `google_compute_interconnect` to support correct `available_features` option of `IF_MACSEC`
```
