### PR TITLE
commit terraform-redis-tags1

### DIFF
--- a/mmv1/products/redis/Instance.yaml
+++ b/mmv1/products/redis/Instance.yaml
@@ -566,3 +566,12 @@ properties:
       Optional. The KMS key reference that you want to use to encrypt the data at rest for this Redis
       instance. If this is provided, CMEK is enabled.
     immutable: true
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456.
+      The field is ignored (both PUT & PATCH) when empty.
+    immutable: true
+    ignore_read: true

--- a/mmv1/third_party/terraform/services/redis/resource_redis_instance_test.go
+++ b/mmv1/third_party/terraform/services/redis/resource_redis_instance_test.go
@@ -461,3 +461,46 @@ resource "google_redis_instance" "test" {
 }
 `, name)
 }
+
+func TestAccRedisInstance_tags(t *testing.T) {
+
+	t.Parallel()
+
+	name := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+	org := envvar.GetTestOrgFromEnv(t)
+	tagKey := acctest.BootstrapSharedTestTagKey(t, "redis-instances-tagkey")
+	tagValue := acctest.BootstrapSharedTestTagValue(t, "redis-instances-tagvalue", tagKey)
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckRedisInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRedisInstanceTags(name, map[string]string{org + "/" + tagKey: tagValue}),
+			},
+			{
+				ResourceName:            "google_redis_instance.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"tags"},
+			},
+		},
+	})
+}
+
+func testAccRedisInstanceTags(name string, tags map[string]string) string {
+
+	r := fmt.Sprintf(`
+	resource "google_redis_instance" "test" {
+	  name = "tf-instance-%s"
+	  memory_size_gb = 5
+	  tags = {`, name)
+
+	l := ""
+	for key, value := range tags {
+		l += fmt.Sprintf("%q = %q\n", key, value)
+	}
+
+	l += fmt.Sprintf("}\n}")
+	return r + l
+}

--- a/mmv1/third_party/terraform/website/docs/d/redis_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/redis_instance.html.markdown
@@ -7,6 +7,7 @@ description: |-
 # google_redis_instance
 
 Get info about a Google Cloud Redis instance.
+~> It may take a while for the attached tag bindings to be deleted after the instance is scheduled to be deleted.
 
 ## Example Usage
 
@@ -27,7 +28,14 @@ output "instance_authorized_network" {
   value = data.google_redis_instance.my_instance.authorized_network
 }
 ```
+To create an instance with a tag
 
+```tf
+resource "fgoogle_redis_instance" "my_instance" {
+  name       = "My instance"
+  tags = {"tagKeys/281478409127147" : "tagValues/281479442205542"}
+}
+```
 ## Argument Reference
 
 The following arguments are supported:
@@ -41,6 +49,8 @@ The following arguments are supported:
 
 * `region` - (Optional) The region in which the resource belongs. If it
     is not provided, the provider region is used.
+    
+* `tags` - (Optional) A map of resource manager tags. Resource manager tag keys and values have the same definition as resource manager tags. Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456. The field is ignored when empty. The field is immutable and causes resource replacement when mutated.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Add tags field to instance resource to allow setting tags on instance resources at creation time.
Part of b/367402264

Release Note Template for Downstream PRs (will be copied)
```
redis: added `tags` field to `redis_instance` to allow setting tags for instances at creation time
```