### PR TITLE
container: make `cpu_manager_policy` optional in `kubelet_config`

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -601,9 +601,9 @@ func schemaNodeConfig() *schema.Schema {
 						Schema: map[string]*schema.Schema{
 							"cpu_manager_policy": {
 								Type:         schema.TypeString,
-								Required:     true,
+								Optional:     true,
 								ValidateFunc: validation.StringInSlice([]string{"static", "none", ""}, false),
-								Description: `Control the CPU management policy on the node.`,
+								Description:  `Control the CPU management policy on the node.`,
 							},
 							"cpu_cfs_quota": {
 								Type:     schema.TypeBool,
@@ -1204,6 +1204,7 @@ func expandKubeletConfig(v interface{}) *container.NodeKubeletConfig {
 	kConfig := &container.NodeKubeletConfig{}
 	if cpuManagerPolicy, ok := cfg["cpu_manager_policy"]; ok {
 		kConfig.CpuManagerPolicy = cpuManagerPolicy.(string)
+		kConfig.ForceSendFields = append(kConfig.ForceSendFields, "CpuManagerPolicy")
 	}
 	if cpuCfsQuota, ok := cfg["cpu_cfs_quota"]; ok {
 		kConfig.CpuCfsQuota = cpuCfsQuota.(bool)

--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -1204,7 +1204,6 @@ func expandKubeletConfig(v interface{}) *container.NodeKubeletConfig {
 	kConfig := &container.NodeKubeletConfig{}
 	if cpuManagerPolicy, ok := cfg["cpu_manager_policy"]; ok {
 		kConfig.CpuManagerPolicy = cpuManagerPolicy.(string)
-		kConfig.ForceSendFields = append(kConfig.ForceSendFields, "CpuManagerPolicy")
 	}
 	if cpuCfsQuota, ok := cfg["cpu_cfs_quota"]; ok {
 		kConfig.CpuCfsQuota = cpuCfsQuota.(bool)

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -1536,6 +1536,40 @@ func TestAccContainerCluster_withNodeConfig(t *testing.T) {
 	})
 }
 
+// Note: Updates for these are currently known to be broken (b/361634104), and
+// so are not tested here.
+// They can probably be made similar to, or consolidated with,
+// TestAccContainerCluster_withInsecureKubeletReadonlyPortEnabledInNodeConfigUpdates
+// after that's resolved.
+func TestAccContainerCluster_withNodeConfigKubeletConfigSettings(t *testing.T) {
+	t.Parallel()
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withNodeConfigKubeletConfigSettings(clusterName, networkName, subnetworkName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						acctest.ExpectNoDelete(),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_container_cluster.with_node_config_kubelet_config_settings",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
 // This is for node_config.kubelet_config, which affects the default node-pool
 // (default-pool) when created via the google_container_cluster resource
 func TestAccContainerCluster_withInsecureKubeletReadonlyPortEnabledInNodeConfigUpdates(t *testing.T) {
@@ -6655,6 +6689,28 @@ resource "google_container_cluster" "with_node_config" {
   deletion_protection = false
   network    = "%s"
   subnetwork    = "%s"
+}
+`, clusterName, networkName, subnetworkName)
+}
+
+func testAccContainerCluster_withNodeConfigKubeletConfigSettings(clusterName, networkName, subnetworkName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_node_config_kubelet_config_settings" {
+  name               = "%s"
+  location           = "us-central1-f"
+  initial_node_count = 1
+
+  node_config {
+    kubelet_config {
+      cpu_manager_policy   = "static"
+      cpu_cfs_quota        = true
+      cpu_cfs_quota_period = "100ms"
+      pod_pids_limit       = 2048
+    }
+  }
+  deletion_protection = false
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, clusterName, networkName, subnetworkName)
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -6668,9 +6668,6 @@ resource "google_container_cluster" "with_insecure_kubelet_readonly_port_enabled
 
   node_config {
     kubelet_config {
-      # Must be set when kubelet_config is, but causes permadrift unless set to
-      # undocumented empty value
-      cpu_manager_policy                     = ""
       insecure_kubelet_readonly_port_enabled = "%s"
     }
   }

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1292,8 +1292,7 @@ Enables monitoring and attestation of the boot integrity of the instance. The at
 
 * `cpu_manager_policy` - (Optional) The CPU management policy on the node. See
 [K8S CPU Management Policies](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/).
-One of `"none"` or `"static"` (empty string `""` is also allowed, which is the
-API default). Default is unset (`"none"`).
+One of `"none"` or `"static"`. If unset (or set to the empty string `""`), the API will treat the field as if set to "none".
 
 * `cpu_cfs_quota` - (Optional) If true, enables CPU CFS quota enforcement for
 containers that specify CPU limits.

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1290,9 +1290,10 @@ Enables monitoring and attestation of the boot integrity of the instance. The at
 
 <a name="nested_kubelet_config"></a>The `kubelet_config` block supports:
 
-* `cpu_manager_policy` - (Required) The CPU management policy on the node. See
+* `cpu_manager_policy` - (Optional) The CPU management policy on the node. See
 [K8S CPU Management Policies](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/).
-One of `"none"` or `"static"`. Defaults to `none` when `kubelet_config` is unset.
+One of `"none"` or `"static"` (empty string `""` is also allowed, which is the
+API default). Default is unset (`"none"`).
 
 * `cpu_cfs_quota` - (Optional) If true, enables CPU CFS quota enforcement for
 containers that specify CPU limits.
@@ -1301,11 +1302,6 @@ containers that specify CPU limits.
 as a sequence of decimal numbers, each with optional fraction and a unit suffix,
 such as `"300ms"`. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m",
 "h". The value must be a positive duration.
-
--> Note: At the time of writing (2020/08/18) the GKE API rejects the `none`
-value and accepts an invalid `default` value instead. While this remains true,
-not specifying the `kubelet_config` block should be the equivalent of specifying
-`none`.
 
 * `insecure_kubelet_readonly_port_enabled` - (Optional) Controls whether the kubelet read-only port is enabled. It is strongly recommended to set this to `FALSE`. Possible values: `TRUE`, `FALSE`.
 


### PR DESCRIPTION
Part of https://github.com/hashicorp/terraform-provider-google/issues/19225

This should resolve some confusing behavior with `cpu_manager_policy`

* It frequently will show a permadrift when it can't be set
* It also doesn't seem to accept the documented value of "none" as an empty value, though the previously undocumented empty string (`""`) seems to work.

https://github.com/GoogleCloudPlatform/magic-modules/pull/3760/commits/efb71a903fc26775d568b8129ef18ce707dfbdc6#r458238583
https://github.com/GoogleCloudPlatform/magic-modules/pull/3760/commits/efb71a903fc26775d568b8129ef18ce707dfbdc6#r473173480
☝️ context on when it was originally marked `Required`

This doesn't resolve all of the issues, but resolves other issues where it must be set where it's not actually needed (for example, if `insecure_kubelet_readonly_port_enabled` is set).

It appears that it was marked as `Required` somewhat arbitrarily (see above), and it's also possible that some of what's in place is tied to an API level bug that may have since been resolved. Maybe we could require at last one instead -- happy to do that if there's a good example to follow.

I did come across https://github.com/hashicorp/terraform-provider-google/issues/15767 while testing this, but I think this is neutral as far as that goes.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: make `cpu_manager_policy` optional in `kubelet_config`
```
