### PR TITLE
container: Add `node_kublet_config` support for autopilot clusters

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -120,6 +120,41 @@ func schemaGcfsConfig(forceNew bool) *schema.Schema {
         }
 }
 
+func schemaKubeletConfig() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Description: `Node kubelet configs.`,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"cpu_manager_policy": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice([]string{"static", "none", ""}, false),
+					Description: `Control the CPU management policy on the node.`,
+				},
+				"cpu_cfs_quota": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Description: `Enable CPU CFS quota enforcement for containers that specify CPU limits.`,
+				},
+				"cpu_cfs_quota_period": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Description: `Set the CPU CFS quota period value 'cpu.cfs_period_us'.`,
+				},
+				"insecure_kubelet_readonly_port_enabled": schemaInsecureKubeletReadonlyPortEnabled(),
+				"pod_pids_limit": {
+					Type:        schema.TypeInt,
+					Optional:    true,
+					Description: `Controls the maximum number of processes allowed to run in a pod.`,
+				},
+			},
+		},
+	}
+}
+
 func schemaNodeConfig() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
@@ -586,39 +621,7 @@ func schemaNodeConfig() *schema.Schema {
 				},
 				// Note that AtLeastOneOf can't be set because this schema is reused by
 				// two different resources.
-				"kubelet_config": {
-					Type:     schema.TypeList,
-					Optional: true,
-					MaxItems: 1,
-					Description: `Node kubelet configs.`,
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"cpu_manager_policy": {
-								Type:         schema.TypeString,
-								Required:     true,
-								ValidateFunc: validation.StringInSlice([]string{"static", "none", ""}, false),
-								Description: `Control the CPU management policy on the node.`,
-							},
-							"cpu_cfs_quota": {
-								Type:     schema.TypeBool,
-								Optional: true,
-								Description: `Enable CPU CFS quota enforcement for containers that specify CPU limits.`,
-							},
-							"cpu_cfs_quota_period": {
-								Type:     schema.TypeString,
-								Optional: true,
-								Description: `Set the CPU CFS quota period value 'cpu.cfs_period_us'.`,
-							},
-							"insecure_kubelet_readonly_port_enabled": schemaInsecureKubeletReadonlyPortEnabled(),
-							"pod_pids_limit": {
-								Type:        schema.TypeInt,
-								Optional:    true,
-								Description: `Controls the maximum number of processes allowed to run in a pod.`,
-							},
-						},
-					},
-				},
-
+				"kubelet_config": schemaKubeletConfig(),
 				"linux_node_config": {
 					Type:     schema.TypeList,
 					Optional: true,

--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -120,41 +120,6 @@ func schemaGcfsConfig(forceNew bool) *schema.Schema {
         }
 }
 
-func schemaKubeletConfig() *schema.Schema {
-	return &schema.Schema{
-		Type:     schema.TypeList,
-		Optional: true,
-		MaxItems: 1,
-		Description: `Node kubelet configs.`,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"cpu_manager_policy": {
-					Type:         schema.TypeString,
-					Required:     true,
-					ValidateFunc: validation.StringInSlice([]string{"static", "none", ""}, false),
-					Description: `Control the CPU management policy on the node.`,
-				},
-				"cpu_cfs_quota": {
-					Type:     schema.TypeBool,
-					Optional: true,
-					Description: `Enable CPU CFS quota enforcement for containers that specify CPU limits.`,
-				},
-				"cpu_cfs_quota_period": {
-					Type:     schema.TypeString,
-					Optional: true,
-					Description: `Set the CPU CFS quota period value 'cpu.cfs_period_us'.`,
-				},
-				"insecure_kubelet_readonly_port_enabled": schemaInsecureKubeletReadonlyPortEnabled(),
-				"pod_pids_limit": {
-					Type:        schema.TypeInt,
-					Optional:    true,
-					Description: `Controls the maximum number of processes allowed to run in a pod.`,
-				},
-			},
-		},
-	}
-}
-
 func schemaNodeConfig() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeList,
@@ -621,7 +586,39 @@ func schemaNodeConfig() *schema.Schema {
 				},
 				// Note that AtLeastOneOf can't be set because this schema is reused by
 				// two different resources.
-				"kubelet_config": schemaKubeletConfig(),
+				"kubelet_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Description: `Node kubelet configs.`,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"cpu_manager_policy": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringInSlice([]string{"static", "none", ""}, false),
+								Description: `Control the CPU management policy on the node.`,
+							},
+							"cpu_cfs_quota": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Description: `Enable CPU CFS quota enforcement for containers that specify CPU limits.`,
+							},
+							"cpu_cfs_quota_period": {
+								Type:     schema.TypeString,
+								Optional: true,
+								Description: `Set the CPU CFS quota period value 'cpu.cfs_period_us'.`,
+							},
+							"insecure_kubelet_readonly_port_enabled": schemaInsecureKubeletReadonlyPortEnabled(),
+							"pod_pids_limit": {
+								Type:        schema.TypeInt,
+								Optional:    true,
+								Description: `Controls the maximum number of processes allowed to run in a pod.`,
+							},
+						},
+					},
+				},
+
 				"linux_node_config": {
 					Type:     schema.TypeList,
 					Optional: true,
@@ -779,6 +776,22 @@ func schemaNodeConfig() *schema.Schema {
 						ForceNew: true,
 						Description: `If enabled boot disks are configured with confidential mode.`,
 				},
+			},
+		},
+	}
+}
+
+// Separate since this currently only supports a single value -- a subset of
+// the overall NodeKubeletConfig
+func schemaNodePoolAutoConfigNodeKubeletConfig() *schema.Schema {
+  return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		MaxItems:    1,
+		Description: `Node kubelet configs.`,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"insecure_kubelet_readonly_port_enabled": schemaInsecureKubeletReadonlyPortEnabled(),
 			},
 		},
 	}

--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -1768,6 +1768,16 @@ func flattenKubeletConfig(c *container.NodeKubeletConfig) []map[string]interface
 	return result
 }
 
+func flattenNodePoolAutoConfigNodeKubeletConfig(c *container.NodeKubeletConfig) []map[string]interface{} {
+	result := []map[string]interface{}{}
+	if c != nil {
+		result = append(result, map[string]interface{}{
+			"insecure_kubelet_readonly_port_enabled": flattenInsecureKubeletReadonlyPortEnabled(c),
+		})
+	}
+	return result
+}
+
 func flattenLinuxNodeConfig(c *container.LinuxNodeConfig) []map[string]interface{} {
 	result := []map[string]interface{}{}
 	if c != nil {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -1505,7 +1505,7 @@ func ResourceContainerCluster() *schema.Resource {
 				Description: `Node pool configs that apply to all auto-provisioned node pools in autopilot clusters and node auto-provisioning enabled clusters.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"node_kubelet_config": schemaKubeletConfig(),
+						"node_kubelet_config": schemaNodePoolAutoConfigNodeKubeletConfig(),
 						"network_tags": {
 							Type:        schema.TypeList,
 							Optional:    true,

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -1505,6 +1505,7 @@ func ResourceContainerCluster() *schema.Resource {
 				Description: `Node pool configs that apply to all auto-provisioned node pools in autopilot clusters and node auto-provisioning enabled clusters.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"node_kubelet_config": schemaKubeletConfig(),
 						"network_tags": {
 							Type:        schema.TypeList,
 							Optional:    true,
@@ -4403,6 +4404,24 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
+	if d.HasChange("node_pool_auto_config.0.node_kubelet_config") {
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				DesiredNodePoolAutoConfigKubeletConfig: expandKubeletConfig(
+					d.Get("node_pool_auto_config.0.node_kubelet_config"),
+				),
+			},
+		}
+
+		updateF := updateFunc(req, "updating GKE cluster node pool auto config node_kubelet_config parameters")
+		// Call update serially.
+		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] GKE cluster %s node pool auto config node_kubelet_config parameters have been updated", d.Id())
+	}
+
 	if d.HasChange("node_pool_auto_config.0.network_tags.0.tags") {
 		tags := d.Get("node_pool_auto_config.0.network_tags.0.tags").([]interface{})
 
@@ -5737,6 +5756,10 @@ func expandNodePoolAutoConfig(configured interface{}) *container.NodePoolAutoCon
 	npac := &container.NodePoolAutoConfig{}
 	config := l[0].(map[string]interface{})
 
+	if v, ok := config["node_kubelet_config"]; ok {
+		npac.NodeKubeletConfig = expandKubeletConfig(v)
+	}
+
 	if v, ok := config["network_tags"]; ok && len(v.([]interface{})) > 0 {
 		npac.NetworkTags = expandNodePoolAutoConfigNetworkTags(v)
 	}
@@ -6575,6 +6598,9 @@ func flattenNodePoolAutoConfig(c *container.NodePoolAutoConfig) []map[string]int
 	}
 
 	result := make(map[string]interface{})
+	if c.NodeKubeletConfig != nil {
+		result["node_kubelet_config"] = flattenKubeletConfig(c.NodeKubeletConfig)
+	}
 	if c.NetworkTags != nil {
 		result["network_tags"] = flattenNodePoolAutoConfigNetworkTags(c.NetworkTags)
 	}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -6599,7 +6599,7 @@ func flattenNodePoolAutoConfig(c *container.NodePoolAutoConfig) []map[string]int
 
 	result := make(map[string]interface{})
 	if c.NodeKubeletConfig != nil {
-		result["node_kubelet_config"] = flattenKubeletConfig(c.NodeKubeletConfig)
+		result["node_kubelet_config"] = flattenNodePoolAutoConfigNodeKubeletConfig(c.NodeKubeletConfig)
 	}
 	if c.NetworkTags != nil {
 		result["network_tags"] = flattenNodePoolAutoConfigNetworkTags(c.NetworkTags)

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -3248,6 +3248,52 @@ func TestAccContainerCluster_withAutopilotNetworkTags(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_withAutopilotKubeletConfig(t *testing.T) {
+	t.Parallel()
+
+	randomSuffix := acctest.RandString(t, 10)
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randomSuffix)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withAutopilotKubeletConfigBaseline(clusterName),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_autopilot_kubelet_config",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_withAutopilotKubeletConfigUpdates(clusterName, "FALSE"),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_autopilot_kubelet_config",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_withAutopilotKubeletConfigUpdates(clusterName, "TRUE"),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_autopilot_kubelet_config",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
+			},
+		},
+	})
+}
+
+
 func TestAccContainerCluster_withAutopilotResourceManagerTags(t *testing.T) {
 	t.Parallel()
 
@@ -10516,6 +10562,41 @@ func testAccContainerCluster_withWorkloadALTSConfigAutopilot(projectID, name str
 }
 
 <% end -%>
+
+func testAccContainerCluster_withAutopilotKubeletConfigBaseline(name string) string {
+  return fmt.Sprintf(`
+  resource "google_container_cluster" "with_autopilot_kubelet_config" {
+    name                = "%s"
+    location            = "us-central1"
+    initial_node_count  = 1
+    enable_autopilot    = true
+    deletion_protection = false
+  }
+`, name)
+}
+
+func testAccContainerCluster_withAutopilotKubeletConfigUpdates(name, insecureKubeletReadonlyPortEnabled string) string {
+  return fmt.Sprintf(`
+  resource "google_container_cluster" "with_autopilot_kubelet_config" {
+    name               = "%s"
+    location           = "us-central1"
+    initial_node_count = 1
+
+    node_pool_auto_config {
+      node_kubelet_config {
+        # Needed to work around being required but not actually needed
+        cpu_manager_policy = ""
+
+        # Currently the only supported parameter here
+        insecure_kubelet_readonly_port_enabled = "%s"
+      }
+    }
+
+    enable_autopilot    = true
+    deletion_protection = false
+  }
+`, name, insecureKubeletReadonlyPortEnabled)
+}
 
 func testAccContainerCluster_resourceManagerTags(projectID, clusterName, networkName, subnetworkName, randomSuffix string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -10584,10 +10584,6 @@ func testAccContainerCluster_withAutopilotKubeletConfigUpdates(name, insecureKub
 
     node_pool_auto_config {
       node_kubelet_config {
-        # Needed to work around being required but not actually needed
-        cpu_manager_policy = ""
-
-        # Currently the only supported parameter here
         insecure_kubelet_readonly_port_enabled = "%s"
       }
     }

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1085,7 +1085,7 @@ workload_identity_config {
 <a name="nested_node_pool_auto_config"></a>The `node_pool_auto_config` block supports:
 
 * `node_kubelet_config` - (Optional) Kubelet configuration. Currently, only `insecure_kubelet_readonly_port_enabled` is supported here.
-Structure is [documented below](#nested_kubelet_config).
+Structure is [documented below](#nested_node_kubelet_config).
 
 * `resource_manager_tags` - (Optional) A map of resource manager tag keys and values to be attached to the nodes for managing Compute Engine firewalls using Network Firewall Policies. Tags must be according to specifications found [here](https://cloud.google.com/vpc/docs/tags-firewalls-overview#specifications). A maximum of 5 tag key-value pairs can be specified. Existing tags will be replaced with new values. Tags must be in one of the following formats ([KEY]=[VALUE]) 1. `tagKeys/{tag_key_id}=tagValues/{tag_value_id}` 2. `{org_id}/{tag_key_name}={tag_value_name}` 3. `{project_id}/{tag_key_name}={tag_value_name}`.
 
@@ -1102,6 +1102,10 @@ node_pool_auto_config {
   }
 }
 ```
+
+<a name="nested_node_kubelet_config"></a>The `node_kubelet_config` block for `node_pool_auto_config` supports:
+
+* `insecure_kubelet_readonly_port_enabled` - (Optional) Controls whether the kubelet read-only port is enabled. It is strongly recommended to set this to `FALSE`. Possible values: `TRUE`, `FALSE`.
 
 <a name="nested_node_pool_defaults"></a>The `node_pool_defaults` block supports:
 * `node_config_defaults` (Optional) - Subset of NodeConfig message that has defaults.

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1089,13 +1089,13 @@ Structure is [documented below](#nested_node_kubelet_config).
 
 * `resource_manager_tags` - (Optional) A map of resource manager tag keys and values to be attached to the nodes for managing Compute Engine firewalls using Network Firewall Policies. Tags must be according to specifications found [here](https://cloud.google.com/vpc/docs/tags-firewalls-overview#specifications). A maximum of 5 tag key-value pairs can be specified. Existing tags will be replaced with new values. Tags must be in one of the following formats ([KEY]=[VALUE]) 1. `tagKeys/{tag_key_id}=tagValues/{tag_value_id}` 2. `{org_id}/{tag_key_name}={tag_value_name}` 3. `{project_id}/{tag_key_name}={tag_value_name}`.
 
-* `network_tags` (Optional) - The network tag config for the cluster's automatically provisioned node pools.
+* `network_tags` (Optional) - The network tag config for the cluster's automatically provisioned node pools. Structure is [documented below](#nested_network_tags).
 
 <a name="nested_node_kubelet_config"></a>The `node_kubelet_config` block supports:
 
 * `insecure_kubelet_readonly_port_enabled` - (Optional) Controls whether the kubelet read-only port is enabled. It is strongly recommended to set this to `FALSE`. Possible values: `TRUE`, `FALSE`.
 
-The `network_tags` block supports:
+<a name="nested_network_tags"></a>The `network_tags` block supports:
 
 * `tags` (Optional) - List of network tags applied to auto-provisioned node pools.
 

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1084,8 +1084,12 @@ workload_identity_config {
 
 <a name="nested_node_pool_auto_config"></a>The `node_pool_auto_config` block supports:
 
-* `node_kubelet_config` - (Optional) Kubelet configuration. Currently, only `insecure_kubelet_readonly_port_enabled` is supported here.
+* `node_kubelet_config` - (Optional) Kubelet configuration for Autopilot clusters. Currently, only `insecure_kubelet_readonly_port_enabled` is supported here.
 Structure is [documented below](#nested_node_kubelet_config).
+
+<a name="nested_node_kubelet_config"></a>The `node_kubelet_config` block supports:
+
+* `insecure_kubelet_readonly_port_enabled` - (Optional) Controls whether the kubelet read-only port is enabled. It is strongly recommended to set this to `FALSE`. Possible values: `TRUE`, `FALSE`.
 
 * `resource_manager_tags` - (Optional) A map of resource manager tag keys and values to be attached to the nodes for managing Compute Engine firewalls using Network Firewall Policies. Tags must be according to specifications found [here](https://cloud.google.com/vpc/docs/tags-firewalls-overview#specifications). A maximum of 5 tag key-value pairs can be specified. Existing tags will be replaced with new values. Tags must be in one of the following formats ([KEY]=[VALUE]) 1. `tagKeys/{tag_key_id}=tagValues/{tag_value_id}` 2. `{org_id}/{tag_key_name}={tag_value_name}` 3. `{project_id}/{tag_key_name}={tag_value_name}`.
 
@@ -1102,10 +1106,6 @@ node_pool_auto_config {
   }
 }
 ```
-
-<a name="nested_node_kubelet_config"></a>The `node_kubelet_config` block for `node_pool_auto_config` supports:
-
-* `insecure_kubelet_readonly_port_enabled` - (Optional) Controls whether the kubelet read-only port is enabled. It is strongly recommended to set this to `FALSE`. Possible values: `TRUE`, `FALSE`.
 
 <a name="nested_node_pool_defaults"></a>The `node_pool_defaults` block supports:
 * `node_config_defaults` (Optional) - Subset of NodeConfig message that has defaults.

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1084,6 +1084,9 @@ workload_identity_config {
 
 <a name="nested_node_pool_auto_config"></a>The `node_pool_auto_config` block supports:
 
+* `node_kubelet_config` - (Optional) Kubelet configuration. Currently, only `insecure_kubelet_readonly_port_enabled` is supported here.
+Structure is [documented below](#nested_kubelet_config).
+
 * `resource_manager_tags` - (Optional) A map of resource manager tag keys and values to be attached to the nodes for managing Compute Engine firewalls using Network Firewall Policies. Tags must be according to specifications found [here](https://cloud.google.com/vpc/docs/tags-firewalls-overview#specifications). A maximum of 5 tag key-value pairs can be specified. Existing tags will be replaced with new values. Tags must be in one of the following formats ([KEY]=[VALUE]) 1. `tagKeys/{tag_key_id}=tagValues/{tag_value_id}` 2. `{org_id}/{tag_key_name}={tag_value_name}` 3. `{project_id}/{tag_key_name}={tag_value_name}`.
 
 * `network_tags` (Optional) - The network tag config for the cluster's automatically provisioned node pools.

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1087,13 +1087,13 @@ workload_identity_config {
 * `node_kubelet_config` - (Optional) Kubelet configuration for Autopilot clusters. Currently, only `insecure_kubelet_readonly_port_enabled` is supported here.
 Structure is [documented below](#nested_node_kubelet_config).
 
-<a name="nested_node_kubelet_config"></a>The `node_kubelet_config` block supports:
-
-* `insecure_kubelet_readonly_port_enabled` - (Optional) Controls whether the kubelet read-only port is enabled. It is strongly recommended to set this to `FALSE`. Possible values: `TRUE`, `FALSE`.
-
 * `resource_manager_tags` - (Optional) A map of resource manager tag keys and values to be attached to the nodes for managing Compute Engine firewalls using Network Firewall Policies. Tags must be according to specifications found [here](https://cloud.google.com/vpc/docs/tags-firewalls-overview#specifications). A maximum of 5 tag key-value pairs can be specified. Existing tags will be replaced with new values. Tags must be in one of the following formats ([KEY]=[VALUE]) 1. `tagKeys/{tag_key_id}=tagValues/{tag_value_id}` 2. `{org_id}/{tag_key_name}={tag_value_name}` 3. `{project_id}/{tag_key_name}={tag_value_name}`.
 
 * `network_tags` (Optional) - The network tag config for the cluster's automatically provisioned node pools.
+
+<a name="nested_node_kubelet_config"></a>The `node_kubelet_config` block supports:
+
+* `insecure_kubelet_readonly_port_enabled` - (Optional) Controls whether the kubelet read-only port is enabled. It is strongly recommended to set this to `FALSE`. Possible values: `TRUE`, `FALSE`.
 
 The `network_tags` block supports:
 


### PR DESCRIPTION
Add support for `node_kubelet_config` in `node_pool_auto_config`.

See:
https://github.com/hashicorp/terraform-provider-google/issues/15208#issuecomment-2299669810

Per:
https://pkg.go.dev/google.golang.org/api/container/v1#NodePoolAutoConfig Currently only `insecure_kubelet_readonly_port_enabled` can be set here. I'm not sure what the future plans are, and whether the provider should allow the other set of flags to be set; otherwise, we may have to adjust some of this so that only supported parameters are allowed.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/19236
Fixes https://github.com/hashicorp/terraform-provider-google/issues/19153

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: Add `node_kublet_config` support for autopilot clusters.
```
