### PR TITLE
chore: ignore `mmv1/vendor` path in `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ final_api.yaml
 # Used by OiCS tutorial
 mmv1/build/*
 
+# Ignore vendored Ruby libs as well
+mmv1/vendor/
+
 # ignore node modules folders utilized by npm
 **/node_modules
 


### PR DESCRIPTION
From what I can see, the setup process for now still involves installing ruby libs that potentially get installed in `mmv1/vendor`. Feel free to close if my setup is outdated and this is not needed, but I think it should be harmless.

Add these to `.gitignore`. It doesn't appear that a trailing `*` is needed the way `mmv1/build/*` is, so I left that, but didn't add it here

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
