### PR TITLE
continue sweeper run for other resources if no resource found

### DIFF
--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_active_directory_sweeper.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_active_directory_sweeper.go
@@ -55,7 +55,7 @@ func testSweepNetappActiveDirectory(region string) error {
 		listUrl, err := tpgresource.ReplaceVars(d, config, listTemplate)
 		if err != nil {
 			log.Printf("[INFO][SWEEPER_LOG] error preparing sweeper list url: %s", err)
-			return nil
+			continue
 		}
 
 		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
@@ -67,7 +67,7 @@ func testSweepNetappActiveDirectory(region string) error {
 		})
 		if err != nil {
 			log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)
-			return nil
+			continue
 		}
 
 		resourceList, ok := res["activeDirectories"]
@@ -85,7 +85,7 @@ func testSweepNetappActiveDirectory(region string) error {
 			obj := ri.(map[string]interface{})
 			if obj["name"] == nil {
 				log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
-				return nil
+				continue
 			}
 
 			name := tpgresource.GetResourceNameFromSelfLink(obj["name"].(string))
@@ -99,7 +99,7 @@ func testSweepNetappActiveDirectory(region string) error {
 			deleteUrl, err := tpgresource.ReplaceVars(d, config, deleteTemplate)
 			if err != nil {
 				log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
-				return nil
+				continue
 			}
 			deleteUrl = deleteUrl + name
 

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_active_directory_sweeper.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_active_directory_sweeper.go
@@ -73,7 +73,7 @@ func testSweepNetappActiveDirectory(region string) error {
 		resourceList, ok := res["activeDirectories"]
 		if !ok {
 			log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
-			return nil
+			continue
 		}
 
 		rl := resourceList.([]interface{})

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_policy_sweeper.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_policy_sweeper.go
@@ -55,7 +55,7 @@ func testSweepNetappBackupPolicy(region string) error {
 		listUrl, err := tpgresource.ReplaceVars(d, config, listTemplate)
 		if err != nil {
 			log.Printf("[INFO][SWEEPER_LOG] error preparing sweeper list url: %s", err)
-			return nil
+			continue
 		}
 
 		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
@@ -67,7 +67,7 @@ func testSweepNetappBackupPolicy(region string) error {
 		})
 		if err != nil {
 			log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)
-			return nil
+			continue
 		}
 
 		resourceList, ok := res["backupPolicies"]
@@ -85,7 +85,7 @@ func testSweepNetappBackupPolicy(region string) error {
 			obj := ri.(map[string]interface{})
 			if obj["name"] == nil {
 				log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
-				return nil
+				continue
 			}
 
 			name := tpgresource.GetResourceNameFromSelfLink(obj["name"].(string))
@@ -99,7 +99,7 @@ func testSweepNetappBackupPolicy(region string) error {
 			deleteUrl, err := tpgresource.ReplaceVars(d, config, deleteTemplate)
 			if err != nil {
 				log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
-				return nil
+				continue
 			}
 			deleteUrl = deleteUrl + name
 

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_policy_sweeper.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_policy_sweeper.go
@@ -73,7 +73,7 @@ func testSweepNetappBackupPolicy(region string) error {
 		resourceList, ok := res["backupPolicies"]
 		if !ok {
 			log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
-			return nil
+			continue
 		}
 
 		rl := resourceList.([]interface{})

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_sweeper.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_sweeper.go
@@ -55,7 +55,7 @@ func testSweepNetappBackup(region string) error {
 		listUrl, err := tpgresource.ReplaceVars(d, config, listTemplate)
 		if err != nil {
 			log.Printf("[INFO][SWEEPER_LOG] error preparing sweeper list url: %s", err)
-			return nil
+			continue
 		}
 
 		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
@@ -67,7 +67,7 @@ func testSweepNetappBackup(region string) error {
 		})
 		if err != nil {
 			log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)
-			return nil
+			continue
 		}
 
 		resourceList, ok := res["backups"]
@@ -85,7 +85,7 @@ func testSweepNetappBackup(region string) error {
 			obj := ri.(map[string]interface{})
 			if obj["name"] == nil {
 				log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
-				return nil
+				continue
 			}
 
 			name := tpgresource.GetResourceNameFromSelfLink(obj["name"].(string))
@@ -99,7 +99,7 @@ func testSweepNetappBackup(region string) error {
 			deleteUrl, err := tpgresource.ReplaceVars(d, config, deleteTemplate)
 			if err != nil {
 				log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
-				return nil
+				continue
 			}
 			deleteUrl = deleteUrl + name
 

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_sweeper.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_sweeper.go
@@ -73,7 +73,7 @@ func testSweepNetappBackup(region string) error {
 		resourceList, ok := res["backups"]
 		if !ok {
 			log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
-			return nil
+			continue
 		}
 
 		rl := resourceList.([]interface{})

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_vault_sweeper.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_vault_sweeper.go
@@ -73,7 +73,7 @@ func testSweepNetappBackupVault(region string) error {
 		resourceList, ok := res["backupVaults"]
 		if !ok {
 			log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
-			return nil
+			continue
 		}
 
 		rl := resourceList.([]interface{})

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_vault_sweeper.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_vault_sweeper.go
@@ -55,7 +55,7 @@ func testSweepNetappBackupVault(region string) error {
 		listUrl, err := tpgresource.ReplaceVars(d, config, listTemplate)
 		if err != nil {
 			log.Printf("[INFO][SWEEPER_LOG] error preparing sweeper list url: %s", err)
-			return nil
+			continue
 		}
 
 		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
@@ -67,7 +67,7 @@ func testSweepNetappBackupVault(region string) error {
 		})
 		if err != nil {
 			log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)
-			return nil
+			continue
 		}
 
 		resourceList, ok := res["backupVaults"]
@@ -85,7 +85,7 @@ func testSweepNetappBackupVault(region string) error {
 			obj := ri.(map[string]interface{})
 			if obj["name"] == nil {
 				log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
-				return nil
+				continue
 			}
 
 			name := tpgresource.GetResourceNameFromSelfLink(obj["name"].(string))
@@ -99,7 +99,7 @@ func testSweepNetappBackupVault(region string) error {
 			deleteUrl, err := tpgresource.ReplaceVars(d, config, deleteTemplate)
 			if err != nil {
 				log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
-				return nil
+				continue
 			}
 			deleteUrl = deleteUrl + name
 

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_kmsconfig_sweeper.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_kmsconfig_sweeper.go
@@ -73,7 +73,7 @@ func testSweepNetappkmsconfig(region string) error {
 		resourceList, ok := res["kmsconfigs"]
 		if !ok {
 			log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
-			return nil
+			continue
 		}
 
 		rl := resourceList.([]interface{})

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_kmsconfig_sweeper.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_kmsconfig_sweeper.go
@@ -55,7 +55,7 @@ func testSweepNetappkmsconfig(region string) error {
 		listUrl, err := tpgresource.ReplaceVars(d, config, listTemplate)
 		if err != nil {
 			log.Printf("[INFO][SWEEPER_LOG] error preparing sweeper list url: %s", err)
-			return nil
+			continue
 		}
 
 		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
@@ -67,7 +67,7 @@ func testSweepNetappkmsconfig(region string) error {
 		})
 		if err != nil {
 			log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)
-			return nil
+			continue
 		}
 
 		resourceList, ok := res["kmsconfigs"]
@@ -85,7 +85,7 @@ func testSweepNetappkmsconfig(region string) error {
 			obj := ri.(map[string]interface{})
 			if obj["name"] == nil {
 				log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
-				return nil
+				continue
 			}
 
 			name := tpgresource.GetResourceNameFromSelfLink(obj["name"].(string))
@@ -99,7 +99,7 @@ func testSweepNetappkmsconfig(region string) error {
 			deleteUrl, err := tpgresource.ReplaceVars(d, config, deleteTemplate)
 			if err != nil {
 				log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
-				return nil
+				continue
 			}
 			deleteUrl = deleteUrl + name
 

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_storage_pool_sweeper.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_storage_pool_sweeper.go
@@ -55,7 +55,7 @@ func testSweepNetappStoragePool(region string) error {
 		listUrl, err := tpgresource.ReplaceVars(d, config, listTemplate)
 		if err != nil {
 			log.Printf("[INFO][SWEEPER_LOG] error preparing sweeper list url: %s", err)
-			return nil
+			continue
 		}
 
 		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
@@ -67,7 +67,7 @@ func testSweepNetappStoragePool(region string) error {
 		})
 		if err != nil {
 			log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)
-			return nil
+			continue
 		}
 
 		resourceList, ok := res["storagePools"]
@@ -85,7 +85,7 @@ func testSweepNetappStoragePool(region string) error {
 			obj := ri.(map[string]interface{})
 			if obj["name"] == nil {
 				log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
-				return nil
+				continue
 			}
 
 			name := tpgresource.GetResourceNameFromSelfLink(obj["name"].(string))
@@ -99,7 +99,7 @@ func testSweepNetappStoragePool(region string) error {
 			deleteUrl, err := tpgresource.ReplaceVars(d, config, deleteTemplate)
 			if err != nil {
 				log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
-				return nil
+				continue
 			}
 			deleteUrl = deleteUrl + name
 

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_storage_pool_sweeper.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_storage_pool_sweeper.go
@@ -73,7 +73,7 @@ func testSweepNetappStoragePool(region string) error {
 		resourceList, ok := res["storagePools"]
 		if !ok {
 			log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
-			return nil
+			continue
 		}
 
 		rl := resourceList.([]interface{})

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_snapshot_sweeper.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_snapshot_sweeper.go
@@ -55,7 +55,7 @@ func testSweepNetappVolumeSnapshot(region string) error {
 		listUrl, err := tpgresource.ReplaceVars(d, config, listTemplate)
 		if err != nil {
 			log.Printf("[INFO][SWEEPER_LOG] error preparing sweeper list url: %s", err)
-			return nil
+			continue
 		}
 
 		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
@@ -67,7 +67,7 @@ func testSweepNetappVolumeSnapshot(region string) error {
 		})
 		if err != nil {
 			log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)
-			return nil
+			continue
 		}
 
 		resourceList, ok := res["volumeSnapshots"]
@@ -85,7 +85,7 @@ func testSweepNetappVolumeSnapshot(region string) error {
 			obj := ri.(map[string]interface{})
 			if obj["name"] == nil {
 				log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
-				return nil
+				continue
 			}
 
 			name := tpgresource.GetResourceNameFromSelfLink(obj["name"].(string))
@@ -99,7 +99,7 @@ func testSweepNetappVolumeSnapshot(region string) error {
 			deleteUrl, err := tpgresource.ReplaceVars(d, config, deleteTemplate)
 			if err != nil {
 				log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
-				return nil
+				continue
 			}
 			deleteUrl = deleteUrl + name
 

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_snapshot_sweeper.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_snapshot_sweeper.go
@@ -73,7 +73,7 @@ func testSweepNetappVolumeSnapshot(region string) error {
 		resourceList, ok := res["volumeSnapshots"]
 		if !ok {
 			log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
-			return nil
+			continue
 		}
 
 		rl := resourceList.([]interface{})


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
netapp: modified manual sweepers to continue or other locations if no resource found
```
