### PR TITLE
Move validator tests into their own explicit file

### DIFF
--- a/mmv1/third_party/terraform/fwprovider/framework_provider_internal_test.go
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider_internal_test.go
@@ -1,85 +1,11 @@
 package fwprovider
 
 import (
-	"context"
-	"io/ioutil"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 func TestFrameworkProvider_impl(t *testing.T) {
 	var _ provider.ProviderWithMetaSchema = New()
-}
-
-func TestFrameworkProvider_CredentialsValidator(t *testing.T) {
-	cases := map[string]struct {
-		ConfigValue          func(t *testing.T) types.String
-		ExpectedWarningCount int
-		ExpectedErrorCount   int
-	}{
-		"configuring credentials as a path to a credentials JSON file is valid": {
-			ConfigValue: func(t *testing.T) types.String {
-				return types.StringValue(transport_tpg.TestFakeCredentialsPath) // Path to a test fixture
-			},
-		},
-		"configuring credentials as a path to a non-existant file is NOT valid": {
-			ConfigValue: func(t *testing.T) types.String {
-				return types.StringValue("./this/path/doesnt/exist.json") // Doesn't exist
-			},
-			ExpectedErrorCount: 1,
-		},
-		"configuring credentials as a credentials JSON string is valid": {
-			ConfigValue: func(t *testing.T) types.String {
-				contents, err := ioutil.ReadFile(transport_tpg.TestFakeCredentialsPath)
-				if err != nil {
-					t.Fatalf("Unexpected error: %s", err)
-				}
-				stringContents := string(contents)
-				return types.StringValue(stringContents)
-			},
-		},
-		"configuring credentials as an empty string is not valid": {
-			ConfigValue: func(t *testing.T) types.String {
-				return types.StringValue("")
-			},
-			ExpectedErrorCount: 1,
-		},
-		"leaving credentials unconfigured is valid": {
-			ConfigValue: func(t *testing.T) types.String {
-				return types.StringNull()
-			},
-		},
-	}
-
-	for tn, tc := range cases {
-		t.Run(tn, func(t *testing.T) {
-			// Arrange
-			req := validator.StringRequest{
-				ConfigValue: tc.ConfigValue(t),
-			}
-
-			resp := validator.StringResponse{
-				Diagnostics: diag.Diagnostics{},
-			}
-
-			cv := CredentialsValidator()
-
-			// Act
-			cv.ValidateString(context.Background(), req, &resp)
-
-			// Assert
-			if resp.Diagnostics.WarningsCount() > tc.ExpectedWarningCount {
-				t.Errorf("Expected %d warnings, got %d", tc.ExpectedWarningCount, resp.Diagnostics.WarningsCount())
-			}
-			if resp.Diagnostics.ErrorsCount() > tc.ExpectedErrorCount {
-				t.Errorf("Expected %d errors, got %d", tc.ExpectedErrorCount, resp.Diagnostics.ErrorsCount())
-			}
-		})
-	}
 }

--- a/mmv1/third_party/terraform/fwprovider/framework_provider_internal_test.go
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider_internal_test.go
@@ -1,11 +1,12 @@
-package fwprovider
+package fwprovider_test
 
 import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-provider-google/google/fwprovider"
 )
 
 func TestFrameworkProvider_impl(t *testing.T) {
-	var _ provider.ProviderWithMetaSchema = New()
+	var _ provider.ProviderWithMetaSchema = fwprovider.New()
 }

--- a/mmv1/third_party/terraform/fwprovider/framework_validators_test.go
+++ b/mmv1/third_party/terraform/fwprovider/framework_validators_test.go
@@ -1,0 +1,82 @@
+package fwprovider_test
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/hashicorp/terraform-provider-google/google/fwprovider"
+
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func TestFrameworkProvider_CredentialsValidator(t *testing.T) {
+	cases := map[string]struct {
+		ConfigValue          func(t *testing.T) types.String
+		ExpectedWarningCount int
+		ExpectedErrorCount   int
+	}{
+		"configuring credentials as a path to a credentials JSON file is valid": {
+			ConfigValue: func(t *testing.T) types.String {
+				return types.StringValue(transport_tpg.TestFakeCredentialsPath) // Path to a test fixture
+			},
+		},
+		"configuring credentials as a path to a non-existant file is NOT valid": {
+			ConfigValue: func(t *testing.T) types.String {
+				return types.StringValue("./this/path/doesnt/exist.json") // Doesn't exist
+			},
+			ExpectedErrorCount: 1,
+		},
+		"configuring credentials as a credentials JSON string is valid": {
+			ConfigValue: func(t *testing.T) types.String {
+				contents, err := ioutil.ReadFile(transport_tpg.TestFakeCredentialsPath)
+				if err != nil {
+					t.Fatalf("Unexpected error: %s", err)
+				}
+				stringContents := string(contents)
+				return types.StringValue(stringContents)
+			},
+		},
+		"configuring credentials as an empty string is not valid": {
+			ConfigValue: func(t *testing.T) types.String {
+				return types.StringValue("")
+			},
+			ExpectedErrorCount: 1,
+		},
+		"leaving credentials unconfigured is valid": {
+			ConfigValue: func(t *testing.T) types.String {
+				return types.StringNull()
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			// Arrange
+			req := validator.StringRequest{
+				ConfigValue: tc.ConfigValue(t),
+			}
+
+			resp := validator.StringResponse{
+				Diagnostics: diag.Diagnostics{},
+			}
+
+			cv := fwprovider.CredentialsValidator()
+
+			// Act
+			cv.ValidateString(context.Background(), req, &resp)
+
+			// Assert
+			if resp.Diagnostics.WarningsCount() > tc.ExpectedWarningCount {
+				t.Errorf("Expected %d warnings, got %d", tc.ExpectedWarningCount, resp.Diagnostics.WarningsCount())
+			}
+			if resp.Diagnostics.ErrorsCount() > tc.ExpectedErrorCount {
+				t.Errorf("Expected %d errors, got %d", tc.ExpectedErrorCount, resp.Diagnostics.ErrorsCount())
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

As part of splitting up and re-doing https://github.com/GoogleCloudPlatform/magic-modules/pull/11563, this PR makes an explicit file for validator tests and puts tests into the `fwprovider_test` package.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
