### PR TITLE
Add tags field to Alloydb Cluster for TagsR2401

### DIFF
--- a/mmv1/products/alloydb/Cluster.yaml
+++ b/mmv1/products/alloydb/Cluster.yaml
@@ -584,3 +584,12 @@ properties:
         type: String
         description: |
           Grace end time of the trial cluster.
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+      The field is ignored (both PUT & PATCH) when empty.
+    immutable: true
+    ignore_read: true

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_test.go
@@ -3,9 +3,11 @@ package alloydb_test
 import (
 	"regexp"
 	"testing"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestAccAlloydbCluster_update(t *testing.T) {
@@ -1568,4 +1570,54 @@ func TestAccAlloydbCluster_standardClusterUpdateFailure(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccAlloydbCluster_tags(t *testing.T) {
+	t.Parallel()
+        
+        org := envvar.GetTestOrgFromEnv(t)
+        tagKey := acctest.BootstrapSharedTestTagKey(t, "alloydb-clusters-tagkey-new")
+	tagValue := acctest.BootstrapSharedTestTagValue(t, "alloydb-clusters-tagvalue-new", tagKey)
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckAlloydbClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlloydbClusterTags(context, map[string]string{org + "/" + tagKey: tagValue}),
+			},
+			{
+				ResourceName:            "google_alloydb_cluster.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"initial_user", "cluster_id", "location", "tags"},
+			},
+		},
+	})
+}
+
+func testAccAlloydbClusterTags(context map[string]interface{}, tags map[string]string) string {
+
+	r := acctest.Nprintf(`
+
+data "google_project" "project" {}
+
+
+resource "google_alloydb_cluster" "default" {
+  cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
+  location   = "us-central1"
+            
+	tags = {`, context)
+
+	l := ""
+	for key, value := range tags {
+		l += fmt.Sprintf("%q = %q\n", key, value)
+	}
+
+	l += fmt.Sprintf("}\n}")
+	return r + l
 }


### PR DESCRIPTION
Add tags field to cluster resource to allow setting tags on cluster resources at creation time.
b/365030846

Release Note Template for Downstream PRs (will be copied)
```
alloydb: added `tags` field to `alloydb_cluster` to allow setting tags for clusters at creation time
