### PR TITLE
Dataproc - `kerberosConfig` is optional, not required.

### DIFF
--- a/mmv1/third_party/terraform/services/dataproc/export_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataproc/export_test.go.erb
@@ -1,0 +1,8 @@
+<% autogen_exception -%>
+package dataproc
+
+// This file is used to export private functions purely for the unit tests, which are in a
+// different package (dataproc vs dataproc_test).
+
+var FlattenSecurityConfig = flattenSecurityConfig
+

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
@@ -1243,7 +1243,7 @@ func ResourceDataprocCluster() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"kerberos_config": {
 										Type:        schema.TypeList,
-										Required:    true,
+										Optional:    true,
 										Description: "Kerberos related configuration",
 										MaxItems:    1,
 										Elem: &schema.Resource{
@@ -2883,8 +2883,10 @@ func flattenSecurityConfig(d *schema.ResourceData, sc *dataproc.SecurityConfig) 
 	if sc == nil {
 		return nil
 	}
-	data := map[string]interface{}{
-		"kerberos_config": flattenKerberosConfig(d, sc.KerberosConfig),
+	data := map[string]interface{}{}
+
+	if kfg := sc.KerberosConfig; kfg != nil {
+		data["kerberos_config"] = flattenKerberosConfig(d, kfg)
 	}
 
 	return []map[string]interface{}{data}

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
@@ -11,11 +11,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	dataproctf "github.com/hashicorp/terraform-provider-google/google/services/dataproc"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
@@ -982,6 +984,62 @@ func TestAccDataprocCluster_KMS(t *testing.T) {
 	})
 }
 
+func TestFlattenSecurityConfig(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct{
+		sc *dataproc.SecurityConfig
+		expected []map[string]interface{}
+	} {
+		"nil": {
+			sc: nil,
+			expected: nil,
+		},
+		"empty": {
+			sc: &dataproc.SecurityConfig{},
+			expected: []map[string]interface{}{
+				map[string]interface{}{},
+			},
+		},
+		"with kerberos": {
+			sc: &dataproc.SecurityConfig{
+				KerberosConfig: &dataproc.KerberosConfig{},
+			},
+			expected: []map[string]interface{}{
+				map[string]interface{}{
+					"kerberos_config": []map[string]interface{}{
+						map[string]interface{}{
+							"cross_realm_trust_admin_server": "",
+ 							"cross_realm_trust_kdc": "",
+ 							"cross_realm_trust_realm": "",
+ 							"cross_realm_trust_shared_password_uri": "",
+ 							"enable_kerberos": false,
+							"kdc_db_key_uri": "",
+ 							"key_password_uri": "",
+ 							"keystore_password_uri": "",
+ 							"keystore_uri": "",
+ 							"kms_key_uri": "",
+ 							"realm": "",
+ 							"root_principal_password_uri": "",
+ 							"tgt_lifetime_hours": int64(0),
+							"truststore_password_uri": "",
+ 							"truststore_uri": "",
+						},
+					},
+				},
+			},
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			actual := dataproctf.FlattenSecurityConfig(nil, tc.sc)
+			if diff := cmp.Diff(tc.expected, actual); diff != "" {
+				t.Errorf("Unexpected flattened security config. Diff (-want +got): %s", diff)
+			}
+		})
+	}
+}
+
 func TestAccDataprocCluster_withKerberos(t *testing.T) {
 	t.Parallel()
 
@@ -999,6 +1057,31 @@ func TestAccDataprocCluster_withKerberos(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataprocCluster_withKerberos(rnd, kms.CryptoKey.Name, subnetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.kerb", &cluster),
+				),
+			},
+		},
+	})
+}
+
+
+func TestAccDataprocCluster_withSecurityConfig_withoutKerberosConfig(t *testing.T) {
+	t.Parallel()
+
+	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
+	var cluster dataproc.Cluster
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataprocCluster_withSecurityConfig_withoutKerberosConfig(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.kerb", &cluster),
 				),
@@ -2394,6 +2477,33 @@ resource "google_dataproc_cluster" "kms" {
   }
 }
 `, rnd, subnetworkName, kmsKey)
+}
+
+func testAccDataprocCluster_withSecurityConfig_withoutKerberosConfig(rnd, subnetworkName string) string {
+	return fmt.Sprintf(`
+resource "google_storage_bucket" "bucket" {
+  name     = "tf-test-dproc-%s"
+  location = "US"
+}
+resource "google_storage_bucket_object" "password" {
+  name = "dataproc-password-%s"
+  bucket = google_storage_bucket.bucket.name
+  content = "hunter2"
+}
+
+resource "google_dataproc_cluster" "nokerb" {
+  name   = "tf-test-dproc-%s"
+  region = "us-central1"
+
+  cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+
+    security_config {}
+  }
+}
+`, rnd, rnd, rnd, subnetworkName)
 }
 
 func testAccDataprocCluster_withKerberos(rnd, kmsKey, subnetworkName string) string {

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.erb
@@ -1083,7 +1083,7 @@ func TestAccDataprocCluster_withSecurityConfig_withoutKerberosConfig(t *testing.
 			{
 				Config: testAccDataprocCluster_withSecurityConfig_withoutKerberosConfig(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.kerb", &cluster),
+					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.nokerb", &cluster),
 				),
 			},
 		},

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -709,7 +709,7 @@ cluster_config {
 }
 ```
 
-* `kerberos_config` (Required) Kerberos Configuration
+* `kerberos_config` (Optional) Kerberos Configuration
 
     * `cross_realm_trust_admin_server` - (Optional) The admin server (IP or hostname) for the
        remote trusted realm in a cross realm trust relationship.


### PR DESCRIPTION
`kerberosConfig` is optional, not required.

Add a test for the private `flattenSecurityConfig` function to ensure a missing `kerberosConfig` does not lead to a nil-pointer error. Because the test is in a different package, create `export_test.go`, which exports private functions from the main `dataproc` package to any tests within the folder.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
dataproc: `KerberosConfig` is optional within the `SecurityConfig` message.
```
