### PR TITLE
Bootstrap storage pool in tests

### DIFF
--- a/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
+++ b/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
@@ -1113,7 +1113,7 @@ func BootstrapComputeStoragePool(t *testing.T, storagePoolName, storagePoolType 
 	projectID := envvar.GetTestProjectFromEnv()
 	zone := envvar.GetTestZoneFromEnv()
 
-	storagePoolName = SharedStoragePoolPrefix + storagePoolName
+	storagePoolName = SharedStoragePoolPrefix + storagePoolType + "-" + storagePoolName
 
 	config := BootstrapConfig(t)
 	if config == nil {

--- a/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
+++ b/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
@@ -1107,6 +1107,78 @@ func BootstrapFirewallForDataprocSharedNetwork(t *testing.T, firewallName string
 	return firewall.Name
 }
 
+const SharedStoragePoolPrefix = "tf-bootstrap-storage-pool-"
+
+func BootstrapComputeStoragePool(t *testing.T, storagePoolName, storagePoolType string) string {
+	projectID := envvar.GetTestProjectFromEnv()
+	zone := envvar.GetTestZoneFromEnv()
+
+	storagePoolName = SharedStoragePoolPrefix + storagePoolName
+
+	config := BootstrapConfig(t)
+	if config == nil {
+		t.Fatal("Could not bootstrap config.")
+	}
+
+	computeService := config.NewComputeClient(config.UserAgent)
+	if computeService == nil {
+		t.Fatal("Could not create compute client.")
+	}
+
+	_, err := computeService.StoragePools.Get(projectID, zone, storagePoolName).Do()
+	if err != nil && transport_tpg.IsGoogleApiErrorWithCode(err, 404) {
+		log.Printf("[DEBUG] Storage pool %q not found, bootstrapping", storagePoolName)
+
+		url := fmt.Sprintf("%sprojects/%s/zones/%s/storagePools", config.ComputeBasePath, projectID, zone)
+		storagePoolTypeUrl := fmt.Sprintf("/projects/%s/zones/%s/storagePoolTypes/%s", projectID, zone, storagePoolType)
+
+		storagePoolObj := map[string]interface{}{
+			"name":                      storagePoolName,
+			"poolProvisionedCapacityGb": 10240,
+			"poolProvisionedThroughput": 180,
+			"storagePoolType":           storagePoolTypeUrl,
+			"capacityProvisioningType":  "ADVANCED",
+		}
+
+		if storagePoolType == "hyperdisk-balanced" {
+			storagePoolObj["poolProvisionedIops"] = 10000
+			storagePoolObj["poolProvisionedThroughput"] = 1024
+		}
+
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   projectID,
+			RawURL:    url,
+			UserAgent: config.UserAgent,
+			Body:      storagePoolObj,
+			Timeout:   20 * time.Minute,
+		})
+
+		log.Printf("Response is, %s", res)
+		if err != nil {
+			t.Fatalf("Error bootstrapping storage pool %s: %s", storagePoolName, err)
+		}
+
+		log.Printf("[DEBUG] Waiting for storage pool creation to finish")
+		err = tpgcompute.ComputeOperationWaitTime(config, res, projectID, "Error bootstrapping storage pool", config.UserAgent, 4*time.Minute)
+		if err != nil {
+			t.Fatalf("Error bootstrapping test storage pool %s: %s", storagePoolName, err)
+		}
+	}
+
+	storagePool, err := computeService.StoragePools.Get(projectID, zone, storagePoolName).Do()
+
+	if storagePool == nil {
+		t.Fatalf("Error getting storage pool %s: is nil", storagePoolName)
+	}
+
+	if err != nil {
+		t.Fatalf("Error getting storage pool %s: %s", storagePoolName, err)
+	}
+	return storagePool.SelfLink
+}
+
 func SetupProjectsAndGetAccessToken(org, billing, pid, service string, config *transport_tpg.Config) (string, error) {
 	// Create project-1 and project-2
 	rmService := config.NewResourceManagerClient(config.UserAgent)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.erb
@@ -1614,7 +1614,7 @@ resource "google_compute_disk" "foobar" {
 func TestAccComputeDisk_storagePoolSpecified(t *testing.T) {
 	t.Parallel()
 
-	storagePoolNameLong := acctest.BootstrapComputeStoragePool(t, "hyperdisk-throughput", "hyperdisk-throughput")
+	storagePoolNameLong := acctest.BootstrapComputeStoragePool(t, "basic-1", "hyperdisk-throughput")
 	diskName := fmt.Sprintf("tf-test-disk-%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.erb
@@ -3,17 +3,14 @@ package compute_test
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
-	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 <% if version == "ga" -%>
 	"google.golang.org/api/compute/v1"

--- a/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.erb
@@ -1617,7 +1617,7 @@ resource "google_compute_disk" "foobar" {
 func TestAccComputeDisk_storagePoolSpecified(t *testing.T) {
 	t.Parallel()
 
-	storagePoolNameLong := acctest.BootstrapComputeStoragePool(t, "disk", "hyperdisk-throughput")
+	storagePoolNameLong := acctest.BootstrapComputeStoragePool(t, "hyperdisk-throughput", "hyperdisk-throughput")
 	diskName := fmt.Sprintf("tf-test-disk-%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -1634,72 +1634,6 @@ func TestAccComputeDisk_storagePoolSpecified(t *testing.T) {
 			},
 		},
 	})
-}
-
-func setupTestingStoragePool(t *testing.T, storagePoolName string) func() {
-	return func() {
-		config := acctest.GoogleProviderConfig(t)
-		headers := make(http.Header)
-		project := envvar.GetTestProjectFromEnv()
-		zone := envvar.GetTestZoneFromEnv()
-		url := fmt.Sprintf("%sprojects/%s/zones/%s/storagePools", config.ComputeBasePath, project, zone)
-		storagePoolTypeUrl := fmt.Sprintf("/projects/%s/zones/%s/storagePoolTypes/hyperdisk-throughput", project, zone)
-		defaultTimeout := 20 * time.Minute
-		obj := make(map[string]interface{})
-		obj["name"] = storagePoolName
-		obj["poolProvisionedCapacityGb"] = 10240
-		obj["poolProvisionedThroughput"] = 180
-		obj["storagePoolType"] = storagePoolTypeUrl
-		obj["capacityProvisioningType"] = "ADVANCED"
-
-		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-			Config:    config,
-			Method:    "POST",
-			Project:   project,
-			RawURL:    url,
-			UserAgent: config.UserAgent,
-			Body:      obj,
-			Timeout:   defaultTimeout,
-			Headers:   headers,
-		})
-		if err != nil {
-			t.Errorf("Error creating StoragePool: %s", err)
-		}
-
-		err = tpgcompute.ComputeOperationWaitTime(config, res, project, "Creating StoragePool", config.UserAgent, defaultTimeout)
-		if err != nil {
-			t.Errorf("Error waiting to create StoragePool: %s", err)
-		}
-	}
-}
-
-func cleanupTestingStoragePool(t *testing.T, storagePoolName string) {
-	config := acctest.GoogleProviderConfig(t)
-	headers := make(http.Header)
-	project := envvar.GetTestProjectFromEnv()
-	zone := envvar.GetTestZoneFromEnv()
-	url := fmt.Sprintf("%sprojects/%s/zones/%s/storagePools/%s", config.ComputeBasePath, project, zone, storagePoolName)
-	defaultTimeout := 20 * time.Minute
-	var obj map[string]interface{}
-
-	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-		Config:    config,
-		Method:    "DELETE",
-		Project:   project,
-		RawURL:    url,
-		UserAgent: config.UserAgent,
-		Body:      obj,
-		Timeout:   defaultTimeout,
-		Headers:   headers,
-	})
-	if err != nil {
-		t.Errorf("Error deleting StoragePool: %s", err)
-	}
-
-	err = tpgcompute.ComputeOperationWaitTime(config, res, project, "Deleting StoragePool", config.UserAgent, defaultTimeout)
-	if err != nil {
-		t.Errorf("Error waiting to delete StoragePool: %s", err)
-	}
 }
 
 func testAccComputeDisk_storagePoolSpecified(diskName, storagePoolUrl string) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.erb
@@ -1615,12 +1615,9 @@ resource "google_compute_disk" "foobar" {
 }
 
 func TestAccComputeDisk_storagePoolSpecified(t *testing.T) {
-	// Currently failing
-	acctest.SkipIfVcr(t)
 	t.Parallel()
 
-	storagePoolName := fmt.Sprintf("tf-test-storage-pool-%s", acctest.RandString(t, 10))
-	storagePoolUrl := fmt.Sprintf("/projects/%s/zones/%s/storagePools/%s", envvar.GetTestProjectFromEnv(), envvar.GetTestZoneFromEnv(), storagePoolName)
+	storagePoolNameLong := acctest.BootstrapComputeStoragePool(t, "disk", "hyperdisk-throughput")
 	diskName := fmt.Sprintf("tf-test-disk-%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -1628,11 +1625,7 @@ func TestAccComputeDisk_storagePoolSpecified(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				PreConfig: setupTestingStoragePool(t, storagePoolName),
-				Config:    testAccComputeDisk_storagePoolSpecified(diskName, storagePoolUrl),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("google_compute_disk.foobar", "storage_pool", storagePoolName),
-				),
+				Config: testAccComputeDisk_storagePoolSpecified(diskName, storagePoolNameLong),
 			},
 			{
 				ResourceName:      "google_compute_disk.foobar",
@@ -1641,8 +1634,6 @@ func TestAccComputeDisk_storagePoolSpecified(t *testing.T) {
 			},
 		},
 	})
-
-	cleanupTestingStoragePool(t, storagePoolName)
 }
 
 func setupTestingStoragePool(t *testing.T, storagePoolName string) func() {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -10206,7 +10206,7 @@ func TestAccComputeInstance_bootDisk_storagePoolSpecified(t *testing.T) {
 	t.Parallel()
 
 	instanceName := fmt.Sprintf("tf-test-instance-%s", acctest.RandString(t, 10))
-	storagePoolNameLong := acctest.BootstrapComputeStoragePool(t, "disk", "hyperdisk-throughput")
+	storagePoolNameLong := acctest.BootstrapComputeStoragePool(t, "hyperdisk-balanced", "hyperdisk-balanced")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -10222,44 +10222,6 @@ func TestAccComputeInstance_bootDisk_storagePoolSpecified(t *testing.T) {
 			},
 		},
 	})
-}
-
-func setupTestingStoragePool_HyperdiskBalanced(t *testing.T, storagePoolName string) func() {
-	return func() {
-		config := acctest.GoogleProviderConfig(t)
-		headers := make(http.Header)
-		project := envvar.GetTestProjectFromEnv()
-		zone := envvar.GetTestZoneFromEnv()
-		url := fmt.Sprintf("%sprojects/%s/zones/%s/storagePools", config.ComputeBasePath, project, zone)
-		storagePoolTypeUrl := fmt.Sprintf("/projects/%s/zones/%s/storagePoolTypes/hyperdisk-balanced", project, zone)
-		defaultTimeout := 20 * time.Minute
-		obj := make(map[string]interface{})
-		obj["name"] = storagePoolName
-		obj["poolProvisionedCapacityGb"] = 10240
-		obj["poolProvisionedIops"] = 10000
-		obj["poolProvisionedThroughput"] = 1024
-		obj["storagePoolType"] = storagePoolTypeUrl
-		obj["capacityProvisioningType"] = "ADVANCED"
-
-		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-			Config:    config,
-			Method:    "POST",
-			Project:   project,
-			RawURL:    url,
-			UserAgent: config.UserAgent,
-			Body:      obj,
-			Timeout:   defaultTimeout,
-			Headers:   headers,
-		})
-		if err != nil {
-			t.Errorf("Error creating StoragePool: %s", err)
-		}
-
-		err = tpgcompute.ComputeOperationWaitTime(config, res, project, "Creating StoragePool", config.UserAgent, defaultTimeout)
-		if err != nil {
-			t.Errorf("Error waiting to create StoragePool: %s", err)
-		}
-	}
 }
 
 func testAccComputeInstance_bootDisk_storagePoolSpecified(instanceName, storagePoolUrl, zone string) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -9,7 +9,6 @@ import (
 	<% unless version == 'ga' -%>
 	"google.golang.org/api/googleapi"
 	<% end -%>
-	"net/http"
 	"reflect"
 	"regexp"
 	"sort"
@@ -25,7 +24,6 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
-	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 
 <% if version == "ga" -%>

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -10204,7 +10204,7 @@ func TestAccComputeInstance_bootDisk_storagePoolSpecified(t *testing.T) {
 	t.Parallel()
 
 	instanceName := fmt.Sprintf("tf-test-instance-%s", acctest.RandString(t, 10))
-	storagePoolNameLong := acctest.BootstrapComputeStoragePool(t, "hyperdisk-balanced", "hyperdisk-balanced")
+	storagePoolNameLong := acctest.BootstrapComputeStoragePool(t, "basic-1", "hyperdisk-balanced")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -10203,24 +10203,17 @@ resource "google_compute_instance" "foobar" {
 }
 
 func TestAccComputeInstance_bootDisk_storagePoolSpecified(t *testing.T) {
-	// Currently failing
-	acctest.SkipIfVcr(t)
 	t.Parallel()
 
 	instanceName := fmt.Sprintf("tf-test-instance-%s", acctest.RandString(t, 10))
-	storagePoolName := fmt.Sprintf("tf-test-storage-pool-%s", acctest.RandString(t, 10))
-	storagePoolUrl := fmt.Sprintf("/projects/%s/zones/%s/storagePools/%s", envvar.GetTestProjectFromEnv(), envvar.GetTestZoneFromEnv(), storagePoolName)
+	storagePoolNameLong := acctest.BootstrapComputeStoragePool(t, "disk", "hyperdisk-throughput")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				PreConfig: setupTestingStoragePool_HyperdiskBalanced(t, storagePoolName),
-				Config:    testAccComputeInstance_bootDisk_storagePoolSpecified(instanceName, storagePoolUrl, envvar.GetTestZoneFromEnv()),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("google_compute_instance.foobar", "boot_disk.0.initialize_params.0.storage_pool", storagePoolName),
-				),
+				Config:    testAccComputeInstance_bootDisk_storagePoolSpecified(instanceName, storagePoolNameLong, envvar.GetTestZoneFromEnv()),
 			},
 			{
 				ResourceName:      "google_compute_instance.foobar",
@@ -10229,8 +10222,6 @@ func TestAccComputeInstance_bootDisk_storagePoolSpecified(t *testing.T) {
 			},
 		},
 	})
-
-	cleanupTestingStoragePool(t, storagePoolName)
 }
 
 func setupTestingStoragePool_HyperdiskBalanced(t *testing.T, storagePoolName string) func() {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Given the [limitations of storage pools per project](https://cloud.google.com/compute/docs/disks/storage-pools#sp_limitations), we'll need to bootstrap the storage pool resource in our testing project so it can be shared and reused across multiple tests to avoid hitting the quota limit.

This should help https://github.com/hashicorp/terraform-provider-google/issues/19199 and https://github.com/GoogleCloudPlatform/magic-modules/pull/11391

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
