### PR TITLE
Adds support for Filestore instance new feature: deletion protection.

### DIFF
--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -265,3 +265,11 @@ properties:
     immutable: true
     description: |
       KMS key name used for data encryption.
+  - !ruby/object:Api::Type::Boolean
+    name: 'deletionProtectionEnabled'
+    description: |
+      Indicates whether the instance is protected against deletion.
+  - !ruby/object:Api::Type::String
+    name: 'deletionProtectionReason'
+    description: |
+      The reason for enabling deletion protection.

--- a/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
+++ b/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
@@ -212,10 +212,16 @@ func TestAccFilestoreInstance_deletionProtection_update(t *testing.T) {
 				ResourceName:            "google_filestore_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"zone", "location"},
+				ImportStateVerifyIgnore: []string{"zone"},
 			},
 			{
 				Config: testAccFilestoreInstance_deletionProtection_update(name, location, tier, deletionProtection),
+			},
+			{
+				ResourceName:            "google_filestore_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"zone"},
 			},
 			{
 				Config: testAccFilestoreInstance_deletionProtection_update(name, location, tier, !deletionProtection),
@@ -224,7 +230,7 @@ func TestAccFilestoreInstance_deletionProtection_update(t *testing.T) {
 				ResourceName:            "google_filestore_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"zone", "location"},
+				ImportStateVerifyIgnore: []string{"zone"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
+++ b/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
@@ -190,3 +190,92 @@ resource "google_filestore_instance" "instance" {
 }
 `, name)
 }
+
+func TestAccFilestoreInstance_deletionProtection_update(t *testing.T) {
+	t.Parallel()
+
+	name := fmt.Sprintf("tf-instance-test-%d", acctest.RandInt(t))
+	location := "us-central1-a"
+	tier := "ZONAL"
+
+	deletionProtection := true
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckFilestoreInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFilestoreInstance_deletionProtection_create(name, location, tier),
+			},
+			{
+				ResourceName:            "google_filestore_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"zone", "location"},
+			},
+			{
+				Config: testAccFilestoreInstance_deletionProtection_update(name, location, tier, deletionProtection),
+			},
+			{
+				Config: testAccFilestoreInstance_deletionProtection_update(name, location, tier, !deletionProtection),
+			},
+			{
+				ResourceName:            "google_filestore_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"zone", "location"},
+			},
+		},
+	})
+}
+
+func testAccFilestoreInstance_deletionProtection_create(name, location, tier string) string {
+	return fmt.Sprintf(`
+resource "google_filestore_instance" "instance" {
+  name        = "%s"
+  zone        = "%s"
+  tier        = "%s"
+  description = "An instance created during testing."
+
+  file_shares {
+    capacity_gb = 1024
+    name        = "share"
+  }
+
+  networks {
+    network = "default"
+		modes   = ["MODE_IPV4"]
+  }
+}
+`, name, location, tier)
+}
+
+func testAccFilestoreInstance_deletionProtection_update(name, location, tier string, deletionProtection bool) string {
+	deletionProtectionReason := ""
+	if deletionProtection {
+		deletionProtectionReason = "A reason for deletion protection"
+	}
+
+	return fmt.Sprintf(`
+resource "google_filestore_instance" "instance" {
+  name        = "%s"
+  zone        = "%s"
+  tier        = "%s"
+  description = "An instance created during testing."
+
+  file_shares {
+    capacity_gb = 1024
+    name        = "share"
+  }
+
+  networks {
+    network = "default"
+		modes   = ["MODE_IPV4"]
+  }
+
+	deletion_protection_enabled = %t
+	deletion_protection_reason = "%s"
+}
+`, name, location, tier, deletionProtection, deletionProtectionReason)
+}

--- a/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
+++ b/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
@@ -194,7 +194,7 @@ resource "google_filestore_instance" "instance" {
 func TestAccFilestoreInstance_deletionProtection_update(t *testing.T) {
 	t.Parallel()
 
-	name := fmt.Sprintf("tf-instance-test-%d", acctest.RandInt(t))
+	name := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
 	location := "us-central1-a"
 	tier := "ZONAL"
 


### PR DESCRIPTION
Users will be able to enable **deletion protection** on their new or existing Filestore instances by providing an instance's `deletion_protection_enabled` boolean field and optionally also `deletion_protection_reason` string field specifying the reason for enabling the protection.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/19336

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
filestore: added `deletion_protection_enabled` and `deletion_protection_reason` fields to `google_filestore_instance`
```
