### PR TITLE
`google_network_connectivity_spoke`: add `include_export_ranges`

### DIFF
--- a/mmv1/products/networkconnectivity/Spoke.yaml
+++ b/mmv1/products/networkconnectivity/Spoke.yaml
@@ -194,6 +194,12 @@ properties:
         min_version: ga
         immutable: true
         item_type: Api::Type::String
+      - !ruby/object:Api::Type::Array
+        name: includeExportRanges
+        description: IP ranges allowed to be included from peering.
+        min_version: ga
+        immutable: true
+        item_type: Api::Type::String
   - !ruby/object:Api::Type::String
     name: uniqueId
     description: Output only. The Google-generated UUID for the spoke. This value is unique across all spoke resources. If a spoke is deleted and another with the same name is created, the new spoke is assigned a different unique_id.

--- a/mmv1/products/networkconnectivity/go_Spoke.yaml
+++ b/mmv1/products/networkconnectivity/go_Spoke.yaml
@@ -189,6 +189,12 @@ properties:
         immutable: true
         item_type:
           type: String
+      - name: 'includeExportRanges'
+        type: Array
+        description: IP ranges allowed to be included from peering.
+        immutable: true
+        item_type:
+          type: String
   - name: 'uniqueId'
     type: String
     description: Output only. The Google-generated UUID for the spoke. This value is unique across all spoke resources. If a spoke is deleted and another with the same name is created, the new spoke is assigned a different unique_id.

--- a/mmv1/templates/terraform/examples/go/network_connectivity_spoke_linked_vpc_network_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/network_connectivity_spoke_linked_vpc_network_basic.tf.tmpl
@@ -24,6 +24,10 @@ resource "google_network_connectivity_spoke" "{{$.PrimaryResourceId}}"  {
       "198.51.100.0/24",
       "10.10.0.0/16"
     ]
+    include_export_ranges = [
+      "198.51.100.0/23", 
+      "10.0.0.0/8"
+    ]
     uri = google_compute_network.network.self_link
   }
 }

--- a/mmv1/templates/terraform/examples/network_connectivity_spoke_linked_vpc_network_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/network_connectivity_spoke_linked_vpc_network_basic.tf.erb
@@ -24,6 +24,10 @@ resource "google_network_connectivity_spoke" "<%= ctx[:primary_resource_id] %>" 
       "198.51.100.0/24",
       "10.10.0.0/16"
     ]
+    include_export_ranges = [
+      "198.51.100.0/23", 
+      "10.0.0.0/8"
+    ]
     uri = google_compute_network.network.self_link
   }
 }

--- a/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_spoke_test.go
+++ b/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_spoke_test.go
@@ -180,6 +180,10 @@ resource "google_network_connectivity_spoke" "primary" {
       "198.51.100.0/24",
       "10.10.0.0/16"
     ]
+    include_export_ranges = [
+      "198.51.100.0/23", 
+      "10.0.0.0/8"
+    ]
     uri = google_compute_network.network.self_link
   }
 }
@@ -214,6 +218,10 @@ resource "google_network_connectivity_spoke" "primary" {
     exclude_export_ranges = [
       "198.51.100.0/24",
       "10.10.0.0/16"
+    ]
+    include_export_ranges = [
+      "198.51.100.0/23", 
+      "10.0.0.0/8"
     ]
     uri = google_compute_network.network.self_link
   }
@@ -375,6 +383,10 @@ resource "google_network_connectivity_spoke" "primary" {
       "198.51.100.0/24",
       "10.10.0.0/16"
     ]
+    include_export_ranges = [
+      "198.51.100.0/23", 
+      "10.0.0.0/8"
+    ]
     uri = google_compute_network.network.self_link
   }
 }
@@ -409,6 +421,10 @@ resource "google_network_connectivity_spoke" "primary" {
     exclude_export_ranges = [
       "198.51.100.0/24",
       "10.10.0.0/16"
+    ]
+    include_export_ranges = [
+      "198.51.100.0/23", 
+      "10.0.0.0/8"
     ]
     uri = google_compute_network.network.self_link
   }

--- a/tpgtools/overrides/networkconnectivity/samples/spoke/linked_vpc_network.tf.tmpl
+++ b/tpgtools/overrides/networkconnectivity/samples/spoke/linked_vpc_network.tf.tmpl
@@ -25,6 +25,10 @@ resource "google_network_connectivity_spoke" "primary" {
       "198.51.100.0/24",
       "10.10.0.0/16"
     ]
+    include_export_ranges = [
+      "198.51.100.0/23", 
+      "10.0.0.0/8"
+    ]
     uri = google_compute_network.network.self_link
   }
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR adds the field `includeExportRanges` for VPC Spokes in NCC. It was somehow missing in our terraform provider.

https://cloud.google.com/network-connectivity/docs/reference/networkconnectivity/rest/Shared.Types/Spoke#LinkedVpcNetwork

Tests for networkconnectivity were already successfully executed locally 

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
networkconnectivity: added `include_export_ranges` to `google_network_connectivity_spoke`
```
