### PR TITLE
FixDoc google_vpc_access_connector [max,min]_throughput

### DIFF
--- a/mmv1/products/vpcaccess/Connector.yaml
+++ b/mmv1/products/vpcaccess/Connector.yaml
@@ -113,8 +113,8 @@ properties:
     name: minThroughput
     description: |
       Minimum throughput of the connector in Mbps. Default and min is 200. Refers to the expected throughput when using an e2-micro machine type.
-      Value must be a multiple of 100 from 200 through 900. Must be lower than the value specified by max_throughput. If both min_throughput and
-      min_instances are provided, min_instances takes precedence over min_throughput. The use of min_throughput is discouraged in favor of min_instances.
+      Value must be a multiple of 100 from 200 through 900. Must be lower than the value specified by max_throughput.
+      Only one of `min_throughput` and `min_instances` can be specified. The use of min_throughput is discouraged in favor of min_instances.
     validation: !ruby/object:Provider::Terraform::Validation
       function: 'validation.IntBetween(200, 1000)'
     default_from_api: true
@@ -141,8 +141,7 @@ properties:
     description: |
       Maximum throughput of the connector in Mbps, must be greater than `min_throughput`. Default is 300. Refers to the expected throughput
       when using an e2-micro machine type. Value must be a multiple of 100 from 300 through 1000. Must be higher than the value specified by
-      min_throughput. If both max_throughput and max_instances are provided, max_instances takes precedence over max_throughput. The use of
-      max_throughput is discouraged in favor of max_instances.
+      min_throughput. Only one of `max_throughput` and `max_instances` can be specified. The use of max_throughput is discouraged in favor of max_instances.
     validation: !ruby/object:Provider::Terraform::Validation
       function: 'validation.IntBetween(200, 1000)'
     default_from_api: true


### PR DESCRIPTION
A change was made to check for duplicates for the following four items, but the documentation was not modified.
https://github.com/hashicorp/terraform-provider-google/commit/a2176b1bf08b4dca9c744a798c458efcb2d64903#diff-c3b7f8261da0f41a69f379fbef4757ab26a958b8a247ecce16ce09612d69bd1d
- `google_vpc_access_connector.max_throughput`
- `google_vpc_access_connector.min_throughput`
- `google_vpc_access_connector.max_instances`
- `google_vpc_access_connector.min_instances`

This PR clarifies that the values ​​are mutually exclusive and that `throughput` is deprecated.

release-note:none