### PR TITLE
fix: Router advertised-route-priority undefined behavior

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.erb
@@ -420,7 +420,7 @@ func resourceComputeRouterBgpPeerCreate(d *schema.ResourceData, meta interface{}
 	advertisedRoutePriorityProp, err := expandNestedComputeRouterBgpPeerAdvertisedRoutePriority(d.Get("advertised_route_priority"), d, config)
 	if err != nil {
 		return err
-	} else if v, ok := d.GetOkExists("advertised_route_priority"); ok || !reflect.DeepEqual(v, advertisedRoutePriorityProp) {
+	} else if v, ok := d.GetOk("advertised_route_priority"); ok || !reflect.DeepEqual(v, advertisedRoutePriorityProp) {
 		obj["advertisedRoutePriority"] = advertisedRoutePriorityProp
 	}
 	advertiseModeProp, err := expandNestedComputeRouterBgpPeerAdvertiseMode(d.Get("advertise_mode"), d, config)
@@ -773,7 +773,7 @@ func resourceComputeRouterBgpPeerUpdate(d *schema.ResourceData, meta interface{}
 	advertisedRoutePriorityProp, err := expandNestedComputeRouterBgpPeerAdvertisedRoutePriority(d.Get("advertised_route_priority"), d, config)
 	if err != nil {
 		return err
-	} else if v, ok := d.GetOkExists("advertised_route_priority"); ok || !reflect.DeepEqual(v, advertisedRoutePriorityProp) {
+	} else if v, ok := d.GetOk("advertised_route_priority"); ok || !reflect.DeepEqual(v, advertisedRoutePriorityProp) {
 		obj["advertisedRoutePriority"] = advertisedRoutePriorityProp
 	}
 	advertiseModeProp, err := expandNestedComputeRouterBgpPeerAdvertiseMode(d.Get("advertise_mode"), d, config)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Bug: b/356353797
Issue: advertised-route-priority is an optional field and if not present, the value in the GCP is considered to be 100.
However, TF would set advertised-route-priority to be 0 even if the user has not explicitly set the value to be 0 when there is an update to the resource.

Repro steps:
1. Create a Router peer resource without advertised route priority value set.
resource "google_compute_router_peer" "foobar" {
  name                      = "tf-my-router"
  router                    = google_compute_router.foobar.name
  region                    = google_compute_router.foobar.region
  peer_asn                  = 65515
  interface                 = google_compute_router_interface.foobar.name
  advertise_mode            = "DEFAULT"
}

Query gcloud to check the value of advertised_route_priority, it will be empty
`gcloud compute routers describe {router-name}
`

2. Update the router peer resource (ex: enableIpv6 = true) without advertised route priority. However, TF would add advertised route priority = 0 in the update api call. 
resource "google_compute_router_peer" "foobar" {
  name                      = "tf-my-router"
  router                    = google_compute_router.foobar.name
  region                    = google_compute_router.foobar.region
  peer_asn                  = 65515
  interface                 = google_compute_router_interface.foobar.name
  advertise_mode            = "DEFAULT"
  enable_ipv6           = true
}

Query gcloud to check the value of advertised_route_priority, it will be 0 even though it is not set by the user.
`gcloud compute routers describe {router-name}
`

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed advertised_route_priority set to 0 without user update in 'google_compute_router_peer'
```
