### PR TITLE
Add availability_domain field to GCE instance scheduling

### DIFF
--- a/mmv1/third_party/cai2hcl/services/compute/compute_instance.go
+++ b/mmv1/third_party/cai2hcl/services/compute/compute_instance.go
@@ -211,7 +211,8 @@ func convertScheduling(sched *compute.Scheduling) []map[string]interface{} {
 		"preemptible":         sched.Preemptible,
 		"on_host_maintenance": sched.OnHostMaintenance,
 		// node_affinities are not converted into cai
-		"node_affinities": convertSchedulingNodeAffinity(sched.NodeAffinities),
+		"node_affinities":     convertSchedulingNodeAffinity(sched.NodeAffinities),
+		"availability_domain": sched.AvailabilityDomain,
 	}
 	if sched.MinNodeCpus > 0 {
 		data["min_node_cpus"] = sched.MinNodeCpus

--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.erb
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.erb
@@ -147,6 +147,9 @@ func expandScheduling(v interface{}) (*compute.Scheduling, error) {
 		scheduling.InstanceTerminationAction = v.(string)
 		scheduling.ForceSendFields = append(scheduling.ForceSendFields, "InstanceTerminationAction")
 	}
+	if v, ok := original["availability_domain"]; ok {
+		scheduling.AvailabilityDomain = int64(v.(int))
+	}
 	if v, ok := original["max_run_duration"]; ok {
 		transformedMaxRunDuration, err := expandComputeMaxRunDuration(v)
 		if err != nil {
@@ -272,6 +275,7 @@ func flattenScheduling(resp *compute.Scheduling) []map[string]interface{} {
 		"min_node_cpus":       resp.MinNodeCpus,
 		"provisioning_model":  resp.ProvisioningModel,
 		"instance_termination_action": resp.InstanceTerminationAction,
+		"availability_domain": resp.AvailabilityDomain,
 	}
 
 	if resp.AutomaticRestart != nil {
@@ -736,6 +740,10 @@ func schedulingHasChangeWithoutReboot(d *schema.ResourceData) bool {
 
 	if oScheduling["instance_termination_action"] != newScheduling["instance_termination_action"] {
 			return true
+	}
+	
+	if oScheduling["availability_domain"] != newScheduling["availability_domain"] {
+		return true
 	}
 
 	return false

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
@@ -84,6 +84,7 @@ var (
 		"scheduling.0.min_node_cpus",
 		"scheduling.0.provisioning_model",
 		"scheduling.0.instance_termination_action",
+		"scheduling.0.availability_domain",
 		"scheduling.0.max_run_duration",
 		"scheduling.0.on_instance_stop_action",
 <% unless version == 'ga' -%>
@@ -843,6 +844,13 @@ func ResourceComputeInstance() *schema.Resource {
 							Optional:      true,
 							AtLeastOneOf:  schedulingKeys,
 							Description:   `Specifies the action GCE should take when SPOT VM is preempted.`,
+						},
+						"availability_domain": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							AtLeastOneOf: schedulingKeys,
+							Description:  `Specifies the availability domain (AD), which this instance should be scheduled on.`,
+
 						},
 						"max_run_duration" : {
 							Type:        schema.TypeList,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -9321,6 +9321,48 @@ resource "google_compute_instance" "foobar" {
 `, suffix, suffix, suffix, suffix, suffix, suffix, policy, instance)
 }
 
+func testAccComputeInstance_setAvailabilityDomain(instance, suffix string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name           = "%s"
+  machine_type   = "c2-standard-4"
+  zone           = "us-east4-b"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+    availability_domain = 5
+  }
+
+  resource_policies = [google_compute_resource_policy.foo.self_link]
+}
+
+
+  resource "google_compute_resource_policy" "foo" {
+  name   = "tf-test-policy-%s"
+  region = "us-east4"
+  group_placement_policy {
+    availability_domain_count = 8
+  }
+}
+`, instance, instance, suffix)
+}
+
 func testAccComputeInstance_nic_securityPolicyCreateWithTwoAccessConfigsWithTwoSecurityPoliciesAndStatus(suffix, policy, instance, policyToSetOne, desiredStatus string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -486,6 +486,8 @@ specified, then this instance will have no external IPv6 Internet access. Struct
 
 * `instance_termination_action` - (Optional) Describe the type of termination action for VM. Can be `STOP` or `DELETE`.  Read more on [here](https://cloud.google.com/compute/docs/instances/create-use-spot)
 
+* `availability_domain` - (Optional) Specifies the availability domain (AD), which this instance should be scheduled on. The AD belongs to the spread placement policy that has been assigned to the instance. Specify a value from 1 to max count of availability domains in your spread placement policy.
+
 * `max_run_duration` -  (Optional) The duration of the instance. Instance will run and be terminated after then, the termination action could be defined in `instance_termination_action`. Structure is [documented below](#nested_max_run_duration).
 
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `availability_domain` field to `google_compute_instance` resource
```