### PR TITLE
[Composer] Reveal cloud_data_lineage_integration to GA.

### DIFF
--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.erb
@@ -56,8 +56,8 @@ var (
 		"config.0.software_config.0.image_version",
 		"config.0.software_config.0.python_version",
 		"config.0.software_config.0.scheduler_count",
-<% unless version == "ga" -%>
 		"config.0.software_config.0.cloud_data_lineage_integration",
+<% unless version == "ga" -%>
 		"config.0.software_config.0.web_server_plugins_mode",
 <% end -%>
 	}
@@ -497,7 +497,6 @@ func ResourceComposerEnvironment() *schema.Resource {
 										Computed:     true,
 										Description:  `The number of schedulers for Airflow. This field is supported for Cloud Composer environments in versions composer-1.*.*-airflow-2.*.*.`,
 									},
-<% unless version == "ga" -%>
 									"cloud_data_lineage_integration": {
 										Type:        	schema.TypeList,
 										Optional:    	true,
@@ -515,6 +514,7 @@ func ResourceComposerEnvironment() *schema.Resource {
 											},
 										},
 									},
+<% unless version == "ga" -%>
 									"web_server_plugins_mode": {
 										Type:         schema.TypeString,
 										Optional:     true,
@@ -1317,7 +1317,6 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 			}
 		}
 
-<% unless version == "ga" -%>
 		if d.HasChange("config.0.software_config.0.cloud_data_lineage_integration") {
 			patchObj := &composer.Environment{
 				Config: &composer.EnvironmentConfig{
@@ -1332,7 +1331,6 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 				return err
 			}
 		}
-<% end -%>
 
 		if d.HasChange("config.0.software_config.0.airflow_config_overrides") {
 			patchObj := &composer.Environment{
@@ -2001,8 +1999,8 @@ func flattenComposerEnvironmentConfigSoftwareConfig(softwareCfg *composer.Softwa
 	transformed["pypi_packages"] = softwareCfg.PypiPackages
 	transformed["env_variables"] = softwareCfg.EnvVariables
 	transformed["scheduler_count"] = softwareCfg.SchedulerCount
-<% unless version == "ga" -%>
 	transformed["cloud_data_lineage_integration"] = flattenComposerEnvironmentConfigSoftwareConfigCloudDataLineageIntegration(softwareCfg.CloudDataLineageIntegration)
+<% unless version == "ga" -%>
 	if softwareCfg.WebServerPluginsMode == "PLUGINS_DISABLED"{
 		transformed["web_server_plugins_mode"] = "DISABLED"
 	} else if softwareCfg.WebServerPluginsMode == "PLUGINS_ENABLED"{
@@ -2014,7 +2012,6 @@ func flattenComposerEnvironmentConfigSoftwareConfig(softwareCfg *composer.Softwa
 	return []interface{}{transformed}
 }
 
-<% unless version == "ga" -%>
 func flattenComposerEnvironmentConfigSoftwareConfigCloudDataLineageIntegration(cloudDataLineageIntegration *composer.CloudDataLineageIntegration) interface{} {
 	if cloudDataLineageIntegration == nil {
 		return nil
@@ -2025,7 +2022,6 @@ func flattenComposerEnvironmentConfigSoftwareConfigCloudDataLineageIntegration(c
 
 	return []interface{}{transformed}
 }
-<% end -%>
 
 func flattenComposerEnvironmentConfigMasterAuthorizedNetworksConfig(masterAuthNetsCfg *composer.MasterAuthorizedNetworksConfig) interface{} {
 	if masterAuthNetsCfg == nil {
@@ -2739,13 +2735,13 @@ func expandComposerEnvironmentConfigSoftwareConfig(v interface{}, d *schema.Reso
 	transformed.EnvVariables = expandComposerEnvironmentConfigSoftwareConfigStringMap(original, "env_variables")
 	transformed.SchedulerCount = int64(original["scheduler_count"].(int))
 
-<% unless version == "ga" -%>
 	transformedCloudDataLineageIntegration, err := expandComposerEnvironmentConfigSoftwareConfigCloudDataLineageIntegration(original["cloud_data_lineage_integration"], d, config)
 	if err != nil {
 		return nil, err
 	}
 	transformed.CloudDataLineageIntegration = transformedCloudDataLineageIntegration
 
+<% unless version == "ga" -%>
 	if original["web_server_plugins_mode"].(string) == "DISABLED"{
 		transformed.WebServerPluginsMode = "PLUGINS_DISABLED"
 	} else if original["web_server_plugins_mode"].(string) == "ENABLED"{
@@ -2766,7 +2762,6 @@ func expandComposerEnvironmentConfigSoftwareConfigStringMap(softwareConfig map[s
 	return map[string]string{}
 }
 
-<% unless version == "ga" -%>
 func expandComposerEnvironmentConfigSoftwareConfigCloudDataLineageIntegration(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) (*composer.CloudDataLineageIntegration, error) {
 	l := v.([]interface{})
 	if len(l) == 0 {
@@ -2780,7 +2775,6 @@ func expandComposerEnvironmentConfigSoftwareConfigCloudDataLineageIntegration(v 
 
 	return transformed, nil
 }
-<% end -%>
 
 func validateComposerEnvironmentPypiPackages(v interface{}, k string) (ws []string, errors []error) {
 	if v == nil {

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go.erb
@@ -2126,11 +2126,9 @@ resource "google_composer_environment" "test" {
 
       software_config {
         image_version = "composer-2-airflow-2"
-<% unless version == "ga" -%>
         cloud_data_lineage_integration {
           enabled = true
         }
-<% end -%>
       }
 
       workloads_config {
@@ -2598,11 +2596,9 @@ resource "google_composer_environment" "test" {
 
       software_config {
         image_version = "composer-2-airflow-2"
-<% unless version == "ga" -%>
         cloud_data_lineage_integration {
           enabled = false
         }
-<% end -%>
       }
 
       workloads_config {

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -1037,8 +1037,7 @@ The following arguments are supported:
   major Cloud Composer or Apache Airflow versions (from `1.x.x` to `2.x.x`). To do so, create a new environment.
 
 * `cloud_data_lineage_integration` -
-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html),
-  Cloud Composer environments in versions composer-2.1.2-airflow-*.*.* and newer)
+  (Optional, Cloud Composer environments in versions composer-2.1.2-airflow-*.*.* and newer)
   The configuration for Cloud Data Lineage integration. Structure is
   [documented below](#nested_cloud_data_lineage_integration_c2).
 
@@ -1465,8 +1464,7 @@ The following arguments are supported:
   **Important**: In-place upgrade for Composer 3 is not yet supported.
 
 * `cloud_data_lineage_integration` -
-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html),
-  Cloud Composer environments in versions composer-2.1.2-airflow-*.*.* and later)
+  (Optional, Cloud Composer environments in versions composer-2.1.2-airflow-*.*.* and later)
   The configuration for Cloud Data Lineage integration. Structure is
   [documented below](#nested_cloud_data_lineage_integration_c3).
 


### PR DESCRIPTION
Google Cloud Composer has promoted Data Lineage integration to GA.
Fixes https://github.com/hashicorp/terraform-provider-google/issues/19345

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
composer: promoted `config.0.workloads_config.0.cloud_data_lineage_integration` to GA in resource `google_composer_environment`
```
