### PR TITLE
Add go yaml validations (part 1)

### DIFF
--- a/mmv1/api/product/version.go
+++ b/mmv1/api/product/version.go
@@ -14,6 +14,8 @@
 package product
 
 import (
+	"log"
+
 	"golang.org/x/exp/slices"
 )
 
@@ -40,12 +42,14 @@ type Version struct {
 	Name string
 }
 
-// def validate
-//   super
-//   check :cai_base_url, type: String, required: false
-//   check :base_url, type: String, required: true
-//   check :name, type: String, allowed: ORDER, required: true
-// end
+func (v *Version) Validate(pName string) {
+	if v.Name == "" {
+		log.Fatalf("Missing `name` in `version` for product %s", pName)
+	}
+	if v.BaseUrl == "" {
+		log.Fatalf("Missing `base_url` in `version` for product %s", pName)
+	}
+}
 
 // def to_s
 //   "//{name}: //{base_url}"

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -14,6 +14,7 @@ package api
 
 import (
 	"fmt"
+	"log"
 	"maps"
 	"regexp"
 	"sort"
@@ -23,7 +24,6 @@ import (
 	"github.com/GoogleCloudPlatform/magic-modules/mmv1/api/resource"
 	"github.com/GoogleCloudPlatform/magic-modules/mmv1/google"
 	"golang.org/x/exp/slices"
-	"gopkg.in/yaml.v3"
 )
 
 type Resource struct {
@@ -308,7 +308,7 @@ type Resource struct {
 	ImportPath string
 }
 
-func (r *Resource) UnmarshalYAML(n *yaml.Node) error {
+func (r *Resource) UnmarshalYAML(unmarshal func(any) error) error {
 	r.CreateVerb = "POST"
 	r.ReadVerb = "GET"
 	r.DeleteVerb = "DELETE"
@@ -317,7 +317,7 @@ func (r *Resource) UnmarshalYAML(n *yaml.Node) error {
 	type resourceAlias Resource
 	aliasObj := (*resourceAlias)(r)
 
-	err := n.Decode(&aliasObj)
+	err := unmarshal(aliasObj)
 	if err != nil {
 		return err
 	}
@@ -327,6 +327,9 @@ func (r *Resource) UnmarshalYAML(n *yaml.Node) error {
 	}
 	if r.CollectionUrlKey == "" {
 		r.CollectionUrlKey = google.Camelize(google.Plural(r.Name), "lower")
+	}
+	if r.IdFormat == "" {
+		r.IdFormat = r.SelfLinkUri()
 	}
 
 	if len(r.VirtualFields) > 0 {
@@ -338,19 +341,76 @@ func (r *Resource) UnmarshalYAML(n *yaml.Node) error {
 	return nil
 }
 
-// TODO: rewrite functions
-func (r *Resource) Validate() {
-	// TODO Q1 Rewrite super
-	// super
-}
-
 func (r *Resource) SetDefault(product *Product) {
 	r.ProductMetadata = product
 	for _, property := range r.AllProperties() {
 		property.SetDefault(r)
 	}
-	if r.IdFormat == "" {
-		r.IdFormat = r.SelfLinkUri()
+}
+
+func (r *Resource) Validate() {
+	if r.NestedQuery != nil && r.NestedQuery.IsListOfIds && len(r.Identity) != 1 {
+		log.Fatalf("`is_list_of_ids: true` implies resource has exactly one `identity` property")
+	}
+
+	// Ensures we have all properties defined
+	for _, i := range r.Identity {
+		hasIdentify := slices.ContainsFunc(r.AllUserProperties(), func(p *Type) bool {
+			return p.Name == i
+		})
+		if !hasIdentify {
+			log.Fatalf("Missing property/parameter for identity %s", i)
+		}
+	}
+
+	if r.Description == "" {
+		log.Fatalf("Missing `description` for resource %s", r.Name)
+	}
+
+	if !r.Exclude {
+		if len(r.Properties) == 0 {
+			log.Fatalf("Missing `properties` for resource %s", r.Name)
+		}
+	}
+
+	allowed := []string{"POST", "PUT", "PATCH"}
+	if !slices.Contains(allowed, r.CreateVerb) {
+		log.Fatalf("Value on `create_verb` should be one of %#v", allowed)
+	}
+
+	allowed = []string{"GET", "POST"}
+	if !slices.Contains(allowed, r.ReadVerb) {
+		log.Fatalf("Value on `read_verb` should be one of %#v", allowed)
+	}
+
+	allowed = []string{"POST", "PUT", "PATCH", "DELETE"}
+	if !slices.Contains(allowed, r.DeleteVerb) {
+		log.Fatalf("Value on `delete_verb` should be one of %#v", allowed)
+	}
+
+	allowed = []string{"POST", "PUT", "PATCH"}
+	if !slices.Contains(allowed, r.UpdateVerb) {
+		log.Fatalf("Value on `update_verb` should be one of %#v", allowed)
+	}
+
+	for _, property := range r.AllProperties() {
+		property.Validate(r.Name)
+	}
+
+	if r.IamPolicy != nil {
+		r.IamPolicy.Validate(r.Name)
+	}
+
+	if r.NestedQuery != nil {
+		r.NestedQuery.Validate(r.Name)
+	}
+
+	for _, example := range r.Examples {
+		example.Validate(r.Name)
+	}
+
+	if r.Async != nil {
+		r.Async.Validate()
 	}
 }
 

--- a/mmv1/api/resource/custom_code.go
+++ b/mmv1/api/resource/custom_code.go
@@ -136,24 +136,3 @@ type CustomCode struct {
 	// with a success HTTP code for deleted resources
 	TestCheckDestroy string `yaml:"test_check_destroy"`
 }
-
-// def validate
-//   super
-
-//   check :extra_schema_entry, type: String
-//   check :encoder, type: String
-//   check :update_encoder, type: String
-//   check :decoder, type: String
-//   check :constants, type: String
-//   check :pre_create, type: String
-//   check :post_create, type: String
-//   check :custom_create, type: String
-//   check :pre_read, type: String
-//   check :pre_update, type: String
-//   check :post_update, type: String
-//   check :custom_update, type: String
-//   check :pre_delete, type: String
-//   check :custom_import, type: String
-//   check :post_import, type: String
-//   check :test_check_destroy, type: String
-// end

--- a/mmv1/api/resource/docs.go
+++ b/mmv1/api/resource/docs.go
@@ -41,12 +41,3 @@ type Docs struct {
 	// attr_reader :
 	Attributes string
 }
-
-// def validate
-//   super
-//   check :warning, type: String
-//   check :note, type: String
-//   check :required_properties, type: String
-//   check :optional_properties, type: String
-//   check :attributes, type: String
-// end

--- a/mmv1/api/resource/iam_policy.go
+++ b/mmv1/api/resource/iam_policy.go
@@ -14,7 +14,8 @@
 package resource
 
 import (
-	"gopkg.in/yaml.v3"
+	"log"
+	"slices"
 )
 
 // Information about the IAM policy for this resource
@@ -117,7 +118,7 @@ type IamPolicy struct {
 	SubstituteZoneValue bool `yaml:"substitute_zone_value"`
 }
 
-func (p *IamPolicy) UnmarshalYAML(n *yaml.Node) error {
+func (p *IamPolicy) UnmarshalYAML(unmarshal func(any) error) error {
 	p.MethodNameSeparator = "/"
 	p.FetchIamPolicyVerb = "GET"
 	p.FetchIamPolicyMethod = "getIamPolicy"
@@ -132,7 +133,7 @@ func (p *IamPolicy) UnmarshalYAML(n *yaml.Node) error {
 	type iamPolicyAlias IamPolicy
 	aliasObj := (*iamPolicyAlias)(p)
 
-	err := n.Decode(&aliasObj)
+	err := unmarshal(aliasObj)
 	if err != nil {
 		return err
 	}
@@ -140,6 +141,19 @@ func (p *IamPolicy) UnmarshalYAML(n *yaml.Node) error {
 	return nil
 }
 
-// func (p *IamPolicy) validate() {
+func (p *IamPolicy) Validate(rName string) {
+	allowed := []string{"GET", "POST"}
+	if !slices.Contains(allowed, p.FetchIamPolicyVerb) {
+		log.Fatalf("Value on `fetch_iam_policy_verb` should be one of %#v in resource %s", allowed, rName)
+	}
 
-// }
+	allowed = []string{"POST", "PUT"}
+	if !slices.Contains(allowed, p.SetIamPolicyVerb) {
+		log.Fatalf("Value on `set_iam_policy_verb` should be one of %#v in resource %s", allowed, rName)
+	}
+
+	allowed = []string{"REQUEST_BODY", "QUERY_PARAM", "QUERY_PARAM_NESTED"}
+	if p.IamConditionsRequestType != "" && !slices.Contains(allowed, p.IamConditionsRequestType) {
+		log.Fatalf("Value on `iam_conditions_request_type` should be one of %#v in resource %s", allowed, rName)
+	}
+}

--- a/mmv1/api/resource/nested_query.go
+++ b/mmv1/api/resource/nested_query.go
@@ -13,6 +13,8 @@
 
 package resource
 
+import "log"
+
 // Metadata for resources that are nested within a parent resource, as
 // a list of resources or single object within the parent.
 // e.g. Fine-grained resources
@@ -43,10 +45,8 @@ type NestedQuery struct {
 	ModifyByPatch bool `yaml:"modify_by_patch"`
 }
 
-// def validate
-//   super
-
-//   check :keys, type: Array, item_type: String, required: true
-//   check :is_list_of_ids, type: :boolean, default: false
-//   check :modify_by_patch, type: :boolean, default: false
-// end
+func (q *NestedQuery) Validate(rName string) {
+	if len(q.Keys) == 0 {
+		log.Fatalf("Missing `keys` for `nested_query` in resource %s", rName)
+	}
+}

--- a/mmv1/api/resource/reference_links.go
+++ b/mmv1/api/resource/reference_links.go
@@ -13,14 +13,8 @@
 
 package resource
 
-import (
-	"github.com/GoogleCloudPlatform/magic-modules/mmv1/google"
-)
-
 // Represents a list of documentation links.
 type ReferenceLinks struct {
-	google.YamlValidator
-
 	// guides containing
 	// name: The title of the link
 	// value: The URL to navigate on click
@@ -33,7 +27,3 @@ type ReferenceLinks struct {
 	//attr_reader
 	Api string
 }
-
-// func (l *ReferenceLinks) validate() {
-
-// }

--- a/mmv1/api/resource/sweeper.go
+++ b/mmv1/api/resource/sweeper.go
@@ -19,9 +19,3 @@ type Sweeper struct {
 	// eligibility for deletion for generated resources
 	SweepableIdentifierField string `yaml:"sweepable_identifier_field"`
 }
-
-// def validate
-//   super
-
-//   check :sweepable_identifier_field, type: String
-// end

--- a/mmv1/api/resource/validation.go
+++ b/mmv1/api/resource/validation.go
@@ -20,10 +20,3 @@ type Validation struct {
 	Regex    string
 	Function string
 }
-
-// def validate
-// super
-
-// check :regex, type: String
-// check :function, type: String
-// end

--- a/mmv1/api/timeouts.go
+++ b/mmv1/api/timeouts.go
@@ -40,11 +40,3 @@ func NewTimeouts() *Timeouts {
 		DeleteMinutes: DEFAULT_DELETE_TIMEOUT_MINUTES,
 	}
 }
-
-// def validate
-//   super
-
-//   check :insert_minutes, type: Integer, default: DEFAULT_INSERT_TIMEOUT_MINUTES
-//   check :update_minutes, type: Integer, default: DEFAULT_UPDATE_TIMEOUT_MINUTES
-//   check :delete_minutes, type: Integer, default: DEFAULT_DELETE_TIMEOUT_MINUTES
-// end

--- a/mmv1/api/type.go
+++ b/mmv1/api/type.go
@@ -337,6 +337,28 @@ func (t *Type) SetDefault(r *Resource) {
 	}
 }
 
+func (t *Type) Validate(rName string) {
+	if t.Output && t.Required {
+		log.Fatalf("Property %s cannot be output and required at the same time in resource %s.", t.Name, rName)
+	}
+
+	if t.DefaultFromApi && t.DefaultValue != nil {
+		log.Fatalf("'default_value' and 'default_from_api' cannot be both set in resource %s", rName)
+	}
+
+	switch {
+	case t.IsA("Array"):
+		t.ItemType.Validate(rName)
+	case t.IsA("Map"):
+		t.ValueType.Validate(rName)
+	case t.IsA("NestedObject"):
+		for _, p := range t.Properties {
+			p.Validate(rName)
+		}
+	default:
+	}
+}
+
 // super
 // check :description, type: ::String, required: true
 // check :exclude, type: :boolean, default: false, required: true

--- a/mmv1/go.mod
+++ b/mmv1/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225
-	gopkg.in/yaml.v3 v3.0.1
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require github.com/golang/glog v1.2.0

--- a/mmv1/go.sum
+++ b/mmv1/go.sum
@@ -6,5 +6,5 @@ golang.org/x/exp v0.0.0-20240222234643-814bf88cf225 h1:LfspQV/FYTatPTr/3HzIcmiUF
 golang.org/x/exp v0.0.0-20240222234643-814bf88cf225/go.mod h1:CxmFvTBINI24O/j8iY7H1xHzx2i4OsyguNBmN/uPtqc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/mmv1/google/yaml_validator.go
+++ b/mmv1/google/yaml_validator.go
@@ -16,7 +16,7 @@ package google
 import (
 	"log"
 
-	"gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v2"
 )
 
 // A helper class to validate contents coming from YAML files.
@@ -26,7 +26,7 @@ func (v *YamlValidator) Parse(content []byte, obj interface{}, yamlPath string) 
 	// TODO(nelsonjr): Allow specifying which symbols to restrict it further.
 	// But it requires inspecting all configuration files for symbol sources,
 	// such as Enum values. Leaving it as a nice-to-have for the future.
-	if err := yaml.Unmarshal(content, obj); err != nil {
+	if err := yaml.UnmarshalStrict(content, obj); err != nil {
 		log.Fatalf("Cannot unmarshal data from file %s: %v", yamlPath, err)
 	}
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
1. Replaced yaml v3 with yaml v2 library, as yaml v3 doesn't have UnmarshalStrict method. UnmarshalStrict is used to check extraneous fields in the yaml files.
2. Added the validation for most objects except `type`

The remaining validation to be added is on the type object:
1. Add the same validation with the ruby object for the fields, like required fields, conflicted fields if any.
2. Add the validation for nested types, like array, object to make sure no extraneous fields. This validation could be difficult as all of fields are in the same Go Type object.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
