### PR TITLE
go rewrite - initial concurrency

### DIFF
--- a/mmv1/provider/terraform.go
+++ b/mmv1/provider/terraform.go
@@ -104,7 +104,7 @@ func (t *Terraform) GenerateObject(object api.Resource, outputFolder, productPat
 		t.GenerateResource(object, *templateData, outputFolder, generateCode, generateDocs)
 
 		if generateCode {
-			log.Printf("Generating %s tests", object.Name)
+			// log.Printf("Generating %s tests", object.Name)
 			t.GenerateResourceTests(object, *templateData, outputFolder)
 			t.GenerateResourceSweeper(object, *templateData, outputFolder)
 		}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

adds a quick attempt at running the product generation concurrently

Emulates how we currently do parallelization in Ruby. See https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/compiler.rb#L155. I did not try to improve upon this

reduces full generation time from 1 minute 45 seconds -> 53 seconds after https://github.com/GoogleCloudPlatform/magic-modules/pull/11626

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
