### PR TITLE
Make vcr tester Run and RunParallel use options struct

### DIFF
--- a/.ci/magician/cmd/check_cassettes.go
+++ b/.ci/magician/cmd/check_cassettes.go
@@ -103,7 +103,10 @@ func execCheckCassettes(commit string, vt *vcr.Tester, ctlr *source.Controller) 
 	}
 	vt.SetRepoPath(provider.Beta, providerRepo.Path)
 
-	result, err := vt.Run(vcr.Replaying, provider.Beta, nil)
+	result, err := vt.Run(vcr.RunOptions{
+		Mode:    vcr.Replaying,
+		Version: provider.Beta,
+	})
 	if err != nil {
 		fmt.Println("Error running VCR: ", err)
 	}

--- a/.ci/magician/cmd/generate_comment.go
+++ b/.ci/magician/cmd/generate_comment.go
@@ -435,7 +435,7 @@ func buildDiffProcessor(diffProcessorPath, providerLocalPath string, env map[str
 		}
 	}
 	if _, err := rnr.Run("make", []string{"build"}, env); err != nil {
-		return fmt.Errorf("Error running make build in %s: %v\n", diffProcessorPath, err)
+		return fmt.Errorf("error running make build in %s: %v", diffProcessorPath, err)
 	}
 	return rnr.PopDir()
 }

--- a/.ci/magician/cmd/request_service_reviewers.go
+++ b/.ci/magician/cmd/request_service_reviewers.go
@@ -107,7 +107,7 @@ func execRequestServiceReviewers(prNumber string, gh GithubClient, enrolledTeams
 	}
 
 	exitCode := 0
-	for githubTeam, _ := range githubTeamsSet {
+	for githubTeam := range githubTeamsSet {
 		members, err := gh.GetTeamMembers("GoogleCloudPlatform", githubTeam)
 		if err != nil {
 			fmt.Printf("Error fetching members for GoogleCloudPlatform/%s: %s", githubTeam, err)

--- a/.ci/magician/cmd/scheduled_pr_reminders.go
+++ b/.ci/magician/cmd/scheduled_pr_reminders.go
@@ -189,7 +189,7 @@ func execScheduledPrReminders(gh *github.Client) error {
 					},
 				)
 				if err != nil {
-					return fmt.Errorf("Error posting comment to PR %d: %w", *pr.Number, err)
+					return fmt.Errorf("error posting comment to PR %d: %w", *pr.Number, err)
 				}
 			}
 		}
@@ -208,7 +208,7 @@ func execScheduledPrReminders(gh *github.Client) error {
 					},
 				)
 				if err != nil {
-					return fmt.Errorf("Error closing PR %d: %w", *pr.Number, err)
+					return fmt.Errorf("error closing PR %d: %w", *pr.Number, err)
 				}
 			}
 		}

--- a/.ci/magician/cmd/test_terraform_vcr.go
+++ b/.ci/magician/cmd/test_terraform_vcr.go
@@ -403,7 +403,7 @@ func runReplaying(runFullVCR bool, services map[string]struct{}, vt *vcr.Tester)
 	var testDirs []string
 	var replayingErr error
 	if runFullVCR {
-		fmt.Println("run full VCR tests")
+		fmt.Println("runReplaying: full VCR tests")
 		result, replayingErr = vt.Run(vcr.RunOptions{
 			Mode:    vcr.Replaying,
 			Version: provider.Beta,

--- a/.ci/magician/cmd/vcr_cassette_update.go
+++ b/.ci/magician/cmd/vcr_cassette_update.go
@@ -125,7 +125,10 @@ func execVCRCassetteUpdate(buildID, today string, rnr ExecRunner, ctlr *source.C
 	vt.SetRepoPath(provider.Beta, providerRepo.Path)
 
 	fmt.Println("running tests in REPLAYING mode now")
-	replayingResult, replayingErr := vt.Run(vcr.Replaying, provider.Beta, nil)
+	replayingResult, replayingErr := vt.Run(vcr.RunOptions{
+		Mode:    vcr.Replaying,
+		Version: provider.Beta,
+	})
 
 	// upload replay build and test logs
 	buildLogPath := filepath.Join(rnr.GetCWD(), "testlogs", fmt.Sprintf("%s_test.log", vcr.Replaying.Lower()))
@@ -156,7 +159,11 @@ func execVCRCassetteUpdate(buildID, today string, rnr ExecRunner, ctlr *source.C
 	if len(replayingResult.FailedTests) != 0 {
 		fmt.Println("running tests in RECORDING mode now")
 
-		recordingResult, recordingErr := vt.RunParallel(vcr.Recording, provider.Beta, nil, replayingResult.FailedTests)
+		recordingResult, recordingErr := vt.RunParallel(vcr.RunOptions{
+			Mode:    vcr.Recording,
+			Version: provider.Beta,
+			Tests:   replayingResult.FailedTests,
+		})
 
 		// upload build and test logs first to preserve debugging logs in case
 		// uploading cassettes failed because recording not work

--- a/mmv1/third_party/terraform/services/pubsub/data_source_pubsub_subscription.go
+++ b/mmv1/third_party/terraform/services/pubsub/data_source_pubsub_subscription.go
@@ -1,5 +1,7 @@
 package pubsub
 
+// Force a test run.
+
 import (
 	"fmt"
 

--- a/mmv1/third_party/terraform/services/pubsub/data_source_pubsub_subscription.go
+++ b/mmv1/third_party/terraform/services/pubsub/data_source_pubsub_subscription.go
@@ -1,7 +1,5 @@
 package pubsub
 
-// Force a test run.
-
 import (
 	"fmt"
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Adding an options struct for these methods so that their parameters can be changed without breaking current usage.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
