### PR TITLE
Fix dnssecConfig filed on google_dns_managed_zone resource

### DIFF
--- a/mmv1/products/dns/ManagedZone.yaml
+++ b/mmv1/products/dns/ManagedZone.yaml
@@ -149,6 +149,7 @@ properties:
   - !ruby/object:Api::Type::NestedObject
     name: 'dnssecConfig'
     description: DNSSEC configuration
+    default_from_api: true
     properties:
       - !ruby/object:Api::Type::String
         name: 'kind'


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This PR fixes the issue https://github.com/hashicorp/terraform-provider-google/issues/17682 by adding a `default_from_api: true` config on `dnssecConfig` field on the resouce `google_dns_managed_zone`.
This will prevent the terraform diff when running a second apply which the resource was changed outside terraform.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
dns: fixed permadiff on `dnssec_config` field of `google_dns_managed_zone` resource
```
