### PR TITLE
Fixed potential panics during VCR tests

### DIFF
--- a/.ci/magician/cmd/test_terraform_vcr.go
+++ b/.ci/magician/cmd/test_terraform_vcr.go
@@ -393,9 +393,10 @@ func runReplaying(runFullVCR bool, services map[string]struct{}, vt *vcr.Tester)
 	var testDirs []string
 	var replayingErr error
 	if runFullVCR {
-		fmt.Println("run full VCR tests")
+		fmt.Println("runReplaying: full VCR tests")
 		result, replayingErr = vt.Run(vcr.Replaying, provider.Beta, nil)
 	} else if len(services) > 0 {
+		fmt.Printf("runReplaying: %d specific services: %v\n", len(services), services)
 		result = &vcr.Result{}
 		for service := range services {
 			servicePath := "./" + filepath.Join("google-beta", "services", service)
@@ -410,6 +411,9 @@ func runReplaying(runFullVCR bool, services map[string]struct{}, vt *vcr.Tester)
 			result.FailedTests = append(result.FailedTests, serviceResult.FailedTests...)
 			result.Panics = append(result.Panics, serviceResult.Panics...)
 		}
+	} else {
+		fmt.Println("runReplaying: no impacted services")
+		result = &vcr.Result{}
 	}
 
 	return result, testDirs, replayingErr

--- a/.ci/magician/cmd/test_terraform_vcr_test.go
+++ b/.ci/magician/cmd/test_terraform_vcr_test.go
@@ -75,14 +75,14 @@ func TestModifiedPackagesFromDiffs(t *testing.T) {
 func TestNotRunTests(t *testing.T) {
 	cases := map[string]struct {
 		gaDiff, betaDiff string
-		result           *vcr.Result
+		result           vcr.Result
 		wantNotRunBeta   []string
 		wantNotRunGa     []string
 	}{
 		"no diff": {
 			gaDiff:   "",
 			betaDiff: "",
-			result: &vcr.Result{
+			result: vcr.Result{
 				PassedTests: []string{"TestAccOne"},
 				FailedTests: []string{"TestAccTwo"},
 			},
@@ -92,7 +92,7 @@ func TestNotRunTests(t *testing.T) {
 		"no added tests": {
 			gaDiff:   "+// some change",
 			betaDiff: "+// some change",
-			result: &vcr.Result{
+			result: vcr.Result{
 				PassedTests: []string{"TestAccOne"},
 				FailedTests: []string{"TestAccTwo"},
 			},
@@ -102,7 +102,7 @@ func TestNotRunTests(t *testing.T) {
 		"test added and passed": {
 			gaDiff:   "+func TestAccTwo(t *testing.T) {",
 			betaDiff: "+func TestAccTwo(t *testing.T) {",
-			result: &vcr.Result{
+			result: vcr.Result{
 				PassedTests: []string{"TestAccTwo"},
 				FailedTests: []string{},
 			},
@@ -114,7 +114,7 @@ func TestNotRunTests(t *testing.T) {
 +func TestAccThree(t *testing.T) {`,
 			betaDiff: `+func TestAccTwo(t *testing.T) {
 +func TestAccThree(t *testing.T) {`,
-			result: &vcr.Result{
+			result: vcr.Result{
 				PassedTests: []string{"TestAccTwo", "TestAccThree"},
 				FailedTests: []string{},
 			},
@@ -124,7 +124,7 @@ func TestNotRunTests(t *testing.T) {
 		"test added and failed": {
 			gaDiff:   "+func TestAccTwo(t *testing.T) {",
 			betaDiff: "+func TestAccTwo(t *testing.T) {",
-			result: &vcr.Result{
+			result: vcr.Result{
 				PassedTests: []string{},
 				FailedTests: []string{"TestAccTwo"},
 			},
@@ -134,7 +134,7 @@ func TestNotRunTests(t *testing.T) {
 		"tests removed and run": {
 			gaDiff:   "-func TestAccOne(t *testing.T) {",
 			betaDiff: "-func TestAccTwo(t *testing.T) {",
-			result: &vcr.Result{
+			result: vcr.Result{
 				PassedTests: []string{"TestAccOne"},
 				FailedTests: []string{"TestAccTwo"},
 			},
@@ -144,7 +144,7 @@ func TestNotRunTests(t *testing.T) {
 		"test added and not run": {
 			gaDiff:   "+func TestAccThree(t *testing.T) {",
 			betaDiff: "+func TestAccFour(t *testing.T) {",
-			result: &vcr.Result{
+			result: vcr.Result{
 				PassedTests: []string{"TestAccOne"},
 				FailedTests: []string{"TestAccTwo"},
 			},
@@ -156,7 +156,7 @@ func TestNotRunTests(t *testing.T) {
 +func TestAccThree(t *testing.T) {`,
 			betaDiff: `+func TestAccTwo(t *testing.T) {
 +func TestAccThree(t *testing.T) {`,
-			result: &vcr.Result{
+			result: vcr.Result{
 				PassedTests: []string{"TestAccOne"},
 				FailedTests: []string{"TestAccFour"},
 			},
@@ -166,7 +166,7 @@ func TestNotRunTests(t *testing.T) {
 		"tests removed and not run": {
 			gaDiff:   "-func TestAccThree(t *testing.T) {",
 			betaDiff: "-func TestAccFour(t *testing.T) {",
-			result: &vcr.Result{
+			result: vcr.Result{
 				PassedTests: []string{"TestAccOne"},
 				FailedTests: []string{"TestAccTwo"},
 			},
@@ -176,7 +176,7 @@ func TestNotRunTests(t *testing.T) {
 		"tests added but commented out": {
 			gaDiff:   "+//func TestAccThree(t *testing.T) {",
 			betaDiff: "+//func TestAccFour(t *testing.T) {",
-			result: &vcr.Result{
+			result: vcr.Result{
 				PassedTests: []string{"TestAccOne"},
 				FailedTests: []string{"TestAccTwo"},
 			},
@@ -189,7 +189,7 @@ func TestNotRunTests(t *testing.T) {
 +func TestAccCloudRunService_cloudRunServiceMulticontainerExample(t *testing.T) {`,
 			betaDiff: `diff --git a/google-beta/services/alloydb/resource_alloydb_backup_generated_test.go b/google-beta/services/alloydb/resource_alloydb_backup_generated_test.go
 +func TestAccAlloydbBackup_alloydbBackupFullTestNewExample(t *testing.T) {`,
-			result: &vcr.Result{
+			result: vcr.Result{
 				PassedTests: []string{},
 				FailedTests: []string{},
 			},
@@ -199,7 +199,7 @@ func TestNotRunTests(t *testing.T) {
 		"always count GA-only added tests": {
 			gaDiff:   "+func TestAccOne(t *testing.T) {",
 			betaDiff: "",
-			result: &vcr.Result{
+			result: vcr.Result{
 				PassedTests: []string{"TestAccOne"},
 				FailedTests: []string{"TestAccTwo"},
 			},
@@ -226,7 +226,7 @@ func TestAnalyticsComment(t *testing.T) {
 		{
 			name: "run full vcr is false and no affected services",
 			data: analytics{
-				ReplayingResult: &vcr.Result{
+				ReplayingResult: vcr.Result{
 					PassedTests:  []string{"a", "b", "c"},
 					SkippedTests: []string{"d", "e"},
 					FailedTests:  []string{"f"},
@@ -257,7 +257,7 @@ func TestAnalyticsComment(t *testing.T) {
 		{
 			name: "run full vcr is false and has affected services",
 			data: analytics{
-				ReplayingResult: &vcr.Result{
+				ReplayingResult: vcr.Result{
 					PassedTests:  []string{"a", "b", "c"},
 					SkippedTests: []string{"d", "e"},
 					FailedTests:  []string{"f"},
@@ -292,7 +292,7 @@ func TestAnalyticsComment(t *testing.T) {
 		{
 			name: "run full vcr is true",
 			data: analytics{
-				ReplayingResult: &vcr.Result{
+				ReplayingResult: vcr.Result{
 					PassedTests:  []string{"a", "b", "c"},
 					SkippedTests: []string{"d", "e"},
 					FailedTests:  []string{"f"},
@@ -427,7 +427,7 @@ func TestWithReplayFailedTests(t *testing.T) {
 		{
 			name: "with failed tests",
 			data: withReplayFailedTests{
-				ReplayingResult: &vcr.Result{
+				ReplayingResult: vcr.Result{
 					FailedTests: []string{"a", "b"},
 				},
 			},
@@ -525,11 +525,11 @@ func TestRecordReplay(t *testing.T) {
 		{
 			name: "ReplayingAfterRecordingResult has failed tests",
 			data: recordReplay{
-				RecordingResult: &vcr.Result{
+				RecordingResult: vcr.Result{
 					PassedTests: []string{"a", "b", "c"},
 					FailedTests: []string{"d", "e"},
 				},
-				ReplayingAfterRecordingResult: &vcr.Result{
+				ReplayingAfterRecordingResult: vcr.Result{
 					PassedTests: []string{"a"},
 					FailedTests: []string{"b", "c"},
 				},
@@ -572,10 +572,10 @@ func TestRecordReplay(t *testing.T) {
 		{
 			name: "ReplayingAfterRecordingResult does not have failed tests",
 			data: recordReplay{
-				RecordingResult: &vcr.Result{
+				RecordingResult: vcr.Result{
 					PassedTests: []string{"a", "b", "c"},
 				},
-				ReplayingAfterRecordingResult: &vcr.Result{
+				ReplayingAfterRecordingResult: vcr.Result{
 					PassedTests: []string{"a", "b", "c"},
 				},
 				AllRecordingPassed: true,

--- a/.ci/magician/cmd/vcr_cassette_update.go
+++ b/.ci/magician/cmd/vcr_cassette_update.go
@@ -46,13 +46,13 @@ var (
 )
 
 type vcrCassetteUpdateReplayingResult struct {
-	ReplayingResult    *vcr.Result
+	ReplayingResult    vcr.Result
 	ReplayingErr       error
 	AllReplayingPassed bool
 }
 
 type vcrCassetteUpdateRecordingResult struct {
-	RecordingResult    *vcr.Result
+	RecordingResult    vcr.Result
 	HasTerminatedTests bool
 	RecordingErr       error
 	AllRecordingPassed bool

--- a/.ci/magician/cmd/vcr_cassette_update_test.go
+++ b/.ci/magician/cmd/vcr_cassette_update_test.go
@@ -23,7 +23,7 @@ func TestFormatVCRCassettesUpdateReplaying(t *testing.T) {
 			name: "replay error",
 			data: vcrCassetteUpdateReplayingResult{
 				ReplayingErr: fmt.Errorf("some error"),
-				ReplayingResult: &vcr.Result{
+				ReplayingResult: vcr.Result{
 					PassedTests:  []string{"a", "b"},
 					FailedTests:  []string{"c", "d"},
 					SkippedTests: []string{"e"},
@@ -55,7 +55,7 @@ func TestFormatVCRCassettesUpdateReplaying(t *testing.T) {
 		{
 			name: "replay success",
 			data: vcrCassetteUpdateReplayingResult{
-				ReplayingResult: &vcr.Result{
+				ReplayingResult: vcr.Result{
 					PassedTests:  []string{"a", "b"},
 					SkippedTests: []string{"e"},
 				},
@@ -82,7 +82,7 @@ func TestFormatVCRCassettesUpdateReplaying(t *testing.T) {
 		{
 			name: "replay failure without error",
 			data: vcrCassetteUpdateReplayingResult{
-				ReplayingResult: &vcr.Result{
+				ReplayingResult: vcr.Result{
 					PassedTests:  []string{"a", "b"},
 					FailedTests:  []string{"c", "d"},
 					SkippedTests: []string{"e"},
@@ -111,7 +111,7 @@ func TestFormatVCRCassettesUpdateReplaying(t *testing.T) {
 		{
 			name: "replay panic",
 			data: vcrCassetteUpdateReplayingResult{
-				ReplayingResult: &vcr.Result{
+				ReplayingResult: vcr.Result{
 					PassedTests:  []string{"a", "b"},
 					FailedTests:  []string{"c", "d"},
 					SkippedTests: []string{"e"},
@@ -150,7 +150,7 @@ func TestFormatVCRCassettesUpdateRecording(t *testing.T) {
 			name: "record error",
 			data: vcrCassetteUpdateRecordingResult{
 				RecordingErr: fmt.Errorf("some error"),
-				RecordingResult: &vcr.Result{
+				RecordingResult: vcr.Result{
 					PassedTests: []string{"a", "b"},
 					FailedTests: []string{"c", "d"},
 				},
@@ -181,7 +181,7 @@ func TestFormatVCRCassettesUpdateRecording(t *testing.T) {
 		{
 			name: "record success",
 			data: vcrCassetteUpdateRecordingResult{
-				RecordingResult: &vcr.Result{
+				RecordingResult: vcr.Result{
 					PassedTests: []string{"a", "b"},
 				},
 				AllRecordingPassed: true,
@@ -209,7 +209,7 @@ func TestFormatVCRCassettesUpdateRecording(t *testing.T) {
 		{
 			name: "record failed without error",
 			data: vcrCassetteUpdateRecordingResult{
-				RecordingResult: &vcr.Result{
+				RecordingResult: vcr.Result{
 					PassedTests: []string{"a", "b"},
 					FailedTests: []string{"c", "d"},
 				},
@@ -235,7 +235,7 @@ func TestFormatVCRCassettesUpdateRecording(t *testing.T) {
 		{
 			name: "record panic",
 			data: vcrCassetteUpdateRecordingResult{
-				RecordingResult: &vcr.Result{
+				RecordingResult: vcr.Result{
 					PassedTests: []string{"a", "b"},
 					FailedTests: []string{"c", "d"},
 					Panics:      []string{"e"},
@@ -254,7 +254,7 @@ func TestFormatVCRCassettesUpdateRecording(t *testing.T) {
 		{
 			name: "has terminated test",
 			data: vcrCassetteUpdateRecordingResult{
-				RecordingResult: &vcr.Result{
+				RecordingResult: vcr.Result{
 					PassedTests: []string{"a", "b"},
 				},
 				HasTerminatedTests: true,

--- a/.ci/magician/vcr/tester.go
+++ b/.ci/magician/vcr/tester.go
@@ -145,21 +145,21 @@ func (vt *Tester) LogPath(mode Mode, version provider.Version) string {
 func (vt *Tester) Run(mode Mode, version provider.Version, testDirs []string) (*Result, error) {
 	logPath, err := vt.getLogPath(mode, version)
 	if err != nil {
-		return nil, err
+		return &Result{}, err
 	}
 
 	repoPath, ok := vt.repoPaths[version]
 	if !ok {
-		return nil, fmt.Errorf("no repo cloned for version %s in %v", version, vt.repoPaths)
+		return &Result{}, fmt.Errorf("no repo cloned for version %s in %v", version, vt.repoPaths)
 	}
 	if err := vt.rnr.PushDir(repoPath); err != nil {
-		return nil, err
+		return &Result{}, err
 	}
 	if len(testDirs) == 0 {
 		var err error
 		testDirs, err = vt.googleTestDirectory()
 		if err != nil {
-			return nil, err
+			return &Result{}, err
 		}
 	}
 
@@ -168,14 +168,14 @@ func (vt *Tester) Run(mode Mode, version provider.Version, testDirs []string) (*
 	case Replaying:
 		cassettePath, ok = vt.cassettePaths[version]
 		if !ok {
-			return nil, fmt.Errorf("cassettes not fetched for version %s", version)
+			return &Result{}, fmt.Errorf("cassettes not fetched for version %s", version)
 		}
 	case Recording:
 		if err := vt.rnr.RemoveAll(cassettePath); err != nil {
-			return nil, fmt.Errorf("error removing cassettes: %v", err)
+			return &Result{}, fmt.Errorf("error removing cassettes: %v", err)
 		}
 		if err := vt.rnr.Mkdir(cassettePath); err != nil {
-			return nil, fmt.Errorf("error creating cassette dir: %v", err)
+			return &Result{}, fmt.Errorf("error creating cassette dir: %v", err)
 		}
 		vt.cassettePaths[version] = cassettePath
 	}
@@ -228,7 +228,7 @@ func (vt *Tester) Run(mode Mode, version provider.Version, testDirs []string) (*
 	}
 	// Leave repo directory.
 	if err := vt.rnr.PopDir(); err != nil {
-		return nil, err
+		return &Result{}, err
 	}
 
 	logFileName := filepath.Join(vt.baseDir, "testlogs", fmt.Sprintf("%s_test.log", mode.Lower()))
@@ -240,7 +240,7 @@ func (vt *Tester) Run(mode Mode, version provider.Version, testDirs []string) (*
 	}
 	allOutput += output
 	if err := vt.rnr.WriteFile(logFileName, allOutput); err != nil {
-		return nil, fmt.Errorf("error writing log: %v, test output: %v", err, allOutput)
+		return &Result{}, fmt.Errorf("error writing log: %v, test output: %v", err, allOutput)
 	}
 	return collectResult(output), testErr
 }

--- a/.ci/magician/vcr/tester.go
+++ b/.ci/magician/vcr/tester.go
@@ -248,23 +248,23 @@ func (vt *Tester) Run(mode Mode, version provider.Version, testDirs []string) (*
 func (vt *Tester) RunParallel(mode Mode, version provider.Version, testDirs, tests []string) (*Result, error) {
 	logPath, err := vt.getLogPath(mode, version)
 	if err != nil {
-		return nil, err
+		return &Result{}, err
 	}
 	if err := vt.rnr.Mkdir(filepath.Join(vt.baseDir, "testlogs", mode.Lower()+"_build")); err != nil {
-		return nil, err
+		return &Result{}, err
 	}
 	repoPath, ok := vt.repoPaths[version]
 	if !ok {
-		return nil, fmt.Errorf("no repo cloned for version %s in %v", version, vt.repoPaths)
+		return &Result{}, fmt.Errorf("no repo cloned for version %s in %v", version, vt.repoPaths)
 	}
 	if err := vt.rnr.PushDir(repoPath); err != nil {
-		return nil, err
+		return &Result{}, err
 	}
 	if len(testDirs) == 0 {
 		var err error
 		testDirs, err = vt.googleTestDirectory()
 		if err != nil {
-			return nil, err
+			return &Result{}, err
 		}
 	}
 
@@ -273,14 +273,14 @@ func (vt *Tester) RunParallel(mode Mode, version provider.Version, testDirs, tes
 	case Replaying:
 		cassettePath, ok = vt.cassettePaths[version]
 		if !ok {
-			return nil, fmt.Errorf("cassettes not fetched for version %s", version)
+			return &Result{}, fmt.Errorf("cassettes not fetched for version %s", version)
 		}
 	case Recording:
 		if err := vt.rnr.RemoveAll(cassettePath); err != nil {
-			return nil, fmt.Errorf("error removing cassettes: %v", err)
+			return &Result{}, fmt.Errorf("error removing cassettes: %v", err)
 		}
 		if err := vt.rnr.Mkdir(cassettePath); err != nil {
-			return nil, fmt.Errorf("error creating cassette dir: %v", err)
+			return &Result{}, fmt.Errorf("error creating cassette dir: %v", err)
 		}
 		vt.cassettePaths[version] = cassettePath
 	}
@@ -304,7 +304,7 @@ func (vt *Tester) RunParallel(mode Mode, version provider.Version, testDirs, tes
 
 	// Leave repo directory.
 	if err := vt.rnr.PopDir(); err != nil {
-		return nil, err
+		return &Result{}, err
 	}
 	var output string
 	for otpt := range outputs {
@@ -312,7 +312,7 @@ func (vt *Tester) RunParallel(mode Mode, version provider.Version, testDirs, tes
 	}
 	logFileName := filepath.Join(vt.baseDir, "testlogs", fmt.Sprintf("%s_test.log", mode.Lower()))
 	if err := vt.rnr.WriteFile(logFileName, output); err != nil {
-		return nil, err
+		return &Result{}, err
 	}
 	var testErr error
 	for err := range errs {

--- a/mmv1/products/alloydb/Backup.yaml
+++ b/mmv1/products/alloydb/Backup.yaml
@@ -110,7 +110,7 @@ properties:
     name: 'name'
     output: true
     description: |
-      Output only. The name of the backup resource with the format: * projects/{project}/locations/{region}/backups/{backupId}
+      Output only. The name of the backup resource with the format: * projects/{project}/locations/{region}/backups/{backupId}FORCE TEST RUN
   - !ruby/object:Api::Type::String
     name: 'displayName'
     description: |

--- a/mmv1/products/alloydb/Backup.yaml
+++ b/mmv1/products/alloydb/Backup.yaml
@@ -110,7 +110,7 @@ properties:
     name: 'name'
     output: true
     description: |
-      Output only. The name of the backup resource with the format: * projects/{project}/locations/{region}/backups/{backupId}FORCE TEST RUN
+      Output only. The name of the backup resource with the format: * projects/{project}/locations/{region}/backups/{backupId}
   - !ruby/object:Api::Type::String
     name: 'displayName'
     description: |


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes errors like https://pantheon.corp.google.com/cloud-build/builds/fd3758bb-622f-42d9-9e15-13ef09651e83;step=23?inv=1&invt=AbbPDQ&project=graphite-docker-images

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
