### PR TITLE
Add field httpKeepAliveTimeoutSec to resources google_compute_region_target_http_proxy and google_compute_region_target_https_proxy

### DIFF
--- a/mmv1/products/compute/RegionTargetHttpProxy.yaml
+++ b/mmv1/products/compute/RegionTargetHttpProxy.yaml
@@ -51,6 +51,14 @@ examples:
       region_backend_service_name: 'backend-service'
       region_health_check_name: 'http-health-check'
   - !ruby/object:Provider::Terraform::Examples
+    name: 'region_target_http_proxy_http_keep_alive_timeout'
+    primary_resource_id: 'default'
+    vars:
+      region_target_http_proxy_name: 'test-http-keep-alive-timeout-proxy'
+      region_url_map_name: 'url-map'
+      region_backend_service_name: 'backend-service'
+      region_health_check_name: 'http-health-check'
+  - !ruby/object:Provider::Terraform::Examples
     name: 'region_target_http_proxy_https_redirect'
     primary_resource_id: 'default'
     vars:
@@ -104,3 +112,12 @@ properties:
     update_verb: :POST
     custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.erb'
     update_url: 'projects/{{project}}/regions/{{region}}/targetHttpProxies/{{name}}/setUrlMap'
+  - !ruby/object:Api::Type::Integer
+    name: 'httpKeepAliveTimeoutSec'
+    description: |
+      Specifies how long to keep a connection open, after completing a response,
+      while there is no matching traffic (in seconds). If an HTTP keepalive is
+      not specified, a default value (600 seconds) will be used. For Regional
+      HTTP(S) load balancer, the minimum allowed value is 5 seconds and the
+      maximum allowed value is 600 seconds.
+

--- a/mmv1/products/compute/RegionTargetHttpProxy.yaml
+++ b/mmv1/products/compute/RegionTargetHttpProxy.yaml
@@ -120,4 +120,3 @@ properties:
       not specified, a default value (600 seconds) will be used. For Regional
       HTTP(S) load balancer, the minimum allowed value is 5 seconds and the
       maximum allowed value is 600 seconds.
-

--- a/mmv1/products/compute/RegionTargetHttpsProxy.yaml
+++ b/mmv1/products/compute/RegionTargetHttpsProxy.yaml
@@ -59,6 +59,15 @@ examples:
       region_backend_service_name: 'backend-service'
       region_health_check_name: 'http-health-check'
   - !ruby/object:Provider::Terraform::Examples
+    name: 'region_target_https_proxy_http_keep_alive_timeout'
+    primary_resource_id: 'default'
+    vars:
+      region_target_https_proxy_name: 'test-http-keep-alive-timeout-proxy'
+      region_ssl_certificate_name: 'my-certificate'
+      region_url_map_name: 'url-map'
+      region_backend_service_name: 'backend-service'
+      region_health_check_name: 'http-health-check'
+  - !ruby/object:Provider::Terraform::Examples
     name: 'region_target_https_proxy_mtls'
     primary_resource_id: 'default'
     min_version: 'beta'
@@ -190,6 +199,14 @@ properties:
     update_verb: :POST
     custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.erb'
     update_url: 'projects/{{project}}/regions/{{region}}/targetHttpsProxies/{{name}}/setUrlMap'
+  - !ruby/object:Api::Type::Integer
+    name: 'httpKeepAliveTimeoutSec'
+    description: |
+      Specifies how long to keep a connection open, after completing a response,
+      while there is no matching traffic (in seconds). If an HTTP keepalive is
+      not specified, a default value (600 seconds) will be used. For Regioanl
+      HTTP(S) load balancer, the minimum allowed value is 5 seconds and the
+      maximum allowed value is 600 seconds.
   - !ruby/object:Api::Type::ResourceRef
     name: 'serverTlsPolicy'
     resource: 'SslPolicy'

--- a/mmv1/products/compute/TargetHttpProxy.yaml
+++ b/mmv1/products/compute/TargetHttpProxy.yaml
@@ -112,7 +112,10 @@ properties:
     description: |
       Specifies how long to keep a connection open, after completing a response,
       while there is no matching traffic (in seconds). If an HTTP keepalive is
-      not specified, a default value (610 seconds) will be used. For Global
-      external HTTP(S) load balancer, the minimum allowed value is 5 seconds and
-      the maximum allowed value is 1200 seconds. For Global external HTTP(S)
-      load balancer (classic), this option is not available publicly.
+      not specified, a default value will be used. For Global
+      external HTTP(S) load balancer, the default value is 610 seconds, the
+      minimum allowed value is 5 seconds and the maximum allowed value is 1200
+      seconds. For cross-region internal HTTP(S) load balancer, the default
+      value is 600 seconds, the minimum allowed value is 5 seconds, and the
+      maximum allowed value is 600 seconds. For Global external HTTP(S) load
+      balancer (classic), this option is not available publicly.

--- a/mmv1/products/compute/TargetHttpsProxy.yaml
+++ b/mmv1/products/compute/TargetHttpsProxy.yaml
@@ -215,10 +215,13 @@ properties:
     description: |
       Specifies how long to keep a connection open, after completing a response,
       while there is no matching traffic (in seconds). If an HTTP keepalive is
-      not specified, a default value (610 seconds) will be used. For Global
-      external HTTP(S) load balancer, the minimum allowed value is 5 seconds and
-      the maximum allowed value is 1200 seconds. For Global external HTTP(S)
-      load balancer (classic), this option is not available publicly.
+      not specified, a default value will be used. For Global
+      external HTTP(S) load balancer, the default value is 610 seconds, the
+      minimum allowed value is 5 seconds and the maximum allowed value is 1200
+      seconds. For cross-region internal HTTP(S) load balancer, the default
+      value is 600 seconds, the minimum allowed value is 5 seconds, and the
+      maximum allowed value is 600 seconds. For Global external HTTP(S) load
+      balancer (classic), this option is not available publicly.
   - !ruby/object:Api::Type::ResourceRef
     name: 'serverTlsPolicy'
     resource: 'ServerTlsPolicy'

--- a/mmv1/templates/terraform/examples/region_target_http_proxy_http_keep_alive_timeout.tf.erb
+++ b/mmv1/templates/terraform/examples/region_target_http_proxy_http_keep_alive_timeout.tf.erb
@@ -1,0 +1,47 @@
+resource "google_compute_region_target_http_proxy" "<%= ctx[:primary_resource_id] %>" {
+  region                      = "us-central1"
+  name                        = "<%= ctx[:vars]['region_target_http_proxy_name'] %>"
+  http_keep_alive_timeout_sec = 600
+  url_map                     = google_compute_region_url_map.default.id
+}
+
+resource "google_compute_region_url_map" "default" {
+  region          = "us-central1"
+  name            = "<%= ctx[:vars]['region_url_map_name'] %>"
+  default_service = google_compute_region_backend_service.default.id
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name            = "allpaths"
+    default_service = google_compute_region_backend_service.default.id
+
+    path_rule {
+      paths   = ["/*"]
+      service = google_compute_region_backend_service.default.id
+    }
+  }
+}
+
+resource "google_compute_region_backend_service" "default" {
+  region                = "us-central1"
+  name                  = "<%= ctx[:vars]['region_backend_service_name'] %>"
+  port_name             = "http"
+  protocol              = "HTTP"
+  timeout_sec           = 10
+  load_balancing_scheme = "INTERNAL_MANAGED"
+
+  health_checks = [google_compute_region_health_check.default.id]
+}
+
+resource "google_compute_region_health_check" "default" {
+  region = "us-central1"
+  name   = "<%= ctx[:vars]['region_health_check_name'] %>"
+
+  http_health_check {
+    port = 80
+  }
+}

--- a/mmv1/templates/terraform/examples/region_target_https_proxy_http_keep_alive_timeout.tf.erb
+++ b/mmv1/templates/terraform/examples/region_target_https_proxy_http_keep_alive_timeout.tf.erb
@@ -1,0 +1,57 @@
+resource "google_compute_region_target_https_proxy" "<%= ctx[:primary_resource_id] %>" {
+  region                      = "us-central1"
+  name                        = "<%= ctx[:vars]['region_target_https_proxy_name'] %>"
+  http_keep_alive_timeout_sec = 610
+  url_map                     = google_compute_region_url_map.default.id
+  ssl_certificates            = [google_compute_ssl_certificate.default.id]
+}
+
+resource "google_compute_region_ssl_certificate" "default" {
+  region      = "us-central1"
+  name        = "<%= ctx[:vars]['region_ssl_certificate_name'] %>"
+  private_key = file("path/to/private.key")
+  certificate = file("path/to/certificate.crt")
+}
+
+resource "google_compute_region_url_map" "default" {
+  region      = "us-central1"
+  name        = "<%= ctx[:vars]['region_url_map_name'] %>"
+  description = "a description"
+
+  default_service = google_compute_region_backend_service.default.id
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name            = "allpaths"
+    default_service = google_compute_region_backend_service.default.id
+
+    path_rule {
+      paths   = ["/*"]
+      service = google_compute_region_backend_service.default.id
+    }
+  }
+}
+
+resource "google_compute_region_backend_service" "default" {
+  region                = "us-central1"
+  name                  = "<%= ctx[:vars]['region_backend_service_name'] %>"
+  port_name             = "http"
+  protocol              = "HTTP"
+  timeout_sec           = 10
+  load_balancing_scheme = "INTERNAL_MANAGED"
+
+  health_checks = [google_compute_region_health_check.default.id]
+}
+
+resource "google_compute_region_health_check" "default" {
+  region = "us-central1"
+  name   = "<%= ctx[:vars]['region_health_check_name'] %>"
+
+  http_health_check {
+    port = 80
+  }
+}

--- a/mmv1/templates/terraform/examples/region_target_https_proxy_http_keep_alive_timeout.tf.erb
+++ b/mmv1/templates/terraform/examples/region_target_https_proxy_http_keep_alive_timeout.tf.erb
@@ -1,9 +1,9 @@
 resource "google_compute_region_target_https_proxy" "<%= ctx[:primary_resource_id] %>" {
   region                      = "us-central1"
   name                        = "<%= ctx[:vars]['region_target_https_proxy_name'] %>"
-  http_keep_alive_timeout_sec = 610
+  http_keep_alive_timeout_sec = 600
   url_map                     = google_compute_region_url_map.default.id
-  ssl_certificates            = [google_compute_ssl_certificate.default.id]
+  ssl_certificates            = [google_compute_region_ssl_certificate.default.id]
 }
 
 resource "google_compute_region_ssl_certificate" "default" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add the `httpKeepAliveTimeoutSec` field to Region Target HTTP Proxy and Region Target HTTPS Proxy resources.

fixes https://github.com/hashicorp/terraform-provider-google/issues/16230

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**


```release-note:enhancement
compute: added field `http_keep_alive_timeout_sec` to resource `google_region_compute_target_http_proxy`
```

```release-note:enhancement
compute: added field `http_keep_alive_timeout_sec` to resource `google_region_compute_target_https_proxy`
```
