### PR TITLE
Removed always-failing build cancellation

### DIFF
--- a/.ci/gcb-pr-downstream-generation-and-test.yml
+++ b/.ci/gcb-pr-downstream-generation-and-test.yml
@@ -1,21 +1,5 @@
 ---
 steps:
-    - name: 'gcr.io/cloud-builders/gcloud'
-      id: "Stop Other Ongoing Build"
-      entrypoint: 'bash'
-      args:
-      - -c
-      - |
-        on_going_build=($(gcloud builds list --ongoing --format='value[separator=","](id,substitutions.REVISION_ID)' --filter="substitutions.TRIGGER_NAME:$TRIGGER_NAME substitutions._PR_NUMBER:$_PR_NUMBER" | xargs))
-        for (( i=0; i<${#on_going_build[@]}; i++ )); do
-          IFS="," read -r -a fields <<< "${on_going_build[i]}"
-          if [ "$i" -gt "0" ] && [ "${fields[1]}" != $COMMIT_SHA ]; then # skip current
-            echo "Cancelling build ${fields[0]}"
-
-            gcloud builds cancel ${fields[0]}
-          fi
-        done
-
     # The GCB / GH integration uses a shallow clone of the repo. We need to convert
     # that to a full clone in order to work with it properly.
     # https://cloud.google.com/source-repositories/docs/integrating-with-cloud-build#unshallowing_clones
@@ -235,7 +219,7 @@ steps:
         - $COMMIT_SHA
         - $BUILD_ID
         - $PROJECT_ID
-        - "18"  # Build step
+        - "19"  # Build step
         - terraform-google-conversion
 
     - name: 'gcr.io/graphite-docker-images/go-plus'


### PR DESCRIPTION
The pipeline correctly doesn't have these permissions, so we should remove this step.

Example failure: https://console.cloud.google.com/cloud-build/builds;region=global/84ce7f85-926b-4c82-929d-e68e7154e96c;step=0?inv=1&invt=AbbPhw&project=graphite-docker-images

b/236120722
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
