### PR TITLE
Fix deep_merge function to correctly handle nil arrays

### DIFF
--- a/mmv1/api/object.go
+++ b/mmv1/api/object.go
@@ -34,11 +34,18 @@ type NamedObject struct {
 // }
 
 // func (n *Named) deep_merge(arr1, arr2) {
+// if arr1.nil?
+//   return arr2
+// end
+// if arr2.nil?
+//   return arr1
+// end
+
 // // Scopes is an array of standard strings. In which case return the
 // // version in the overrides. This allows scopes to be removed rather
 // // than allowing for a merge of the two arrays
 // if string_array?(arr1)
-//   return arr2.nil? ? arr1 : arr2
+//   return arr2
 // end
 
 // // Merge any elements that exist in both

--- a/mmv1/api/object.rb
+++ b/mmv1/api/object.rb
@@ -30,12 +30,13 @@ module Api
     end
 
     def deep_merge(arr1, arr2)
+      return arr2 if arr1.nil?
+      return arr1 if arr2.nil?
+
       # Scopes is an array of standard strings. In which case return the
       # version in the overrides. This allows scopes to be removed rather
       # than allowing for a merge of the two arrays
-      if string_array?(arr1)
-        return arr2.nil? ? arr1 : arr2
-      end
+      return arr2 if string_array?(arr1)
 
       # Merge any elements that exist in both
       result = arr1.map do |el1|


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This was discovered on https://cloud-internal-review.git.corp.google.com/c/cloud-graphite-eng/magic-modules-private-overrides/+/47770.

Previously, we could have a state where a new array field was added in the overrides (like `conflicts`), and this would cause a build failure. This occurred because `string_array?` assumes the array is not nil.

This fix checks both arrays for nil, and instead of failing when the array from magic-modules is nil, it returns the other array, which is what the caller likely expects.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
