### PR TITLE
Update docs for new image types support for VmwareNodePool

### DIFF
--- a/mmv1/products/gkeonprem/VmwareNodePool.yaml
+++ b/mmv1/products/gkeonprem/VmwareNodePool.yaml
@@ -113,7 +113,7 @@ properties:
         required: true
         description: |
           The OS image to be used for each node in a node pool.
-          Currently `cos`, `ubuntu`, `ubuntu_containerd` and `windows` are supported.
+          Currently `cos`, `cos_cgv2`, `ubuntu`, `ubuntu_cgv2`, `ubuntu_containerd` and `windows` are supported.
       - !ruby/object:Api::Type::String
         name: "image"
         description: The OS image name in vCenter, only valid when using Windows.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Update docs for new image types support for VmwareNodePool

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:note
Update docs for new image types support for`google_gkeonprem_vmware_node_pool`
```
