### PR TITLE
Add `host_error_timeout_seconds` field to `compute_instance` on beta provider

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.erb
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.erb
@@ -165,6 +165,10 @@ func expandScheduling(v interface{}) (*compute.Scheduling, error) {
 		scheduling.ForceSendFields = append(scheduling.ForceSendFields, "OnInstanceStopAction")
 	}
 <% unless version == 'ga' -%>
+	if v, ok := original["host_error_timeout_seconds"]; ok {
+		scheduling.HostErrorTimeoutSeconds = int64(v.(int))
+	}
+
 	if v, ok := original["maintenance_interval"]; ok {
 		scheduling.MaintenanceInterval = v.(string)
 	}
@@ -287,6 +291,10 @@ func flattenScheduling(resp *compute.Scheduling) []map[string]interface{} {
 	}
 
 <% unless version == 'ga' -%>
+	if resp.HostErrorTimeoutSeconds != 0 {
+		schedulingMap["host_error_timeout_seconds"] = resp.HostErrorTimeoutSeconds
+	}
+
 	if resp.MaintenanceInterval != "" {
 		schedulingMap["maintenance_interval"] = resp.MaintenanceInterval
 	}
@@ -737,6 +745,11 @@ func schedulingHasChangeWithoutReboot(d *schema.ResourceData) bool {
 	if oScheduling["instance_termination_action"] != newScheduling["instance_termination_action"] {
 			return true
 	}
+<% unless version == 'ga' -%>
+	if oScheduling["host_error_timeout_seconds"] != newScheduling["host_error_timeout_seconds"] {
+		return true
+	}
+<% end -%>
 
 	return false
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
@@ -88,6 +88,7 @@ var (
 		"scheduling.0.on_instance_stop_action",
 <% unless version == 'ga' -%>
 		"scheduling.0.maintenance_interval",
+		"scheduling.0.host_error_timeout_seconds",
 <% end -%>
 		"scheduling.0.local_ssd_recovery_timeout",
 	}
@@ -920,6 +921,12 @@ be from 0 to 999,999,999 inclusive.`,
 							},
 						},
 <% unless version == 'ga' -%>
+						"host_error_timeout_seconds": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: `Specify the time in seconds for host error detection, the value must be within the range of [90, 330] with the increment of 30, if unset, the default behavior of host error recovery will be used.`,
+						},
+						
 						"maintenance_interval": {
 							Type:          schema.TypeString,
 							Optional:      true,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.erb
@@ -39,6 +39,7 @@ var (
 		"scheduling.0.on_instance_stop_action",
 <% unless version == 'ga' -%>
 		"scheduling.0.maintenance_interval",
+		"scheduling.0.host_error_timeout_seconds",
 <% end -%>
 		"scheduling.0.local_ssd_recovery_timeout",
 	}
@@ -761,6 +762,13 @@ be from 0 to 999,999,999 inclusive.`,
 							},
 						},
 <% unless version == 'ga' -%>
+						"host_error_timeout_seconds": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `Specify the time in seconds for host error detection, the value must be within the range of [90, 330] with the increment of 30, if unset, the default behavior of host error recovery will be used.`,
+						},
+						
 						"maintenance_interval" : {
 							Type:        schema.TypeString,
 							Optional:    true,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.erb
@@ -158,6 +158,44 @@ func TestAccComputeInstanceTemplate_maintenance_interval(t *testing.T) {
 }
 <% end -%>
 
+<% unless version == "ga" -%>
+func TestAccComputeInstanceTemplate_hostErrorTimeoutSeconds(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceTemplate_hostErrorTimeoutSeconds(acctest.RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceTemplateExists(
+						t, "google_compute_instance_template.foobar", &instanceTemplate),
+					resource.TestCheckResourceAttr("google_compute_instance_template.foobar", "scheduling.0.host_error_timeout_seconds", "120"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccComputeInstanceTemplate_basic(acctest.RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceTemplateExists(
+						t, "google_compute_instance_template.foobar", &instanceTemplate),
+					resource.TestCheckResourceAttr("google_compute_instance_template.foobar", "scheduling.0.host_error_timeout_seconds", "0"),
+				),
+			},
+		},
+	})
+}
+<% end -%>
+
 func TestAccComputeInstanceTemplate_IP(t *testing.T) {
 	t.Parallel()
 
@@ -2391,6 +2429,49 @@ resource "google_compute_instance_template" "foobar" {
 }
 `, suffix)
 }
+
+func testAccComputeInstanceTemplate_hostErrorTimeoutSeconds(suffix string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name           = "tf-test-instance-template-%s"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+    host_error_timeout_sec = 120
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+
+  labels = {
+    my_label = "foobar"
+  }
+}
+`, suffix)
+}
+
 <% end -%>
 
 func testAccComputeInstanceTemplate_ip(suffix string) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.erb
@@ -2454,7 +2454,7 @@ resource "google_compute_instance_template" "foobar" {
   }
 
   scheduling {
-    host_error_timeout_sec = 120
+    host_error_timeout_seconds = 120
   }
 
   metadata = {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -8004,7 +8004,6 @@ data "google_compute_image" "my_image" {
 }
 
 resource "google_compute_instance" "foobar" {
-  provider     = google-beta
   name         = "%{instance_name}"
   zone         = "%{zone}"
   machine_type = "n2-standard-2"

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -1449,6 +1449,49 @@ func TestAccComputeInstance_reservationAffinities(t *testing.T) {
 	})
 }
 
+<% unless version == 'ga' -%>
+func TestAccComputeInstance_hostErrorTimeoutSecconds(t *testing.T) {
+	t.Parallel()
+	
+	var instance compute.Instance
+	context_1 := map[string]interface{}{
+		"instance_name":          fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"zone":                   "us-central1-a",
+		"host_error_timeout_sec": 90,
+	}
+
+	context_2 := map[string]interface{}{
+		"instance_name":          context_1["instance_name"],
+		"zone":                   context_1["zone"],
+		"host_error_timeout_sec": 120,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_hostErrorTimeoutSeconds(context_1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "scheduling.0.host_error_timeout_seconds", "90"),
+				),
+			},
+			computeInstanceImportStep(context_1["zone"].(string), context_1["instance_name"].(string), []string{}),
+			{
+				Config: testAccComputeInstance_hostErrorTimeoutSeconds(context_2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "scheduling.0.host_error_timeout_seconds", "120"),
+				),
+			},
+			computeInstanceImportStep(context_2["zone"].(string), context_2["instance_name"].(string), []string{}),
+		},
+	})
+}
+<% end -%>
+
 func TestAccComputeInstance_subnet_auto(t *testing.T) {
 	t.Parallel()
 
@@ -7951,6 +7994,36 @@ resource "google_compute_instance" "foobar" {
   }
 }`, instanceName)
 }
+
+<% unless version == 'ga' -%>
+func testAccComputeInstance_hostErrorTimeoutSeconds(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-12"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  provider     = google-beta
+  name         = "%{instance_name}"
+  zone         = "%{zone}"
+  machine_type = "n2-standard-2"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+  scheduling {
+    host_error_timeout_seconds = %{host_error_timeout_sec}
+  }
+}`, context)
+}
+<% end -%>
 
 func testAccComputeInstance_shieldedVmConfig(instance string, enableSecureBoot bool, enableVtpm bool, enableIntegrityMonitoring bool) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.erb
@@ -721,6 +721,13 @@ be from 0 to 999,999,999 inclusive.`,
 							},
 						},
 <% unless version == 'ga' -%>
+						"host_error_timeout_seconds": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `Specify the time in seconds for host error detection, the value must be within the range of [90, 330] with the increment of 30, if unset, the default behavior of host error recovery will be used.`,
+						},
+
 						"maintenance_interval" : {
 							Type:        schema.TypeString,
 							Optional:    true,

--- a/mmv1/third_party/terraform/website/docs/d/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance.html.markdown
@@ -186,6 +186,8 @@ The following arguments are supported:
 
 <a name="nested_scheduling"></a>The `scheduling` block supports:
 
+* `host_error_timeout_seconds` - [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Time in seconds for host error detection
+
 * `preemptible` - Whether the instance is preemptible.
 
 * `on_host_maintenance` - Describes maintenance behavior for the

--- a/mmv1/third_party/terraform/website/docs/d/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance.html.markdown
@@ -186,7 +186,7 @@ The following arguments are supported:
 
 <a name="nested_scheduling"></a>The `scheduling` block supports:
 
-* `host_error_timeout_seconds` - [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Time in seconds for host error detection
+* `host_error_timeout_seconds` - [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Time in seconds for host error detection.
 
 * `preemptible` - Whether the instance is preemptible.
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance_template.html.markdown
@@ -276,7 +276,9 @@ The `disk_encryption_key` block supports:
    groups will use as host systems. Read more on sole-tenant node creation
    [here](https://cloud.google.com/compute/docs/nodes/create-nodes).
    Structure [documented below](#nested_node_affinities).
-   
+
+* `host_error_timeout_seconds` - [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Time in seconds for host error detection
+
 * `provisioning_model` - Describe the type of preemptible VM. 
 
 * `instance_termination_action` - Describe the type of termination action for `SPOT` VM. Can be `STOP` or `DELETE`.  Read more on [here](https://cloud.google.com/compute/docs/instances/create-use-spot) 

--- a/mmv1/third_party/terraform/website/docs/d/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance_template.html.markdown
@@ -277,7 +277,7 @@ The `disk_encryption_key` block supports:
    [here](https://cloud.google.com/compute/docs/nodes/create-nodes).
    Structure [documented below](#nested_node_affinities).
 
-* `host_error_timeout_seconds` - [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Time in seconds for host error detection
+* `host_error_timeout_seconds` - [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Time in seconds for host error detection.
 
 * `provisioning_model` - Describe the type of preemptible VM. 
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_region_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_region_instance_template.html.markdown
@@ -260,7 +260,9 @@ The `disk_encryption_key` block supports:
    groups will use as host systems. Read more on sole-tenant node creation
    [here](https://cloud.google.com/compute/docs/nodes/create-nodes).
    Structure [documented below](#nested_node_affinities).
-   
+
+* `host_error_timeout_seconds` - [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Time in seconds for host error detection
+
 * `provisioning_model` - Describe the type of preemptible VM. 
 
 * `instance_termination_action` - Describe the type of termination action for `SPOT` VM. Can be `STOP` or `DELETE`.  Read more on [here](https://cloud.google.com/compute/docs/instances/create-use-spot) 

--- a/mmv1/third_party/terraform/website/docs/d/compute_region_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_region_instance_template.html.markdown
@@ -261,7 +261,7 @@ The `disk_encryption_key` block supports:
    [here](https://cloud.google.com/compute/docs/nodes/create-nodes).
    Structure [documented below](#nested_node_affinities).
 
-* `host_error_timeout_seconds` - [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Time in seconds for host error detection
+* `host_error_timeout_seconds` - [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Time in seconds for host error detection.
 
 * `provisioning_model` - Describe the type of preemptible VM. 
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -491,6 +491,7 @@ specified, then this instance will have no external IPv6 Internet access. Struct
 
 * `on_instance_stop_action` - (Optional) Specifies the action to be performed when the instance is terminated using `max_run_duration` and `STOP` `instance_termination_action`. Only support `true` `discard_local_ssd` at this point. Structure is [documented below](#nested_on_instance_stop_action).
 
+* `host_error_timeout_seconds` - (Optional) [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Specifies the time in seconds for host error detection, the value must be within the range of [90, 330] with the increment of 30, if unset, the default behavior of host error recovery will be used.
 
 * `maintenance_interval` - (Optional) [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Specifies the frequency of planned maintenance events. The accepted values are: `PERIODIC`.
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -641,6 +641,8 @@ specified, then this instance will have no external IPv6 Internet access. Struct
 
 * `on_instance_stop_action` - (Optional) Specifies the action to be performed when the instance is terminated using `max_run_duration` and `STOP` `instance_termination_action`. Only support `true` `discard_local_ssd` at this point. Structure is [documented below](#nested_on_instance_stop_action).
 
+* `host_error_timeout_seconds` - (Optional) [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Specifies the time in seconds for host error detection, the value must be within the range of [90, 330] with the increment of 30, if unset, the default behavior of host error recovery will be used.
+
 * `maintenance_interval` - (Optional) [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Specifies the frequency of planned maintenance events. The accepted values are: `PERIODIC`.
 
 * `local_ssd_recovery_timeout` -  (Optional) (https://terraform.io/docs/providers/google/guides/provider_versions.html) Specifies the maximum amount of time a Local Ssd Vm should wait while recovery of the Local Ssd state is attempted. Its value should be in between 0 and 168 hours with hour granularity and the default value being 1 hour. Structure is [documented below](#nested_local_ssd_recovery_timeout).

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
@@ -603,6 +603,8 @@ specified, then this instance will have no external IPv6 Internet access. Struct
 
 * `instance_termination_action` - (Optional) Describe the type of termination action for `SPOT` VM. Can be `STOP` or `DELETE`.  Read more on [here](https://cloud.google.com/compute/docs/instances/create-use-spot)
 
+* `host_error_timeout_seconds` - (Optional) [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Specifies the time in seconds for host error detection, the value must be within the range of [90, 330] with the increment of 30, if unset, the default behavior of host error recovery will be used.
+
 * `max_run_duration` -  (Optional)  The duration of the instance. Instance will run and be terminated after then, the termination action could be defined in `instance_termination_action`. Only support `DELETE` `instance_termination_action` at this point. Structure is [documented below](#nested_max_run_duration).
 
 <a name="nested_max_run_duration"></a>The `max_run_duration` block supports:


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
-Added field to `google_compute_instance` and `google_compute_instance_template`
-Added tests
-Added doc changes
-Added data_source support

Do you want me to introduce plan-time validation of this field or should the API handle errors on this field?

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `host_error_timeout_seconds` to `google_compute_instance` (beta)
```
