### PR TITLE
DC apigee collector addition - first time contributor, long time user and admirer!!

### DIFF
--- a/mmv1/products/apigee/DcCollector.yaml
+++ b/mmv1/products/apigee/DcCollector.yaml
@@ -1,0 +1,77 @@
+!ruby/object:Api::Resource
+# Copyright 2023 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: 'DataCollector'
+base_url: '{{org}}/datacollectors'
+create_url: '{{org}}/datacollectors'
+delete_url: '{{org}}/datacollectors/{{name}}'
+self_link: '{{org}}/datacollectors/{{name}}'
+description: |
+  An `Organization` is the top-level container in Apigee.
+update_verb: :PATCH
+immutable: true
+description: |
+  A `DataCollector` in Apigee.
+references: !ruby/object:Api::Resource::ReferenceLinks
+  guides:
+    'Creating a Data Collector': 'https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.datacollectors'
+  api: 'https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.environments.datacollectors/create'
+autogen_async: true
+import_format: ['{{org}}/datacollectors/{{name}}', '{{org}}/{{name}}']
+skip_sweeper: true
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'apigee_datacollector_basic_test'
+    primary_resource_id: 'apigee_datacollector'
+    test_env_vars:
+      org_id: 'ORG_ID'
+      billing_account: 'BILLING_ACCT'
+    ignore_read_extra:
+      - 'properties'
+    skip_vcr: true
+    skip_docs: true
+    # Resource creation race
+    skip_vcr: true
+timeouts: !ruby/object:Api::Timeouts
+  insert_minutes: 1
+  delete_minutes: 1
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  custom_import: templates/terraform/custom_import/apigee_datacollector.go.erb
+parameters:
+  - !ruby/object:Api::Type::String
+    name: 'envId'
+    description: |
+      The Apigee data collector group associated with the Apigee organization,
+      in the format `organizations/{{org_name}}/datacollectors`.
+    required: true
+    immutable: true
+    url_param_only: true
+  - !ruby/object:Api::Type::String
+    name: 'name'
+    description: |
+      The name of the newly created data collector.
+    immutable: true
+  - !ruby/object:Api::Type::String
+    name: 'org'
+    required: true
+    description: |
+      Name of the Apigee organization.
+    url_param_only: true
+    immutable: true
+properties:
+  - !ruby/object:Api::Type::Array
+    name: 'aliases'
+    item_type: Api::Type::String
+    description: |
+      Aliases in this keystore.
+    output: true

--- a/mmv1/templates/terraform/custom_create/apigee_datacollector.go
+++ b/mmv1/templates/terraform/custom_create/apigee_datacollector.go
@@ -1,0 +1,46 @@
+
+userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+if err != nil {
+    return err
+}
+obj := make(map[string]interface{})
+nameProp, err := expandApigeeDataCollectorName(d.Get("name"), d, config)
+if err != nil {
+    return err
+} else if v, ok := d.GetOkExists("name"); !tpgresource.IsEmptyValue(reflect.ValueOf(nameProp)) && (ok || !reflect.DeepEqual(v, nameProp)) {
+    obj["name"] = nameProp
+}
+if v, ok := d.GetOkExists("description"); ok {
+    obj["description"] = v
+}
+if v, ok := d.GetOkExists("type"); ok {
+    obj["type"] = v
+}
+url, err := tpgresource.ReplaceVars(d, config, "{{ApigeeBasePath}}/organizations/{{org_id}}/datacollectors")
+if err != nil {
+    return err
+}
+log.Printf("[DEBUG] Creating new DataCollector: %#v", obj)
+billingProject := ""
+if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+    billingProject = bp
+}
+res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+    Config:    config,
+    Method:    "POST",
+    Project:   billingProject,
+    RawURL:    url,
+    UserAgent: userAgent,
+    Body:      obj,
+    Timeout:   d.Timeout(schema.TimeoutCreate),
+})
+if err != nil {
+    return fmt.Errorf("Error creating DataCollector: %s", err)
+}
+id, err := tpgresource.ReplaceVars(d, config, "{{org_id}}/datacollectors/{{name}}")
+if err != nil {
+    return fmt.Errorf("Error constructing id: %s", err)
+}
+d.SetId(id)
+log.Printf("[DEBUG] Finished creating DataCollector %q: %#v", d.Id(), res)
+return resourceApigeeDataCollectorRead(d, meta)

--- a/mmv1/templates/terraform/custom_create/go/apigee_datacollector.go.tmpl
+++ b/mmv1/templates/terraform/custom_create/go/apigee_datacollector.go.tmpl
@@ -1,0 +1,46 @@
+
+userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+if err != nil {
+    return err
+}
+obj := make(map[string]interface{})
+nameProp, err := expandApigeeDataCollectorName(d.Get("name"), d, config)
+if err != nil {
+    return err
+} else if v, ok := d.GetOkExists("name"); !tpgresource.IsEmptyValue(reflect.ValueOf(nameProp)) && (ok || !reflect.DeepEqual(v, nameProp)) {
+    obj["name"] = nameProp
+}
+if v, ok := d.GetOkExists("description"); ok {
+    obj["description"] = v
+}
+if v, ok := d.GetOkExists("type"); ok {
+    obj["type"] = v
+}
+url, err := tpgresource.ReplaceVars(d, config, "{{ApigeeBasePath}}/organizations/{{org_id}}/datacollectors")
+if err != nil {
+    return err
+}
+log.Printf("[DEBUG] Creating new DataCollector: %#v", obj)
+billingProject := ""
+if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+    billingProject = bp
+}
+res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+    Config:    config,
+    Method:    "POST",
+    Project:   billingProject,
+    RawURL:    url,
+    UserAgent: userAgent,
+    Body:      obj,
+    Timeout:   d.Timeout(schema.TimeoutCreate),
+})
+if err != nil {
+    return fmt.Errorf("Error creating DataCollector: %s", err)
+}
+id, err := tpgresource.ReplaceVars(d, config, "{{org_id}}/datacollectors/{{name}}")
+if err != nil {
+    return fmt.Errorf("Error constructing id: %s", err)
+}
+d.SetId(id)
+log.Printf("[DEBUG] Finished creating DataCollector %q: %#v", d.Id(), res)
+return resourceApigeeDataCollectorRead(d, meta)

--- a/mmv1/templates/terraform/custom_import/apigee_datacollector.go.erb
+++ b/mmv1/templates/terraform/custom_import/apigee_datacollector.go.erb
@@ -1,0 +1,18 @@
+config := meta.(*transport_tpg.Config)
+
+// current import_formats cannot import fields with forward slashes in their value
+if err := tpgresource.ParseImportId([]string{
+		"(?P<org>.+)/datacollectors/(?P<name>.+)",
+		"(?P<org>.+)/(?P<name>.+)",
+	}, d, config); err != nil {
+		return nil, err
+	}
+
+// Replace import id for the resource id
+id, err := tpgresource.ReplaceVars(d, config, "{{org}}/datacollectors/{{name}}")
+if err != nil {
+	return nil, fmt.Errorf("Error constructing id: %s", err)
+}
+d.SetId(id)
+
+return []*schema.ResourceData{d}, nil

--- a/mmv1/templates/terraform/examples/apigee_datacollector_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_datacollector_basic.tf.erb
@@ -1,0 +1,54 @@
+data "google_client_config" "current" {}
+
+resource "google_compute_network" "apigee_network" {
+  name       = "apigee-network"
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+}
+
+resource "google_apigee_organization" "org" {
+  analytics_region   = "us-central1"
+  project_id         = data.google_client_config.current.project
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on         = [google_service_networking_connection.apigee_vpc_connection]
+}
+
+resource "apigee_datacollector" "<%= ctx[:primary_resource_id] %>_test" {
+  project_id = data.google_client_config.current.project
+  depends_on = [google_apigee_organization.org]
+  name       = "<%= ctx[:primary_resource_id] %>  resource "google_compute_network" "apigee_network" {
+    name       = "apigee-network"
+  }
+  
+  resource "google_compute_global_address" "apigee_range" {
+    name          = "apigee-range"
+    purpose       = "VPC_PEERING"
+    address_type  = "INTERNAL"
+    prefix_length = 16
+    network       = google_compute_network.apigee_network.id
+  }
+  
+  resource "google_service_networking_connection" "apigee_vpc_connection" {
+    network                 = google_compute_network.apigee_network.id
+    service                 = "servicenetworking.googleapis.com"
+  }
+  
+  resource "google_apigee_data_collector" "example" {
+    name        = "dc_example"
+    description = "Example Data Collector"
+    type        = "STRING"
+  }"
+  org        = google_apigee_organization.org.name
+}

--- a/mmv1/templates/terraform/examples/apigee_datacollector_basic_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_datacollector_basic_test.tf.erb
@@ -49,6 +49,5 @@ resource "apigee_datacollector" "<%= ctx[:primary_resource_id] %>_test" {
     name        = "dc_example"
     description = "Example Data Collector"
     type        = "STRING"
-  }"
-  org        = google_apigee_organization.org.name
+    org        = google_apigee_organization.org.name
 }

--- a/mmv1/templates/terraform/examples/apigee_datacollector_basic_test.tf.erb
+++ b/mmv1/templates/terraform/examples/apigee_datacollector_basic_test.tf.erb
@@ -1,0 +1,54 @@
+data "google_client_config" "current" {}
+
+resource "google_compute_network" "apigee_network" {
+  name       = "apigee-network"
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+}
+
+resource "google_apigee_organization" "org" {
+  analytics_region   = "us-central1"
+  project_id         = data.google_client_config.current.project
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on         = [google_service_networking_connection.apigee_vpc_connection]
+}
+
+resource "apigee_datacollector" "<%= ctx[:primary_resource_id] %>_test" {
+  project_id = data.google_client_config.current.project
+  depends_on = [google_apigee_organization.org]
+  name       = "<%= ctx[:primary_resource_id] %>  resource "google_compute_network" "apigee_network" {
+    name       = "apigee-network"
+  }
+  
+  resource "google_compute_global_address" "apigee_range" {
+    name          = "apigee-range"
+    purpose       = "VPC_PEERING"
+    address_type  = "INTERNAL"
+    prefix_length = 16
+    network       = google_compute_network.apigee_network.id
+  }
+  
+  resource "google_service_networking_connection" "apigee_vpc_connection" {
+    network                 = google_compute_network.apigee_network.id
+    service                 = "servicenetworking.googleapis.com"
+  }
+  
+  resource "google_apigee_data_collector" "example" {
+    name        = "dc_example"
+    description = "Example Data Collector"
+    type        = "STRING"
+  }"
+  org        = google_apigee_organization.org.name
+}


### PR DESCRIPTION
# Apigee Data Collector addition
This solves a pernicious issue within apigee, where one can have configured the entire suite in terraform but is unable to create or import dc resources, which greatly affect the ordering of analytical data should you gather and structure request downstream
<img width="990" alt="image" src="https://github.com/user-attachments/assets/96653286-ce77-4471-8f00-2d945436d029">
I've added basic testing to exercise the code and I already had a crack at doing this fully on my [own](https://registry.terraform.io/providers/seanogor/dc-apigee/latest)

I did get sense and no reinvent the wheel, I also looked at the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues?q=is%3Aissue+is%3Aopen+apigee) for apigee related stuff, to no avail


****

```release-note:new-resource
`google_apigee_datacollector' - create or import existing datacollector which are critical to the analytical structure of the request you consume from on apigee
```

