### PR TITLE
Implement metadata_options in storage transfer job

### DIFF
--- a/mmv1/third_party/terraform/services/storagetransfer/go/resource_storage_transfer_job.go.tmpl
+++ b/mmv1/third_party/terraform/services/storagetransfer/go/resource_storage_transfer_job.go.tmpl
@@ -393,6 +393,7 @@ func transferOptionsSchema() *schema.Schema {
 					ValidateFunc: validation.StringInSlice([]string{"DIFFERENT", "NEVER", "ALWAYS"}, false),
 					Description:  `When to overwrite objects that already exist in the sink. If not set, overwrite behavior is determined by overwriteObjectsAlreadyExistingInSink.`,
 				},
+				"metadata_options": metadataOptionsSchema(),
 			},
 		},
 		Description: `Characteristics of how to treat files from datasource and sink during job. If the option delete_objects_unique_in_sink is true, object conditions based on objects' last_modification_time are ignored and do not exclude objects in a data source or a data sink.`,
@@ -595,6 +596,63 @@ func azureBlobStorageDataSchema() *schema.Resource {
 			{{- end }}
 		},
 	}
+}
+
+func metadataOptionsSchema() *schema.Schema {
+    return &schema.Schema{
+        Type:     schema.TypeList,
+        Optional: true,
+        MaxItems: 1,
+        Elem: &schema.Resource{
+            Schema: map[string]*schema.Schema{
+                "symlink": {
+                    Type:         schema.TypeString,
+                    Optional:     true,
+                    ValidateFunc: validation.StringInSlice([]string{"SYMLINK_UNSPECIFIED","SYMLINK_SKIP","SYMLINK_PRESERVE"}, false),
+                },
+                "mode": {
+                    Type:         schema.TypeString,
+                    Optional:     true,
+                    ValidateFunc: validation.StringInSlice([]string{"MODE_UNSPECIFIED","MODE_SKIP","MODE_PRESERVE"}, false),
+                },
+                "gid": {
+                    Type:         schema.TypeString,
+                    Optional:     true,
+                    ValidateFunc: validation.StringInSlice([]string{"GID_UNSPECIFIED","GID_SKIP","GID_NUMBER"}, false),
+                },
+                "uid": {
+                    Type:         schema.TypeString,
+                    Optional:     true,
+                    ValidateFunc: validation.StringInSlice([]string{"UID_UNSPECIFIED","UID_SKIP","UID_NUMBER"}, false),
+                },
+                "acl": {
+                    Type:         schema.TypeString,
+                    Optional:     true,
+                    ValidateFunc: validation.StringInSlice([]string{"ACL_UNSPECIFIED","ACL_DESTINATION_BUCKET_DEFAULT","ACL_PRESERVE"}, false),
+                },
+                "storage_class": {
+                    Type:         schema.TypeString,
+                    Optional:     true,
+                    ValidateFunc: validation.StringInSlice([]string{"STORAGE_CLASS_UNSPECIFIED","STORAGE_CLASS_DESTINATION_BUCKET_DEFAULT","STORAGE_CLASS_PRESERVE","STORAGE_CLASS_STANDARD","STORAGE_CLASS_NEARLINE","STORAGE_CLASS_COLDLINE","STORAGE_CLASS_ARCHIVE"}, false),
+                },
+                "temporary_hold": {
+                    Type:         schema.TypeString,
+                    Optional:     true,
+                    ValidateFunc: validation.StringInSlice([]string{"TEMPORARY_HOLD_UNSPECIFIED","TEMPORARY_HOLD_SKIP","TEMPORARY_HOLD_PRESERVE"}, false),
+                },
+                "kms_key": {
+                    Type:         schema.TypeString,
+                    Optional:     true,
+                    ValidateFunc: validation.StringInSlice([]string{"KMS_KEY_UNSPECIFIED","KMS_KEY_DESTINATION_BUCKET_DEFAULT","KMS_KEY_PRESERVE"}, false),
+                },
+                "time_created": {
+                    Type:         schema.TypeString,
+                    Optional:     true,
+                    ValidateFunc: validation.StringInSlice([]string{"TIME_CREATED_UNSPECIFIED","TIME_CREATED_SKIP","TIME_CREATED_PRESERVE_AS_CUSTOM_TIME"}, false),
+                },
+            },
+        },
+    }
 }
 
 func diffSuppressEmptyStartTimeOfDay(k, old, new string, d *schema.ResourceData) bool {
@@ -1200,6 +1258,7 @@ func expandTransferOptions(options []interface{}) *storagetransfer.TransferOptio
 		DeleteObjectsUniqueInSink:             option["delete_objects_unique_in_sink"].(bool),
 		OverwriteObjectsAlreadyExistingInSink: option["overwrite_objects_already_existing_in_sink"].(bool),
 		OverwriteWhen:                         option["overwrite_when"].(string),
+		MetadataOptions:                       expandMetadataOptions(option["metadata_options"].([]interface{})),
 	}
 }
 
@@ -1209,6 +1268,7 @@ func flattenTransferOption(option *storagetransfer.TransferOptions) []map[string
 		"delete_objects_unique_in_sink":              option.DeleteObjectsUniqueInSink,
 		"overwrite_objects_already_existing_in_sink": option.OverwriteObjectsAlreadyExistingInSink,
 		"overwrite_when":                             option.OverwriteWhen,
+		"metadata_options":                           flattenMetadataOptions(option.MetadataOptions),
 	}
 
 	return []map[string]interface{}{data}
@@ -1270,6 +1330,46 @@ func flattenTransferSpec(transferSpec *storagetransfer.TransferSpec, d *schema.R
 	}
 
 	return []map[string]interface{}{data}
+}
+
+func expandMetadataOptions(metadataOptions []interface{}) *storagetransfer.MetadataOptions {
+    if len(metadataOptions) == 0 || metadataOptions[0] == nil {
+        return nil
+    }
+
+    metadataOption := metadataOptions[0].(map[string]interface{})
+    return &storagetransfer.MetadataOptions{
+        Symlink:        metadataOption["symlink"].(string),
+        Mode:           metadataOption["mode"].(string),
+        Gid:            metadataOption["gid"].(string),
+        Uid:            metadataOption["uid"].(string),
+        Acl:            metadataOption["acl"].(string),
+        StorageClass:   metadataOption["storageClass"].(string),
+        TemporaryHold:  metadataOption["temporaryHold"].(string),
+        KmsKey:         metadataOption["kmsKey"].(string),
+        TimeCreated:    metadataOption["timeCreated"].(string),
+    }
+}
+
+// Define flattenMetadataOptions function
+func flattenMetadataOptions(metadataOptions *storagetransfer.MetadataOptions) []map[string]interface{} {
+    if metadataOptions == nil {
+        return nil
+    }
+
+    data := map[string]interface{}{
+        "symlink":        metadataOptions.Symlink,
+        "mode":           metadataOptions.Mode,
+        "gid":            metadataOptions.Gid,
+        "uid":            metadataOptions.Uid,
+        "acl":            metadataOptions.Acl,
+        "storageClass":   metadataOptions.StorageClass,
+        "temporaryHold":  metadataOptions.TemporaryHold,
+        "kmsKey":         metadataOptions.KmsKey,
+        "timeCreated":    metadataOptions.TimeCreated,
+    }
+
+    return []map[string]interface{}{data}
 }
 
 func usingPosix(transferSpec *storagetransfer.TransferSpec) bool {

--- a/mmv1/third_party/terraform/services/storagetransfer/go/resource_storage_transfer_job.go.tmpl
+++ b/mmv1/third_party/terraform/services/storagetransfer/go/resource_storage_transfer_job.go.tmpl
@@ -393,7 +393,6 @@ func transferOptionsSchema() *schema.Schema {
 					ValidateFunc: validation.StringInSlice([]string{"DIFFERENT", "NEVER", "ALWAYS"}, false),
 					Description:  `When to overwrite objects that already exist in the sink. If not set, overwrite behavior is determined by overwriteObjectsAlreadyExistingInSink.`,
 				},
-				"metadata_options": metadataOptionsSchema(),
 			},
 		},
 		Description: `Characteristics of how to treat files from datasource and sink during job. If the option delete_objects_unique_in_sink is true, object conditions based on objects' last_modification_time are ignored and do not exclude objects in a data source or a data sink.`,
@@ -596,63 +595,6 @@ func azureBlobStorageDataSchema() *schema.Resource {
 			{{- end }}
 		},
 	}
-}
-
-func metadataOptionsSchema() *schema.Schema {
-    return &schema.Schema{
-        Type:     schema.TypeList,
-        Optional: true,
-        MaxItems: 1,
-        Elem: &schema.Resource{
-            Schema: map[string]*schema.Schema{
-                "symlink": {
-                    Type:         schema.TypeString,
-                    Optional:     true,
-                    ValidateFunc: validation.StringInSlice([]string{"SYMLINK_UNSPECIFIED","SYMLINK_SKIP","SYMLINK_PRESERVE"}, false),
-                },
-                "mode": {
-                    Type:         schema.TypeString,
-                    Optional:     true,
-                    ValidateFunc: validation.StringInSlice([]string{"MODE_UNSPECIFIED","MODE_SKIP","MODE_PRESERVE"}, false),
-                },
-                "gid": {
-                    Type:         schema.TypeString,
-                    Optional:     true,
-                    ValidateFunc: validation.StringInSlice([]string{"GID_UNSPECIFIED","GID_SKIP","GID_NUMBER"}, false),
-                },
-                "uid": {
-                    Type:         schema.TypeString,
-                    Optional:     true,
-                    ValidateFunc: validation.StringInSlice([]string{"UID_UNSPECIFIED","UID_SKIP","UID_NUMBER"}, false),
-                },
-                "acl": {
-                    Type:         schema.TypeString,
-                    Optional:     true,
-                    ValidateFunc: validation.StringInSlice([]string{"ACL_UNSPECIFIED","ACL_DESTINATION_BUCKET_DEFAULT","ACL_PRESERVE"}, false),
-                },
-                "storage_class": {
-                    Type:         schema.TypeString,
-                    Optional:     true,
-                    ValidateFunc: validation.StringInSlice([]string{"STORAGE_CLASS_UNSPECIFIED","STORAGE_CLASS_DESTINATION_BUCKET_DEFAULT","STORAGE_CLASS_PRESERVE","STORAGE_CLASS_STANDARD","STORAGE_CLASS_NEARLINE","STORAGE_CLASS_COLDLINE","STORAGE_CLASS_ARCHIVE"}, false),
-                },
-                "temporary_hold": {
-                    Type:         schema.TypeString,
-                    Optional:     true,
-                    ValidateFunc: validation.StringInSlice([]string{"TEMPORARY_HOLD_UNSPECIFIED","TEMPORARY_HOLD_SKIP","TEMPORARY_HOLD_PRESERVE"}, false),
-                },
-                "kms_key": {
-                    Type:         schema.TypeString,
-                    Optional:     true,
-                    ValidateFunc: validation.StringInSlice([]string{"KMS_KEY_UNSPECIFIED","KMS_KEY_DESTINATION_BUCKET_DEFAULT","KMS_KEY_PRESERVE"}, false),
-                },
-                "time_created": {
-                    Type:         schema.TypeString,
-                    Optional:     true,
-                    ValidateFunc: validation.StringInSlice([]string{"TIME_CREATED_UNSPECIFIED","TIME_CREATED_SKIP","TIME_CREATED_PRESERVE_AS_CUSTOM_TIME"}, false),
-                },
-            },
-        },
-    }
 }
 
 func diffSuppressEmptyStartTimeOfDay(k, old, new string, d *schema.ResourceData) bool {
@@ -1258,7 +1200,6 @@ func expandTransferOptions(options []interface{}) *storagetransfer.TransferOptio
 		DeleteObjectsUniqueInSink:             option["delete_objects_unique_in_sink"].(bool),
 		OverwriteObjectsAlreadyExistingInSink: option["overwrite_objects_already_existing_in_sink"].(bool),
 		OverwriteWhen:                         option["overwrite_when"].(string),
-		MetadataOptions:                       expandMetadataOptions(option["metadata_options"].([]interface{})),
 	}
 }
 
@@ -1268,7 +1209,6 @@ func flattenTransferOption(option *storagetransfer.TransferOptions) []map[string
 		"delete_objects_unique_in_sink":              option.DeleteObjectsUniqueInSink,
 		"overwrite_objects_already_existing_in_sink": option.OverwriteObjectsAlreadyExistingInSink,
 		"overwrite_when":                             option.OverwriteWhen,
-		"metadata_options":                           flattenMetadataOptions(option.MetadataOptions),
 	}
 
 	return []map[string]interface{}{data}
@@ -1330,46 +1270,6 @@ func flattenTransferSpec(transferSpec *storagetransfer.TransferSpec, d *schema.R
 	}
 
 	return []map[string]interface{}{data}
-}
-
-func expandMetadataOptions(metadataOptions []interface{}) *storagetransfer.MetadataOptions {
-    if len(metadataOptions) == 0 || metadataOptions[0] == nil {
-        return nil
-    }
-
-    metadataOption := metadataOptions[0].(map[string]interface{})
-    return &storagetransfer.MetadataOptions{
-        Symlink:        metadataOption["symlink"].(string),
-        Mode:           metadataOption["mode"].(string),
-        Gid:            metadataOption["gid"].(string),
-        Uid:            metadataOption["uid"].(string),
-        Acl:            metadataOption["acl"].(string),
-        StorageClass:   metadataOption["storageClass"].(string),
-        TemporaryHold:  metadataOption["temporaryHold"].(string),
-        KmsKey:         metadataOption["kmsKey"].(string),
-        TimeCreated:    metadataOption["timeCreated"].(string),
-    }
-}
-
-// Define flattenMetadataOptions function
-func flattenMetadataOptions(metadataOptions *storagetransfer.MetadataOptions) []map[string]interface{} {
-    if metadataOptions == nil {
-        return nil
-    }
-
-    data := map[string]interface{}{
-        "symlink":        metadataOptions.Symlink,
-        "mode":           metadataOptions.Mode,
-        "gid":            metadataOptions.Gid,
-        "uid":            metadataOptions.Uid,
-        "acl":            metadataOptions.Acl,
-        "storageClass":   metadataOptions.StorageClass,
-        "temporaryHold":  metadataOptions.TemporaryHold,
-        "kmsKey":         metadataOptions.KmsKey,
-        "timeCreated":    metadataOptions.TimeCreated,
-    }
-
-    return []map[string]interface{}{data}
 }
 
 func usingPosix(transferSpec *storagetransfer.TransferSpec) bool {

--- a/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go.erb
+++ b/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go.erb
@@ -34,6 +34,7 @@ var (
 		"transfer_spec.0.transfer_options.0.delete_objects_unique_in_sink",
 		"transfer_spec.0.transfer_options.0.delete_objects_from_source_after_transfer",
 		"transfer_spec.0.transfer_options.0.overwrite_when",
+		"transfer_spec.0.transfer_options.0.metadata_options",
 	}
 
 	transferSpecDataSourceKeys = []string{
@@ -394,10 +395,68 @@ func transferOptionsSchema() *schema.Schema {
 					ValidateFunc: validation.StringInSlice([]string{"DIFFERENT", "NEVER", "ALWAYS"}, false),
 					Description:  `When to overwrite objects that already exist in the sink. If not set, overwrite behavior is determined by overwriteObjectsAlreadyExistingInSink.`,
 				},
+				"metadata_options": metadataOptionsSchema(),
 			},
 		},
 		Description: `Characteristics of how to treat files from datasource and sink during job. If the option delete_objects_unique_in_sink is true, object conditions based on objects' last_modification_time are ignored and do not exclude objects in a data source or a data sink.`,
 	}
+}
+
+func metadataOptionsSchema() *schema.Schema {
+return &schema.Schema{
+Type:     schema.TypeList,
+Optional: true,
+MaxItems: 1,
+Elem: &schema.Resource{
+Schema: map[string]*schema.Schema{
+"symlink": {
+Type:         schema.TypeString,
+Optional:     true,
+ValidateFunc: validation.StringInSlice([]string{"SYMLINK_UNSPECIFIED","SYMLINK_SKIP","SYMLINK_PRESERVE"}, false),
+},
+"mode": {
+Type:         schema.TypeString,
+Optional:     true,
+ValidateFunc: validation.StringInSlice([]string{"MODE_UNSPECIFIED","MODE_SKIP","MODE_PRESERVE"}, false),
+},
+"gid": {
+Type:         schema.TypeString,
+Optional:     true,
+ValidateFunc: validation.StringInSlice([]string{"GID_UNSPECIFIED","GID_SKIP","GID_NUMBER"}, false),
+},
+"uid": {
+Type:         schema.TypeString,
+Optional:     true,
+ValidateFunc: validation.StringInSlice([]string{"UID_UNSPECIFIED","UID_SKIP","UID_NUMBER"}, false),
+},
+"acl": {
+Type:         schema.TypeString,
+Optional:     true,
+ValidateFunc: validation.StringInSlice([]string{"ACL_UNSPECIFIED","ACL_DESTINATION_BUCKET_DEFAULT","ACL_PRESERVE"}, false),
+},
+"storage_class": {
+Type:         schema.TypeString,
+Optional:     true,
+ValidateFunc: validation.StringInSlice([]string{"STORAGE_CLASS_UNSPECIFIED","STORAGE_CLASS_DESTINATION_BUCKET_DEFAULT","STORAGE_CLASS_PRESERVE","STORAGE_CLASS_STANDARD","STORAGE_CLASS_NEARLINE","STORAGE_CLASS_COLDLINE","STORAGE_CLASS_ARCHIVE"}, false),
+},
+"temporary_hold": {
+Type:         schema.TypeString,
+Optional:     true,
+ValidateFunc: validation.StringInSlice([]string{"TEMPORARY_HOLD_UNSPECIFIED","TEMPORARY_HOLD_SKIP","TEMPORARY_HOLD_PRESERVE"}, false),
+},
+"kms_key": {
+Type:         schema.TypeString,
+Optional:     true,
+ValidateFunc: validation.StringInSlice([]string{"KMS_KEY_UNSPECIFIED","KMS_KEY_DESTINATION_BUCKET_DEFAULT","KMS_KEY_PRESERVE"}, false),
+},
+"time_created": {
+Type:         schema.TypeString,
+Optional:     true,
+ValidateFunc: validation.StringInSlice([]string{"TIME_CREATED_UNSPECIFIED","TIME_CREATED_SKIP","TIME_CREATED_PRESERVE_AS_CUSTOM_TIME"}, false),
+},
+},
+},
+}
 }
 
 func timeObjectSchema() *schema.Resource {
@@ -1201,6 +1260,7 @@ func expandTransferOptions(options []interface{}) *storagetransfer.TransferOptio
 		DeleteObjectsUniqueInSink:             option["delete_objects_unique_in_sink"].(bool),
 		OverwriteObjectsAlreadyExistingInSink: option["overwrite_objects_already_existing_in_sink"].(bool),
 		OverwriteWhen:                         option["overwrite_when"].(string),
+		MetadataOptions:                       expandMetadataOptions(option["metadata_options"].([]interface{})),
 	}
 }
 
@@ -1210,9 +1270,49 @@ func flattenTransferOption(option *storagetransfer.TransferOptions) []map[string
 		"delete_objects_unique_in_sink":              option.DeleteObjectsUniqueInSink,
 		"overwrite_objects_already_existing_in_sink": option.OverwriteObjectsAlreadyExistingInSink,
 		"overwrite_when":                             option.OverwriteWhen,
+		"metadata_options":                           flattenMetadataOptions(option.MetadataOptions),
 	}
 
 	return []map[string]interface{}{data}
+}
+
+func expandMetadataOptions(metadataOptions []interface{}) *storagetransfer.MetadataOptions {
+if len(metadataOptions) == 0 || metadataOptions[0] == nil {
+return nil
+}
+
+metadataOption := metadataOptions[0].(map[string]interface{})
+return &storagetransfer.MetadataOptions{
+Symlink:        metadataOption["symlink"].(string),
+Mode:           metadataOption["mode"].(string),
+Gid:            metadataOption["gid"].(string),
+Uid:            metadataOption["uid"].(string),
+Acl:            metadataOption["acl"].(string),
+StorageClass:   metadataOption["storage_class"].(string),
+TemporaryHold:  metadataOption["temporary_hold"].(string),
+KmsKey:         metadataOption["kms_key"].(string),
+TimeCreated:    metadataOption["time_created"].(string),
+}
+}
+
+func flattenMetadataOptions(metadataOptions *storagetransfer.MetadataOptions) []map[string]interface{} {
+if metadataOptions == nil {
+return nil
+}
+
+data := map[string]interface{}{
+"symlink":        metadataOptions.Symlink,
+"mode":           metadataOptions.Mode,
+"gid":            metadataOptions.Gid,
+"uid":            metadataOptions.Uid,
+"acl":            metadataOptions.Acl,
+"storage_class":   metadataOptions.StorageClass,
+"temporary_hold":  metadataOptions.TemporaryHold,
+"kms_key":         metadataOptions.KmsKey,
+"time_created":    metadataOptions.TimeCreated,
+}
+
+return []map[string]interface{}{data}
 }
 
 func expandTransferSpecs(transferSpecs []interface{}) *storagetransfer.TransferSpec {

--- a/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go.erb
+++ b/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go.erb
@@ -403,60 +403,60 @@ func transferOptionsSchema() *schema.Schema {
 }
 
 func metadataOptionsSchema() *schema.Schema {
-return &schema.Schema{
-Type:     schema.TypeList,
-Optional: true,
-MaxItems: 1,
-Elem: &schema.Resource{
-Schema: map[string]*schema.Schema{
-"symlink": {
-Type:         schema.TypeString,
-Optional:     true,
-ValidateFunc: validation.StringInSlice([]string{"SYMLINK_UNSPECIFIED","SYMLINK_SKIP","SYMLINK_PRESERVE"}, false),
-},
-"mode": {
-Type:         schema.TypeString,
-Optional:     true,
-ValidateFunc: validation.StringInSlice([]string{"MODE_UNSPECIFIED","MODE_SKIP","MODE_PRESERVE"}, false),
-},
-"gid": {
-Type:         schema.TypeString,
-Optional:     true,
-ValidateFunc: validation.StringInSlice([]string{"GID_UNSPECIFIED","GID_SKIP","GID_NUMBER"}, false),
-},
-"uid": {
-Type:         schema.TypeString,
-Optional:     true,
-ValidateFunc: validation.StringInSlice([]string{"UID_UNSPECIFIED","UID_SKIP","UID_NUMBER"}, false),
-},
-"acl": {
-Type:         schema.TypeString,
-Optional:     true,
-ValidateFunc: validation.StringInSlice([]string{"ACL_UNSPECIFIED","ACL_DESTINATION_BUCKET_DEFAULT","ACL_PRESERVE"}, false),
-},
-"storage_class": {
-Type:         schema.TypeString,
-Optional:     true,
-ValidateFunc: validation.StringInSlice([]string{"STORAGE_CLASS_UNSPECIFIED","STORAGE_CLASS_DESTINATION_BUCKET_DEFAULT","STORAGE_CLASS_PRESERVE","STORAGE_CLASS_STANDARD","STORAGE_CLASS_NEARLINE","STORAGE_CLASS_COLDLINE","STORAGE_CLASS_ARCHIVE"}, false),
-},
-"temporary_hold": {
-Type:         schema.TypeString,
-Optional:     true,
-ValidateFunc: validation.StringInSlice([]string{"TEMPORARY_HOLD_UNSPECIFIED","TEMPORARY_HOLD_SKIP","TEMPORARY_HOLD_PRESERVE"}, false),
-},
-"kms_key": {
-Type:         schema.TypeString,
-Optional:     true,
-ValidateFunc: validation.StringInSlice([]string{"KMS_KEY_UNSPECIFIED","KMS_KEY_DESTINATION_BUCKET_DEFAULT","KMS_KEY_PRESERVE"}, false),
-},
-"time_created": {
-Type:         schema.TypeString,
-Optional:     true,
-ValidateFunc: validation.StringInSlice([]string{"TIME_CREATED_UNSPECIFIED","TIME_CREATED_SKIP","TIME_CREATED_PRESERVE_AS_CUSTOM_TIME"}, false),
-},
-},
-},
-}
+  return &schema.Schema{
+    Type:     schema.TypeList,
+    Optional: true,
+    MaxItems: 1,
+    Elem: &schema.Resource{
+      Schema: map[string]*schema.Schema{
+        "symlink": {
+          Type:         schema.TypeString,
+          Optional:     true,
+          ValidateFunc: validation.StringInSlice([]string{"SYMLINK_UNSPECIFIED","SYMLINK_SKIP","SYMLINK_PRESERVE"}, false),
+        },
+        "mode": {
+          Type:         schema.TypeString,
+          Optional:     true,
+          ValidateFunc: validation.StringInSlice([]string{"MODE_UNSPECIFIED","MODE_SKIP","MODE_PRESERVE"}, false),
+        },
+        "gid": {
+          Type:         schema.TypeString,
+          Optional:     true,
+          ValidateFunc: validation.StringInSlice([]string{"GID_UNSPECIFIED","GID_SKIP","GID_NUMBER"}, false),
+        },
+        "uid": {
+          Type:         schema.TypeString,
+          Optional:     true,
+          ValidateFunc: validation.StringInSlice([]string{"UID_UNSPECIFIED","UID_SKIP","UID_NUMBER"}, false),
+        },
+        "acl": {
+          Type:         schema.TypeString,
+          Optional:     true,
+          ValidateFunc: validation.StringInSlice([]string{"ACL_UNSPECIFIED","ACL_DESTINATION_BUCKET_DEFAULT","ACL_PRESERVE"}, false),
+        },
+        "storage_class": {
+          Type:         schema.TypeString,
+          Optional:     true,
+          ValidateFunc: validation.StringInSlice([]string{"STORAGE_CLASS_UNSPECIFIED","STORAGE_CLASS_DESTINATION_BUCKET_DEFAULT","STORAGE_CLASS_PRESERVE","STORAGE_CLASS_STANDARD","STORAGE_CLASS_NEARLINE","STORAGE_CLASS_COLDLINE","STORAGE_CLASS_ARCHIVE"}, false),
+        },
+        "temporary_hold": {
+          Type:         schema.TypeString,
+          Optional:     true,
+          ValidateFunc: validation.StringInSlice([]string{"TEMPORARY_HOLD_UNSPECIFIED","TEMPORARY_HOLD_SKIP","TEMPORARY_HOLD_PRESERVE"}, false),
+        },
+        "kms_key": {
+          Type:         schema.TypeString,
+          Optional:     true,
+          ValidateFunc: validation.StringInSlice([]string{"KMS_KEY_UNSPECIFIED","KMS_KEY_DESTINATION_BUCKET_DEFAULT","KMS_KEY_PRESERVE"}, false),
+        },
+        "time_created": {
+          Type:         schema.TypeString,
+          Optional:     true,
+          ValidateFunc: validation.StringInSlice([]string{"TIME_CREATED_UNSPECIFIED","TIME_CREATED_SKIP","TIME_CREATED_PRESERVE_AS_CUSTOM_TIME"}, false),
+        },
+      },
+    },
+  }
 }
 
 func timeObjectSchema() *schema.Resource {
@@ -1277,42 +1277,42 @@ func flattenTransferOption(option *storagetransfer.TransferOptions) []map[string
 }
 
 func expandMetadataOptions(metadataOptions []interface{}) *storagetransfer.MetadataOptions {
-if len(metadataOptions) == 0 || metadataOptions[0] == nil {
-return nil
+  if len(metadataOptions) == 0 || metadataOptions[0] == nil {
+    return nil
 }
 
 metadataOption := metadataOptions[0].(map[string]interface{})
-return &storagetransfer.MetadataOptions{
-Symlink:        metadataOption["symlink"].(string),
-Mode:           metadataOption["mode"].(string),
-Gid:            metadataOption["gid"].(string),
-Uid:            metadataOption["uid"].(string),
-Acl:            metadataOption["acl"].(string),
-StorageClass:   metadataOption["storage_class"].(string),
-TemporaryHold:  metadataOption["temporary_hold"].(string),
-KmsKey:         metadataOption["kms_key"].(string),
-TimeCreated:    metadataOption["time_created"].(string),
-}
+  return &storagetransfer.MetadataOptions{
+    Symlink:        metadataOption["symlink"].(string),
+    Mode:           metadataOption["mode"].(string),
+    Gid:            metadataOption["gid"].(string),
+    Uid:            metadataOption["uid"].(string),
+    Acl:            metadataOption["acl"].(string),
+    StorageClass:   metadataOption["storage_class"].(string),
+    TemporaryHold:  metadataOption["temporary_hold"].(string),
+    KmsKey:         metadataOption["kms_key"].(string),
+    TimeCreated:    metadataOption["time_created"].(string),
+  }
 }
 
 func flattenMetadataOptions(metadataOptions *storagetransfer.MetadataOptions) []map[string]interface{} {
-if metadataOptions == nil {
-return nil
-}
+  if metadataOptions == nil {
+    return nil
+  }
 
-data := map[string]interface{}{
-"symlink":        metadataOptions.Symlink,
-"mode":           metadataOptions.Mode,
-"gid":            metadataOptions.Gid,
-"uid":            metadataOptions.Uid,
-"acl":            metadataOptions.Acl,
-"storage_class":   metadataOptions.StorageClass,
-"temporary_hold":  metadataOptions.TemporaryHold,
-"kms_key":         metadataOptions.KmsKey,
-"time_created":    metadataOptions.TimeCreated,
-}
+  data := map[string]interface{}{
+    "symlink":        metadataOptions.Symlink,
+    "mode":           metadataOptions.Mode,
+    "gid":            metadataOptions.Gid,
+    "uid":            metadataOptions.Uid,
+    "acl":            metadataOptions.Acl,
+    "storage_class":   metadataOptions.StorageClass,
+    "temporary_hold":  metadataOptions.TemporaryHold,
+    "kms_key":         metadataOptions.KmsKey,
+    "time_created":    metadataOptions.TimeCreated,
+  }
 
-return []map[string]interface{}{data}
+  return []map[string]interface{}{data}
 }
 
 func expandTransferSpecs(transferSpecs []interface{}) *storagetransfer.TransferSpec {

--- a/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job_test.go
+++ b/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job_test.go
@@ -220,6 +220,14 @@ func TestAccStorageTransferJob_transferOptions(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccStorageTransferJob_transferOptions_withTimeCreated(envvar.GetTestProjectFromEnv(), testDataSourceBucketName, testDataSinkName, testTransferJobDescription, true, false, true, testOverwriteWhen[2], testPubSubTopicName, "TIME_CREATED_PRESERVE_AS_CUSTOM_TIME"),
+			},
+			{
+				ResourceName:      "google_storage_transfer_job.transfer_job",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -1127,6 +1135,114 @@ resource "google_storage_transfer_job" "transfer_job" {
   ]
 }
 `, project, dataSourceBucketName, project, dataSinkBucketName, project, pubSubTopicName, transferJobDescription, project, overwriteObjectsAlreadyExistingInSink, deleteObjectsUniqueInSink, deleteObjectsFromSourceAfterTransfer, overwriteWhenVal)
+}
+
+func testAccStorageTransferJob_transferOptions_withTimeCreated(project string, dataSourceBucketName string, dataSinkBucketName string, transferJobDescription string, overwriteObjectsAlreadyExistingInSink bool, deleteObjectsUniqueInSink bool, deleteObjectsFromSourceAfterTransfer bool, overwriteWhenVal string, pubSubTopicName string, timeCreatedVal string) string {
+	return fmt.Sprintf(`
+data "google_storage_transfer_project_service_account" "default" {
+  project = "%s"
+}
+
+resource "google_storage_bucket" "data_source" {
+  name          = "%s"
+  project       = "%s"
+  location      = "US"
+  force_destroy = true
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket_iam_member" "data_source" {
+  bucket = google_storage_bucket.data_source.name
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${data.google_storage_transfer_project_service_account.default.email}"
+}
+
+resource "google_storage_bucket" "data_sink" {
+  name          = "%s"
+  project       = "%s"
+  location      = "US"
+  force_destroy = true
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket_iam_member" "data_sink" {
+  bucket = google_storage_bucket.data_sink.name
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${data.google_storage_transfer_project_service_account.default.email}"
+}
+
+resource "google_pubsub_topic" "topic" {
+  name = "%s"
+}
+
+resource "google_pubsub_topic_iam_member" "notification_config" {
+  topic = google_pubsub_topic.topic.id
+  role = "roles/pubsub.publisher"
+  member = "serviceAccount:${data.google_storage_transfer_project_service_account.default.email}"
+}
+
+resource "google_storage_transfer_job" "transfer_job" {
+  description = "%s"
+  project     = "%s"
+
+  transfer_spec {
+    gcs_data_source {
+      bucket_name = google_storage_bucket.data_source.name
+      path  = "foo/bar/"
+    }
+    gcs_data_sink {
+      bucket_name = google_storage_bucket.data_sink.name
+      path  = "foo/bar/"
+    }
+    transfer_options {
+      overwrite_objects_already_existing_in_sink = %t
+      delete_objects_unique_in_sink = %t
+      delete_objects_from_source_after_transfer = %t
+      overwrite_when = "%s"
+      metadata_options {
+        time_created = "%s"
+        kms_key = "KMS_KEY_UNSPECIFIED"
+        temporary_hold = "TEMPORARY_HOLD_SKIP"
+      }
+    }
+  }
+
+  schedule {
+    schedule_start_date {
+      year  = 2018
+      month = 10
+      day   = 1
+    }
+    schedule_end_date {
+      year  = 2019
+      month = 10
+      day   = 1
+    }
+    start_time_of_day {
+      hours   = 0
+      minutes = 30
+      seconds = 0
+      nanos   = 0
+    }
+	  repeat_interval = "604800s"
+  }
+
+  notification_config {
+    pubsub_topic  = google_pubsub_topic.topic.id
+    event_types   = [
+      "TRANSFER_OPERATION_SUCCESS",
+      "TRANSFER_OPERATION_FAILED"
+    ]
+    payload_format = "JSON"
+  }
+
+  depends_on = [
+    google_storage_bucket_iam_member.data_source,
+    google_storage_bucket_iam_member.data_sink,
+    google_pubsub_topic_iam_member.notification_config,
+  ]
+}
+`, project, dataSourceBucketName, project, dataSinkBucketName, project, pubSubTopicName, transferJobDescription, project, overwriteObjectsAlreadyExistingInSink, deleteObjectsUniqueInSink, deleteObjectsFromSourceAfterTransfer, overwriteWhenVal, timeCreatedVal)
 }
 
 func testAccStorageTransferJob_objectConditions(project string, dataSourceBucketName string, dataSinkBucketName string, transferJobDescription string, pubSubTopicName string) string {

--- a/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
@@ -61,6 +61,17 @@ resource "google_storage_transfer_job" "s3-bucket-nightly-backup" {
     }
     transfer_options {
       delete_objects_unique_in_sink = false
+      metadata_options {
+        symlink = "SYMLINK_PRESERVE"
+        mode = "MODE_PRESERVE"
+        gid = "GID_NUMBER"
+        uid = "UID_NUMBER"
+        acl = "ACL_PRESERVE"
+        storage_class = "STORAGE_CLASS_UNSPECIFIED"
+        time_created = "TIME_CREATED_UNSPECIFIED"
+        kms_key = "KMS_KEY_UNSPECIFIED"
+        temporary_hold = "TEMPORARY_HOLD_SKIP"
+      }
     }
     aws_s3_data_source {
       bucket_name = var.aws_s3_bucket
@@ -198,6 +209,21 @@ A duration in seconds with up to nine fractional digits, terminated by 's'. Exam
 * `delete_objects_from_source_after_transfer` - (Optional) Whether objects should be deleted from the source after they are transferred to the sink. Note that this option and `delete_objects_unique_in_sink` are mutually exclusive.
 
 * `overwrite_when` - (Optional) When to overwrite objects that already exist in the sink. If not set, overwrite behavior is determined by `overwrite_objects_already_existing_in_sink`. Possible values: ALWAYS, DIFFERENT, NEVER.
+
+* `metadata_options` - (Optional) Metadata options represents the selected metadata options for a transfer job. Structure [documented below](#nested_metadata_options).
+
+<a name="nested_metadata_options"></a>The `metadata_options` block supports:
+
+* `symlink` - (Optional) Specifies how symlinks should be handled by the transfer. By default, symlinks are not preserved. Only applicable to transfers involving POSIX file systems, and ignored for other transfers.
+* `mode` - (Optional) Specifies how each file's mode attribute should be handled by the transfer. By default, mode is not preserved. Only applicable to transfers involving POSIX file systems, and ignored for other transfers.
+* `gid` - (Optional) Specifies how each file's POSIX group ID (GID) attribute should be handled by the transfer. By default, GID is not preserved. Only applicable to transfers involving POSIX file systems, and ignored for other transfers.
+* `uid` - (Optional) Specifies how each file's POSIX user ID (UID) attribute should be handled by the transfer. By default, UID is not preserved. Only applicable to transfers involving POSIX file systems, and ignored for other transfers.
+* `acl` - (Optional) Specifies how each object's ACLs should be preserved for transfers between Google Cloud Storage buckets. If unspecified, the default behavior is the same as ACL_DESTINATION_BUCKET_DEFAULT.
+* `storage_class` - (Optional) Specifies the storage class to set on objects being transferred to Google Cloud Storage buckets. If unspecified, the default behavior is the same as STORAGE_CLASS_DESTINATION_BUCKET_DEFAULT.
+* `temporary_hold` - (Optional) Specifies how each object's temporary hold status should be preserved for transfers between Google Cloud Storage buckets. If unspecified, the default behavior is the same as TEMPORARY_HOLD_PRESERVE.
+* `kms_key` - (Optional) Specifies how each object's Cloud KMS customer-managed encryption key (CMEK) is preserved for transfers between Google Cloud Storage buckets. If unspecified, the default behavior is the same as KMS_KEY_DESTINATION_BUCKET_DEFAULT.
+* `time_created` - (Optional) Specifies how each object's timeCreated metadata is preserved for transfers. If unspecified, the default behavior is the same as TIME_CREATED_SKIP. This option is supported for transfers to Cloud Storage from Cloud Storage, Amazon S3, Microsoft Azure, and S3-compatible storage.
+
 
 <a name="nested_gcs_data_sink"></a>The `gcs_data_sink` block supports:
 


### PR DESCRIPTION
This pull request implements the ability to pass metadata_options to google cloud storage transfer jobs via terraform. In the current state, it does not accept any metadata_options. We consider this crucial functionality in our current data migration project.

This should close https://github.com/hashicorp/terraform-provider-google/issues/11949.

```release-note:enhancement
storagetransfer: added `metadata_options` field to `google_storage_transfer_job` resource
```
