### PR TITLE
Add post create 5s sleep to Topic creation

### DIFF
--- a/mmv1/products/managedkafka/Topic.yaml
+++ b/mmv1/products/managedkafka/Topic.yaml
@@ -31,6 +31,8 @@ examples:
     vars:
       cluster_id: "my-cluster"
       topic_id: "my-topic"
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  post_create: templates/terraform/post_create/sleep.go.erb
 parameters:
   - !ruby/object:Api::Type::String
     name: location


### PR DESCRIPTION
Description: Adding a `post_create` sleep time of 5 seconds to the `Managed Service for Apache Kafka` terraform Topic resource.

Issue: https://buganizer.corp.google.com/issues/357620880

```release-note:bug
managedkafka: added 5 second wait post `google_managed_kafka_topic` creation to fix eventual consistency errors 
```
