### PR TITLE
scripts to convert a branch from Ruby->Go

### DIFF
--- a/mmv1/compiler.rb
+++ b/mmv1/compiler.rb
@@ -46,6 +46,7 @@ types_to_generate = []
 version = 'ga'
 override_dir = nil
 openapi_generate = false
+go_yaml_files = []
 
 ARGV << '-h' if ARGV.empty?
 Google::LOGGER.level = Logger::INFO
@@ -97,6 +98,10 @@ OptionParser.new do |opt|
   end
   opt.on('--go-yaml', 'Generate MMv1 Go YAML from Ruby YAML') do
     go_yaml = true
+  end
+  opt.on('--go-yaml-files FILE[,FILE...]', Array, 'Generate temp Go YAML from files') do |f|
+    go_yaml = true
+    go_yaml_files = f
   end
 end.parse!
 # rubocop:enable Metrics/BlockLength
@@ -269,6 +274,8 @@ products_for_version = Parallel.map(all_product_files, in_processes: 8) do |prod
     provider = \
       override_providers[force_provider].new(product_api, version, start_time)
   end
+
+  provider.go_yaml_files = go_yaml_files if go_yaml_files
 
   unless products_to_generate.include?(product_name)
     Google::LOGGER.info "#{product_name}: Not specified, skipping generation"

--- a/mmv1/main.go
+++ b/mmv1/main.go
@@ -45,20 +45,25 @@ var templateMode = flag.Bool("template", false, "copy templates over from .erb t
 // Example usage: --handwritten
 var handwrittenMode = flag.Bool("handwritten", false, "copy handwritten files over from .erb to go .tmpl")
 
+var yamlTempMode = flag.Bool("yaml-temp", false, "copy text over from ruby yaml to go yaml in a temp file")
+
+var handwrittenTempFiles = flag.String("handwritten-temp", "", "copy specific handwritten files over from .erb to go .tmpl.temp comma separated")
+var templateTempFiles = flag.String("template-temp", "", "copy specific templates over from .erb to go .tmpl.temp comma separated")
+
 func main() {
 
 	flag.Parse()
 
-	if *yamlMode {
-		CopyAllDescriptions()
+	if *yamlMode || *yamlTempMode {
+		CopyAllDescriptions(*yamlTempMode)
 	}
 
-	if *templateMode {
-		convertTemplates()
+	if *templateMode || *templateTempFiles != "" {
+		convertTemplates(*templateTempFiles)
 	}
 
-	if *handwrittenMode {
-		convertAllHandwrittenFiles()
+	if *handwrittenMode || *handwrittenTempFiles != "" {
+		convertAllHandwrittenFiles(*handwrittenTempFiles)
 	}
 
 	if outputPath == nil || *outputPath == "" {

--- a/mmv1/products/developerconnect/Connection.yaml
+++ b/mmv1/products/developerconnect/Connection.yaml
@@ -1,3 +1,4 @@
+# Copyright 2024 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/mmv1/products/developerconnect/GitRepositoryLink.yaml
+++ b/mmv1/products/developerconnect/GitRepositoryLink.yaml
@@ -1,3 +1,16 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 --- !ruby/object:Api::Resource
 base_url: projects/{{project}}/locations/{{location}}/connections/{{parent_connection}}/gitRepositoryLinks
 create_url: projects/{{project}}/locations/{{location}}/connections/{{parent_connection}}/gitRepositoryLinks?gitRepositoryLinkId={{git_repository_link_id}}

--- a/mmv1/products/developerconnect/product.yaml
+++ b/mmv1/products/developerconnect/product.yaml
@@ -1,3 +1,16 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 --- !ruby/object:Api::Product
 versions:
   - !ruby/object:Api::Product::Version

--- a/mmv1/provider/terraform.rb
+++ b/mmv1/provider/terraform.rb
@@ -38,6 +38,7 @@ module Provider
     attr_accessor :resource_count
     attr_accessor :iam_resource_count
     attr_accessor :resources_for_version
+    attr_accessor :go_yaml_files
 
     TERRAFORM_PROVIDER_GA = 'github.com/hashicorp/terraform-provider-google'.freeze
     TERRAFORM_PROVIDER_BETA = 'github.com/hashicorp/terraform-provider-google-beta'.freeze
@@ -71,6 +72,7 @@ module Provider
       @resource_count = 0
       @iam_resource_count = 0
       @resources_for_version = []
+      @go_yaml_files = []
     end
 
     # This provides the ProductFileTemplate class with access to a provider.
@@ -413,11 +415,29 @@ module Provider
       # skip healthcare - exceptional case will be done manually
       return if (output_folder.include? 'healthcare') || (output_folder.include? 'memorystore')
 
+      generate_product = false
+      if @go_yaml_files
+        found = false
+        @go_yaml_files.each do |f|
+          no_ext = Pathname.new(f).sub_ext ''
+          parts = no_ext.each_filename.to_a
+          target_product = "#{parts[-3]}/#{parts[-2]}"
+          target_resource = parts[-1]
+          generate_product = true if target_resource == 'product'
+          found = true if output_folder == target_product && object.name == target_resource
+        end
+        return unless found
+      end
+
       pwd = Dir.pwd
       data = build_object_data(pwd, object, output_folder, version_name)
       Dir.chdir output_folder
       Google::LOGGER.info "Generating #{object.name} rewrite yaml"
-      generate_newyaml(pwd, data.clone)
+      if @go_yaml_files
+        generate_newyaml_temp(pwd, data.clone, generate_product)
+      else
+        generate_newyaml(pwd, data.clone)
+      end
       Dir.chdir pwd
     end
 
@@ -432,6 +452,19 @@ module Provider
                       'go_product.yaml',
                       self)
       end
+    end
+
+    def generate_newyaml_temp(pwd, data, generate_product)
+      data.generate(pwd,
+                    '/templates/terraform/yaml_conversion.erb',
+                    "#{data.object.name}.yaml.temp",
+                    self)
+      return unless generate_product
+
+      data.generate(pwd,
+                    '/templates/terraform/product_yaml_conversion.erb',
+                    'product.yaml.temp',
+                    self)
     end
 
     def build_env

--- a/mmv1/template-converter.go
+++ b/mmv1/template-converter.go
@@ -30,19 +30,22 @@ func find(root, ext string) []string {
 	return a
 }
 
-func convertTemplates() {
+func convertTemplates(tempFileTargets string) {
 	// exculding iam
 	folders := []string{"examples", "constants", "custom_check_destroy", "custom_create", "custom_delete", "custom_import", "custom_update", "decoders", "encoders", "extra_schema_entry", "post_create", "post_create_failure", "post_delete", "post_import", "post_update", "pre_create", "pre_delete", "pre_read", "pre_update", "state_migrations", "update_encoder", "custom_expand", "custom_flatten", "iam/example_config_body"}
 	counts := 0
 	for _, folder := range folders {
-		counts += convertTemplate(folder)
+		counts += convertTemplate(folder, tempFileTargets)
 	}
 	// log.Printf("%d template files in %d subfolders total", counts, len(folders))
 }
 
-func convertTemplate(folder string) int {
+func convertTemplate(folder, tempFileTargets string) int {
 	rubyDir := fmt.Sprintf("templates/terraform/%s", folder)
 	goDir := fmt.Sprintf("%s/go", rubyDir)
+	if tempFileTargets != "" {
+		goDir = rubyDir
+	}
 
 	if err := os.MkdirAll(goDir, os.ModePerm); err != nil {
 		glog.Error(fmt.Errorf("error creating directory %v: %v", goDir, err))
@@ -51,10 +54,19 @@ func convertTemplate(folder string) int {
 	templates := find(rubyDir, ".erb")
 	// log.Printf("%d template files in folder %s", len(templates), folder)
 
+	tempSlice := strings.Split(tempFileTargets, ",")
+
 	for _, file := range templates {
 		filePath := path.Join(rubyDir, file)
 		if checkExceptionList(filePath) {
 			continue
+		}
+		if len(tempSlice) > 0 {
+			// log.Printf("%s", filePath)
+			if !slices.Contains(tempSlice, filePath) {
+				continue
+			}
+			log.Printf("continuing with template temp target %s", filePath)
 		}
 		data, err := os.ReadFile(filePath)
 		if err != nil {
@@ -64,7 +76,11 @@ func convertTemplate(folder string) int {
 		data = replace(data)
 
 		goTemplate := strings.Replace(file, "erb", "tmpl", 1)
-		err = ioutil.WriteFile(path.Join(goDir, goTemplate), data, 0644)
+		outPath := path.Join(goDir, goTemplate)
+		if len(tempSlice) > 0 {
+			outPath = outPath + ".temp"
+		}
+		err = ioutil.WriteFile(outPath, data, 0644)
 		if err != nil {
 			glog.Exit(err)
 		}
@@ -73,7 +89,7 @@ func convertTemplate(folder string) int {
 	return len(templates)
 }
 
-func convertAllHandwrittenFiles() int {
+func convertAllHandwrittenFiles(handwrittenTempFiles string) int {
 	// Add third_party/terraform to convert files in this folder
 	folders := []string{"third_party/terraform"}
 
@@ -105,15 +121,18 @@ func convertAllHandwrittenFiles() int {
 
 	counts := 0
 	for _, folder := range folders {
-		counts += convertHandwrittenFiles(folder)
+		counts += convertHandwrittenFiles(folder, handwrittenTempFiles)
 	}
 	// log.Printf("%d handwritten files in total", counts)
 
 	return counts
 }
 
-func convertHandwrittenFiles(folder string) int {
+func convertHandwrittenFiles(folder, handwrittenTempFiles string) int {
 	goDir := fmt.Sprintf("%s/go", folder)
+	if handwrittenTempFiles != "" {
+		goDir = folder
+	}
 
 	if err := os.MkdirAll(goDir, os.ModePerm); err != nil {
 		glog.Error(fmt.Errorf("error creating directory %v: %v", goDir, err))
@@ -122,10 +141,18 @@ func convertHandwrittenFiles(folder string) int {
 	files := find(folder, ".erb")
 	// log.Printf("%d handwritten files in folder %s", len(files), folder)
 
+	tempSlice := strings.Split(handwrittenTempFiles, ",")
+
 	for _, file := range files {
 		filePath := path.Join(folder, file)
 		if checkExceptionList(filePath) {
 			continue
+		}
+		if len(tempSlice) > 0 {
+			if !slices.Contains(tempSlice, filePath) {
+				continue
+			}
+			log.Printf("continuing with handwritten temp target %s", filePath)
 		}
 		data, err := os.ReadFile(filePath)
 		if err != nil {
@@ -138,7 +165,11 @@ func convertHandwrittenFiles(folder string) int {
 		} else {
 			goTemplate = strings.Replace(file, ".erb", "", 1)
 		}
-		err = ioutil.WriteFile(path.Join(goDir, goTemplate), data, 0644)
+		outPath := path.Join(goDir, goTemplate)
+		if len(tempSlice) > 0 {
+			outPath = outPath + ".temp"
+		}
+		err = ioutil.WriteFile(outPath, data, 0644)
 		if err != nil {
 			glog.Exit(err)
 		}

--- a/scripts/cherry-pick.sh
+++ b/scripts/cherry-pick.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+safecommit=$1
+
+# prepare temp file commit
+git add .
+git commit -m "temp file commit" 
+currentcommit="$(git rev-parse HEAD)"
+
+# checkout a new branch from a given post-switchover commit
+git checkout -b go-rewrite-convert $safecommit
+
+echo $currentcommit
+
+# cherry-pick the previous temp file commit to the new post-switchover branch
+git cherry-pick $currentcommit --no-commit
+
+# overwrite the converted files with the temporary files to produce final diff
+files=`git diff --name-only --diff-filter=A --cached`
+for file in $files; do
+  mv $file ${file%".temp"}
+done

--- a/scripts/convert-go.sh
+++ b/scripts/convert-go.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -e
+outputPath=$1
+files=$2
+
+yamllist=()
+erblist=()
+otherlist=()
+yamlstring=""
+erbstring=""
+
+# Read all input files
+IFS=',' read -ra file <<< "$files"
+for i in "${file[@]}"; do
+  filename=$(basename -- "$i")
+  extension="${filename##*.}"
+  if [[ $extension == "yaml" ]]; then
+    yamllist+=($i)
+    if [[ $yamlstring == "" ]]; then
+        yamlstring=$i
+    else
+        yamlstring="${yamlstring},${i}"
+    fi
+  elif [[ $extension == "erb" ]]; then
+    erblist+=($i)
+    if [[ $erbstring == "" ]]; then
+        erbstring=$i
+    else
+        erbstring="${erbstring},${i}"
+    fi
+  else
+    otherlist+=($i)
+  fi
+done
+
+# run yaml conversion with given .yaml files
+bundle exec compiler.rb -e terraform -o $1 -v beta -a --go-yaml-files $yamlstring
+go run . --yaml-temp
+
+# convert .erb files with given .erb files
+go run . --template-temp $erbstring
+go run . --handwritten-temp $erbstring
+
+# add temporary file for all other files that do not need conversion
+for i in "${otherlist[@]}"
+do
+    cp "$i" "${i}.temp" 
+done


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Two scripts to convert a pre-switchover change to a post-switchover change without dealing with conflicts

`scripts/convert-go.sh` does the conversion in a pre-switchover commit and outputs the converted files to *.temp files. 
Example command from mmv1/ (in a pre-switchover commit)

```
sh ../scripts/convert-go.sh <provider output directory> <comma separated list of files that have changed in the PR> 
```

`scripts/cherry-pick.sh` prepares a new branch in a post-switchover commit and cherry-picks the previous *.temp files
Example command from root MM directory
```
sh scripts/cherry-pick <hash of a post-switchover commit>
```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
