### PR TITLE
Add state "SUSPENDED" to `desired_status` field on `google_compute_instance`

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
@@ -1131,8 +1131,8 @@ be from 0 to 999,999,999 inclusive.`,
 			"desired_status": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"RUNNING", "TERMINATED"}, false),
-				Description:  `Desired status of the instance. Either "RUNNING" or "TERMINATED".`,
+				ValidateFunc: validation.StringInSlice([]string{"RUNNING", "TERMINATED", "SUSPENDED"}, false),
+				Description:  `Desired status of the instance. Either "RUNNING", "SUSPENDED" or "TERMINATED".`,
 			},
 			"current_status": {
 				Type:        schema.TypeString,
@@ -2468,18 +2468,30 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 	needToStopInstanceBeforeUpdating := scopesChange || d.HasChange("service_account.0.email") || d.HasChange("machine_type") || d.HasChange("min_cpu_platform") || d.HasChange("enable_display") || d.HasChange("shielded_instance_config") || len(updatesToNIWhileStopped) > 0 || bootRequiredSchedulingChange || d.HasChange("advanced_machine_features")
 
 	if d.HasChange("desired_status") && !needToStopInstanceBeforeUpdating {
-		desiredStatus := d.Get("desired_status").(string)
+		previousStatus, desiredStatus := d.GetChange("desired_status")
 
 		if desiredStatus != "" {
 			var op *compute.Operation
 
 			if desiredStatus == "RUNNING" {
-				op, err = startInstanceOperation(d, config)
-				if err != nil {
-					return errwrap.Wrapf("Error starting instance: {{err}}", err)
+				if previousStatus == "SUSPENDED" {
+					op, err = config.NewComputeClient(userAgent).Instances.Resume(project, zone, instance.Name).Do()
+					if err != nil {
+						return err
+					}
+				} else {
+					op, err = startInstanceOperation(d, config)
+					if err != nil {
+						return errwrap.Wrapf("Error starting instance: {{err}}", err)
+					}
 				}
 			} else if desiredStatus == "TERMINATED" {
 				op, err = config.NewComputeClient(userAgent).Instances.Stop(project, zone, instance.Name).Do()
+				if err != nil {
+					return err
+				}
+			} else if desiredStatus == "SUSPENDED" {
+				op, err = config.NewComputeClient(userAgent).Instances.Suspend(project, zone, instance.Name).Do()
 				if err != nil {
 					return err
 				}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.erb
@@ -2475,7 +2475,11 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 
 			if desiredStatus == "RUNNING" {
 				if previousStatus == "SUSPENDED" {
+<% unless version == 'ga' -%>
+					op, err = config.NewComputeClient(userAgent).Instances.Resume(project, zone, instance.Name, &compute.InstancesResumeRequest{}).Do()
+<% else -%>
 					op, err = config.NewComputeClient(userAgent).Instances.Resume(project, zone, instance.Name).Do()
+<% end -%>
 					if err != nil {
 						return err
 					}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -2677,6 +2677,52 @@ func TestAccComputeInstance_updateTerminated_desiredStatusRunning_notAllowStoppi
 	})
 }
 
+func TestAccComputeInstance_desiredStatus_suspended(t *testing.T) {
+	t.Parallel()
+
+	var instance compute.Instance
+	context_1 := map[string]interface{}{
+		"instance_name":  fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"desired_status": "RUNNING",
+	}
+	context_2 := map[string]interface{}{
+		"instance_name":  context_1["instance_name"],
+		"desired_status": "SUSPENDED",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_desiredStatus_suspended(context_1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceHasStatus(&instance, "RUNNING"),
+				),
+			},
+			{
+				Config: testAccComputeInstance_desiredStatus_suspended(context_2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceHasStatus(&instance, "SUSPENDED"),
+				),
+			},
+			{
+				Config: testAccComputeInstance_desiredStatus_suspended(context_1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceHasStatus(&instance, "RUNNING"), // this mimics resume method behavior
+				),
+			},
+		},
+	})
+}
+
 func TestAccComputeInstance_resourcePolicyCollocate(t *testing.T) {
 	t.Parallel()
 
@@ -8630,6 +8676,33 @@ resource "google_compute_instance" "foobar" {
 	allow_stopping_for_update = %t
 }
 `, instance, machineType, desiredStatusConfigSection, allowStoppingForUpdate)
+}
+
+func testAccComputeInstance_desiredStatus_suspended(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-11"
+	project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+	name           = "%{instance_name}"
+	machine_type   = "e2-medium"
+	zone           = "us-central1-a"
+
+	boot_disk {
+		initialize_params{
+			image = "${data.google_compute_image.my_image.self_link}"
+		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+
+	desired_status = "%{desired_status}"
+}
+`, context)
 }
 
 func testAccComputeInstance_desiredStatusTerminatedUpdate(instance string) string {

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -150,7 +150,7 @@ The following arguments are supported:
 * `description` - (Optional) A brief description of this resource.
 
 * `desired_status` - (Optional) Desired status of the instance. Either
-`"RUNNING"` or `"TERMINATED"`.
+`"RUNNING"`, `"SUSPENDED"` or `"TERMINATED"`.
 
 * `deletion_protection` - (Optional) Enable deletion protection on this instance. Defaults to false.
     **Note:** you must disable deletion protection before removing the resource (e.g., via `terraform destroy`), or the instance cannot be deleted and the Terraform run will not complete successfully.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
closes https://github.com/hashicorp/terraform-provider-google/issues/11374

- Added the field
- Added tests for it
- Added doc changes

There is an additional piece of logic that uses Resume instead of Start method when necessary to simplify the UX when using this. So there is no need to add a "RESUMED" state.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: add "SUSPENDED" as a possible value to `desired_state` on `google_compute_instance`
```
