### PR TITLE
Address google_compute_router_nat nat_ips dependency issue with updates to docs

### DIFF
--- a/mmv1/products/compute/RouterNat.yaml
+++ b/mmv1/products/compute/RouterNat.yaml
@@ -158,8 +158,7 @@ properties:
     description: |
       Self-links of NAT IPs. Only valid if natIpAllocateOption
       is set to MANUAL_ONLY.
-
-      ~> **Note:** If this field is used alongside with a count created list of address resources `google_compute_address.foobar.*.self_link`,
+      If this field is used alongside with a count created list of address resources `google_compute_address.foobar.*.self_link`,
       the access level resource for the address resource must have a `lifecycle` block with `create_before_destroy = true` so
       the number of resources can be increased/decreased without triggering the `resourceInUseByAnotherResource` error.
     send_empty_value: true

--- a/mmv1/products/compute/RouterNat.yaml
+++ b/mmv1/products/compute/RouterNat.yaml
@@ -30,6 +30,9 @@ nested_query: !ruby/object:Api::Resource::NestedQuery
     - nats
 description: |
   A NAT service created in a router.
+
+  ~> **Note:** Recreating a `google_compute_address` that is being used by `google_compute_router_nat` will give a `resourceInUseByAnotherResource` error.
+  Use `lifecycle.create_before_destroy` on this address resource to avoid this type of error as shown in the Manual Ips example.
 references: !ruby/object:Api::Resource::ReferenceLinks
   guides:
     'Google Cloud Router': 'https://cloud.google.com/router/docs/'
@@ -157,8 +160,8 @@ properties:
       is set to MANUAL_ONLY.
 
       ~> **Note:** If this field is used alongside with a count created list of address resources `google_compute_address.foobar.*.self_link`,
-      the access level resource must have a `lifecycle` block with `create_before_destroy = true` so
-      the number of address resources can be increased/decreased without triggering the not allowed to delete a dependant resource error.
+      the access level resource for the address resource must have a `lifecycle` block with `create_before_destroy = true` so
+      the number of resources can be increased/decreased without triggering the `resourceInUseByAnotherResource` error.
     send_empty_value: true
     is_set: true
     set_hash_func: computeRouterNatIPsHash

--- a/mmv1/products/compute/RouterNat.yaml
+++ b/mmv1/products/compute/RouterNat.yaml
@@ -155,6 +155,10 @@ properties:
     description: |
       Self-links of NAT IPs. Only valid if natIpAllocateOption
       is set to MANUAL_ONLY.
+
+      ~> **Note:** If this field is used alongside with a count created list of address resources `google_compute_address.foobar.*.self_link`,
+      the access level resource must have a `lifecycle` block with `create_before_destroy = true` so
+      the number of address resources can be increased/decreased without triggering the not allowed to delete a dependant resource error.
     send_empty_value: true
     is_set: true
     set_hash_func: computeRouterNatIPsHash

--- a/mmv1/templates/terraform/examples/go/router_nat_manual_ips.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/router_nat_manual_ips.tf.tmpl
@@ -19,6 +19,10 @@ resource "google_compute_address" "address" {
   count  = 2
   name   = "{{index $.Vars "address_name"}}-${count.index}"
   region = google_compute_subnetwork.subnet.region
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "google_compute_router_nat" "{{$.PrimaryResourceId}}" {

--- a/mmv1/templates/terraform/examples/router_nat_manual_ips.tf.erb
+++ b/mmv1/templates/terraform/examples/router_nat_manual_ips.tf.erb
@@ -19,6 +19,10 @@ resource "google_compute_address" "address" {
   count  = 2
   name   = "<%= ctx[:vars]['address_name'] %>-${count.index}"
   region = google_compute_subnetwork.subnet.region
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "google_compute_router_nat" "<%= ctx[:primary_resource_id] %>" {

--- a/mmv1/third_party/terraform/services/compute/go/resource_compute_router_nat_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/go/resource_compute_router_nat_test.go.tmpl
@@ -699,6 +699,45 @@ func TestAccComputeRouterNat_withPrivateNatAndEmptyActionActiveRanges(t *testing
 }
 {{- end }}
 
+func TestAccComputeRouterNat_withAddressCountDecrease(t *testing.T) {
+	t.Parallel()
+
+	testId := acctest.RandString(t, 10)
+	routerName := fmt.Sprintf("tf-test-router-nat-%s", testId)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRouterNatDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRouterNat_withAddressCountDecrease1(routerName, "3"),
+			},
+			{
+				ResourceName:      "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterNat_withAddressCountDecrease2(routerName, "3"),
+			},
+			{
+				ResourceName:      "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterNat_withAddressCountDecrease3(routerName, "2"),
+			},
+			{
+				ResourceName:      "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckComputeRouterNatDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
@@ -806,6 +845,164 @@ resource "google_compute_router_nat" "foobar" {
   }
 }
 `, routerName, routerName, routerName, routerName)
+}
+
+func testAccComputeRouterNat_withAddressCountDecrease1(routerName, routerCount string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  name = "%s-net"
+}
+
+resource "google_compute_subnetwork" "foobar" {
+  name          = "%s-subnet"
+  network       = google_compute_network.foobar.self_link
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+}
+
+resource "google_compute_router" "foobar" {
+  name    = "%s"
+  region  = google_compute_subnetwork.foobar.region
+  network = google_compute_network.foobar.self_link
+}
+
+resource "google_compute_address" "foobar" {
+  count         = %s
+  name          = "%s-address-${count.index}"
+  region        = google_compute_subnetwork.foobar.region
+}
+
+resource "google_compute_router_nat" "foobar" {
+  name                               = "%s-nat"
+  router                             = google_compute_router.foobar.name
+  region                             = google_compute_router.foobar.region
+
+  nat_ip_allocate_option             = "MANUAL_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+
+  nat_ips = google_compute_address.foobar.*.self_link
+
+  subnetwork {
+    name  = google_compute_subnetwork.foobar.name
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+
+  min_ports_per_vm = 1024
+
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}
+`, routerName, routerName, routerName, routerCount, routerName, routerName)
+}
+
+func testAccComputeRouterNat_withAddressCountDecrease2(routerName, routerCount string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  name = "%s-net"
+}
+
+resource "google_compute_subnetwork" "foobar" {
+  name          = "%s-subnet"
+  network       = google_compute_network.foobar.self_link
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+}
+
+resource "google_compute_router" "foobar" {
+  name    = "%s"
+  region  = google_compute_subnetwork.foobar.region
+  network = google_compute_network.foobar.self_link
+}
+
+resource "google_compute_address" "foobar" {
+  count         = %s
+  name          = "%s-address-${count.index}"
+  region        = google_compute_subnetwork.foobar.region
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "google_compute_router_nat" "foobar" {
+  name                               = "%s-nat"
+  router                             = google_compute_router.foobar.name
+  region                             = google_compute_router.foobar.region
+
+  nat_ip_allocate_option             = "MANUAL_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+
+  nat_ips = google_compute_address.foobar.*.self_link
+
+  subnetwork {
+    name  = google_compute_subnetwork.foobar.name
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+
+  min_ports_per_vm = 1024
+
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}
+`, routerName, routerName, routerName, routerCount, routerName, routerName)
+}
+
+func testAccComputeRouterNat_withAddressCountDecrease3(routerName, routerCount string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  name = "%s-net"
+}
+
+resource "google_compute_subnetwork" "foobar" {
+  name          = "%s-subnet"
+  network       = google_compute_network.foobar.self_link
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+}
+
+resource "google_compute_router" "foobar" {
+  name    = "%s"
+  region  = google_compute_subnetwork.foobar.region
+  network = google_compute_network.foobar.self_link
+}
+
+resource "google_compute_address" "foobar" {
+  count         = %s
+  name          = "%s-address-${count.index}"
+  region        = google_compute_subnetwork.foobar.region
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "google_compute_router_nat" "foobar" {
+  name                               = "%s-nat"
+  router                             = google_compute_router.foobar.name
+  region                             = google_compute_router.foobar.region
+
+  nat_ip_allocate_option             = "MANUAL_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+
+  nat_ips = google_compute_address.foobar.*.self_link
+
+  subnetwork {
+    name  = google_compute_subnetwork.foobar.name
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+
+  min_ports_per_vm = 1024
+
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}
+`, routerName, routerName, routerName, routerCount, routerName, routerName)
 }
 
 // Like basic but with extra resources

--- a/mmv1/third_party/terraform/services/compute/go/resource_compute_router_nat_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/go/resource_compute_router_nat_test.go.tmpl
@@ -867,15 +867,15 @@ resource "google_compute_router" "foobar" {
 }
 
 resource "google_compute_address" "foobar" {
-  count         = %s
-  name          = "%s-address-${count.index}"
-  region        = google_compute_subnetwork.foobar.region
+  count  = %s
+  name   = "%s-address-${count.index}"
+  region = google_compute_subnetwork.foobar.region
 }
 
 resource "google_compute_router_nat" "foobar" {
-  name                               = "%s-nat"
-  router                             = google_compute_router.foobar.name
-  region                             = google_compute_router.foobar.region
+  name   = "%s-nat"
+  router = google_compute_router.foobar.name
+  region = google_compute_router.foobar.region
 
   nat_ip_allocate_option             = "MANUAL_ONLY"
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
@@ -917,9 +917,9 @@ resource "google_compute_router" "foobar" {
 }
 
 resource "google_compute_address" "foobar" {
-  count         = %s
-  name          = "%s-address-${count.index}"
-  region        = google_compute_subnetwork.foobar.region
+  count  = %s
+  name   = "%s-address-${count.index}"
+  region = google_compute_subnetwork.foobar.region
 
   lifecycle {
     create_before_destroy = true
@@ -927,9 +927,9 @@ resource "google_compute_address" "foobar" {
 }
 
 resource "google_compute_router_nat" "foobar" {
-  name                               = "%s-nat"
-  router                             = google_compute_router.foobar.name
-  region                             = google_compute_router.foobar.region
+  name   = "%s-nat"
+  router = google_compute_router.foobar.name
+  region = google_compute_router.foobar.region
 
   nat_ip_allocate_option             = "MANUAL_ONLY"
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
@@ -971,9 +971,9 @@ resource "google_compute_router" "foobar" {
 }
 
 resource "google_compute_address" "foobar" {
-  count         = %s
-  name          = "%s-address-${count.index}"
-  region        = google_compute_subnetwork.foobar.region
+  count  = %s
+  name   = "%s-address-${count.index}"
+  region = google_compute_subnetwork.foobar.region
 
   lifecycle {
     create_before_destroy = true
@@ -981,9 +981,9 @@ resource "google_compute_address" "foobar" {
 }
 
 resource "google_compute_router_nat" "foobar" {
-  name                               = "%s-nat"
-  router                             = google_compute_router.foobar.name
-  region                             = google_compute_router.foobar.region
+  name   = "%s-nat"
+  router = google_compute_router.foobar.name
+  region = google_compute_router.foobar.region
 
   nat_ip_allocate_option             = "MANUAL_ONLY"
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_nat_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_nat_test.go.erb
@@ -700,6 +700,45 @@ func TestAccComputeRouterNat_withPrivateNatAndEmptyActionActiveRanges(t *testing
 }
 <% end -%>
 
+func TestAccComputeRouterNat_withAddressCountDecrease(t *testing.T) {
+	t.Parallel()
+
+	testId := acctest.RandString(t, 10)
+	routerName := fmt.Sprintf("tf-test-router-nat-%s", testId)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRouterNatDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRouterNat_withAddressCountDecrease1(routerName, "3"),
+			},
+			{
+				ResourceName:      "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterNat_withAddressCountDecrease2(routerName, "3"),
+			},
+			{
+				ResourceName:      "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterNat_withAddressCountDecrease3(routerName, "2"),
+			},
+			{
+				ResourceName:      "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckComputeRouterNatDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
@@ -807,6 +846,164 @@ resource "google_compute_router_nat" "foobar" {
   }
 }
 `, routerName, routerName, routerName, routerName)
+}
+
+func testAccComputeRouterNat_withAddressCountDecrease1(routerName, routerCount string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  name = "%s-net"
+}
+
+resource "google_compute_subnetwork" "foobar" {
+  name          = "%s-subnet"
+  network       = google_compute_network.foobar.self_link
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+}
+
+resource "google_compute_router" "foobar" {
+  name    = "%s"
+  region  = google_compute_subnetwork.foobar.region
+  network = google_compute_network.foobar.self_link
+}
+
+resource "google_compute_address" "foobar" {
+  count         = %s
+  name          = "%s-address-${count.index}"
+  region        = google_compute_subnetwork.foobar.region
+}
+
+resource "google_compute_router_nat" "foobar" {
+  name                               = "%s-nat"
+  router                             = google_compute_router.foobar.name
+  region                             = google_compute_router.foobar.region
+
+  nat_ip_allocate_option             = "MANUAL_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+
+  nat_ips = google_compute_address.foobar.*.self_link
+
+  subnetwork {
+    name  = google_compute_subnetwork.foobar.name
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+
+  min_ports_per_vm = 1024
+
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}
+`, routerName, routerName, routerName, routerCount, routerName, routerName)
+}
+
+func testAccComputeRouterNat_withAddressCountDecrease2(routerName, routerCount string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  name = "%s-net"
+}
+
+resource "google_compute_subnetwork" "foobar" {
+  name          = "%s-subnet"
+  network       = google_compute_network.foobar.self_link
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+}
+
+resource "google_compute_router" "foobar" {
+  name    = "%s"
+  region  = google_compute_subnetwork.foobar.region
+  network = google_compute_network.foobar.self_link
+}
+
+resource "google_compute_address" "foobar" {
+  count         = %s
+  name          = "%s-address-${count.index}"
+  region        = google_compute_subnetwork.foobar.region
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "google_compute_router_nat" "foobar" {
+  name                               = "%s-nat"
+  router                             = google_compute_router.foobar.name
+  region                             = google_compute_router.foobar.region
+
+  nat_ip_allocate_option             = "MANUAL_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+
+  nat_ips = google_compute_address.foobar.*.self_link
+
+  subnetwork {
+    name  = google_compute_subnetwork.foobar.name
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+
+  min_ports_per_vm = 1024
+
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}
+`, routerName, routerName, routerName, routerCount, routerName, routerName)
+}
+
+func testAccComputeRouterNat_withAddressCountDecrease3(routerName, routerCount string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  name = "%s-net"
+}
+
+resource "google_compute_subnetwork" "foobar" {
+  name          = "%s-subnet"
+  network       = google_compute_network.foobar.self_link
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+}
+
+resource "google_compute_router" "foobar" {
+  name    = "%s"
+  region  = google_compute_subnetwork.foobar.region
+  network = google_compute_network.foobar.self_link
+}
+
+resource "google_compute_address" "foobar" {
+  count         = %s
+  name          = "%s-address-${count.index}"
+  region        = google_compute_subnetwork.foobar.region
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "google_compute_router_nat" "foobar" {
+  name                               = "%s-nat"
+  router                             = google_compute_router.foobar.name
+  region                             = google_compute_router.foobar.region
+
+  nat_ip_allocate_option             = "MANUAL_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+
+  nat_ips = google_compute_address.foobar.*.self_link
+
+  subnetwork {
+    name  = google_compute_subnetwork.foobar.name
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+
+  min_ports_per_vm = 1024
+
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}
+`, routerName, routerName, routerName, routerCount, routerName, routerName)
 }
 
 // Like basic but with extra resources

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_nat_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_nat_test.go.erb
@@ -868,15 +868,15 @@ resource "google_compute_router" "foobar" {
 }
 
 resource "google_compute_address" "foobar" {
-  count         = %s
-  name          = "%s-address-${count.index}"
-  region        = google_compute_subnetwork.foobar.region
+  count  = %s
+  name   = "%s-address-${count.index}"
+  region = google_compute_subnetwork.foobar.region
 }
 
 resource "google_compute_router_nat" "foobar" {
-  name                               = "%s-nat"
-  router                             = google_compute_router.foobar.name
-  region                             = google_compute_router.foobar.region
+  name   = "%s-nat"
+  router = google_compute_router.foobar.name
+  region = google_compute_router.foobar.region
 
   nat_ip_allocate_option             = "MANUAL_ONLY"
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
@@ -918,9 +918,9 @@ resource "google_compute_router" "foobar" {
 }
 
 resource "google_compute_address" "foobar" {
-  count         = %s
-  name          = "%s-address-${count.index}"
-  region        = google_compute_subnetwork.foobar.region
+  count  = %s
+  name   = "%s-address-${count.index}"
+  region = google_compute_subnetwork.foobar.region
 
   lifecycle {
     create_before_destroy = true
@@ -928,9 +928,9 @@ resource "google_compute_address" "foobar" {
 }
 
 resource "google_compute_router_nat" "foobar" {
-  name                               = "%s-nat"
-  router                             = google_compute_router.foobar.name
-  region                             = google_compute_router.foobar.region
+  name   = "%s-nat"
+  router = google_compute_router.foobar.name
+  region = google_compute_router.foobar.region
 
   nat_ip_allocate_option             = "MANUAL_ONLY"
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
@@ -972,9 +972,9 @@ resource "google_compute_router" "foobar" {
 }
 
 resource "google_compute_address" "foobar" {
-  count         = %s
-  name          = "%s-address-${count.index}"
-  region        = google_compute_subnetwork.foobar.region
+  count  = %s
+  name   = "%s-address-${count.index}"
+  region = google_compute_subnetwork.foobar.region
 
   lifecycle {
     create_before_destroy = true
@@ -982,9 +982,9 @@ resource "google_compute_address" "foobar" {
 }
 
 resource "google_compute_router_nat" "foobar" {
-  name                               = "%s-nat"
-  router                             = google_compute_router.foobar.name
-  region                             = google_compute_router.foobar.region
+  name   = "%s-nat"
+  router = google_compute_router.foobar.name
+  region = google_compute_router.foobar.region
 
   nat_ip_allocate_option             = "MANUAL_ONLY"
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/6812

This PR is based on work done by @matheusaleixo-cit [here](https://github.com/GoogleCloudPlatform/magic-modules/pull/11390) but focuses on reducing the impact from the fix

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: added guidance in documentation to resolve dependency issues that block deletion of `google_compute_address` resources when they're referenced in `google_compute_router_nat` resources, specifically  when using `count` references
```
