### PR TITLE
Public outbound ip 

### DIFF
--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -389,4 +389,3 @@ properties:
       The outbound public IP addresses for the instance. This is available ONLY when
       networkConfig.enableOutboundPublicIp is set to true. These IP addresses are used
       for outbound connections.
-      

--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -389,3 +389,4 @@ properties:
       The outbound public IP addresses for the instance. This is available ONLY when
       networkConfig.enableOutboundPublicIp is set to true. These IP addresses are used
       for outbound connections.
+      

--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -370,6 +370,10 @@ properties:
           Enabling public ip for the instance. If a user wishes to disable this,
           please also clear the list of the authorized external networks set on
           the same instance.
+      - !ruby/object:Api::Type::Boolean
+        name: enableOutboundPublicIp
+        description: |
+          Enabling outbound public ip for the instance.      
   - !ruby/object:Api::Type::String
     name: 'publicIpAddress'
     output: true
@@ -377,3 +381,12 @@ properties:
       The public IP addresses for the Instance. This is available ONLY when
       networkConfig.enablePublicIp is set to true. This is the connection
       endpoint for an end-user application.
+  - !ruby/object:Api::Type::Array
+    item_type: Api::Type::String
+    name: 'outboundPublicIpAddresses'
+    output: true
+    description: |
+      The outbound public IP addresses for the instance. This is available ONLY when
+      networkConfig.enableOutboundPublicIp is set to true. These IP addresses are used
+      for outbound connections.
+

--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -373,7 +373,7 @@ properties:
       - !ruby/object:Api::Type::Boolean
         name: enableOutboundPublicIp
         description: |
-          Enabling outbound public ip for the instance.      
+          Enabling outbound public ip for the instance.
   - !ruby/object:Api::Type::String
     name: 'publicIpAddress'
     output: true
@@ -389,4 +389,3 @@ properties:
       The outbound public IP addresses for the instance. This is available ONLY when
       networkConfig.enableOutboundPublicIp is set to true. These IP addresses are used
       for outbound connections.
-

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
@@ -644,6 +644,9 @@ func TestAccAlloydbInstance_networkConfig(t *testing.T) {
 				Config: testAccAlloydbInstance_networkConfig(context2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_alloydb_instance.default", "network_config.0.enable_public_ip", "true"),
+					resource.TestCheckResourceAttr("google_alloydb_instance.default", "network_config.0.authorized_external_networks.0.cidr_range", "8.8.8.8/30"),
+					resource.TestCheckResourceAttr("google_alloydb_instance.default", "network_config.0.authorized_external_networks.1.cidr_range", "8.8.4.4/30"),
+					resource.TestCheckResourceAttr("google_alloydb_instance.default", "network_config.0.authorized_external_networks.#", "2"),
 					resource.TestCheckResourceAttr("google_alloydb_instance.default", "network_config.0.enable_outbound_public_ip", "false"),
 					resource.TestCheckResourceAttr("google_alloydb_instance.default", "outbound_public_ip_addresses.#", "0"),
 				),
@@ -658,6 +661,8 @@ func TestAccAlloydbInstance_networkConfig(t *testing.T) {
 				Config: testAccAlloydbInstance_networkConfigWithAnAuthNetwork(context3),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_alloydb_instance.default", "network_config.0.enable_public_ip", "true"),
+					resource.TestCheckResourceAttr("google_alloydb_instance.default", "network_config.0.authorized_external_networks.0.cidr_range", "8.8.8.8/30"),
+					resource.TestCheckResourceAttr("google_alloydb_instance.default", "network_config.0.authorized_external_networks.#", "1"),
 					resource.TestCheckResourceAttr("google_alloydb_instance.default", "network_config.0.enable_outbound_public_ip", "true"),
 					resource.TestCheckResourceAttrSet("google_alloydb_instance.default", "outbound_public_ip_addresses.0"),
 				),


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This PR adds the enableOutboundPublicIp boolean field and outboundPublicIpAddresses (output only field) to the AlloyDB instance resource. Setting this field to true enables public outbound IP within the AlloyDB instance. PR addresses (b/353749975). It also adds testing which covers:
1. Creating an instance with the enableOutboundPublicIp set to true
2. Updating an instance with the enableOutboundPublicIp set to false
3. Updating an instance with the enableOutboundPublicIp set to true

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
alloyDB: added `enableOutboundPublicIp` field to `google_alloydb_instance` resource
```
