### PR TITLE
fix: Match all whitespace and non-whitespace for Pub/Sub subscription filter validation

### DIFF
--- a/mmv1/products/pubsub/Subscription.yaml
+++ b/mmv1/products/pubsub/Subscription.yaml
@@ -396,7 +396,7 @@ properties:
     name: 'filter'
     required: false
     validation: !ruby/object:Provider::Terraform::Validation
-      regex: '^.{0,256}$'
+      regex: '^[\s\S]{0,256}$'
     description: |
       The subscription only delivers the messages that match the filter.
       Pub/Sub automatically acknowledges the messages that don't match the filter. You can filter messages

--- a/mmv1/products/pubsub/go_Subscription.yaml
+++ b/mmv1/products/pubsub/go_Subscription.yaml
@@ -402,7 +402,7 @@ properties:
     required: false
     immutable: true
     validation:
-      regex: '^.{0,256}$'
+      regex: '^[\s\S]{0,256}$'
   - name: 'deadLetterPolicy'
     type: NestedObject
     description: |


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This change the regular expression validation for Pub/Sub subscriptions to use `[\s\S]` instead of `.` when matching characters to match both whitespace and non-whitespace characters. Because we allow empty filters (see [this issue](https://github.com/hashicorp/terraform-provider-google/issues/19269)), having only whitespace characters (which would be matched by this filter) is valid as well. This will not introduce any breaking changes as it only expands the character set for subscription filters.

This fixes [this issue](https://github.com/hashicorp/terraform-provider-google/issues/19296).
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
Allows Pub/Sub subscription filters to contain line breaks
```
