### PR TITLE
Add support for regional secret resource `google_secret_manager_regional_secret`

### DIFF
--- a/mmv1/products/secretmanager/product.yaml
+++ b/mmv1/products/secretmanager/product.yaml
@@ -14,6 +14,7 @@
 --- !ruby/object:Api::Product
 name: SecretManager
 display_name: Secret Manager
+legacy_name: secret_manager
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/mmv1/products/secretmanagerregional/RegionalSecret.yaml
+++ b/mmv1/products/secretmanagerregional/RegionalSecret.yaml
@@ -1,0 +1,222 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Resource
+name: RegionalSecret
+self_link: projects/{{project}}/locations/{{location}}/secrets/{{secret_id}}
+base_url: projects/{{project}}/locations/{{location}}/secrets
+create_url: projects/{{project}}/locations/{{location}}/secrets?secretId={{secret_id}}
+update_verb: :PATCH
+update_mask: true
+references: !ruby/object:Api::Resource::ReferenceLinks
+  # TODO : Update the below api reference link
+  api: 'https://cloud.google.com/secret-manager/docs/reference/rest/v1/projects.secrets'
+description: |
+  A Regional Secret is a logical secret whose value and versions can be created and accessed within a region only.
+iam_policy: !ruby/object:Api::Resource::IamPolicy
+  parent_resource_attribute: secret_id
+  method_name_separator: ':'
+  allowed_iam_role: roles/secretmanager.secretAccessor
+  iam_conditions_request_type: :QUERY_PARAM_NESTED
+  example_config_body: 'templates/terraform/iam/example_config_body/secret_manager_regional_secret.tf.erb'
+  import_format: [
+      'projects/{{project}}/locations/{{location}}/secrets/{{secret_id}}',
+      '{{secret_id}}',
+    ]
+examples:
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'regional_secret_config_basic'
+    primary_resource_id: 'regional-secret-basic'
+    primary_resource_name: 'fmt.Sprintf("tf-test-tf-reg-secret%s", context["random_suffix"])'
+    vars:
+      secret_id: 'tf-reg-secret'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'regional_secret_with_cmek'
+    primary_resource_id: 'regional-secret-with-cmek'
+    vars:
+      secret_id: 'tf-reg-secret'
+      kms_key_name: 'kms-key'
+    test_vars_overrides:
+      kms_key_name: 'acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'regional_secret_with_rotation'
+    primary_resource_id: 'regional-secret-with-rotation'
+    vars:
+      secret_id: 'tf-reg-secret'
+      topic_id: 'tf-topic'
+      timestamp: '2045-11-30T00:00:00Z'
+    test_vars_overrides:
+      timestamp: '"2122-11-30T00:00:00Z"'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'regional_secret_with_ttl'
+    primary_resource_id: 'regional-secret-with-ttl'
+    vars:
+      secret_id: 'tf-reg-secret'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'regional_secret_with_expire_time'
+    primary_resource_id: 'regional-secret-with-expire-time'
+    vars:
+      secret_id: 'tf-reg-secret'
+      timestamp: '2055-11-30T00:00:00Z'
+    test_vars_overrides:
+      timestamp: '"2122-11-30T00:00:00Z"'
+  - !ruby/object:Provider::Terraform::Examples
+    name: 'regional_secret_with_version_destroy_ttl'
+    primary_resource_id: 'regional-secret-with-version-destroy-ttl'
+    vars:
+      secret_id: 'tf-reg-secret'
+import_format: ['projects/{{project}}/locations/{{location}}/secrets/{{secret_id}}']
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  pre_update: templates/terraform/pre_update/secret_manager_regional_secret.go.erb
+parameters:
+  - !ruby/object:Api::Type::String
+    name: location
+    description: |
+      The location of the regional secret. eg us-central1
+    required: true
+    immutable: true
+    url_param_only: true
+  - !ruby/object:Api::Type::String
+    name: secretId
+    description: |
+      This must be unique within the project.
+    required: true
+    immutable: true
+    url_param_only: true
+properties:
+  - !ruby/object:Api::Type::String
+    name: name
+    output: true
+    description: |
+      The resource name of the regional secret. Format:
+      `projects/{{project}}/locations/{{location}}/secrets/{{secret_id}}`
+  - !ruby/object:Api::Type::String
+    name: createTime
+    output: true
+    description: |
+      The time at which the regional secret was created.
+  - !ruby/object:Api::Type::KeyValueLabels
+    name: labels
+    description: |
+      The labels assigned to this regional secret.
+
+      Label keys must be between 1 and 63 characters long, have a UTF-8 encoding of maximum 128 bytes,
+      and must conform to the following PCRE regular expression: [\p{Ll}\p{Lo}][\p{Ll}\p{Lo}\p{N}_-]{0,62}
+
+      Label values must be between 0 and 63 characters long, have a UTF-8 encoding of maximum 128 bytes,
+      and must conform to the following PCRE regular expression: [\p{Ll}\p{Lo}\p{N}_-]{0,63}
+
+      No more than 64 labels can be assigned to a given resource.
+
+      An object containing a list of "key": value pairs. Example:
+      { "name": "wrench", "mass": "1.3kg", "count": "3" }.
+  - !ruby/object:Api::Type::KeyValueAnnotations
+    name: annotations
+    description: |
+      Custom metadata about the regional secret.
+
+      Annotations are distinct from various forms of labels. Annotations exist to allow
+      client tools to store their own state information without requiring a database.
+
+      Annotation keys must be between 1 and 63 characters long, have a UTF-8 encoding of
+      maximum 128 bytes, begin and end with an alphanumeric character ([a-z0-9A-Z]), and
+      may have dashes (-), underscores (_), dots (.), and alphanumerics in between these
+      symbols.
+
+      The total size of annotation keys and values must be less than 16KiB.
+
+      An object containing a list of "key": value pairs. Example:
+      { "name": "wrench", "mass": "1.3kg", "count": "3" }.
+  # TODO : Add versionAliases field support once google_secret_manager_regional_secret_version is added
+  # - !ruby/object:Api::Type::KeyValuePairs
+  #   name: versionAliases
+  #   description: |
+  #     Mapping from version alias to version name.
+
+  #     A version alias is a string with a maximum length of 63 characters and can contain
+  #     uppercase and lowercase letters, numerals, and the hyphen (-) and underscore ('_')
+  #     characters. An alias string must start with a letter and cannot be the string
+  #     'latest' or 'NEW'. No more than 50 aliases can be assigned to a given secret.
+
+  #     An object containing a list of "key": value pairs. Example:
+  #     { "name": "wrench", "mass": "1.3kg", "count": "3" }.
+  - !ruby/object:Api::Type::NestedObject
+    name: customerManagedEncryption
+    description: |
+      The customer-managed encryption configuration of the regional secret.
+    properties:
+      - !ruby/object:Api::Type::String
+        name: kmsKeyName
+        required: true
+        description: |
+          The resource name of the Cloud KMS CryptoKey used to encrypt secret payloads.
+  - !ruby/object:Api::Type::Array
+    name: topics
+    description: |
+      A list of up to 10 Pub/Sub topics to which messages are published when control plane
+      operations are called on the regional secret or its versions.
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties:
+        - !ruby/object:Api::Type::String
+          name: name
+          required: true
+          description: |
+            The resource name of the Pub/Sub topic that will be published to, in the following
+            format: projects/*/topics/*. For publication to succeed, the Secret Manager Service
+            Agent service account must have pubsub.publisher permissions on the topic.
+  - !ruby/object:Api::Type::NestedObject
+    name: rotation
+    required_with:
+      - topics
+    description: |
+      The rotation time and period for a regional secret. At `next_rotation_time`, Secret Manager
+      will send a Pub/Sub notification to the topics configured on the Secret. `topics` must be
+      set to configure rotation.
+    properties:
+      - !ruby/object:Api::Type::String
+        name: nextRotationTime
+        description: |
+          Timestamp in UTC at which the Secret is scheduled to rotate.
+          A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine
+          fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+      - !ruby/object:Api::Type::String
+        name: rotationPeriod
+        description: |
+          The Duration between rotation notifications. Must be in seconds and at least 3600s (1h)
+          and at most 3153600000s (100 years). If rotationPeriod is set, `next_rotation_time` must
+          be set. `next_rotation_time` will be advanced by this period when the service
+          automatically sends rotation notifications.
+        required_with:
+          - rotation.0.next_rotation_time
+  - !ruby/object:Api::Type::String
+    name: expireTime
+    description: |
+      Timestamp in UTC when the regional secret is scheduled to expire. This is always provided on
+      output, regardless of what was sent on input. A timestamp in RFC3339 UTC "Zulu" format, with
+      nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and
+      "2014-10-02T15:01:23.045123456Z". Only one of `expire_time` or `ttl` can be provided.
+    default_from_api: true
+  - !ruby/object:Api::Type::String
+    name: ttl
+    description: |
+      The TTL for the regional secret. A duration in seconds with up to nine fractional digits,
+      terminated by 's'. Example: "3.5s". Only one of `ttl` or `expire_time` can be provided.
+    ignore_read: true
+  - !ruby/object:Api::Type::String
+    name: versionDestroyTtl
+    description: |
+      Secret Version TTL after destruction request.
+      This is a part of the delayed delete feature on Secret Version.
+      For secret with versionDestroyTtl>0, version destruction doesn't happen immediately
+      on calling destroy instead the version goes to a disabled state and
+      the actual destruction happens after this TTL expires. It must be atleast 24h.

--- a/mmv1/products/secretmanagerregional/RegionalSecret.yaml
+++ b/mmv1/products/secretmanagerregional/RegionalSecret.yaml
@@ -30,9 +30,9 @@ iam_policy: !ruby/object:Api::Resource::IamPolicy
   iam_conditions_request_type: :QUERY_PARAM_NESTED
   example_config_body: 'templates/terraform/iam/example_config_body/secret_manager_regional_secret.tf.erb'
   import_format: [
-      'projects/{{project}}/locations/{{location}}/secrets/{{secret_id}}',
-      '{{secret_id}}',
-    ]
+    'projects/{{project}}/locations/{{location}}/secrets/{{secret_id}}',
+    '{{secret_id}}',
+  ]
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'regional_secret_config_basic'

--- a/mmv1/products/secretmanagerregional/product.yaml
+++ b/mmv1/products/secretmanagerregional/product.yaml
@@ -11,15 +11,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Warning: This is a temporary file, and should not be edited directly
----
-name: 'SecretManager'
-display_name: 'Secret Manager'
-legacy_name: 'secret_manager'
+--- !ruby/object:Api::Product
+name: SecretManagerRegional
+display_name: Secret Manager
+legacy_name: secret_manager
 versions:
-  - name: 'ga'
-    base_url: 'https://secretmanager.googleapis.com/v1/'
-  - name: 'beta'
-    base_url: 'https://secretmanager.googleapis.com/v1/'
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: https://secretmanager.{{location}}.rep.googleapis.com/v1/
+  - !ruby/object:Api::Product::Version
+    name: beta
+    base_url: https://secretmanager.{{location}}.rep.googleapis.com/v1/
 scopes:
-  - 'https://www.googleapis.com/auth/cloud-platform'
+  - https://www.googleapis.com/auth/cloud-platform

--- a/mmv1/templates/terraform/examples/regional_secret_config_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/regional_secret_config_basic.tf.erb
@@ -1,0 +1,14 @@
+resource "google_secret_manager_regional_secret" "<%= ctx[:primary_resource_id] %>" {
+  secret_id = "<%= ctx[:vars]['secret_id'] %>"
+  location = "us-central1"
+
+  labels = {
+    label = "my-label"
+  }
+
+  annotations = {
+    key1 = "value1",
+    key2 = "value2",
+    key3 = "value3"
+  }
+}

--- a/mmv1/templates/terraform/examples/regional_secret_with_cmek.tf.erb
+++ b/mmv1/templates/terraform/examples/regional_secret_with_cmek.tf.erb
@@ -1,0 +1,18 @@
+data "google_project" "project" {}
+
+resource "google_kms_crypto_key_iam_member" "kms-secret-binding" {
+  crypto_key_id = "<%= ctx[:vars]['kms_key_name'] %>"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+
+resource "google_secret_manager_regional_secret" "<%= ctx[:primary_resource_id] %>" {
+  secret_id = "<%= ctx[:vars]['secret_id'] %>"
+  location = "us-central1"
+
+  customer_managed_encryption {
+    kms_key_name = "<%= ctx[:vars]['kms_key_name'] %>"
+  }
+
+  depends_on = [ google_kms_crypto_key_iam_member.kms-secret-binding ]
+}

--- a/mmv1/templates/terraform/examples/regional_secret_with_expire_time.tf.erb
+++ b/mmv1/templates/terraform/examples/regional_secret_with_expire_time.tf.erb
@@ -1,0 +1,16 @@
+resource "google_secret_manager_regional_secret" "<%= ctx[:primary_resource_id] %>" {
+  secret_id = "<%= ctx[:vars]['secret_id'] %>"
+  location = "us-central1"
+
+  labels = {
+    label = "my-label"
+  }
+
+  annotations = {
+    key1 = "value1",
+    key2 = "value2",
+    key3 = "value3"
+  }
+
+  expire_time = "<%= ctx[:vars]['timestamp'] %>"
+}

--- a/mmv1/templates/terraform/examples/regional_secret_with_rotation.tf.erb
+++ b/mmv1/templates/terraform/examples/regional_secret_with_rotation.tf.erb
@@ -1,0 +1,29 @@
+data "google_project" "project" {}
+
+resource "google_pubsub_topic" "topic" {
+  name = "<%= ctx[:vars]['topic_id'] %>"
+}
+
+resource "google_pubsub_topic_iam_member" "secrets_manager_access" {
+  topic  = google_pubsub_topic.topic.name
+  role   = "roles/pubsub.publisher"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+
+resource "google_secret_manager_regional_secret" "<%= ctx[:primary_resource_id] %>" {
+  secret_id = "<%= ctx[:vars]['secret_id'] %>"
+  location = "us-central1"
+
+  topics {
+    name = google_pubsub_topic.topic.id
+  }
+
+  rotation {
+    rotation_period = "3600s"
+    next_rotation_time = "<%= ctx[:vars]['timestamp'] %>"
+  }
+
+  depends_on = [
+    google_pubsub_topic_iam_member.secrets_manager_access,
+  ]
+}

--- a/mmv1/templates/terraform/examples/regional_secret_with_ttl.tf.erb
+++ b/mmv1/templates/terraform/examples/regional_secret_with_ttl.tf.erb
@@ -1,0 +1,16 @@
+resource "google_secret_manager_regional_secret" "<%= ctx[:primary_resource_id] %>" {
+  secret_id = "<%= ctx[:vars]['secret_id'] %>"
+  location = "us-central1"
+
+  labels = {
+    label = "my-label"
+  }
+
+  annotations = {
+    key1 = "value1",
+    key2 = "value2",
+    key3 = "value3"
+  }
+
+  ttl = "36000s"
+}

--- a/mmv1/templates/terraform/examples/regional_secret_with_version_destroy_ttl.tf.erb
+++ b/mmv1/templates/terraform/examples/regional_secret_with_version_destroy_ttl.tf.erb
@@ -1,0 +1,16 @@
+resource "google_secret_manager_regional_secret" "<%= ctx[:primary_resource_id] %>" {
+  secret_id = "<%= ctx[:vars]['secret_id'] %>"
+  location = "us-central1"
+
+  labels = {
+    label = "my-label"
+  }
+
+  annotations = {
+    key1 = "value1",
+    key2 = "value2",
+    key3 = "value3"
+  }
+
+  version_destroy_ttl = "86400s"
+}

--- a/mmv1/templates/terraform/iam/example_config_body/secret_manager_regional_secret.tf.erb
+++ b/mmv1/templates/terraform/iam/example_config_body/secret_manager_regional_secret.tf.erb
@@ -1,0 +1,3 @@
+  project = google_secret_manager_regional_secret.regional-secret-basic.project
+  location = google_secret_manager_regional_secret.regional-secret-basic.location
+  secret_id = google_secret_manager_regional_secret.regional-secret-basic.secret_id

--- a/mmv1/templates/terraform/pre_update/secret_manager_regional_secret.go.erb
+++ b/mmv1/templates/terraform/pre_update/secret_manager_regional_secret.go.erb
@@ -1,0 +1,18 @@
+<%- # the license inside this block applies to this file
+	# Copyright 2024 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+// As the API expects only one of ttl or expireTime
+if d.HasChange("ttl") && !d.HasChange("expire_time") {
+    delete(obj, "expireTime")
+}

--- a/mmv1/third_party/terraform/.teamcity/components/inputs/services_beta.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/inputs/services_beta.kt
@@ -616,6 +616,11 @@ var ServicesListBeta = mapOf(
         "displayName" to "Secretmanager",
         "path" to "./google-beta/services/secretmanager"
     ),
+    "secretmanagerregional" to mapOf(
+        "name" to "secretmanagerregional",
+        "displayName" to "Secretmanagerregional",
+        "path" to "./google-beta/services/secretmanagerregional"
+    ),
     "securesourcemanager" to mapOf(
         "name" to "securesourcemanager",
         "displayName" to "Securesourcemanager",

--- a/mmv1/third_party/terraform/.teamcity/components/inputs/services_ga.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/inputs/services_ga.kt
@@ -611,6 +611,11 @@ var ServicesListGa = mapOf(
         "displayName" to "Secretmanager",
         "path" to "./google/services/secretmanager"
     ),
+    "secretmanagerregional" to mapOf(
+        "name" to "secretmanagerregional",
+        "displayName" to "Secretmanagerregional",
+        "path" to "./google/services/secretmanagerregional"
+    ),
     "securesourcemanager" to mapOf(
         "name" to "securesourcemanager",
         "displayName" to "Securesourcemanager",

--- a/mmv1/third_party/terraform/services/secretmanagerregional/iam_secret_manager_regional_secret_test.go.erb
+++ b/mmv1/third_party/terraform/services/secretmanagerregional/iam_secret_manager_regional_secret_test.go.erb
@@ -1,0 +1,198 @@
+<% autogen_exception -%>
+package secretmanagerregional_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccSecretManagerRegionalRegionalSecretIam_iamPolicyUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"role":          "roles/secretmanager.secretAccessor",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerRegionalRegionalSecretDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretManagerRegionalRegionalSecretIam_iamPolicyBasic(context),
+			},
+			{
+				ResourceName:      "google_secret_manager_regional_secret_iam_policy.default",
+				ImportStateId:     fmt.Sprintf("projects/%s/locations/%s/secrets/%s", envvar.GetTestProjectFromEnv(), envvar.GetTestRegionFromEnv(), fmt.Sprintf("tf-test-tf-reg-secret%s", context["random_suffix"])),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccSecretManagerRegionalRegionalSecretIam_iamPolicyUpdate(context),
+			},
+			{
+				ResourceName:      "google_secret_manager_regional_secret_iam_policy.default",
+				ImportStateId:     fmt.Sprintf("projects/%s/locations/%s/secrets/%s", envvar.GetTestProjectFromEnv(), envvar.GetTestRegionFromEnv(), fmt.Sprintf("tf-test-tf-reg-secret%s", context["random_suffix"])),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccSecretManagerRegionalRegionalSecretIam_iamPolicyBasic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_regional_secret" "default" {
+  secret_id = "tf-test-tf-reg-secret%{random_suffix}"
+  location = "us-central1"
+  ttl = "3600s"
+
+  labels = {
+    label = "my-label"
+  }
+
+  annotations = {
+    key1 = "value1"
+  }
+}
+
+data "google_iam_policy" "default" {
+  binding {
+    role = "%{role}"
+    members = ["user:admin@hashicorptest.com"]
+  }
+}
+
+resource "google_secret_manager_regional_secret_iam_policy" "default" {
+  project = google_secret_manager_regional_secret.default.project
+  location = google_secret_manager_regional_secret.default.location
+  secret_id = google_secret_manager_regional_secret.default.secret_id
+  policy_data = data.google_iam_policy.default.policy_data
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalRegionalSecretIam_iamPolicyUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_regional_secret" "default" {
+  secret_id = "tf-test-tf-reg-secret%{random_suffix}"
+  location = "us-central1"
+  ttl = "3600s"
+
+  labels = {
+    label = "my-label"
+  }
+
+  annotations = {
+    key1 = "value1"
+  }
+}
+
+data "google_iam_policy" "default" {
+  binding {
+    role = "%{role}"
+    members = ["user:admin@hashicorptest.com", "user:gterraformtest1@gmail.com"]
+  }
+}
+
+resource "google_secret_manager_regional_secret_iam_policy" "default" {
+  project = google_secret_manager_regional_secret.default.project
+  location = google_secret_manager_regional_secret.default.location
+  secret_id = google_secret_manager_regional_secret.default.secret_id
+  policy_data = data.google_iam_policy.default.policy_data
+}
+`, context)
+}
+
+func TestAccSecretManagerRegionalRegionalSecretIam_iamBindingUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"role":          "roles/secretmanager.secretAccessor",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerRegionalRegionalSecretDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretManagerRegionalRegionalSecretIam_iamBindingBasic(context),
+			},
+			{
+				ResourceName:      "google_secret_manager_regional_secret_iam_binding.default",
+				ImportStateId:     fmt.Sprintf("projects/%s/locations/%s/secrets/%s roles/secretmanager.secretAccessor", envvar.GetTestProjectFromEnv(), envvar.GetTestRegionFromEnv(), fmt.Sprintf("tf-test-tf-reg-secret%s", context["random_suffix"])),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccSecretManagerRegionalRegionalSecretIam_iamBindingUpdate(context),
+			},
+			{
+				ResourceName:      "google_secret_manager_regional_secret_iam_binding.default",
+				ImportStateId:     fmt.Sprintf("projects/%s/locations/%s/secrets/%s roles/secretmanager.secretAccessor", envvar.GetTestProjectFromEnv(), envvar.GetTestRegionFromEnv(), fmt.Sprintf("tf-test-tf-reg-secret%s", context["random_suffix"])),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccSecretManagerRegionalRegionalSecretIam_iamBindingBasic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_regional_secret" "default" {
+  secret_id = "tf-test-tf-reg-secret%{random_suffix}"
+  location = "us-central1"
+  ttl = "3600s"
+
+  labels = {
+    label = "my-label"
+  }
+
+  annotations = {
+    key1 = "value1"
+  }
+}
+
+resource "google_secret_manager_regional_secret_iam_binding" "default" {
+  project = google_secret_manager_regional_secret.default.project
+  location = google_secret_manager_regional_secret.default.location
+  secret_id = google_secret_manager_regional_secret.default.secret_id
+  role = "%{role}"
+  members = ["user:admin@hashicorptest.com", "user:gterraformtest1@gmail.com"]
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalRegionalSecretIam_iamBindingUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_regional_secret" "default" {
+  secret_id = "tf-test-tf-reg-secret%{random_suffix}"
+  location = "us-central1"
+  ttl = "3600s"
+
+  labels = {
+    label = "my-label"
+  }
+
+  annotations = {
+    key1 = "value1"
+  }
+}
+
+resource "google_secret_manager_regional_secret_iam_binding" "default" {
+  project = google_secret_manager_regional_secret.default.project
+  location = google_secret_manager_regional_secret.default.location
+  secret_id = google_secret_manager_regional_secret.default.secret_id
+  role = "%{role}"
+  members = ["user:admin@hashicorptest.com"]
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/secretmanagerregional/resource_secret_manager_regional_secret_test.go.erb
+++ b/mmv1/third_party/terraform/services/secretmanagerregional/resource_secret_manager_regional_secret_test.go.erb
@@ -1,0 +1,1312 @@
+<% autogen_exception -%>
+package secretmanagerregional_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccSecretManagerRegionalRegionalSecret_import(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerRegionalRegionalSecretDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretManagerRegionalSecret_basic(context),
+			},
+			{
+				ResourceName:      "google_secret_manager_regional_secret.regional-secret-basic",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func TestAccSecretManagerRegionalRegionalSecret_labelsUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerRegionalRegionalSecretDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretManagerRegionalSecret_withoutLabels(context),
+			},
+			{
+				ResourceName:      "google_secret_manager_regional_secret.regional-secret-with-labels",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_labelsUpdate(context),
+			},
+			{
+				ResourceName:      "google_secret_manager_regional_secret.regional-secret-with-labels",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_labelsUpdateOther(context),
+			},
+			{
+				ResourceName:      "google_secret_manager_regional_secret.regional-secret-with-labels",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_withoutLabels(context),
+			},
+			{
+				ResourceName:      "google_secret_manager_regional_secret.regional-secret-with-labels",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func TestAccSecretManagerRegionalRegionalSecret_annotationsUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerRegionalRegionalSecretDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretManagerRegionalSecret_withoutAnnotations(context),
+			},
+			{
+				ResourceName:      "google_secret_manager_regional_secret.regional-secret-with-annotations",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_annotationsUpdate(context),
+			},
+			{
+				ResourceName:      "google_secret_manager_regional_secret.regional-secret-with-annotations",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_annotationsUpdateOther(context),
+			},
+			{
+				ResourceName:      "google_secret_manager_regional_secret.regional-secret-with-annotations",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_withoutAnnotations(context),
+			},
+			{
+				ResourceName:      "google_secret_manager_regional_secret.regional-secret-with-annotations",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func TestAccSecretManagerRegionalRegionalSecret_cmekUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"kms_key_name":  acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-secret-manager-managed-central-key3").CryptoKey.Name,
+		"kms_key_name_other":  acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-secret-manager-managed-central-key4").CryptoKey.Name,
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerRegionalRegionalSecretDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretManagerRegionalSecret_withoutCmek(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-cmek-update",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_cmekUpdate(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-cmek-update",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_cmekUpdateOther(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-cmek-update",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_withoutCmek(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-cmek-update",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func TestAccSecretManagerRegionalRegionalSecret_topicsUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerRegionalRegionalSecretDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretManagerRegionalSecret_withoutTopics(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-topics",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_topicsUpdate(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-topics",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_topicsUpdateOther(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-topics",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_withoutTopics(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-topics",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func TestAccSecretManagerRegionalRegionalSecret_rotationInfoUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"timestamp_1":   "2114-11-30T00:00:00Z",
+		"timestamp_2":   "2116-11-30T00:00:00Z",
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerRegionalRegionalSecretDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretManagerRegionalSecret_rotationBasic(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-rotation-update",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_rotationTimeUpdate(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-rotation-update",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_rotationPeriodUpdate(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-rotation-update",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_rotationBasic(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-rotation-update",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func TestAccSecretManagerRegionalRegionalSecret_expireTimeUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"timestamp_1":   "2114-11-30T00:00:00Z",
+		"timestamp_2":   "2116-11-30T00:00:00Z",
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerRegionalRegionalSecretDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretManagerRegionalSecret_withoutTtlAndExpireTime(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-expiration",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_expireTimeBasic(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-expiration",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_expireTimeUpdate(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-expiration",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_withoutTtlAndExpireTime(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-expiration",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func TestAccSecretManagerRegionalRegionalSecret_ttlUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerRegionalRegionalSecretDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretManagerRegionalSecret_withoutTtlAndExpireTime(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-expiration",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl", "annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_ttlBasic(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-expiration",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl", "annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_ttlUpdate(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-expiration",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl", "annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_withoutTtlAndExpireTime(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-expiration",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl", "annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func TestAccSecretManagerRegionalRegionalSecret_updateBetweenTtlAndExpireTime(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"timestamp_1":   "2114-11-30T00:00:00Z",
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerRegionalRegionalSecretDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretManagerRegionalSecret_ttlBasic(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-expiration",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl", "annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_expireTimeBasic(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-expiration",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl", "annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_ttlBasic(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-expiration",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl", "annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func TestAccSecretManagerRegionalRegionalSecret_versionDestroyTtlUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerRegionalRegionalSecretDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretManagerRegionalSecret_withoutVersionDestroyTtl(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-version-destroy-ttl",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_versionDestroyTtlBasic(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-version-destroy-ttl",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_versionDestroyTtlUpdate(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-version-destroy-ttl",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+			{
+				Config: testAccSecretManagerRegionalSecret_withoutVersionDestroyTtl(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-version-destroy-ttl",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+		},
+	})
+}
+
+// TODO: Uncomment once google_secret_manager_regional_secret_version is added
+// func TestAccSecretManagerRegionalRegionalSecret_versionAliasesUpdate(t *testing.T) {
+// 	t.Parallel()
+//
+// 	context := map[string]interface{}{
+// 		"random_suffix": acctest.RandString(t, 10),
+// 	}
+//
+// 	acctest.VcrTest(t, resource.TestCase{
+// 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+// 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+// 		CheckDestroy:             testAccCheckSecretManagerRegionalRegionalSecretDestroyProducer(t),
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config: testAccSecretManagerRegionalSecret_basicRegionalSecretWithVersions(context),
+// 			},
+// 			{
+// 				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-version-aliases",
+// 				ImportState:             true,
+// 				ImportStateVerify:       true,
+// 				ImportStateVerifyIgnore: []string{"ttl", "annotations", "labels", "location", "secret_id", "terraform_labels"},
+// 			},
+// 			{
+// 				Config: testAccSecretManagerRegionalSecret_versionAliasesBasic(context),
+// 			},
+// 			{
+// 				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-version-aliases",
+// 				ImportState:             true,
+// 				ImportStateVerify:       true,
+// 				ImportStateVerifyIgnore: []string{"ttl", "annotations", "labels", "location", "secret_id", "terraform_labels"},
+// 			},
+// 			{
+// 				Config: testAccSecretManagerRegionalSecret_versionAliasesUpdate(context),
+// 			},
+// 			{
+// 				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-version-aliases",
+// 				ImportState:             true,
+// 				ImportStateVerify:       true,
+// 				ImportStateVerifyIgnore: []string{"ttl", "annotations", "labels", "location", "secret_id", "terraform_labels"},
+// 			},
+// 			{
+// 				Config: testAccSecretManagerRegionalSecret_basicRegionalSecretWithVersions(context),
+// 			},
+// 			{
+// 				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-version-aliases",
+// 				ImportState:             true,
+// 				ImportStateVerify:       true,
+// 				ImportStateVerifyIgnore: []string{"ttl", "annotations", "labels", "location", "secret_id", "terraform_labels"},
+// 			},
+// 		},
+// 	})
+// }
+
+func testAccSecretManagerRegionalSecret_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_regional_secret" "regional-secret-basic" {
+  secret_id = "tf-test-reg-secret-%{random_suffix}"
+  location = "us-central1"
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecret_withoutLabels(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_regional_secret" "regional-secret-with-labels" {
+  secret_id = "tf-test-reg-secret-%{random_suffix}"
+  location = "us-central1"
+
+  annotations = {
+    annotationkey = "annotation-value"
+  }
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecret_labelsUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_regional_secret" "regional-secret-with-labels" {
+  secret_id = "tf-test-reg-secret-%{random_suffix}"
+  location = "us-central1"
+
+  labels = {
+    key1 = "value1"
+    key2 = "value2"
+    key3 = "value3"
+    key4 = "value4"
+    key5 = "value5"
+  }
+
+  annotations = {
+    annotationkey = "annotation-value"
+  }
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecret_labelsUpdateOther(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_regional_secret" "regional-secret-with-labels" {
+  secret_id = "tf-test-reg-secret-%{random_suffix}"
+  location = "us-central1"
+
+  labels = {
+    key1 = "value1"
+    key2 = "updatevalue2"
+    updatekey3 = "value3"
+    updatekey4 = "updatevalue4"
+    key6 = "value6"
+  }
+
+  annotations = {
+    annotationkey = "annotation-value"
+  }
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecret_withoutAnnotations(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_regional_secret" "regional-secret-with-annotations" {
+  secret_id = "tf-test-reg-secret-%{random_suffix}"
+  location = "us-central1"
+
+  labels = {
+    mykey = "myvalue"
+  }
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecret_annotationsUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_regional_secret" "regional-secret-with-annotations" {
+  secret_id = "tf-test-reg-secret-%{random_suffix}"
+  location = "us-central1"
+
+  labels = {
+    mykey = "myvalue"
+  }
+
+  annotations = {
+    key1 = "value1"
+    key2 = "value2"
+    key3 = "value3"
+    key4 = "value4"
+    key5 = "value5"
+  }
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecret_annotationsUpdateOther(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_regional_secret" "regional-secret-with-annotations" {
+  secret_id = "tf-test-reg-secret-%{random_suffix}"
+  location = "us-central1"
+
+  labels = {
+    mykey = "myvalue"
+  }
+
+  annotations = {
+    key1 = "value1"
+    key2 = "updatevalue2"
+    updatekey3 = "value3"
+    updatekey4 = "updatevalue4"
+    key6 = "value6"
+  }
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecret_withoutCmek(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {}
+
+resource "google_kms_crypto_key_iam_member" "kms-regional-secret-binding-1" {
+  crypto_key_id = "%{kms_key_name}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+
+resource "google_kms_crypto_key_iam_member" "kms-regional-secret-binding-2" {
+  crypto_key_id = "%{kms_key_name_other}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+
+resource "google_secret_manager_regional_secret" "regional-secret-cmek-update" {
+  secret_id = "tf-test-secret%{random_suffix}"
+  location = "us-central1"
+
+  depends_on = [
+    google_kms_crypto_key_iam_member.kms-regional-secret-binding-1,
+    google_kms_crypto_key_iam_member.kms-regional-secret-binding-2,
+  ]
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecret_cmekUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {}
+
+resource "google_kms_crypto_key_iam_member" "kms-regional-secret-binding-1" {
+  crypto_key_id = "%{kms_key_name}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+
+resource "google_kms_crypto_key_iam_member" "kms-regional-secret-binding-2" {
+  crypto_key_id = "%{kms_key_name_other}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+
+resource "google_secret_manager_regional_secret" "regional-secret-cmek-update" {
+  secret_id = "tf-test-secret%{random_suffix}"
+  location = "us-central1"
+
+  customer_managed_encryption {
+    kms_key_name = "%{kms_key_name}"
+  }
+
+  depends_on = [
+    google_kms_crypto_key_iam_member.kms-regional-secret-binding-1,
+    google_kms_crypto_key_iam_member.kms-regional-secret-binding-2,
+  ]
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecret_cmekUpdateOther(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {}
+
+resource "google_kms_crypto_key_iam_member" "kms-regional-secret-binding-1" {
+  crypto_key_id = "%{kms_key_name}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+
+resource "google_kms_crypto_key_iam_member" "kms-regional-secret-binding-2" {
+  crypto_key_id = "%{kms_key_name_other}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+
+resource "google_secret_manager_regional_secret" "regional-secret-cmek-update" {
+  secret_id = "tf-test-secret%{random_suffix}"
+  location = "us-central1"
+
+  customer_managed_encryption {
+    kms_key_name = "%{kms_key_name_other}"
+  }
+
+  depends_on = [
+    google_kms_crypto_key_iam_member.kms-regional-secret-binding-1,
+    google_kms_crypto_key_iam_member.kms-regional-secret-binding-2,
+  ]
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecret_withoutTopics(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {}
+
+resource "google_pubsub_topic" "topic-1" {
+  name = "tf-test-topic-1-%{random_suffix}"
+}
+
+resource "google_pubsub_topic" "topic-2" {
+  name = "tf-test-topic-2-%{random_suffix}"
+}
+
+resource "google_pubsub_topic" "topic-3" {
+  name = "tf-test-topic-3-%{random_suffix}"
+}
+
+resource "google_pubsub_topic_iam_member" "secrets_manager_access_1" {
+  topic  = google_pubsub_topic.topic-1.name
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+  role   = "roles/pubsub.publisher"
+}
+
+resource "google_pubsub_topic_iam_member" "secrets_manager_access_2" {
+  topic  = google_pubsub_topic.topic-2.name
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+  role   = "roles/pubsub.publisher"
+}
+
+resource "google_pubsub_topic_iam_member" "secrets_manager_access_3" {
+  topic  = google_pubsub_topic.topic-3.name
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+  role   = "roles/pubsub.publisher"
+}
+
+resource "google_secret_manager_regional_secret" "regional-secret-with-topics" {
+  secret_id = "tf-test-reg-secret-%{random_suffix}"
+  location = "us-central1"
+
+  labels = {
+    mykey = "myvalue"
+  }
+
+  depends_on = [
+    google_pubsub_topic_iam_member.secrets_manager_access_1,
+    google_pubsub_topic_iam_member.secrets_manager_access_2,
+    google_pubsub_topic_iam_member.secrets_manager_access_3,
+  ]
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecret_topicsUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {}
+
+resource "google_pubsub_topic" "topic-1" {
+  name = "tf-test-topic-1-%{random_suffix}"
+}
+
+resource "google_pubsub_topic" "topic-2" {
+  name = "tf-test-topic-2-%{random_suffix}"
+}
+
+resource "google_pubsub_topic" "topic-3" {
+  name = "tf-test-topic-3-%{random_suffix}"
+}
+
+resource "google_pubsub_topic_iam_member" "secrets_manager_access_1" {
+  topic  = google_pubsub_topic.topic-1.name
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+  role   = "roles/pubsub.publisher"
+}
+
+resource "google_pubsub_topic_iam_member" "secrets_manager_access_2" {
+  topic  = google_pubsub_topic.topic-2.name
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+  role   = "roles/pubsub.publisher"
+}
+
+resource "google_pubsub_topic_iam_member" "secrets_manager_access_3" {
+  topic  = google_pubsub_topic.topic-3.name
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+  role   = "roles/pubsub.publisher"
+}
+
+resource "google_secret_manager_regional_secret" "regional-secret-with-topics" {
+  secret_id = "tf-test-reg-secret-%{random_suffix}"
+  location = "us-central1"
+
+  labels = {
+    mykey = "myvalue"
+  }
+
+  topics {
+    name = google_pubsub_topic.topic-1.id
+  }
+
+  topics {
+    name = google_pubsub_topic.topic-2.id
+  }
+
+  depends_on = [
+    google_pubsub_topic_iam_member.secrets_manager_access_1,
+    google_pubsub_topic_iam_member.secrets_manager_access_2,
+    google_pubsub_topic_iam_member.secrets_manager_access_3,
+  ]
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecret_topicsUpdateOther(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {}
+
+resource "google_pubsub_topic" "topic-1" {
+  name = "tf-test-topic-1-%{random_suffix}"
+}
+
+resource "google_pubsub_topic" "topic-2" {
+  name = "tf-test-topic-2-%{random_suffix}"
+}
+
+resource "google_pubsub_topic" "topic-3" {
+  name = "tf-test-topic-3-%{random_suffix}"
+}
+
+resource "google_pubsub_topic_iam_member" "secrets_manager_access_1" {
+  topic  = google_pubsub_topic.topic-1.name
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+  role   = "roles/pubsub.publisher"
+}
+
+resource "google_pubsub_topic_iam_member" "secrets_manager_access_2" {
+  topic  = google_pubsub_topic.topic-2.name
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+  role   = "roles/pubsub.publisher"
+}
+
+resource "google_pubsub_topic_iam_member" "secrets_manager_access_3" {
+  topic  = google_pubsub_topic.topic-3.name
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+  role   = "roles/pubsub.publisher"
+}
+
+resource "google_secret_manager_regional_secret" "regional-secret-with-topics" {
+  secret_id = "tf-test-reg-secret-%{random_suffix}"
+  location = "us-central1"
+
+  labels = {
+    mykey = "myvalue"
+  }
+
+  topics {
+    name = google_pubsub_topic.topic-1.id
+  }
+
+  topics {
+    name = google_pubsub_topic.topic-3.id
+  }
+
+  depends_on = [
+    google_pubsub_topic_iam_member.secrets_manager_access_1,
+    google_pubsub_topic_iam_member.secrets_manager_access_2,
+    google_pubsub_topic_iam_member.secrets_manager_access_3,
+  ]
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecret_rotationBasic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {}
+
+resource "google_pubsub_topic" "topic-update" {
+  name = "tf-test-topic%{random_suffix}"
+}
+
+resource "google_pubsub_topic_iam_member" "secrets_manager_topic_access" {
+  topic  = google_pubsub_topic.topic-update.name
+  role   = "roles/pubsub.publisher"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+
+resource "google_secret_manager_regional_secret" "regional-secret-with-rotation-update" {
+  secret_id = "tf-test-reg-secret%{random_suffix}"
+  location = "us-central1"
+
+  topics {
+    name = google_pubsub_topic.topic-update.id
+  }
+
+  rotation {
+    rotation_period = "7200s"
+    next_rotation_time = "%{timestamp_1}"
+  }
+
+  depends_on = [
+    google_pubsub_topic_iam_member.secrets_manager_topic_access,
+  ]
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecret_rotationTimeUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {}
+
+resource "google_pubsub_topic" "topic-update" {
+  name = "tf-test-topic%{random_suffix}"
+}
+
+resource "google_pubsub_topic_iam_member" "secrets_manager_topic_access" {
+  topic  = google_pubsub_topic.topic-update.name
+  role   = "roles/pubsub.publisher"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+
+resource "google_secret_manager_regional_secret" "regional-secret-with-rotation-update" {
+  secret_id = "tf-test-reg-secret%{random_suffix}"
+  location = "us-central1"
+
+  topics {
+    name = google_pubsub_topic.topic-update.id
+  }
+
+  rotation {
+    rotation_period = "7200s"
+    next_rotation_time = "%{timestamp_2}"
+  }
+
+  depends_on = [
+    google_pubsub_topic_iam_member.secrets_manager_topic_access,
+  ]
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecret_rotationPeriodUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {}
+
+resource "google_pubsub_topic" "topic-update" {
+  name = "tf-test-topic%{random_suffix}"
+}
+
+resource "google_pubsub_topic_iam_member" "secrets_manager_topic_access" {
+  topic  = google_pubsub_topic.topic-update.name
+  role   = "roles/pubsub.publisher"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+
+resource "google_secret_manager_regional_secret" "regional-secret-with-rotation-update" {
+  secret_id = "tf-test-reg-secret%{random_suffix}"
+  location = "us-central1"
+
+  topics {
+    name = google_pubsub_topic.topic-update.id
+  }
+
+  rotation {
+    rotation_period = "10800s"
+    next_rotation_time = "%{timestamp_2}"
+  }
+
+  depends_on = [
+    google_pubsub_topic_iam_member.secrets_manager_topic_access,
+  ]
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecret_withoutTtlAndExpireTime(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_regional_secret" "regional-secret-with-expiration" {
+  secret_id = "tf-test-reg-secret%{random_suffix}"
+  location = "us-central1"
+
+  labels = {
+    mylabel = "mykey"
+  }
+
+  annotations = {
+    myannot = "myannotkey"
+  }
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecret_expireTimeBasic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_regional_secret" "regional-secret-with-expiration" {
+  secret_id = "tf-test-reg-secret%{random_suffix}"
+  location = "us-central1"
+
+  labels = {
+    mylabel = "mykey"
+  }
+
+  annotations = {
+    myannot = "myannotkey"
+  }
+
+  expire_time = "%{timestamp_1}"
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecret_expireTimeUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_regional_secret" "regional-secret-with-expiration" {
+  secret_id = "tf-test-reg-secret%{random_suffix}"
+  location = "us-central1"
+
+  labels = {
+    mylabel = "mykey"
+  }
+
+  annotations = {
+    myannot = "myannotkey"
+  }
+
+  expire_time = "%{timestamp_2}"
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecret_ttlBasic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_regional_secret" "regional-secret-with-expiration" {
+  secret_id = "tf-test-reg-secret%{random_suffix}"
+  location = "us-central1"
+
+  labels = {
+    mylabel = "mykey"
+  }
+
+  annotations = {
+    myannot = "myannotkey"
+  }
+
+  ttl = "360000s"
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecret_ttlUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_regional_secret" "regional-secret-with-expiration" {
+  secret_id = "tf-test-reg-secret%{random_suffix}"
+  location = "us-central1"
+
+  labels = {
+    mylabel = "mykey"
+  }
+
+  annotations = {
+    myannot = "myannotkey"
+  }
+
+  ttl = "720000s"
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecret_withoutVersionDestroyTtl(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_regional_secret" "regional-secret-with-version-destroy-ttl" {
+  secret_id = "tf-test-reg-secret%{random_suffix}"
+  location = "us-central1"
+
+  labels = {
+    mylabel = "mykey"
+  }
+
+  annotations = {
+    myannot = "myannotkey"
+  }
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecret_versionDestroyTtlBasic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_regional_secret" "regional-secret-with-version-destroy-ttl" {
+  secret_id = "tf-test-reg-secret%{random_suffix}"
+  location = "us-central1"
+
+  labels = {
+    mylabel = "mykey"
+  }
+
+  annotations = {
+    myannot = "myannotkey"
+  }
+
+  version_destroy_ttl = "90000s"
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecret_versionDestroyTtlUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_regional_secret" "regional-secret-with-version-destroy-ttl" {
+  secret_id = "tf-test-reg-secret%{random_suffix}"
+  location = "us-central1"
+
+  labels = {
+    mylabel = "mykey"
+  }
+
+  annotations = {
+    myannot = "myannotkey"
+  }
+
+  version_destroy_ttl = "360000s"
+}
+`, context)
+}
+
+// TODO: Uncomment once google_secret_manager_regional_secret_version is added
+// func testAccSecretManagerRegionalSecret_basicRegionalSecretWithVersions(context map[string]interface{}) string {
+// 	return acctest.Nprintf(`
+// resource "google_secret_manager_regional_secret" "regional-secret-with-version-aliases" {
+//   secret_id = "tf-test-reg-secret%{random_suffix}"
+//   location = "us-central1"
+//
+//   labels = {
+//     mylabel = "mykey"
+//   }
+// }
+//
+// resource "google_secret_manager_regional_secret_version" "reg-secret-version-1" {
+//   secret = google_secret_manager_regional_secret.regional-secret-with-version-aliases.id
+//
+//   secret_data = "very secret data keep it down %{random_suffix}-1"
+// }
+//
+// resource "google_secret_manager_regional_secret_version" "reg-secret-version-2" {
+//   secret = google_secret_manager_regional_secret.regional-secret-with-version-aliases.id
+//
+//   secret_data = "very secret data keep it down %{random_suffix}-2"
+// }
+//
+// resource "google_secret_manager_regional_secret_version" "reg-secret-version-3" {
+//   secret = google_secret_manager_regional_secret.regional-secret-with-version-aliases.id
+//
+//   secret_data = "very secret data keep it down %{random_suffix}-3"
+// }
+//
+// resource "google_secret_manager_regional_secret_version" "reg-secret-version-4" {
+//   secret = google_secret_manager_regional_secret.regional-secret-with-version-aliases.id
+//
+//   secret_data = "very secret data keep it down %{random_suffix}-4"
+// }
+// `, context)
+// }
+//
+// func testAccSecretManagerRegionalSecret_versionAliasesBasic(context map[string]interface{}) string {
+// 	return acctest.Nprintf(`
+// resource "google_secret_manager_regional_secret" "regional-secret-with-version-aliases" {
+//   secret_id = "tf-test-reg-secret%{random_suffix}"
+//   location = "us-central1"
+//
+//   version_aliases = {
+//     firstalias = "1",
+//     secondalias = "2",
+//     thirdalias = "3",
+//     otheralias = "2",
+//     somealias = "3"
+//   }
+//
+//   labels = {
+//     mylabel = "mykey"
+//   }
+// }
+//
+// resource "google_secret_manager_regional_secret_version" "reg-secret-version-1" {
+//   secret = google_secret_manager_regional_secret.regional-secret-with-version-aliases.id
+//
+//   secret_data = "very secret data keep it down %{random_suffix}-1"
+// }
+//
+// resource "google_secret_manager_regional_secret_version" "reg-secret-version-2" {
+//   secret = google_secret_manager_regional_secret.regional-secret-with-version-aliases.id
+//
+//   secret_data = "very secret data keep it down %{random_suffix}-2"
+// }
+//
+// resource "google_secret_manager_regional_secret_version" "reg-secret-version-3" {
+//   secret = google_secret_manager_regional_secret.regional-secret-with-version-aliases.id
+//
+//   secret_data = "very secret data keep it down %{random_suffix}-3"
+// }
+//
+// resource "google_secret_manager_regional_secret_version" "reg-secret-version-4" {
+//   secret = google_secret_manager_regional_secret.regional-secret-with-version-aliases.id
+//
+//   secret_data = "very secret data keep it down %{random_suffix}-4"
+// }
+// `, context)
+// }
+//
+// func testAccSecretManagerRegionalSecret_versionAliasesUpdate(context map[string]interface{}) string {
+// 	return acctest.Nprintf(`
+// resource "google_secret_manager_regional_secret" "regional-secret-with-version-aliases" {
+//   secret_id = "tf-test-reg-secret%{random_suffix}"
+//   location = "us-central1"
+//
+//   version_aliases = {
+//     firstalias = "1",
+//     secondaliasupdated = "2",
+//     otheralias = "1",
+//     somealias = "3",
+//     fourthalias = "4"
+//   }
+//
+//   labels = {
+//     mylabel = "mykey"
+//   }
+// }
+//
+// resource "google_secret_manager_regional_secret_version" "reg-secret-version-1" {
+//   secret = google_secret_manager_regional_secret.regional-secret-with-version-aliases.id
+//
+//   secret_data = "very secret data keep it down %{random_suffix}-1"
+// }
+//
+// resource "google_secret_manager_regional_secret_version" "reg-secret-version-2" {
+//   secret = google_secret_manager_regional_secret.regional-secret-with-version-aliases.id
+//
+//   secret_data = "very secret data keep it down %{random_suffix}-2"
+// }
+//
+// resource "google_secret_manager_regional_secret_version" "reg-secret-version-3" {
+//   secret = google_secret_manager_regional_secret.regional-secret-with-version-aliases.id
+//
+//   secret_data = "very secret data keep it down %{random_suffix}-3"
+// }
+//
+// resource "google_secret_manager_regional_secret_version" "reg-secret-version-4" {
+//   secret = google_secret_manager_regional_secret.regional-secret-with-version-aliases.id
+//
+//   secret_data = "very secret data keep it down %{random_suffix}-4"
+// }
+// `, context)
+// }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add support for new regional secret resource `google_secret_manager_regional_secret`. I have also defined the `iam_policy` field in the RegionalSecret.yaml file to include the IAM resources and IAM datasources as well.

More info about regional secrets: https://cloud.google.com/secret-manager/docs/regional-secrets-overview

**Notes:**
1. In `RegionalSecret.yaml` file, the versionAliases field is commented and the respective test cases covered in the `resource_secret_manager_regional_secret_test.go.erb` file  are also commented because this field depends on creating regional_secret_version_resource. We intend to uncomment once this PR is merged and dependent tests can pass.
2. As of now, the API reference of the regional secrets are being documented on GCP docs side. Hence, the link mentioned in the `ResourceSecret.yaml` file will be updated later.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_secret_manager_regional_secret`
```