### PR TITLE
Ensure oneOf condition is honored when expanding the job configs.

### DIFF
--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job.go.erb
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job.go.erb
@@ -931,8 +931,7 @@ func expandHiveJob(config map[string]interface{}) *dataproc.HiveJob {
 	job := &dataproc.HiveJob{}
 	if v, ok := config["query_file_uri"]; ok {
 		job.QueryFileUri = v.(string)
-	}
-	if v, ok := config["query_list"]; ok {
+	} else if v, ok := config["query_list"]; ok {
 		job.QueryList = &dataproc.QueryList{
 			Queries: tpgresource.ConvertStringArr(v.([]interface{})),
 		}
@@ -1039,8 +1038,7 @@ func expandPigJob(config map[string]interface{}) *dataproc.PigJob {
 	job := &dataproc.PigJob{}
 	if v, ok := config["query_file_uri"]; ok {
 		job.QueryFileUri = v.(string)
-	}
-	if v, ok := config["query_list"]; ok {
+	} else if v, ok := config["query_list"]; ok {
 		job.QueryList = &dataproc.QueryList{
 			Queries: tpgresource.ConvertStringArr(v.([]interface{})),
 		}
@@ -1140,8 +1138,7 @@ func expandSparkSqlJob(config map[string]interface{}) *dataproc.SparkSqlJob {
 	job := &dataproc.SparkSqlJob{}
 	if v, ok := config["query_file_uri"]; ok {
 		job.QueryFileUri = v.(string)
-	}
-	if v, ok := config["query_list"]; ok {
+	} else if v, ok := config["query_list"]; ok {
 		job.QueryList = &dataproc.QueryList{
 			Queries: tpgresource.ConvertStringArr(v.([]interface{})),
 		}
@@ -1248,8 +1245,7 @@ func expandPrestoJob(config map[string]interface{}) *dataproc.PrestoJob {
 	}
 	if v, ok := config["query_file_uri"]; ok {
 		job.QueryFileUri = v.(string)
-	}
-	if v, ok := config["query_list"]; ok {
+	} else if v, ok := config["query_list"]; ok {
 		job.QueryList = &dataproc.QueryList{
 			Queries: tpgresource.ConvertStringArr(v.([]interface{})),
 		}


### PR DESCRIPTION
Ensure oneOf condition is honored when expanding the job configuration for Hive, Pig, Spark-sql, and Presto.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/13278

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
dataproc: Ensure oneOf condition is honored when expanding the job configuration for Hive, Pig, Spark-sql, and Presto.
```
