### PR TITLE
Do not force send insecure_kubelet_readonly_port_enabled during creation

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -816,7 +816,6 @@ func expandNodeConfigDefaults(configured interface{}) *container.NodeConfigDefau
 	if v, ok := config["insecure_kubelet_readonly_port_enabled"]; ok {
 		nodeConfigDefaults.NodeKubeletConfig = &container.NodeKubeletConfig{
 			InsecureKubeletReadonlyPortEnabled: expandInsecureKubeletReadonlyPortEnabled(v),
-			ForceSendFields: []string{"InsecureKubeletReadonlyPortEnabled"},
 		}
 	}
 	if variant, ok := config["logging_variant"]; ok {

--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -101,18 +101,11 @@ func schemaLoggingVariant() *schema.Schema {
 }
 
 func schemaGcfsConfig() *schema.Schema {
-<<<<<<< HEAD
 	return &schema.Schema{
 		Type:        schema.TypeList,
 		Optional:    true,
 		Computed:    true,
 		MaxItems:    1,
-=======
-        return &schema.Schema{
-                Type:     schema.TypeList,
-		Optional: true,
-		MaxItems: 1,
->>>>>>> 8b0ff8b92 (revert change for GcfsConfig)
 		Description: `GCFS configuration for this node.`,
 		Elem:        &schema.Resource{
 			Schema: map[string]*schema.Schema{

--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -101,11 +101,18 @@ func schemaLoggingVariant() *schema.Schema {
 }
 
 func schemaGcfsConfig() *schema.Schema {
+<<<<<<< HEAD
 	return &schema.Schema{
 		Type:        schema.TypeList,
 		Optional:    true,
 		Computed:    true,
 		MaxItems:    1,
+=======
+        return &schema.Schema{
+                Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+>>>>>>> 8b0ff8b92 (revert change for GcfsConfig)
 		Description: `GCFS configuration for this node.`,
 		Elem:        &schema.Resource{
 			Schema: map[string]*schema.Schema{

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -4363,7 +4363,6 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 				Update: &container.ClusterUpdate{
 					DesiredNodeKubeletConfig: &container.NodeKubeletConfig{
 						InsecureKubeletReadonlyPortEnabled: expandInsecureKubeletReadonlyPortEnabled(insecureKubeletReadonlyPortEnabled),
-						ForceSendFields:                    []string{"InsecureKubeletReadonlyPortEnabled"},
 					},
 				},
 			}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -4363,6 +4363,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 				Update: &container.ClusterUpdate{
 					DesiredNodeKubeletConfig: &container.NodeKubeletConfig{
 						InsecureKubeletReadonlyPortEnabled: expandInsecureKubeletReadonlyPortEnabled(insecureKubeletReadonlyPortEnabled),
+						ForceSendFields:                    []string{"InsecureKubeletReadonlyPortEnabled"},
 					},
 				},
 			}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -3390,7 +3390,7 @@ func TestAccContainerCluster_withAutopilot_withNodePoolDefaults(t *testing.T) {
 				ResourceName:            "google_container_cluster.primary",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{deletion_protection"},
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
 	})
@@ -10736,7 +10736,7 @@ func testAccContainerCluster_withAutopilotKubeletConfigUpdates(name, insecureKub
 `, name, insecureKubeletReadonlyPortEnabled)
 }
 
-func TestAccContainerCluster_withAutopilot_withNodePoolDefaults(name, networkName, subnetworkName string) string {
+func testAccContainerCluster_withAutopilot_withNodePoolDefaults(name, networkName, subnetworkName string) string {
   return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
   name                = "%s"

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -3370,6 +3370,32 @@ func TestAccContainerCluster_withAutopilotKubeletConfig(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_withAutopilot_withNodePoolDefaults(t *testing.T) {
+	t.Parallel()
+
+	randomSuffix := acctest.RandString(t, 10)
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randomSuffix)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withAutopilot_withNodePoolDefaults(clusterName, networkName, subnetworkName),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{deletion_protection"},
+			},
+		},
+	})
+}
+
 
 func TestAccContainerCluster_withAutopilotResourceManagerTags(t *testing.T) {
 	t.Parallel()
@@ -10708,6 +10734,25 @@ func testAccContainerCluster_withAutopilotKubeletConfigUpdates(name, insecureKub
     deletion_protection = false
   }
 `, name, insecureKubeletReadonlyPortEnabled)
+}
+
+func TestAccContainerCluster_withAutopilot_withNodePoolDefaults(name, networkName, subnetworkName string) string {
+  return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name                = "%s"
+  location            = "us-central1"
+  enable_autopilot    = true
+
+  node_pool_defaults {
+    node_config_defaults {
+    }
+  }
+
+  deletion_protection = false
+  network    = "%s"
+  subnetwork    = "%s"
+ }
+`, name, networkName, subnetworkName)
 }
 
 func testAccContainerCluster_resourceManagerTags(projectID, clusterName, networkName, subnetworkName, randomSuffix string) string {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

potentially fixes https://github.com/hashicorp/terraform-provider-google/issues/19428

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: fixed a bug where specifying `node_pool_defaults.node_config_defaults` with `enable_autopilot = true` will cause `google_container_cluster` resource creation failure
```
