### PR TITLE
Fix broken KMS KeyHandle and AutokeyConfig tests.

### DIFF
--- a/mmv1/products/kms/KeyHandle.yaml
+++ b/mmv1/products/kms/KeyHandle.yaml
@@ -44,10 +44,12 @@ examples:
       'example-keyhandle'
     min_version: beta
     vars:
+      folder_name:
+        'my-folder'
       key_project_name:
         'key-proj'
       resource_project_name:
-        'resources'
+        'res-proj'
     test_env_vars:
       org_id: :ORG_ID
       billing_account: :BILLING_ACCT

--- a/mmv1/templates/terraform/examples/kms_key_handle_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/kms_key_handle_basic.tf.erb
@@ -1,7 +1,7 @@
 # Create Folder in GCP Organization
 resource "google_folder" "autokms_folder" {
   provider     = google-beta
-  display_name = "folder-example"
+  display_name = "<%= ctx[:vars]["folder_name"] %>"
   parent       = "organizations/<%= ctx[:test_env_vars]['org_id'] %>"
   deletion_protection = false
 }
@@ -89,7 +89,7 @@ resource "time_sleep" "wait_autokey_config" {
 resource "google_kms_key_handle" "<%= ctx[:primary_resource_id] %>" {
   provider               = google-beta
   project                = google_project.resource_project.project_id
-  name                   = "example-key-handle" 
+  name                   = "tf-test-key-handle" 
   location               = "global"
   resource_type_selector = "storage.googleapis.com/Bucket"
   depends_on             = [time_sleep.wait_autokey_config]


### PR DESCRIPTION
Make key handle and resource project name sweepable too.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
kms: fixed TestAccKMSKeyHandle_kmsKeyHandleBasicExample and TestAccKMSAutokeyConfig_kmsAutokeyConfigAllExample
```
