### PR TITLE
Renaming all remaining skip_* attributes

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -252,7 +252,7 @@ type Resource struct {
 	StateUpgraders bool `yaml:"state_upgraders"`
 
 	// Do not apply the default attribution label
-	SkipAttributionLabel bool `yaml:"skip_attribution_label"`
+	ExcludeAttributionLabel bool `yaml:"exclude_attribution_label"`
 
 	// This block inserts the named function and its attribute into the
 	// resource schema -- the code for the migrate_state function must
@@ -267,12 +267,12 @@ type Resource struct {
 
 	// Set to true for resources that are unable to be read from the API, such as
 	// public ca external account keys
-	SkipRead bool `yaml:"skip_read"`
+	ExcludeRead bool `yaml:"exclude_read"`
 
 	// Set to true for resources that wish to disable automatic generation of default provider
 	// value customdiff functions
 	// TODO rewrite: 1 instance used
-	SkipDefaultCdiff bool `yaml:"skip_default_cdiff"`
+	ExcludeDefaultCdiff bool `yaml:"exclude_default_cdiff"`
 
 	// This enables resources that get their project via a reference to a different resource
 	// instead of a project field to use User Project Overrides
@@ -604,7 +604,7 @@ func (r *Resource) AddLabelsRelatedFields(props []*Type, parent *Type) []*Type {
 
 func (r *Resource) addLabelsFields(props []*Type, parent *Type, labels *Type) []*Type {
 	if parent == nil || parent.FlattenObject {
-		if r.SkipAttributionLabel {
+		if r.ExcludeAttributionLabel {
 			r.CustomDiff = append(r.CustomDiff, "tpgresource.SetLabelsDiffWithoutAttributionLabel")
 		} else {
 			r.CustomDiff = append(r.CustomDiff, "tpgresource.SetLabelsDiff")
@@ -1291,7 +1291,7 @@ func (r Resource) IamAttributes() []string {
 // we can reuse that config to create a resource to test IAM resources with.
 func (r Resource) FirstTestExample() resource.Examples {
 	examples := google.Reject(r.Examples, func(e resource.Examples) bool {
-		return e.SkipTest
+		return e.ExcludeTest
 	})
 	examples = google.Reject(examples, func(e resource.Examples) bool {
 		return (r.ProductMetadata.VersionObjOrClosest(r.TargetVersionName).CompareTo(r.ProductMetadata.VersionObjOrClosest(e.MinVersion)) < 0)
@@ -1302,7 +1302,7 @@ func (r Resource) FirstTestExample() resource.Examples {
 
 func (r Resource) ExamplePrimaryResourceId() string {
 	examples := google.Reject(r.Examples, func(e resource.Examples) bool {
-		return e.SkipTest
+		return e.ExcludeTest
 	})
 	examples = google.Reject(examples, func(e resource.Examples) bool {
 		return (r.ProductMetadata.VersionObjOrClosest(r.TargetVersionName).CompareTo(r.ProductMetadata.VersionObjOrClosest(e.MinVersion)) < 0)
@@ -1580,7 +1580,7 @@ func (r Resource) IsExcluded() bool {
 
 func (r Resource) TestExamples() []resource.Examples {
 	return google.Reject(google.Reject(r.Examples, func(e resource.Examples) bool {
-		return e.SkipTest
+		return e.ExcludeTest
 	}), func(e resource.Examples) bool {
 		return e.MinVersion != "" && slices.Index(product.ORDER, r.TargetVersionName) < slices.Index(product.ORDER, e.MinVersion)
 	})

--- a/mmv1/api/resource/examples.go
+++ b/mmv1/api/resource/examples.go
@@ -122,13 +122,13 @@ type Examples struct {
 	IgnoreReadExtra []string `yaml:"ignore_read_extra"`
 
 	// Whether to skip generating tests for this resource
-	SkipTest bool `yaml:"skip_test"`
+	ExcludeTest bool `yaml:"exclude_test"`
 
 	// Whether to skip generating docs for this example
-	SkipDocs bool `yaml:"skip_docs"`
+	ExcludeDocs bool `yaml:"exclude_docs"`
 
 	// Whether to skip import tests for this example
-	SkipImportTest bool `yaml:"skip_import_test"`
+	ExcludeImportTest bool `yaml:"exclude_import_test"`
 
 	// The name of the primary resource for use in IAM tests. IAM tests need
 	// a reference to the primary resource to create IAM policies for

--- a/mmv1/api/resource/iam_policy.go
+++ b/mmv1/api/resource/iam_policy.go
@@ -32,7 +32,7 @@ type IamPolicy struct {
 	// Boolean of if tests for IAM resources should exclude import test steps
 	// Used to handle situations where typical generated IAM tests cannot import
 	// due to the parent resource having an API-generated id
-	SkipImportTest bool `yaml:"skip_import_test"`
+	ExcludeImportTest bool `yaml:"exclude_import_test"`
 
 	// Character that separates resource identifier from method call in URL
 	// For example, PubSub subscription uses {resource}:getIamPolicy

--- a/mmv1/api/type.go
+++ b/mmv1/api/type.go
@@ -135,7 +135,7 @@ type Type struct {
 
 	EnumValues []string `yaml:"enum_values"`
 
-	SkipDocsValues bool `yaml:"skip_docs_values"`
+	ExcludeDocsValues bool `yaml:"exclude_docs_values"`
 
 	// ====================
 	// Array Fields

--- a/mmv1/products/accessapproval/go_FolderSettings.yaml
+++ b/mmv1/products/accessapproval/go_FolderSettings.yaml
@@ -43,14 +43,14 @@ examples:
       folder_name: 'my-folder'
     test_env_vars:
       org_id: 'ORG_ID'
-    skip_test: true
+    exclude_test: true
   - name: 'folder_access_approval_active_key_version'
     primary_resource_id: 'folder_access_approval'
     vars:
       folder_name: 'my-folder'
     test_env_vars:
       org_id: 'ORG_ID'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'folder_id'
     type: String

--- a/mmv1/products/accessapproval/go_OrganizationSettings.yaml
+++ b/mmv1/products/accessapproval/go_OrganizationSettings.yaml
@@ -40,12 +40,12 @@ examples:
     primary_resource_id: 'organization_access_approval'
     test_env_vars:
       org_id: 'ORG_ID'
-    skip_test: true
+    exclude_test: true
   - name: 'organization_access_approval_active_key_version'
     primary_resource_id: 'organization_access_approval'
     test_env_vars:
       org_id: 'ORG_ID'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'organization_id'
     type: String

--- a/mmv1/products/accessapproval/go_ProjectSettings.yaml
+++ b/mmv1/products/accessapproval/go_ProjectSettings.yaml
@@ -41,13 +41,13 @@ examples:
     test_env_vars:
       project: 'PROJECT_NAME'
       org_id: 'ORG_ID'
-    skip_test: true
+    exclude_test: true
   - name: 'project_access_approval_active_key_version'
     primary_resource_id: 'project_access_approval'
     test_env_vars:
       project: 'PROJECT_NAME'
       org_id: 'ORG_ID'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'project_id'
     type: String

--- a/mmv1/products/accesscontextmanager/go_AccessLevel.yaml
+++ b/mmv1/products/accesscontextmanager/go_AccessLevel.yaml
@@ -63,7 +63,7 @@ examples:
     primary_resource_id: 'access-level'
     vars:
       access_level_name: 'chromeos_no_lock'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'parent'
     type: String

--- a/mmv1/products/accesscontextmanager/go_AccessLevelCondition.yaml
+++ b/mmv1/products/accesscontextmanager/go_AccessLevelCondition.yaml
@@ -80,7 +80,7 @@ examples:
     vars:
       access_level_name: 'chromeos_no_lock'
       account_id: 'my-account-id'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'accessLevel'
     type: ResourceRef

--- a/mmv1/products/accesscontextmanager/go_AccessLevels.yaml
+++ b/mmv1/products/accesscontextmanager/go_AccessLevels.yaml
@@ -64,7 +64,7 @@ examples:
     vars:
       access_level_name1: 'chromeos_no_lock'
       access_level_name2: 'mac_no_lock'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'parent'
     type: String

--- a/mmv1/products/accesscontextmanager/go_AccessPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/go_AccessPolicy.yaml
@@ -71,14 +71,14 @@ exclude_sweeper: true
 examples:
   - name: 'access_context_manager_access_policy_basic'
     primary_resource_id: 'access-policy'
-    skip_test: true
+    exclude_test: true
   - name: 'access_context_manager_access_policy_scoped'
     primary_resource_id: 'access-policy'
     test_env_vars:
       org_id: 'ORG_ID'
       project: 'PROJECT_NAME'
-    skip_test: true
-    skip_import_test: true
+    exclude_test: true
+    exclude_import_test: true
 parameters:
   - name: 'parent'
     type: String

--- a/mmv1/products/accesscontextmanager/go_AuthorizedOrgsDesc.yaml
+++ b/mmv1/products/accesscontextmanager/go_AuthorizedOrgsDesc.yaml
@@ -65,7 +65,7 @@ exclude_sweeper: true
 examples:
   - name: 'access_context_manager_authorized_orgs_desc_basic'
     primary_resource_id: 'authorized-orgs-desc'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'parent'
     type: String

--- a/mmv1/products/accesscontextmanager/go_GcpUserAccessBinding.yaml
+++ b/mmv1/products/accesscontextmanager/go_GcpUserAccessBinding.yaml
@@ -59,7 +59,7 @@ examples:
       org_id: 'ORG_ID'
       org_domain: 'ORG_DOMAIN'
       cust_id: 'CUST_ID'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'organizationId'
     type: String

--- a/mmv1/products/accesscontextmanager/go_ServicePerimeter.yaml
+++ b/mmv1/products/accesscontextmanager/go_ServicePerimeter.yaml
@@ -72,17 +72,17 @@ examples:
     vars:
       access_level_name: 'chromeos_no_lock'
       service_perimeter_name: 'restrict_storage'
-    skip_test: true
+    exclude_test: true
   - name: 'access_context_manager_service_perimeter_secure_data_exchange'
     primary_resource_id: 'secure-data-exchange'
     vars:
       access_level_name: 'secure_data_exchange'
-    skip_test: true
+    exclude_test: true
   - name: 'access_context_manager_service_perimeter_dry-run'
     primary_resource_id: 'service-perimeter'
     vars:
       service_perimeter_name: 'restrict_bigquery_dryrun_storage'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'parent'
     type: String

--- a/mmv1/products/accesscontextmanager/go_ServicePerimeterDryRunEgressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/go_ServicePerimeterDryRunEgressPolicy.yaml
@@ -79,7 +79,7 @@ exclude_tgc: true
 exclude_sweeper: true
 examples:
   - name: 'access_context_manager_service_perimeter_dry_run_egress_policy'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'perimeter'
     type: ResourceRef

--- a/mmv1/products/accesscontextmanager/go_ServicePerimeterDryRunIngressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/go_ServicePerimeterDryRunIngressPolicy.yaml
@@ -80,7 +80,7 @@ exclude_tgc: true
 exclude_sweeper: true
 examples:
   - name: 'access_context_manager_service_perimeter_dry_run_ingress_policy'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'perimeter'
     type: ResourceRef

--- a/mmv1/products/accesscontextmanager/go_ServicePerimeterDryRunResource.yaml
+++ b/mmv1/products/accesscontextmanager/go_ServicePerimeterDryRunResource.yaml
@@ -84,7 +84,7 @@ examples:
     primary_resource_id: 'service-perimeter-dry-run-resource'
     vars:
       service_perimeter_name: 'restrict_all'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'perimeterName'
     type: ResourceRef

--- a/mmv1/products/accesscontextmanager/go_ServicePerimeterEgressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/go_ServicePerimeterEgressPolicy.yaml
@@ -76,7 +76,7 @@ exclude_tgc: true
 exclude_sweeper: true
 examples:
   - name: 'access_context_manager_service_perimeter_egress_policy'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'perimeter'
     type: ResourceRef

--- a/mmv1/products/accesscontextmanager/go_ServicePerimeterIngressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/go_ServicePerimeterIngressPolicy.yaml
@@ -77,7 +77,7 @@ exclude_tgc: true
 exclude_sweeper: true
 examples:
   - name: 'access_context_manager_service_perimeter_ingress_policy'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'perimeter'
     type: ResourceRef

--- a/mmv1/products/accesscontextmanager/go_ServicePerimeterResource.yaml
+++ b/mmv1/products/accesscontextmanager/go_ServicePerimeterResource.yaml
@@ -81,7 +81,7 @@ examples:
     primary_resource_id: 'service-perimeter-resource'
     vars:
       service_perimeter_name: 'restrict_all'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'perimeterName'
     type: ResourceRef

--- a/mmv1/products/accesscontextmanager/go_ServicePerimeters.yaml
+++ b/mmv1/products/accesscontextmanager/go_ServicePerimeters.yaml
@@ -58,7 +58,7 @@ examples:
     vars:
       access_level_name: 'chromeos_no_lock'
       service_perimeter_name: 'restrict_storage'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'parent'
     type: String

--- a/mmv1/products/activedirectory/go_Domain.yaml
+++ b/mmv1/products/activedirectory/go_Domain.yaml
@@ -66,7 +66,7 @@ examples:
       domain_name: 'tfgen'
     ignore_read_extra:
       - 'deletion_protection'
-    skip_test: true
+    exclude_test: true
 virtual_fields:
   - name: 'deletion_protection'
     description: |

--- a/mmv1/products/activedirectory/go_DomainTrust.yaml
+++ b/mmv1/products/activedirectory/go_DomainTrust.yaml
@@ -64,7 +64,7 @@ custom_code:
 examples:
   - name: 'active_directory_domain_trust_basic'
     primary_resource_id: 'ad-domain-trust'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'domain'
     type: String

--- a/mmv1/products/activedirectory/go_Peering.yaml
+++ b/mmv1/products/activedirectory/go_Peering.yaml
@@ -58,8 +58,8 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_test: true
-    skip_import_test: true
+    exclude_test: true
+    exclude_import_test: true
 parameters:
   - name: 'peeringId'
     type: String

--- a/mmv1/products/alloydb/go_Backup.yaml
+++ b/mmv1/products/alloydb/go_Backup.yaml
@@ -52,7 +52,7 @@ examples:
     ignore_read_extra:
       - 'reconciling'
       - 'update_time'
-    skip_test: true
+    exclude_test: true
   - name: 'alloydb_backup_basic_test'
     primary_resource_id: 'default'
     vars:
@@ -65,7 +65,7 @@ examples:
     ignore_read_extra:
       - 'reconciling'
       - 'update_time'
-    skip_docs: true
+    exclude_docs: true
   - name: 'alloydb_backup_full'
     primary_resource_id: 'default'
     vars:
@@ -76,7 +76,7 @@ examples:
     ignore_read_extra:
       - 'reconciling'
       - 'update_time'
-    skip_test: true
+    exclude_test: true
   - name: 'alloydb_backup_full_test'
     primary_resource_id: 'default'
     vars:
@@ -89,7 +89,7 @@ examples:
     ignore_read_extra:
       - 'reconciling'
       - 'update_time'
-    skip_docs: true
+    exclude_docs: true
     skip_vcr: true
 parameters:
   - name: 'backupId'

--- a/mmv1/products/alloydb/go_Cluster.yaml
+++ b/mmv1/products/alloydb/go_Cluster.yaml
@@ -89,14 +89,14 @@ examples:
     ignore_read_extra:
       - 'reconciling'
       - 'update_time'
-    skip_test: true
+    exclude_test: true
   - name: 'alloydb_secondary_cluster_basic'
     primary_resource_id: 'secondary'
     vars:
       alloydb_primary_cluster_name: 'alloydb-primary-cluster'
       alloydb_primary_instance_name: 'alloydb-primary-instance'
       alloydb_secondary_cluster_name: 'alloydb-secondary-cluster'
-    skip_test: true
+    exclude_test: true
   - name: 'alloydb_secondary_cluster_basic_test'
     primary_resource_id: 'secondary'
     vars:
@@ -106,7 +106,7 @@ examples:
       network_name: 'alloydb-network'
     test_vars_overrides:
       'network_name': 'acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydbinstance-network-config-1")'
-    skip_docs: true
+    exclude_docs: true
 virtual_fields:
   - name: 'deletion_policy'
     description: |

--- a/mmv1/products/alloydb/go_Instance.yaml
+++ b/mmv1/products/alloydb/go_Instance.yaml
@@ -68,7 +68,7 @@ examples:
     ignore_read_extra:
       - 'reconciling'
       - 'update_time'
-    skip_test: true
+    exclude_test: true
   - name: 'alloydb_secondary_instance_basic'
     primary_resource_id: 'secondary'
     vars:
@@ -80,7 +80,7 @@ examples:
     ignore_read_extra:
       - 'reconciling'
       - 'update_time'
-    skip_test: true
+    exclude_test: true
   - name: 'alloydb_instance_basic_test'
     primary_resource_id: 'default'
     vars:
@@ -92,7 +92,7 @@ examples:
     ignore_read_extra:
       - 'reconciling'
       - 'update_time'
-    skip_docs: true
+    exclude_docs: true
   - name: 'alloydb_secondary_instance_basic_test'
     primary_resource_id: 'secondary'
     vars:
@@ -106,7 +106,7 @@ examples:
     ignore_read_extra:
       - 'reconciling'
       - 'update_time'
-    skip_docs: true
+    exclude_docs: true
   - name: 'alloydb_instance_psc_test'
     primary_resource_id: 'default'
     vars:
@@ -116,7 +116,7 @@ examples:
     ignore_read_extra:
       - 'reconciling'
       - 'update_time'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'cluster'
     type: ResourceRef
@@ -369,6 +369,10 @@ properties:
           Enabling public ip for the instance. If a user wishes to disable this,
           please also clear the list of the authorized external networks set on
           the same instance.
+      - name: 'enableOutboundPublicIp'
+        type: Boolean
+        description: |
+          Enabling outbound public ip for the instance.
   - name: 'publicIpAddress'
     type: String
     description: |
@@ -376,3 +380,12 @@ properties:
       networkConfig.enablePublicIp is set to true. This is the connection
       endpoint for an end-user application.
     output: true
+  - name: 'outboundPublicIpAddresses'
+    type: Array
+    description: |
+      The outbound public IP addresses for the instance. This is available ONLY when
+      networkConfig.enableOutboundPublicIp is set to true. These IP addresses are used
+      for outbound connections.
+    output: true
+    item_type:
+      type: String

--- a/mmv1/products/alloydb/go_User.yaml
+++ b/mmv1/products/alloydb/go_User.yaml
@@ -47,7 +47,7 @@ examples:
       network_name: 'alloydb-network'
     ignore_read_extra:
       - 'password'
-    skip_test: true
+    exclude_test: true
   - name: 'alloydb_user_builtin_test'
     primary_resource_id: 'user1'
     vars:
@@ -61,7 +61,7 @@ examples:
       'network_name': 'acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydbinstance-network-config-1")'
     ignore_read_extra:
       - 'password'
-    skip_docs: true
+    exclude_docs: true
   - name: 'alloydb_user_iam'
     primary_resource_id: 'user2'
     vars:
@@ -70,7 +70,7 @@ examples:
       alloydb_cluster_pass: 'cluster_secret'
       alloydb_user_name: 'user2@foo.com'
       network_name: 'alloydb-network'
-    skip_test: true
+    exclude_test: true
   - name: 'alloydb_user_iam_test'
     primary_resource_id: 'user2'
     vars:
@@ -81,7 +81,7 @@ examples:
       network_name: 'alloydb-network'
     test_vars_overrides:
       'network_name': 'acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydbinstance-network-config-1")'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'cluster'
     type: ResourceRef

--- a/mmv1/products/apigateway/go_Api.yaml
+++ b/mmv1/products/apigateway/go_Api.yaml
@@ -71,7 +71,7 @@ examples:
     min_version: 'beta'
     vars:
       api_id: 'my-api'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'apiId'
     type: String

--- a/mmv1/products/apigateway/go_ApiConfig.yaml
+++ b/mmv1/products/apigateway/go_ApiConfig.yaml
@@ -53,7 +53,7 @@ async:
 identity:
   - apiConfigId
 iam_policy:
-  skip_import_test: true
+  exclude_import_test: true
   method_name_separator: ':'
   allowed_iam_role: 'roles/apigateway.viewer'
   parent_resource_attribute: 'api_config'
@@ -82,7 +82,7 @@ examples:
     vars:
       api_id: 'my-api'
       config_id: 'my-config'
-    skip_docs: true
+    exclude_docs: true
   - name: 'apigateway_api_config_grpc'
     primary_resource_id: 'api_cfg'
     primary_resource_name: 'fmt.Sprintf("tf-test-my-api%s", context["random_suffix"])'
@@ -98,7 +98,7 @@ examples:
     vars:
       api_id: 'my-api'
       config_id: 'my-config'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'api'
     type: String

--- a/mmv1/products/apigateway/go_Gateway.yaml
+++ b/mmv1/products/apigateway/go_Gateway.yaml
@@ -48,7 +48,7 @@ async:
 identity:
   - gatewayId
 iam_policy:
-  skip_import_test: true
+  exclude_import_test: true
   method_name_separator: ':'
   allowed_iam_role: 'roles/apigateway.viewer'
   parent_resource_attribute: 'gateway'
@@ -77,7 +77,7 @@ examples:
       api_id: 'my-api'
       config_id: 'my-config'
       gateway_id: 'my-gateway'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'region'
     type: String

--- a/mmv1/products/apigee/go_AddonsConfig.yaml
+++ b/mmv1/products/apigee/go_AddonsConfig.yaml
@@ -50,15 +50,15 @@ custom_code:
   test_check_destroy: 'templates/terraform/custom_check_destroy/go/apigee_addons_override.go.tmpl'
 examples:
   - name: 'apigee_addons_basic'
-    skip_test: true
+    exclude_test: true
   - name: 'apigee_addons_full'
-    skip_test: true
+    exclude_test: true
   - name: 'apigee_addons_test'
     primary_resource_id: 'apigee_org_addons'
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'org'
     type: String

--- a/mmv1/products/apigee/go_EndpointAttachment.yaml
+++ b/mmv1/products/apigee/go_EndpointAttachment.yaml
@@ -52,13 +52,13 @@ custom_code:
 exclude_sweeper: true
 examples:
   - name: 'apigee_endpoint_attachment_basic'
-    skip_test: true
+    exclude_test: true
   - name: 'apigee_endpoint_attachment_basic_test'
     primary_resource_id: 'apigee_endpoint_attachment'
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
     skip_vcr: true
 parameters:
   - name: 'orgId'

--- a/mmv1/products/apigee/go_EnvKeystore.yaml
+++ b/mmv1/products/apigee/go_EnvKeystore.yaml
@@ -43,7 +43,7 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'envId'
     type: String

--- a/mmv1/products/apigee/go_EnvReferences.yaml
+++ b/mmv1/products/apigee/go_EnvReferences.yaml
@@ -43,7 +43,7 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'envId'
     type: String

--- a/mmv1/products/apigee/go_Envgroup.yaml
+++ b/mmv1/products/apigee/go_Envgroup.yaml
@@ -53,13 +53,13 @@ examples:
   - name: 'apigee_environment_group_basic'
     vars:
       envgroup_name: 'my-envgroup'
-    skip_test: true
+    exclude_test: true
   - name: 'apigee_environment_group_basic_test'
     primary_resource_id: 'apigee_environment_group'
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
     skip_vcr: true
 parameters:
   - name: 'orgId'

--- a/mmv1/products/apigee/go_EnvgroupAttachment.yaml
+++ b/mmv1/products/apigee/go_EnvgroupAttachment.yaml
@@ -56,13 +56,13 @@ examples:
       project_id: 'my-project'
       envgroup_name: 'my-envgroup'
       environment_name: 'my-environment'
-    skip_test: true
+    exclude_test: true
   - name: 'apigee_environment_group_attachment_basic_test'
     primary_resource_id: 'apigee_environment_group_attachment'
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
     skip_vcr: true
 parameters:
   - name: 'envgroupId'

--- a/mmv1/products/apigee/go_Environment.yaml
+++ b/mmv1/products/apigee/go_Environment.yaml
@@ -63,14 +63,14 @@ examples:
   - name: 'apigee_environment_basic'
     vars:
       environment_name: 'my-environment'
-    skip_test: true
+    exclude_test: true
   - name: 'apigee_environment_basic_test'
     primary_resource_id: 'apigee_environment'
     primary_resource_name: 'fmt.Sprintf("organizations/tf-test%s", context["random_suffix"]), fmt.Sprintf("tf-test%s", context["random_suffix"])'
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
     skip_vcr: true
   - name: 'apigee_environment_basic_deployment_apiproxy_type_test'
     primary_resource_id: 'apigee_environment'
@@ -78,7 +78,7 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
     skip_vcr: true
   - name: 'apigee_environment_patch_update_test'
     primary_resource_id: 'apigee_environment'
@@ -87,7 +87,7 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
     skip_vcr: true
 parameters:
   - name: 'orgId'

--- a/mmv1/products/apigee/go_EnvironmentKeyvaluemaps.yaml
+++ b/mmv1/products/apigee/go_EnvironmentKeyvaluemaps.yaml
@@ -45,20 +45,20 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_test: true
+    exclude_test: true
   - name: 'apigee_environment_keyvaluemaps_test'
     primary_resource_id: 'apigee_environment_keyvaluemaps'
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
   - name: 'apigee_environment_keyvaluemaps_beta_test'
     primary_resource_id: 'apigee_environment_keyvaluemaps'
     min_version: 'beta'
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'envId'
     type: String

--- a/mmv1/products/apigee/go_EnvironmentKeyvaluemapsEntries.yaml
+++ b/mmv1/products/apigee/go_EnvironmentKeyvaluemapsEntries.yaml
@@ -43,20 +43,20 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_test: true
+    exclude_test: true
   - name: 'apigee_environment_keyvaluemaps_entries_test'
     primary_resource_id: 'apigee_environment_keyvaluemaps_entries'
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
   - name: 'apigee_environment_keyvaluemaps_entries_beta_test'
     primary_resource_id: 'apigee_environment_keyvaluemaps_entries'
     min_version: 'beta'
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'env_keyvaluemap_id'
     type: String

--- a/mmv1/products/apigee/go_Instance.yaml
+++ b/mmv1/products/apigee/go_Instance.yaml
@@ -24,7 +24,9 @@ docs:
 base_url: 'instances'
 self_link: '{{org_id}}/instances/{{name}}'
 create_url: '{{org_id}}/instances'
-immutable: true
+update_verb: 'PATCH'
+update_mask: true
+immutable: false
 mutex: '{{org_id}}/apigeeInstances'
 import_format:
   - '{{org_id}}/instances/{{name}}'
@@ -57,54 +59,54 @@ examples:
   - name: 'apigee_instance_basic'
     vars:
       instance_name: 'my-instance-name'
-    skip_test: true
+    exclude_test: true
   - name: 'apigee_instance_basic_test'
     primary_resource_id: 'apigee_instance'
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
     skip_vcr: true
   - name: 'apigee_instance_cidr_range'
     vars:
       instance_name: 'my-instance-name'
-    skip_test: true
+    exclude_test: true
   - name: 'apigee_instance_cidr_range_test'
     primary_resource_id: 'apigee_instance'
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
     skip_vcr: true
   - name: 'apigee_instance_ip_range'
     vars:
       instance_name: 'my-instance-name'
-    skip_test: true
+    exclude_test: true
   - name: 'apigee_instance_ip_range_test'
     primary_resource_id: 'apigee_instance'
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
     skip_vcr: true
   - name: 'apigee_instance_full'
     vars:
       instance_name: 'my-instance-name'
-    skip_test: true
+    exclude_test: true
   - name: 'apigee_instance_full_test'
     primary_resource_id: 'apigee_instance'
     min_version: 'beta'
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
     skip_vcr: true
   - name: 'apigee_instance_service_attachment_basic_test'
     primary_resource_id: 'apigee_instance'
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
     skip_vcr: true
 parameters:
   - name: 'orgId'
@@ -121,16 +123,19 @@ properties:
     description: |
       Resource ID of the instance.
     required: true
+    immutable: true
   - name: 'location'
     type: String
     description: |
       Required. Compute Engine location where the instance resides.
     required: true
+    immutable: true
   - name: 'peeringCidrRange'
     type: String
     description: |
       The size of the CIDR block range that will be reserved by the instance. For valid values,
       see [CidrRange](https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.instances#CidrRange) on the documentation.
+    immutable: true
     default_from_api: true
   - name: 'ipRange'
     type: String
@@ -142,15 +147,18 @@ properties:
       available /22 CIDR block from Service Networking. The customer should use this CIDR block
       for configuring their firewall needs to allow traffic from Apigee.
       Input format: "a.b.c.d/22"
+    immutable: true
     ignore_read: true
   - name: 'description'
     type: String
     description: |
       Description of the instance.
+    immutable: true
   - name: 'displayName'
     type: String
     description: |
       Display name of the instance.
+    immutable: true
   - name: 'diskEncryptionKeyName'
     type: String
     description: |

--- a/mmv1/products/apigee/go_InstanceAttachment.yaml
+++ b/mmv1/products/apigee/go_InstanceAttachment.yaml
@@ -57,13 +57,13 @@ examples:
       project_id: 'my-project'
       instance_name: 'my-instance-name'
       environment_name: 'my-environment-name'
-    skip_test: true
+    exclude_test: true
   - name: 'apigee_instance_attachment_basic_test'
     primary_resource_id: 'apigee_instance_attachment'
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
     skip_vcr: true
 parameters:
   - name: 'instanceId'

--- a/mmv1/products/apigee/go_NatAddress.yaml
+++ b/mmv1/products/apigee/go_NatAddress.yaml
@@ -55,13 +55,13 @@ examples:
   - name: 'apigee_nat_address_basic'
     vars:
       nat_address_name: 'my-nat-address'
-    skip_test: true
+    exclude_test: true
   - name: 'apigee_nat_address_basic_test'
     primary_resource_id: 'apigee_nat_address'
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
     skip_vcr: true
 parameters:
   - name: 'instanceId'

--- a/mmv1/products/apigee/go_Organization.yaml
+++ b/mmv1/products/apigee/go_Organization.yaml
@@ -52,7 +52,7 @@ custom_code:
   custom_import: 'templates/terraform/custom_import/go/apigee_organization.go.tmpl'
 examples:
   - name: 'apigee_organization_cloud_basic'
-    skip_test: true
+    exclude_test: true
   - name: 'apigee_organization_cloud_basic_test'
     primary_resource_id: 'org'
     test_env_vars:
@@ -60,10 +60,10 @@ examples:
       billing_account: 'BILLING_ACCT'
     ignore_read_extra:
       - 'properties'
-    skip_docs: true
+    exclude_docs: true
     skip_vcr: true
   - name: 'apigee_organization_cloud_basic_disable_vpc_peering'
-    skip_test: true
+    exclude_test: true
   - name: 'apigee_organization_cloud_basic_disable_vpc_peering_test'
     primary_resource_id: 'org'
     test_env_vars:
@@ -71,10 +71,10 @@ examples:
       billing_account: 'BILLING_ACCT'
     ignore_read_extra:
       - 'properties'
-    skip_docs: true
+    exclude_docs: true
     skip_vcr: true
   - name: 'apigee_organization_cloud_full'
-    skip_test: true
+    exclude_test: true
   - name: 'apigee_organization_cloud_full_test'
     primary_resource_id: 'org'
     min_version: 'beta'
@@ -83,10 +83,10 @@ examples:
       billing_account: 'BILLING_ACCT'
     ignore_read_extra:
       - 'properties'
-    skip_docs: true
+    exclude_docs: true
     skip_vcr: true
   - name: 'apigee_organization_cloud_full_disable_vpc_peering'
-    skip_test: true
+    exclude_test: true
   - name: 'apigee_organization_cloud_full_disable_vpc_peering_test'
     primary_resource_id: 'org'
     min_version: 'beta'
@@ -95,7 +95,7 @@ examples:
       billing_account: 'BILLING_ACCT'
     ignore_read_extra:
       - 'properties'
-    skip_docs: true
+    exclude_docs: true
     skip_vcr: true
   - name: 'apigee_organization_retention_test'
     primary_resource_id: 'org'
@@ -103,7 +103,7 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
     skip_vcr: true
   - name: 'apigee_organization_drz_test'
     primary_resource_id: 'org'
@@ -111,7 +111,7 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
     skip_vcr: true
 parameters:
   - name: 'projectId'

--- a/mmv1/products/apigee/go_TargetServer.yaml
+++ b/mmv1/products/apigee/go_TargetServer.yaml
@@ -47,13 +47,13 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_test: true
+    exclude_test: true
   - name: 'apigee_target_server_test'
     primary_resource_id: 'apigee_target_server'
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'envId'
     type: String

--- a/mmv1/products/appengine/go_FlexibleAppVersion.yaml
+++ b/mmv1/products/appengine/go_FlexibleAppVersion.yaml
@@ -76,7 +76,7 @@ examples:
     ignore_read_extra:
       - 'noop_on_destroy'
       - 'deployment.0.zip'
-    skip_test: true
+    exclude_test: true
 virtual_fields:
   - name: 'noop_on_destroy'
     description: |

--- a/mmv1/products/artifactregistry/go_VPCSCConfig.yaml
+++ b/mmv1/products/artifactregistry/go_VPCSCConfig.yaml
@@ -48,7 +48,7 @@ custom_code:
 examples:
   - name: 'artifact_registry_vpcsc_config'
     primary_resource_id: 'my-config'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/backupdr/go_ManagementServer.yaml
+++ b/mmv1/products/backupdr/go_ManagementServer.yaml
@@ -54,7 +54,7 @@ examples:
       managementserver_name: 'ms-console'
     test_env_vars:
       project: 'PROJECT_NAME'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/bigquery/go_Dataset.yaml
+++ b/mmv1/products/bigquery/go_Dataset.yaml
@@ -50,14 +50,14 @@ examples:
     vars:
       dataset_id: 'example_dataset'
       account_name: 'bqowner'
-    skip_docs: true
+    exclude_docs: true
   - name: 'bigquery_dataset_cmek'
     primary_resource_id: 'dataset'
     vars:
       dataset_id: 'example_dataset'
       key_name: 'example-key'
       keyring_name: 'example-keyring'
-    skip_test: true
+    exclude_test: true
   - name: 'bigquery_dataset_authorized_dataset'
     primary_resource_id: 'dataset'
     vars:
@@ -77,23 +77,23 @@ examples:
     vars:
       dataset_id: 'example_dataset'
       account_name: 'bqowner'
-    skip_docs: true
+    exclude_docs: true
   - name: 'bigquery_dataset_default_collation_set'
     primary_resource_id: 'dataset'
     vars:
       dataset_id: 'example_dataset'
       account_name: 'bqowner'
-    skip_docs: true
+    exclude_docs: true
   - name: 'bigquery_dataset_external_reference_aws_test'
     primary_resource_id: 'dataset'
     vars:
       dataset_id: 'example_dataset'
-    skip_docs: true
+    exclude_docs: true
   - name: 'bigquery_dataset_external_reference_aws'
     primary_resource_id: 'dataset'
     vars:
       dataset_id: 'example_dataset'
-    skip_test: true
+    exclude_test: true
   - name: 'bigquery_dataset_resource_tags'
     primary_resource_id: 'dataset'
     primary_resource_name: 'fmt.Sprintf("tf_test_dataset%s", context["random_suffix"])'
@@ -103,7 +103,7 @@ examples:
       tag_value1: 'tag_value1'
       tag_key2: 'tag_key2'
       tag_value2: 'tag_value2'
-    skip_docs: true
+    exclude_docs: true
 virtual_fields:
   - name: 'delete_contents_on_destroy'
     description: |

--- a/mmv1/products/bigquery/go_DatasetAccess.yaml
+++ b/mmv1/products/bigquery/go_DatasetAccess.yaml
@@ -73,27 +73,27 @@ examples:
     vars:
       dataset_id: 'example_dataset'
       account_name: 'bqowner'
-    skip_test: true
+    exclude_test: true
   - name: 'bigquery_dataset_access_view'
     primary_resource_id: 'access'
     vars:
       dataset_id: 'example_dataset'
       dataset_id2: 'example_dataset2'
       table_id: 'example_table'
-    skip_test: true
+    exclude_test: true
   - name: 'bigquery_dataset_access_authorized_dataset'
     primary_resource_id: 'access'
     vars:
       private: 'private'
       public: 'public'
-    skip_test: true
+    exclude_test: true
   - name: 'bigquery_dataset_access_authorized_routine'
     primary_resource_id: 'authorized_routine'
     vars:
       private_dataset: 'private_dataset'
       public_dataset: 'public_dataset'
       public_routine: 'public_routine'
-    skip_test: true
+    exclude_test: true
 parameters:
 properties:
   - name: 'datasetId'

--- a/mmv1/products/bigquery/go_Job.yaml
+++ b/mmv1/products/bigquery/go_Job.yaml
@@ -100,7 +100,7 @@ examples:
       - 'etag'
       - 'load.0.destination_table.0.table_id'
       - 'status.0.state'
-    skip_docs: true
+    exclude_docs: true
   - name: 'bigquery_job_copy'
     primary_resource_id: 'job'
     vars:
@@ -128,7 +128,7 @@ examples:
       - 'copy.0.source_tables.0.table_id'
       - 'copy.0.source_tables.1.table_id'
       - 'status.0.state'
-    skip_docs: true
+    exclude_docs: true
   - name: 'bigquery_job_extract'
     primary_resource_id: 'job'
     vars:
@@ -146,7 +146,7 @@ examples:
       - 'etag'
       - 'extract.0.source_table.0.table_id'
       - 'status.0.state'
-    skip_docs: true
+    exclude_docs: true
 parameters:
 properties:
   - name: 'user_email'

--- a/mmv1/products/bigquery/go_Routine.yaml
+++ b/mmv1/products/bigquery/go_Routine.yaml
@@ -79,7 +79,7 @@ examples:
       dataset_id: 'dataset_id'
       connection_id: 'connection_id'
       routine_id: 'routine_id'
-    skip_test: true
+    exclude_test: true
 parameters:
 properties:
   - name: 'routineReference'

--- a/mmv1/products/bigquerydatatransfer/go_Config.yaml
+++ b/mmv1/products/bigquerydatatransfer/go_Config.yaml
@@ -52,20 +52,20 @@ examples:
     vars:
       display_name: 'my-query'
       dataset_id: 'my_dataset'
-    skip_test: true
+    exclude_test: true
   - name: 'bigquerydatatransfer_config_cmek'
     primary_resource_id: 'query_config_cmek'
     vars:
       dataset_id: 'example_dataset'
       key_name: 'example-key'
       keyring_name: 'example-keyring'
-    skip_test: true
+    exclude_test: true
   - name: 'bigquerydatatransfer_config_salesforce'
     primary_resource_id: 'salesforce_config'
     vars:
       display_name: 'my-salesforce-config'
       dataset_id: 'my_dataset'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/bigqueryreservation/go_BiReservation.yaml
+++ b/mmv1/products/bigqueryreservation/go_BiReservation.yaml
@@ -45,7 +45,7 @@ examples:
     test_env_vars:
       project: 'PROJECT_NAME'
     external_providers: ["random", "time"]
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/bigqueryreservation/go_CapacityCommitment.yaml
+++ b/mmv1/products/bigqueryreservation/go_CapacityCommitment.yaml
@@ -42,13 +42,13 @@ examples:
   - name: 'bigquery_reservation_capacity_commitment_basic'
     primary_resource_id: 'commitment'
     external_providers: ["random", "time"]
-    skip_docs: true
+    exclude_docs: true
   - name: 'bigquery_reservation_capacity_commitment_no_id'
     primary_resource_id: 'commitment'
     external_providers: ["random", "time"]
-    skip_docs: true
+    exclude_docs: true
   - name: 'bigquery_reservation_capacity_commitment_docs'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'capacityCommitmentId'
     type: String

--- a/mmv1/products/bigqueryreservation/go_ReservationAssignment.yaml
+++ b/mmv1/products/bigqueryreservation/go_ReservationAssignment.yaml
@@ -54,7 +54,7 @@ examples:
       reservation_name: 'example-reservation'
     test_env_vars:
       project: 'PROJECT_NAME'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/billing/go_ProjectInfo.yaml
+++ b/mmv1/products/billing/go_ProjectInfo.yaml
@@ -42,7 +42,7 @@ examples:
     test_env_vars:
       billing_account: 'BILLING_ACCT'
       org_id: 'ORG_ID'
-    skip_import_test: true
+    exclude_import_test: true
 parameters:
 properties:
   - name: 'billing_account'

--- a/mmv1/products/billingbudget/go_Budget.yaml
+++ b/mmv1/products/billingbudget/go_Budget.yaml
@@ -89,7 +89,7 @@ examples:
       topic_name: 'example-topic'
     test_env_vars:
       billing_acct: 'MASTER_BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'billingAccount'
     type: String

--- a/mmv1/products/binaryauthorization/go_Attestor.yaml
+++ b/mmv1/products/binaryauthorization/go_Attestor.yaml
@@ -49,7 +49,7 @@ examples:
       note_name: 'test-attestor-note'
       key_name: 'test-attestor-key'
       keyring_name: 'test-attestor-key-ring'
-    skip_test: true
+    exclude_test: true
 parameters:
 properties:
   - name: 'name'

--- a/mmv1/products/binaryauthorization/go_Policy.yaml
+++ b/mmv1/products/binaryauthorization/go_Policy.yaml
@@ -41,13 +41,13 @@ examples:
     vars:
       attestor_name: 'test-attestor'
       note_name: 'test-attestor-note'
-    skip_test: true
+    exclude_test: true
   - name: 'binary_authorization_policy_global_evaluation'
     primary_resource_id: 'policy'
     vars:
       attestor_name: 'test-attestor'
       note_name: 'test-attestor-note'
-    skip_test: true
+    exclude_test: true
 parameters:
 properties:
   - name: 'description'

--- a/mmv1/products/cloudbuild/go_BitbucketServerConfig.yaml
+++ b/mmv1/products/cloudbuild/go_BitbucketServerConfig.yaml
@@ -61,7 +61,7 @@ examples:
     primary_resource_id: 'bbs-config-with-repos'
     vars:
       config_id: 'bbs-config'
-    skip_test: true
+    exclude_test: true
   - name: 'cloudbuild_bitbucket_server_config_peered_network'
     primary_resource_id: 'bbs-config-with-peered-network'
     vars:

--- a/mmv1/products/cloudbuild/go_Trigger.yaml
+++ b/mmv1/products/cloudbuild/go_Trigger.yaml
@@ -58,7 +58,7 @@ examples:
       sa_name: 'cloud-sa'
   - name: 'cloudbuild_trigger_include_build_logs'
     primary_resource_id: 'include-build-logs-trigger'
-    skip_test: true
+    exclude_test: true
   - name: 'cloudbuild_trigger_pubsub_config'
     primary_resource_id: 'pubsub-config-trigger'
     vars:
@@ -75,7 +75,7 @@ examples:
       cloudbuild_trigger_name: 'manual-trigger'
   - name: 'cloudbuild_trigger_manual_github_enterprise'
     primary_resource_id: 'manual-ghe-trigger'
-    skip_test: true
+    exclude_test: true
   - name: 'cloudbuild_trigger_manual_bitbucket_server'
     primary_resource_id: 'manual-bitbucket-trigger'
   - name: 'cloudbuild_trigger_repo'
@@ -102,7 +102,7 @@ examples:
     primary_resource_id: 'ghe-trigger'
     vars:
       cloudbuild_trigger_name: 'ghe-trigger'
-    skip_test: true
+    exclude_test: true
   - name: 'cloudbuild_trigger_allow_failure'
     primary_resource_id: 'allow-failure-trigger'
     vars:

--- a/mmv1/products/cloudbuildv2/go_Connection.yaml
+++ b/mmv1/products/cloudbuildv2/go_Connection.yaml
@@ -42,7 +42,7 @@ async:
   result:
     resource_inside_response: false
 iam_policy:
-  skip_import_test: true
+  exclude_import_test: true
   method_name_separator: ':'
   allowed_iam_role: 'roles/cloudbuild.connectionViewer'
   parent_resource_attribute: 'name'
@@ -57,9 +57,9 @@ examples:
     vars:
       connection_name: 'tf-test-connection'
   - name: 'cloudbuildv2_connection_ghe'
-    skip_test: true
+    exclude_test: true
   - name: 'cloudbuildv2_connection_github'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'name'
     type: String

--- a/mmv1/products/cloudbuildv2/go_Repository.yaml
+++ b/mmv1/products/cloudbuildv2/go_Repository.yaml
@@ -46,23 +46,23 @@ examples:
     vars:
       connection_name: 'connection'
       repository_name: 'repository'
-    skip_docs: true
+    exclude_docs: true
   - name: 'cloudbuildv2_repository_github'
     primary_resource_id: 'primary'
     vars:
       connection_name: 'connection'
       repository_name: 'repository'
-    skip_docs: true
+    exclude_docs: true
   - name: 'cloudbuildv2_repository_gle'
     primary_resource_id: 'primary'
     vars:
       connection_name: 'connection'
       repository_name: 'repository'
-    skip_docs: true
+    exclude_docs: true
   - name: 'cloudbuildv2_repository_ghe_doc'
-    skip_test: true
+    exclude_test: true
   - name: 'cloudbuildv2_repository_github_doc'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/clouddomains/go_Registration.yaml
+++ b/mmv1/products/clouddomains/go_Registration.yaml
@@ -58,7 +58,7 @@ custom_code:
 examples:
   - name: 'clouddomains_registration_full'
     primary_resource_id: 'my_registration'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/cloudfunctions2/go_Function.yaml
+++ b/mmv1/products/cloudfunctions2/go_Function.yaml
@@ -110,7 +110,7 @@ examples:
     ignore_read_extra:
       - 'build_config.0.source.0.storage_source.0.object'
       - 'build_config.0.source.0.storage_source.0.bucket'
-    skip_test: true
+    exclude_test: true
   - name: 'cloudfunctions2_basic_gcs'
     primary_resource_id: 'function'
     vars:
@@ -229,7 +229,7 @@ examples:
     ignore_read_extra:
       - 'build_config.0.source.0.storage_source.0.object'
       - 'build_config.0.source.0.storage_source.0.bucket'
-    skip_docs: true
+    exclude_docs: true
     skip_vcr: true
   - name: 'cloudfunctions2_cmek_docs'
     primary_resource_id: 'function'
@@ -243,7 +243,7 @@ examples:
       unencoded-ar-repo: 'ar-repo'
       kms_key_name: 'cmek-key'
       project: 'my-project-name'
-    skip_test: true
+    exclude_test: true
   - name: 'cloudfunctions2_abiu'
     primary_resource_id: 'function'
     min_version: 'beta'

--- a/mmv1/products/cloudidentity/go_Group.yaml
+++ b/mmv1/products/cloudidentity/go_Group.yaml
@@ -57,7 +57,7 @@ examples:
     test_env_vars:
       org_domain: 'ORG_DOMAIN'
       cust_id: 'CUST_ID'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'initialGroupConfig'
     type: Enum

--- a/mmv1/products/cloudidentity/go_GroupMembership.yaml
+++ b/mmv1/products/cloudidentity/go_GroupMembership.yaml
@@ -50,7 +50,7 @@ examples:
     test_env_vars:
       org_domain: 'ORG_DOMAIN'
       cust_id: 'CUST_ID'
-    skip_test: true
+    exclude_test: true
   - name: 'cloud_identity_group_membership_user'
     primary_resource_id: 'cloud_identity_group_membership_basic'
     vars:
@@ -59,7 +59,7 @@ examples:
       org_domain: 'ORG_DOMAIN'
       cust_id: 'CUST_ID'
       identity_user: 'IDENTITY_USER'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'group'
     type: ResourceRef

--- a/mmv1/products/cloudids/go_Endpoint.yaml
+++ b/mmv1/products/cloudids/go_Endpoint.yaml
@@ -51,7 +51,7 @@ exclude_sweeper: true
 examples:
   - name: 'cloudids_endpoint'
     primary_resource_id: 'example-endpoint'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/cloudquotas/go_QuotaPreference.yaml
+++ b/mmv1/products/cloudquotas/go_QuotaPreference.yaml
@@ -43,7 +43,7 @@ examples:
       name: 'compute_googleapis_com-CPUS-per-project_us-east1'
     test_env_vars:
       project: 'PROJECT_NAME'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'parent'
     type: String

--- a/mmv1/products/cloudrun/go_Service.yaml
+++ b/mmv1/products/cloudrun/go_Service.yaml
@@ -96,7 +96,7 @@ examples:
       project: 'PROJECT_NAME'
     ignore_read_extra:
       - 'autogenerate_revision_name'
-    skip_docs: true
+    exclude_docs: true
   - name: 'cloud_run_service_secret_environment_variables'
     primary_resource_id: 'default'
     primary_resource_name: 'fmt.Sprintf("tf-test-cloudrun-srv%s", context["random_suffix"])'
@@ -107,7 +107,7 @@ examples:
       project: 'PROJECT_NAME'
     ignore_read_extra:
       - 'autogenerate_revision_name'
-    skip_docs: true
+    exclude_docs: true
   - name: 'cloud_run_service_secret_volumes'
     primary_resource_id: 'default'
     primary_resource_name: 'fmt.Sprintf("tf-test-cloudrun-srv%s", context["random_suffix"])'
@@ -118,7 +118,7 @@ examples:
       project: 'PROJECT_NAME'
     ignore_read_extra:
       - 'autogenerate_revision_name'
-    skip_docs: true
+    exclude_docs: true
   - name: 'cloud_run_service_probes'
     primary_resource_id: 'default'
     vars:

--- a/mmv1/products/compute/go_Address.yaml
+++ b/mmv1/products/compute/go_Address.yaml
@@ -78,7 +78,7 @@ examples:
     primary_resource_id: 'internal_with_shared_loadbalancer_vip'
     vars:
       address_name: 'my-internal-address'
-    skip_docs: true
+    exclude_docs: true
   - name: 'instance_with_ip'
     primary_resource_id: 'static'
     vars:

--- a/mmv1/products/compute/go_BackendBucket.yaml
+++ b/mmv1/products/compute/go_BackendBucket.yaml
@@ -72,7 +72,7 @@ examples:
     vars:
       backend_bucket_name: 'image-backend-bucket-full'
       bucket_name: 'image-store-bucket-full'
-    skip_docs: true
+    exclude_docs: true
   - name: 'backend_bucket_security_policy'
     primary_resource_id: 'image_backend'
     vars:
@@ -98,19 +98,19 @@ examples:
       http_lb_proxy: 'http-lb-proxy'
       http_lb: 'http-lb'
       cat_backend_bucket: 'cat-backend-bucket'
-    skip_docs: true
+    exclude_docs: true
   - name: 'backend_bucket_bypass_cache'
     primary_resource_id: 'image_backend'
     vars:
       backend_bucket_name: 'image-backend-bucket'
       bucket_name: 'image-store-bucket'
-    skip_docs: true
+    exclude_docs: true
   - name: 'backend_bucket_coalescing'
     primary_resource_id: 'image_backend'
     vars:
       backend_bucket_name: 'image-backend-bucket'
       bucket_name: 'image-store-bucket'
-    skip_docs: true
+    exclude_docs: true
 parameters:
 properties:
   - name: 'bucketName'

--- a/mmv1/products/compute/go_BackendBucketSignedUrlKey.yaml
+++ b/mmv1/products/compute/go_BackendBucketSignedUrlKey.yaml
@@ -66,7 +66,7 @@ examples:
       backend_name: 'test-signed-backend-bucket'
       bucket_name: 'test-storage-bucket'
     external_providers: ["random", "time"]
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'backendBucket'
     type: ResourceRef

--- a/mmv1/products/compute/go_BackendServiceSignedUrlKey.yaml
+++ b/mmv1/products/compute/go_BackendServiceSignedUrlKey.yaml
@@ -66,7 +66,7 @@ examples:
       backend_name: 'my-backend-service'
       igm_name: 'my-webservers'
     external_providers: ["random", "time"]
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'backendService'
     type: ResourceRef

--- a/mmv1/products/compute/go_ExternalVpnGateway.yaml
+++ b/mmv1/products/compute/go_ExternalVpnGateway.yaml
@@ -58,7 +58,7 @@ examples:
     primary_resource_id: 'external_gateway'
     vars:
       external_gateway_name: 'external-gateway'
-    skip_docs: true
+    exclude_docs: true
 parameters:
 properties:
   - name: 'description'

--- a/mmv1/products/compute/go_ForwardingRule.yaml
+++ b/mmv1/products/compute/go_ForwardingRule.yaml
@@ -19,7 +19,7 @@ description: |
   A ForwardingRule resource. A ForwardingRule resource specifies which pool
   of target virtual machines to forward a packet to if it matches the given
   [IPAddress, IPProtocol, portRange] tuple.
-skip_attribution_label: true
+exclude_attribution_label: true
 references:
   guides:
     'Official Documentation': 'https://cloud.google.com/compute/docs/load-balancing/network/forwarding-rules'

--- a/mmv1/products/compute/go_GlobalForwardingRule.yaml
+++ b/mmv1/products/compute/go_GlobalForwardingRule.yaml
@@ -22,7 +22,7 @@ description: |
   balancing.
 
   For more information, see https://cloud.google.com/compute/docs/load-balancing/http/
-skip_attribution_label: true
+exclude_attribution_label: true
 docs:
 base_url: 'projects/{{project}}/global/forwardingRules'
 has_self_link: true
@@ -68,7 +68,7 @@ examples:
       - 'port_range'
       - 'target'
       - 'ip_address'
-    skip_test: true
+    exclude_test: true
   - name: 'external_tcp_proxy_lb_mig_backend'
     primary_resource_id: 'default'
     min_version: 'beta'

--- a/mmv1/products/compute/go_GlobalNetworkEndpoint.yaml
+++ b/mmv1/products/compute/go_GlobalNetworkEndpoint.yaml
@@ -71,7 +71,7 @@ examples:
     primary_resource_id: 'default-endpoint'
     vars:
       neg_name: 'my-lb-neg'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'globalNetworkEndpointGroup'
     type: ResourceRef

--- a/mmv1/products/compute/go_HaVpnGateway.yaml
+++ b/mmv1/products/compute/go_HaVpnGateway.yaml
@@ -68,8 +68,8 @@ examples:
       ha_vpn_gateway2_name: 'ha-vpn-2'
       network2_name: 'network2'
       router2_name: 'ha-vpn-router2'
-    skip_test: true
-    skip_docs: true
+    exclude_test: true
+    exclude_docs: true
     skip_vcr: true
   - name: 'compute_ha_vpn_gateway_encrypted_interconnect'
     primary_resource_id: 'vpn-gateway'
@@ -81,7 +81,7 @@ examples:
       address2_name: 'test-address2'
       router_name: 'test-router'
       network_name: 'test-network'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'region'
     type: ResourceRef

--- a/mmv1/products/compute/go_InstanceGroupMembership.yaml
+++ b/mmv1/products/compute/go_InstanceGroupMembership.yaml
@@ -78,7 +78,7 @@ examples:
       network_name: 'network'
       instance_group_name: 'instance-group'
       instance_name: 'instance'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'zone'
     type: ResourceRef

--- a/mmv1/products/compute/go_Interconnect.yaml
+++ b/mmv1/products/compute/go_Interconnect.yaml
@@ -55,12 +55,12 @@ examples:
       deletion_protection: 'true'
     test_vars_overrides:
       'deletion_protection': 'false'
-    skip_test: true
+    exclude_test: true
   - name: 'compute_interconnect_basic_test'
     primary_resource_id: 'example-interconnect'
     vars:
       interconnect_name: 'example-interconnect'
-    skip_docs: true
+    exclude_docs: true
 parameters:
 properties:
   - name: 'description'

--- a/mmv1/products/compute/go_InterconnectAttachment.yaml
+++ b/mmv1/products/compute/go_InterconnectAttachment.yaml
@@ -59,7 +59,7 @@ examples:
       interconnect_attachment_name: 'on-prem-attachment'
       router_name: 'router-1'
       network_name: 'network-1'
-    skip_docs: true
+    exclude_docs: true
   - name: 'compute_interconnect_attachment_ipsec_encryption'
     primary_resource_id: 'ipsec-encrypted-interconnect-attachment'
     vars:

--- a/mmv1/products/compute/go_NetworkEndpoint.yaml
+++ b/mmv1/products/compute/go_NetworkEndpoint.yaml
@@ -80,7 +80,7 @@ examples:
       instance_name: 'endpoint-instance'
       network_name: 'neg-network'
       subnetwork_name: 'neg-subnetwork'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'zone'
     type: ResourceRef

--- a/mmv1/products/compute/go_NetworkEndpoints.yaml
+++ b/mmv1/products/compute/go_NetworkEndpoints.yaml
@@ -81,7 +81,7 @@ examples:
       instance_name: 'endpoint-instance'
       network_name: 'neg-network'
       subnetwork_name: 'neg-subnetwork'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'zone'
     type: ResourceRef

--- a/mmv1/products/compute/go_PerInstanceConfig.yaml
+++ b/mmv1/products/compute/go_PerInstanceConfig.yaml
@@ -70,7 +70,7 @@ examples:
       template_name: 'my-template'
       igm_name: 'my-igm'
       disk_name: 'my-disk-name'
-    skip_test: true
+    exclude_test: true
 virtual_fields:
   - name: 'minimal_action'
     description: |

--- a/mmv1/products/compute/go_ProjectCloudArmorTier.yaml
+++ b/mmv1/products/compute/go_ProjectCloudArmorTier.yaml
@@ -53,7 +53,7 @@ custom_code:
 examples:
   - name: 'compute_project_cloud_armor_tier_basic'
     primary_resource_id: 'cloud_armor_tier_config'
-    skip_test: true
+    exclude_test: true
   - name: 'compute_project_cloud_armor_tier_project_set'
     primary_resource_id: 'cloud_armor_tier_config'
     vars:
@@ -61,7 +61,7 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_test: true
+    exclude_test: true
 parameters:
 properties:
   - name: 'cloudArmorTier'

--- a/mmv1/products/compute/go_PublicAdvertisedPrefix.yaml
+++ b/mmv1/products/compute/go_PublicAdvertisedPrefix.yaml
@@ -50,7 +50,7 @@ examples:
       prefixes_name: 'my-prefix'
     test_env_vars:
       desc: 'PAP_DESCRIPTION'
-    skip_test: true
+    exclude_test: true
 parameters:
 properties:
   - name: 'description'

--- a/mmv1/products/compute/go_PublicDelegatedPrefix.yaml
+++ b/mmv1/products/compute/go_PublicDelegatedPrefix.yaml
@@ -50,7 +50,7 @@ examples:
       prefixes_name: 'my-prefix'
     test_env_vars:
       desc: 'PAP_DESCRIPTION'
-    skip_test: true
+    exclude_test: true
 parameters:
 properties:
   - name: 'region'

--- a/mmv1/products/compute/go_RegionCommitment.yaml
+++ b/mmv1/products/compute/go_RegionCommitment.yaml
@@ -55,12 +55,12 @@ examples:
     primary_resource_id: 'foobar'
     vars:
       region_commitment_name: 'my-region-commitment'
-    skip_test: true
+    exclude_test: true
   - name: 'compute_region_commitment_full'
     primary_resource_id: 'foobar'
     vars:
       region_commitment_name: 'my-full-commitment'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'region'
     type: ResourceRef

--- a/mmv1/products/compute/go_RegionNetworkEndpoint.yaml
+++ b/mmv1/products/compute/go_RegionNetworkEndpoint.yaml
@@ -87,7 +87,7 @@ examples:
       subnetwork_name: 'subnetwork'
       instance_name: 'instance'
       neg_name: 'portmap-neg'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'region'
     type: ResourceRef

--- a/mmv1/products/compute/go_RegionPerInstanceConfig.yaml
+++ b/mmv1/products/compute/go_RegionPerInstanceConfig.yaml
@@ -71,7 +71,7 @@ examples:
       template_name: 'my-template'
       igm_name: 'my-rigm'
       disk_name: 'my-disk-name'
-    skip_test: true
+    exclude_test: true
 virtual_fields:
   - name: 'minimal_action'
     description: |

--- a/mmv1/products/compute/go_RegionSecurityPolicyRule.yaml
+++ b/mmv1/products/compute/go_RegionSecurityPolicyRule.yaml
@@ -73,7 +73,7 @@ examples:
     min_version: 'beta'
     vars:
       sec_policy_name: 'policyfornetworkmatch'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'region'
     type: String

--- a/mmv1/products/compute/go_RegionTargetHttpProxy.yaml
+++ b/mmv1/products/compute/go_RegionTargetHttpProxy.yaml
@@ -52,6 +52,13 @@ examples:
       region_url_map_name: 'url-map'
       region_backend_service_name: 'backend-service'
       region_health_check_name: 'http-health-check'
+  - name: 'region_target_http_proxy_http_keep_alive_timeout'
+    primary_resource_id: 'default'
+    vars:
+      region_target_http_proxy_name: 'test-http-keep-alive-timeout-proxy'
+      region_url_map_name: 'url-map'
+      region_backend_service_name: 'backend-service'
+      region_health_check_name: 'http-health-check'
   - name: 'region_target_http_proxy_https_redirect'
     primary_resource_id: 'default'
     vars:
@@ -105,3 +112,11 @@ properties:
     custom_expand: 'templates/terraform/custom_expand/go/resourceref_with_validation.go.tmpl'
     resource: 'RegionUrlMap'
     imports: 'selfLink'
+  - name: 'httpKeepAliveTimeoutSec'
+    type: Integer
+    description: |
+      Specifies how long to keep a connection open, after completing a response,
+      while there is no matching traffic (in seconds). If an HTTP keepalive is
+      not specified, a default value (600 seconds) will be used. For Regional
+      HTTP(S) load balancer, the minimum allowed value is 5 seconds and the
+      maximum allowed value is 600 seconds.

--- a/mmv1/products/compute/go_RegionTargetHttpsProxy.yaml
+++ b/mmv1/products/compute/go_RegionTargetHttpsProxy.yaml
@@ -56,6 +56,14 @@ examples:
       region_url_map_name: 'url-map'
       region_backend_service_name: 'backend-service'
       region_health_check_name: 'http-health-check'
+  - name: 'region_target_https_proxy_http_keep_alive_timeout'
+    primary_resource_id: 'default'
+    vars:
+      region_target_https_proxy_name: 'test-http-keep-alive-timeout-proxy'
+      region_ssl_certificate_name: 'my-certificate'
+      region_url_map_name: 'url-map'
+      region_backend_service_name: 'backend-service'
+      region_health_check_name: 'http-health-check'
   - name: 'region_target_https_proxy_mtls'
     primary_resource_id: 'default'
     min_version: 'beta'
@@ -168,6 +176,14 @@ properties:
     custom_expand: 'templates/terraform/custom_expand/go/resourceref_with_validation.go.tmpl'
     resource: 'RegionUrlMap'
     imports: 'selfLink'
+  - name: 'httpKeepAliveTimeoutSec'
+    type: Integer
+    description: |
+      Specifies how long to keep a connection open, after completing a response,
+      while there is no matching traffic (in seconds). If an HTTP keepalive is
+      not specified, a default value (600 seconds) will be used. For Regioanl
+      HTTP(S) load balancer, the minimum allowed value is 5 seconds and the
+      maximum allowed value is 600 seconds.
   - name: 'serverTlsPolicy'
     type: ResourceRef
     description: |

--- a/mmv1/products/compute/go_RegionUrlMap.yaml
+++ b/mmv1/products/compute/go_RegionUrlMap.yaml
@@ -104,7 +104,7 @@ examples:
     ignore_read_extra:
       - 'target'
       - 'ip_address'
-    skip_test: true
+    exclude_test: true
   - name: 'regional_external_http_load_balancer'
     primary_resource_id: 'default'
     min_version: 'beta'
@@ -122,8 +122,8 @@ examples:
       regional_l7_xlb_map: 'regional-l7-xlb-map'
       l7_xlb_proxy: 'l7-xlb-proxy'
       l7_xlb_forwarding_rule: 'l7-xlb-forwarding-rule'
-    skip_test: true
-    skip_docs: true
+    exclude_test: true
+    exclude_docs: true
   - name: 'region_url_map_path_template_match'
     primary_resource_id: 'urlmap'
     vars:

--- a/mmv1/products/compute/go_Reservation.yaml
+++ b/mmv1/products/compute/go_Reservation.yaml
@@ -68,7 +68,7 @@ examples:
       project: 'PROJECT_NAME'
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
     skip_vcr: true
 parameters:
   - name: 'zone'

--- a/mmv1/products/compute/go_ResourcePolicy.yaml
+++ b/mmv1/products/compute/go_ResourcePolicy.yaml
@@ -55,7 +55,7 @@ examples:
     primary_resource_id: 'foo'
     vars:
       name: 'gce-policy'
-    skip_docs: true
+    exclude_docs: true
   - name: 'resource_policy_full'
     primary_resource_id: 'bar'
     vars:

--- a/mmv1/products/compute/go_RouterNat.yaml
+++ b/mmv1/products/compute/go_RouterNat.yaml
@@ -72,7 +72,7 @@ examples:
       nat_name: 'my-router-nat'
       network_name: 'my-network'
       subnet_name: 'my-subnetwork'
-    skip_test: true
+    exclude_test: true
   - name: 'router_nat_manual_ips'
     primary_resource_id: 'nat_manual'
     vars:
@@ -81,7 +81,7 @@ examples:
       network_name: 'my-network'
       subnet_name: 'my-subnetwork'
       address_name: 'nat-manual-ip'
-    skip_test: true
+    exclude_test: true
   - name: 'router_nat_rules'
     primary_resource_id: 'nat_rules'
     vars:
@@ -92,7 +92,7 @@ examples:
       address_name1: 'nat-address1'
       address_name2: 'nat-address2'
       address_name3: 'nat-address3'
-    skip_test: true
+    exclude_test: true
   - name: 'router_nat_private'
     primary_resource_id: 'nat_type'
     min_version: 'beta'
@@ -103,7 +103,7 @@ examples:
       subnet_name: 'my-subnetwork'
       hub_name: 'my-hub'
       spoke_name: 'my-spoke'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'router'
     type: ResourceRef

--- a/mmv1/products/compute/go_SecurityPolicyRule.yaml
+++ b/mmv1/products/compute/go_SecurityPolicyRule.yaml
@@ -61,7 +61,7 @@ examples:
     vars:
       sec_policy_name: 'policyruletest'
       project_id: 'PROJECT_NAME'
-    skip_test: true
+    exclude_test: true
   - name: 'security_policy_rule_multiple_rules'
     primary_resource_id: 'policy_rule_one'
     vars:

--- a/mmv1/products/compute/go_ServiceAttachment.yaml
+++ b/mmv1/products/compute/go_ServiceAttachment.yaml
@@ -156,6 +156,22 @@ properties:
             The status of the connection from the consumer forwarding rule to
             this service attachment.
           output: true
+        - name: 'consumerNetwork'
+          type: String
+          description: |
+            The url of the consumer network.
+          output: true
+        - name: 'pscConnectionId'
+          type: String
+          description: |
+            The PSC connection id of the connected endpoint.
+          output: true
+        - name: 'propagatedConnectionCount'
+          type: Integer
+          description: |
+            The number of consumer Network Connectivity Center spokes that the connected Private Service Connect endpoint has propagated to.
+          min_version: 'beta'
+          output: true
   - name: 'targetService'
     type: String
     description: |
@@ -239,3 +255,15 @@ properties:
       If true, update will affect both PENDING and ACCEPTED/REJECTED PSC endpoints. For example, an ACCEPTED PSC endpoint will be moved to REJECTED if its project is added to the reject list.
     default_from_api: true
     send_empty_value: true
+  - name: 'propagatedConnectionLimit'
+    type: Integer
+    description: |
+      The number of consumer spokes that connected Private Service Connect endpoints can be propagated to through Network Connectivity Center.
+      This limit lets the service producer limit how many propagated Private Service Connect connections can be established to this service attachment from a single consumer.
+
+      If the connection preference of the service attachment is ACCEPT_MANUAL, the limit applies to each project or network that is listed in the consumer accept list.
+      If the connection preference of the service attachment is ACCEPT_AUTOMATIC, the limit applies to each project that contains a connected endpoint.
+
+      If unspecified, the default propagated connection limit is 250.
+    min_version: 'beta'
+    default_from_api: true

--- a/mmv1/products/compute/go_TargetHttpProxy.yaml
+++ b/mmv1/products/compute/go_TargetHttpProxy.yaml
@@ -113,7 +113,10 @@ properties:
     description: |
       Specifies how long to keep a connection open, after completing a response,
       while there is no matching traffic (in seconds). If an HTTP keepalive is
-      not specified, a default value (610 seconds) will be used. For Global
-      external HTTP(S) load balancer, the minimum allowed value is 5 seconds and
-      the maximum allowed value is 1200 seconds. For Global external HTTP(S)
-      load balancer (classic), this option is not available publicly.
+      not specified, a default value will be used. For Global
+      external HTTP(S) load balancer, the default value is 610 seconds, the
+      minimum allowed value is 5 seconds and the maximum allowed value is 1200
+      seconds. For cross-region internal HTTP(S) load balancer, the default
+      value is 600 seconds, the minimum allowed value is 5 seconds, and the
+      maximum allowed value is 600 seconds. For Global external HTTP(S) load
+      balancer (classic), this option is not available publicly.

--- a/mmv1/products/compute/go_TargetHttpsProxy.yaml
+++ b/mmv1/products/compute/go_TargetHttpsProxy.yaml
@@ -213,10 +213,13 @@ properties:
     description: |
       Specifies how long to keep a connection open, after completing a response,
       while there is no matching traffic (in seconds). If an HTTP keepalive is
-      not specified, a default value (610 seconds) will be used. For Global
-      external HTTP(S) load balancer, the minimum allowed value is 5 seconds and
-      the maximum allowed value is 1200 seconds. For Global external HTTP(S)
-      load balancer (classic), this option is not available publicly.
+      not specified, a default value will be used. For Global
+      external HTTP(S) load balancer, the default value is 610 seconds, the
+      minimum allowed value is 5 seconds and the maximum allowed value is 1200
+      seconds. For cross-region internal HTTP(S) load balancer, the default
+      value is 600 seconds, the minimum allowed value is 5 seconds, and the
+      maximum allowed value is 600 seconds. For Global external HTTP(S) load
+      balancer (classic), this option is not available publicly.
   - name: 'serverTlsPolicy'
     type: ResourceRef
     description: |

--- a/mmv1/products/compute/go_UrlMap.yaml
+++ b/mmv1/products/compute/go_UrlMap.yaml
@@ -108,8 +108,8 @@ examples:
     ignore_read_extra:
       - 'metadata'
       - 'metadata_startup_script'
-    skip_test: true
-    skip_docs: true
+    exclude_test: true
+    exclude_docs: true
   - name: 'url_map_path_template_match'
     primary_resource_id: 'urlmap'
     vars:

--- a/mmv1/products/containeranalysis/go_Occurrence.yaml
+++ b/mmv1/products/containeranalysis/go_Occurrence.yaml
@@ -44,7 +44,7 @@ examples:
     vars:
       note_name: 'attestation-note'
       attestor: 'attestor'
-    skip_test: true
+    exclude_test: true
 parameters:
 properties:
   - name: 'name'

--- a/mmv1/products/databasemigrationservice/go_ConnectionProfile.yaml
+++ b/mmv1/products/databasemigrationservice/go_ConnectionProfile.yaml
@@ -84,7 +84,7 @@ examples:
       profile: 'my-profileid'
     ignore_read_extra:
       - 'oracle.0.password'
-    skip_test: true
+    exclude_test: true
   - name: 'database_migration_service_connection_profile_alloydb'
     primary_resource_id: 'alloydbprofile'
     vars:
@@ -93,7 +93,7 @@ examples:
       network_name: 'vpc-network'
     ignore_read_extra:
       - 'alloydb.0.settings.0.initial_user.0.password'
-    skip_test: true
+    exclude_test: true
   - name: 'database_migration_service_connection_profile_existing_mysql'
     primary_resource_id: 'existing-mysql'
     vars:

--- a/mmv1/products/datacatalog/go_PolicyTag.yaml
+++ b/mmv1/products/datacatalog/go_PolicyTag.yaml
@@ -32,7 +32,7 @@ timeouts:
   update_minutes: 20
   delete_minutes: 20
 iam_policy:
-  skip_import_test: true
+  exclude_import_test: true
   method_name_separator: ':'
   fetch_iam_policy_verb: 'POST'
   parent_resource_attribute: 'policy_tag'

--- a/mmv1/products/datacatalog/go_Tag.yaml
+++ b/mmv1/products/datacatalog/go_Tag.yaml
@@ -85,7 +85,7 @@ examples:
       force_delete: 'false'
     test_vars_overrides:
       'force_delete': 'true'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'parent'
     type: String

--- a/mmv1/products/datacatalog/go_Taxonomy.yaml
+++ b/mmv1/products/datacatalog/go_Taxonomy.yaml
@@ -32,7 +32,7 @@ timeouts:
   update_minutes: 20
   delete_minutes: 20
 iam_policy:
-  skip_import_test: true
+  exclude_import_test: true
   method_name_separator: ':'
   fetch_iam_policy_verb: 'POST'
   parent_resource_attribute: 'taxonomy'

--- a/mmv1/products/dataform/go_Repository.yaml
+++ b/mmv1/products/dataform/go_Repository.yaml
@@ -49,7 +49,7 @@ examples:
       secret_name: 'my-secret'
       key_ring_name: 'example-key-ring'
       crypto_key_name: 'example-crypto-key-name'
-    skip_test: true
+    exclude_test: true
   - name: 'dataform_repository_with_cloudsource_repo'
     primary_resource_id: 'dataform_repository'
     primary_resource_name: 'fmt.Sprintf("tf_test_dataform_repository%s", context["random_suffix"])'
@@ -61,7 +61,7 @@ examples:
       secret_name: 'my-secret'
       key_ring_name: 'example-key-ring'
       crypto_key_name: 'example-crypto-key-name'
-    skip_docs: true
+    exclude_docs: true
   - name: 'dataform_repository_with_cloudsource_repo_and_ssh'
     primary_resource_id: 'dataform_repository'
     min_version: 'beta'
@@ -70,7 +70,7 @@ examples:
       dataform_repository_name: 'dataform_repository'
       data: 'secret-data'
       secret_name: 'my-secret'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'region'
     type: String

--- a/mmv1/products/dataplex/go_AspectType.yaml
+++ b/mmv1/products/dataplex/go_AspectType.yaml
@@ -47,7 +47,7 @@ async:
     path: 'error'
     message: 'message'
 iam_policy:
-  skip_import_test: true
+  exclude_import_test: true
   method_name_separator: ':'
   parent_resource_attribute: 'aspect_type_id'
   example_config_body: 'templates/terraform/iam/go/iam_attributes.go.tmpl'

--- a/mmv1/products/dataplex/go_Datascan.yaml
+++ b/mmv1/products/dataplex/go_Datascan.yaml
@@ -16,7 +16,7 @@
 name: 'Datascan'
 description: |
   Represents a user-visible job which provides the insights for the related data source.
-skip_attribution_label: true
+exclude_attribution_label: true
 references:
   guides:
     'Official Documentation': 'https://cloud.google.com/dataplex/docs'

--- a/mmv1/products/dataplex/go_EntryGroup.yaml
+++ b/mmv1/products/dataplex/go_EntryGroup.yaml
@@ -47,7 +47,7 @@ async:
     path: 'error'
     message: 'message'
 iam_policy:
-  skip_import_test: true
+  exclude_import_test: true
   method_name_separator: ':'
   parent_resource_attribute: 'entry_group_id'
   example_config_body: 'templates/terraform/iam/go/iam_attributes.go.tmpl'

--- a/mmv1/products/dataplex/go_EntryType.yaml
+++ b/mmv1/products/dataplex/go_EntryType.yaml
@@ -47,7 +47,7 @@ async:
     path: 'error'
     message: 'message'
 iam_policy:
-  skip_import_test: true
+  exclude_import_test: true
   method_name_separator: ':'
   parent_resource_attribute: 'entry_type_id'
   example_config_body: 'templates/terraform/iam/go/iam_attributes.go.tmpl'

--- a/mmv1/products/dataplex/go_Task.yaml
+++ b/mmv1/products/dataplex/go_Task.yaml
@@ -16,7 +16,7 @@
 name: 'Task'
 description: |
   A Dataplex task represents the work that you want Dataplex to do on a schedule. It encapsulates code, parameters, and the schedule.
-skip_attribution_label: true
+exclude_attribution_label: true
 references:
   guides:
     'Official Documentation': 'https://cloud.google.com/dataplex/docs'

--- a/mmv1/products/dataproc/go_AutoscalingPolicy.yaml
+++ b/mmv1/products/dataproc/go_AutoscalingPolicy.yaml
@@ -42,7 +42,7 @@ examples:
     primary_resource_name: 'fmt.Sprintf("tf-test-dataproc-policy%s", context["random_suffix"])'
     vars:
       name: 'dataproc-policy'
-    skip_docs: true
+    exclude_docs: true
   - name: 'dataproc_autoscaling_policy'
     primary_resource_id: 'asp'
     vars:

--- a/mmv1/products/datastream/go_ConnectionProfile.yaml
+++ b/mmv1/products/datastream/go_ConnectionProfile.yaml
@@ -78,7 +78,7 @@ examples:
       deletion_protection: 'true'
     test_vars_overrides:
       'deletion_protection': 'false'
-    skip_test: true
+    exclude_test: true
   - name: 'datastream_connection_profile_sql_server'
     primary_resource_id: 'default'
     vars:
@@ -91,7 +91,7 @@ examples:
       sql_server_root_password: 'root-password'
     test_vars_overrides:
       'deletion_protection': 'false'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'connectionProfileId'
     type: String

--- a/mmv1/products/datastream/go_Stream.yaml
+++ b/mmv1/products/datastream/go_Stream.yaml
@@ -70,7 +70,7 @@ examples:
     test_vars_overrides:
       'deletion_protection': 'false'
     external_providers: ["random", "time"]
-    skip_docs: true
+    exclude_docs: true
     skip_vcr: true
   - name: 'datastream_stream_full'
     primary_resource_id: 'default'
@@ -95,14 +95,14 @@ examples:
       stream_id: 'my-stream'
       source_connection_profile_id: 'source-profile'
       destination_connection_profile_id: 'destination-profile'
-    skip_test: true
+    exclude_test: true
   - name: 'datastream_stream_oracle'
     primary_resource_id: 'default'
     vars:
       stream_id: 'my-stream'
       source_connection_profile_id: 'source-profile'
       destination_connection_profile_id: 'destination-profile'
-    skip_test: true
+    exclude_test: true
   - name: 'datastream_stream_sql_server'
     primary_resource_id: 'default'
     vars:
@@ -117,7 +117,7 @@ examples:
       stream_id: 'stream'
     test_vars_overrides:
       'deletion_protection': 'false'
-    skip_test: true
+    exclude_test: true
   - name: 'datastream_stream_sql_server_change_tables'
     primary_resource_id: 'default'
     vars:
@@ -132,7 +132,7 @@ examples:
       stream_id: 'stream'
     test_vars_overrides:
       'deletion_protection': 'false'
-    skip_test: true
+    exclude_test: true
   - name: 'datastream_stream_postgresql_bigquery_dataset_id'
     primary_resource_id: 'default'
     vars:

--- a/mmv1/products/deploymentmanager/go_Deployment.yaml
+++ b/mmv1/products/deploymentmanager/go_Deployment.yaml
@@ -71,13 +71,13 @@ examples:
     primary_resource_name: 'fmt.Sprintf("tf-test-my-deployment-%s", context["random_suffix"])'
     vars:
       deployment_name: 'my-deployment'
-    skip_test: true
+    exclude_test: true
   - name: 'deployment_manager_deployment_imports'
     primary_resource_id: 'deployment'
     primary_resource_name: 'fmt.Sprintf("tf-test-my-deployment-%s", context["random_suffix"])'
     vars:
       deployment_name: 'my-deployment'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'createPolicy'
     type: Enum

--- a/mmv1/products/developerconnect/Connection.yaml
+++ b/mmv1/products/developerconnect/Connection.yaml
@@ -101,7 +101,7 @@ properties:
             name: oauthTokenSecretVersion
             description: |
               Required. A SecretManager resource containing the OAuth token
-              that authorizes the connection. 
+              that authorizes the connection.
               Format: `projects/*/secrets/*/versions/*`.
             required: true
           - !ruby/object:Api::Type::String
@@ -147,7 +147,7 @@ properties:
   - !ruby/object:Api::Type::NestedObject
     name: installationState
     description: |
-      Describes stage and necessary actions to be taken by the user to complete the installation. 
+      Describes stage and necessary actions to be taken by the user to complete the installation.
       Used for GitHub and GitHub Enterprise based connections.
     output: true
     properties:
@@ -176,7 +176,7 @@ properties:
     name: disabled
     description:
       Optional. If disabled is set to true, functionality is disabled for
-      this connection. Repository based API methods and webhooks processing 
+      this connection. Repository based API methods and webhooks processing
       for repositories in this connection will be disabled.
   - !ruby/object:Api::Type::Boolean
     name: reconciling
@@ -187,7 +187,7 @@ properties:
   - !ruby/object:Api::Type::KeyValueAnnotations
     name: annotations
     description: |
-      Optional. Allows clients to store small amounts of arbitrary data. 
+      Optional. Allows clients to store small amounts of arbitrary data.
   - !ruby/object:Api::Type::String
     name: etag
     description: |

--- a/mmv1/products/developerconnect/Connection.yaml
+++ b/mmv1/products/developerconnect/Connection.yaml
@@ -32,7 +32,8 @@ examples:
     name: "developer_connect_connection_github_doc"
     skip_test: true
 name: Connection
-description: "A connection to a GitHub App installation."
+description: |
+  A connection to a GitHub App installation.
 min_version: "beta"
 update_verb: :PATCH
 update_mask: true
@@ -40,18 +41,18 @@ autogen_async: true
 parameters:
   - !ruby/object:Api::Type::String
     name: location
-    description:
-      "Resource ID segment making up resource `name`. It identifies the resource
+    description: |
+      Resource ID segment making up resource `name`. It identifies the resource
       within its parent collection as described in https://google.aip.dev/122. See documentation
-      for resource type `developerconnect.googleapis.com/GitRepositoryLink`. "
+      for resource type `developerconnect.googleapis.com/GitRepositoryLink`.
     url_param_only: true
     required: true
     immutable: true
   - !ruby/object:Api::Type::String
     name: connectionId
-    description:
-      "Required. Id of the requesting object\nIf auto-generating Id server-side,
-      remove this field and\nconnection_id from the method_signature of Create RPC "
+    description: |
+      Required. Id of the requesting object. If auto-generating Id server-side,
+      remove this field and connection_id from the method_signature of Create RPC.
     url_param_only: true
     required: true
     immutable: true
@@ -76,104 +77,125 @@ async: !ruby/object:Api::OpAsync
 properties:
   - !ruby/object:Api::Type::NestedObject
     name: githubConfig
-    description: "Configuration for connections to github.com. "
+    description: |
+      Configuration for connections to github.com.
     properties:
       - !ruby/object:Api::Type::String
         name: githubApp
-        description:
-          "Required. Immutable. The GitHub Application that was installed to
-          the GitHub user or\norganization. \n Possible values:\n GIT_HUB_APP_UNSPECIFIED\nDEVELOPER_CONNECT\nFIREBASE"
+        description: |
+          Required. Immutable. The GitHub Application that was installed to
+          the GitHub user or organization.
+          Possible values:
+            GIT_HUB_APP_UNSPECIFIED
+            DEVELOPER_CONNECT
+            FIREBASE"
         required: true
         immutable: true
       - !ruby/object:Api::Type::NestedObject
         name: authorizerCredential
-        description:
-          "Represents an OAuth token of the account that authorized the Connection,\nand
-          associated metadata. "
+        description: |
+          Represents an OAuth token of the account that authorized the Connection,and
+          associated metadata.
         properties:
           - !ruby/object:Api::Type::String
             name: oauthTokenSecretVersion
-            description:
-              "Required. A SecretManager resource containing the OAuth token
-              that authorizes\nthe connection. Format: `projects/*/secrets/*/versions/*`. "
+            description: |
+              Required. A SecretManager resource containing the OAuth token
+              that authorizes the connection. 
+              Format: `projects/*/secrets/*/versions/*`.
             required: true
           - !ruby/object:Api::Type::String
             name: username
-            description: "Output only. The username associated with this token. "
+            description: |
+              Output only. The username associated with this token.
             output: true
       - !ruby/object:Api::Type::String
         name: appInstallationId
-        description: "Optional. GitHub App installation id. "
+        description: |
+          Optional. GitHub App installation id.
       - !ruby/object:Api::Type::String
         name: installationUri
-        description:
-          "Output only. The URI to navigate to in order to manage the installation
-          associated\nwith this GitHubConfig. "
+        description: |
+          Output only. The URI to navigate to in order to manage the installation
+          associated with this GitHubConfig.
         output: true
   - !ruby/object:Api::Type::String
     name: name
-    description: "Identifier. The resource name of the connection, in the format\n`projects/{project}/locations/{location}/connections/{connection_id}`. "
+    description: |
+      Identifier. The resource name of the connection, in the format
+      `projects/{project}/locations/{location}/connections/{connection_id}`.
     output: true
   - !ruby/object:Api::Type::String
     name: createTime
-    description: "Output only. [Output only] Create timestamp "
+    description: |
+      Output only. [Output only] Create timestamp
     output: true
   - !ruby/object:Api::Type::String
     name: updateTime
-    description: "Output only. [Output only] Update timestamp "
+    description: |
+      Output only. [Output only] Update timestamp
     output: true
   - !ruby/object:Api::Type::String
     name: deleteTime
-    description: "Output only. [Output only] Delete timestamp "
+    description: |
+      Output only. [Output only] Delete timestamp
     output: true
   - !ruby/object:Api::Type::KeyValueLabels
     name: labels
-    description: "Optional. Labels as key value pairs "
+    description: |
+      Optional. Labels as key value pairs
   - !ruby/object:Api::Type::NestedObject
     name: installationState
-    description:
-      "Describes stage and necessary actions to be taken by the\nuser to
-      complete the installation. Used for GitHub and GitHub Enterprise\nbased connections. "
+    description: |
+      Describes stage and necessary actions to be taken by the user to complete the installation. 
+      Used for GitHub and GitHub Enterprise based connections.
     output: true
     properties:
       - !ruby/object:Api::Type::String
         name: stage
-        description:
-          "Output only. Current step of the installation process. \n Possible
-          values:\n STAGE_UNSPECIFIED\nPENDING_CREATE_APP\nPENDING_USER_OAUTH\nPENDING_INSTALL_APP\nCOMPLETE"
+        description: |
+          Output only. Current step of the installation process.
+          Possible values:
+            STAGE_UNSPECIFIED
+            PENDING_CREATE_APP
+            PENDING_USER_OAUTH
+            PENDING_INSTALL_APP
+            COMPLETE
         output: true
       - !ruby/object:Api::Type::String
         name: message
-        description:
-          "Output only. Message of what the user should do next to continue
-          the installation.\nEmpty string if the installation is already complete. "
+        description: |
+          Output only. Message of what the user should do next to continue
+          the installation.Empty string if the installation is already complete.
       - !ruby/object:Api::Type::String
         name: actionUri
-        description:
-          "Output only. Link to follow for next action. Empty string if the
-          installation is already\ncomplete. "
+        description: |
+          Output only. Link to follow for next action. Empty string if the
+          installation is already complete.
   - !ruby/object:Api::Type::Boolean
     name: disabled
     description:
-      "Optional. If disabled is set to true, functionality is disabled for
-      this connection.\nRepository based API methods and webhooks processing for repositories
-      in\nthis connection will be disabled. "
+      Optional. If disabled is set to true, functionality is disabled for
+      this connection. Repository based API methods and webhooks processing 
+      for repositories in this connection will be disabled.
   - !ruby/object:Api::Type::Boolean
     name: reconciling
-    description:
-      "Output only. Set to true when the connection is being set up or updated
-      in the\nbackground. "
+    description: |
+      Output only. Set to true when the connection is being set up or updated
+      in the background.
     output: true
   - !ruby/object:Api::Type::KeyValueAnnotations
     name: annotations
-    description: "Optional. Allows clients to store small amounts of arbitrary data. "
+    description: |
+      Optional. Allows clients to store small amounts of arbitrary data. 
   - !ruby/object:Api::Type::String
     name: etag
-    description:
-      "Optional. This checksum is computed by the server based on the value
-      of other\nfields, and may be sent on update and delete requests to ensure the\nclient
-      has an up-to-date value before proceeding. "
+    description: |
+      Optional. This checksum is computed by the server based on the value
+      of other fields, and may be sent on update and delete requests to ensure the
+      client has an up-to-date value before proceeding.
   - !ruby/object:Api::Type::String
     name: uid
-    description: "Output only. A system-assigned unique identifier for a the GitRepositoryLink. "
+    description: |
+      Output only. A system-assigned unique identifier for a the GitRepositoryLink.
     output: true

--- a/mmv1/products/developerconnect/go_Connection.yaml
+++ b/mmv1/products/developerconnect/go_Connection.yaml
@@ -105,7 +105,7 @@ properties:
             type: String
             description: |
               Required. A SecretManager resource containing the OAuth token
-              that authorizes the connection. 
+              that authorizes the connection.
               Format: `projects/*/secrets/*/versions/*`.
             min_version: 'beta'
             required: true
@@ -160,7 +160,7 @@ properties:
   - name: 'installationState'
     type: NestedObject
     description: |
-      Describes stage and necessary actions to be taken by the user to complete the installation. 
+      Describes stage and necessary actions to be taken by the user to complete the installation.
       Used for GitHub and GitHub Enterprise based connections.
     min_version: 'beta'
     output: true
@@ -193,7 +193,7 @@ properties:
     type: Boolean
     description:
       Optional. If disabled is set to true, functionality is disabled for
-      this connection. Repository based API methods and webhooks processing 
+      this connection. Repository based API methods and webhooks processing
       for repositories in this connection will be disabled.
     min_version: 'beta'
   - name: 'reconciling'
@@ -206,7 +206,7 @@ properties:
   - name: 'annotations'
     type: KeyValueAnnotations
     description: |
-      Optional. Allows clients to store small amounts of arbitrary data. 
+      Optional. Allows clients to store small amounts of arbitrary data.
     min_version: 'beta'
   - name: 'etag'
     type: String

--- a/mmv1/products/developerconnect/go_Connection.yaml
+++ b/mmv1/products/developerconnect/go_Connection.yaml
@@ -1,0 +1,200 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Warning: This is a temporary file, and should not be edited directly
+---
+name: 'Connection'
+description: "A connection to a GitHub App installation."
+min_version: 'beta'
+docs:
+id_format: 'projects/{{project}}/locations/{{location}}/connections/{{connection_id}}'
+base_url: 'projects/{{project}}/locations/{{location}}/connections'
+self_link: 'projects/{{project}}/locations/{{location}}/connections/{{connection_id}}'
+create_url: 'projects/{{project}}/locations/{{location}}/connections?connectionId={{connection_id}}'
+update_verb: 'PATCH'
+update_mask: true
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/connections/{{connection_id}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+autogen_async: true
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+    path: 'name'
+    wait_ms: 1000
+  result:
+    path: 'response'
+    resource_inside_response: true
+  error:
+    path: 'error'
+    message: 'message'
+custom_code:
+examples:
+  - name: 'developer_connect_connection_basic'
+    primary_resource_id: 'my-connection'
+    primary_resource_name: 'fmt.Sprintf("tf-test-connection%s", context["random_suffix"])'
+    min_version: 'beta'
+    vars:
+      connection_name: 'tf-test-connection'
+  - name: 'developer_connect_connection_github_doc'
+    min_version: 'beta'
+    exclude_test: true
+parameters:
+  - name: 'location'
+    type: String
+    description:
+      "Resource ID segment making up resource `name`. It identifies the resource
+      within its parent collection as described in https://google.aip.dev/122. See documentation
+      for resource type `developerconnect.googleapis.com/GitRepositoryLink`. "
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+  - name: 'connectionId'
+    type: String
+    description:
+      "Required. Id of the requesting object\nIf auto-generating Id server-side,
+      remove this field and\nconnection_id from the method_signature of Create RPC "
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+properties:
+  - name: 'githubConfig'
+    type: NestedObject
+    description: "Configuration for connections to github.com. "
+    min_version: 'beta'
+    properties:
+      - name: 'githubApp'
+        type: String
+        description:
+          "Required. Immutable. The GitHub Application that was installed to
+          the GitHub user or\norganization. \n Possible values:\n GIT_HUB_APP_UNSPECIFIED\nDEVELOPER_CONNECT\nFIREBASE"
+        min_version: 'beta'
+        required: true
+        immutable: true
+      - name: 'authorizerCredential'
+        type: NestedObject
+        description:
+          "Represents an OAuth token of the account that authorized the Connection,\nand
+          associated metadata. "
+        min_version: 'beta'
+        properties:
+          - name: 'oauthTokenSecretVersion'
+            type: String
+            description:
+              "Required. A SecretManager resource containing the OAuth token
+              that authorizes\nthe connection. Format: `projects/*/secrets/*/versions/*`. "
+            min_version: 'beta'
+            required: true
+          - name: 'username'
+            type: String
+            description: "Output only. The username associated with this token. "
+            min_version: 'beta'
+            output: true
+      - name: 'appInstallationId'
+        type: String
+        description: "Optional. GitHub App installation id. "
+        min_version: 'beta'
+      - name: 'installationUri'
+        type: String
+        description:
+          "Output only. The URI to navigate to in order to manage the installation
+          associated\nwith this GitHubConfig. "
+        min_version: 'beta'
+        output: true
+  - name: 'name'
+    type: String
+    description: "Identifier. The resource name of the connection, in the format\n`projects/{project}/locations/{location}/connections/{connection_id}`. "
+    min_version: 'beta'
+    output: true
+  - name: 'createTime'
+    type: String
+    description: "Output only. [Output only] Create timestamp "
+    min_version: 'beta'
+    output: true
+  - name: 'updateTime'
+    type: String
+    description: "Output only. [Output only] Update timestamp "
+    min_version: 'beta'
+    output: true
+  - name: 'deleteTime'
+    type: String
+    description: "Output only. [Output only] Delete timestamp "
+    min_version: 'beta'
+    output: true
+  - name: 'labels'
+    type: KeyValueLabels
+    description: "Optional. Labels as key value pairs "
+    min_version: 'beta'
+  - name: 'installationState'
+    type: NestedObject
+    description:
+      "Describes stage and necessary actions to be taken by the\nuser to
+      complete the installation. Used for GitHub and GitHub Enterprise\nbased connections. "
+    min_version: 'beta'
+    output: true
+    properties:
+      - name: 'stage'
+        type: String
+        description:
+          "Output only. Current step of the installation process. \n Possible
+        min_version: 'beta'
+        output: true
+      - name: 'message'
+        type: String
+        description:
+          "Output only. Message of what the user should do next to continue
+          the installation.\nEmpty string if the installation is already complete. "
+        min_version: 'beta'
+      - name: 'actionUri'
+        type: String
+        description:
+          "Output only. Link to follow for next action. Empty string if the
+          installation is already\ncomplete. "
+        min_version: 'beta'
+  - name: 'disabled'
+    type: Boolean
+    description:
+      "Optional. If disabled is set to true, functionality is disabled for
+      this connection.\nRepository based API methods and webhooks processing for repositories
+      in\nthis connection will be disabled. "
+    min_version: 'beta'
+  - name: 'reconciling'
+    type: Boolean
+    description:
+      "Output only. Set to true when the connection is being set up or updated
+      in the\nbackground. "
+    min_version: 'beta'
+    output: true
+  - name: 'annotations'
+    type: KeyValueAnnotations
+    description: "Optional. Allows clients to store small amounts of arbitrary data. "
+    min_version: 'beta'
+  - name: 'etag'
+    type: String
+    description:
+      "Optional. This checksum is computed by the server based on the value
+      of other\nfields, and may be sent on update and delete requests to ensure the\nclient
+      has an up-to-date value before proceeding. "
+    min_version: 'beta'
+  - name: 'uid'
+    type: String
+    description: "Output only. A system-assigned unique identifier for a the GitRepositoryLink. "
+    min_version: 'beta'
+    output: true

--- a/mmv1/products/developerconnect/go_Connection.yaml
+++ b/mmv1/products/developerconnect/go_Connection.yaml
@@ -14,7 +14,8 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'Connection'
-description: "A connection to a GitHub App installation."
+description: |
+  A connection to a GitHub App installation.
 min_version: 'beta'
 docs:
 id_format: 'projects/{{project}}/locations/{{location}}/connections/{{connection_id}}'
@@ -57,19 +58,19 @@ examples:
 parameters:
   - name: 'location'
     type: String
-    description:
-      "Resource ID segment making up resource `name`. It identifies the resource
+    description: |
+      Resource ID segment making up resource `name`. It identifies the resource
       within its parent collection as described in https://google.aip.dev/122. See documentation
-      for resource type `developerconnect.googleapis.com/GitRepositoryLink`. "
+      for resource type `developerconnect.googleapis.com/GitRepositoryLink`.
     min_version: 'beta'
     url_param_only: true
     required: true
     immutable: true
   - name: 'connectionId'
     type: String
-    description:
-      "Required. Id of the requesting object\nIf auto-generating Id server-side,
-      remove this field and\nconnection_id from the method_signature of Create RPC "
+    description: |
+      Required. Id of the requesting object. If auto-generating Id server-side,
+      remove this field and connection_id from the method_signature of Create RPC.
     min_version: 'beta'
     url_param_only: true
     required: true
@@ -77,124 +78,146 @@ parameters:
 properties:
   - name: 'githubConfig'
     type: NestedObject
-    description: "Configuration for connections to github.com. "
+    description: |
+      Configuration for connections to github.com.
     min_version: 'beta'
     properties:
       - name: 'githubApp'
         type: String
-        description:
-          "Required. Immutable. The GitHub Application that was installed to
-          the GitHub user or\norganization. \n Possible values:\n GIT_HUB_APP_UNSPECIFIED\nDEVELOPER_CONNECT\nFIREBASE"
+        description: |
+          Required. Immutable. The GitHub Application that was installed to
+          the GitHub user or organization.
+          Possible values:
+            GIT_HUB_APP_UNSPECIFIED
+            DEVELOPER_CONNECT
+            FIREBASE"
         min_version: 'beta'
         required: true
         immutable: true
       - name: 'authorizerCredential'
         type: NestedObject
-        description:
-          "Represents an OAuth token of the account that authorized the Connection,\nand
-          associated metadata. "
+        description: |
+          Represents an OAuth token of the account that authorized the Connection,and
+          associated metadata.
         min_version: 'beta'
         properties:
           - name: 'oauthTokenSecretVersion'
             type: String
-            description:
-              "Required. A SecretManager resource containing the OAuth token
-              that authorizes\nthe connection. Format: `projects/*/secrets/*/versions/*`. "
+            description: |
+              Required. A SecretManager resource containing the OAuth token
+              that authorizes the connection. 
+              Format: `projects/*/secrets/*/versions/*`.
             min_version: 'beta'
             required: true
           - name: 'username'
             type: String
-            description: "Output only. The username associated with this token. "
+            description: |
+              Output only. The username associated with this token.
             min_version: 'beta'
             output: true
       - name: 'appInstallationId'
         type: String
-        description: "Optional. GitHub App installation id. "
+        description: |
+          Optional. GitHub App installation id.
         min_version: 'beta'
       - name: 'installationUri'
         type: String
-        description:
-          "Output only. The URI to navigate to in order to manage the installation
-          associated\nwith this GitHubConfig. "
+        description: |
+          Output only. The URI to navigate to in order to manage the installation
+          associated with this GitHubConfig.
         min_version: 'beta'
         output: true
   - name: 'name'
     type: String
-    description: "Identifier. The resource name of the connection, in the format\n`projects/{project}/locations/{location}/connections/{connection_id}`. "
+    description: |
+      Identifier. The resource name of the connection, in the format
+      `projects/{project}/locations/{location}/connections/{connection_id}`.
     min_version: 'beta'
     output: true
   - name: 'createTime'
     type: String
-    description: "Output only. [Output only] Create timestamp "
+    description: |
+      Output only. [Output only] Create timestamp
     min_version: 'beta'
     output: true
   - name: 'updateTime'
     type: String
-    description: "Output only. [Output only] Update timestamp "
+    description: |
+      Output only. [Output only] Update timestamp
     min_version: 'beta'
     output: true
   - name: 'deleteTime'
     type: String
-    description: "Output only. [Output only] Delete timestamp "
+    description: |
+      Output only. [Output only] Delete timestamp
     min_version: 'beta'
     output: true
   - name: 'labels'
     type: KeyValueLabels
-    description: "Optional. Labels as key value pairs "
+    description: |
+      Optional. Labels as key value pairs
     min_version: 'beta'
   - name: 'installationState'
     type: NestedObject
-    description:
-      "Describes stage and necessary actions to be taken by the\nuser to
-      complete the installation. Used for GitHub and GitHub Enterprise\nbased connections. "
+    description: |
+      Describes stage and necessary actions to be taken by the user to complete the installation. 
+      Used for GitHub and GitHub Enterprise based connections.
     min_version: 'beta'
     output: true
     properties:
       - name: 'stage'
         type: String
-        description:
-          "Output only. Current step of the installation process. \n Possible
+        description: |
+          Output only. Current step of the installation process.
+          Possible values:
+            STAGE_UNSPECIFIED
+            PENDING_CREATE_APP
+            PENDING_USER_OAUTH
+            PENDING_INSTALL_APP
+            COMPLETE
         min_version: 'beta'
         output: true
       - name: 'message'
         type: String
-        description:
-          "Output only. Message of what the user should do next to continue
-          the installation.\nEmpty string if the installation is already complete. "
+        description: |
+          Output only. Message of what the user should do next to continue
+          the installation.Empty string if the installation is already complete.
         min_version: 'beta'
       - name: 'actionUri'
         type: String
-        description:
-          "Output only. Link to follow for next action. Empty string if the
-          installation is already\ncomplete. "
+        description: |
+          Output only. Link to follow for next action. Empty string if the
+          installation is already complete.
         min_version: 'beta'
   - name: 'disabled'
     type: Boolean
     description:
-      "Optional. If disabled is set to true, functionality is disabled for
-      this connection.\nRepository based API methods and webhooks processing for repositories
-      in\nthis connection will be disabled. "
+      Optional. If disabled is set to true, functionality is disabled for
+      this connection. Repository based API methods and webhooks processing 
+      for repositories in this connection will be disabled.
     min_version: 'beta'
   - name: 'reconciling'
     type: Boolean
-    description:
-      "Output only. Set to true when the connection is being set up or updated
-      in the\nbackground. "
+    description: |
+      Output only. Set to true when the connection is being set up or updated
+      in the background.
     min_version: 'beta'
     output: true
   - name: 'annotations'
     type: KeyValueAnnotations
-    description: "Optional. Allows clients to store small amounts of arbitrary data. "
+    description: |
+      Optional. Allows clients to store small amounts of arbitrary data. 
     min_version: 'beta'
   - name: 'etag'
     type: String
-    description:
-      "Optional. This checksum is computed by the server based on the value
-      of other\nfields, and may be sent on update and delete requests to ensure the\nclient
-      has an up-to-date value before proceeding. "
+    description: |
+      Optional. This checksum is computed by the server based on the value
+      of other fields, and may be sent on update and delete requests to ensure the
+      client has an up-to-date value before proceeding.
     min_version: 'beta'
   - name: 'uid'
     type: String
-    description: "Output only. A system-assigned unique identifier for a the GitRepositoryLink. "
+    description: |
+      Output only. A system-assigned unique identifier for a the GitRepositoryLink.
     min_version: 'beta'
     output: true

--- a/mmv1/products/developerconnect/go_GitRepositoryLink.yaml
+++ b/mmv1/products/developerconnect/go_GitRepositoryLink.yaml
@@ -1,0 +1,140 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Warning: This is a temporary file, and should not be edited directly
+---
+name: 'GitRepositoryLink'
+description: "A git repository link to a parent connection."
+min_version: 'beta'
+docs:
+id_format: 'projects/{{project}}/locations/{{location}}/connections/{{parent_connection}}/gitRepositoryLinks/{{git_repository_link_id}}'
+base_url: 'projects/{{project}}/locations/{{location}}/connections/{{parent_connection}}/gitRepositoryLinks'
+self_link: 'projects/{{project}}/locations/{{location}}/connections/{{parent_connection}}/gitRepositoryLinks/{{git_repository_link_id}}'
+create_url: 'projects/{{project}}/locations/{{location}}/connections/{{parent_connection}}/gitRepositoryLinks?gitRepositoryLinkId={{git_repository_link_id}}'
+immutable: true
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/connections/{{parent_connection}}/gitRepositoryLinks/{{git_repository_link_id}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+autogen_async: true
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+    path: 'name'
+    wait_ms: 1000
+  result:
+    path: 'response'
+    resource_inside_response: true
+  error:
+    path: 'error'
+    message: 'message'
+custom_code:
+examples:
+  - name: 'developer_connect_git_repository_link_github'
+    primary_resource_id: 'primary'
+    min_version: 'beta'
+    vars:
+      connection_name: 'my-connection'
+      git_repository_link_name: 'my-repository'
+    exclude_docs: true
+  - name: 'developer_connect_git_repository_link_github_doc'
+    min_version: 'beta'
+    exclude_test: true
+parameters:
+  - name: 'location'
+    type: String
+    description:
+      "Resource ID segment making up resource `name`. It identifies the resource
+      within its parent collection as described in https://google.aip.dev/122. See documentation
+      for resource type `developerconnect.googleapis.com/GitRepositoryLink`. "
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+  - name: 'parent_connection'
+    type: String
+    description:
+      "Resource ID segment making up resource `name`. It identifies the resource
+      within its parent collection as described in https://google.aip.dev/122. See documentation
+      for resource type `developerconnect.googleapis.com/GitRepositoryLink`. "
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+  - name: 'gitRepositoryLinkId'
+    type: String
+    description:
+      "Required. The ID to use for the repository, which will become the
+      final component of\nthe repository's resource name. This ID should be unique in
+      the connection.\nAllows alphanumeric characters and any of -._~%!$&'()*+,;=@. "
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+properties:
+  - name: 'name'
+    type: String
+    description: "Identifier. Resource name of the repository, in the format\n`projects/*/locations/*/connections/*/gitRepositoryLinks/*`. "
+    min_version: 'beta'
+    output: true
+  - name: 'cloneUri'
+    type: String
+    description: "Required. Git Clone URI. "
+    min_version: 'beta'
+    required: true
+  - name: 'createTime'
+    type: String
+    description: "Output only. [Output only] Create timestamp "
+    min_version: 'beta'
+    output: true
+  - name: 'updateTime'
+    type: String
+    description: "Output only. [Output only] Update timestamp "
+    min_version: 'beta'
+    output: true
+  - name: 'deleteTime'
+    type: String
+    description: "Output only. [Output only] Delete timestamp "
+    min_version: 'beta'
+    output: true
+  - name: 'labels'
+    type: KeyValueLabels
+    description: "Optional. Labels as key value pairs "
+    min_version: 'beta'
+  - name: 'etag'
+    type: String
+    description:
+      "Optional. This checksum is computed by the server based on the value
+      of other\nfields, and may be sent on update and delete requests to ensure the\nclient
+      has an up-to-date value before proceeding. "
+    min_version: 'beta'
+  - name: 'reconciling'
+    type: Boolean
+    description:
+      "Output only. Set to true when the connection is being set up or updated
+      in the\nbackground. "
+    min_version: 'beta'
+    output: true
+  - name: 'annotations'
+    type: KeyValueAnnotations
+    description: "Optional. Allows clients to store small amounts of arbitrary data. "
+    min_version: 'beta'
+  - name: 'uid'
+    type: String
+    description: "Output only. A system-assigned unique identifier for a the GitRepositoryLink. "
+    min_version: 'beta'
+    output: true

--- a/mmv1/products/developerconnect/go_product.yaml
+++ b/mmv1/products/developerconnect/go_product.yaml
@@ -1,0 +1,22 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Warning: This is a temporary file, and should not be edited directly
+---
+name: 'DeveloperConnect'
+display_name: 'Developer Connect'
+versions:
+  - name: 'beta'
+    base_url: 'https://developerconnect.googleapis.com/v1/'
+scopes:
+  - 'https://www.googleapis.com/auth/cloud-platform'

--- a/mmv1/products/dialogflow/go_EntityType.yaml
+++ b/mmv1/products/dialogflow/go_EntityType.yaml
@@ -40,7 +40,7 @@ examples:
     primary_resource_id: 'basic_entity_type'
     vars:
       intent_name: 'basic-entity-type'
-    skip_test: true
+    exclude_test: true
 parameters:
 properties:
   - name: 'name'

--- a/mmv1/products/dialogflow/go_Fulfillment.yaml
+++ b/mmv1/products/dialogflow/go_Fulfillment.yaml
@@ -46,7 +46,7 @@ examples:
     primary_resource_id: 'basic_fulfillment'
     vars:
       fulfillment_name: 'basic-fulfillment'
-    skip_test: true
+    exclude_test: true
 parameters:
 properties:
   - name: 'name'

--- a/mmv1/products/dialogflow/go_Intent.yaml
+++ b/mmv1/products/dialogflow/go_Intent.yaml
@@ -41,7 +41,7 @@ examples:
     primary_resource_id: 'basic_intent'
     vars:
       intent_name: 'basic-intent'
-    skip_test: true
+    exclude_test: true
   - name: 'dialogflow_intent_full'
     primary_resource_id: 'full_intent'
     vars:

--- a/mmv1/products/dialogflowcx/go_Environment.yaml
+++ b/mmv1/products/dialogflowcx/go_Environment.yaml
@@ -68,7 +68,7 @@ examples:
     primary_resource_id: 'development'
     vars:
       agent_name: 'issue-12880'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'parent'
     type: String

--- a/mmv1/products/dialogflowcx/go_Flow.yaml
+++ b/mmv1/products/dialogflowcx/go_Flow.yaml
@@ -52,7 +52,7 @@ examples:
     primary_resource_id: 'default_start_flow'
     vars:
       agent_name: 'dialogflowcx-agent'
-    skip_docs: true
+    exclude_docs: true
 virtual_fields:
   - name: 'is_default_start_flow'
     description: |

--- a/mmv1/products/dialogflowcx/go_Intent.yaml
+++ b/mmv1/products/dialogflowcx/go_Intent.yaml
@@ -47,12 +47,12 @@ examples:
     primary_resource_id: 'default_negative_intent'
     vars:
       agent_name: 'dialogflowcx-agent'
-    skip_docs: true
+    exclude_docs: true
   - name: 'dialogflowcx_intent_default_welcome_intent'
     primary_resource_id: 'default_welcome_intent'
     vars:
       agent_name: 'dialogflowcx-agent'
-    skip_docs: true
+    exclude_docs: true
 virtual_fields:
   - name: 'is_default_welcome_intent'
     description: |

--- a/mmv1/products/dialogflowcx/go_Version.yaml
+++ b/mmv1/products/dialogflowcx/go_Version.yaml
@@ -67,7 +67,7 @@ examples:
     primary_resource_id: 'version_1'
     vars:
       agent_name: 'issue-12880'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'parent'
     type: String

--- a/mmv1/products/discoveryengine/go_DataStore.yaml
+++ b/mmv1/products/discoveryengine/go_DataStore.yaml
@@ -60,13 +60,13 @@ examples:
     primary_resource_name: 'fmt.Sprintf("tf_test_data_store%s", context["random_suffix"])'
     vars:
       data_store_id: 'data-store-id'
-    skip_docs: true
+    exclude_docs: true
   - name: 'discoveryengine_datastore_document_processing_config_layout'
     primary_resource_id: 'document_processing_config_layout'
     primary_resource_name: 'fmt.Sprintf("tf_test_data_store%s", context["random_suffix"])'
     vars:
       data_store_id: 'data-store-id'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/dlp/go_DeidentifyTemplate.yaml
+++ b/mmv1/products/dlp/go_DeidentifyTemplate.yaml
@@ -46,7 +46,7 @@ examples:
     primary_resource_id: 'basic'
     test_env_vars:
       project: 'PROJECT_NAME'
-    skip_docs: true
+    exclude_docs: true
   - name: 'dlp_deidentify_template_image_transformations'
     primary_resource_id: 'basic'
     test_env_vars:
@@ -57,7 +57,7 @@ examples:
       name: 'my-template'
     test_env_vars:
       project: 'PROJECT_NAME'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'parent'
     type: String

--- a/mmv1/products/dlp/go_DiscoveryConfig.yaml
+++ b/mmv1/products/dlp/go_DiscoveryConfig.yaml
@@ -44,18 +44,18 @@ examples:
     test_env_vars:
       project: 'PROJECT_NAME'
       location: 'REGION'
-    skip_test: true
+    exclude_test: true
   - name: 'dlp_discovery_config_actions'
     primary_resource_id: 'actions'
     test_env_vars:
       project: 'PROJECT_NAME'
-    skip_test: true
+    exclude_test: true
   - name: 'dlp_discovery_config_org_running'
     primary_resource_id: 'org_running'
     test_env_vars:
       project: 'PROJECT_NAME'
       organization: 'ORG_ID'
-    skip_test: true
+    exclude_test: true
   - name: 'dlp_discovery_config_org_folder_paused'
     primary_resource_id: 'org_folder_paused'
     test_env_vars:
@@ -65,22 +65,22 @@ examples:
     primary_resource_id: 'conditions_cadence'
     test_env_vars:
       project: 'PROJECT_NAME'
-    skip_test: true
+    exclude_test: true
   - name: 'dlp_discovery_config_filter_regexes_and_conditions'
     primary_resource_id: 'filter_regexes_and_conditions'
     test_env_vars:
       project: 'PROJECT_NAME'
-    skip_test: true
+    exclude_test: true
   - name: 'dlp_discovery_config_cloud_sql'
     primary_resource_id: 'cloud_sql'
     test_env_vars:
       project: 'PROJECT_NAME'
-    skip_test: true
+    exclude_test: true
   - name: 'dlp_discovery_config_cloud_storage'
     primary_resource_id: 'cloud_storage'
     test_env_vars:
       project: 'PROJECT_NAME'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'parent'
     type: String

--- a/mmv1/products/dlp/go_InspectTemplate.yaml
+++ b/mmv1/products/dlp/go_InspectTemplate.yaml
@@ -60,7 +60,7 @@ examples:
       name: 'my-template'
     test_env_vars:
       project: 'PROJECT_NAME'
-    skip_docs: true
+    exclude_docs: true
   - name: 'dlp_inspect_template_max_infotype_per_finding_default'
     primary_resource_id: 'max_infotype_per_finding_default'
     test_env_vars:

--- a/mmv1/products/dlp/go_JobTrigger.yaml
+++ b/mmv1/products/dlp/go_JobTrigger.yaml
@@ -62,14 +62,14 @@ examples:
       trigger: 'trigger'
     test_env_vars:
       project: 'PROJECT_NAME'
-    skip_docs: true
+    exclude_docs: true
   - name: 'dlp_job_trigger_scc_output'
     primary_resource_id: 'scc_output'
     vars:
       trigger: 'trigger'
     test_env_vars:
       project: 'PROJECT_NAME'
-    skip_docs: true
+    exclude_docs: true
   - name: 'dlp_job_trigger_job_notification_emails'
     primary_resource_id: 'job_notification_emails'
     test_env_vars:

--- a/mmv1/products/dns/go_ManagedZone.yaml
+++ b/mmv1/products/dns/go_ManagedZone.yaml
@@ -54,12 +54,12 @@ examples:
       'dns_name': '"m-z.gcp.tfacc.hashicorptest.com."'
     ignore_read_extra:
       - 'force_destroy'
-    skip_docs: true
+    exclude_docs: true
   - name: 'dns_record_set_basic'
     primary_resource_id: 'parent-zone'
     vars:
       sample_zone: 'sample-zone'
-    skip_docs: true
+    exclude_docs: true
   - name: 'dns_managed_zone_basic'
     primary_resource_id: 'example-zone'
     external_providers: ["random", "time"]
@@ -81,14 +81,14 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
   - name: 'dns_managed_zone_private_forwarding'
     primary_resource_id: 'private-zone'
     vars:
       zone_name: 'private-zone'
       network_1_name: 'network-1'
       network_2_name: 'network-2'
-    skip_test: true
+    exclude_test: true
   - name: 'dns_managed_zone_private_gke'
     primary_resource_id: 'private-zone-gke'
     vars:

--- a/mmv1/products/dns/go_Policy.yaml
+++ b/mmv1/products/dns/go_Policy.yaml
@@ -50,7 +50,7 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_docs: true
+    exclude_docs: true
 parameters:
 properties:
   - name: 'alternativeNameServerConfig'

--- a/mmv1/products/documentai/go_Processor.yaml
+++ b/mmv1/products/documentai/go_Processor.yaml
@@ -37,7 +37,7 @@ examples:
     primary_resource_id: 'processor'
     vars:
       processor_name: 'test-processor'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/documentaiwarehouse/go_DocumentSchema.yaml
+++ b/mmv1/products/documentaiwarehouse/go_DocumentSchema.yaml
@@ -34,7 +34,7 @@ custom_code:
 examples:
   - name: 'document_ai_warehouse_document_schema_text'
     primary_resource_id: 'example_text'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'project_number'
     type: String

--- a/mmv1/products/documentaiwarehouse/go_Location.yaml
+++ b/mmv1/products/documentaiwarehouse/go_Location.yaml
@@ -23,7 +23,7 @@ references:
 docs:
 id_format: 'projects/{{project_number}}/locations/{{location}}'
 base_url: 'projects/{{project_number}}/locations/{{location}}:initialize'
-skip_read: true
+exclude_read: true
 exclude_delete: true
 immutable: true
 exclude_import: true
@@ -50,7 +50,7 @@ exclude_sweeper: true
 examples:
   - name: 'document_ai_warehouse_location'
     primary_resource_id: 'example'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'project_number'
     type: String

--- a/mmv1/products/edgecontainer/go_Cluster.yaml
+++ b/mmv1/products/edgecontainer/go_Cluster.yaml
@@ -67,7 +67,7 @@ examples:
     primary_resource_id: 'default'
     vars:
       edgecontainer_cluster_name: 'local-control-plane-cluster'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/edgecontainer/go_NodePool.yaml
+++ b/mmv1/products/edgecontainer/go_NodePool.yaml
@@ -55,17 +55,17 @@ custom_code:
 examples:
   - name: 'edgecontainer_node_pool'
     primary_resource_id: 'default'
-    skip_test: true
+    exclude_test: true
   - name: 'edgecontainer_node_pool_with_cmek'
     primary_resource_id: 'default'
-    skip_test: true
+    exclude_test: true
   - name: 'edgecontainer_local_control_plane_node_pool'
     primary_resource_id: 'default'
-    skip_test: true
+    exclude_test: true
   - name: 'edgecontainer_local_control_plane_node_pool_internal'
     primary_resource_id: 'default'
-    skip_test: true
-    skip_docs: true
+    exclude_test: true
+    exclude_docs: true
     skip_vcr: true
 parameters:
   - name: 'name'

--- a/mmv1/products/edgecontainer/go_VpnConnection.yaml
+++ b/mmv1/products/edgecontainer/go_VpnConnection.yaml
@@ -49,7 +49,7 @@ custom_code:
 examples:
   - name: 'edgecontainer_vpn_connection'
     primary_resource_id: 'default'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'name'
     type: String

--- a/mmv1/products/edgenetwork/go_Network.yaml
+++ b/mmv1/products/edgenetwork/go_Network.yaml
@@ -55,7 +55,7 @@ examples:
     test_env_vars:
       location: 'REGION'
       zone: 'ZONE'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/edgenetwork/go_Subnet.yaml
+++ b/mmv1/products/edgenetwork/go_Subnet.yaml
@@ -56,7 +56,7 @@ examples:
     test_env_vars:
       location: 'REGION'
       zone: 'ZONE'
-    skip_test: true
+    exclude_test: true
   - name: 'edgenetwork_subnet_with_vlan_id'
     primary_resource_id: 'example_subnet_with_vlan_id'
     vars:
@@ -65,7 +65,7 @@ examples:
     test_env_vars:
       location: 'REGION'
       zone: 'ZONE'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/filestore/go_Instance.yaml
+++ b/mmv1/products/filestore/go_Instance.yaml
@@ -71,7 +71,7 @@ examples:
     primary_resource_id: 'instance'
     vars:
       instance_name: 'test-instance'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'zone'
     type: String

--- a/mmv1/products/firestore/go_Database.yaml
+++ b/mmv1/products/firestore/go_Database.yaml
@@ -65,7 +65,7 @@ examples:
       - 'project'
       - 'etag'
       - 'deletion_policy'
-    skip_test: true
+    exclude_test: true
   - name: 'firestore_database'
     primary_resource_id: 'database'
     vars:
@@ -102,7 +102,7 @@ examples:
       - 'project'
       - 'etag'
       - 'deletion_policy'
-    skip_test: true
+    exclude_test: true
   - name: 'firestore_database_in_datastore_mode'
     primary_resource_id: 'datastore_mode_database'
     vars:

--- a/mmv1/products/gkehub2/go_Feature.yaml
+++ b/mmv1/products/gkehub2/go_Feature.yaml
@@ -63,51 +63,51 @@ examples:
   - name: 'gkehub_feature_multi_cluster_ingress'
     primary_resource_id: 'feature'
     primary_resource_name: 'fmt.Sprint("multiclusteringress")'
-    skip_test: true
+    exclude_test: true
   - name: 'gkehub_feature_multi_cluster_service_discovery'
     primary_resource_id: 'feature'
     primary_resource_name: 'fmt.Sprint("multiclusterservicediscovery")'
-    skip_test: true
+    exclude_test: true
   - name: 'gkehub_feature_anthos_service_mesh'
     primary_resource_id: 'feature'
     primary_resource_name: 'fmt.Sprint("servicemesh")'
-    skip_test: true
+    exclude_test: true
   - name: 'enable_fleet_observability_for_default_logs_with_COPY'
     primary_resource_id: 'feature'
     primary_resource_name: 'fmt.Sprint("fleetobservability")'
-    skip_test: true
+    exclude_test: true
   - name: 'enable_fleet_observability_for_scope_logs_with_MOVE'
     primary_resource_id: 'feature'
     primary_resource_name: 'fmt.Sprint("fleetobservability")'
-    skip_test: true
+    exclude_test: true
   - name: 'enable_fleet_observability_for_both_default_and_scope_logs'
     primary_resource_id: 'feature'
     primary_resource_name: 'fmt.Sprint("fleetobservability")'
-    skip_test: true
+    exclude_test: true
   - name: 'enable_fleet_default_member_config_service_mesh'
     primary_resource_id: 'feature'
     primary_resource_name: 'fmt.Sprintf("servicemesh")'
-    skip_test: true
+    exclude_test: true
   - name: 'enable_fleet_default_member_config_configmanagement'
     primary_resource_id: 'feature'
     primary_resource_name: 'fmt.Sprintf("configmanagement")'
-    skip_test: true
+    exclude_test: true
   - name: 'enable_fleet_default_member_config_policycontroller'
     primary_resource_id: 'feature'
     primary_resource_name: 'fmt.Sprintf("policycontroller")'
-    skip_test: true
+    exclude_test: true
   - name: 'enable_fleet_default_member_config_policycontroller_full'
     primary_resource_id: 'feature'
     primary_resource_name: 'fmt.Sprintf("policycontroller")'
-    skip_test: true
+    exclude_test: true
   - name: 'enable_fleet_default_member_config_policycontroller_minimal'
     primary_resource_id: 'feature'
     primary_resource_name: 'fmt.Sprintf("policycontroller")'
-    skip_test: true
+    exclude_test: true
   - name: 'gkehub_feature_clusterupgrade'
     primary_resource_id: 'feature'
     primary_resource_name: 'fmt.Sprint("clusterupgrade")'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/gkehub2/go_Fleet.yaml
+++ b/mmv1/products/gkehub2/go_Fleet.yaml
@@ -53,7 +53,7 @@ custom_code:
 examples:
   - name: 'gkehub_fleet_basic'
     primary_resource_id: 'default'
-    skip_test: true
+    exclude_test: true
 parameters:
 properties:
   - name: 'displayName'

--- a/mmv1/products/iam2/go_AccessBoundaryPolicy.yaml
+++ b/mmv1/products/iam2/go_AccessBoundaryPolicy.yaml
@@ -55,7 +55,7 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_test: true
+    exclude_test: true
 parameters:
 properties:
   - name: 'name'

--- a/mmv1/products/iamworkforcepool/go_WorkforcePoolProvider.yaml
+++ b/mmv1/products/iamworkforcepool/go_WorkforcePoolProvider.yaml
@@ -96,7 +96,7 @@ examples:
       org_id: 'ORG_ID'
     ignore_read_extra:
       - 'oidc.0.client_secret.0.value.0.plain_text'
-    skip_docs: true
+    exclude_docs: true
   - name: 'iam_workforce_pool_provider_extra_attributes_oauth2_config_client_basic'
     primary_resource_id: 'example'
     vars:

--- a/mmv1/products/iap/go_AppEngineService.yaml
+++ b/mmv1/products/iap/go_AppEngineService.yaml
@@ -46,7 +46,7 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_test: true
+    exclude_test: true
 parameters:
 properties:
   - name: 'appId'

--- a/mmv1/products/iap/go_Brand.yaml
+++ b/mmv1/products/iap/go_Brand.yaml
@@ -61,7 +61,7 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
       org_domain: 'ORG_DOMAIN'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'name'
     type: String

--- a/mmv1/products/iap/go_TunnelDestGroup.yaml
+++ b/mmv1/products/iap/go_TunnelDestGroup.yaml
@@ -34,7 +34,7 @@ timeouts:
   update_minutes: 20
   delete_minutes: 20
 iam_policy:
-  skip_import_test: true
+  exclude_import_test: true
   method_name_separator: ':'
   fetch_iam_policy_verb: 'POST'
   allowed_iam_role: 'roles/iap.tunnelResourceAccessor'

--- a/mmv1/products/identityplatform/go_Config.yaml
+++ b/mmv1/products/identityplatform/go_Config.yaml
@@ -69,7 +69,7 @@ examples:
     ignore_read_extra:
       - 'client.0.api_key'
       - 'client.0.firebase_subdomain'
-    skip_docs: true
+    exclude_docs: true
 parameters:
 properties:
   - name: 'name'

--- a/mmv1/products/identityplatform/go_DefaultSupportedIdpConfig.yaml
+++ b/mmv1/products/identityplatform/go_DefaultSupportedIdpConfig.yaml
@@ -36,7 +36,7 @@ custom_code:
 examples:
   - name: 'identity_platform_default_supported_idp_config_basic'
     primary_resource_id: 'idp_config'
-    skip_test: true
+    exclude_test: true
 parameters:
 properties:
   - name: 'name'

--- a/mmv1/products/integrationconnectors/go_Connection.yaml
+++ b/mmv1/products/integrationconnectors/go_Connection.yaml
@@ -60,7 +60,7 @@ examples:
       connection_name: 'test-pubsub'
     ignore_read_extra:
       - 'status.0.description'
-    skip_test: true
+    exclude_test: true
   - name: 'integration_connectors_connection_advanced'
     primary_resource_id: 'zendeskconnection'
     vars:
@@ -68,7 +68,7 @@ examples:
       secret_id: 'test-secret'
     ignore_read_extra:
       - 'status.0.description'
-    skip_test: true
+    exclude_test: true
   - name: 'integration_connectors_connection_sa'
     primary_resource_id: 'zendeskconnection'
     vars:
@@ -76,8 +76,8 @@ examples:
       secret_id: 'test-secret'
     ignore_read_extra:
       - 'status.0.description'
-    skip_test: true
-    skip_docs: true
+    exclude_test: true
+    exclude_docs: true
   - name: 'integration_connectors_connection_oauth'
     primary_resource_id: 'boxconnection'
     vars:
@@ -85,8 +85,8 @@ examples:
       secret_id: 'test-secret'
     ignore_read_extra:
       - 'status.0.description'
-    skip_test: true
-    skip_docs: true
+    exclude_test: true
+    exclude_docs: true
   - name: 'integration_connectors_connection_oauth_ssh'
     primary_resource_id: 'boxconnection'
     vars:
@@ -94,8 +94,8 @@ examples:
       secret_id: 'test-secret'
     ignore_read_extra:
       - 'status.0.description'
-    skip_test: true
-    skip_docs: true
+    exclude_test: true
+    exclude_docs: true
   - name: 'integration_connectors_connection_oauth_cc'
     primary_resource_id: 'boxconnection'
     vars:
@@ -103,8 +103,8 @@ examples:
       secret_id: 'test-secret'
     ignore_read_extra:
       - 'status.0.description'
-    skip_test: true
-    skip_docs: true
+    exclude_test: true
+    exclude_docs: true
   - name: 'integration_connectors_connection_oauth_jwt'
     primary_resource_id: 'boxconnection'
     vars:
@@ -112,8 +112,8 @@ examples:
       secret_id: 'test-secret'
     ignore_read_extra:
       - 'status.0.description'
-    skip_test: true
-    skip_docs: true
+    exclude_test: true
+    exclude_docs: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/integrations/go_AuthConfig.yaml
+++ b/mmv1/products/integrations/go_AuthConfig.yaml
@@ -43,54 +43,54 @@ examples:
     primary_resource_id: 'basic_example'
     vars:
       auth_config_name: 'test-authconfig'
-    skip_test: true
+    exclude_test: true
   - name: 'integrations_auth_config_advance'
     primary_resource_id: 'advance_example'
     vars:
       auth_config_name: 'test-authconfig'
-    skip_docs: true
+    exclude_docs: true
   - name: 'integrations_auth_config_username_and_password'
     primary_resource_id: 'username_and_password_example'
     vars:
       auth_config_name: 'test-authconfig-username-and-password'
-    skip_docs: true
+    exclude_docs: true
   - name: 'integrations_auth_config_oauth2_authorization_code'
     primary_resource_id: 'oauth2_authotization_code_example'
     vars:
       auth_config_name: 'test-authconfig-oauth2-authorization-code'
-    skip_docs: true
+    exclude_docs: true
   - name: 'integrations_auth_config_oauth2_client_credentials'
     primary_resource_id: 'oauth2_client_credentials_example'
     vars:
       auth_config_name: 'test-authconfig-oauth2-client-credentials'
-    skip_docs: true
+    exclude_docs: true
   - name: 'integrations_auth_config_jwt'
     primary_resource_id: 'jwt_example'
     vars:
       auth_config_name: 'test-authconfig-jwt'
-    skip_docs: true
+    exclude_docs: true
   - name: 'integrations_auth_config_auth_token'
     primary_resource_id: 'auth_token_example'
     vars:
       auth_config_name: 'test-authconfig-auth-token'
-    skip_docs: true
+    exclude_docs: true
   - name: 'integrations_auth_config_service_account'
     primary_resource_id: 'service_account_example'
     vars:
       auth_config_name: 'test-authconfig-service-account'
       service_account_id: 'sa'
-    skip_docs: true
+    exclude_docs: true
   - name: 'integrations_auth_config_oidc_token'
     primary_resource_id: 'oidc_token_example'
     vars:
       auth_config_name: 'test-authconfig-oidc-token'
       service_account_id: 'sa'
-    skip_docs: true
+    exclude_docs: true
   - name: 'integrations_auth_config_client_certificate_only'
     primary_resource_id: 'client_certificate_example'
     vars:
       auth_config_name: 'test-authconfig-client-certificate'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/kms/go_CryptoKey.yaml
+++ b/mmv1/products/kms/go_CryptoKey.yaml
@@ -55,10 +55,10 @@ supports_indirect_user_project_override: true
 examples:
   - name: 'kms_crypto_key_basic'
     primary_resource_id: 'example-key'
-    skip_test: true
+    exclude_test: true
   - name: 'kms_crypto_key_asymmetric_sign'
     primary_resource_id: 'example-asymmetric-sign-key'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'keyRing'
     type: String

--- a/mmv1/products/kms/go_CryptoKeyVersion.yaml
+++ b/mmv1/products/kms/go_CryptoKeyVersion.yaml
@@ -45,7 +45,7 @@ custom_code:
 examples:
   - name: 'kms_crypto_key_version_basic'
     primary_resource_id: 'example-key'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'cryptoKey'
     type: String

--- a/mmv1/products/kms/go_EkmConnection.yaml
+++ b/mmv1/products/kms/go_EkmConnection.yaml
@@ -51,7 +51,7 @@ examples:
     primary_resource_id: 'example-ekmconnection'
     vars:
       ekmconnection_name: 'ekmconnection_example'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/kms/go_KeyRing.yaml
+++ b/mmv1/products/kms/go_KeyRing.yaml
@@ -44,7 +44,7 @@ custom_code:
 examples:
   - name: 'kms_key_ring_basic'
     primary_resource_id: 'example-keyring'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/kms/go_KeyRingImportJob.yaml
+++ b/mmv1/products/kms/go_KeyRingImportJob.yaml
@@ -48,7 +48,7 @@ examples:
     vars:
       keyring: 'keyring-example'
       cryptokey: 'cryptokey-example'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'keyRing'
     type: String

--- a/mmv1/products/kms/go_SecretCiphertext.yaml
+++ b/mmv1/products/kms/go_SecretCiphertext.yaml
@@ -48,7 +48,7 @@ examples:
     primary_resource_id: 'my_password'
     vars:
       instance_name: 'my-instance'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'cryptoKey'
     type: String

--- a/mmv1/products/logging/go_LogView.yaml
+++ b/mmv1/products/logging/go_LogView.yaml
@@ -32,7 +32,7 @@ timeouts:
   update_minutes: 20
   delete_minutes: 20
 iam_policy:
-  skip_import_test: true
+  exclude_import_test: true
   method_name_separator: ':'
   fetch_iam_policy_verb: 'POST'
   allowed_iam_role: 'roles/logging.admin'
@@ -57,7 +57,7 @@ examples:
     primary_resource_id: 'logging_log_view'
     test_env_vars:
       project: 'PROJECT_NAME'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'parent'
     type: String

--- a/mmv1/products/logging/go_OrganizationSettings.yaml
+++ b/mmv1/products/logging/go_OrganizationSettings.yaml
@@ -42,7 +42,7 @@ examples:
       key_name: 'kms-key'
     test_env_vars:
       org_id: 'ORG_TARGET'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'organization'
     type: String

--- a/mmv1/products/looker/go_Instance.yaml
+++ b/mmv1/products/looker/go_Instance.yaml
@@ -72,7 +72,7 @@ examples:
       instance_name: 'my-instance'
       client_id: 'my-client-id'
       client_secret: 'my-client-secret'
-    skip_test: true
+    exclude_test: true
   - name: 'looker_instance_enterprise_full_test'
     primary_resource_id: 'looker-instance'
     vars:
@@ -87,7 +87,7 @@ examples:
       'address_name': 'acctest.BootstrapSharedTestGlobalAddress(t, "looker-vpc-network-3", acctest.AddressWithPrefixLength(8))'
       'kms_key_name': 'acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
       'network_name': 'acctest.BootstrapSharedServiceNetworkingConnection(t, "looker-vpc-network-3", acctest.ServiceNetworkWithPrefixLength(8))'
-    skip_docs: true
+    exclude_docs: true
   - name: 'looker_instance_custom_domain'
     primary_resource_id: 'looker-instance'
     vars:

--- a/mmv1/products/managedkafka/go_Topic.yaml
+++ b/mmv1/products/managedkafka/go_Topic.yaml
@@ -30,6 +30,7 @@ timeouts:
   update_minutes: 20
   delete_minutes: 20
 custom_code:
+  post_create: 'templates/terraform/post_create/go/sleep.go.tmpl'
 examples:
   - name: 'managedkafka_topic_basic'
     primary_resource_id: 'example'

--- a/mmv1/products/memcache/go_Instance.yaml
+++ b/mmv1/products/memcache/go_Instance.yaml
@@ -52,7 +52,7 @@ examples:
       instance_name: 'test-instance'
       network_name: 'test-network'
       address_name: 'address'
-    skip_test: true
+    exclude_test: true
   - name: 'memcache_instance_basic_test'
     primary_resource_id: 'instance'
     vars:
@@ -61,7 +61,7 @@ examples:
       address_name: 'address'
     test_vars_overrides:
       'network_name': 'acctest.BootstrapSharedServiceNetworkingConnection(t, "vpc-network-1")'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'region'
     type: String

--- a/mmv1/products/metastore/go_Federation.yaml
+++ b/mmv1/products/metastore/go_Federation.yaml
@@ -43,7 +43,7 @@ async:
     path: 'error'
     message: 'message'
 iam_policy:
-  skip_import_test: true
+  exclude_import_test: true
   method_name_separator: ':'
   parent_resource_attribute: 'federation_id'
   example_config_body: 'templates/terraform/iam/go/iam_attributes.go.tmpl'

--- a/mmv1/products/metastore/go_Service.yaml
+++ b/mmv1/products/metastore/go_Service.yaml
@@ -70,7 +70,7 @@ examples:
       metastore_service_name: 'example-service'
       key_name: 'example-key'
       keyring_name: 'example-keyring'
-    skip_docs: true
+    exclude_docs: true
     skip_vcr: true
   - name: 'dataproc_metastore_service_cmek_example'
     primary_resource_id: 'default'
@@ -78,29 +78,29 @@ examples:
       metastore_service_name: 'example-service'
       key_name: 'example-key'
       keyring_name: 'example-keyring'
-    skip_test: true
+    exclude_test: true
   - name: 'dataproc_metastore_service_endpoint'
     primary_resource_id: 'endpoint'
     vars:
       metastore_service_name: 'metastore-endpoint'
-    skip_docs: true
+    exclude_docs: true
   - name: 'dataproc_metastore_service_aux'
     primary_resource_id: 'aux'
     vars:
       metastore_service_name: 'metastore-aux'
-    skip_docs: true
+    exclude_docs: true
   - name: 'dataproc_metastore_service_metadata'
     primary_resource_id: 'metadata'
     vars:
       metastore_service_name: 'metastore-metadata'
-    skip_docs: true
+    exclude_docs: true
   - name: 'dataproc_metastore_service_private_service_connect'
     primary_resource_id: 'default'
     vars:
       metastore_service_name: 'metastore-srv'
       network_name: 'my-network'
       subnet_name: 'my-subnetwork'
-    skip_test: true
+    exclude_test: true
   - name: 'dataproc_metastore_service_private_service_connect_custom_routes'
     primary_resource_id: 'default'
     min_version: 'beta'
@@ -108,12 +108,12 @@ examples:
       metastore_service_name: 'metastore-srv'
       network_name: 'my-network'
       subnet_name: 'my-subnetwork'
-    skip_test: true
+    exclude_test: true
   - name: 'dataproc_metastore_service_telemetry'
     primary_resource_id: 'telemetry'
     vars:
       metastore_service_name: 'ms-telemetry'
-    skip_docs: true
+    exclude_docs: true
   - name: 'dataproc_metastore_service_dpms2'
     primary_resource_id: 'dpms2'
     vars:
@@ -126,7 +126,7 @@ examples:
     primary_resource_id: 'dpms2_scaling_factor_lt1'
     vars:
       metastore_service_name: 'ms-dpms2sflt1'
-    skip_docs: true
+    exclude_docs: true
   - name: 'dataproc_metastore_service_scheduled_backup'
     primary_resource_id: 'backup'
     vars:

--- a/mmv1/products/monitoring/go_AlertPolicy.yaml
+++ b/mmv1/products/monitoring/go_AlertPolicy.yaml
@@ -50,22 +50,22 @@ examples:
     primary_resource_id: 'alert_policy'
     vars:
       alert_policy_display_name: 'My Alert Policy'
-    skip_test: true
+    exclude_test: true
   - name: 'monitoring_alert_policy_evaluation_missing_data'
     primary_resource_id: 'alert_policy'
     vars:
       alert_policy_display_name: 'My Alert Policy'
-    skip_test: true
+    exclude_test: true
   - name: 'monitoring_alert_policy_forecast_options'
     primary_resource_id: 'alert_policy'
     vars:
       alert_policy_display_name: 'My Alert Policy'
-    skip_test: true
+    exclude_test: true
   - name: 'monitoring_alert_policy_promql_condition'
     primary_resource_id: 'alert_policy'
     vars:
       alert_policy_display_name: 'My Alert Policy'
-    skip_test: true
+    exclude_test: true
 parameters:
 properties:
   - name: 'name'

--- a/mmv1/products/monitoring/go_MonitoredProject.yaml
+++ b/mmv1/products/monitoring/go_MonitoredProject.yaml
@@ -57,7 +57,7 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
       project_id: 'PROJECT_NAME'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'metricsScope'
     type: String

--- a/mmv1/products/monitoring/go_NotificationChannel.yaml
+++ b/mmv1/products/monitoring/go_NotificationChannel.yaml
@@ -69,7 +69,7 @@ examples:
     primary_resource_id: 'default'
     vars:
       display_name: 'Sensitive Notification Channel test'
-    skip_test: true
+    exclude_test: true
 virtual_fields:
   - name: 'force_delete'
     description: |

--- a/mmv1/products/netapp/go_BackupVault.yaml
+++ b/mmv1/products/netapp/go_BackupVault.yaml
@@ -51,7 +51,7 @@ examples:
     primary_resource_id: 'test_backup_vault'
     vars:
       backup_vault_name: 'test-backup-vault'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/networksecurity/go_FirewallEndpoint.yaml
+++ b/mmv1/products/networksecurity/go_FirewallEndpoint.yaml
@@ -59,7 +59,7 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
       project: 'PROJECT_NAME'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'name'
     type: String

--- a/mmv1/products/networksecurity/go_FirewallEndpointAssociation.yaml
+++ b/mmv1/products/networksecurity/go_FirewallEndpointAssociation.yaml
@@ -59,7 +59,7 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
       project: 'PROJECT_NAME'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'name'
     type: String

--- a/mmv1/products/networksecurity/go_ProjectAddressGroup.yaml
+++ b/mmv1/products/networksecurity/go_ProjectAddressGroup.yaml
@@ -27,7 +27,7 @@ timeouts:
   update_minutes: 20
   delete_minutes: 20
 iam_policy:
-  skip_import_test: true
+  exclude_import_test: true
   method_name_separator: ':'
   parent_resource_type: 'google_network_security_address_group'
   allowed_iam_role: 'roles/compute.networkAdmin'

--- a/mmv1/products/orgpolicy/go_Policy.yaml
+++ b/mmv1/products/orgpolicy/go_Policy.yaml
@@ -42,19 +42,19 @@ error_retry_predicates:
 examples:
   - name: 'org_policy_policy_enforce'
     primary_resource_id: 'primary'
-    skip_test: true
+    exclude_test: true
   - name: 'org_policy_policy_folder'
     primary_resource_id: 'primary'
-    skip_test: true
+    exclude_test: true
   - name: 'org_policy_policy_organization'
     primary_resource_id: 'primary'
-    skip_test: true
+    exclude_test: true
   - name: 'org_policy_policy_project'
     primary_resource_id: 'primary'
-    skip_test: true
+    exclude_test: true
   - name: 'org_policy_policy_dry_run_spec'
     primary_resource_id: 'primary'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'parent'
     type: String

--- a/mmv1/products/privateca/go_CaPool.yaml
+++ b/mmv1/products/privateca/go_CaPool.yaml
@@ -66,8 +66,8 @@ examples:
     vars:
       my_ca_pool: 'my-ca-pool'
       my_certificate: 'my-certificate'
-    skip_test: true
-    skip_docs: true
+    exclude_test: true
+    exclude_docs: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/privateca/go_Certificate.yaml
+++ b/mmv1/products/privateca/go_Certificate.yaml
@@ -43,10 +43,10 @@ examples:
       certificate_name: 'my-certificate'
     test_env_vars:
       project: 'PROJECT_NAME'
-    skip_docs: true
+    exclude_docs: true
   - name: 'privateca_certificate_generated_key'
     primary_resource_id: 'default'
-    skip_test: true
+    exclude_test: true
   - name: 'privateca_certificate_with_template'
     primary_resource_id: 'default'
     vars:

--- a/mmv1/products/privateca/go_CertificateAuthority.yaml
+++ b/mmv1/products/privateca/go_CertificateAuthority.yaml
@@ -107,7 +107,7 @@ examples:
       'deletion_protection': 'false'
     ignore_read_extra:
       - 'deletion_protection'
-    skip_test: true
+    exclude_test: true
     skip_vcr: true
   - name: 'privateca_certificate_authority_custom_ski'
     primary_resource_id: 'default'

--- a/mmv1/products/publicca/go_ExternalAccountKey.yaml
+++ b/mmv1/products/publicca/go_ExternalAccountKey.yaml
@@ -33,7 +33,7 @@ id_format: '{{name}}'
 base_url: 'projects/{{project}}/locations/{{location}}/externalAccountKeys'
 self_link: 'projects/{{project}}/locations/{{location}}/externalAccountKeys/{{key_id}}'
 create_url: 'projects/{{project}}/locations/{{location}}/externalAccountKeys'
-skip_read: true
+exclude_read: true
 exclude_delete: true
 immutable: true
 exclude_import: true
@@ -52,7 +52,7 @@ examples:
     primary_resource_id: 'prod'
     test_env_vars:
       project: 'PROJECT_NAME'
-    skip_import_test: true
+    exclude_import_test: true
 parameters:
 properties:
   - name: 'name'

--- a/mmv1/products/pubsub/go_Topic.yaml
+++ b/mmv1/products/pubsub/go_Topic.yaml
@@ -68,7 +68,7 @@ examples:
       topic_name: 'example-topic'
       key_name: 'example-key'
       keyring_name: 'example-keyring'
-    skip_test: true
+    exclude_test: true
   - name: 'pubsub_topic_geo_restricted'
     primary_resource_id: 'example'
     vars:

--- a/mmv1/products/redis/go_Instance.yaml
+++ b/mmv1/products/redis/go_Instance.yaml
@@ -45,7 +45,7 @@ custom_code:
 custom_diff:
   - 'customdiff.ForceNewIfChange("redis_version", isRedisVersionDecreasing)'
   - 'tpgresource.DefaultProviderProject'
-skip_default_cdiff: true
+exclude_default_cdiff: true
 examples:
   - name: 'redis_instance_basic'
     primary_resource_id: 'cache'
@@ -81,7 +81,7 @@ examples:
       prevent_destroy: 'true'
     test_vars_overrides:
       'prevent_destroy': 'false'
-    skip_test: true
+    exclude_test: true
   - name: 'redis_instance_private_service_test'
     primary_resource_id: 'cache'
     vars:
@@ -91,7 +91,7 @@ examples:
     test_vars_overrides:
       'network_name': 'acctest.BootstrapSharedServiceNetworkingConnection(t, "vpc-network-1")'
       'prevent_destroy': 'false'
-    skip_docs: true
+    exclude_docs: true
   - name: 'redis_instance_mrr'
     primary_resource_id: 'cache'
     vars:
@@ -110,7 +110,7 @@ examples:
     test_vars_overrides:
       'network_name': 'acctest.BootstrapSharedTestNetwork(t, "redis-cmek")'
       'prevent_destroy': 'false'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'region'
     type: String

--- a/mmv1/products/resourcemanager/go_Lien.yaml
+++ b/mmv1/products/resourcemanager/go_Lien.yaml
@@ -45,7 +45,7 @@ examples:
     primary_resource_id: 'lien'
     vars:
       project_id: 'staging-project'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'parent'
     type: String

--- a/mmv1/products/securitycenter/go_EventThreatDetectionCustomModule.yaml
+++ b/mmv1/products/securitycenter/go_EventThreatDetectionCustomModule.yaml
@@ -41,7 +41,7 @@ examples:
       type: 'CONFIGURABLE_BAD_IP'
     test_env_vars:
       org_id: 'ORG_ID'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'organization'
     type: String

--- a/mmv1/products/securitycenter/go_FolderCustomModule.yaml
+++ b/mmv1/products/securitycenter/go_FolderCustomModule.yaml
@@ -47,7 +47,7 @@ examples:
     test_vars_overrides:
       'sleep': 'true'
     external_providers: ["random", "time"]
-    skip_test: true
+    exclude_test: true
   - name: 'scc_folder_custom_module_full'
     primary_resource_id: 'example'
     vars:
@@ -59,7 +59,7 @@ examples:
     test_vars_overrides:
       'sleep': 'true'
     external_providers: ["random", "time"]
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'folder'
     type: String

--- a/mmv1/products/securitycenter/go_FolderNotificationConfig.yaml
+++ b/mmv1/products/securitycenter/go_FolderNotificationConfig.yaml
@@ -50,7 +50,7 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
     external_providers: ["random", "time"]
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'folder'
     type: String

--- a/mmv1/products/securitycenter/go_OrganizationCustomModule.yaml
+++ b/mmv1/products/securitycenter/go_OrganizationCustomModule.yaml
@@ -44,7 +44,7 @@ examples:
       org_id: 'ORG_ID'
     test_vars_overrides:
       'sleep': 'true'
-    skip_test: true
+    exclude_test: true
   - name: 'scc_organization_custom_module_full'
     primary_resource_id: 'example'
     vars:
@@ -53,7 +53,7 @@ examples:
       org_id: 'ORG_ID'
     test_vars_overrides:
       'sleep': 'true'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'organization'
     type: String

--- a/mmv1/products/securitycenter/go_ProjectCustomModule.yaml
+++ b/mmv1/products/securitycenter/go_ProjectCustomModule.yaml
@@ -40,12 +40,12 @@ examples:
     primary_resource_id: 'example'
     vars:
       display_name: 'basic_custom_module'
-    skip_test: true
+    exclude_test: true
   - name: 'scc_project_custom_module_full'
     primary_resource_id: 'example'
     vars:
       display_name: 'full_custom_module'
-    skip_test: true
+    exclude_test: true
 parameters:
 properties:
   - name: 'name'

--- a/mmv1/products/securitycenter/go_Source.yaml
+++ b/mmv1/products/securitycenter/go_Source.yaml
@@ -52,7 +52,7 @@ examples:
       source_display_name: 'My Source'
     test_env_vars:
       org_id: 'ORG_ID'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'organization'
     type: String

--- a/mmv1/products/securitycentermanagement/go_FolderSecurityHealthAnalyticsCustomModule.yaml
+++ b/mmv1/products/securitycentermanagement/go_FolderSecurityHealthAnalyticsCustomModule.yaml
@@ -47,7 +47,7 @@ examples:
     test_vars_overrides:
       'sleep': 'true'
     external_providers: ["random", "time"]
-    skip_test: true
+    exclude_test: true
   - name: 'scc_management_folder_security_health_analytics_custom_module_full'
     primary_resource_id: 'example'
     vars:
@@ -59,7 +59,7 @@ examples:
     test_vars_overrides:
       'sleep': 'true'
     external_providers: ["random", "time"]
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'folder'
     type: String

--- a/mmv1/products/securitycentermanagement/go_OrganizationEventThreatDetectionCustomModule.yaml
+++ b/mmv1/products/securitycentermanagement/go_OrganizationEventThreatDetectionCustomModule.yaml
@@ -41,7 +41,7 @@ examples:
       type: 'CONFIGURABLE_BAD_IP'
     test_env_vars:
       org_id: 'ORG_ID'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'organization'
     type: String

--- a/mmv1/products/securitycentermanagement/go_OrganizationSecurityHealthAnalyticsCustomModule.yaml
+++ b/mmv1/products/securitycentermanagement/go_OrganizationSecurityHealthAnalyticsCustomModule.yaml
@@ -44,7 +44,7 @@ examples:
       org_id: 'ORG_ID'
     test_vars_overrides:
       'sleep': 'true'
-    skip_test: true
+    exclude_test: true
   - name: 'scc_management_organization_security_health_analytics_custom_module_full'
     primary_resource_id: 'example'
     vars:
@@ -53,7 +53,7 @@ examples:
       org_id: 'ORG_ID'
     test_vars_overrides:
       'sleep': 'true'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'organization'
     type: String

--- a/mmv1/products/securitycentermanagement/go_ProjectSecurityHealthAnalyticsCustomModule.yaml
+++ b/mmv1/products/securitycentermanagement/go_ProjectSecurityHealthAnalyticsCustomModule.yaml
@@ -40,12 +40,12 @@ examples:
     primary_resource_id: 'example'
     vars:
       display_name: 'basic_custom_module'
-    skip_test: true
+    exclude_test: true
   - name: 'scc_management_organization_project_security_health_analytics_custom_module_full'
     primary_resource_id: 'example'
     vars:
       display_name: 'full_custom_module'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/securitycenterv2/go_FolderMuteConfig.yaml
+++ b/mmv1/products/securitycenterv2/go_FolderMuteConfig.yaml
@@ -46,7 +46,7 @@ examples:
     test_vars_overrides:
       'sleep': 'true'
     external_providers: ["random", "time"]
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'folder'
     type: String

--- a/mmv1/products/securitycenterv2/go_FolderNotificationConfig.yaml
+++ b/mmv1/products/securitycenterv2/go_FolderNotificationConfig.yaml
@@ -50,7 +50,7 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
     external_providers: ["random", "time"]
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'folder'
     type: String

--- a/mmv1/products/securitycenterv2/go_FolderSccBigQueryExport.yaml
+++ b/mmv1/products/securitycenterv2/go_FolderSccBigQueryExport.yaml
@@ -51,7 +51,7 @@ examples:
       org_id: 'ORG_ID'
       project: 'PROJECT_NAME'
     external_providers: ["random", "time"]
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'folder'
     type: String

--- a/mmv1/products/securitycenterv2/go_OrganizationSccBigQueryExports.yaml
+++ b/mmv1/products/securitycenterv2/go_OrganizationSccBigQueryExports.yaml
@@ -50,7 +50,7 @@ examples:
       org_id: 'ORG_ID'
       project: 'PROJECT_NAME'
     external_providers: ["random", "time"]
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'organization'
     type: String

--- a/mmv1/products/securitycenterv2/go_OrganizationSource.yaml
+++ b/mmv1/products/securitycenterv2/go_OrganizationSource.yaml
@@ -52,7 +52,7 @@ examples:
       source_display_name: 'My Source'
     test_env_vars:
       org_id: 'ORG_ID'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'organization'
     type: String

--- a/mmv1/products/securitycenterv2/go_ProjectMuteConfig.yaml
+++ b/mmv1/products/securitycenterv2/go_ProjectMuteConfig.yaml
@@ -42,7 +42,7 @@ examples:
       mute_config_id: 'my-config'
     test_env_vars:
       project_id: 'PROJECT_NAME'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/securitycenterv2/go_ProjectSccBigQueryExport.yaml
+++ b/mmv1/products/securitycenterv2/go_ProjectSccBigQueryExport.yaml
@@ -52,7 +52,7 @@ examples:
     ignore_read_extra:
       - 'project'
     external_providers: ["random", "time"]
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'bigQueryExportId'
     type: String

--- a/mmv1/products/servicedirectory/go_Namespace.yaml
+++ b/mmv1/products/servicedirectory/go_Namespace.yaml
@@ -35,7 +35,7 @@ timeouts:
   update_minutes: 20
   delete_minutes: 20
 iam_policy:
-  skip_import_test: true
+  exclude_import_test: true
   method_name_separator: ':'
   fetch_iam_policy_verb: 'POST'
   parent_resource_attribute: 'name'

--- a/mmv1/products/servicedirectory/go_Service.yaml
+++ b/mmv1/products/servicedirectory/go_Service.yaml
@@ -34,7 +34,7 @@ timeouts:
   update_minutes: 20
   delete_minutes: 20
 iam_policy:
-  skip_import_test: true
+  exclude_import_test: true
   method_name_separator: ':'
   fetch_iam_policy_verb: 'POST'
   parent_resource_attribute: 'name'

--- a/mmv1/products/serviceusage/go_ConsumerQuotaOverride.yaml
+++ b/mmv1/products/serviceusage/go_ConsumerQuotaOverride.yaml
@@ -77,7 +77,7 @@ examples:
       project_id: 'quota'
     test_env_vars:
       org_id: 'ORG_ID'
-    skip_docs: true
+    exclude_docs: true
   - name: 'region_consumer_quota_override'
     primary_resource_id: 'override'
     min_version: 'beta'

--- a/mmv1/products/storagetransfer/go_AgentPool.yaml
+++ b/mmv1/products/storagetransfer/go_AgentPool.yaml
@@ -41,7 +41,7 @@ examples:
       agent-pool-name: 'agent-pool-example'
     test_env_vars:
       project_id: 'PROJECT_NAME'
-    skip_test: true
+    exclude_test: true
 parameters:
 properties:
   - name: 'name'

--- a/mmv1/products/tags/go_TagBinding.yaml
+++ b/mmv1/products/tags/go_TagBinding.yaml
@@ -70,7 +70,7 @@ examples:
       'key_short_name': '"tf-test-key-" + acctest.RandString(t, 10)'
       'value_short_name': '"tf-test-value-" + acctest.RandString(t, 10)'
       'project_id': '"tf-test-" + acctest.RandString(t, 10)'
-    skip_test: true
+    exclude_test: true
 parameters:
 properties:
   - name: 'name'

--- a/mmv1/products/tags/go_TagKey.yaml
+++ b/mmv1/products/tags/go_TagKey.yaml
@@ -63,7 +63,7 @@ examples:
       org_id: 'ORG_ID'
     test_vars_overrides:
       'short_name': '"tf-test-key-" + acctest.RandString(t, 10)'
-    skip_test: true
+    exclude_test: true
 parameters:
 properties:
   - name: 'name'

--- a/mmv1/products/tags/go_TagValue.yaml
+++ b/mmv1/products/tags/go_TagValue.yaml
@@ -67,7 +67,7 @@ examples:
     test_vars_overrides:
       'key_short_name': '"tf-test-key-" + acctest.RandString(t, 10)'
       'value_short_name': '"tf-test-value-" + acctest.RandString(t, 10)'
-    skip_test: true
+    exclude_test: true
 parameters:
 properties:
   - name: 'name'

--- a/mmv1/products/tpu/go_Node.yaml
+++ b/mmv1/products/tpu/go_Node.yaml
@@ -58,7 +58,7 @@ examples:
       node_name: 'test-tpu'
       global_address_name: 'my-global-address'
       network_name: 'tpu-node-network'
-    skip_test: true
+    exclude_test: true
   - name: 'tpu_node_full_test'
     primary_resource_id: 'tpu'
     vars:
@@ -66,7 +66,7 @@ examples:
       network_name: 'tpu-node-network'
     test_vars_overrides:
       'network_name': 'acctest.BootstrapSharedServiceNetworkingConnection(t, "vpc-network-1")'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'zone'
     type: String

--- a/mmv1/products/vertexai/IndexEndpointDeployedIndex.yaml
+++ b/mmv1/products/vertexai/IndexEndpointDeployedIndex.yaml
@@ -226,8 +226,9 @@ properties:
     properties:
       - !ruby/object:Api::Type::NestedObject
         name: 'machineSpec'
-        description: The minimum number of replicas this DeployedModel will be always deployed on.
-            # This field (and its nested fields) is not updatable via the mutateDeployedIndex method in the API, which is the only update method usable by this 'fine-grained' resource. This is why the field is marked as immutable despite the API docs not marking the field as immutable.
+        description: |
+          The minimum number of replicas this DeployedModel will be always deployed on.
+        # This field (and its nested fields) is not updatable via the mutateDeployedIndex method in the API, which is the only update method usable by this 'fine-grained' resource. This is why the field is marked as immutable despite the API docs not marking the field as immutable.
         immutable: true
         required: true
         properties:
@@ -252,13 +253,15 @@ properties:
         default_from_api: true
   - !ruby/object:Api::Type::Boolean
     name: enableAccessLogging
-    description: If true, private endpoint's access logs are sent to Cloud Logging.
+    description: |
+      If true, private endpoint's access logs are sent to Cloud Logging.
     # This field is not updatable via the mutateDeployedIndex method in the API, which is the only update method usable by this 'fine-grained' resource. This is why the field is marked as immutable despite the API docs not marking the field as immutable.
     immutable: true
     default_value: false
   - !ruby/object:Api::Type::NestedObject
     name: deployedIndexAuthConfig
-    description: If set, the authentication is enabled for the private endpoint.
+    description: |
+      If set, the authentication is enabled for the private endpoint.
     # This field (and its nested fields) is not updatable via the mutateDeployedIndex method in the API, which is the only update method usable by this 'fine-grained' resource. This is why the field is marked as immutable despite the API docs not marking the field as immutable.
     immutable: true
     properties:
@@ -279,7 +282,6 @@ properties:
             item_type: Api::Type::String
   - !ruby/object:Api::Type::Array
     name: reservedIpRanges
-    # This field is not updatable via the mutateDeployedIndex method in the API, which is the only update method usable by this 'fine-grained' resource. This is why the field is marked as immutable despite the API docs not marking the field as immutable.
     immutable: true
     description: |
       A list of reserved ip ranges under the VPC network that can be used for this DeployedIndex.
@@ -288,13 +290,14 @@ properties:
       The value should be the name of the address (https://cloud.google.com/compute/docs/reference/rest/v1/addresses) Example: ['vertex-ai-ip-range'].
 
       For more information about subnets and network IP ranges, please see https://cloud.google.com/vpc/docs/subnets#manually_created_subnet_ip_ranges.
+    # This field is not updatable via the mutateDeployedIndex method in the API, which is the only update method usable by this 'fine-grained' resource. This is why the field is marked as immutable despite the API docs not marking the field as immutable.
     item_type: Api::Type::String
   - !ruby/object:Api::Type::String
     name: deploymentGroup
-    # This field is not updatable via the mutateDeployedIndex method in the API, which is the only update method usable by this 'fine-grained' resource. This is why the field is marked as immutable despite the API docs not marking the field as immutable.
     immutable: true
     default_value: 'default'
     description: |
       The deployment group can be no longer than 64 characters (eg: 'test', 'prod'). If not set, we will use the 'default' deployment group.
       Creating deployment_groups with reserved_ip_ranges is a recommended practice when the peered network has multiple peering ranges. This creates your deployments from predictable IP spaces for easier traffic administration. Also, one deployment_group (except 'default') can only be used with the same reserved_ip_ranges which means if the deployment_group has been used with reserved_ip_ranges: [a, b, c], using it with [a, b] or [d, e] is disallowed. [See the official documentation here](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.indexEndpoints#DeployedIndex.FIELDS.deployment_group).
       Note: we only support up to 5 deployment groups (not including 'default').
+    # This field is not updatable via the mutateDeployedIndex method in the API, which is the only update method usable by this 'fine-grained' resource. This is why the field is marked as immutable despite the API docs not marking the field as immutable.

--- a/mmv1/products/vertexai/go_Dataset.yaml
+++ b/mmv1/products/vertexai/go_Dataset.yaml
@@ -50,7 +50,7 @@ examples:
     primary_resource_id: 'dataset'
     vars:
       display_name: 'terraform'
-    skip_import_test: true
+    exclude_import_test: true
 parameters:
   - name: 'region'
     type: String

--- a/mmv1/products/vertexai/go_Endpoint.yaml
+++ b/mmv1/products/vertexai/go_Endpoint.yaml
@@ -64,7 +64,7 @@ examples:
       address_name: 'address-name'
       kms_key_name: 'kms-name'
       network_name: 'network-name'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/vertexai/go_FeatureGroupFeature.yaml
+++ b/mmv1/products/vertexai/go_FeatureGroupFeature.yaml
@@ -58,7 +58,7 @@ examples:
       job_id: 'job_load'
       name: 'example_feature'
       feature_group_name: 'example_feature_group'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'featureGroup'
     type: String

--- a/mmv1/products/vertexai/go_IndexEndpoint.yaml
+++ b/mmv1/products/vertexai/go_IndexEndpoint.yaml
@@ -49,20 +49,20 @@ examples:
     vars:
       address_name: 'address-name'
       network_name: 'network-name'
-    skip_test: true
+    exclude_test: true
   - name: 'vertex_ai_index_endpoint_test'
     primary_resource_id: 'index_endpoint'
     vars:
       network_name: 'network-name'
     test_vars_overrides:
       'network_name': 'acctest.BootstrapSharedServiceNetworkingConnection(t, "vpc-network-1")'
-    skip_docs: true
+    exclude_docs: true
   - name: 'vertex_ai_index_endpoint_with_psc'
     primary_resource_id: 'index_endpoint'
   - name: 'vertex_ai_index_endpoint_with_false_psc'
     primary_resource_id: 'index_endpoint'
-    skip_import_test: true
-    skip_docs: true
+    exclude_import_test: true
+    exclude_docs: true
   - name: 'vertex_ai_index_endpoint_with_public_endpoint'
     primary_resource_id: 'index_endpoint'
     test_vars_overrides:

--- a/mmv1/products/vertexai/go_IndexEndpointDeployedIndex.yaml
+++ b/mmv1/products/vertexai/go_IndexEndpointDeployedIndex.yaml
@@ -222,8 +222,9 @@ properties:
     properties:
       - name: 'machineSpec'
         type: NestedObject
-        description: The minimum number of replicas this DeployedModel will be always deployed on.
-            # This field (and its nested fields) is not updatable via the mutateDeployedIndex method in the API, which is the only update method usable by this 'fine-grained' resource. This is why the field is marked as immutable despite the API docs not marking the field as immutable.
+        description: |
+          The minimum number of replicas this DeployedModel will be always deployed on.
+        # This field (and its nested fields) is not updatable via the mutateDeployedIndex method in the API, which is the only update method usable by this 'fine-grained' resource. This is why the field is marked as immutable despite the API docs not marking the field as immutable.
         required: true
         immutable: true
         properties:
@@ -248,13 +249,15 @@ properties:
         default_from_api: true
   - name: 'enableAccessLogging'
     type: Boolean
-    description: If true, private endpoint's access logs are sent to Cloud Logging.
+    description: |
+      If true, private endpoint's access logs are sent to Cloud Logging.
     # This field is not updatable via the mutateDeployedIndex method in the API, which is the only update method usable by this 'fine-grained' resource. This is why the field is marked as immutable despite the API docs not marking the field as immutable.
     immutable: true
     default_value: false
   - name: 'deployedIndexAuthConfig'
     type: NestedObject
-    description: If set, the authentication is enabled for the private endpoint.
+    description: |
+      If set, the authentication is enabled for the private endpoint.
     # This field (and its nested fields) is not updatable via the mutateDeployedIndex method in the API, which is the only update method usable by this 'fine-grained' resource. This is why the field is marked as immutable despite the API docs not marking the field as immutable.
     immutable: true
     properties:
@@ -284,6 +287,7 @@ properties:
       The value should be the name of the address (https://cloud.google.com/compute/docs/reference/rest/v1/addresses) Example: ['vertex-ai-ip-range'].
 
       For more information about subnets and network IP ranges, please see https://cloud.google.com/vpc/docs/subnets#manually_created_subnet_ip_ranges.
+    # This field is not updatable via the mutateDeployedIndex method in the API, which is the only update method usable by this 'fine-grained' resource. This is why the field is marked as immutable despite the API docs not marking the field as immutable.
     immutable: true
     item_type:
       type: String
@@ -293,5 +297,6 @@ properties:
       The deployment group can be no longer than 64 characters (eg: 'test', 'prod'). If not set, we will use the 'default' deployment group.
       Creating deployment_groups with reserved_ip_ranges is a recommended practice when the peered network has multiple peering ranges. This creates your deployments from predictable IP spaces for easier traffic administration. Also, one deployment_group (except 'default') can only be used with the same reserved_ip_ranges which means if the deployment_group has been used with reserved_ip_ranges: [a, b, c], using it with [a, b] or [d, e] is disallowed. [See the official documentation here](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.indexEndpoints#DeployedIndex.FIELDS.deployment_group).
       Note: we only support up to 5 deployment groups (not including 'default').
+    # This field is not updatable via the mutateDeployedIndex method in the API, which is the only update method usable by this 'fine-grained' resource. This is why the field is marked as immutable despite the API docs not marking the field as immutable.
     immutable: true
     default_value: "default"

--- a/mmv1/products/vertexai/go_IndexEndpointDeployedIndex.yaml
+++ b/mmv1/products/vertexai/go_IndexEndpointDeployedIndex.yaml
@@ -94,7 +94,7 @@ examples:
       bucket_name: 'bucket-name'
       display_name: 'vertex-deployed-index'
       deployed_index_id: 'deployed_index_id'
-    skip_docs: true
+    exclude_docs: true
   - name: 'vertex_ai_index_endpoint_deployed_index_automatic_resources'
     primary_resource_id: 'automatic_resources'
     vars:
@@ -102,7 +102,7 @@ examples:
       bucket_name: 'bucket-name'
       display_name: 'vertex-deployed-index'
       deployed_index_id: 'deployed_index_id'
-    skip_docs: true
+    exclude_docs: true
 parameters:
   - name: 'indexEndpoint'
     type: ResourceRef

--- a/mmv1/products/vertexai/go_MetadataStore.yaml
+++ b/mmv1/products/vertexai/go_MetadataStore.yaml
@@ -54,7 +54,7 @@ examples:
     primary_resource_id: 'store'
     vars:
       name: 'test-store'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'region'
     type: String

--- a/mmv1/products/vmwareengine/go_Cluster.yaml
+++ b/mmv1/products/vmwareengine/go_Cluster.yaml
@@ -66,7 +66,7 @@ examples:
       management_cluster_id: 'sample-mgmt-cluster'
     test_env_vars:
       region: 'REGION'
-    skip_test: true
+    exclude_test: true
   - name: 'vmware_engine_cluster_full'
     primary_resource_id: 'vmw-ext-cluster'
     vars:
@@ -76,7 +76,7 @@ examples:
       management_cluster_id: 'sample-mgmt-cluster'
     test_env_vars:
       region: 'REGION'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'parent'
     type: String

--- a/mmv1/products/vmwareengine/go_ExternalAccessRule.yaml
+++ b/mmv1/products/vmwareengine/go_ExternalAccessRule.yaml
@@ -58,7 +58,7 @@ examples:
       network_policy_id: 'sample-np'
     test_env_vars:
       region: 'REGION'
-    skip_test: true
+    exclude_test: true
   - name: 'vmware_engine_external_access_rule_full'
     primary_resource_id: 'vmw-engine-external-access-rule'
     vars:
@@ -70,7 +70,7 @@ examples:
       external_address_id: 'sample-ea'
     test_env_vars:
       region: 'REGION'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'parent'
     type: String

--- a/mmv1/products/vmwareengine/go_ExternalAddress.yaml
+++ b/mmv1/products/vmwareengine/go_ExternalAddress.yaml
@@ -65,7 +65,7 @@ examples:
       private_cloud_id: 'sample-pc'
       management_cluster_id: 'sample-mgmt-cluster'
       network_policy_id: 'sample-np'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'parent'
     type: String

--- a/mmv1/products/vmwareengine/go_Network.yaml
+++ b/mmv1/products/vmwareengine/go_Network.yaml
@@ -59,7 +59,7 @@ examples:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
     external_providers: ["random", "time"]
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/vmwareengine/go_PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/go_PrivateCloud.yaml
@@ -68,7 +68,7 @@ examples:
       management_cluster_id: 'sample-mgmt-cluster'
     test_env_vars:
       region: 'REGION'
-    skip_test: true
+    exclude_test: true
   - name: 'vmware_engine_private_cloud_full'
     primary_resource_id: 'vmw-engine-pc'
     vars:
@@ -77,7 +77,7 @@ examples:
       management_cluster_id: 'sample-mgmt-cluster'
     test_env_vars:
       region: 'REGION'
-    skip_test: true
+    exclude_test: true
 virtual_fields:
   - name: 'deletion_delay_hours'
     description: |

--- a/mmv1/products/vmwareengine/go_Subnet.yaml
+++ b/mmv1/products/vmwareengine/go_Subnet.yaml
@@ -62,7 +62,7 @@ examples:
       subnet_id: 'service-1'
     test_env_vars:
       region: 'REGION'
-    skip_test: true
+    exclude_test: true
 parameters:
   - name: 'parent'
     type: String

--- a/mmv1/products/vpcaccess/go_Connector.yaml
+++ b/mmv1/products/vpcaccess/go_Connector.yaml
@@ -113,8 +113,8 @@ properties:
     type: Integer
     description: |
       Minimum throughput of the connector in Mbps. Default and min is 200. Refers to the expected throughput when using an e2-micro machine type.
-      Value must be a multiple of 100 from 200 through 900. Must be lower than the value specified by max_throughput. If both min_throughput and
-      min_instances are provided, min_instances takes precedence over min_throughput. The use of min_throughput is discouraged in favor of min_instances.
+      Value must be a multiple of 100 from 200 through 900. Must be lower than the value specified by max_throughput.
+      Only one of `min_throughput` and `min_instances` can be specified. The use of min_throughput is discouraged in favor of min_instances.
     default_from_api: true
     conflicts:
       - min_instances
@@ -141,8 +141,7 @@ properties:
     description: |
       Maximum throughput of the connector in Mbps, must be greater than `min_throughput`. Default is 300. Refers to the expected throughput
       when using an e2-micro machine type. Value must be a multiple of 100 from 300 through 1000. Must be higher than the value specified by
-      min_throughput. If both max_throughput and max_instances are provided, max_instances takes precedence over max_throughput. The use of
-      max_throughput is discouraged in favor of max_instances.
+      min_throughput. Only one of `max_throughput` and `max_instances` can be specified. The use of max_throughput is discouraged in favor of max_instances.
     default_from_api: true
     conflicts:
       - max_instances

--- a/mmv1/products/workflows/go_Workflow.yaml
+++ b/mmv1/products/workflows/go_Workflow.yaml
@@ -60,7 +60,7 @@ examples:
     vars:
       name: 'workflow'
       account_id: 'my-account'
-    skip_import_test: true
+    exclude_import_test: true
 parameters:
   - name: 'region'
     type: String

--- a/mmv1/provider/terraform.go
+++ b/mmv1/provider/terraform.go
@@ -148,7 +148,7 @@ func (t *Terraform) GenerateResource(object api.Resource, templateData TemplateD
 func (t *Terraform) GenerateResourceTests(object api.Resource, templateData TemplateData, outputFolder string) {
 	eligibleExample := false
 	for _, example := range object.Examples {
-		if !example.SkipTest {
+		if !example.ExcludeTest {
 			if object.ProductMetadata.VersionObjOrClosest(t.Version.Name).CompareTo(object.ProductMetadata.VersionObjOrClosest(example.MinVersion)) >= 0 {
 				eligibleExample = true
 				break
@@ -214,7 +214,7 @@ func (t *Terraform) GenerateIamPolicy(object api.Resource, templateData Template
 
 		// Only generate test if testable examples exist.
 		examples := google.Reject(object.Examples, func(e resource.Examples) bool {
-			return e.SkipTest
+			return e.ExcludeTest
 		})
 		if len(examples) != 0 {
 			targetFilePath := path.Join(targetFolder, fmt.Sprintf("iam_%s_generated_test.go", t.FullResourceName(object)))

--- a/mmv1/templates/terraform/examples/base_configs/iam_test_file.go.tmpl
+++ b/mmv1/templates/terraform/examples/base_configs/iam_test_file.go.tmpl
@@ -52,7 +52,7 @@ func TestAcc{{ $.ResourceName }}IamBindingGenerated(t *testing.T) {
 			{
 				Config: testAcc{{ $.ResourceName }}IamBinding_basicGenerated(context),
 			},
-{{- if not $.IamPolicy.SkipImportTest }}
+{{- if not $.IamPolicy.ExcludeImportTest }}
 			{
 				ResourceName:      "{{ $.IamTerraformName }}_binding.foo",
 				ImportStateId:     fmt.Sprintf("{{ $.IamImportFormat }} {{ $.IamPolicy.AllowedIamRole }}", {{ if ne $.IamImportQualifiersForTest "" }}{{ $.IamImportQualifiersForTest }}, {{ end }}{{ $example.PrimaryResourceName }}),
@@ -64,7 +64,7 @@ func TestAcc{{ $.ResourceName }}IamBindingGenerated(t *testing.T) {
 				// Test Iam Binding update
 				Config: testAcc{{ $.ResourceName }}IamBinding_updateGenerated(context),
 			},
-{{- if not $.IamPolicy.SkipImportTest }}
+{{- if not $.IamPolicy.ExcludeImportTest }}
 			{
 				ResourceName:      "{{ $.IamTerraformName }}_binding.foo",
 				ImportStateId:     fmt.Sprintf("{{ $.IamImportFormat }} {{ $.IamPolicy.AllowedIamRole }}", {{ if ne $.IamImportQualifiersForTest "" }}{{ $.IamImportQualifiersForTest }}, {{ end }}{{ $example.PrimaryResourceName }}),
@@ -99,7 +99,7 @@ func TestAcc{{ $.ResourceName }}IamMemberGenerated(t *testing.T) {
 				// Test Iam Member creation (no update for member, no need to test)
 				Config: testAcc{{ $.ResourceName }}IamMember_basicGenerated(context),
 			},
-{{- if not $.IamPolicy.SkipImportTest }}
+{{- if not $.IamPolicy.ExcludeImportTest }}
 			{
 				ResourceName:      "{{ $.IamTerraformName }}_member.foo",
 				ImportStateId:     fmt.Sprintf("{{ $.IamImportFormat }} {{ $.IamPolicy.AllowedIamRole }} user:admin@hashicorptest.com", {{ if ne $.IamImportQualifiersForTest "" }}{{ $.IamImportQualifiersForTest }}, {{ end }}{{ $example.PrimaryResourceName }}),
@@ -140,7 +140,7 @@ func TestAcc{{ $.ResourceName }}IamPolicyGenerated(t *testing.T) {
 				Config: testAcc{{ $.ResourceName }}IamPolicy_basicGenerated(context),
 				Check:  resource.TestCheckResourceAttrSet("data.{{ $.IamTerraformName }}_policy.foo", "policy_data"),
 			},
-{{- if not $.IamPolicy.SkipImportTest }}
+{{- if not $.IamPolicy.ExcludeImportTest }}
 			{
 				ResourceName:      "{{ $.IamTerraformName }}_policy.foo",
 				ImportStateId:     fmt.Sprintf("{{ $.IamImportFormat }}", {{ if ne $.IamImportQualifiersForTest "" }}{{ $.IamImportQualifiersForTest }}, {{ end }}{{ $example.PrimaryResourceName }}),
@@ -151,7 +151,7 @@ func TestAcc{{ $.ResourceName }}IamPolicyGenerated(t *testing.T) {
 			{
 				Config: testAcc{{ $.ResourceName }}IamPolicy_emptyBinding(context),
 			},
-{{- if not $.IamPolicy.SkipImportTest }}
+{{- if not $.IamPolicy.ExcludeImportTest }}
 			{
 				ResourceName:      "{{ $.IamTerraformName }}_policy.foo",
 				ImportStateId:     fmt.Sprintf("{{ $.IamImportFormat }}", {{ if ne $.IamImportQualifiersForTest "" }}{{ $.IamImportQualifiersForTest }}, {{ end }}{{ $example.PrimaryResourceName }}),
@@ -185,7 +185,7 @@ func TestAcc{{ $.ResourceName }}IamBindingGenerated_withCondition(t *testing.T) 
 			{
 				Config: testAcc{{ $.ResourceName }}IamBinding_withConditionGenerated(context),
 			},
-{{- if not $.IamPolicy.SkipImportTest }}
+{{- if not $.IamPolicy.ExcludeImportTest }}
 			{
 				ResourceName:      "{{ $.IamTerraformName }}_binding.foo",
 				ImportStateId:     fmt.Sprintf("{{ $.IamImportFormat }} {{ $.IamPolicy.AllowedIamRole }} %s", {{ if ne $.IamImportQualifiersForTest "" }}{{ $.IamImportQualifiersForTest }}, {{ end }}{{ $example.PrimaryResourceName }}, context["condition_title"]),
@@ -221,7 +221,7 @@ func TestAcc{{ $.ResourceName }}IamBindingGenerated_withAndWithoutCondition(t *t
 			{
 				Config: testAcc{{ $.ResourceName }}IamBinding_withAndWithoutConditionGenerated(context),
 			},
-{{- if not $.IamPolicy.SkipImportTest }}
+{{- if not $.IamPolicy.ExcludeImportTest }}
 			{
 				ResourceName:      "{{ $.IamTerraformName }}_binding.foo",
 				ImportStateId:     fmt.Sprintf("{{ $.IamImportFormat }} {{ $.IamPolicy.AllowedIamRole }}", {{ if ne $.IamImportQualifiersForTest "" }}{{ $.IamImportQualifiersForTest }}, {{ end }}{{ $example.PrimaryResourceName }}),
@@ -268,7 +268,7 @@ func TestAcc{{ $.ResourceName }}IamMemberGenerated_withCondition(t *testing.T) {
 			{
 				Config: testAcc{{ $.ResourceName }}IamMember_withConditionGenerated(context),
 			},
-{{- if not $.IamPolicy.SkipImportTest }}
+{{- if not $.IamPolicy.ExcludeImportTest }}
 			{
 				ResourceName:      "{{ $.IamTerraformName }}_member.foo",
 				ImportStateId:     fmt.Sprintf("{{ $.IamImportFormat }} {{ $.IamPolicy.AllowedIamRole }} user:admin@hashicorptest.com %s", {{ if ne $.IamImportQualifiersForTest "" }}{{ $.IamImportQualifiersForTest }}, {{ end }}{{ $example.PrimaryResourceName }}, context["condition_title"]),
@@ -304,7 +304,7 @@ func TestAcc{{ $.ResourceName }}IamMemberGenerated_withAndWithoutCondition(t *te
 			{
 				Config: testAcc{{ $.ResourceName }}IamMember_withAndWithoutConditionGenerated(context),
 			},
-{{- if not $.IamPolicy.SkipImportTest }}
+{{- if not $.IamPolicy.ExcludeImportTest }}
 			{
 				ResourceName:      "{{ $.IamTerraformName }}_member.foo",
 				ImportStateId:     fmt.Sprintf("{{ $.IamImportFormat }} {{ $.IamPolicy.AllowedIamRole }} user:admin@hashicorptest.com", {{ if ne $.IamImportQualifiersForTest "" }}{{ $.IamImportQualifiersForTest }}, {{ end }}{{ $example.PrimaryResourceName }}),
@@ -371,7 +371,7 @@ func TestAcc{{ $.ResourceName }}IamPolicyGenerated_withCondition(t *testing.T) {
 					resource.TestCheckResourceAttrWith("data.google_iam_policy.foo", "policy_data", tpgresource.CheckGoogleIamPolicy),
 				),
 			},
-{{- if not $.IamPolicy.SkipImportTest }}
+{{- if not $.IamPolicy.ExcludeImportTest }}
 			{
 				ResourceName:      "{{ $.IamTerraformName }}_policy.foo",
 				ImportStateId:     fmt.Sprintf("{{ $.IamImportFormat }}", {{ if ne $.IamImportQualifiersForTest "" }}{{ $.IamImportQualifiersForTest }}, {{ end }}{{ $example.PrimaryResourceName }}),

--- a/mmv1/templates/terraform/examples/base_configs/test_file.go.tmpl
+++ b/mmv1/templates/terraform/examples/base_configs/test_file.go.tmpl
@@ -72,7 +72,7 @@ func TestAcc{{ $e.TestSlug $.Res.ProductMetadata.Name $.Res.Name }}(t *testing.T
 			{
 				Config: testAcc{{ $e.TestSlug $.Res.ProductMetadata.Name $.Res.Name }}(context),
 			},
-	{{- if not $e.SkipImportTest }}
+	{{- if not $e.ExcludeImportTest }}
 			{
 				ResourceName:      "{{ $e.ResourceType $.Res.TerraformName }}.{{ $e.PrimaryResourceId }}",
 				ImportState:       true,

--- a/mmv1/templates/terraform/property_documentation.html.markdown.tmpl
+++ b/mmv1/templates/terraform/property_documentation.html.markdown.tmpl
@@ -22,12 +22,12 @@
     {{- end}}
   {{- end }}
   {{- $.ResourceMetadata.FormatDocDescription $.GetDescription true -}}
-  {{- if and (and ($.IsA "Array") ($.ItemType.IsA "Enum")) (and (not $.Output) (not $.ItemType.SkipDocsValues))}}
+  {{- if and (and ($.IsA "Array") ($.ItemType.IsA "Enum")) (and (not $.Output) (not $.ItemType.ExcludeDocsValues))}}
     {{- if $.ItemType.DefaultValue }}
   Default value is `{{ $.ItemType.DefaultValue }}`.
     {{- end }}
   Each value may be one of: {{ $.ItemType.EnumValuesToString "`" false }}.
-  {{- else if and ($.IsA "Enum") (and (not $.Output) (not $.SkipDocsValues))}}
+  {{- else if and ($.IsA "Enum") (and (not $.Output) (not $.ExcludeDocsValues))}}
     {{- if $.DefaultValue }}
   Default value is `{{ $.DefaultValue }}`.
     {{- end }}

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -106,7 +106,7 @@ func Resource{{ $.ResourceName -}}() *schema.Resource {
 {{-       end }}
         },
 {{- end }}
-{{- if or (and (or $.HasProject $.HasRegion $.HasZone) (not $.SkipDefaultCdiff)) $.CustomDiff }}
+{{- if or (and (or $.HasProject $.HasRegion $.HasZone) (not $.ExcludeDefaultCdiff)) $.CustomDiff }}
         CustomizeDiff: customdiff.All(
 {{-   if $.UnorderedListProperties }}
 {{-     range $prop := $.UnorderedListProperties }}
@@ -118,13 +118,13 @@ func Resource{{ $.ResourceName -}}() *schema.Resource {
         {{ $cdiff }},
 {{- end}}
 {{- end}}
-{{- if and ($.HasProject) (not $.SkipDefaultCdiff) }}
+{{- if and ($.HasProject) (not $.ExcludeDefaultCdiff) }}
             tpgresource.DefaultProviderProject,
 {{- end -}}
-{{if and ($.HasRegion) (not $.SkipDefaultCdiff)  }}
+{{if and ($.HasRegion) (not $.ExcludeDefaultCdiff)  }}
             tpgresource.DefaultProviderRegion,
 {{- end -}}
-{{if and ($.HasZone) (not $.SkipDefaultCdiff)  }}
+{{if and ($.HasZone) (not $.ExcludeDefaultCdiff)  }}
             tpgresource.DefaultProviderZone,
 {{- end }}
         ),
@@ -505,7 +505,7 @@ func resource{{ $.ResourceName -}}PollRead(d *schema.ResourceData, meta interfac
 }
 {{  end }}
 func resource{{ $.ResourceName -}}Read(d *schema.ResourceData, meta interface{}) error {
-{{if $.SkipRead -}}
+{{if $.ExcludeRead -}}
   // This resource could not be read from the API.
   return nil
 {{  else  -}}

--- a/mmv1/templates/terraform/resource.html.markdown.tmpl
+++ b/mmv1/templates/terraform/resource.html.markdown.tmpl
@@ -72,8 +72,8 @@ values will be stored in the raw state as plain text: {{ $.SensitivePropsToStrin
 {{ end }}
 {{- if $.Examples }}
 	{{- range $e := $.Examples }}
-		{{- if not $e.SkipDocs }}
-			{{- if not (or $e.SkipTest $e.TestEnvVars) }}
+		{{- if not $e.ExcludeDocs }}
+			{{- if not (or $e.ExcludeTest $e.TestEnvVars) }}
 <div class = "oics-button" style="float: right; margin: 0 0 -15px">
   <a href="{{ $e.OiCSLink }}" target="_blank">
     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">

--- a/mmv1/templates/terraform/schema_property.go.tmpl
+++ b/mmv1/templates/terraform/schema_property.go.tmpl
@@ -59,7 +59,7 @@
 	StateFunc: {{ .StateFunc }},
 {{ end -}}
   Description: `{{ replace .GetDescription "`" "'" -1 -}}
-{{- if and (eq .Type "Array") (eq .ItemType.Type "Enum") (not .Output) (not .ItemType.SkipDocsValues) -}}
+{{- if and (eq .Type "Array") (eq .ItemType.Type "Enum") (not .Output) (not .ItemType.ExcludeDocsValues) -}}
   {{- if .ItemType.DefaultValue -}}
 Default value: {{ .ItemType.DefaultValue -}}
   {{- end -}}

--- a/mmv1/templates/terraform/yaml_conversion.erb
+++ b/mmv1/templates/terraform/yaml_conversion.erb
@@ -40,7 +40,7 @@ exclude: <%= object.exclude %>
 readonly: <%= object.readonly %>
 <%  end -%>
 <%  unless !object.skip_attribution_label -%>
-skip_attribution_label: <%= object.skip_attribution_label %>
+exclude_attribution_label: <%= object.skip_attribution_label %>
 <%  end -%>
 <%
 #references blocks
@@ -118,7 +118,7 @@ read_verb: '<%= object.read_verb.to_s %>'
 read_query_params: '<%= object.read_query_params %>'
 <%  end -%>
 <%  unless !object.skip_read -%>
-skip_read: <%= object.skip_read %>
+exclude_read: <%= object.skip_read %>
 <%  end -%>
 <%  unless object.delete_url.nil? -%>
 delete_url: '<%= object.delete_url %>'
@@ -287,7 +287,7 @@ iam_policy:
   exclude_tgc: <%= object.iam_policy.exclude_tgc %>
 <%    end -%>
 <%    unless !object.iam_policy.skip_import_test -%>
-  skip_import_test: <%= object.iam_policy.skip_import_test %>
+  exclude_import_test: <%= object.iam_policy.skip_import_test %>
 <%    end -%>
 <%    unless object.iam_policy.method_name_separator == '/' -%>
   method_name_separator: '<%= object.iam_policy.method_name_separator %>'
@@ -428,7 +428,7 @@ custom_diff:
 <%    end -%>
 <%  end -%>
 <%  unless !object.skip_default_cdiff -%>
-skip_default_cdiff: <%= object.skip_default_cdiff %>
+exclude_default_cdiff: <%= object.skip_default_cdiff %>
 <%  end -%>
 <%
 #terraform overrides
@@ -541,13 +541,13 @@ examples:
     external_providers: <%= example.external_providers %>
 <%      end -%>
 <%      unless example.skip_test.nil? -%>
-    skip_test: <%= example.skip_test %>
+    exclude_test: <%= example.skip_test %>
 <%      end -%>
 <%      unless example.skip_import_test.nil? -%>
-    skip_import_test: <%= example.skip_import_test %>
+    exclude_import_test: <%= example.skip_import_test %>
 <%      end -%>
 <%      unless example.skip_docs.nil? -%>
-    skip_docs: <%= example.skip_docs %>
+    exclude_docs: <%= example.skip_docs %>
 <%      end -%>
 <%      unless example.skip_vcr.nil? -%>
     skip_vcr: <%= example.skip_vcr %>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
all attributes except `skip_vcr` renamed. There are a few in tpgtools override files, but tpgtools isnt being touched in go rewrite so it doesn't seem like it needs to happen with this batch

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
