### PR TITLE
Fix interconnect immutability issue causing macsec failure

### DIFF
--- a/mmv1/products/compute/Interconnect.yaml
+++ b/mmv1/products/compute/Interconnect.yaml
@@ -23,7 +23,7 @@ references: !ruby/object:Api::Resource::ReferenceLinks
   api: 'https://cloud.google.com/compute/docs/reference/rest/v1/interconnects'
 base_url: 'projects/{{project}}/global/interconnects'
 self_link: 'projects/{{project}}/global/interconnects/{{name}}'
-immutable: true
+update_verb: :PATCH
 async: !ruby/object:Api::OpAsync
   operation: !ruby/object:Api::OpAsync::Operation
     kind: 'compute#operation'
@@ -366,11 +366,13 @@ properties:
       MACsec enablement fails if the MACsec object is not specified.
   - !ruby/object:Api::Type::String
     name: 'remoteLocation'
+    immutable: true
     description: |
       Indicates that this is a Cross-Cloud Interconnect. This field specifies the location outside
       of Google's network that the interconnect is connected to.
   - !ruby/object:Api::Type::Array
     name: 'requestedFeatures'
+    immutable: true
     description: |
       interconnects.list of features requested for this Interconnect connection. Options: IF_MACSEC (
       If specified then the connection is created on MACsec capable hardware ports. If not

--- a/mmv1/third_party/terraform/services/compute/resource_compute_interconnect_macsec_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_interconnect_macsec_test.go
@@ -1,0 +1,90 @@
+package compute_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccComputeInterconnect_computeInterconnectMacsecTest(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInterconnectDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInterconnect_computeInterconnectCreate(context),
+			},
+			{
+				ResourceName:            "google_compute_interconnect.example-interconnect",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "terraform_labels"},
+			},
+			{
+				Config: testAccComputeInterconnect_computeInterconnectEnableMacsec(context),
+			},
+			{
+				ResourceName:            "google_compute_interconnect.example-interconnect",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccComputeInterconnect_computeInterconnectCreate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {}
+
+resource "google_compute_interconnect" "example-interconnect" {
+  name                 = "tf-test-example-interconnect%{random_suffix}"
+  customer_name        = "internal_customer" # Special customer only available for Google testing.
+  interconnect_type    = "DEDICATED"
+  link_type            = "LINK_TYPE_ETHERNET_100G_LR"
+  location             = "https://www.googleapis.com/compute/v1/projects/${data.google_project.project.name}/global/interconnectLocations/z2z-us-east4-zone1-lciadl-a" # Special location only available for Google testing.
+  requested_link_count = 1
+  admin_enabled        = true
+  description          = "example description"
+  macsec_enabled       = false
+  noc_contact_email    = "user@example.com"
+  requested_features   = ["IF_MACSEC"]
+}
+`, context)
+}
+
+func testAccComputeInterconnect_computeInterconnectEnableMacsec(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {}
+
+resource "google_compute_interconnect" "example-interconnect" {
+  name                 = "tf-test-example-interconnect%{random_suffix}"
+  customer_name        = "internal_customer" # Special customer only available for Google testing.
+  interconnect_type    = "DEDICATED"
+  link_type            = "LINK_TYPE_ETHERNET_100G_LR"
+  location             = "https://www.googleapis.com/compute/v1/projects/${data.google_project.project.name}/global/interconnectLocations/z2z-us-east4-zone1-lciadl-a" # Special location only available for Google testing.
+  requested_link_count = 1
+  admin_enabled        = true
+  description          = "example description"
+  macsec_enabled       = true
+  noc_contact_email    = "user@example.com"
+  requested_features   = ["IF_MACSEC"]
+  macsec {
+    pre_shared_keys {
+      name = "test-key"
+      start_time = "2023-07-01T21:00:01.000Z"
+      fail_open = true
+    }
+  }
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_interconnect_macsec_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_interconnect_macsec_test.go
@@ -82,7 +82,6 @@ resource "google_compute_interconnect" "example-interconnect" {
     pre_shared_keys {
       name = "test-key"
       start_time = "2023-07-01T21:00:01.000Z"
-      fail_open = true
     }
   }
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fixes https://github.com/hashicorp/terraform-provider-google/issues/19410

Customer issue: b/365795490
When Customer tries to deploy an interconnect with macsec enabled. The deployment fails. The circuit needs to be deployed first before enabling macsec, however, if macsec is enabled after, it causes the circuit to be destroyed and recreated. 
Interconnect can't created with macsec enabled.

Fix: remove immutability from the interconnect resource and add it at field level.


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note: enhancement
compute: added in-place update in `google_compute_interconnect` resource except for `remote_location ` and `requested_features` fields
```
