### PR TITLE
Update error codes in TestAccFrameworkProviderBasePath_setInvalidBasePath, TestAccProviderBasePath_setInvalidBasePath

### DIFF
--- a/mmv1/third_party/terraform/fwprovider/framework_provider_test.go.erb
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider_test.go.erb
@@ -52,12 +52,12 @@ func TestAccFrameworkProviderBasePath_setInvalidBasePath(t *testing.T) {
 					},
 				},
 				Config:      testAccProviderBasePath_setBasePath("https://www.example.com/compute/beta/", acctest.RandString(t, 10)),
-				ExpectError: regexp.MustCompile("got HTTP response code 404 with body"),
+				ExpectError: regexp.MustCompile("got HTTP response code 405 with body"),
 			},
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 				Config:                   testAccProviderBasePath_setBasePath("https://www.example.com/compute/beta/", acctest.RandString(t, 10)),
-				ExpectError:              regexp.MustCompile("got HTTP response code 404 with body"),
+				ExpectError:              regexp.MustCompile("got HTTP response code 405 with body"),
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/fwprovider/framework_provider_test.go.erb
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider_test.go.erb
@@ -52,12 +52,12 @@ func TestAccFrameworkProviderBasePath_setInvalidBasePath(t *testing.T) {
 					},
 				},
 				Config:      testAccProviderBasePath_setBasePath("https://www.example.com/compute/beta/", acctest.RandString(t, 10)),
-				ExpectError: regexp.MustCompile("got HTTP response code 405 with body"),
+				ExpectError: regexp.MustCompile("got HTTP response code [4-5][0-9]{2} with body"),
 			},
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 				Config:                   testAccProviderBasePath_setBasePath("https://www.example.com/compute/beta/", acctest.RandString(t, 10)),
-				ExpectError:              regexp.MustCompile("got HTTP response code 405 with body"),
+				ExpectError:              regexp.MustCompile("got HTTP response code [4-5][0-9]{2} with body"),
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/provider/provider_test.go.erb
+++ b/mmv1/third_party/terraform/provider/provider_test.go.erb
@@ -72,7 +72,7 @@ func TestAccProviderBasePath_setInvalidBasePath(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccProviderBasePath_setBasePath("https://www.example.com/compute/beta/", acctest.RandString(t, 10)),
-				ExpectError: regexp.MustCompile("got HTTP response code 404 with body"),
+				ExpectError: regexp.MustCompile("got HTTP response code 405 with body"),
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/provider/provider_test.go.erb
+++ b/mmv1/third_party/terraform/provider/provider_test.go.erb
@@ -72,7 +72,7 @@ func TestAccProviderBasePath_setInvalidBasePath(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccProviderBasePath_setBasePath("https://www.example.com/compute/beta/", acctest.RandString(t, 10)),
-				ExpectError: regexp.MustCompile("got HTTP response code 405 with body"),
+				ExpectError: regexp.MustCompile("got HTTP response code [4-5][0-9]{2} with body"),
 			},
 		},
 	})


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/19468

In response to a test failure here: https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_GoogleCloud_GOOGLE_BETA_NIGHTLYTESTS_GOOGLEBETA_PACKAGE_FWPROVIDER/233695?hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildDeploymentsSection=false&expandBuildTestsSection=true&expandBuildChangesSection=true

It might be worth waiting to see if that failure repeats in future, as it's only failed once so far.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
