### PR TITLE
Add deletion_protection field to Alloydb Cluster

### DIFF
--- a/mmv1/products/alloydb/Cluster.yaml
+++ b/mmv1/products/alloydb/Cluster.yaml
@@ -90,6 +90,7 @@ examples:
     ignore_read_extra:
       - 'reconciling'
       - 'update_time'
+      - 'deletion_protection'
   - !ruby/object:Provider::Terraform::Examples
     name: 'alloydb_secondary_cluster_basic'
     primary_resource_id: 'secondary'
@@ -122,6 +123,16 @@ virtual_fields:
       Deleting a Secondary cluster with a secondary instance REQUIRES setting deletion_policy = "FORCE" otherwise an error is returned. This is needed as there is no support to delete just the secondary instance, and the only way to delete secondary instance is to delete the associated secondary cluster forcefully which also deletes the secondary instance.
       Possible values: DEFAULT, FORCE
     default_value: DEFAULT
+  - !ruby/object:Api::Type::Boolean
+    name: 'deletion_protection'
+    default_value: false
+    description: |
+      Whether Terraform will be prevented from destroying the cluster. Defaults to true.
+      When a`terraform destroy` or `terraform apply` would delete the cluster,
+      the command will fail if this field is not set to false in Terraform state.
+      When the field is set to true or unset in Terraform state, a `terraform apply`
+      or `terraform destroy` that would delete the cluster will fail.
+      When the field is set to false, deleting the cluster is allowed.
 parameters:
   - !ruby/object:Api::Type::String
     name: 'clusterId'

--- a/mmv1/products/alloydb/go_Cluster.yaml
+++ b/mmv1/products/alloydb/go_Cluster.yaml
@@ -89,6 +89,7 @@ examples:
     ignore_read_extra:
       - 'reconciling'
       - 'update_time'
+      - 'deletion_protection'
     skip_test: true
   - name: 'alloydb_secondary_cluster_basic'
     primary_resource_id: 'secondary'
@@ -116,6 +117,16 @@ virtual_fields:
       Possible values: DEFAULT, FORCE
     type: String
     default_value: "DEFAULT"
+  - !ruby/object:Api::Type::Boolean
+    name: 'deletion_protection'
+    default_value: false
+    description: |
+      Whether Terraform will be prevented from destroying the cluster. Defaults to true.
+      When a`terraform destroy` or `terraform apply` would delete the cluster,
+      the command will fail if this field is not set to false in Terraform state.
+      When the field is set to true or unset in Terraform state, a `terraform apply`
+      or `terraform destroy` that would delete the cluster will fail.
+      When the field is set to false, deleting the cluster is allowed.
 parameters:
   - name: 'clusterId'
     type: String

--- a/mmv1/templates/terraform/examples/alloydb_cluster_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/alloydb_cluster_basic.tf.erb
@@ -4,6 +4,7 @@ resource "google_alloydb_cluster" "<%= ctx[:primary_resource_id] %>" {
   network_config {
     network = google_compute_network.default.id
   }
+  deletion_protection = false
 }
 
 data "google_project" "project" {}

--- a/mmv1/templates/terraform/examples/alloydb_cluster_full.tf.erb
+++ b/mmv1/templates/terraform/examples/alloydb_cluster_full.tf.erb
@@ -44,6 +44,7 @@ resource "google_alloydb_cluster" "<%= ctx[:primary_resource_id] %>" {
   labels = {
     test = "<%= ctx[:vars]['alloydb_cluster_name'] %>"
   }
+  deletion_protection = false
 }
 
 data "google_project" "project" {}

--- a/mmv1/templates/terraform/examples/go/alloydb_cluster_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/alloydb_cluster_basic.tf.tmpl
@@ -4,6 +4,7 @@ resource "google_alloydb_cluster" "{{$.PrimaryResourceId}}" {
   network_config {
     network = google_compute_network.default.id
   }
+  deletion_protection = false
 }
 
 data "google_project" "project" {}

--- a/mmv1/templates/terraform/examples/go/alloydb_cluster_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/alloydb_cluster_full.tf.tmpl
@@ -4,6 +4,7 @@ resource "google_alloydb_cluster" "{{$.PrimaryResourceId}}" {
   network_config {
     network = google_compute_network.default.id
   }
+  deletion_protection = false
   database_version = "POSTGRES_15"
 
   initial_user {

--- a/mmv1/templates/terraform/pre_delete/alloydb_cluster.go.erb
+++ b/mmv1/templates/terraform/pre_delete/alloydb_cluster.go.erb
@@ -2,3 +2,6 @@
 if deletionPolicy := d.Get("deletion_policy"); deletionPolicy == "FORCE" {
     url = url + "?force=true"
 }
+if d.Get("deletion_protection").(bool) {
+    return fmt.Errorf("cannot destroy domain without setting deletion_protection=false and running `terraform apply`")
+}

--- a/mmv1/templates/terraform/pre_delete/go/alloydb_cluster.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/go/alloydb_cluster.go.tmpl
@@ -2,3 +2,6 @@
 if deletionPolicy := d.Get("deletion_policy"); deletionPolicy == "FORCE" {
     url = url + "?force=true"
 }
+if d.Get("deletion_protection").(bool) {
+    return fmt.Errorf("cannot destroy domain without setting deletion_protection=false and running `terraform apply`")
+}

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_restore_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_restore_test.go
@@ -34,7 +34,7 @@ func TestAccAlloydbCluster_restore(t *testing.T) {
 				ResourceName:            "google_alloydb_cluster.source",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"initial_user", "cluster_id", "location"},
+				ImportStateVerifyIgnore: []string{"initial_user", "cluster_id", "location", "deletion_protection"},
 			},
 			{
 				// Invalid input check - cannot pass in both sources
@@ -54,7 +54,7 @@ func TestAccAlloydbCluster_restore(t *testing.T) {
 				ResourceName:            "google_alloydb_cluster.restored_from_backup",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"initial_user", "cluster_id", "location", "restore_backup_source"},
+				ImportStateVerifyIgnore: []string{"initial_user", "cluster_id", "location", "restore_backup_source", "deletion_protection"},
 			},
 			{
 				// Validate PITR succeeds
@@ -64,7 +64,7 @@ func TestAccAlloydbCluster_restore(t *testing.T) {
 				ResourceName:            "google_alloydb_cluster.restored_from_point_in_time",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"initial_user", "cluster_id", "location", "restore_continuous_backup_source"},
+				ImportStateVerifyIgnore: []string{"initial_user", "cluster_id", "location", "restore_continuous_backup_source", "deletion_protection"},
 			},
 			{
 				// Make sure updates work without recreating the clusters

--- a/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
@@ -415,3 +415,16 @@ that are derived from the API.
 ### `host.gce_instance.disable_ssh` now defaults to true
 
 `disable_ssh` field now defaults to true. To enable SSH, please set `disable_ssh` to false.
+
+## Resource: `alloydb_cluster`
+
+### Cluster deletion now prevented by default with `deletion_protection`
+
+The field `deletion_protection` has been added with a default value of `true`. This field prevents
+Terraform from destroying or recreating the Cluater. In 6.0.0, existing clusters will have 
+`deletion_protection` set to `true` during the next refresh unless otherwise set in configuration.
+
+**`deletion_protection` does NOT prevent deletion outside of Terraform.**
+
+To disable deletion protection, explicitly set this field to `false` in configuration
+and then run `terraform apply` to apply the change.


### PR DESCRIPTION
Add deletion_protection field to make deletion actions require an explicit intent
Part of b/366427439

Part of https://github.com/hashicorp/terraform-provider-google/issues/18854

**Release Note Template for Downstream PRs (will be copied)**

```

Alloydb: added `deletion_protection` field to `alloydb_cluster` to make deleting them require an explicit intent. `alloydb_cluster` resources now cannot be destroyed unless `deletion_protection = false` is set for the resource.

```