### PR TITLE
Add deletion_protection field to Alloydb Backup

### DIFF
--- a/mmv1/products/alloydb/Backup.yaml
+++ b/mmv1/products/alloydb/Backup.yaml
@@ -33,6 +33,17 @@ async: !ruby/object:Api::OpAsync
 import_format:
   ['projects/{{project}}/locations/{{location}}/backups/{{backup_id}}']
 autogen_async: true
+virtual_fields:
+  - !ruby/object:Api::Type::Boolean
+    name: 'deletion_protection'
+    default_value: false
+    description: |
+      Whether Terraform will be prevented from destroying the backup. Defaults to true.
+      When a`terraform destroy` or `terraform apply` would delete the backup,
+      the command will fail if this field is not set to false in Terraform state.
+      When the field is set to true or unset in Terraform state, a `terraform apply`
+      or `terraform destroy` that would delete the backup will fail.
+      When the field is set to false, deleting the backup is allowed.
 examples:
   - !ruby/object:Provider::Terraform::Examples
     name: 'alloydb_backup_basic'
@@ -45,6 +56,7 @@ examples:
     ignore_read_extra:
       - 'reconciling'
       - 'update_time'
+      - 'deletion_protection'
     skip_test: true
   - !ruby/object:Provider::Terraform::Examples
     name: 'alloydb_backup_basic_test'
@@ -90,6 +102,7 @@ examples:
     skip_docs: true
 custom_code: !ruby/object:Provider::Terraform::CustomCode
   encoder: templates/terraform/encoders/alloydb_backup.erb
+  pre_delete: 'templates/terraform/pre_delete/alloydb_backup.go.erb'
 parameters:
   - !ruby/object:Api::Type::String
     name: 'backupId'

--- a/mmv1/products/alloydb/go_Backup.yaml
+++ b/mmv1/products/alloydb/go_Backup.yaml
@@ -41,6 +41,18 @@ async:
     resource_inside_response: false
 custom_code:
   encoder: 'templates/terraform/encoders/go/alloydb_backup.tmpl'
+  pre_delete: 'templates/terraform/pre_delete/go/alloydb_backup.tmpl'
+virtual_fields:
+  - !ruby/object:Api::Type::Boolean
+    name: 'deletion_protection'
+    default_value: false
+    description: |
+      Whether Terraform will be prevented from destroying the backup. Defaults to true.
+      When a`terraform destroy` or `terraform apply` would delete the backup,
+      the command will fail if this field is not set to false in Terraform state.
+      When the field is set to true or unset in Terraform state, a `terraform apply`
+      or `terraform destroy` that would delete the backup will fail.
+      When the field is set to false, deleting the backup is allowed.
 examples:
   - name: 'alloydb_backup_basic'
     primary_resource_id: 'default'
@@ -52,6 +64,7 @@ examples:
     ignore_read_extra:
       - 'reconciling'
       - 'update_time'
+      - 'deletion_protection'
     skip_test: true
   - name: 'alloydb_backup_basic_test'
     primary_resource_id: 'default'

--- a/mmv1/templates/terraform/examples/alloydb_backup_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/alloydb_backup_basic.tf.erb
@@ -2,6 +2,7 @@ resource "google_alloydb_backup" "<%= ctx[:primary_resource_id] %>" {
   location     = "us-central1"
   backup_id    = "<%= ctx[:vars]['alloydb_backup_id'] %>"
   cluster_name = google_alloydb_cluster.<%= ctx[:primary_resource_id] %>.name
+  deletion_protection = false
 
   depends_on = [google_alloydb_instance.<%= ctx[:primary_resource_id] %>]
 }

--- a/mmv1/templates/terraform/examples/alloydb_backup_full.tf.erb
+++ b/mmv1/templates/terraform/examples/alloydb_backup_full.tf.erb
@@ -4,6 +4,7 @@ resource "google_alloydb_backup" "<%= ctx[:primary_resource_id] %>" {
   cluster_name = google_alloydb_cluster.<%= ctx[:primary_resource_id] %>.name
 
   description = "example description"
+  deletion_protection = false
   type = "ON_DEMAND"
   labels = {
     "label" = "key"

--- a/mmv1/templates/terraform/examples/go/alloydb_backup_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/go/alloydb_backup_basic.tf.tmpl
@@ -4,6 +4,7 @@ resource "google_alloydb_backup" "{{$.PrimaryResourceId}}" {
   cluster_name = google_alloydb_cluster.{{$.PrimaryResourceId}}.name
 
   depends_on = [google_alloydb_instance.{{$.PrimaryResourceId}}]
+  deletion_protection = false
 }
 
 resource "google_alloydb_cluster" "{{$.PrimaryResourceId}}" {

--- a/mmv1/templates/terraform/pre_delete/alloydb_backup.go.erb
+++ b/mmv1/templates/terraform/pre_delete/alloydb_backup.go.erb
@@ -1,0 +1,3 @@
+if d.Get("deletion_protection").(bool) {
+  return fmt.Errorf("cannot destroy domain without setting deletion_protection=false and running `terraform apply`")
+}

--- a/mmv1/templates/terraform/pre_delete/go/alloydb_backup.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/go/alloydb_backup.go.tmpl
@@ -1,0 +1,3 @@
+if d.Get("deletion_protection").(bool) {
+    return fmt.Errorf("cannot destroy domain without setting deletion_protection=false and running `terraform apply`")
+}

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_backup_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_backup_test.go
@@ -28,7 +28,7 @@ func TestAccAlloydbBackup_update(t *testing.T) {
 				ResourceName:            "google_alloydb_backup.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"backup_id", "location", "reconciling", "update_time", "labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"backup_id", "location", "reconciling", "update_time", "labels", "terraform_labels", "deletion_protection"},
 			},
 			{
 				Config: testAccAlloydbBackup_update(context),
@@ -37,7 +37,7 @@ func TestAccAlloydbBackup_update(t *testing.T) {
 				ResourceName:            "google_alloydb_backup.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"backup_id", "location", "reconciling", "update_time", "labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"backup_id", "location", "reconciling", "update_time", "labels", "terraform_labels", "deletion_protection"},
 			},
 		},
 	})
@@ -49,6 +49,7 @@ resource "google_alloydb_backup" "default" {
   location     = "us-central1"
   backup_id    = "tf-test-alloydb-backup%{random_suffix}"
   cluster_name = google_alloydb_cluster.default.name
+	deletion_protection = false
 
   description = "example description"
   labels = {
@@ -84,6 +85,7 @@ resource "google_alloydb_backup" "default" {
   location     = "us-central1"
   backup_id    = "tf-test-alloydb-backup%{random_suffix}"
   cluster_name = google_alloydb_cluster.default.name
+	deletion_protection = false
 
   description = "example description"
   labels = {

--- a/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_6_upgrade.html.markdown
@@ -415,3 +415,16 @@ that are derived from the API.
 ### `host.gce_instance.disable_ssh` now defaults to true
 
 `disable_ssh` field now defaults to true. To enable SSH, please set `disable_ssh` to false.
+
+## Resource: `alloydb_backup`
+
+### Backup deletion now prevented by default with `deletion_protection`
+
+The field `deletion_protection` has been added with a default value of `true`. This field prevents
+Terraform from destroying or recreating the backup. In 6.0.0, existing domains will have 
+`deletion_protection` set to `true` during the next refresh unless otherwise set in configuration.
+
+**`deletion_protection` does NOT prevent deletion outside of Terraform.**
+
+To disable deletion protection, explicitly set this field to `false` in configuration
+and then run `terraform apply` to apply the change.


### PR DESCRIPTION
Add deletion_protection field to make deletion actions require an explicit intent
Part of b/366454654

Part of https://github.com/hashicorp/terraform-provider-google/issues/18854

**Release Note Template for Downstream PRs (will be copied)**
```

Alloydb: added `deletion_protection` field to `alloydb_cbackup` to make deleting them require an explicit intent. `alloydb_backup` resources now cannot be destroyed unless `deletion_protection = false` is set for the resource.
```