### PR TITLE
Fix api resource names for mmv1

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -312,6 +312,8 @@ type Resource struct {
 	Compiler string
 
 	ImportPath string
+
+	ApiResourceType string `yaml:"api_resource_type"`
 }
 
 func (r *Resource) UnmarshalYAML(unmarshal func(any) error) error {

--- a/mmv1/products/accessapproval/go_FolderSettings.yaml
+++ b/mmv1/products/accessapproval/go_FolderSettings.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'FolderSettings'
+api_resource_type: AccessApprovalSettings
 legacy_name: 'google_folder_access_approval_settings'
 description: |
   Access Approval enables you to require your explicit approval whenever Google support and engineering need to access your customer content.

--- a/mmv1/products/accessapproval/go_OrganizationSettings.yaml
+++ b/mmv1/products/accessapproval/go_OrganizationSettings.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'OrganizationSettings'
+api_resource_type: AccessApprovalSettings
 legacy_name: 'google_organization_access_approval_settings'
 description: |
   Access Approval enables you to require your explicit approval whenever Google support and engineering need to access your customer content.

--- a/mmv1/products/accessapproval/go_ProjectSettings.yaml
+++ b/mmv1/products/accessapproval/go_ProjectSettings.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'ProjectSettings'
+api_resource_type: AccessApprovalSettings
 legacy_name: 'google_project_access_approval_settings'
 description: |
   Access Approval enables you to require your explicit approval whenever Google support and engineering need to access your customer content.

--- a/mmv1/products/accesscontextmanager/go_EgressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/go_EgressPolicy.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'EgressPolicy'
+api_resource_type: ServicePerimeter
 description: |
   This resource has been deprecated, please refer to ServicePerimeterEgressPolicy.
 references:

--- a/mmv1/products/accesscontextmanager/go_IngressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/go_IngressPolicy.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'IngressPolicy'
+api_resource_type: ServicePerimeter
 description: |
   This resource has been deprecated, please refer to ServicePerimeterIngressPolicy.
 references:

--- a/mmv1/products/accesscontextmanager/go_ServicePerimeterDryRunEgressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/go_ServicePerimeterDryRunEgressPolicy.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'ServicePerimeterDryRunEgressPolicy'
+api_resource_type: ServicePerimeter
 description: |
   Manage a single EgressPolicy in the spec (dry-run) configuration for a service perimeter.
   EgressPolicies match requests based on egressFrom and egressTo stanzas.

--- a/mmv1/products/accesscontextmanager/go_ServicePerimeterDryRunIngressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/go_ServicePerimeterDryRunIngressPolicy.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'ServicePerimeterDryRunIngressPolicy'
+api_resource_type: ServicePerimeter
 description: |
   Manage a single IngressPolicy in the spec (dry-run) configuration for a service perimeter.
   IngressPolicies match requests based on ingressFrom and ingressTo stanzas. For an ingress policy to match,

--- a/mmv1/products/accesscontextmanager/go_ServicePerimeterDryRunResource.yaml
+++ b/mmv1/products/accesscontextmanager/go_ServicePerimeterDryRunResource.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'ServicePerimeterDryRunResource'
+api_resource_type: ServicePerimeter
 description: |
   Allows configuring a single GCP resource that should be inside of the `spec` block of a dry run service perimeter.
   This resource is intended to be used in cases where it is not possible to compile a full list

--- a/mmv1/products/accesscontextmanager/go_ServicePerimeterEgressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/go_ServicePerimeterEgressPolicy.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'ServicePerimeterEgressPolicy'
+api_resource_type: ServicePerimeter
 description: |
   Manage a single EgressPolicy in the status (enforced) configuration for a service perimeter.
   EgressPolicies match requests based on egressFrom and egressTo stanzas.

--- a/mmv1/products/accesscontextmanager/go_ServicePerimeterIngressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/go_ServicePerimeterIngressPolicy.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'ServicePerimeterIngressPolicy'
+api_resource_type: ServicePerimeter
 description: |
   Manage a single IngressPolicy in the status (enforced) configuration for a service perimeter.
   IngressPolicies match requests based on ingressFrom and ingressTo stanzas. For an ingress policy to match,

--- a/mmv1/products/accesscontextmanager/go_ServicePerimeterResource.yaml
+++ b/mmv1/products/accesscontextmanager/go_ServicePerimeterResource.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'ServicePerimeterResource'
+api_resource_type: ServicePerimeter
 description: |
   Allows configuring a single GCP resource that should be inside the `status` block of a service perimeter.
   This resource is intended to be used in cases where it is not possible to compile a full list

--- a/mmv1/products/accesscontextmanager/go_ServicePerimeters.yaml
+++ b/mmv1/products/accesscontextmanager/go_ServicePerimeters.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'ServicePerimeters'
+api_resource_type: ServicePerimeter
 description: |
   Replace all existing Service Perimeters in an Access Policy with the Service Perimeters provided. This is done atomically.
   This is a bulk edit of all Service Perimeters and may override existing Service Perimeters created by `google_access_context_manager_service_perimeter`,

--- a/mmv1/products/activedirectory/go_DomainTrust.yaml
+++ b/mmv1/products/activedirectory/go_DomainTrust.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'DomainTrust'
+api_resource_type: Domain
 kind: 'activedirectory#trust'
 description: Adds a trust between Active Directory domains
 references:

--- a/mmv1/products/apigee/go_EnvironmentKeyvaluemaps.yaml
+++ b/mmv1/products/apigee/go_EnvironmentKeyvaluemaps.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'EnvironmentKeyvaluemaps'
+api_resource_type: KeyValueMap
 description: |
   Collection of key/value string pairs.
 references:

--- a/mmv1/products/apigee/go_EnvironmentKeyvaluemapsEntries.yaml
+++ b/mmv1/products/apigee/go_EnvironmentKeyvaluemapsEntries.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'EnvironmentKeyvaluemapsEntries'
+api_resource_type: KeyValueEntry
 description: |
   Creates key value entries in a key value map scoped to an environment.
 references:

--- a/mmv1/products/artifactregistry/go_VPCSCConfig.yaml
+++ b/mmv1/products/artifactregistry/go_VPCSCConfig.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'VPCSCConfig'
+api_resource_type: VpcscConfig
 description: |-
   The Artifact Registry VPC SC config that applies to a Project.
 min_version: 'beta'

--- a/mmv1/products/bigquerydatatransfer/go_Config.yaml
+++ b/mmv1/products/bigquerydatatransfer/go_Config.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'Config'
+api_resource_type: TransferConfig
 description: |
   Represents a data transfer configuration. A transfer configuration
   contains all metadata needed to perform a data transfer.

--- a/mmv1/products/billing/go_ProjectInfo.yaml
+++ b/mmv1/products/billing/go_ProjectInfo.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'ProjectInfo'
+api_resource_type: ProjectBillingInfo
 description: |
   Billing information for a project.
 references:

--- a/mmv1/products/blockchainnodeengine/go_BlockchainNodes.yaml
+++ b/mmv1/products/blockchainnodeengine/go_BlockchainNodes.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'BlockchainNodes'
+api_resource_type: BlockchainNode
 description: |
   A representation of a blockchain node.
 references:

--- a/mmv1/products/cloudasset/go_FolderFeed.yaml
+++ b/mmv1/products/cloudasset/go_FolderFeed.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'FolderFeed'
+api_resource_type: Feed
 description: |
   Describes a Cloud Asset Inventory feed used to to listen to asset updates.
 references:

--- a/mmv1/products/cloudasset/go_OrganizationFeed.yaml
+++ b/mmv1/products/cloudasset/go_OrganizationFeed.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'OrganizationFeed'
+api_resource_type: Feed
 description: |
   Describes a Cloud Asset Inventory feed used to to listen to asset updates.
 references:

--- a/mmv1/products/cloudasset/go_ProjectFeed.yaml
+++ b/mmv1/products/cloudasset/go_ProjectFeed.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'ProjectFeed'
+api_resource_type: Feed
 description: |
   Describes a Cloud Asset Inventory feed used to to listen to asset updates.
 references:

--- a/mmv1/products/cloudbuild/go_Trigger.yaml
+++ b/mmv1/products/cloudbuild/go_Trigger.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'Trigger'
+api_resource_type: BuildTrigger
 description: |
   Configuration for an automated build in response to source repository changes.
 references:

--- a/mmv1/products/cloudfunctions2/go_Function.yaml
+++ b/mmv1/products/cloudfunctions2/go_Function.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'function'
+api_resource_type: Function
 description: |
   A Cloud Function that contains user computation executed in response to an event.
 references:

--- a/mmv1/products/cloudidentity/go_GroupMembership.yaml
+++ b/mmv1/products/cloudidentity/go_GroupMembership.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'GroupMembership'
+api_resource_type: Membership
 description: |
   A Membership defines a relationship between a Group and an entity belonging to that Group, referred to as a "member".
 references:

--- a/mmv1/products/containerattached/go_Cluster.yaml
+++ b/mmv1/products/containerattached/go_Cluster.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'Cluster'
+api_resource_type: AttachedCluster
 description: |
   An Anthos cluster running on customer owned infrastructure.
 references:

--- a/mmv1/products/dataform/go_RepositoryReleaseConfig.yaml
+++ b/mmv1/products/dataform/go_RepositoryReleaseConfig.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'RepositoryReleaseConfig'
+api_resource_type: ReleaseConfig
 description: |-
   A resource represents a Dataform release configuration
 min_version: 'beta'

--- a/mmv1/products/dataform/go_RepositoryWorkflowConfig.yaml
+++ b/mmv1/products/dataform/go_RepositoryWorkflowConfig.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'RepositoryWorkflowConfig'
+api_resource_type: WorkflowConfig
 description: |-
   A resource represents a Dataform workflow configuration
 min_version: 'beta'

--- a/mmv1/products/dataplex/go_Datascan.yaml
+++ b/mmv1/products/dataplex/go_Datascan.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'Datascan'
+api_resource_type: DataScan
 description: |
   Represents a user-visible job which provides the insights for the related data source.
 skip_attribution_label: true

--- a/mmv1/products/discoveryengine/go_ChatEngine.yaml
+++ b/mmv1/products/discoveryengine/go_ChatEngine.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'ChatEngine'
+api_resource_type: Engine
 description: |
   Vertex chat and Conversation Engine Chat type
 references:

--- a/mmv1/products/discoveryengine/go_SearchEngine.yaml
+++ b/mmv1/products/discoveryengine/go_SearchEngine.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'SearchEngine'
+api_resource_type: Engine
 description: |
   Vertex AI Search and Conversation can be used to create a search engine or a chat application by connecting it with a datastore
 references:

--- a/mmv1/products/documentai/ProcessorDefaultVersion.yaml
+++ b/mmv1/products/documentai/ProcessorDefaultVersion.yaml
@@ -13,6 +13,7 @@
 
 --- !ruby/object:Api::Resource
 name: 'ProcessorDefaultVersion'
+api_resource_type: Processor
 immutable: true
 base_url: '{{processor}}'
 create_url: '{{processor}}:setDefaultProcessorVersion'

--- a/mmv1/products/firebase/go_AppleApp.yaml
+++ b/mmv1/products/firebase/go_AppleApp.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'AppleApp'
+api_resource_type: IosApp
 description: |
   A Google Cloud Firebase Apple application instance
 min_version: 'beta'

--- a/mmv1/products/firebaseappcheck/go_RecaptchaV3Config.yaml
+++ b/mmv1/products/firebaseappcheck/go_RecaptchaV3Config.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'RecaptchaV3Config'
+api_resource_type: RecaptchaConfig
 description: |
   An app's reCAPTCHA V3 configuration object.
 references:

--- a/mmv1/products/firebaseappcheck/go_ServiceConfig.yaml
+++ b/mmv1/products/firebaseappcheck/go_ServiceConfig.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'ServiceConfig'
+api_resource_type: Service
 description: The enforcement configuration for a service supported by App Check.
 references:
   guides:

--- a/mmv1/products/firebaseextensions/go_Instance.yaml
+++ b/mmv1/products/firebaseextensions/go_Instance.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'Instance'
+api_resource_type: ExtensionInstance
 description: An Instance is an installation of an Extension into a user's project.
 min_version: 'beta'
 references:

--- a/mmv1/products/gkehub2/go_MembershipRBACRoleBinding.yaml
+++ b/mmv1/products/gkehub2/go_MembershipRBACRoleBinding.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'MembershipRBACRoleBinding'
+api_resource_type: RBACRoleBinding
 description: |
   RBACRoleBinding represents a rbacrolebinding across the Fleet.
 min_version: 'beta'

--- a/mmv1/products/gkehub2/go_ScopeRBACRoleBinding.yaml
+++ b/mmv1/products/gkehub2/go_ScopeRBACRoleBinding.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'ScopeRBACRoleBinding'
+api_resource_type: RBACRoleBinding
 description: |
   RBACRoleBinding represents a rbacrolebinding across the Fleet.
 references:

--- a/mmv1/products/kms/go_KeyRingImportJob.yaml
+++ b/mmv1/products/kms/go_KeyRingImportJob.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'KeyRingImportJob'
+api_resource_type: ImportJob
 description: |
   A `KeyRingImportJob` can be used to create `CryptoKeys` and `CryptoKeyVersions` using pre-existing
   key material, generated outside of Cloud KMS. A `KeyRingImportJob` expires 3 days after it is created.

--- a/mmv1/products/kms/go_SecretCiphertext.yaml
+++ b/mmv1/products/kms/go_SecretCiphertext.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'SecretCiphertext'
+api_resource_type: CryptoKey
 description: |
   Encrypts secret data with Google Cloud KMS and provides access to the ciphertext.
 

--- a/mmv1/products/logging/go_FolderSettings.yaml
+++ b/mmv1/products/logging/go_FolderSettings.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'FolderSettings'
+api_resource_type: Settings
 description: |
   Default resource settings control whether CMEK is required for new log buckets. These settings also determine the storage location for the _Default and _Required log buckets, and whether the _Default sink is enabled or disabled.
 references:

--- a/mmv1/products/logging/go_LinkedDataset.yaml
+++ b/mmv1/products/logging/go_LinkedDataset.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'LinkedDataset'
+api_resource_type: Link
 description: |
   Describes a BigQuery linked dataset
 references:

--- a/mmv1/products/logging/go_Metric.yaml
+++ b/mmv1/products/logging/go_Metric.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'Metric'
+api_resource_type: LogMetric
 description: |
   Logs-based metric can also be used to extract values from logs and create a a distribution
   of the values. The distribution records the statistics of the extracted values along with

--- a/mmv1/products/logging/go_OrganizationSettings.yaml
+++ b/mmv1/products/logging/go_OrganizationSettings.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'OrganizationSettings'
+api_resource_type: Settings
 description: |
   Default resource settings control whether CMEK is required for new log buckets. These settings also determine the storage location for the _Default and _Required log buckets, and whether the _Default sink is enabled or disabled.
 references:

--- a/mmv1/products/monitoring/go_GenericService.yaml
+++ b/mmv1/products/monitoring/go_GenericService.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'GenericService'
+api_resource_type: Service
 legacy_name: 'google_monitoring_service'
 description: |
   A Service is a discrete, autonomous, and network-accessible unit,

--- a/mmv1/products/monitoring/go_Slo.yaml
+++ b/mmv1/products/monitoring/go_Slo.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'Slo'
+api_resource_type: ServiceLevelObjective
 description: |
   A Service-Level Objective (SLO) describes the level of desired good
   service. It consists of a service-level indicator (SLI), a performance

--- a/mmv1/products/netapp/go_VolumeSnapshot.yaml
+++ b/mmv1/products/netapp/go_VolumeSnapshot.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'VolumeSnapshot'
+api_resource_type: Snapshot
 description: |
   NetApp Volumes helps you manage your data usage with snapshots that can quickly restore lost data.
   Snapshots are point-in-time versions of your volume's content. They are resources of volumes and are

--- a/mmv1/products/netapp/go_kmsconfig.yaml
+++ b/mmv1/products/netapp/go_kmsconfig.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'kmsconfig'
+api_resource_type: KmsConfig
 description: |
   NetApp Volumes always encrypts your data at rest using volume-specific keys.
 

--- a/mmv1/products/networksecurity/go_UrlLists.yaml
+++ b/mmv1/products/networksecurity/go_UrlLists.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'UrlLists'
+api_resource_type: UrlList
 description: |
   UrlList proto helps users to set reusable, independently manageable lists of hosts, host patterns, URLs, URL patterns.
 references:

--- a/mmv1/products/networkservices/go_ServiceLbPolicies.yaml
+++ b/mmv1/products/networkservices/go_ServiceLbPolicies.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'ServiceLbPolicies'
+api_resource_type: ServiceLbPolicy
 description: |
   ServiceLbPolicy holds global load balancing and traffic distribution configuration that can be applied to a BackendService.
 min_version: 'beta'

--- a/mmv1/products/osconfig/go_GuestPolicies.yaml
+++ b/mmv1/products/osconfig/go_GuestPolicies.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'GuestPolicies'
+api_resource_type: GuestPolicy
 description: |
   An OS Config resource representing a guest configuration policy. These policies represent
   the desired state for VM instance guest environments including packages to install or remove,

--- a/mmv1/products/oslogin/go_SSHPublicKey.yaml
+++ b/mmv1/products/oslogin/go_SSHPublicKey.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'SSHPublicKey'
+api_resource_type: SshPublicKey
 kind: 'user#sshPublicKeys'
 description: |
   The SSH public key information associated with a Google account.

--- a/mmv1/products/securitycenter/go_FolderCustomModule.yaml
+++ b/mmv1/products/securitycenter/go_FolderCustomModule.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'FolderCustomModule'
+api_resource_type: SecurityHealthAnalyticsCustomModule
 description: |
   Represents an instance of a Security Health Analytics custom module, including
   its full module name, display name, enablement state, and last updated time.

--- a/mmv1/products/securitycenter/go_FolderNotificationConfig.yaml
+++ b/mmv1/products/securitycenter/go_FolderNotificationConfig.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'FolderNotificationConfig'
+api_resource_type: NotificationConfig
 description: |
   A Cloud Security Command Center (Cloud SCC) notification configs. A
   notification config is a Cloud SCC resource that contains the

--- a/mmv1/products/securitycenter/go_OrganizationCustomModule.yaml
+++ b/mmv1/products/securitycenter/go_OrganizationCustomModule.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'OrganizationCustomModule'
+api_resource_type: SecurityHealthAnalyticsCustomModule
 description: |
   Represents an instance of a Security Health Analytics custom module, including
   its full module name, display name, enablement state, and last updated time.

--- a/mmv1/products/securitycenter/go_ProjectCustomModule.yaml
+++ b/mmv1/products/securitycenter/go_ProjectCustomModule.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'ProjectCustomModule'
+api_resource_type: SecurityHealthAnalyticsCustomModule
 description: |
   Represents an instance of a Security Health Analytics custom module, including
   its full module name, display name, enablement state, and last updated time.

--- a/mmv1/products/securitycenter/go_ProjectNotificationConfig.yaml
+++ b/mmv1/products/securitycenter/go_ProjectNotificationConfig.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'ProjectNotificationConfig'
+api_resource_type: NotificationConfig
 description: |
   A Cloud Security Command Center (Cloud SCC) notification configs. A
   notification config is a Cloud SCC resource that contains the

--- a/mmv1/products/securitycentermanagement/go_FolderSecurityHealthAnalyticsCustomModule.yaml
+++ b/mmv1/products/securitycentermanagement/go_FolderSecurityHealthAnalyticsCustomModule.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'FolderSecurityHealthAnalyticsCustomModule'
+api_resource_type: SecurityHealthAnalyticsCustomModule
 description: |
   Represents an instance of a Security Health Analytics custom module, including
   its full module name, display name, enablement state, and last updated time.

--- a/mmv1/products/securitycentermanagement/go_OrganizationEventThreatDetectionCustomModule.yaml
+++ b/mmv1/products/securitycentermanagement/go_OrganizationEventThreatDetectionCustomModule.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'OrganizationEventThreatDetectionCustomModule'
+api_resource_type: EventThreatDetectionCustomModule
 description: |
   Represents an instance of an Event Threat Detection custom module, including
   its full module name, display name, enablement state, and last updated time.

--- a/mmv1/products/securitycentermanagement/go_OrganizationSecurityHealthAnalyticsCustomModule.yaml
+++ b/mmv1/products/securitycentermanagement/go_OrganizationSecurityHealthAnalyticsCustomModule.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'OrganizationSecurityHealthAnalyticsCustomModule'
+api_resource_type: SecurityHealthAnalyticsCustomModule
 description: |
   Represents an instance of a Security Health Analytics custom module, including
   its full module name, display name, enablement state, and last updated time.

--- a/mmv1/products/securitycentermanagement/go_ProjectSecurityHealthAnalyticsCustomModule.yaml
+++ b/mmv1/products/securitycentermanagement/go_ProjectSecurityHealthAnalyticsCustomModule.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'ProjectSecurityHealthAnalyticsCustomModule'
+api_resource_type: SecurityHealthAnalyticsCustomModule
 description: |
   Represents an instance of a Security Health Analytics custom module, including
   its full module name, display name, enablement state, and last updated time.

--- a/mmv1/products/securitycenterv2/go_FolderMuteConfig.yaml
+++ b/mmv1/products/securitycenterv2/go_FolderMuteConfig.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'FolderMuteConfig'
+api_resource_type: MuteConfig
 description: |
   Mute Findings is a volume management feature in Security Command Center
   that lets you manually or programmatically hide irrelevant findings,

--- a/mmv1/products/securitycenterv2/go_FolderNotificationConfig.yaml
+++ b/mmv1/products/securitycenterv2/go_FolderNotificationConfig.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'FolderNotificationConfig'
+api_resource_type: NotificationConfig
 description: |
   A Cloud Security Command Center (Cloud SCC) notification configs. A
   notification config is a Cloud SCC resource that contains the

--- a/mmv1/products/securitycenterv2/go_FolderSccBigQueryExport.yaml
+++ b/mmv1/products/securitycenterv2/go_FolderSccBigQueryExport.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'FolderSccBigQueryExport'
+api_resource_type: BigQueryExport
 description: |
   A Cloud Security Command Center (Cloud SCC) Big Query Export Config.
   It represents exporting Security Command Center data, including assets, findings, and security marks

--- a/mmv1/products/securitycenterv2/go_OrganizationMuteConfig.yaml
+++ b/mmv1/products/securitycenterv2/go_OrganizationMuteConfig.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'OrganizationMuteConfig'
+api_resource_type: MuteConfig
 description: |
   Mute Findings is a volume management feature in Security Command Center
   that lets you manually or programmatically hide irrelevant findings,

--- a/mmv1/products/securitycenterv2/go_OrganizationNotificationConfig.yaml
+++ b/mmv1/products/securitycenterv2/go_OrganizationNotificationConfig.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'OrganizationNotificationConfig'
+api_resource_type: NotificationConfig
 description: |
   A Cloud Security Command Center (Cloud SCC) notification configs. A
   notification config is a Cloud SCC resource that contains the

--- a/mmv1/products/securitycenterv2/go_OrganizationSccBigQueryExports.yaml
+++ b/mmv1/products/securitycenterv2/go_OrganizationSccBigQueryExports.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'OrganizationSccBigQueryExports'
+api_resource_type: BigQueryExport
 description: |
   A Cloud Security Command Center (Cloud SCC) Big Query Export Config.
   It represents exporting Security Command Center data, including assets, findings, and security marks

--- a/mmv1/products/securitycenterv2/go_OrganizationSource.yaml
+++ b/mmv1/products/securitycenterv2/go_OrganizationSource.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'OrganizationSource'
+api_resource_type: Source
 description: |
   A Cloud Security Command Center's (Cloud SCC) finding source. A finding
   source is an entity or a mechanism that can produce a finding. A source is

--- a/mmv1/products/securitycenterv2/go_ProjectMuteConfig.yaml
+++ b/mmv1/products/securitycenterv2/go_ProjectMuteConfig.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'ProjectMuteConfig'
+api_resource_type: MuteConfig
 description: |
   Mute Findings is a volume management feature in Security Command Center
   that lets you manually or programmatically hide irrelevant findings,

--- a/mmv1/products/securitycenterv2/go_ProjectNotificationConfig.yaml
+++ b/mmv1/products/securitycenterv2/go_ProjectNotificationConfig.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'ProjectNotificationConfig'
+api_resource_type: NotificationConfig
 description: |
   A Cloud Security Command Center (Cloud SCC) notification configs. A
   notification config is a Cloud SCC resource that contains the

--- a/mmv1/products/securitycenterv2/go_ProjectSccBigQueryExport.yaml
+++ b/mmv1/products/securitycenterv2/go_ProjectSccBigQueryExport.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'ProjectSccBigQueryExport'
+api_resource_type: BigQueryExport
 description: |
   A Cloud Security Command Center (Cloud SCC) Big Query Export Config.
   It represents exporting Security Command Center data, including assets, findings, and security marks

--- a/mmv1/products/sql/go_SourceRepresentationInstance.yaml
+++ b/mmv1/products/sql/go_SourceRepresentationInstance.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'SourceRepresentationInstance'
+api_resource_type: Instance
 kind: 'sql#instance'
 description: |
   A source representation instance is a Cloud SQL instance that represents

--- a/mmv1/products/storagetransfer/go_AgentPool.yaml
+++ b/mmv1/products/storagetransfer/go_AgentPool.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'AgentPool'
+api_resource_type: agentPools
 description: 'Represents an On-Premises Agent pool.'
 references:
   guides:

--- a/mmv1/products/tpuv2/go_Vm.yaml
+++ b/mmv1/products/tpuv2/go_Vm.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'Vm'
+api_resource_type: Node
 description: |
   A Cloud TPU VM instance.
 min_version: 'beta'

--- a/mmv1/products/vertexai/go_FeatureGroupFeature.yaml
+++ b/mmv1/products/vertexai/go_FeatureGroupFeature.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'FeatureGroupFeature'
+api_resource_type: Feature
 description: Vertex AI Feature Group Feature is feature metadata information.
 references:
   guides:

--- a/mmv1/products/vertexai/go_FeatureOnlineStoreFeatureview.yaml
+++ b/mmv1/products/vertexai/go_FeatureOnlineStoreFeatureview.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'FeatureOnlineStoreFeatureview'
+api_resource_type: FeatureView
 description: |-
   FeatureView is representation of values that the FeatureOnlineStore will serve based on its syncConfig.
 references:

--- a/mmv1/products/vertexai/go_FeaturestoreEntitytype.yaml
+++ b/mmv1/products/vertexai/go_FeaturestoreEntitytype.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'FeaturestoreEntitytype'
+api_resource_type: EntityType
 description: |-
   An entity type is a type of object in a system that needs to be modeled and have stored information about. For example, driver is an entity type, and driver0 is an instance of an entity type driver.
 references:

--- a/mmv1/products/vertexai/go_FeaturestoreEntitytypeFeature.yaml
+++ b/mmv1/products/vertexai/go_FeaturestoreEntitytypeFeature.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'FeaturestoreEntitytypeFeature'
+api_resource_type: Feature
 description: |-
   Feature Metadata information that describes an attribute of an entity type. For example, apple is an entity type, and color is a feature that describes apple.
 references:

--- a/mmv1/products/vertexai/go_IndexEndpointDeployedIndex.yaml
+++ b/mmv1/products/vertexai/go_IndexEndpointDeployedIndex.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'IndexEndpointDeployedIndex'
+api_resource_type: IndexEndpoint
 description: |-
   An endpoint indexes are deployed into. An index endpoint can have multiple deployed indexes.
 references:

--- a/mmv1/products/vmwareengine/go_Network.yaml
+++ b/mmv1/products/vmwareengine/go_Network.yaml
@@ -14,6 +14,7 @@
 # Warning: This is a temporary file, and should not be edited directly
 ---
 name: 'Network'
+api_resource_type: VmwareEngineNetwork
 description: |
   Provides connectivity for VMware Engine private clouds.
 references:


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

@melinath really just sharing this for visibility. These are the names that need to be manually overridden to get from a TF resource to the API resource, so you can see roughly how many we have (and perhaps notice any patterns we could use to automate). At this point, I do expect we will need a new field like I have here to specify these name overrides.

This does not include some or all resources for the following APIs:
* apigee.googleapis.com
* appengine.googleapis.com
* bigquery.googleapis.com
* compute.googleapis.com
* containeranalysis.googleapis.com
* dns.googleapis.com
* documentai.googleapis.com
* firestore.googleapis.com
* iam.googleapis.com
* iap.googleapis.com
* identitytoolkit.googleapis.com
* integrations.googleapis.com
* ml.googleapis.com
* monitoring.googleapis.com
* notebooks.googleapis.com
* servicenetworking.googleapis.com
* sourcerepo.googleapis.com
* sqladmin.googleapis.com
* storage.googleapis.com

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
