### PR TITLE
Clarifying documentation for google_compute_region_backend_service locality_lb_policy

### DIFF
--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -828,7 +828,8 @@ properties:
                   Maglev, refer to https://ai.google/research/pubs/pub44824
 
       * `WEIGHTED_MAGLEV`: Per-instance weighted Load Balancing via health check
-                           reported weights. If set, the Backend Service must
+                           reported weights. Only applicable to loadBalancingScheme
+                           EXTERNAL. If set, the Backend Service must
                            configure a non legacy HTTP-based Health Check, and
                            health check replies are expected to contain
                            non-standard HTTP response header field
@@ -840,7 +841,7 @@ properties:
                            UNAVAILABLE_WEIGHT. Otherwise, Load Balancing remains
                            equal-weight.
 
-      This field is applicable to either:
+      locality_lb_policy is applicable to either:
 
       * A regional backend service with the service_protocol set to HTTP, HTTPS, or HTTP2,
         and loadBalancingScheme set to INTERNAL_MANAGED.
@@ -849,7 +850,7 @@ properties:
         Load Balancing). Only MAGLEV and WEIGHTED_MAGLEV values are possible for External
         Network Load Balancing. The default is MAGLEV.
 
-      If session_affinity is not NONE, and this field is not set to MAGLEV, WEIGHTED_MAGLEV,
+      If session_affinity is not NONE, and locality_lb_policy is not set to MAGLEV, WEIGHTED_MAGLEV,
       or RING_HASH, session affinity settings will not take effect.
 
       Only ROUND_ROBIN and RING_HASH are supported when the backend service is referenced

--- a/mmv1/products/compute/go_RegionBackendService.yaml
+++ b/mmv1/products/compute/go_RegionBackendService.yaml
@@ -814,7 +814,8 @@ properties:
                   Maglev, refer to https://ai.google/research/pubs/pub44824
 
       * `WEIGHTED_MAGLEV`: Per-instance weighted Load Balancing via health check
-                           reported weights. If set, the Backend Service must
+                           reported weights. Only applicable to loadBalancingScheme
+                           EXTERNAL. If set, the Backend Service must
                            configure a non legacy HTTP-based Health Check, and
                            health check replies are expected to contain
                            non-standard HTTP response header field
@@ -826,7 +827,7 @@ properties:
                            UNAVAILABLE_WEIGHT. Otherwise, Load Balancing remains
                            equal-weight.
 
-      This field is applicable to either:
+      locality_lb_policy is applicable to either:
 
       * A regional backend service with the service_protocol set to HTTP, HTTPS, or HTTP2,
         and loadBalancingScheme set to INTERNAL_MANAGED.
@@ -835,7 +836,7 @@ properties:
         Load Balancing). Only MAGLEV and WEIGHTED_MAGLEV values are possible for External
         Network Load Balancing. The default is MAGLEV.
 
-      If session_affinity is not NONE, and this field is not set to MAGLEV, WEIGHTED_MAGLEV,
+      If session_affinity is not NONE, and locality_lb_policy is not set to MAGLEV, WEIGHTED_MAGLEV,
       or RING_HASH, session affinity settings will not take effect.
 
       Only ROUND_ROBIN and RING_HASH are supported when the backend service is referenced


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

- Updating the documentation to more clearly indicate that the footer note for `locality_lb_policy` refers to the field `locality_lb_policy`, and not `WEIGHTED_MAGLEV`.
- Replacing the pronoun `This field` with explicit noun of `locality_lb_policy`.
- Also adds clarifying statement that `WEIGHTED_MAGLEV` is only applicable to loadBalancingScheme EXTERNAL.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
