### PR TITLE
Add google_site_verification_owner resource

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
@@ -382,6 +382,7 @@ var handwrittenResources = map[string]*schema.Resource{
 	"google_service_account":                       resourcemanager.ResourceGoogleServiceAccount(),
 	"google_service_account_key":                   resourcemanager.ResourceGoogleServiceAccountKey(),
 	"google_service_networking_peered_dns_domain":  servicenetworking.ResourceGoogleServiceNetworkingPeeredDNSDomain(),
+	"google_site_verification_owner":               siteverification.ResourceSiteVerificationOwner(),
 	"google_storage_bucket":                        storage.ResourceStorageBucket(),
 	"google_storage_bucket_acl":                    storage.ResourceStorageBucketAcl(),
 	"google_storage_bucket_object":                 storage.ResourceStorageBucketObject(),

--- a/mmv1/third_party/terraform/services/siteverification/resource_site_verification_owner.go
+++ b/mmv1/third_party/terraform/services/siteverification/resource_site_verification_owner.go
@@ -1,0 +1,275 @@
+package siteverification
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func ResourceSiteVerificationOwner() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSiteVerificationOwnerCreate,
+		Read:   resourceSiteVerificationOwnerRead,
+		Delete: resourceSiteVerificationOwnerDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: resourceSiteVerificationOwnerImport,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"email": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The email address of the owner.`,
+			},
+			"web_resource_id": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName,
+				Description:      `The id of the Web Resource to add this owner to, in the form "webResource/<web-resource-id>".`,
+			},
+		},
+		UseJSONNumber: true,
+	}
+}
+
+func resourceSiteVerificationOwnerCreate(d *schema.ResourceData, meta interface{}) error {
+	email := d.Get("email").(string)
+
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Reading existing WebResource")
+
+	url, err := tpgresource.ReplaceVars(d, config, "{{SiteVerificationBasePath}}{{web_resource_id}}")
+	if err != nil {
+		return err
+	}
+
+	billingProject := ""
+
+	// err == nil indicates that the billing_project value was found
+	if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+		billingProject = bp
+	}
+
+	headers := make(http.Header)
+	obj, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   billingProject,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Headers:   headers,
+	})
+	if err != nil {
+		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("SiteVerificationWebResource %q", d.Id()))
+	}
+
+	log.Printf("[DEBUG] Finished reading WebResource: %#v", obj)
+
+	owners, ok := obj["owners"].([]interface{})
+	if !ok {
+		return fmt.Errorf("WebResource has no existing owners")
+	}
+	found := false
+	for _, owner := range owners {
+		if s, ok := owner.(string); ok && s == email {
+			found = true
+		}
+	}
+	if !found {
+		owners = append(owners, email)
+		obj["owners"] = owners
+
+		log.Printf("[DEBUG] Creating new Owner: %#v", obj)
+
+		headers = make(http.Header)
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "PUT",
+			Project:   billingProject,
+			RawURL:    url,
+			UserAgent: userAgent,
+			Body:      obj,
+			Timeout:   d.Timeout(schema.TimeoutCreate),
+			Headers:   headers,
+		})
+		if err != nil {
+			return fmt.Errorf("Error creating Owner: %s", err)
+		}
+
+		log.Printf("[DEBUG] Finished creating Owner %q: %#v", d.Id(), res)
+	}
+
+	// Store the ID now
+	id, err := tpgresource.ReplaceVars(d, config, "{{web_resource_id}}/{{email}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+
+	return resourceSiteVerificationOwnerRead(d, meta)
+}
+
+func resourceSiteVerificationOwnerRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	url, err := tpgresource.ReplaceVars(d, config, "{{SiteVerificationBasePath}}{{web_resource_id}}")
+	if err != nil {
+		return err
+	}
+
+	billingProject := ""
+
+	// err == nil indicates that the billing_project value was found
+	if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+		billingProject = bp
+	}
+
+	headers := make(http.Header)
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   billingProject,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Headers:   headers,
+	})
+	if err != nil {
+		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("SiteVerificationOwner %q", d.Id()))
+	}
+
+	owners, ok := res["owners"].([]interface{})
+	if !ok {
+		return fmt.Errorf("WebResource has no owners")
+	}
+
+	found := false
+	email := d.Get("email").(string)
+	for _, owner := range owners {
+		if s, ok := owner.(string); ok && s == email {
+			found = true
+		}
+	}
+
+	if !found {
+		// Owner isn't there any more - remove from the state.
+		log.Printf("[DEBUG] Removing SiteVerificationOwner because it couldn't be matched.")
+		d.SetId("")
+		return nil
+	}
+
+	return nil
+}
+
+func resourceSiteVerificationOwnerDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	billingProject := ""
+
+	url, err := tpgresource.ReplaceVars(d, config, "{{SiteVerificationBasePath}}{{web_resource_id}}")
+	if err != nil {
+		return err
+	}
+
+	// err == nil indicates that the billing_project value was found
+	if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+		billingProject = bp
+	}
+
+	log.Printf("[DEBUG] Reading existing WebResource")
+
+	headers := make(http.Header)
+	obj, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   billingProject,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Headers:   headers,
+	})
+	if err != nil {
+		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("SiteVerificationWebResource %q", d.Id()))
+	}
+
+	log.Printf("[DEBUG] Finished reading WebResource: %#v", obj)
+
+	owners, ok := obj["owners"].([]interface{})
+	if !ok {
+		return fmt.Errorf("WebResource has no existing owners")
+	}
+	var updatedOwners []interface{}
+	email := d.Get("email").(string)
+	for _, owner := range owners {
+		if s, ok := owner.(string); ok {
+			if s != email {
+				updatedOwners = append(updatedOwners, s)
+			}
+		}
+	}
+	obj["owners"] = updatedOwners
+
+	headers = make(http.Header)
+
+	log.Printf("[DEBUG] Deleting Owner %q", d.Id())
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "PUT",
+		Project:   billingProject,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Body:      obj,
+		Timeout:   d.Timeout(schema.TimeoutDelete),
+		Headers:   headers,
+	})
+	if err != nil {
+		return transport_tpg.HandleNotFoundError(err, d, "Owner")
+	}
+
+	log.Printf("[DEBUG] Finished deleting Owner %q: %#v", d.Id(), res)
+	return nil
+}
+
+func resourceSiteVerificationOwnerImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	config := meta.(*transport_tpg.Config)
+	if err := tpgresource.ParseImportId([]string{
+		"^(?P<web_resource_id>webResource/[^/]+)/(?P<email>[^/]+)$",
+	}, d, config); err != nil {
+		return nil, err
+	}
+
+	// Replace import id for the resource id
+	id, err := tpgresource.ReplaceVars(d, config, "{{web_resource_id}}/{{email}}")
+	if err != nil {
+		return nil, fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+
+	log.Printf("[DEBUG] Finished importing Owner %q", d.Id())
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/mmv1/third_party/terraform/services/siteverification/resource_site_verification_owner_test.go
+++ b/mmv1/third_party/terraform/services/siteverification/resource_site_verification_owner_test.go
@@ -1,0 +1,292 @@
+package siteverification_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccSiteVerificationOwner_siteVerificationBucket(t *testing.T) {
+	t.Parallel()
+
+	account1 := "tf-test-" + acctest.RandString(t, 10)
+	account2 := "tf-test-" + acctest.RandString(t, 10)
+
+	bucket := "tf-siteverification-test-" + acctest.RandString(t, 10)
+	context := map[string]interface{}{
+		"bucket":   bucket,
+		"account1": account1,
+		"account2": account2,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				// Initial configuration with one owner resource.
+				Config: testAccSiteVerificationOwner_siteVerificationBucket(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_site_verification_web_resource.example", "owners.#", "1"),
+				),
+			},
+			{
+				ResourceName:      "google_site_verification_owner.example1",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// Add a second owner resource.
+				Config: testAccSiteVerificationOwner_siteVerificationBucketSecondOwner(context),
+			},
+			{
+				ResourceName:      "google_site_verification_owner.example1",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "google_site_verification_owner.example2",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// Remove both owners.
+				Config: testAccSiteVerificationOwner_siteVerificationBucketRemoveOwners(context),
+			},
+			{
+				// Remove the object before the test deletes the web resource. The API will not
+				// allow the web resource to be deleted if the object still exists, and this
+				// ensures the proper order of deletion.
+				Config: testAccSiteVerificationOwner_siteVerificationRemoveObject(context),
+			},
+		},
+	})
+}
+
+func testAccSiteVerificationOwner_siteVerificationBucket(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+provider "google" {
+  alias                 = "scoped"
+  user_project_override = true
+  scopes = [
+    "https://www.googleapis.com/auth/siteverification",
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/userinfo.email",
+  ]
+}
+
+resource "google_service_account" "test-account1" {
+  account_id   = "%{account1}"
+  display_name = "Site Verification Testing Account One"
+}
+
+resource "google_service_account" "test-account2" {
+  account_id   = "%{account2}"
+  display_name = "Site Verification Testing Account Two"
+}
+
+resource "google_storage_bucket" "bucket" {
+  provider = google.scoped
+  name     = "%{bucket}"
+  location = "US"
+}
+
+data "google_site_verification_token" "token" {
+  provider            = google.scoped
+  type                = "SITE"
+  identifier          = "https://${google_storage_bucket.bucket.name}.storage.googleapis.com/"
+  verification_method = "FILE"
+}
+
+resource "google_storage_bucket_object" "object" {
+  provider = google.scoped
+  name     = "${data.google_site_verification_token.token.token}"
+  content  = "google-site-verification: ${data.google_site_verification_token.token.token}"
+  bucket   = google_storage_bucket.bucket.name
+}
+
+resource "google_storage_object_access_control" "public_rule" {
+  provider = google.scoped
+  bucket   = google_storage_bucket.bucket.name
+  object   = google_storage_bucket_object.object.name
+  role     = "READER"
+  entity   = "allUsers"
+}
+
+resource "google_site_verification_web_resource" "example" {
+  provider = google.scoped
+  site {
+    type       = data.google_site_verification_token.token.type
+    identifier = data.google_site_verification_token.token.identifier
+  }
+  verification_method = data.google_site_verification_token.token.verification_method
+}
+
+resource "google_site_verification_owner" "example1" {
+  provider        = google.scoped
+  web_resource_id = google_site_verification_web_resource.example.id
+  email           = "${google_service_account.test-account1.email}"
+}
+`, context)
+}
+
+func testAccSiteVerificationOwner_siteVerificationBucketSecondOwner(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+provider "google" {
+  alias                 = "scoped"
+  user_project_override = true
+  scopes = [
+    "https://www.googleapis.com/auth/siteverification",
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/userinfo.email",
+  ]
+}
+
+resource "google_service_account" "test-account1" {
+  account_id   = "%{account1}"
+  display_name = "Site Verification Testing Account One"
+}
+
+resource "google_service_account" "test-account2" {
+  account_id   = "%{account2}"
+  display_name = "Site Verification Testing Account Two"
+}
+
+resource "google_storage_bucket" "bucket" {
+  provider = google.scoped
+  name     = "%{bucket}"
+  location = "US"
+}
+
+data "google_site_verification_token" "token" {
+  provider            = google.scoped
+  type                = "SITE"
+  identifier          = "https://${google_storage_bucket.bucket.name}.storage.googleapis.com/"
+  verification_method = "FILE"
+}
+
+resource "google_storage_bucket_object" "object" {
+  provider = google.scoped
+  name     = "${data.google_site_verification_token.token.token}"
+  content  = "google-site-verification: ${data.google_site_verification_token.token.token}"
+  bucket   = google_storage_bucket.bucket.name
+}
+
+resource "google_storage_object_access_control" "public_rule" {
+  provider = google.scoped
+  bucket   = google_storage_bucket.bucket.name
+  object   = google_storage_bucket_object.object.name
+  role     = "READER"
+  entity   = "allUsers"
+}
+
+resource "google_site_verification_web_resource" "example" {
+  provider = google.scoped
+  site {
+    type       = data.google_site_verification_token.token.type
+    identifier = data.google_site_verification_token.token.identifier
+  }
+  verification_method = data.google_site_verification_token.token.verification_method
+}
+
+resource "google_site_verification_owner" "example1" {
+  provider        = google.scoped
+  web_resource_id = google_site_verification_web_resource.example.id
+  email           = "${google_service_account.test-account1.email}"
+}
+
+resource "google_site_verification_owner" "example2" {
+  provider        = google.scoped
+  web_resource_id = google_site_verification_web_resource.example.id
+  email           = "${google_service_account.test-account2.email}"
+}
+`, context)
+}
+
+func testAccSiteVerificationOwner_siteVerificationBucketRemoveOwners(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+provider "google" {
+  alias                 = "scoped"
+  user_project_override = true
+  scopes = [
+    "https://www.googleapis.com/auth/siteverification",
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/userinfo.email",
+  ]
+}
+
+resource "google_storage_bucket" "bucket" {
+  provider = google.scoped
+  name     = "%{bucket}"
+  location = "US"
+}
+
+data "google_site_verification_token" "token" {
+  provider            = google.scoped
+  type                = "SITE"
+  identifier          = "https://${google_storage_bucket.bucket.name}.storage.googleapis.com/"
+  verification_method = "FILE"
+}
+
+resource "google_storage_bucket_object" "object" {
+  provider = google.scoped
+  name     = "${data.google_site_verification_token.token.token}"
+  content  = "google-site-verification: ${data.google_site_verification_token.token.token}"
+  bucket   = google_storage_bucket.bucket.name
+}
+
+resource "google_storage_object_access_control" "public_rule" {
+  provider = google.scoped
+  bucket   = google_storage_bucket.bucket.name
+  object   = google_storage_bucket_object.object.name
+  role     = "READER"
+  entity   = "allUsers"
+}
+
+resource "google_site_verification_web_resource" "example" {
+  provider = google.scoped
+  site {
+    type       = data.google_site_verification_token.token.type
+    identifier = data.google_site_verification_token.token.identifier
+  }
+  verification_method = data.google_site_verification_token.token.verification_method
+}
+`, context)
+}
+
+func testAccSiteVerificationOwner_siteVerificationRemoveObject(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+provider "google" {
+  alias                 = "scoped"
+  user_project_override = true
+  scopes = [
+    "https://www.googleapis.com/auth/siteverification",
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/userinfo.email",
+  ]
+}
+
+resource "google_storage_bucket" "bucket" {
+  provider = google.scoped
+  name     = "%{bucket}"
+  location = "US"
+}
+
+data "google_site_verification_token" "token" {
+  provider            = google.scoped
+  type                = "SITE"
+  identifier          = "https://${google_storage_bucket.bucket.name}.storage.googleapis.com/"
+  verification_method = "FILE"
+}
+
+resource "google_site_verification_web_resource" "example" {
+  provider = google.scoped
+  site {
+    type       = data.google_site_verification_token.token.type
+    identifier = data.google_site_verification_token.token.identifier
+  }
+  verification_method = data.google_site_verification_token.token.verification_method
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/website/docs/r/site_verification_owner.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/site_verification_owner.html.markdown
@@ -1,0 +1,137 @@
+subcategory: "Site Verification"
+description: |-
+  Manages additional owners on verified web resources.
+---
+
+# google_site_verification_owner
+
+An owner is an additional user that may manage a verified web site in the
+[Google Search Console](https://www.google.com/webmasters/tools/). There
+are two types of web resource owners:
+
+* Verified owners, which are added to a web resource automatically when it
+    is created (i.e., when the resource is verified). A verified owner is
+    determined by the identity of the user requesting verification.
+* Additional owners, which can be added to the resource by verified owners.
+
+`google_site_verification_owner` creates additional owners. If your web site
+was verified using the
+[`google_site_verification_web_resource`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_site_verification_web_resource)
+resource then you (or the identity was used to create the resource, such as a
+service account) are already an owner.
+
+~> **Note:** The email address of the owner must belong to a Google account,
+such as a Gmail account, a Google Workspace account, or a GCP service account.
+
+Working with site verification requires the `https://www.googleapis.com/auth/siteverification`
+authentication scope. See the
+[Google Provider authentication documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#authentication)
+to learn how to configure additional scopes.
+
+To get more information about site owners, see:
+
+* [API documentation](https://developers.google.com/site-verification/v1)
+* How-to Guides
+    * [Getting Started](https://developers.google.com/site-verification/v1/getting_started)
+
+## Example Usage - Site Verification Storage Bucket
+
+This example uses the `FILE` verification method to verify ownership of web site hosted
+in a Google Cloud Storage bucket. Ownership is proved by creating a file with a Google-provided
+value in a known location. The user applying this configuration will automatically be
+added as a verified owner, and the `google_site_verification_owner` resource will add
+`user@example.com` as an additional owner.
+
+```hcl
+resource "google_storage_bucket" "bucket" {
+  name     = "example-storage-bucket"
+  location = "US"
+}
+
+data "google_site_verification_token" "token" {
+  type                = "SITE"
+  identifier          = "https://${google_storage_bucket.bucket.name}.storage.googleapis.com/"
+  verification_method = "FILE"
+}
+
+resource "google_storage_bucket_object" "object" {
+  name     = "${data.google_site_verification_token.token.token}"
+  content  = "google-site-verification: ${data.google_site_verification_token.token.token}"
+  bucket   = google_storage_bucket.bucket.name
+}
+
+resource "google_storage_object_access_control" "public_rule" {
+  bucket   = google_storage_bucket.bucket.name
+  object   = google_storage_bucket_object.object.name
+  role     = "READER"
+  entity   = "allUsers"
+}
+
+resource "google_site_verification_web_resource" "example" {
+  site {
+    type       = data.google_site_verification_token.token.type
+    identifier = data.google_site_verification_token.token.identifier
+  }
+  verification_method = data.google_site_verification_token.token.verification_method
+}
+
+resource "google_site_verification_owner" "example" {
+  web_resource_id = google_site_verification_web_resource.example.id
+  email           = "user@example.com"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+
+* `web_resource_id` -
+  (Required)
+  The id of of the web resource to which the owner will be added, in the form `webResource/<resource_id>`,
+  such as `webResource/https://www.example.com/`
+
+* `email` -
+  (Required)
+  The email of the user to be added as an owner.
+
+- - -
+
+
+## Timeouts
+
+This resource provides the following
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options:
+
+- `create` - Default is 20 minutes.
+- `delete` - Default is 20 minutes.
+
+## Import
+
+
+Owner can be imported using this format:
+
+* `webResource/{{web_resource_id}}/{{email}}`
+
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import a site owner using the format above. For example:
+
+```tf
+import {
+  id = "webResource/{{web_resource_id}}/{{email}}"
+  to = google_site_verification_web_resource.default
+}
+```
+
+When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), Site owners can be imported using the format above. For example:
+
+```
+$ terraform import google_site_verification_web_resource.default webResource/{{web_resource_id}}/{{email}}
+```
+
+~> **Note:** While verified owners can be successfully imported, attempting to later delete the imported resource will fail. The only way to remove
+verified owners is to delete the web resource itself.
+
+## User Project Overrides
+
+This resource supports [User Project Overrides](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#user_project_override).


### PR DESCRIPTION
This is the third and final (hopefully) PR implementing [issue 5698](https://github.com/hashicorp/terraform-provider-google/issues/5698). The first two were #10999 and #11624.

`google_site_verification_owner` is a fine grained resource on the `owners` field of `google_site_verification_web_resource`.  That field is a little funky: it's automatically populated with every user that has verified ownership and every user that verified owners have optionally added. What makes it particularly funky is that multiple users can independently verify ownership, for example:

1. `user_a@example.com` verifies `www.example.com`, the `owners` field will contain `["user_a@example.com"]`
2. Separately, `user_b@example.com` verifies `www.example.com`, the `owners` field now contains `["user_a@example.com", "user_b@example.com"]`
3. One of the previous verified owners adds `user_c@example.com` as an owner, the `owners` field now contains `["user_a@example.com", "user_b@example.com", "user_c@example.com"]`

Verified owners aren't explicitly configured either; they're implicitly added based on the authenticated identity of the user requesting verification.

There's more info about the resource in the included markdown doc.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_site_verification_owner`
```
