### PR TITLE
container: fix updates for `node_config.gcfs_config` and make optional

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -101,21 +101,22 @@ func schemaLoggingVariant() *schema.Schema {
 }
 
 func schemaGcfsConfig() *schema.Schema {
-        return &schema.Schema{
-                Type:     schema.TypeList,
-		Optional: true,
-		MaxItems: 1,
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		MaxItems:    1,
 		Description: `GCFS configuration for this node.`,
-		Elem: &schema.Resource{
+		Elem:        &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"enabled": {
 					Type:        schema.TypeBool,
-					Required:    true,
+					Optional:    true,
+					Computed:    true,
 					Description: `Whether or not GCFS is enabled`,
 				},
 			},
 		},
-        }
+	}
 }
 
 func schemaNodeConfig() *schema.Schema {

--- a/mmv1/third_party/terraform/services/container/node_config.go.erb
+++ b/mmv1/third_party/terraform/services/container/node_config.go.erb
@@ -104,14 +104,14 @@ func schemaGcfsConfig() *schema.Schema {
 	return &schema.Schema{
 		Type:        schema.TypeList,
 		Optional:    true,
+		Computed:    true,
 		MaxItems:    1,
 		Description: `GCFS configuration for this node.`,
 		Elem:        &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"enabled": {
 					Type:        schema.TypeBool,
-					Optional:    true,
-					Computed:    true,
+					Required:    true,
 					Description: `Whether or not GCFS is enabled`,
 				},
 			},

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -3883,6 +3883,55 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 				log.Printf("[INFO] GKE cluster %s: default-pool setting for insecure_kubelet_readonly_port_enabled updated to %s", d.Id(), it)
       }
 		}
+
+		if d.HasChange("node_config.0.gcfs_config") {
+
+			defaultPool := "default-pool"
+
+			timeout := d.Timeout(schema.TimeoutCreate)
+
+			nodePoolInfo, err := extractNodePoolInformationFromCluster(d, config, clusterName)
+			if err != nil {
+				return err
+			}
+
+			// Acquire write-lock on nodepool.
+			npLockKey := nodePoolInfo.nodePoolLockKey(defaultPool)
+
+			gcfsEnabled := d.Get("node_config.0.gcfs_config.0.enabled").(bool)
+
+			// While we're getting the value from the drepcated field in
+			// node_config.kubelet_config, the actual setting that needs to be updated
+			// is on the default nodepool.
+			req := &container.UpdateNodePoolRequest{
+				Name: defaultPool,
+				GcfsConfig: &container.GcfsConfig{
+					Enabled: gcfsEnabled,
+				},
+			}
+
+			updateF := func() error {
+				clusterNodePoolsUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.NodePools.Update(nodePoolInfo.fullyQualifiedName(defaultPool), req)
+				if config.UserProjectOverride {
+					clusterNodePoolsUpdateCall.Header().Add("X-Goog-User-Project", nodePoolInfo.project)
+				}
+				op, err := clusterNodePoolsUpdateCall.Do()
+				if err != nil {
+					return err
+				}
+
+				// Wait until it's updated
+				return ContainerOperationWait(config, op, nodePoolInfo.project, nodePoolInfo.location,
+					"updating GKE node pool gcfs_config", userAgent, timeout)
+			}
+
+			if err := retryWhileIncompatibleOperation(timeout, npLockKey, updateF); err != nil {
+				return err
+			}
+
+			log.Printf("[INFO] GKE cluster %s: %s setting for gcfs_config updated to %t", d.Id(), defaultPool, gcfsEnabled)
+		}
+
 	}
 
 	if d.HasChange("notification_config") {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -1536,6 +1536,49 @@ func TestAccContainerCluster_withNodeConfig(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_withNodeConfigGcfsConfig(t *testing.T) {
+	t.Parallel()
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withNodeConfigGcfsConfig(clusterName, networkName, subnetworkName, false),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						acctest.ExpectNoDelete(),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_container_cluster.with_node_config_gcfs_config",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_withNodeConfigGcfsConfig(clusterName, networkName, subnetworkName, true),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						acctest.ExpectNoDelete(),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_container_cluster.with_node_config_gcfs_config",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
 // Note: Updates for these are currently known to be broken (b/361634104), and
 // so are not tested here.
 // They can probably be made similar to, or consolidated with,
@@ -6691,6 +6734,26 @@ resource "google_container_cluster" "with_node_config" {
   subnetwork    = "%s"
 }
 `, clusterName, networkName, subnetworkName)
+}
+
+func testAccContainerCluster_withNodeConfigGcfsConfig(clusterName, networkName, subnetworkName string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_node_config_gcfs_config" {
+  name               = "%s"
+  location           = "us-central1-f"
+  initial_node_count = 1
+
+  node_config {
+    gcfs_config {
+      enabled = %t
+    }
+  }
+
+  deletion_protection = false
+  network             = "%s"
+  subnetwork          = "%s"
+}
+`, clusterName, enabled, networkName, subnetworkName)
 }
 
 func testAccContainerCluster_withNodeConfigKubeletConfigSettings(clusterName, networkName, subnetworkName string) string {

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.erb
@@ -1787,6 +1787,39 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 			log.Printf("[INFO] Updated workload_metadata_config for node pool %s", name)
 		}
 
+		if d.HasChange(prefix + "node_config.0.gcfs_config") {
+			gcfsEnabled := bool(d.Get(prefix + "node_config.0.gcfs_config.0.enabled").(bool))
+			req := &container.UpdateNodePoolRequest{
+				NodePoolId: name,
+				GcfsConfig: &container.GcfsConfig{
+					Enabled: gcfsEnabled,
+				},
+			}
+			updateF := func() error {
+				clusterNodePoolsUpdateCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.NodePools.Update(nodePoolInfo.fullyQualifiedName(name),req)
+				if config.UserProjectOverride {
+					clusterNodePoolsUpdateCall.Header().Add("X-Goog-User-Project", nodePoolInfo.project)
+				}
+				op, err := clusterNodePoolsUpdateCall.Do()
+				if err != nil {
+					return err
+				}
+
+				// Wait until it's updated
+				return ContainerOperationWait(config, op,
+					nodePoolInfo.project,
+					nodePoolInfo.location,
+					"updating GKE node pool gcfs_config", userAgent,
+					timeout)
+			}
+
+			if err := retryWhileIncompatibleOperation(timeout, npLockKey, updateF); err != nil {
+					return err
+			}
+
+			log.Printf("[INFO] Updated gcfs_config for node pool %s", name)
+		}
+
 		if d.HasChange(prefix + "node_config.0.kubelet_config") {
 			req := &container.UpdateNodePoolRequest{
 				NodePoolId: name,

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.erb
@@ -1675,9 +1675,9 @@ resource "google_container_node_pool" "np" {
   node_config {
     machine_type = "n1-standard-8"
     image_type = "COS_CONTAINERD"
-	gcfs_config {
-  		enabled = true
-	}
+    gcfs_config {
+      enabled = true
+    }
     secondary_boot_disks {
       disk_image = ""
       mode = "CONTAINER_IMAGE_CACHE"
@@ -1694,9 +1694,9 @@ resource "google_container_node_pool" "np-no-mode" {
   node_config {
     machine_type = "n1-standard-8"
     image_type = "COS_CONTAINERD"
-	gcfs_config {
-  		enabled = true
-	}
+    gcfs_config {
+      enabled = true
+    }
     secondary_boot_disks {
       disk_image = ""
     }
@@ -1720,10 +1720,14 @@ func TestAccContainerNodePool_gcfsConfig(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccContainerNodePool_gcfsConfig(cluster, np, networkName, subnetworkName, true),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("google_container_node_pool.np",
-						"node_config.0.gcfs_config.0.enabled", "true"),
-				),
+			},
+			{
+				ResourceName:            "google_container_node_pool.np",
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
+			{
+				Config: testAccContainerNodePool_gcfsConfig(cluster, np, networkName, subnetworkName, false),
 			},
 			{
 				ResourceName:            "google_container_node_pool.np",

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1038,7 +1038,7 @@ sole_tenant_config {
 
 <a name="nested_gcfs_config"></a>The `gcfs_config` block supports:
 
-* `enabled` (Optional) - Whether or not the Google Container Filesystem (GCFS) is enabled
+* `enabled` (Required) - Whether or not the Google Container Filesystem (GCFS) is enabled
 
 <a name="nested_gvnic"></a>The `gvnic` block supports:
 

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1038,7 +1038,7 @@ sole_tenant_config {
 
 <a name="nested_gcfs_config"></a>The `gcfs_config` block supports:
 
-* `enabled` (Required) - Whether or not the Google Container Filesystem (GCFS) is enabled
+* `enabled` (Optional) - Whether or not the Google Container Filesystem (GCFS) is enabled
 
 <a name="nested_gvnic"></a>The `gvnic` block supports:
 


### PR DESCRIPTION
Recent changes introduced a couple of issues with `node_config.gcfs_config`:
* Perrmadiff when the cluster was created with an older version of the provider (and in the case of older provider versions, force replacement of the nodepool) because of the attribute being required and not computed. 
* Lack of support for updating the field in place once initially set. While having force replacement of the node pool as existed before #11553 was one way to accomplish this, that fix didn't include the bits to update the node pool in place.

- Handle updates properly for `node_config.gcfs_config`
- Make `node_config.gcfs_config` optional and computed
- Add tests to make sure we test the case where it's defined in `google_container_cluster.node_config`, as well as testing updates for both that and the `google_container_node_pool` resource.
- Some minor fixes to spacing / formatting (to fix incorrect hard / soft tabs)

Fixes https://github.com/hashicorp/terraform-provider-google/issues/19482
Follow up to #11553

Possible fix for https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/2100

Let me know if there are potential negative effects from having the only item in the block be optional and computed. I have tested creating a cluster with an empty `node_config.gcfs_config` block, as well as later enabling it from that state, so I don't think having it be optional and the only item within that nested block will be an issue.

Might need to do a custom expand function or some more complicated code for the update case if more elements are added to the subblock, but this seems to work in my testing.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: fixed the in-place update for `node_config.gcfs_config` in `google_container_cluster` and `google_container_node_pool`
```
```release-note:bug
container: fixed a permadiff on `node_config.gcfs_config` in `google_container_cluster` and `google_container_node_pool`
```