### PR TITLE
Add support for regional secret datasource `google_secret_manager_regional_secret`

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
@@ -180,6 +180,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_runtimeconfig_config":                      runtimeconfig.DataSourceGoogleRuntimeconfigConfig(),
 	"google_runtimeconfig_variable":                    runtimeconfig.DataSourceGoogleRuntimeconfigVariable(),
 	<% end -%>
+	"google_secret_manager_regional_secret":            secretmanagerregional.DataSourceSecretManagerRegionalRegionalSecret(),
 	"google_secret_manager_secret":                     secretmanager.DataSourceSecretManagerSecret(),
 	"google_secret_manager_secrets":                    secretmanager.DataSourceSecretManagerSecrets(),
 	"google_secret_manager_secret_version":             secretmanager.DataSourceSecretManagerSecretVersion(),

--- a/mmv1/third_party/terraform/services/secretmanagerregional/data_source_secret_manager_regional_secret.go
+++ b/mmv1/third_party/terraform/services/secretmanagerregional/data_source_secret_manager_regional_secret.go
@@ -1,0 +1,47 @@
+package secretmanagerregional
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceSecretManagerRegionalRegionalSecret() *schema.Resource {
+
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceSecretManagerRegionalRegionalSecret().Schema)
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "secret_id")
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "location")
+	tpgresource.AddOptionalFieldsToSchema(dsSchema, "project")
+
+	return &schema.Resource{
+		Read:   dataSourceSecretManagerRegionalRegionalSecretRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceSecretManagerRegionalRegionalSecretRead(d *schema.ResourceData, meta interface{}) error {
+	id, err := tpgresource.ReplaceVars(d, meta.(*transport_tpg.Config), "projects/{{project}}/locations/{{location}}/secrets/{{secret_id}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+	err = resourceSecretManagerRegionalRegionalSecretRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if err := tpgresource.SetDataSourceLabels(d); err != nil {
+		return err
+	}
+
+	if err := tpgresource.SetDataSourceAnnotations(d); err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
+}

--- a/mmv1/third_party/terraform/services/secretmanagerregional/data_source_secret_manager_regional_secret_test.go
+++ b/mmv1/third_party/terraform/services/secretmanagerregional/data_source_secret_manager_regional_secret_test.go
@@ -11,7 +11,7 @@ func TestAccDataSourceSecretManagerRegionalRegionalSecret_basic(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"kms_key_name":  acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-secret-manager-managed-central-key5").CryptoKey.Name,
+		"kms_key_name":  acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-secret-manager-managed-central-key6").CryptoKey.Name,
 		"random_suffix": acctest.RandString(t, 10),
 		"timestamp_1":   "2114-11-30T00:00:00Z",
 		"timestamp_2":   "2115-11-30T00:00:00Z",

--- a/mmv1/third_party/terraform/services/secretmanagerregional/data_source_secret_manager_regional_secret_test.go
+++ b/mmv1/third_party/terraform/services/secretmanagerregional/data_source_secret_manager_regional_secret_test.go
@@ -1,0 +1,100 @@
+package secretmanagerregional_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccDataSourceSecretManagerRegionalRegionalSecret_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"kms_key_name":  acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-secret-manager-managed-central-key5").CryptoKey.Name,
+		"random_suffix": acctest.RandString(t, 10),
+		"timestamp_1":   "2114-11-30T00:00:00Z",
+		"timestamp_2":   "2115-11-30T00:00:00Z",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerRegionalRegionalSecretDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceSecretManagerRegionalRegionalSecret_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceState(
+						"data.google_secret_manager_regional_secret.reg-secret-datasource",
+						"google_secret_manager_regional_secret.reg-secret",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceSecretManagerRegionalRegionalSecret_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {}
+
+resource "google_pubsub_topic" "secret-topic" {
+  name = "tf-test-topic%{random_suffix}"
+}
+
+resource "google_pubsub_topic_iam_member" "secret_manager_topic_access" {
+  topic  = google_pubsub_topic.secret-topic.name
+  role   = "roles/pubsub.publisher"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+
+resource "google_kms_crypto_key_iam_member" "secret_manager_kms_access" {
+  crypto_key_id = "%{kms_key_name}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-secretmanager.iam.gserviceaccount.com"
+}
+
+resource "google_secret_manager_regional_secret" "reg-secret" {
+  secret_id = "tf-test-reg-secret-%{random_suffix}"
+  location = "us-central1"
+
+  labels = {
+    key1 = "val1"
+    key2 = "val2"
+    key3 = "val3"
+  }
+
+  annotations = {
+    annotationkey = "annotation-value"
+    otherannotation = "othervalue"
+  }
+
+  customer_managed_encryption {
+    kms_key_name = "%{kms_key_name}"
+  }
+
+  topics {
+    name = google_pubsub_topic.secret-topic.id
+  }
+
+  rotation {
+    rotation_period = "7200s"
+    next_rotation_time = "%{timestamp_1}"
+  }
+
+  expire_time = "%{timestamp_2}"
+  version_destroy_ttl = "108000s"
+
+  depends_on = [
+    google_pubsub_topic_iam_member.secret_manager_topic_access,
+    google_kms_crypto_key_iam_member.secret_manager_kms_access,
+  ]
+}
+
+data "google_secret_manager_regional_secret" "reg-secret-datasource" {
+  secret_id = google_secret_manager_regional_secret.reg-secret.secret_id
+  location = google_secret_manager_regional_secret.reg-secret.location
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/website/docs/d/secret_manager_regional_secret.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/secret_manager_regional_secret.html.markdown
@@ -1,0 +1,32 @@
+---
+subcategory: "Secret Manager"
+description: |-
+  Get information about a Secret Manager Regional Secret
+---
+
+# google_secret_manager_regional_secret
+
+Use this data source to get information about a Secret Manager Regional Secret
+
+## Example Usage 
+
+
+```hcl
+data "google_secret_manager_regional_secret" "secret_datasource" {
+  secret_id = "secretname"
+  location  = "us-central1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `secret_id` - (required) The name of the regional secret.
+
+* `location` - (required) The location of the regional secret. eg us-central1
+
+* `project` - (optional) The ID of the project in which the resource belongs.
+
+## Attributes Reference
+See [google_secret_manager_regional_secret](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_regional_secret) resource for details of all the available attributes.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add support for regional secret datasource `google_secret_manager_regional_secret`.
More info about regional secrets: https://cloud.google.com/secret-manager/docs/regional-secrets-overview

**Note:** We might need to change the reference of terraform registry provided for `google_secret_manager_regional_secret` resource in the Attributes Reference section in the `secret_manager_regional_secret.html.markdown` datasource doc as this link will be documented as a part of [this PR](https://github.com/GoogleCloudPlatform/magic-modules/pull/11678).

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
`google_secret_manager_regional_secret`
```
