### PR TITLE
Re-add SDK tests TestProvider_ProviderConfigure_region, TestProvider_ProviderConfigure_zone, remove unused config from acc tests too

### DIFF
--- a/mmv1/third_party/terraform/fwprovider/framework_provider_credentials_test.go
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider_credentials_test.go
@@ -248,11 +248,6 @@ provider "google" {
 }
 
 data "google_provider_config_plugin_framework" "default" {}
-
-output "credentials" {
-  value = data.google_provider_config_plugin_framework.default.credentials
-  sensitive = true
-}
 `, context)
 }
 
@@ -261,10 +256,5 @@ output "credentials" {
 func testAccFwProvider_credentialsInEnvsOnly(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_provider_config_plugin_framework" "default" {}
-
-output "credentials" {
-  value = data.google_provider_config_plugin_framework.default.credentials
-  sensitive = true
-}
 `, context)
 }

--- a/mmv1/third_party/terraform/fwprovider/framework_provider_region_zone_test.go
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider_region_zone_test.go
@@ -343,11 +343,6 @@ provider "google" {
 }
 
 data "google_provider_config_plugin_framework" "default" {}
-
-output "region" {
-  value = data.google_provider_config_plugin_framework.default.region
-  sensitive = true
-}
 `, context)
 }
 
@@ -356,11 +351,6 @@ output "region" {
 func testAccFwProvider_regionInEnvsOnly(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_provider_config_plugin_framework" "default" {}
-
-output "region" {
-  value = data.google_provider_config_plugin_framework.default.region
-  sensitive = true
-}
 `, context)
 }
 
@@ -373,11 +363,6 @@ provider "google" {
 }
 
 data "google_provider_config_plugin_framework" "default" {}
-
-output "zone" {
-  value = data.google_provider_config_plugin_framework.default.zone
-  sensitive = true
-}
 `, context)
 }
 
@@ -386,10 +371,5 @@ output "zone" {
 func testAccFwProvider_zoneInEnvsOnly(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_provider_config_plugin_framework" "default" {}
-
-output "zone" {
-  value = data.google_provider_config_plugin_framework.default.zone
-  sensitive = true
-}
 `, context)
 }

--- a/mmv1/third_party/terraform/provider/provider_credentials_test.go
+++ b/mmv1/third_party/terraform/provider/provider_credentials_test.go
@@ -247,11 +247,6 @@ provider "google" {
 }
 
 data "google_provider_config_sdk" "default" {}
-
-output "credentials" {
-  value = data.google_provider_config_sdk.default.credentials
-  sensitive = true
-}
 `, context)
 }
 
@@ -260,10 +255,5 @@ output "credentials" {
 func testAccSdkProvider_credentialsInEnvsOnly(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_provider_config_sdk" "default" {}
-
-output "credentials" {
-  value = data.google_provider_config_sdk.default.credentials
-  sensitive = true
-}
 `, context)
 }

--- a/mmv1/third_party/terraform/provider/provider_internal_test.go
+++ b/mmv1/third_party/terraform/provider/provider_internal_test.go
@@ -738,6 +738,284 @@ func TestProvider_ProviderConfigure_billingProject(t *testing.T) {
 	}
 }
 
+func TestProvider_ProviderConfigure_region(t *testing.T) {
+
+	cases := map[string]struct {
+		ConfigValues        map[string]interface{}
+		EnvVariables        map[string]string
+		ExpectedSchemaValue string
+		ExpectedConfigValue string
+		ExpectError         bool
+		ExpectFieldUnset    bool
+	}{
+		"region value set in the provider config is not overridden by ENVs": {
+			ConfigValues: map[string]interface{}{
+				"region":      "region-from-config",
+				"credentials": transport_tpg.TestFakeCredentialsPath,
+			},
+			EnvVariables: map[string]string{
+				"GOOGLE_REGION": "region-from-env",
+			},
+			ExpectedSchemaValue: "region-from-config",
+			ExpectedConfigValue: "region-from-config",
+		},
+		"region values can be supplied as a self link": {
+			ConfigValues: map[string]interface{}{
+				"region":      "https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1",
+				"credentials": transport_tpg.TestFakeCredentialsPath,
+			},
+			ExpectedSchemaValue: "https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1",
+			ExpectedConfigValue: "us-central1",
+		},
+		"region value can be set by environment variable: GOOGLE_REGION is used": {
+			ConfigValues: map[string]interface{}{
+				// region unset
+				"credentials": transport_tpg.TestFakeCredentialsPath,
+			},
+			EnvVariables: map[string]string{
+				"GOOGLE_REGION": "region-from-env",
+			},
+			ExpectedSchemaValue: "region-from-env",
+			ExpectedConfigValue: "region-from-env",
+		},
+		"when no region values are provided via config or environment variables, the field remains unset without error": {
+			ConfigValues: map[string]interface{}{
+				// region unset
+				"credentials": transport_tpg.TestFakeCredentialsPath,
+			},
+			ExpectError:         false,
+			ExpectFieldUnset:    true,
+			ExpectedSchemaValue: "",
+			ExpectedConfigValue: "",
+		},
+		// Handling empty strings in config
+		"when region is set as an empty string the field is treated as if it's unset, without error": {
+			ConfigValues: map[string]interface{}{
+				"region":      "",
+				"credentials": transport_tpg.TestFakeCredentialsPath,
+			},
+			ExpectFieldUnset:    true,
+			ExpectedSchemaValue: "",
+			ExpectedConfigValue: "",
+		},
+		"when region is set as an empty string an environment variable will be used": {
+			ConfigValues: map[string]interface{}{
+				"region":      "",
+				"credentials": transport_tpg.TestFakeCredentialsPath,
+			},
+			EnvVariables: map[string]string{
+				"GOOGLE_REGION": "region-from-env",
+			},
+			ExpectedSchemaValue: "region-from-env",
+			ExpectedConfigValue: "region-from-env",
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+
+			// Arrange
+			ctx := context.Background()
+			acctest.UnsetTestProviderConfigEnvs(t)
+			acctest.SetupTestEnvs(t, tc.EnvVariables)
+			p := provider.Provider()
+			d := tpgresource.SetupTestResourceDataFromConfigMap(t, p.Schema, tc.ConfigValues)
+
+			// Act
+			c, diags := provider.ProviderConfigure(ctx, d, p)
+
+			// Assert
+			if diags.HasError() && !tc.ExpectError {
+				t.Fatalf("unexpected error(s): %#v", diags)
+			}
+			if !diags.HasError() && tc.ExpectError {
+				t.Fatal("expected error(s) but got none")
+			}
+			if diags.HasError() && tc.ExpectError {
+				v, ok := d.GetOk("region")
+				if ok {
+					val := v.(string)
+					if val != tc.ExpectedSchemaValue {
+						t.Fatalf("expected region value set in provider config data to be %s, got %s", tc.ExpectedSchemaValue, val)
+					}
+					if tc.ExpectFieldUnset {
+						t.Fatalf("expected region value to not be set in provider config data, got %s", val)
+					}
+				}
+				// Return early in tests where errors expected
+				return
+			}
+
+			config := c.(*transport_tpg.Config) // Should be non-nil value, as test cases reaching this point experienced no errors
+
+			v, ok := d.GetOk("region")
+			val := v.(string)
+			if ok && tc.ExpectFieldUnset {
+				t.Fatal("expected region value to be unset in provider config data")
+			}
+			if val != tc.ExpectedSchemaValue {
+				t.Fatalf("expected region value set in provider config data to be %s, got %s", tc.ExpectedSchemaValue, val)
+			}
+			if config.Region != tc.ExpectedConfigValue {
+				t.Fatalf("expected region value set in Config struct to be to be %s, got %s", tc.ExpectedConfigValue, config.Region)
+			}
+		})
+	}
+}
+
+func TestProvider_ProviderConfigure_zone(t *testing.T) {
+
+	cases := map[string]struct {
+		ConfigValues        map[string]interface{}
+		EnvVariables        map[string]string
+		ExpectedSchemaValue string
+		ExpectedConfigValue string
+		ExpectError         bool
+		ExpectFieldUnset    bool
+	}{
+		"zone value set in the provider config is not overridden by ENVs": {
+			ConfigValues: map[string]interface{}{
+				"zone":        "zone-from-config",
+				"credentials": transport_tpg.TestFakeCredentialsPath,
+			},
+			EnvVariables: map[string]string{
+				"GOOGLE_ZONE": "zone-from-env",
+			},
+			ExpectedSchemaValue: "zone-from-config",
+			ExpectedConfigValue: "zone-from-config",
+		},
+		"does not shorten zone values when provided as a self link": {
+			ConfigValues: map[string]interface{}{
+				"zone":        "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1",
+				"credentials": transport_tpg.TestFakeCredentialsPath,
+			},
+			ExpectedSchemaValue: "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1",
+			ExpectedConfigValue: "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1", // Value is not shortened from URI to name
+		},
+		"when multiple zone environment variables are provided, `GOOGLE_ZONE` is used first": {
+			ConfigValues: map[string]interface{}{
+				// zone unset,
+				"credentials": transport_tpg.TestFakeCredentialsPath,
+			},
+			EnvVariables: map[string]string{
+				"GOOGLE_ZONE":           "zone-from-GOOGLE_ZONE",
+				"GCLOUD_ZONE":           "zone-from-GCLOUD_ZONE",
+				"CLOUDSDK_COMPUTE_ZONE": "zone-from-CLOUDSDK_COMPUTE_ZONE",
+			},
+			ExpectedSchemaValue: "zone-from-GOOGLE_ZONE",
+			ExpectedConfigValue: "zone-from-GOOGLE_ZONE",
+		},
+		"when multiple zone environment variables are provided, `GCLOUD_ZONE` is used second": {
+			ConfigValues: map[string]interface{}{
+				// zone unset,
+				"credentials": transport_tpg.TestFakeCredentialsPath,
+			},
+			EnvVariables: map[string]string{
+				// GOOGLE_ZONE unset
+				"GCLOUD_ZONE":           "zone-from-GCLOUD_ZONE",
+				"CLOUDSDK_COMPUTE_ZONE": "zone-from-CLOUDSDK_COMPUTE_ZONE",
+			},
+			ExpectedSchemaValue: "zone-from-GCLOUD_ZONE",
+			ExpectedConfigValue: "zone-from-GCLOUD_ZONE",
+		},
+		"when multiple zone environment variables are provided, `CLOUDSDK_COMPUTE_ZONE` is used third": {
+			ConfigValues: map[string]interface{}{
+				// zone unset,
+				"credentials": transport_tpg.TestFakeCredentialsPath,
+			},
+			EnvVariables: map[string]string{
+				// GOOGLE_ZONE unset
+				// GCLOUD_ZONE unset
+				"CLOUDSDK_COMPUTE_ZONE": "zone-from-CLOUDSDK_COMPUTE_ZONE",
+			},
+			ExpectedSchemaValue: "zone-from-CLOUDSDK_COMPUTE_ZONE",
+			ExpectedConfigValue: "zone-from-CLOUDSDK_COMPUTE_ZONE",
+		},
+		"when no zone values are provided via config or environment variables, the field remains unset without error": {
+			ConfigValues: map[string]interface{}{
+				// zone unset
+				"credentials": transport_tpg.TestFakeCredentialsPath,
+			},
+			ExpectError:         false,
+			ExpectFieldUnset:    true,
+			ExpectedSchemaValue: "",
+			ExpectedConfigValue: "",
+		},
+		// Handling empty strings in config
+		"when zone is set as an empty string the field is treated as if it's unset, without error": {
+			ConfigValues: map[string]interface{}{
+				"zone":        "",
+				"credentials": transport_tpg.TestFakeCredentialsPath,
+			},
+			ExpectFieldUnset:    true,
+			ExpectedSchemaValue: "",
+			ExpectedConfigValue: "",
+		},
+		"when zone is set as an empty string an environment variable will be used": {
+			ConfigValues: map[string]interface{}{
+				"zone":        "",
+				"credentials": transport_tpg.TestFakeCredentialsPath,
+			},
+			EnvVariables: map[string]string{
+				"GOOGLE_ZONE": "zone-from-env",
+			},
+			ExpectedSchemaValue: "zone-from-env",
+			ExpectedConfigValue: "zone-from-env",
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+
+			// Arrange
+			ctx := context.Background()
+			acctest.UnsetTestProviderConfigEnvs(t)
+			acctest.SetupTestEnvs(t, tc.EnvVariables)
+			p := provider.Provider()
+			d := tpgresource.SetupTestResourceDataFromConfigMap(t, p.Schema, tc.ConfigValues)
+
+			// Act
+			c, diags := provider.ProviderConfigure(ctx, d, p)
+
+			// Assert
+			if diags.HasError() && !tc.ExpectError {
+				t.Fatalf("unexpected error(s): %#v", diags)
+			}
+			if !diags.HasError() && tc.ExpectError {
+				t.Fatal("expected error(s) but got none")
+			}
+			if diags.HasError() && tc.ExpectError {
+				v, ok := d.GetOk("zone")
+				if ok {
+					val := v.(string)
+					if val != tc.ExpectedSchemaValue {
+						t.Fatalf("expected zone value set in provider config data to be %s, got %s", tc.ExpectedSchemaValue, val)
+					}
+					if tc.ExpectFieldUnset {
+						t.Fatalf("expected zone value to not be set in provider config data, got %s", val)
+					}
+				}
+				// Return early in tests where errors expected
+				return
+			}
+
+			config := c.(*transport_tpg.Config) // Should be non-nil value, as test cases reaching this point experienced no errors
+
+			v, ok := d.GetOk("zone")
+			val := v.(string)
+			if ok && tc.ExpectFieldUnset {
+				t.Fatal("expected zone value to be unset in provider config data")
+			}
+			if val != tc.ExpectedSchemaValue {
+				t.Fatalf("expected zone value set in provider config data to be %s, got %s", tc.ExpectedSchemaValue, val)
+			}
+			if config.Zone != tc.ExpectedConfigValue {
+				t.Fatalf("expected zone value set in Config struct to be to be %s, got %s", tc.ExpectedConfigValue, config.Zone)
+			}
+		})
+	}
+}
+
 func TestProvider_ProviderConfigure_userProjectOverride(t *testing.T) {
 	cases := map[string]struct {
 		ConfigValues     map[string]interface{}

--- a/mmv1/third_party/terraform/provider/provider_region_zone_test.go
+++ b/mmv1/third_party/terraform/provider/provider_region_zone_test.go
@@ -355,11 +355,6 @@ provider "google" {
 }
 
 data "google_provider_config_sdk" "default" {}
-
-output "region" {
-  value = data.google_provider_config_sdk.default.region
-  sensitive = true
-}
 `, context)
 }
 
@@ -368,11 +363,6 @@ output "region" {
 func testAccSdkProvider_regionInEnvsOnly(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_provider_config_sdk" "default" {}
-
-output "region" {
-  value = data.google_provider_config_sdk.default.region
-  sensitive = true
-}
 `, context)
 }
 
@@ -385,11 +375,6 @@ provider "google" {
 }
 
 data "google_provider_config_sdk" "default" {}
-
-output "zone" {
-  value = data.google_provider_config_sdk.default.zone
-  sensitive = true
-}
 `, context)
 }
 
@@ -398,10 +383,5 @@ output "zone" {
 func testAccSdkProvider_zoneInEnvsOnly(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_provider_config_sdk" "default" {}
-
-output "zone" {
-  value = data.google_provider_config_sdk.default.zone
-  sensitive = true
-}
 `, context)
 }


### PR DESCRIPTION
This PR re-adds a test removed in https://github.com/GoogleCloudPlatform/magic-modules/pull/11608

This is following feedback that the new acceptance tests shouldn't replace equivalent test cases in unit tests : https://github.com/GoogleCloudPlatform/magic-modules/pull/11607#issuecomment-2344385887

When I refactor how the plugin-framework is muxed some unit tests will break and will need to be deleted or fixed at that point


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
