### PR TITLE
Add datasource for google_compute_region_instance_group_manager

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
@@ -97,6 +97,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_compute_regions":                           compute.DataSourceGoogleComputeRegions(),
 	"google_compute_region_disk":                       compute.DataSourceGoogleComputeRegionDisk(),
 	"google_compute_region_instance_group":             compute.DataSourceGoogleComputeRegionInstanceGroup(),
+	"google_compute_region_instance_group_manager":     compute.DataSourceGoogleComputeRegionInstanceGroupManager(),
 	"google_compute_region_instance_template":          compute.DataSourceGoogleComputeRegionInstanceTemplate(),
 	"google_compute_region_network_endpoint_group":     compute.DataSourceGoogleComputeRegionNetworkEndpointGroup(),
 	"google_compute_region_ssl_certificate":            compute.DataSourceGoogleRegionComputeSslCertificate(),

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group_manager.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group_manager.go
@@ -22,7 +22,7 @@ func DataSourceGoogleComputeRegionInstanceGroupManager() *schema.Resource {
 
 func dataSourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
-	if selfLink, ok := d.GetOk("self_link"); ok {
+	if selfLink, ok := d.Get("self_link").(string); ok {
 		parsed, err := tpgresource.ParseRegionalInstanceGroupManagersFieldValue(selfLink.(string), d, config)
 		if err != nil {
 			return fmt.Errorf("InstanceGroup name, region or project could not be parsed from %s", selfLink)

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group_manager.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group_manager.go
@@ -37,7 +37,7 @@ func dataSourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, met
 			return fmt.Errorf("Error setting project: %s", err)
 		}
 		d.SetId(fmt.Sprintf("projects/%s/regions/%s/instanceGroupManagers/%s", parsed.Project, parsed.Region, parsed.Name))
-	} else if name, ok := d.Get("name").(string); ok {
+	} else if name, ok := d.Get("name").(string); ok && name != "" {
 		region, err := tpgresource.GetRegion(d, config)
 		if err != nil {
 			return err

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group_manager.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group_manager.go
@@ -23,7 +23,7 @@ func DataSourceGoogleComputeRegionInstanceGroupManager() *schema.Resource {
 func dataSourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
 	if selfLink, ok := d.Get("self_link").(string); ok {
-		parsed, err := tpgresource.ParseRegionalInstanceGroupManagersFieldValue(selfLink.(string), d, config)
+		parsed, err := tpgresource.ParseRegionalInstanceGroupManagersFieldValue(selfLink, d, config)
 		if err != nil {
 			return fmt.Errorf("InstanceGroup name, region or project could not be parsed from %s", selfLink)
 		}
@@ -37,7 +37,7 @@ func dataSourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, met
 			return fmt.Errorf("Error setting project: %s", err)
 		}
 		d.SetId(fmt.Sprintf("projects/%s/regions/%s/instanceGroupManagers/%s", parsed.Project, parsed.Region, parsed.Name))
-	} else if name, ok := d.GetOk("name"); ok {
+	} else if name, ok := d.Get("name").(string); ok {
 		region, err := tpgresource.GetRegion(d, config)
 		if err != nil {
 			return err
@@ -46,7 +46,7 @@ func dataSourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, met
 		if err != nil {
 			return err
 		}
-		d.SetId(fmt.Sprintf("projects/%s/regions/%s/instanceGroupManagers/%s", project, region, name.(string)))
+		d.SetId(fmt.Sprintf("projects/%s/regions/%s/instanceGroupManagers/%s", project, region, name))
 	} else {
 		return errors.New("Must provide either `self_link` or `region/name`")
 	}

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group_manager.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group_manager.go
@@ -1,0 +1,63 @@
+package compute
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceGoogleComputeRegionInstanceGroupManager() *schema.Resource {
+
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceComputeRegionInstanceGroupManager().Schema)
+	tpgresource.AddOptionalFieldsToSchema(dsSchema, "name", "self_link", "project", "region")
+
+	return &schema.Resource{
+		Read:   dataSourceComputeRegionInstanceGroupManagerRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	if selfLink, ok := d.GetOk("self_link"); ok {
+		parsed, err := tpgresource.ParseRegionalInstanceGroupManagersFieldValue(selfLink.(string), d, config)
+		if err != nil {
+			return fmt.Errorf("InstanceGroup name, region or project could not be parsed from %s", selfLink)
+		}
+		if err := d.Set("name", parsed.Name); err != nil {
+			return fmt.Errorf("Error setting name: %s", err)
+		}
+		if err := d.Set("region", parsed.Region); err != nil {
+			return fmt.Errorf("Error setting region: %s", err)
+		}
+		if err := d.Set("project", parsed.Project); err != nil {
+			return fmt.Errorf("Error setting project: %s", err)
+		}
+		d.SetId(fmt.Sprintf("projects/%s/regions/%s/instanceGroupManagers/%s", parsed.Project, parsed.Region, parsed.Name))
+	} else if name, ok := d.GetOk("name"); ok {
+		region, err := tpgresource.GetRegion(d, config)
+		if err != nil {
+			return err
+		}
+		project, err := tpgresource.GetProject(d, config)
+		if err != nil {
+			return err
+		}
+		d.SetId(fmt.Sprintf("projects/%s/regions/%s/instanceGroupManagers/%s", project, region, name.(string)))
+	} else {
+		return errors.New("Must provide either `self_link` or `region/name`")
+	}
+
+	err := resourceComputeRegionInstanceGroupManagerRead(d, meta)
+
+	if err != nil {
+		return err
+	}
+	if d.Id() == "" {
+		return errors.New("Regional Instance Manager Group not found")
+	}
+	return nil
+}

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group_manager.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group_manager.go
@@ -22,7 +22,7 @@ func DataSourceGoogleComputeRegionInstanceGroupManager() *schema.Resource {
 
 func dataSourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
-	if selfLink, ok := d.Get("self_link").(string); ok {
+	if selfLink, ok := d.Get("self_link").(string); ok && selfLink != "" {
 		parsed, err := tpgresource.ParseRegionalInstanceGroupManagersFieldValue(selfLink, d, config)
 		if err != nil {
 			return fmt.Errorf("InstanceGroup name, region or project could not be parsed from %s", selfLink)

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group_manager.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group_manager.go
@@ -25,7 +25,7 @@ func dataSourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, met
 	if selfLink, ok := d.Get("self_link").(string); ok && selfLink != "" {
 		parsed, err := tpgresource.ParseRegionalInstanceGroupManagersFieldValue(selfLink, d, config)
 		if err != nil {
-			return fmt.Errorf("InstanceGroup name, region or project could not be parsed from %s", selfLink)
+			return fmt.Errorf("InstanceGroup name, region or project could not be parsed from %s: %v", selfLink, err)
 		}
 		if err := d.Set("name", parsed.Name); err != nil {
 			return fmt.Errorf("Error setting name: %s", err)

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group_manager_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group_manager_test.go
@@ -1,0 +1,199 @@
+package compute_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccDataSourceGoogleComputeRegionInstanceGroupManager(t *testing.T) {
+	t.Parallel()
+
+	regionName := "us-central1"
+	igmName := "tf-test-igm" + acctest.RandString(t, 6)
+
+	context := map[string]interface{}{
+		"regionName":   regionName,
+		"igmName":      igmName,
+		"baseName":     "tf-test-igm-base" + acctest.RandString(t, 6),
+		"poolName":     "tf-test-pool" + acctest.RandString(t, 6),
+		"templateName": "tf-test-templt" + acctest.RandString(t, 6),
+		"autoHealName": "tf-test-ah-name" + acctest.RandString(t, 6),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleComputeRegionInstanceGroupManager_basic1(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_compute_region_instance_group_manager.data_source", "project", envvar.GetTestProjectFromEnv()),
+					resource.TestCheckResourceAttr("data.google_compute_region_instance_group_manager.data_source", "region", regionName),
+					resource.TestCheckResourceAttr("data.google_compute_region_instance_group_manager.data_source", "name", igmName)),
+			},
+			{
+				Config: testAccDataSourceGoogleComputeRegionInstanceGroupManager_basic2(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_compute_region_instance_group_manager.data_source", "project", envvar.GetTestProjectFromEnv()),
+					resource.TestCheckResourceAttr("data.google_compute_region_instance_group_manager.data_source", "region", regionName),
+					resource.TestCheckResourceAttr("data.google_compute_region_instance_group_manager.data_source", "name", igmName)),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleComputeRegionInstanceGroupManager_basic1(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+    resource "google_compute_health_check" "autohealing" {
+        name                = "%{autoHealName}"
+        check_interval_sec  = 5
+        timeout_sec         = 5
+        healthy_threshold   = 2
+        unhealthy_threshold = 10 # 50 seconds
+
+        http_health_check {
+          request_path = "/healthz"
+          port         = "8080"
+        }
+    }
+
+    resource "google_compute_region_instance_group_manager" "appserver" {
+        name = "%{igmName}"
+        base_instance_name = "%{baseName}"
+        region             = "us-central1"
+
+        version {
+          instance_template  = google_compute_instance_template.igm-basic.id
+          name = "primary"
+        }
+
+        target_pools = [google_compute_target_pool.igm-basic.id]
+        target_size  = 2
+
+        named_port {
+          name = "customhttp"
+          port = 8888
+        }
+
+        auto_healing_policies {
+          health_check      = google_compute_health_check.autohealing.id
+          initial_delay_sec = 300
+        }
+    }
+
+    data "google_compute_region_instance_group_manager" "data_source" {
+        self_link = google_compute_region_instance_group_manager.appserver.instance_group
+    }
+
+    resource "google_compute_target_pool" "igm-basic" {
+        description      = "Resource created for Terraform acceptance testing"
+        name             = "%{poolName}"
+        session_affinity = "CLIENT_IP_PROTO"
+    }
+
+    data "google_compute_image" "my_image" {
+        family  = "debian-11"
+        project = "debian-cloud"
+    }
+
+    resource "google_compute_instance_template" "igm-basic" {
+        name           = "%{templateName}"
+        machine_type   = "e2-medium"
+        can_ip_forward = false
+        tags           = ["foo", "bar"]
+
+        disk {
+            source_image = data.google_compute_image.my_image.self_link
+            auto_delete  = true
+            boot         = true
+        }
+
+        network_interface {
+            network = "default"
+        }
+
+        service_account {
+            scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+        }
+    }`, context)
+}
+
+func testAccDataSourceGoogleComputeRegionInstanceGroupManager_basic2(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+    resource "google_compute_health_check" "autohealing" {
+        name                = "%{autoHealName}"
+        check_interval_sec  = 5
+        timeout_sec         = 5
+        healthy_threshold   = 2
+        unhealthy_threshold = 10 # 50 seconds
+
+        http_health_check {
+          request_path = "/healthz"
+          port         = "8080"
+        }
+    }
+
+    resource "google_compute_region_instance_group_manager" "appserver" {
+        name = "%{igmName}"
+        base_instance_name = "%{baseName}"
+        region             = "us-central1"
+
+        version {
+          instance_template  = google_compute_instance_template.igm-basic.id
+          name = "primary"
+        }
+
+        target_pools = [google_compute_target_pool.igm-basic.id]
+        target_size  = 2
+
+        named_port {
+          name = "customhttp"
+          port = 8888
+        }
+
+        auto_healing_policies {
+          health_check      = google_compute_health_check.autohealing.id
+          initial_delay_sec = 300
+        }
+    }
+
+    data "google_compute_region_instance_group_manager" "data_source" {
+        name   = "%{igmName}"
+        region = "us-central1"
+    }
+
+    resource "google_compute_target_pool" "igm-basic" {
+        description      = "Resource created for Terraform acceptance testing"
+        name             = "%{poolName}"
+        session_affinity = "CLIENT_IP_PROTO"
+    }
+
+    data "google_compute_image" "my_image" {
+        family  = "debian-11"
+        project = "debian-cloud"
+    }
+
+    resource "google_compute_instance_template" "igm-basic" {
+        name           = "%{templateName}"
+        machine_type   = "e2-medium"
+        can_ip_forward = false
+        tags           = ["foo", "bar"]
+
+        disk {
+            source_image = data.google_compute_image.my_image.self_link
+            auto_delete  = true
+            boot         = true
+        }
+
+        network_interface {
+            network = "default"
+        }
+
+        service_account {
+            scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+        }
+    }`, context)
+}

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group_manager_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group_manager_test.go
@@ -45,7 +45,7 @@ func TestAccDataSourceGoogleComputeRegionInstanceGroupManager(t *testing.T) {
 	})
 }
 
-func testAccDataSourceGoogleComputeRegionInstanceGroupManager_basic1(context map[string]interface{}) string {
+func testAccDataSourceGoogleComputeRegionInstanceGroupManager_usingSelfLink(context map[string]interface{}) string {
 	return acctest.Nprintf(`
     resource "google_compute_health_check" "autohealing" {
         name                = "%{autoHealName}"
@@ -121,7 +121,7 @@ func testAccDataSourceGoogleComputeRegionInstanceGroupManager_basic1(context map
     }`, context)
 }
 
-func testAccDataSourceGoogleComputeRegionInstanceGroupManager_basic2(context map[string]interface{}) string {
+func testAccDataSourceGoogleComputeRegionInstanceGroupManager_usingNameAndRegion(context map[string]interface{}) string {
 	return acctest.Nprintf(`
     resource "google_compute_health_check" "autohealing" {
         name                = "%{autoHealName}"

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group_manager_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group_manager_test.go
@@ -28,14 +28,14 @@ func TestAccDataSourceGoogleComputeRegionInstanceGroupManager(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceGoogleComputeRegionInstanceGroupManager_basic1(context),
+				Config: testAccDataSourceGoogleComputeRegionInstanceGroupManager_usingSelfLink(context),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.google_compute_region_instance_group_manager.data_source", "project", envvar.GetTestProjectFromEnv()),
 					resource.TestCheckResourceAttr("data.google_compute_region_instance_group_manager.data_source", "region", regionName),
 					resource.TestCheckResourceAttr("data.google_compute_region_instance_group_manager.data_source", "name", igmName)),
 			},
 			{
-				Config: testAccDataSourceGoogleComputeRegionInstanceGroupManager_basic2(context),
+				Config: testAccDataSourceGoogleComputeRegionInstanceGroupManager_usingNameAndRegion(context),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.google_compute_region_instance_group_manager.data_source", "project", envvar.GetTestProjectFromEnv()),
 					resource.TestCheckResourceAttr("data.google_compute_region_instance_group_manager.data_source", "region", regionName),

--- a/mmv1/third_party/terraform/tpgresource/field_helpers.go
+++ b/mmv1/third_party/terraform/tpgresource/field_helpers.go
@@ -74,6 +74,9 @@ func ParseInstanceFieldValue(instance string, d TerraformResourceData, config *t
 func ParseInstanceGroupFieldValue(instanceGroup string, d TerraformResourceData, config *transport_tpg.Config) (*ZonalFieldValue, error) {
 	return ParseZonalFieldValue("instanceGroups", instanceGroup, "project", "zone", d, config, false)
 }
+func ParseRegionalInstanceGroupManagersFieldValue(instanceGroupManager string, d TerraformResourceData, config *transport_tpg.Config) (*RegionalFieldValue, error) {
+	return ParseRegionalFieldValue("instanceGroupManagers", instanceGroupManager, "project", "region", "zone", d, config, false)
+}
 
 func ParseInstanceTemplateFieldValue(instanceTemplate string, d TerraformResourceData, config *transport_tpg.Config) (*GlobalFieldValue, error) {
 	return ParseGlobalFieldValue("instanceTemplates", instanceTemplate, "project", d, config, false)

--- a/mmv1/third_party/terraform/website/docs/d/compute_region_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_region_instance_group_manager.html.markdown
@@ -13,7 +13,7 @@ and [API](https://cloud.google.com/compute/docs/reference/rest/v1/regionInstance
 ## Example Usage
 
 ```hcl
-data "google_compute_region_instance_group_manager" "igm1" {
+data "google_compute_region_instance_group_manager" "rigm" {
   name = "my-igm"
   region = "us-central1"
 }
@@ -23,11 +23,11 @@ data "google_compute_region_instance_group_manager" "igm1" {
 
 The following arguments are supported:
 
+* `self_link` - (Optional) The self link of the instance group. Either `name` or `self_link` must be provided.
+
 * `name` - (Optional) The name of the instance group. Either `name` or `self_link` must be provided.
 
 * `project` - (Optional) The ID of the project in which the resource belongs. If it is not provided, the provider project is used.
-
-* `self_link` - (Optional) The self link of the instance group. Either `name` or `self_link` must be provided.
 
 * `Region` - (Optional) The region where the managed instance group resides. If not provided, the provider region is used.
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_region_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_region_instance_group_manager.html.markdown
@@ -1,0 +1,38 @@
+subcategory: "Compute Engine"
+page_title: "Google: google_compute_region_instance_group_manager"
+description: |-
+Get a Compute Region Instance Group within GCE.
+---
+
+# google\_compute\_region\_instance\_group\_manager
+
+Get a Compute Region Instance Group Manager within GCE.
+For more information, see [the official documentation](https://cloud.google.com/compute/docs/instance-groups/distributing-instances-with-regional-instance-groups)
+and [API](https://cloud.google.com/compute/docs/reference/rest/v1/regionInstanceGroupManagers)
+
+## Example Usage
+
+```hcl
+data "google_compute_region_instance_group_manager" "igm1" {
+  name = "my-igm"
+  region = "us-central1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Optional) The name of the instance group. Either `name` or `self_link` must be provided.
+
+* `project` - (Optional) The ID of the project in which the resource belongs. If it is not provided, the provider project is used.
+
+* `self_link` - (Optional) The self link of the instance group. Either `name` or `self_link` must be provided.
+
+* `Region` - (Optional) The region where the managed instance group resides. If not provided, the provider region is used.
+
+---
+
+## Attributes Reference
+
+See [google_compute_region_instance_group_manager](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_instance_group_manager) resource for details of all the available attributes.


### PR DESCRIPTION
This PR creates a datasource for google_compute_region_instance_group_manager.
It's based on existing (zonal) google_compute_instance_group_manager datasource and historical https://github.com/GoogleCloudPlatform/magic-modules/pull/7061

fixes #13363

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
`google_compute_region_instance_group_manager`
```
