### PR TITLE
Metastore: add `deletion_protection`

### DIFF
--- a/mmv1/products/metastore/Service.yaml
+++ b/mmv1/products/metastore/Service.yaml
@@ -64,6 +64,18 @@ examples:
     vars:
       metastore_service_name: 'metastore-srv'
   - !ruby/object:Provider::Terraform::Examples
+    name: 'dataproc_metastore_service_deletion_protection'
+    primary_resource_name:
+      'fmt.Sprintf("tf-test-metastore-srv%s", context["random_suffix"])'
+    primary_resource_id: 'default'
+    vars:
+      metastore_service_name: 'metastore-srv'
+      deletion_protection: 'true'
+    test_vars_overrides:
+      deletion_protection: 'false'
+    oics_vars_overrides:
+      deletion_protection: 'false'
+  - !ruby/object:Provider::Terraform::Examples
     name: 'dataproc_metastore_service_cmek_test'
     skip_docs: true
     skip_vcr: true
@@ -313,6 +325,10 @@ properties:
         description: |
           A Cloud Storage URI of a folder, in the format gs://<bucket_name>/<path_inside_bucket>. A sub-folder <backup_folder> containing backup files will be stored below it.
         required: true
+  - !ruby/object:Api::Type::Boolean
+    name: 'deletionProtection'
+    description: |
+      Indicates if the dataproc metastore should be protected against accidental deletions.
   - !ruby/object:Api::Type::NestedObject
     name: 'maintenanceWindow'
     description: |

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_deletion_protection.tf.erb
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_deletion_protection.tf.erb
@@ -1,0 +1,21 @@
+resource "google_dataproc_metastore_service" "<%= ctx[:primary_resource_id] %>" {
+    service_id          = "<%= ctx[:vars]['metastore_service_name'] %>"
+    location            = "us-central1"
+    port                = 9080
+    tier                = "DEVELOPER"
+    deletion_protection = "<%= ctx[:vars]['deletion_protection'] %>"
+  
+    maintenance_window {
+      hour_of_day = 2
+      day_of_week = "SUNDAY"
+    }
+  
+    hive_metastore_config {
+      version = "2.3.6"
+    }
+  
+    labels = {
+      env = "test"
+    }
+  }
+  


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
metastore: added `deletion_protection` in `google_dataproc_metastore_service` resource
```
