### PR TITLE
Magician VCR: Move logBucket and cassetteBucket into Tester struct

### DIFF
--- a/.ci/magician/cmd/check_cassettes.go
+++ b/.ci/magician/cmd/check_cassettes.go
@@ -64,7 +64,7 @@ var checkCassettesCmd = &cobra.Command{
 
 		ctlr := source.NewController(env["GOPATH"], "modular-magician", githubToken, rnr)
 
-		vt, err := vcr.NewTester(env, rnr)
+		vt, err := vcr.NewTester(env, "vcr-check-cassettes", "ci-vcr-cassettes", rnr)
 		if err != nil {
 			return fmt.Errorf("error creating VCR tester: %w", err)
 		}
@@ -111,9 +111,8 @@ func execCheckCassettes(commit string, vt *vcr.Tester, ctlr *source.Controller) 
 		fmt.Println("Error running VCR: ", err)
 	}
 	if err := vt.UploadLogs(vcr.UploadLogsOptions{
-		LogBucket: "vcr-check-cassettes",
-		Mode:      vcr.Replaying,
-		Version:   provider.Beta,
+		Mode:    vcr.Replaying,
+		Version: provider.Beta,
 	}); err != nil {
 		return fmt.Errorf("error uploading logs: %w", err)
 	}

--- a/.ci/magician/cmd/test_terraform_vcr.go
+++ b/.ci/magician/cmd/test_terraform_vcr.go
@@ -120,7 +120,7 @@ var testTerraformVCRCmd = &cobra.Command{
 		}
 		ctlr := source.NewController(env["GOPATH"], "modular-magician", env["GITHUB_TOKEN_DOWNSTREAMS"], rnr)
 
-		vt, err := vcr.NewTester(env, rnr)
+		vt, err := vcr.NewTester(env, "ci-vcr-logs", "ci-vcr-cassettes", rnr)
 		if err != nil {
 			return fmt.Errorf("error creating VCR tester: %w", err)
 		}
@@ -196,11 +196,10 @@ func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, 
 	}
 
 	if err := vt.UploadLogs(vcr.UploadLogsOptions{
-		LogBucket: "ci-vcr-logs",
-		PRNumber:  prNumber,
-		BuildID:   buildID,
-		Mode:      vcr.Replaying,
-		Version:   provider.Beta,
+		PRNumber: prNumber,
+		BuildID:  buildID,
+		Mode:     vcr.Replaying,
+		Version:  provider.Beta,
 	}); err != nil {
 		return fmt.Errorf("error uploading replaying logs: %w", err)
 	}
@@ -262,17 +261,16 @@ func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, 
 			testState = "success"
 		}
 
-		if err := vt.UploadCassettes("ci-vcr-cassettes", prNumber, provider.Beta); err != nil {
+		if err := vt.UploadCassettes(prNumber, provider.Beta); err != nil {
 			return fmt.Errorf("error uploading cassettes: %w", err)
 		}
 
 		if err := vt.UploadLogs(vcr.UploadLogsOptions{
-			LogBucket: "ci-vcr-logs",
-			PRNumber:  prNumber,
-			BuildID:   buildID,
-			Parallel:  true,
-			Mode:      vcr.Recording,
-			Version:   provider.Beta,
+			PRNumber: prNumber,
+			BuildID:  buildID,
+			Parallel: true,
+			Mode:     vcr.Recording,
+			Version:  provider.Beta,
 		}); err != nil {
 			return fmt.Errorf("error uploading recording logs: %w", err)
 		}
@@ -297,7 +295,6 @@ func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, 
 			}
 
 			if err := vt.UploadLogs(vcr.UploadLogsOptions{
-				LogBucket:      "ci-vcr-logs",
 				PRNumber:       prNumber,
 				BuildID:        buildID,
 				Parallel:       true,

--- a/.ci/magician/cmd/vcr_cassette_update.go
+++ b/.ci/magician/cmd/vcr_cassette_update.go
@@ -90,7 +90,7 @@ var vcrCassetteUpdateCmd = &cobra.Command{
 		}
 		ctlr := source.NewController(env["GOPATH"], "hashicorp", env["GITHUB_TOKEN_CLASSIC"], rnr)
 
-		vt, err := vcr.NewTester(env, rnr)
+		vt, err := vcr.NewTester(env, "", "ci-vcr-cassettes", rnr)
 		if err != nil {
 			return fmt.Errorf("error creating VCR tester: %w", err)
 		}

--- a/.ci/magician/cmd/vcr_cassette_update_test.go
+++ b/.ci/magician/cmd/vcr_cassette_update_test.go
@@ -389,7 +389,7 @@ func TestExecVCRCassetteUpdate(t *testing.T) {
 			ctlr := source.NewController("gopath", "hashicorp", "token", rnr)
 			vt, err := vcr.NewTester(map[string]string{
 				"SA_KEY": "sa_key",
-			}, rnr)
+			}, "", "ci-vcr-cassettes", rnr)
 			if err != nil {
 				t.Fatalf("Failed to create new tester: %v", err)
 			}

--- a/.ci/magician/vcr/tester.go
+++ b/.ci/magician/vcr/tester.go
@@ -406,7 +406,6 @@ func (vt *Tester) getLogPath(mode Mode, version provider.Version) (string, error
 // UploadLogsOptions defines options for uploading logs.
 type UploadLogsOptions struct {
 	PRNumber       string
-	Head           string
 	BuildID        string
 	Parallel       bool
 	AfterRecording bool

--- a/.ci/magician/vcr/tester.go
+++ b/.ci/magician/vcr/tester.go
@@ -48,13 +48,15 @@ type logKey struct {
 }
 
 type Tester struct {
-	env           map[string]string           // shared environment variables for running tests
-	rnr           ExecRunner                  // for running commands and manipulating files
-	baseDir       string                      // the directory in which this tester was created
-	saKeyPath     string                      // where sa_key.json is relative to baseDir
-	cassettePaths map[provider.Version]string // where cassettes are relative to baseDir by version
-	logPaths      map[logKey]string           // where logs are relative to baseDir by version and mode
-	repoPaths     map[provider.Version]string // relative paths of already cloned repos by version
+	env            map[string]string           // shared environment variables for running tests
+	rnr            ExecRunner                  // for running commands and manipulating files
+	logBucket      string                      // GCS bucket name to store logs
+	cassetteBucket string                      // GCS bucket name to store cassettes
+	baseDir        string                      // the directory in which this tester was created
+	saKeyPath      string                      // where sa_key.json is relative to baseDir
+	cassettePaths  map[provider.Version]string // where cassettes are relative to baseDir by version
+	logPaths       map[logKey]string           // where logs are relative to baseDir by version and mode
+	repoPaths      map[provider.Version]string // relative paths of already cloned repos by version
 }
 
 const accTestParallelism = 32
@@ -67,19 +69,24 @@ var testResultsExpression = regexp.MustCompile(`(?m:^--- (PASS|FAIL|SKIP): (Test
 var testPanicExpression = regexp.MustCompile(`^panic: .*`)
 
 // Create a new tester in the current working directory and write the service account key file.
-func NewTester(env map[string]string, rnr ExecRunner) (*Tester, error) {
-	saKeyPath := "sa_key.json"
-	if err := rnr.WriteFile(saKeyPath, env["SA_KEY"]); err != nil {
-		return nil, err
+func NewTester(env map[string]string, logBucket, cassetteBucket string, rnr ExecRunner) (*Tester, error) {
+	var saKeyPath string
+	if saKeyVal, ok := env["SA_KEY"]; ok {
+		saKeyPath = "sa_key.json"
+		if err := rnr.WriteFile(saKeyPath, saKeyVal); err != nil {
+			return nil, err
+		}
 	}
 	return &Tester{
-		env:           env,
-		rnr:           rnr,
-		baseDir:       rnr.GetCWD(),
-		saKeyPath:     saKeyPath,
-		cassettePaths: make(map[provider.Version]string, provider.NumVersions),
-		logPaths:      make(map[logKey]string, provider.NumVersions*numModes),
-		repoPaths:     make(map[provider.Version]string, provider.NumVersions),
+		env:            env,
+		rnr:            rnr,
+		logBucket:      logBucket,
+		cassetteBucket: cassetteBucket,
+		baseDir:        rnr.GetCWD(),
+		saKeyPath:      saKeyPath,
+		cassettePaths:  make(map[provider.Version]string, provider.NumVersions),
+		logPaths:       make(map[logKey]string, provider.NumVersions*numModes),
+		repoPaths:      make(map[provider.Version]string, provider.NumVersions),
 	}, nil
 }
 
@@ -98,19 +105,19 @@ func (vt *Tester) FetchCassettes(version provider.Version, baseBranch, prNumber 
 	vt.rnr.Mkdir(cassettePath)
 	if baseBranch != "FEATURE-BRANCH-major-release-6.0.0" {
 		// pull main cassettes (major release uses branch specific casssettes as primary ones)
-		bucketPath := fmt.Sprintf("gs://ci-vcr-cassettes/%sfixtures/*", version.BucketPath())
+		bucketPath := fmt.Sprintf("gs://%s/%sfixtures/*", vt.cassetteBucket, version.BucketPath())
 		if err := vt.fetchBucketPath(bucketPath, cassettePath); err != nil {
 			fmt.Println("Error fetching cassettes: ", err)
 		}
 	}
 	if baseBranch != "main" {
-		bucketPath := fmt.Sprintf("gs://ci-vcr-cassettes/%srefs/branches/%s/fixtures/*", version.BucketPath(), baseBranch)
+		bucketPath := fmt.Sprintf("gs://%s/%srefs/branches/%s/fixtures/*", vt.cassetteBucket, version.BucketPath(), baseBranch)
 		if err := vt.fetchBucketPath(bucketPath, cassettePath); err != nil {
 			fmt.Println("Error fetching cassettes: ", err)
 		}
 	}
 	if prNumber != "" {
-		bucketPath := fmt.Sprintf("gs://ci-vcr-cassettes/%srefs/heads/auto-pr-%s/fixtures/*", version.BucketPath(), prNumber)
+		bucketPath := fmt.Sprintf("gs://%s/%srefs/heads/auto-pr-%s/fixtures/*", vt.cassetteBucket, version.BucketPath(), prNumber)
 		if err := vt.fetchBucketPath(bucketPath, cassettePath); err != nil {
 			fmt.Println("Error fetching cassettes: ", err)
 		}
@@ -398,8 +405,8 @@ func (vt *Tester) getLogPath(mode Mode, version provider.Version) (string, error
 
 // UploadLogsOptions defines options for uploading logs.
 type UploadLogsOptions struct {
-	LogBucket      string
 	PRNumber       string
+	Head           string
 	BuildID        string
 	Parallel       bool
 	AfterRecording bool
@@ -409,7 +416,7 @@ type UploadLogsOptions struct {
 
 // UploadLogs uploads logs to Google Cloud Storage.
 func (vt *Tester) UploadLogs(opts UploadLogsOptions) error {
-	bucketPath := fmt.Sprintf("gs://%s/%s/", opts.LogBucket, opts.Version)
+	bucketPath := fmt.Sprintf("gs://%s/%s/", vt.logBucket, opts.Version)
 	if opts.PRNumber != "" {
 		bucketPath += fmt.Sprintf("refs/heads/auto-pr-%s/", opts.PRNumber)
 	}
@@ -472,12 +479,18 @@ func (vt *Tester) UploadLogs(opts UploadLogsOptions) error {
 	return nil
 }
 
-func (vt *Tester) UploadCassettes(logBucket, prNumber string, version provider.Version) error {
+func (vt *Tester) UploadCassettes(prNumber string, version provider.Version) error {
 	cassettePath, ok := vt.cassettePaths[version]
 	if !ok {
 		return fmt.Errorf("no cassettes found for version %s", version)
 	}
-	args := []string{"-m", "-q", "cp", filepath.Join(cassettePath, "*"), fmt.Sprintf("gs://%s/%s/refs/heads/auto-pr-%s/fixtures/", logBucket, version, prNumber)}
+	args := []string{
+		"-m",
+		"-q",
+		"cp",
+		filepath.Join(cassettePath, "*"),
+		fmt.Sprintf("gs://%s/%s/refs/heads/auto-pr-%s/fixtures/", vt.cassetteBucket, version, prNumber),
+	}
 	fmt.Println("Uploading cassettes:\n", "gsutil", strings.Join(args, " "))
 	if _, err := vt.rnr.Run("gsutil", args, nil); err != nil {
 		fmt.Println("Error uploading cassettes: ", err)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This parameters shouldn't change between method calls, so I'm putting them in the constructor.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
