### PR TITLE
Add deletion_protection field to Redis Instance

### DIFF
--- a/mmv1/products/redis/Instance.yaml
+++ b/mmv1/products/redis/Instance.yaml
@@ -41,6 +41,7 @@ custom_code:
   constants: 'templates/terraform/constants/redis_instance.go.tmpl'
   encoder: 'templates/terraform/encoders/redis_location_id_for_fallback_zone.go.tmpl'
   decoder: 'templates/terraform/decoders/redis_instance.go.tmpl'
+  pre_delete: 'templates/terraform/pre_delete/redis_instance.go.tmpl'
 custom_diff:
   - 'customdiff.ForceNewIfChange("redis_version", isRedisVersionDecreasing)'
   - 'tpgresource.DefaultProviderProject'
@@ -55,6 +56,8 @@ examples:
       'prevent_destroy': 'false'
     oics_vars_overrides:
       'prevent_destroy': 'false'
+    ignore_read_extra:
+      - 'deletion_protection'
   - name: 'redis_instance_full'
     primary_resource_id: 'cache'
     vars:
@@ -124,6 +127,17 @@ examples:
     oics_vars_overrides:
       'prevent_destroy': 'false'
     exclude_test: true
+virtual_fields:
+  - name: 'deletion_protection'
+    description: |
+      Whether Terraform will be prevented from destroying the instance. Defaults to true.
+      When a`terraform destroy` or `terraform apply` would delete the instance,
+      the command will fail if this field is not set to false in Terraform state.
+      When the field is set to true or unset in Terraform state, a `terraform apply`
+      or `terraform destroy` that would delete the instance will fail.
+      When the field is set to false, deleting the instance is allowed.
+    type: Boolean
+    default_value: true
 parameters:
   # TODO: resourceref?
   - name: 'region'

--- a/mmv1/templates/terraform/examples/redis_instance_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/redis_instance_basic.tf.tmpl
@@ -1,6 +1,7 @@
 resource "google_redis_instance" "{{$.PrimaryResourceId}}" {
   name           = "{{index $.Vars "instance_name"}}"
   memory_size_gb = 1
+  deletion_protection = false
 
   lifecycle {
     prevent_destroy = {{index $.Vars "prevent_destroy"}}

--- a/mmv1/templates/terraform/pre_delete/redis_instance.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/redis_instance.go.tmpl
@@ -1,0 +1,3 @@
+if d.Get("deletion_protection").(bool) {
+    return fmt.Errorf("cannot destroy redis instance without setting deletion_protection=false and running `terraform apply`")
+}

--- a/mmv1/third_party/terraform/services/redis/resource_redis_instance_test.go
+++ b/mmv1/third_party/terraform/services/redis/resource_redis_instance_test.go
@@ -304,7 +304,7 @@ func TestAccRedisInstance_selfServiceUpdate(t *testing.T) {
 				ResourceName:            "google_redis_instance.cache",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"region", "deletion_protection"},
+				ImportStateVerifyIgnore: []string{"region"},
 			},
 			{
 				Config: testAccRedisInstance_selfServiceUpdate20240503_00_00(context),
@@ -313,7 +313,7 @@ func TestAccRedisInstance_selfServiceUpdate(t *testing.T) {
 				ResourceName:            "google_redis_instance.cache",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"region", "deletion_protection"},
+				ImportStateVerifyIgnore: []string{"region"},
 			},
 		},
 	})
@@ -393,7 +393,6 @@ func testAccRedisInstance_update2(name string, preventDestroy bool) string {
 resource "google_redis_instance" "test" {
   name           = "%s"
   display_name   = "post-update"
-  deletion_protection = true
   memory_size_gb = 1
 	%s
 
@@ -477,7 +476,6 @@ func testAccRedisInstance_selfServiceUpdate20240411_00_00(context map[string]int
 resource "google_redis_instance" "cache" {
   name           = "tf-test-memory-cache%{random_suffix}"
   memory_size_gb = 1
-  deletion_protection = true
   maintenance_version = "20240411_00_00"
 }
 `, context)
@@ -488,7 +486,6 @@ func testAccRedisInstance_selfServiceUpdate20240503_00_00(context map[string]int
 resource "google_redis_instance" "cache" {
   name           = "tf-test-memory-cache%{random_suffix}"
   memory_size_gb = 1
-  deletion_protection = true
   maintenance_version = "20240503_00_00"
 }
 `, context)

--- a/mmv1/third_party/terraform/services/redis/resource_redis_instance_test.go
+++ b/mmv1/third_party/terraform/services/redis/resource_redis_instance_test.go
@@ -64,8 +64,11 @@ func TestAccRedisInstance_deletionprotection(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"labels", "terraform_labels", "deletion_protection"},
 			},
 			{
-				Config:      testAccRedisInstance_deletionprotection2(name, "us-west2", true),
+				Config:      testAccRedisInstance_deletionprotection(name, "us-west2", true),
 				ExpectError: regexp.MustCompile("deletion_protection"),
+			},
+			{
+				Config: testAccRedisInstance_update(name, true),
 			},
 		},
 	})
@@ -359,7 +362,7 @@ resource "google_redis_instance" "test" {
   name           = "%s"
   display_name   = "pre-update"
   memory_size_gb = 1
-  deletion_protection = true
+  deletion_protection = false
 
   region         = "us-central1"
 	%s
@@ -435,37 +438,6 @@ resource "google_redis_instance" "test" {
     notify-keyspace-events = "KEA"
   }
   redis_version = "REDIS_4_0"
-}
-`, name, region, lifecycleBlock)
-}
-
-func testAccRedisInstance_deletionprotection2(name string, region string, preventDestroy bool) string {
-	lifecycleBlock := ""
-	if preventDestroy {
-		lifecycleBlock = `
-		lifecycle {
-			prevent_destroy = false
-		}`
-	}
-	return fmt.Sprintf(`
-resource "google_redis_instance" "test" {
-  name           = "%s"
-  region       = "%s"
-  deletion_protection = true
-  display_name   = "post-update"
-  memory_size_gb = 1
-	%s
-
-  labels = {
-    my_key    = "my_val"
-    other_key = "new_val"
-  }
-
-  redis_configs = {
-    maxmemory-policy       = "noeviction"
-    notify-keyspace-events = ""
-  }
-  redis_version = "REDIS_5_0"
 }
 `, name, region, lifecycleBlock)
 }


### PR DESCRIPTION
Add deletion_protection field to make deletion actions require an explicit intent
Part of b/367733375

Part of https://github.com/hashicorp/terraform-provider-google/issues/18854

**Release Note Template for Downstream PRs (will be copied)**
```

Redis: added `deletion_protection` field to `redis_instance` to make deleting them require an explicit intent. `redis_instance` resources now cannot be destroyed unless `deletion_protection = false` is set for the resource.
```