### PR TITLE
Fix: Interconnect fail_open field

### DIFF
--- a/mmv1/products/compute/Interconnect.yaml
+++ b/mmv1/products/compute/Interconnect.yaml
@@ -359,6 +359,17 @@ properties:
                 traffic if the MKA session cannot be established. By default, the Interconnect
                 connection is configured with a must-secure security policy that drops all traffic
                 if the MKA session cannot be established with your router.
+              deprecation_message: >-
+                `failOpen` is deprecated and will be removed in a future major release. Use
+                other `failOpen` instead.
+      - !ruby/object:Api::Type::Boolean
+        name: 'failOpen'
+        description: |
+          If set to true, the Interconnect connection is configured with a should-secure
+          MACsec security policy, that allows the Google router to fallback to cleartext
+          traffic if the MKA session cannot be established. By default, the Interconnect
+          connection is configured with a must-secure security policy that drops all traffic
+          if the MKA session cannot be established with your router.
   - !ruby/object:Api::Type::Boolean
     name: 'macsecEnabled'
     description: |

--- a/mmv1/third_party/terraform/services/compute/resource_compute_interconnect_macsec_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_interconnect_macsec_test.go
@@ -83,7 +83,7 @@ resource "google_compute_interconnect" "example-interconnect" {
       name = "test-key"
       start_time = "2023-07-01T21:00:01.000Z"
     }
-	fail_open = true
+    fail_open = true
   }
 }
 `, context)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_interconnect_macsec_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_interconnect_macsec_test.go
@@ -83,6 +83,7 @@ resource "google_compute_interconnect" "example-interconnect" {
       name = "test-key"
       start_time = "2023-07-01T21:00:01.000Z"
     }
+	fail_open = true
   }
 }
 `, context)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
b/367757958

The schema is wrong for fail open field. 
Moving it outside of the pre_shared_keys

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: added `macsec.fail_open` field to `google_compute_interconnect`
```

```release-note:deprecation
compute: deprecated `macsec.pre_shared_keys.fail_open` field in `google_compute_interconnect`. Use the new `macsec.fail_open` field instead
```
