### PR TITLE
container: add support for autopilot to set gcp_filestore_csi_driver_config in addons config

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.erb
@@ -363,8 +363,7 @@ func ResourceContainerCluster() *schema.Resource {
 							Computed:      true,
 							AtLeastOneOf:  addonsConfigKeys,
 							MaxItems:      1,
-							Description:   `The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes. Defaults to disabled; set enabled = true to enable.`,
-							ConflictsWith: []string{"enable_autopilot"},
+							Description:   `The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes. Defaults to disabled for Standard clusters; set enabled = true to enable. It is enabled by default for Autopilot clusters; set enabled = true to enable it explicitly.`,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"enabled": {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_migratev1.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_migratev1.go.erb
@@ -136,8 +136,7 @@ func resourceContainerClusterResourceV1() *schema.Resource {
 							Computed:      true,
 							AtLeastOneOf:  addonsConfigKeys,
 							MaxItems:      1,
-							Description:   `The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes. Defaults to disabled; set enabled = true to enable.`,
-							ConflictsWith: []string{"enable_autopilot"},
+							Description:   `The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes. Defaults to disabled for Standard clusters; set enabled = true to enable. It is enabled by default for Autopilot clusters; set enabled = true to enable it explicitly.`,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"enabled": {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.erb
@@ -11787,3 +11787,69 @@ func extractSPName(url string) (string, error) {
     }
 }
 
+func TestAccContainerCluster_withAutopilotGcpFilestoreCsiDriver(t *testing.T) {
+	t.Parallel()
+
+	randomSuffix := acctest.RandString(t, 10)
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randomSuffix)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withAutopilotGcpFilestoreCsiDriverDefault(clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.with_autopilot_gcp_filestore", "addons_config.0.gcp_filestore_csi_driver_config.0.enabled", "true"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_autopilot_gcp_filestore",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_withAutopilotGcpFilestoreCsiDriverUpdated(clusterName),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_autopilot_gcp_filestore",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{ "deletion_protection"},
+			},
+		},
+	})
+}
+
+func testAccContainerCluster_withAutopilotGcpFilestoreCsiDriverDefault(name string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_autopilot_gcp_filestore" {
+  name                = "%s"
+  location            = "us-central1"
+  enable_autopilot    = true
+  deletion_protection = false
+}
+`, name)
+}
+
+func testAccContainerCluster_withAutopilotGcpFilestoreCsiDriverUpdated(name string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_autopilot_gcp_filestore" {
+  name                = "%s"
+  location            = "us-central1"
+  enable_autopilot    = true
+  deletion_protection = false
+
+  addons_config {
+    gcp_filestore_csi_driver_config {
+      enabled = false
+    }
+  }
+}
+`, name)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add support for creating Autopilot Clusters with the `gcp_filestore_csi_driver_config` setting disabled, as supported by the API.
Explanation and API example on my [comment](https://github.com/hashicorp/terraform-provider-google/issues/17215#issuecomment-2355860874).

Fixes https://github.com/hashicorp/terraform-provider-google/issues/17215

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

It also sets the `gcp_filestore_csi_driver_config` to `disabled` as default same as creating a non Autopilot Cluster.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added support for manually setting `gcp_filestore_csi_driver_config` in the addons configuration in `google_container_cluster` for autopilot clusters.
```
