### PR TITLE
Add PlanCheck to update test creation

### DIFF
--- a/docs/content/develop/test/test.md
+++ b/docs/content/develop/test/test.md
@@ -178,6 +178,7 @@ An update test is a test that creates the target resource and then makes updates
    - Change the suffix of the test function to `_update`.
    - Copy the 2 `TestStep` blocks and paste them immediately after, so that there are 4 total test steps.
    - Change the suffix of the second `Config` value to `_update`.
+   - Add `ConfigPlanChecks` to the update step of the test to ensure the resource is updated in-place.
    - The resulting test function would look similar to this:
    ```go
    func TestAccPubsubTopic_update(t *testing.T) {
@@ -193,6 +194,11 @@ An update test is a test that creates the target resource and then makes updates
             },
             {
                Config: testAccPubsubTopic_update(...),
+               ConfigPlanChecks: resource.ConfigPlanChecks{
+                  PreApply: []plancheck.PlanCheck{
+                     plancheck.ExpectResourceAction("google_pubsub_topic.foo", plancheck.ResourceActionUpdate),
+                  },
+               },
             },
             {
                ...


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This additional step will ensure that new update tests always update the resource in-place rather than delete and recreate.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
