### PR TITLE
Add deletion_protection field to Memcache Instance

### DIFF
--- a/mmv1/products/memcache/Instance.yaml
+++ b/mmv1/products/memcache/Instance.yaml
@@ -43,7 +43,8 @@ async:
   error:
     path: 'error'
     message: 'message'
-custom_code:
+custom_code:!ruby/object:Provider::Terraform::CustomCode
+  pre_delete: 'templates/terraform/pre_delete/memcache_instance.go.erb'
 examples:
   - name: 'memcache_instance_basic'
     primary_resource_id: 'instance'

--- a/mmv1/products/memcache/Instance.yaml
+++ b/mmv1/products/memcache/Instance.yaml
@@ -51,6 +51,8 @@ examples:
       instance_name: 'test-instance'
       network_name: 'test-network'
       address_name: 'address'
+    ignore_read_extra:
+      - 'deletion_protection'
     exclude_test: true
   - name: 'memcache_instance_basic_test'
     primary_resource_id: 'instance'
@@ -61,6 +63,17 @@ examples:
     test_vars_overrides:
       'network_name': 'acctest.BootstrapSharedServiceNetworkingConnection(t, "vpc-network-1")'
     exclude_docs: true
+virtual_fields:
+  - name: 'deletion_protection'
+    description: |
+      Whether Terraform will be prevented from destroying the instance. Defaults to true.
+      When a`terraform destroy` or `terraform apply` would delete the instance,
+      the command will fail if this field is not set to false in Terraform state.
+      When the field is set to true or unset in Terraform state, a `terraform apply`
+      or `terraform destroy` that would delete the instance will fail.
+      When the field is set to false, deleting the instance is allowed.
+    type: Boolean
+    default_value: true
 parameters:
   - name: 'region'
     type: String

--- a/mmv1/templates/terraform/examples/memcache_instance_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/memcache_instance_basic.tf.tmpl
@@ -27,6 +27,7 @@ resource "google_service_networking_connection" "private_service_connection" {
 resource "google_memcache_instance" "{{$.PrimaryResourceId}}" {
   name = "{{index $.Vars "instance_name"}}"
   authorized_network = google_service_networking_connection.private_service_connection.network
+  deletion_protection = false
 
   labels = {
     env = "test"

--- a/mmv1/templates/terraform/pre_delete/memcache_instance.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/memcache_instance.go.tmpl
@@ -1,0 +1,3 @@
+if d.Get("deletion_protection").(bool) {
+  return fmt.Errorf("cannot destroy memcache instance without setting deletion_protection=false and running `terraform apply`")
+}

--- a/mmv1/third_party/terraform/services/memcache/resource_memcache_instance_test.go
+++ b/mmv1/third_party/terraform/services/memcache/resource_memcache_instance_test.go
@@ -3,9 +3,11 @@ package memcache_test
 import (
 	"fmt"
 	"testing"
+        "regexp"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestAccMemcacheInstance_update(t *testing.T) {
@@ -27,7 +29,7 @@ func TestAccMemcacheInstance_update(t *testing.T) {
 				ResourceName:            "google_memcache_instance.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"reserved_ip_range_id"},
+				ImportStateVerifyIgnore: []string{"reserved_ip_range_id", "deletion_protection"},
 			},
 			{
 				Config: testAccMemcacheInstance_update2(prefix, name, network),
@@ -47,6 +49,7 @@ resource "google_memcache_instance" "test" {
   name = "%s"
   region = "us-central1"
   authorized_network = data.google_compute_network.memcache_network.id
+  deletion_protection = true
 
   node_config {
     cpu_count      = 1
@@ -97,3 +100,66 @@ data "google_compute_network" "memcache_network" {
 }
 `, name, network)
 }
+
+func TestAccMemcacheInstance_deletionprotection(t *testing.T) {
+	t.Parallel()
+
+	prefix := fmt.Sprintf("%d", acctest.RandInt(t))
+	name := fmt.Sprintf("tf-test-%s", prefix)
+	network := acctest.BootstrapSharedServiceNetworkingConnection(t, "memcache-instance-update-1")
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckMemcacheInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMemcacheInstance_deletionprotection(prefix, name, network, "us-central1"),
+			},
+			{
+				ResourceName:            "google_memcache_instance.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"reserved_ip_range_id", "deletion_protection"},
+			},
+			{
+                                Config: testAccMemcacheInstance_deletionprotection(prefix, name, network, "us-west2"),
+                                ExpectError: regexp.MustCompile("deletion_protection"),
+                        },
+		},
+	})
+}
+
+func testAccMemcacheInstance_deletionprotection(prefix, name, network, region string) string {
+	return fmt.Sprintf(`
+ provider "google" {
+  project                 = "tags-partner-integ-test"
+  user_project_override   = true
+}
+resource "google_memcache_instance" "test" {
+  name = "%s"
+  region = "%s"
+  authorized_network = data.google_compute_network.memcache_network.id
+  deletion_protection = true
+
+  node_config {
+    cpu_count      = 1
+    memory_size_mb = 1024
+  }
+  node_count = 1
+
+  memcache_parameters {
+    params = {
+      "listen-backlog" = "2048"
+      "max-item-size" = "8388608"
+    }
+  }
+  reserved_ip_range_id = ["tf-bootstrap-addr-memcache-instance-update-1"]
+}
+
+data "google_compute_network" "memcache_network" {
+  name = "%s"
+}
+`, name, region, network)
+}
+

--- a/mmv1/third_party/terraform/services/memcache/resource_memcache_instance_test.go
+++ b/mmv1/third_party/terraform/services/memcache/resource_memcache_instance_test.go
@@ -49,7 +49,7 @@ resource "google_memcache_instance" "test" {
   name = "%s"
   region = "us-central1"
   authorized_network = data.google_compute_network.memcache_network.id
-  deletion_protection = true
+  deletion_protection = false
 
   node_config {
     cpu_count      = 1
@@ -126,6 +126,9 @@ func TestAccMemcacheInstance_deletionprotection(t *testing.T) {
                                 Config: testAccMemcacheInstance_deletionprotection(prefix, name, network, "us-west2"),
                                 ExpectError: regexp.MustCompile("deletion_protection"),
                         },
+			{
+				Config: testAccMemcacheInstance_update(prefix, name, network),
+			},
 		},
 	})
 }


### PR DESCRIPTION
Add deletion_protection field to make deletion actions require an explicit intent
Part of b/368232860

Part of https://github.com/hashicorp/terraform-provider-google/issues/18854

Release Note Template for Downstream PRs (will be copied)
```

Memcache: added `deletion_protection` field to `memcache_instance` to make deleting them require an explicit intent. `memcache_instance` resources now cannot be destroyed unless `deletion_protection = false` is set for the resource.
```