### PR TITLE
Add support for regional secret version access datasource `google_secret_manager_regional_secret_version_access`

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.erb
@@ -180,6 +180,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_runtimeconfig_config":                      runtimeconfig.DataSourceGoogleRuntimeconfigConfig(),
 	"google_runtimeconfig_variable":                    runtimeconfig.DataSourceGoogleRuntimeconfigVariable(),
 	<% end -%>
+	"google_secret_manager_regional_secret_version_access": secretmanagerregional.DataSourceSecretManagerRegionalRegionalSecretVersionAccess(),
 	"google_secret_manager_regional_secret_version":    secretmanagerregional.DataSourceSecretManagerRegionalRegionalSecretVersion(),
 	"google_secret_manager_regional_secret":            secretmanagerregional.DataSourceSecretManagerRegionalRegionalSecret(),
 	"google_secret_manager_secret":                     secretmanager.DataSourceSecretManagerSecret(),

--- a/mmv1/third_party/terraform/services/secretmanagerregional/data_source_secret_manager_regional_secret_version_access.go
+++ b/mmv1/third_party/terraform/services/secretmanagerregional/data_source_secret_manager_regional_secret_version_access.go
@@ -1,0 +1,149 @@
+package secretmanagerregional
+
+import (
+	"encoding/base64"
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func DataSourceSecretManagerRegionalRegionalSecretVersionAccess() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceSecretManagerRegionalRegionalSecretVersionAccessRead,
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"location": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"secret": {
+				Type:             schema.TypeString,
+				Required:         true,
+				DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"secret_data": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+func dataSourceSecretManagerRegionalRegionalSecretVersionAccessRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	secretRegex := regexp.MustCompile("projects/(.+)/locations/(.+)/secrets/(.+)$")
+	parts := secretRegex.FindStringSubmatch(d.Get("secret").(string))
+
+	var project string
+
+	// if reference of the secret is provided in the secret field
+	if len(parts) == 4 {
+		// Stores value of project to set in state
+		project = parts[1]
+		if d.Get("project").(string) != "" && d.Get("project").(string) != parts[1] {
+			return fmt.Errorf("The project set on this secret version (%s) is not equal to the project where this secret exists (%s).", d.Get("project").(string), project)
+		}
+		if d.Get("location").(string) != "" && d.Get("location").(string) != parts[2] {
+			return fmt.Errorf("The location set on this secret version (%s) is not equal to the location where this secret exists (%s).", d.Get("location").(string), parts[2])
+		}
+		if err := d.Set("location", parts[2]); err != nil {
+			return fmt.Errorf("Error setting location: %s", err)
+		}
+		if err := d.Set("secret", parts[3]); err != nil {
+			return fmt.Errorf("Error setting secret: %s", err)
+		}
+	} else { // if secret name is provided in the secret field
+		// Stores value of project to set in state
+		project, err = tpgresource.GetProject(d, config)
+		if err != nil {
+			return fmt.Errorf("Error fetching project for Secret: %s", err)
+		}
+		if d.Get("location").(string) == "" {
+			return fmt.Errorf("Location must be set when providing only secret name")
+		}
+	}
+	if err := d.Set("project", project); err != nil {
+		return fmt.Errorf("Error setting project: %s", err)
+	}
+
+	var url string
+	versionNum := d.Get("version")
+
+	// set version if provided, else set version to latest
+	if versionNum != "" {
+		url, err = tpgresource.ReplaceVars(d, config, "{{SecretManagerRegionalBasePath}}projects/{{project}}/locations/{{location}}/secrets/{{secret}}/versions/{{version}}")
+		if err != nil {
+			return err
+		}
+	} else {
+		url, err = tpgresource.ReplaceVars(d, config, "{{SecretManagerRegionalBasePath}}projects/{{project}}/locations/{{location}}/secrets/{{secret}}/versions/latest")
+		if err != nil {
+			return err
+		}
+	}
+
+	url = fmt.Sprintf("%s:access", url)
+	resp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error retrieving available secret manager regional secret version access: %s", err.Error())
+	}
+
+	if err := d.Set("name", resp["name"].(string)); err != nil {
+		return fmt.Errorf("Error setting name: %s", err)
+	}
+
+	secretVersionRegex := regexp.MustCompile("projects/(.+)/locations/(.+)/secrets/(.+)/versions/(.+)$")
+	parts = secretVersionRegex.FindStringSubmatch(resp["name"].(string))
+	if len(parts) != 5 {
+		return fmt.Errorf("secret name, %s, does not match format, projects/{{project}}/locations/{{location}}/secrets/{{secret}}/versions/{{version}}", resp["name"].(string))
+	}
+
+	log.Printf("[DEBUG] Received Google SecretManager Version: %q", parts[3])
+
+	if err := d.Set("version", parts[4]); err != nil {
+		return fmt.Errorf("Error setting version: %s", err)
+	}
+
+	data := resp["payload"].(map[string]interface{})
+	secretData, err := base64.StdEncoding.DecodeString(data["data"].(string))
+	if err != nil {
+		return fmt.Errorf("Error decoding secret manager regional secret version data: %s", err.Error())
+	}
+	if err := d.Set("secret_data", string(secretData)); err != nil {
+		return fmt.Errorf("Error setting secret_data: %s", err)
+	}
+
+	d.SetId(resp["name"].(string))
+	return nil
+}

--- a/mmv1/third_party/terraform/services/secretmanagerregional/data_source_secret_manager_regional_secret_version_access_test.go
+++ b/mmv1/third_party/terraform/services/secretmanagerregional/data_source_secret_manager_regional_secret_version_access_test.go
@@ -1,0 +1,203 @@
+package secretmanagerregional_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccDataSourceSecretManagerRegionalRegionalSecretVersionAccess_basicWithResourceReference(t *testing.T) {
+	t.Parallel()
+
+	randomString := acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerRegionalRegionalSecretVersionDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceSecretManagerRegionalRegionalSecretVersionAccess_basicWithResourceReference(randomString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceSecretManagerRegionalRegionalSecretVersionAccess("data.google_secret_manager_regional_secret_version_access.basic-1", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceSecretManagerRegionalRegionalSecretVersionAccess_basicWithSecretName(t *testing.T) {
+	t.Parallel()
+
+	randomString := acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerRegionalRegionalSecretVersionDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceSecretManagerRegionalRegionalSecretVersionAccess_basicWithSecretName(randomString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceSecretManagerRegionalRegionalSecretVersionAccess("data.google_secret_manager_regional_secret_version_access.basic-2", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceSecretManagerRegionalRegionalSecretVersionAccess_latest(t *testing.T) {
+	t.Parallel()
+
+	randomString := acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerRegionalRegionalSecretVersionDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceSecretManagerRegionalRegionalSecretVersionAccess_latest(randomString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceSecretManagerRegionalRegionalSecretVersionAccess("data.google_secret_manager_regional_secret_version_access.latest-1", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceSecretManagerRegionalRegionalSecretVersionAccess_versionField(t *testing.T) {
+	t.Parallel()
+
+	randomString := acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerRegionalRegionalSecretVersionDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceSecretManagerRegionalRegionalSecretVersionAccess_versionField(randomString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceSecretManagerRegionalRegionalSecretVersionAccess("data.google_secret_manager_regional_secret_version_access.version-access", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceSecretManagerRegionalRegionalSecretVersionAccess_basicWithResourceReference(randomString string) string {
+	return fmt.Sprintf(`
+resource "google_secret_manager_regional_secret" "secret-basic" {
+  secret_id = "tf-test-secret-version-%s"
+  location = "us-central1"
+}
+
+resource "google_secret_manager_regional_secret_version" "secret-version-basic" {
+  secret = google_secret_manager_regional_secret.secret-basic.id
+  secret_data = "my-tf-test-secret-%s"
+}
+
+data "google_secret_manager_regional_secret_version_access" "basic-1" {
+  secret = google_secret_manager_regional_secret_version.secret-version-basic.secret
+}
+`, randomString, randomString)
+}
+
+func testAccDataSourceSecretManagerRegionalRegionalSecretVersionAccess_basicWithSecretName(randomString string) string {
+	return fmt.Sprintf(`
+resource "google_secret_manager_regional_secret" "secret-basic" {
+  secret_id = "tf-test-secret-version-%s"
+  location = "us-central1"
+}
+
+resource "google_secret_manager_regional_secret_version" "secret-version-basic" {
+  secret = google_secret_manager_regional_secret.secret-basic.id
+  secret_data = "my-tf-test-secret-%s"
+}
+
+data "google_secret_manager_regional_secret_version_access" "basic-2" {
+  secret = google_secret_manager_regional_secret.secret-basic.secret_id
+  location = google_secret_manager_regional_secret_version.secret-version-basic.location
+}
+`, randomString, randomString)
+}
+
+func testAccDataSourceSecretManagerRegionalRegionalSecretVersionAccess_latest(randomString string) string {
+	return fmt.Sprintf(`
+resource "google_secret_manager_regional_secret" "secret-basic" {
+  secret_id = "tf-test-secret-version-%s"
+  location = "us-central1"
+}
+
+resource "google_secret_manager_regional_secret_version" "secret-version-basic-1" {
+  secret = google_secret_manager_regional_secret.secret-basic.id
+  secret_data = "my-tf-test-secret-first"
+}
+
+resource "google_secret_manager_regional_secret_version" "secret-version-basic-2" {
+  secret = google_secret_manager_regional_secret.secret-basic.id
+  secret_data = "my-tf-test-secret-second"
+
+  depends_on = [google_secret_manager_regional_secret_version.secret-version-basic-1]
+}
+
+data "google_secret_manager_regional_secret_version_access" "latest-1" {
+  secret = google_secret_manager_regional_secret_version.secret-version-basic-2.secret
+}
+`, randomString)
+}
+
+func testAccDataSourceSecretManagerRegionalRegionalSecretVersionAccess_versionField(randomString string) string {
+	return fmt.Sprintf(`
+resource "google_secret_manager_regional_secret" "secret-basic" {
+  secret_id = "tf-test-secret-version-%s"
+  location = "us-central1"
+}
+
+resource "google_secret_manager_regional_secret_version" "secret-version-basic-1" {
+  secret = google_secret_manager_regional_secret.secret-basic.id
+  secret_data = "my-tf-test-secret-first"
+}
+
+resource "google_secret_manager_regional_secret_version" "secret-version-basic-2" {
+  secret = google_secret_manager_regional_secret.secret-basic.id
+  secret_data = "my-tf-test-secret-second"
+
+  depends_on = [google_secret_manager_regional_secret_version.secret-version-basic-1]
+}
+
+data "google_secret_manager_regional_secret_version_access" "version-access" {
+  secret = google_secret_manager_regional_secret_version.secret-version-basic-2.secret
+  version = "1"
+}
+`, randomString)
+}
+
+func testAccCheckDataSourceSecretManagerRegionalRegionalSecretVersionAccess(n, expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find Regional Secret Version data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("data source ID not set.")
+		}
+
+		version, ok := rs.Primary.Attributes["version"]
+		if !ok {
+			return errors.New("can't find 'version' attribute")
+		}
+
+		if version != expected {
+			return fmt.Errorf("expected %s, got %s, version not found", expected, version)
+		}
+		return nil
+	}
+}

--- a/mmv1/third_party/terraform/services/secretmanagerregional/data_source_secret_manager_regional_secret_version_access_test.go
+++ b/mmv1/third_party/terraform/services/secretmanagerregional/data_source_secret_manager_regional_secret_version_access_test.go
@@ -1,14 +1,12 @@
 package secretmanagerregional_test
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccDataSourceSecretManagerRegionalRegionalSecretVersionAccess_basicWithResourceReference(t *testing.T) {
@@ -24,7 +22,7 @@ func TestAccDataSourceSecretManagerRegionalRegionalSecretVersionAccess_basicWith
 			{
 				Config: testAccDataSourceSecretManagerRegionalRegionalSecretVersionAccess_basicWithResourceReference(randomString),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataSourceSecretManagerRegionalRegionalSecretVersionAccess("data.google_secret_manager_regional_secret_version_access.basic-1", "1"),
+					testAccCheckDataSourceSecretManagerRegionalRegionalSecretVersion("data.google_secret_manager_regional_secret_version_access.basic-1", "1"),
 				),
 			},
 		},
@@ -44,7 +42,7 @@ func TestAccDataSourceSecretManagerRegionalRegionalSecretVersionAccess_basicWith
 			{
 				Config: testAccDataSourceSecretManagerRegionalRegionalSecretVersionAccess_basicWithSecretName(randomString),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataSourceSecretManagerRegionalRegionalSecretVersionAccess("data.google_secret_manager_regional_secret_version_access.basic-2", "1"),
+					testAccCheckDataSourceSecretManagerRegionalRegionalSecretVersion("data.google_secret_manager_regional_secret_version_access.basic-2", "1"),
 				),
 			},
 		},
@@ -64,7 +62,7 @@ func TestAccDataSourceSecretManagerRegionalRegionalSecretVersionAccess_latest(t 
 			{
 				Config: testAccDataSourceSecretManagerRegionalRegionalSecretVersionAccess_latest(randomString),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataSourceSecretManagerRegionalRegionalSecretVersionAccess("data.google_secret_manager_regional_secret_version_access.latest-1", "2"),
+					testAccCheckDataSourceSecretManagerRegionalRegionalSecretVersion("data.google_secret_manager_regional_secret_version_access.latest-1", "2"),
 				),
 			},
 		},
@@ -84,7 +82,7 @@ func TestAccDataSourceSecretManagerRegionalRegionalSecretVersionAccess_versionFi
 			{
 				Config: testAccDataSourceSecretManagerRegionalRegionalSecretVersionAccess_versionField(randomString),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataSourceSecretManagerRegionalRegionalSecretVersionAccess("data.google_secret_manager_regional_secret_version_access.version-access", "1"),
+					testAccCheckDataSourceSecretManagerRegionalRegionalSecretVersion("data.google_secret_manager_regional_secret_version_access.version-access", "1"),
 				),
 			},
 		},
@@ -177,27 +175,4 @@ data "google_secret_manager_regional_secret_version_access" "version-access" {
   version = "1"
 }
 `, randomString)
-}
-
-func testAccCheckDataSourceSecretManagerRegionalRegionalSecretVersionAccess(n, expected string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Can't find Regional Secret Version data source: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return errors.New("data source ID not set.")
-		}
-
-		version, ok := rs.Primary.Attributes["version"]
-		if !ok {
-			return errors.New("can't find 'version' attribute")
-		}
-
-		if version != expected {
-			return fmt.Errorf("expected %s, got %s, version not found", expected, version)
-		}
-		return nil
-	}
 }

--- a/mmv1/third_party/terraform/website/docs/d/secret_manager_regional_secret_version_access.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/secret_manager_regional_secret_version_access.html.markdown
@@ -1,0 +1,44 @@
+---
+subcategory: "Secret Manager"
+page_title: "Google: google_secret_manager_regional_secret_version_access"
+description: |-
+  Get a payload of Secret Manager regional secret's version.
+---
+
+# google_secret_manager_regional_secret_version_access
+
+Get the value from a Secret Manager regional secret version. This is similar to the [google_secret_manager_regional_secret_version](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/secret_manager_regional_secret_version) datasource, but it only requires the [Secret Manager Secret Accessor](https://cloud.google.com/secret-manager/docs/access-control#secretmanager.secretAccessor) role. For more information see the [official documentation](https://cloud.google.com/secret-manager/docs/regional-secrets-overview) and [API](https://cloud.google.com/secret-manager/docs/reference/rest/v1/projects.secrets.versions/access).
+
+## Example Usage
+
+```hcl
+data "google_secret_manager_regional_secret_version_access" "latest" {
+  secret   = "my-secret"
+  location = "us-central1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `project` - (Optional) The project to get the secret version for. If it
+    is not provided, the provider project is used.
+
+- `secret` - (Required) The regional secret to get the secret version for.
+    This can be either the reference of the regional secret as in `projects/{{project}}/locations/{{location}}/secrets/{{secret_id}}` or only the name of the regional secret as in `{{secret_id}}`. If only the name of the regional secret is provided, the location must also be provided.
+
+- `location` - (Optional) Location of Secret Manager regional secret resource.
+    It must be provided when the `secret` field provided consists of only the name of the regional secret.
+
+- `version` - (Optional) The version of the regional secret to get. If it
+    is not provided, the latest version is retrieved.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- `secret_data` - The secret data. No larger than 64KiB.
+
+- `name` - The resource name of the regional SecretVersion. Format:
+  `projects/{{project}}/locations/{{location}}/secrets/{{secret_id}}/versions/{{version}}`


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add support for regional secret version access datasource `google_secret_manager_regional_secret_version_access` that only requires the [Secret Manager Secret Accessor](https://cloud.google.com/secret-manager/docs/access-control#secretmanager.secretAccessor) role.
More info about regional secrets: https://cloud.google.com/secret-manager/docs/regional-secrets-overview

**Note:**
1. As of now, the API reference of the regional secrets are being documented on GCP docs side. Hence, the link mentioned in the `website/docs/d/secret_manager_regional_secret_version_access.html.markdown` file will be updated later.
2. We might also need to change the reference of the terraform registry provided for `google_secret_manager_regional_secret_version` datasource in the datasource description section in the `website/docs/d/secret_manager_regional_secret_version_access.html.markdown` file

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
`google_secret_manager_regional_secret_version_access`
```
