### PR TITLE
Fix test TestAccDataflowJob_withProviderDefaultLabels

### DIFF
--- a/mmv1/third_party/terraform/services/dataflow/resource_dataflow_job_test.go.erb
+++ b/mmv1/third_party/terraform/services/dataflow/resource_dataflow_job_test.go.erb
@@ -280,12 +280,12 @@ func TestAccDataflowJob_withProviderDefaultLabels(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "labels.env", "foo"),
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "labels.default_expiration_ms", "3600000"),
 
-					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.%", "3"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.%", "4"),
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.default_key1", "default_value1"),
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.env", "foo"),
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.default_expiration_ms", "3600000"),
 
-					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.%", "6"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.%", "7"),
 				),
 			},
 			{
@@ -302,12 +302,12 @@ func TestAccDataflowJob_withProviderDefaultLabels(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "labels.default_expiration_ms", "3600000"),
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "labels.default_key1", "value1"),
 
-					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.%", "3"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.%", "4"),
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.default_key1", "value1"),
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.env", "foo"),
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.default_expiration_ms", "3600000"),
 
-					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.%", "6"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.%", "7"),
 				),
 			},
 			{
@@ -325,12 +325,12 @@ func TestAccDataflowJob_withProviderDefaultLabels(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "labels.default_expiration_ms", "3600000"),
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "labels.default_key1", "value1"),
 
-					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.%", "3"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.%", "4"),
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.default_key1", "value1"),
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.env", "foo"),
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.default_expiration_ms", "3600000"),
 
-					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.%", "6"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.%", "7"),
 				),
 			},
 			{
@@ -347,12 +347,12 @@ func TestAccDataflowJob_withProviderDefaultLabels(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "labels.default_expiration_ms", "3600000"),
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "labels.default_key1", "value1"),
 
-					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.%", "3"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.%", "4"),
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.default_key1", "value1"),
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.env", "foo"),
 					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "terraform_labels.default_expiration_ms", "3600000"),
 
-					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.%", "6"),
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.%", "7"),
 				),
 			},
 			{


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

`terraform_labels` merges the provider default labels and the labels configured on the resource through Terraform.
`effective_labels` has all of the labels on the resource.

In the provider release 6.0, a new revenue label is added to the provider default labels by default, so `terraform_labels` and `effective_labels` should have one more label.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
