### PR TITLE
rewrite: tweaks to convert-go.sh (main branch)

### DIFF
--- a/mmv1/template-converter.go
+++ b/mmv1/template-converter.go
@@ -62,8 +62,14 @@ func convertTemplate(folder, tempFileTargets string) int {
 			continue
 		}
 		if len(tempSlice) > 1 {
-			// log.Printf("%s", filePath)
-			if !slices.Contains(tempSlice, filePath) {
+			found := false
+			for _, targetFile := range tempSlice {
+				parts := strings.Split(targetFile, "mmv1/")
+				if filePath == parts[len(parts)-1] {
+					found = true
+				}
+			}
+			if !found {
 				continue
 			}
 			log.Printf("continuing with template temp target %s", filePath)
@@ -149,7 +155,14 @@ func convertHandwrittenFiles(folder, handwrittenTempFiles string) int {
 			continue
 		}
 		if len(tempSlice) > 1 {
-			if !slices.Contains(tempSlice, filePath) {
+			found := false
+			for _, targetFile := range tempSlice {
+				parts := strings.Split(targetFile, "mmv1/")
+				if filePath == parts[len(parts)-1] {
+					found = true
+				}
+			}
+			if !found {
 				continue
 			}
 			log.Printf("continuing with handwritten temp target %s", filePath)

--- a/scripts/cherry-pick.sh
+++ b/scripts/cherry-pick.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# Example command
+# sh scripts/cherry-pick <hash of a post-switchover commit>
+
 set -e
 safecommit=$1
 
@@ -20,3 +24,6 @@ files=`git diff --name-only --diff-filter=A --cached`
 for file in $files; do
   mv $file ${file%".temp"}
 done
+
+# stage all changes
+git add .

--- a/scripts/convert-go.sh
+++ b/scripts/convert-go.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# Example command (in a pre-switchover commit)
+# sh scripts/convert-go.sh <provider output directory> <comma separated list of files that have changed in the PR> 
+
 set -e
 outputPath=$1
 files=$2
@@ -33,13 +37,21 @@ for i in "${file[@]}"; do
   fi
 done
 
-# run yaml conversion with given .yaml files
-bundle exec compiler.rb -e terraform -o $1 -v beta -a --go-yaml-files $yamlstring
-go run . --yaml-temp
+pushd mmv1
 
-# convert .erb files with given .erb files
-go run . --template-temp $erbstring
-go run . --handwritten-temp $erbstring
+if [[ $yamlstring != "" ]]; then
+  # run yaml conversion with given .yaml files
+  bundle exec compiler.rb -e terraform -o $1 -v beta -a --go-yaml-files $yamlstring
+  go run . --yaml-temp
+fi
+
+
+if [[ $erbstring != "" ]]; then
+  # convert .erb files with given .erb files
+  go run . --template-temp $erbstring
+  go run . --handwritten-temp $erbstring
+fi
+popd
 
 # add temporary file for all other files that do not need conversion
 for i in "${otherlist[@]}"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

convert-go.sh runs in root directory, not in mmv1/ folder. Makes it consistent with cherry-pick.sh
Also can handle relative or absolute template files. 

Directions are now:

`scripts/convert-go.sh` does the conversion in a pre-switchover commit and outputs the converted files to *.temp files. 
Example command in the root MM directory (in a pre-switchover commit)

```
sh scripts/convert-go.sh <provider output directory> <comma separated list of files that have changed in the PR> 
```

`scripts/cherry-pick.sh` prepares a new branch in a post-switchover commit and cherry-picks the previous *.temp files
Example command from root MM directory
```
sh scripts/cherry-pick <hash of a post-switchover commit>
```

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
