### PR TITLE
Add tags field to Filestore Instances for TagsR2401

### DIFF
--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -273,6 +273,7 @@ properties:
     name: 'deletionProtectionReason'
     description: |
       The reason for enabling deletion protection.
+  - !ruby/object:Api::Type::KeyValuePairs
   - name: 'tags'
     type: KeyValuePairs
     description: |

--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -273,3 +273,11 @@ properties:
     name: 'deletionProtectionReason'
     description: |
       The reason for enabling deletion protection.
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags. Resource manager tag keys and values have the same definition
+      as resource manager tags. Keys must be in the format tagKeys/{tag_key_id}, and values are in
+      the format tagValues/456. The field is ignored (both PUT & PATCH) when empty.
+    immutable: true
+    ignore_read: true

--- a/mmv1/products/filestore/go_Instance.yaml
+++ b/mmv1/products/filestore/go_Instance.yaml
@@ -295,3 +295,11 @@ properties:
     type: String
     description: |
       The reason for enabling deletion protection.
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags. Resource manager tag keys and values have the same definition
+      as resource manager tags. Keys must be in the format tagKeys/{tag_key_id}, and values are in
+      the format tagValues/456. The field is ignored (both PUT & PATCH) when empty.
+    immutable: true
+    ignore_read: true

--- a/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
+++ b/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"github.com/hashicorp/terraform-provider-google/google/services/filestore"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -234,6 +235,57 @@ func TestAccFilestoreInstance_deletionProtection_update(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccFilestoreInstance_tags(t *testing.T) {
+	t.Parallel()
+	name := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+	org := envvar.GetTestOrgFromEnv(t)
+	tagKey := acctest.BootstrapSharedTestTagKey(t, "filestore-instances-tagkey")
+	tagValue := acctest.BootstrapSharedTestTagValue(t, "filestore-instances-tagvalue", tagKey)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckFilestoreInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFileInstanceTags(name, map[string]string{org + "/" + tagKey: tagValue}),
+			},
+			{
+				ResourceName:            "google_filestore_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"zone", "location", "networks.0.reserved_ip_range", "tags"},
+			},
+		},
+	})
+}
+
+func testAccFileInstanceTags(name string, tags map[string]string) string {
+	r := fmt.Sprintf(`
+resource "google_filestore_instance" "instance" {
+  name = "tf-instance-%s"
+  zone = "us-central1-b"
+  tier = "BASIC_HDD"
+  file_shares {
+    capacity_gb = 1024
+    name        = "share1"
+  }
+  networks {
+    network           = "default"
+    modes             = ["MODE_IPV4"]
+    reserved_ip_range = "172.19.31.8/29"
+  }
+tags = {`, name)
+
+	l := ""
+	for key, value := range tags {
+		l += fmt.Sprintf("%q = %q\n", key, value)
+	}
+
+	l += fmt.Sprintf("}\n}")
+	return r + l
 }
 
 func testAccFilestoreInstance_deletionProtection_create(name, location, tier string) string {

--- a/mmv1/third_party/terraform/website/docs/d/filestore_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/filestore_instance.html.markdown
@@ -8,6 +8,8 @@ description: |-
 
 Get info about a Google Cloud Filestore instance.
 
+~> It may take a while for the attached tag bindings to be deleted after the instance is scheduled to be deleted.
+
 ## Example Usage
 
 ```tf
@@ -28,6 +30,16 @@ output "instance_file_share_name" {
 }
 ```
 
+To create an instance with a tag
+
+```tf
+resource "filestore_instance" "my_instance" {
+  name       = "My instance"
+  instance_id = "your-instance-id"
+  tags = {"tagKeys/281478409127147" : "tagValues/281479442205542"}
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -42,6 +54,8 @@ The following arguments are supported:
 * `location` - (Optional) The name of the location of the instance. This 
     can be a region for ENTERPRISE tier instances. If it is not provided, 
     the provider region or zone is used.
+
+* `tags` - (Optional) A map of resource manager tags. Resource manager tag keys and values have the same definition as resource manager tags. Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456. The field is ignored when empty. The field is immutable and causes resource replacement when mutated.
 
 ## Attributes Reference
 

--- a/mmv1/third_party/terraform/website/docs/d/filestore_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/filestore_instance.html.markdown
@@ -36,7 +36,7 @@ To create an instance with a tag
 resource "filestore_instance" "my_instance" {
   name       = "My instance"
   instance_id = "your-instance-id"
-  tags = {"tagKeys/281478409127147" : "tagValues/281479442205542"}
+  tags = {"1234567/env":"staging"}
 }
 ```
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add tags field to instance resource to allow setting tags on instance resources at creation time.
Part of b/364841739
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
filestore: added `tags` field to `filestore_instance` to allow setting tags for instances at creation time

```
