### PR TITLE
Add new import function to `google_compute_project_metadata_item`

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_project_metadata_item.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_project_metadata_item.go.erb
@@ -33,7 +33,7 @@ func ResourceComputeProjectMetadataItem() *schema.Resource {
 		Update: resourceComputeProjectMetadataItemUpdate,
 		Delete: resourceComputeProjectMetadataItemDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceComputeProjectMetadataItemImportState,
 		},
 
 		CustomizeDiff: customdiff.All(
@@ -180,6 +180,25 @@ func resourceComputeProjectMetadataItemDelete(d *schema.ResourceData, meta inter
 
 	d.SetId("")
 	return nil
+}
+
+func resourceComputeProjectMetadataItemImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	config := meta.(*transport_tpg.Config)
+	if err := tpgresource.ParseImportId([]string{
+		"projects/(?P<project>[^/]+)/meta-data/(?P<key>[^/]+)",
+		"(?P<key>[^/]+)",
+	}, d, config); err != nil {
+		return nil, err
+	}
+
+	// Replace import id for the resource id
+	id, err := tpgresource.ReplaceVars(d, config, "{{key}}")
+	if err != nil {
+		return nil, fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+
+	return []*schema.ResourceData{d}, nil
 }
 
 func updateComputeCommonInstanceMetadata(config *transport_tpg.Config, projectID, key, userAgent string, afterVal *string, timeout time.Duration, failIfPresent metadataPresentBehavior) error {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
closes https://github.com/hashicorp/terraform-provider-google/issues/8024

it used deprecated import method

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added import support for `projects/{{project}}/meta-data/{{key}}` syntax for `google_compute_project_metadata_item` resource
```
