### PR TITLE
Add acceptance tests for how provider handles `impersonate_service_account_delegates` argument

### DIFF
--- a/mmv1/third_party/terraform/fwprovider/data_source_provider_config_plugin_framework.go
+++ b/mmv1/third_party/terraform/fwprovider/data_source_provider_config_plugin_framework.go
@@ -205,7 +205,7 @@ func (d *GoogleProviderConfigPluginFrameworkDataSource) Read(ctx context.Context
 
 	data.Credentials = d.providerConfig.Credentials
 	data.AccessToken = d.providerConfig.AccessToken
-	// TODO(SarahFrench) - impersonate_service_account
+	data.ImpersonateServiceAccount = d.providerConfig.ImpersonateServiceAccount
 	// TODO(SarahFrench) - impersonate_service_account_delegates
 	data.Project = d.providerConfig.Project
 	data.Region = d.providerConfig.Region

--- a/mmv1/third_party/terraform/fwprovider/data_source_provider_config_plugin_framework.go
+++ b/mmv1/third_party/terraform/fwprovider/data_source_provider_config_plugin_framework.go
@@ -206,7 +206,7 @@ func (d *GoogleProviderConfigPluginFrameworkDataSource) Read(ctx context.Context
 	data.Credentials = d.providerConfig.Credentials
 	data.AccessToken = d.providerConfig.AccessToken
 	data.ImpersonateServiceAccount = d.providerConfig.ImpersonateServiceAccount
-	// TODO(SarahFrench) - impersonate_service_account_delegates
+	data.ImpersonateServiceAccountDelegates = d.providerConfig.ImpersonateServiceAccountDelegates
 	data.Project = d.providerConfig.Project
 	data.Region = d.providerConfig.Region
 	data.BillingProject = d.providerConfig.BillingProject

--- a/mmv1/third_party/terraform/fwprovider/framework_provider_access_token_test.go.erb
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider_access_token_test.go.erb
@@ -74,7 +74,8 @@ func testAccFwProvider_access_token_configPrecedenceOverEnvironmentVariables(t *
 				Config: testAccFwProvider_access_tokenInProviderBlock(context),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.google_provider_config_plugin_framework.default", "access_token", providerAccessToken),
-				)},
+				),
+			},
 		},
 	})
 }

--- a/mmv1/third_party/terraform/fwprovider/framework_provider_impersonate_service_account_delegates_test.go
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider_impersonate_service_account_delegates_test.go
@@ -1,0 +1,123 @@
+package fwprovider_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+// TestAccFwProvider_impersonate_service_account_delegates is a series of acc tests asserting how the plugin-framework provider handles impersonate_service_account_delegates arguments
+// It is plugin-framework specific because the HCL used provisions plugin-framework-implemented resources
+// It is a counterpart to TestAccSdkProvider_impersonate_service_account_delegates
+func TestAccFwProvider_impersonate_service_account_delegates(t *testing.T) {
+	testCases := map[string]func(t *testing.T){
+		// Configuring the provider using inputs
+		//     There are no environment variables for this field
+		"impersonate_service_account_delegates can be set in config": testAccFwProvider_impersonate_service_account_delegates_setInConfig,
+
+		// Schema-level validation
+		"when impersonate_service_account_delegates is set to an empty list in the config the value IS ignored": testAccFwProvider_impersonate_service_account_delegates_emptyListUsage,
+
+		// Usage
+		// We need to wait for a non-Firebase resource to be migrated to the plugin-framework to enable writing this test
+		// "impersonate_service_account_delegates controls which service account is used for actions"
+	}
+
+	for name, tc := range testCases {
+		// shadow the tc variable into scope so that when
+		// the loop continues, if t.Run hasn't executed tc(t)
+		// yet, we don't have a race condition
+		// see https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			tc(t)
+		})
+	}
+}
+
+func testAccFwProvider_impersonate_service_account_delegates_setInConfig(t *testing.T) {
+	acctest.SkipIfVcr(t) // Test doesn't interact with API
+
+	delegates := []string{
+		"projects/-/serviceAccounts/my-service-account-1@example.iam.gserviceaccount.com",
+		"projects/-/serviceAccounts/my-service-account-2@example.iam.gserviceaccount.com",
+	}
+	delegatesString := fmt.Sprintf(`["%s","%s"]`, delegates[0], delegates[1])
+
+	// There are no ENVs for this provider argument
+
+	context := map[string]interface{}{
+		"impersonate_service_account_delegates": delegatesString,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		// No PreCheck for checking ENVs
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFwProvider_impersonate_service_account_delegatesInProviderBlock(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_provider_config_plugin_framework.default", "impersonate_service_account_delegates.#", fmt.Sprintf("%d", len(delegates))),
+					resource.TestCheckResourceAttr("data.google_provider_config_plugin_framework.default", "impersonate_service_account_delegates.0", delegates[0]),
+					resource.TestCheckResourceAttr("data.google_provider_config_plugin_framework.default", "impersonate_service_account_delegates.1", delegates[1]),
+				),
+			},
+		},
+	})
+}
+
+func testAccFwProvider_impersonate_service_account_delegates_emptyListUsage(t *testing.T) {
+
+	context := map[string]interface{}{
+		"impersonate_service_account_delegates": "[]", // empty array
+		"random_suffix":                         acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		// No PreCheck for checking ENVs
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFwProvider_impersonate_service_account_delegates_testProvisioning(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_provider_config_plugin_framework.default", "impersonate_service_account_delegates.#", "0"),
+				),
+				// No error expected as empty array is ignored
+			},
+		},
+	})
+}
+
+// testAccFwProvider_impersonate_service_account_delegatesInProviderBlock allows setting the impersonate_service_account_delegates argument in a provider block.
+func testAccFwProvider_impersonate_service_account_delegatesInProviderBlock(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+provider "google" {
+	impersonate_service_account_delegates = %{impersonate_service_account_delegates}
+}
+
+data "google_provider_config_plugin_framework" "default" {}
+
+output "impersonate_service_account_delegates" {
+  value = data.google_provider_config_plugin_framework.default.impersonate_service_account_delegates
+  sensitive = true
+}
+`, context)
+}
+
+// testAccFwProvider_impersonate_service_account_delegates_testProvisioning allows setting the impersonate_service_account_delegates argument in a provider block
+// and testing its impact on provisioning a resource
+func testAccFwProvider_impersonate_service_account_delegates_testProvisioning(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+provider "google" {
+	impersonate_service_account_delegates = %{impersonate_service_account_delegates}
+}
+
+data "google_provider_config_plugin_framework" "default" {}
+
+resource "google_pubsub_topic" "example" {
+  name = "tf-test-%{random_suffix}"
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/fwprovider/framework_provider_impersonate_service_account_test.go
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider_impersonate_service_account_test.go
@@ -1,0 +1,147 @@
+package fwprovider_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+// TestAccFwProvider_impersonate_service_account is a series of acc tests asserting how the plugin-framework provider handles impersonate_service_account arguments
+// It is plugin-framework specific because the HCL used provisions plugin-framework-implemented resources
+// It is a counterpart to TestAccSdkProvider_impersonate_service_account
+func TestAccFwProvider_impersonate_service_account(t *testing.T) {
+	testCases := map[string]func(t *testing.T){
+		// Configuring the provider using inputs
+		"config takes precedence over environment variables":                                                       testAccFwProvider_impersonate_service_account_configPrecedenceOverEnvironmentVariables,
+		"when impersonate_service_account is unset in the config, environment variables are used in a given order": testAccFwProvider_impersonate_service_account_precedenceOrderEnvironmentVariables, // GOOGLE_CREDENTIALS, GOOGLE_CLOUD_KEYFILE_JSON, GCLOUD_KEYFILE_JSON, GOOGLE_APPLICATION_CREDENTIALS
+
+		// Schema-level validation
+		"when impersonate_service_account is set to an empty string in the config the value isn't ignored and results in an error": testAccFwProvider_impersonate_service_account_emptyStringValidation,
+
+		// Usage
+		// We need to wait for a non-Firebase resource to be migrated to the plugin-framework to enable writing this test
+		// "impersonate_service_account controls which service account is used for actions"
+	}
+
+	for name, tc := range testCases {
+		// shadow the tc variable into scope so that when
+		// the loop continues, if t.Run hasn't executed tc(t)
+		// yet, we don't have a race condition
+		// see https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			tc(t)
+		})
+	}
+}
+
+func testAccFwProvider_impersonate_service_account_configPrecedenceOverEnvironmentVariables(t *testing.T) {
+	acctest.SkipIfVcr(t) // Test doesn't interact with API
+
+	impersonateServiceAccountEnvironment := "value-from-envs@example.com"
+	impersonateServiceAccountProviderBlock := "value-from-provider-block@example.com"
+
+	// ensure all possible impersonate_service_account env vars set; show they aren't used
+	t.Setenv("GOOGLE_IMPERSONATE_SERVICE_ACCOUNT", impersonateServiceAccountEnvironment)
+
+	context := map[string]interface{}{
+		"impersonate_service_account": impersonateServiceAccountProviderBlock,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		// No PreCheck for checking ENVs
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFwProvider_impersonate_service_account_inProviderBlock(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_provider_config_plugin_framework.default", "impersonate_service_account", impersonateServiceAccountProviderBlock),
+				),
+			},
+		},
+	})
+}
+
+func testAccFwProvider_impersonate_service_account_precedenceOrderEnvironmentVariables(t *testing.T) {
+	acctest.SkipIfVcr(t) // Test doesn't interact with API
+	/*
+		These are all the ENVs for impersonate_service_account, and they are in order of precedence.
+		GOOGLE_IMPERSONATE_SERVICE_ACCOUNT
+	*/
+
+	impersonateServiceAccount := "foobar@example.com"
+
+	context := map[string]interface{}{}
+
+	acctest.VcrTest(t, resource.TestCase{
+		// No PreCheck for checking ENVs
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					t.Setenv("GOOGLE_IMPERSONATE_SERVICE_ACCOUNT", impersonateServiceAccount)
+				},
+				Config: testAccFwProvider_impersonate_service_account_inEnvsOnly(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_provider_config_plugin_framework.default", "impersonate_service_account", impersonateServiceAccount),
+				),
+			},
+		},
+	})
+}
+
+func testAccFwProvider_impersonate_service_account_emptyStringValidation(t *testing.T) {
+	acctest.SkipIfVcr(t) // Test doesn't interact with API
+
+	impersonateServiceAccountEnvironment := "value-from-envs@example.com"
+
+	// ensure all possible impersonate_service_account env vars set; show they aren't used
+	t.Setenv("GOOGLE_IMPERSONATE_SERVICE_ACCOUNT", impersonateServiceAccountEnvironment)
+
+	context := map[string]interface{}{
+		"impersonate_service_account": "", // empty string used
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		// No PreCheck for checking ENVs
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccFwProvider_impersonate_service_account_inProviderBlock(context),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("expected a non-empty string"),
+			},
+		},
+	})
+}
+
+// testAccFwProvider_impersonate_service_account_inProviderBlock allows setting the impersonate_service_account argument in a provider block.
+func testAccFwProvider_impersonate_service_account_inProviderBlock(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+provider "google" {
+	impersonate_service_account = "%{impersonate_service_account}"
+}
+
+data "google_provider_config_plugin_framework" "default" {}
+
+output "impersonate_service_account" {
+  value = data.google_provider_config_plugin_framework.default.impersonate_service_account
+  sensitive = true
+}
+`, context)
+}
+
+// testAccFwProvider_impersonate_service_account_inEnvsOnly allows testing when the impersonate_service_account argument
+// is only supplied via ENVs
+func testAccFwProvider_impersonate_service_account_inEnvsOnly(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_provider_config_plugin_framework" "default" {}
+
+output "impersonate_service_account" {
+  value = data.google_provider_config_plugin_framework.default.impersonate_service_account
+  sensitive = true
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/fwprovider/framework_provider_impersonate_service_account_test.go
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider_impersonate_service_account_test.go
@@ -15,7 +15,7 @@ func TestAccFwProvider_impersonate_service_account(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
 		// Configuring the provider using inputs
 		"config takes precedence over environment variables":                                                       testAccFwProvider_impersonate_service_account_configPrecedenceOverEnvironmentVariables,
-		"when impersonate_service_account is unset in the config, environment variables are used in a given order": testAccFwProvider_impersonate_service_account_precedenceOrderEnvironmentVariables, // GOOGLE_CREDENTIALS, GOOGLE_CLOUD_KEYFILE_JSON, GCLOUD_KEYFILE_JSON, GOOGLE_APPLICATION_CREDENTIALS
+		"when impersonate_service_account is unset in the config, environment variables are used in a given order": testAccFwProvider_impersonate_service_account_precedenceOrderEnvironmentVariables, // GOOGLE_IMPERSONATE_SERVICE_ACCOUNT
 
 		// Schema-level validation
 		"when impersonate_service_account is set to an empty string in the config the value isn't ignored and results in an error": testAccFwProvider_impersonate_service_account_emptyStringValidation,

--- a/mmv1/third_party/terraform/fwprovider/go/framework_provider_access_token_test.go.tmpl
+++ b/mmv1/third_party/terraform/fwprovider/go/framework_provider_access_token_test.go.tmpl
@@ -73,7 +73,8 @@ func testAccFwProvider_access_token_configPrecedenceOverEnvironmentVariables(t *
 				Config: testAccFwProvider_access_tokenInProviderBlock(context),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.google_provider_config_plugin_framework.default", "access_token", providerAccessToken),
-				)},
+				),
+			},
 		},
 	})
 }

--- a/mmv1/third_party/terraform/fwtransport/framework_config.go.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config.go.erb
@@ -38,6 +38,7 @@ type FrameworkProviderConfig struct {
 	Credentials                types.String
 	AccessToken                types.String
 	ImpersonateServiceAccount  types.String
+	ImpersonateServiceAccountDelegates types.List
 	// End temporary
 
 	BillingProject             types.String
@@ -108,6 +109,7 @@ func (p *FrameworkProviderConfig) LoadAndValidateFramework(ctx context.Context, 
 	p.Credentials = data.Credentials
 	p.AccessToken = data.AccessToken
 	p.ImpersonateServiceAccount = data.ImpersonateServiceAccount
+	p.ImpersonateServiceAccountDelegates = data.ImpersonateServiceAccountDelegates
 	// End temporary
 
 	// Copy values from the ProviderModel struct containing data about the provider configuration (present only when responsing to ConfigureProvider rpc calls)

--- a/mmv1/third_party/terraform/fwtransport/framework_config.go.erb
+++ b/mmv1/third_party/terraform/fwtransport/framework_config.go.erb
@@ -34,9 +34,10 @@ import (
 
 type FrameworkProviderConfig struct {
 	// Temporary, as we'll replace use of FrameworkProviderConfig with transport_tpg.Config soon
-	// transport_tpg.Config has a Credentials field, hence this change is needed
+	// transport_tpg.Config has a the fields below, hence these changes are needed
 	Credentials                types.String
 	AccessToken                types.String
+	ImpersonateServiceAccount  types.String
 	// End temporary
 
 	BillingProject             types.String
@@ -106,6 +107,7 @@ func (p *FrameworkProviderConfig) LoadAndValidateFramework(ctx context.Context, 
 	// Temporary
 	p.Credentials = data.Credentials
 	p.AccessToken = data.AccessToken
+	p.ImpersonateServiceAccount = data.ImpersonateServiceAccount
 	// End temporary
 
 	// Copy values from the ProviderModel struct containing data about the provider configuration (present only when responsing to ConfigureProvider rpc calls)

--- a/mmv1/third_party/terraform/provider/provider_access_token_test.go
+++ b/mmv1/third_party/terraform/provider/provider_access_token_test.go
@@ -68,7 +68,8 @@ func testAccSdkProvider_access_token_configPrecedenceOverEnvironmentVariables(t 
 				Config: testAccSdkProvider_access_tokenInProviderBlock(context),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.google_provider_config_sdk.default", "access_token", providerAccessToken),
-				)},
+				),
+			},
 		},
 	})
 }

--- a/mmv1/third_party/terraform/provider/provider_impersonate_service_account_delegates_test.go
+++ b/mmv1/third_party/terraform/provider/provider_impersonate_service_account_delegates_test.go
@@ -1,0 +1,184 @@
+package provider_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccFwProvider_impersonate_service_account_delegates(t *testing.T) {
+	testCases := map[string]func(t *testing.T){
+		// Configuring the provider using inputs
+		//     There are no environment variables for this field
+		"impersonate_service_account_delegates can be set in config": testAccSdkProvider_impersonate_service_account_delegates_setInConfig,
+
+		// Schema-level validation
+		"when impersonate_service_account_delegates is set to an empty list in the config the value IS ignored": testAccSdkProvider_impersonate_service_account_delegates_emptyListUsage,
+
+		// Usage
+		"impersonate_service_account_delegates controls which service account is used for actions": testAccSdkProvider_impersonate_service_account_delegates_usage,
+	}
+
+	for name, tc := range testCases {
+		// shadow the tc variable into scope so that when
+		// the loop continues, if t.Run hasn't executed tc(t)
+		// yet, we don't have a race condition
+		// see https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			tc(t)
+		})
+	}
+}
+
+func testAccSdkProvider_impersonate_service_account_delegates_setInConfig(t *testing.T) {
+	acctest.SkipIfVcr(t) // Test doesn't interact with API
+
+	delegates := []string{
+		"projects/-/serviceAccounts/my-service-account-1@example.iam.gserviceaccount.com",
+		"projects/-/serviceAccounts/my-service-account-2@example.iam.gserviceaccount.com",
+	}
+	delegatesString := fmt.Sprintf(`["%s","%s"]`, delegates[0], delegates[1])
+
+	// There are no ENVs for this provider argument
+
+	context := map[string]interface{}{
+		"random_suffix":                         acctest.RandString(t, 10),
+		"impersonate_service_account_delegates": delegatesString,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		// No PreCheck for checking ENVs
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSdkProvider_impersonate_service_account_delegates_testProvisioning(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_provider_config_sdk.default", "impersonate_service_account_delegates.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSdkProvider_impersonate_service_account_delegates_emptyListUsage(t *testing.T) {
+	acctest.SkipIfVcr(t) // Test doesn't interact with API
+
+	context := map[string]interface{}{
+		"random_suffix":                         acctest.RandString(t, 10),
+		"impersonate_service_account_delegates": "[]",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		// No PreCheck for checking ENVs
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSdkProvider_impersonate_service_account_delegates_testProvisioning(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_provider_config_sdk.default", "impersonate_service_account_delegates.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSdkProvider_impersonate_service_account_delegates_usage(t *testing.T) {
+	acctest.SkipIfVcr(t) // Test doesn't interact with API
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		// No PreCheck for checking ENVs
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSdkProvider_impersonate_service_account_delegates_testViaFailure_1(context),
+			},
+			{
+				// This needs to be split into a second step as impersonate_service_account_delegates does
+				// not tolerate unknown values
+				Config:      testAccSdkProvider_impersonate_service_account_delegates_testViaFailure_2(context),
+				ExpectError: regexp.MustCompile("Error creating Topic: googleapi: Error 403: User not authorized"),
+			},
+		},
+	})
+}
+
+// testAccSdkProvider_impersonate_service_account_delegates_testProvisioning allows setting the impersonate_service_account_delegates argument in a provider block
+// and testing its impact on provisioning a resource
+func testAccSdkProvider_impersonate_service_account_delegates_testProvisioning(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+provider "google" {
+	impersonate_service_account_delegates = %{impersonate_service_account_delegates}
+}
+
+data "google_provider_config_sdk" "default" {}
+
+resource "google_pubsub_topic" "example" {
+  name = "tf-test-%{random_suffix}"
+}
+`, context)
+}
+
+func testAccSdkProvider_impersonate_service_account_delegates_testViaFailure_1(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+// This will succeed due to the Terraform identity having necessary permissions
+resource "google_pubsub_topic" "ok" {
+  name = "tf-test-%{random_suffix}-ok"
+}
+
+//  Create a first service account and ensure the Terraform identity can make tokens for it
+resource "google_service_account" "default_1" {
+  account_id   = "tf-test-%{random_suffix}-1"
+  display_name = "Acceptance test impersonated service account"
+}
+
+data "google_client_openid_userinfo" "me" {
+}
+
+resource "google_service_account_iam_member" "token_1" {
+  service_account_id = google_service_account.default_1.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${data.google_client_openid_userinfo.me.email}"
+}
+
+//  Create a second service account and ensure the first service account can make tokens for it
+resource "google_service_account" "default_2" {
+  account_id   = "tf-test-%{random_suffix}-2"
+  display_name = "Acceptance test impersonated service account"
+}
+
+resource "google_service_account_iam_member" "token_2" {
+  service_account_id = google_service_account.default_2.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.default_1.email}"
+}
+`, context)
+}
+
+func testAccSdkProvider_impersonate_service_account_delegates_testViaFailure_2(context map[string]interface{}) string {
+	return testAccSdkProvider_impersonate_service_account_delegates_testViaFailure_1(context) + acctest.Nprintf(`
+
+// Use impersonate_service_account_delegates
+provider "google" {
+  alias = "impersonation"
+  impersonate_service_account = google_service_account.default_2.email
+  impersonate_service_account_delegates = [
+    google_service_account.default_1.email,
+    google_service_account.default_2.email,
+  ]
+}
+
+// This will fail due to the impersonated service account not having any permissions
+resource "google_pubsub_topic" "fail" {
+  provider = google.impersonation
+  name = "tf-test-%{random_suffix}-fail"
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/provider/provider_impersonate_service_account_test.go
+++ b/mmv1/third_party/terraform/provider/provider_impersonate_service_account_test.go
@@ -15,7 +15,7 @@ func TestAccSdkProvider_impersonate_service_account(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
 		// Configuring the provider using inputs
 		"config takes precedence over environment variables":                                                       testAccSdkProvider_impersonate_service_account_configPrecedenceOverEnvironmentVariables,
-		"when impersonate_service_account is unset in the config, environment variables are used in a given order": testAccSdkProvider_impersonate_service_account_precedenceOrderEnvironmentVariables, // GOOGLE_CREDENTIALS, GOOGLE_CLOUD_KEYFILE_JSON, GCLOUD_KEYFILE_JSON, GOOGLE_APPLICATION_CREDENTIALS
+		"when impersonate_service_account is unset in the config, environment variables are used in a given order": testAccSdkProvider_impersonate_service_account_precedenceOrderEnvironmentVariables, // GOOGLE_IMPERSONATE_SERVICE_ACCOUNT
 
 		// Schema-level validation
 		"when impersonate_service_account is set to an empty string in the config the value isn't ignored and results in an error": testAccSdkProvider_impersonate_service_account_emptyStringValidation,

--- a/mmv1/third_party/terraform/provider/provider_impersonate_service_account_test.go
+++ b/mmv1/third_party/terraform/provider/provider_impersonate_service_account_test.go
@@ -1,0 +1,203 @@
+package provider_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+// TestAccSdkProvider_impersonate_service_account is a series of acc tests asserting how the SDK provider handles impersonate_service_account arguments
+// It is SDK specific because the HCL used provisions SDK-implemented resources
+// It is a counterpart to TestAccFwProvider_impersonate_service_account
+func TestAccSdkProvider_impersonate_service_account(t *testing.T) {
+	testCases := map[string]func(t *testing.T){
+		// Configuring the provider using inputs
+		"config takes precedence over environment variables":                                                       testAccSdkProvider_impersonate_service_account_configPrecedenceOverEnvironmentVariables,
+		"when impersonate_service_account is unset in the config, environment variables are used in a given order": testAccSdkProvider_impersonate_service_account_precedenceOrderEnvironmentVariables, // GOOGLE_CREDENTIALS, GOOGLE_CLOUD_KEYFILE_JSON, GCLOUD_KEYFILE_JSON, GOOGLE_APPLICATION_CREDENTIALS
+
+		// Schema-level validation
+		"when impersonate_service_account is set to an empty string in the config the value isn't ignored and results in an error": testAccSdkProvider_impersonate_service_account_emptyStringValidation,
+
+		// Usage
+		"impersonate_service_account controls which service account is used for actions": testAccSdkProvider_impersonate_service_account_usage,
+	}
+
+	for name, tc := range testCases {
+		// shadow the tc variable into scope so that when
+		// the loop continues, if t.Run hasn't executed tc(t)
+		// yet, we don't have a race condition
+		// see https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			tc(t)
+		})
+	}
+}
+
+func testAccSdkProvider_impersonate_service_account_configPrecedenceOverEnvironmentVariables(t *testing.T) {
+	acctest.SkipIfVcr(t) // Test doesn't interact with API
+
+	impersonateServiceAccountEnvironment := "value-from-envs@example.com"
+	impersonateServiceAccountProviderBlock := "value-from-provider-block@example.com"
+
+	// ensure all possible impersonate_service_account env vars set; show they aren't used
+	t.Setenv("GOOGLE_IMPERSONATE_SERVICE_ACCOUNT", impersonateServiceAccountEnvironment)
+
+	context := map[string]interface{}{
+		"impersonate_service_account": impersonateServiceAccountProviderBlock,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		// No PreCheck for checking ENVs
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSdkProvider_impersonate_service_account_inProviderBlock(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_provider_config_sdk.default", "impersonate_service_account", impersonateServiceAccountProviderBlock),
+				)},
+		},
+	})
+}
+
+func testAccSdkProvider_impersonate_service_account_precedenceOrderEnvironmentVariables(t *testing.T) {
+	acctest.SkipIfVcr(t) // Test doesn't interact with API
+	/*
+		These are all the ENVs for impersonate_service_account, and they are in order of precedence.
+		GOOGLE_IMPERSONATE_SERVICE_ACCOUNT
+	*/
+
+	impersonateServiceAccount := "foobar@example.com"
+
+	context := map[string]interface{}{}
+
+	acctest.VcrTest(t, resource.TestCase{
+		// No PreCheck for checking ENVs
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					t.Setenv("GOOGLE_IMPERSONATE_SERVICE_ACCOUNT", impersonateServiceAccount)
+				},
+				Config: testAccSdkProvider_impersonate_service_account_inEnvsOnly(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_provider_config_sdk.default", "impersonate_service_account", impersonateServiceAccount),
+				)},
+		},
+	})
+}
+
+func testAccSdkProvider_impersonate_service_account_emptyStringValidation(t *testing.T) {
+	acctest.SkipIfVcr(t) // Test doesn't interact with API
+
+	impersonateServiceAccountEnvironment := "value-from-envs@example.com"
+
+	// ensure all possible impersonate_service_account env vars set; show they aren't used
+	t.Setenv("GOOGLE_IMPERSONATE_SERVICE_ACCOUNT", impersonateServiceAccountEnvironment)
+
+	context := map[string]interface{}{
+		"impersonate_service_account": "", // empty string used
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		// No PreCheck for checking ENVs
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccSdkProvider_impersonate_service_account_inProviderBlock(context),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("expected a non-empty string"),
+			},
+		},
+	})
+}
+
+func testAccSdkProvider_impersonate_service_account_usage(t *testing.T) {
+	acctest.SkipIfVcr(t) // Test doesn't interact with API
+
+	// ensure env vars unset
+	t.Setenv("GOOGLE_IMPERSONATE_SERVICE_ACCOUNT", "")
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		// No PreCheck for checking ENVs
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccSdkProvider_impersonate_service_account_testViaFailure(context),
+				ExpectError: regexp.MustCompile("Error creating Topic: googleapi: Error 403: User not authorized"),
+			},
+		},
+	})
+}
+
+// testAccSdkProvider_impersonate_service_account_inProviderBlock allows setting the impersonate_service_account argument in a provider block.
+// This function uses data.google_provider_config_sdk because it is implemented with the SDKv2
+func testAccSdkProvider_impersonate_service_account_inProviderBlock(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+provider "google" {
+	impersonate_service_account = "%{impersonate_service_account}"
+}
+
+data "google_provider_config_sdk" "default" {}
+
+output "impersonate_service_account" {
+  value = data.google_provider_config_sdk.default.impersonate_service_account
+  sensitive = true
+}
+`, context)
+}
+
+// testAccSdkProvider_impersonate_service_account_inEnvsOnly allows testing when the impersonate_service_account argument
+// is only supplied via ENVs
+func testAccSdkProvider_impersonate_service_account_inEnvsOnly(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_provider_config_sdk" "default" {}
+
+output "impersonate_service_account" {
+  value = data.google_provider_config_sdk.default.impersonate_service_account
+  sensitive = true
+}
+`, context)
+}
+
+func testAccSdkProvider_impersonate_service_account_testViaFailure(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+// This will succeed due to the Terraform identity having necessary permissions
+resource "google_pubsub_topic" "ok" {
+  name = "tf-test-%{random_suffix}-ok"
+}
+
+//  Create a service account and ensure the Terraform identity can make tokens for it
+resource "google_service_account" "default" {
+  account_id   = "tf-test-%{random_suffix}"
+  display_name = "Acceptance test impersonated service account"
+}
+
+data "google_client_openid_userinfo" "me" {
+}
+
+resource "google_service_account_iam_member" "token" {
+  service_account_id = google_service_account.default.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${data.google_client_openid_userinfo.me.email}"
+}
+
+// Impersonate the created service account
+provider "google" {
+  alias = "impersonation"
+  impersonate_service_account = google_service_account.default.email
+}
+
+// This will fail due to the impersonated service account not having any permissions
+resource "google_pubsub_topic" "fail" {
+  provider = google.impersonation
+  name = "tf-test-%{random_suffix}-fail"
+}
+`, context)
+}


### PR DESCRIPTION
This PR adds acceptance tests for usage of `impersonate_service_account_delegates` that demonstrate:

- how the provider behaves when provider configuration arguments come from different sources ( config vs ENVs)
    - _There are no ENVs for `impersonate_service_account_delegates`_ 
- schema-level validation that's in place, e.g. handling of empty arrays
    -  _Empty arrays are silently tolerated_
- use cases: how does this argument impact the providers behaviour in plan/apply


**Note: this PR does not include testing usage of impersonate_service_account_delegates when using PF-implemented resource/data source as doing this in the context of Firebase (the only service with PF-implemented stuff) is very complex.**

---

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
