### PR TITLE
Add acceptance tests for how provider handles `impersonate_service_account_delegates` argument

### DIFF
--- a/mmv1/third_party/terraform/fwprovider/data_source_provider_config_plugin_framework.go
+++ b/mmv1/third_party/terraform/fwprovider/data_source_provider_config_plugin_framework.go
@@ -206,7 +206,7 @@ func (d *GoogleProviderConfigPluginFrameworkDataSource) Read(ctx context.Context
 	data.Credentials = d.providerConfig.Credentials
 	data.AccessToken = d.providerConfig.AccessToken
 	data.ImpersonateServiceAccount = d.providerConfig.ImpersonateServiceAccount
-	// TODO(SarahFrench) - impersonate_service_account_delegates
+	data.ImpersonateServiceAccountDelegates = d.providerConfig.ImpersonateServiceAccountDelegates
 	data.Project = d.providerConfig.Project
 	data.Region = d.providerConfig.Region
 	data.BillingProject = d.providerConfig.BillingProject

--- a/mmv1/third_party/terraform/fwprovider/framework_provider_impersonate_service_account_delegates_test.go
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider_impersonate_service_account_delegates_test.go
@@ -1,0 +1,123 @@
+package fwprovider_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+// TestAccFwProvider_impersonate_service_account_delegates is a series of acc tests asserting how the plugin-framework provider handles impersonate_service_account_delegates arguments
+// It is plugin-framework specific because the HCL used provisions plugin-framework-implemented resources
+// It is a counterpart to TestAccSdkProvider_impersonate_service_account_delegates
+func TestAccFwProvider_impersonate_service_account_delegates(t *testing.T) {
+	testCases := map[string]func(t *testing.T){
+		// Configuring the provider using inputs
+		//     There are no environment variables for this field
+		"impersonate_service_account_delegates can be set in config": testAccFwProvider_impersonate_service_account_delegates_setInConfig,
+
+		// Schema-level validation
+		"when impersonate_service_account_delegates is set to an empty list in the config the value IS ignored": testAccFwProvider_impersonate_service_account_delegates_emptyListUsage,
+
+		// Usage
+		// We need to wait for a non-Firebase resource to be migrated to the plugin-framework to enable writing this test
+		// "impersonate_service_account_delegates controls which service account is used for actions"
+	}
+
+	for name, tc := range testCases {
+		// shadow the tc variable into scope so that when
+		// the loop continues, if t.Run hasn't executed tc(t)
+		// yet, we don't have a race condition
+		// see https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			tc(t)
+		})
+	}
+}
+
+func testAccFwProvider_impersonate_service_account_delegates_setInConfig(t *testing.T) {
+	acctest.SkipIfVcr(t) // Test doesn't interact with API
+
+	delegates := []string{
+		"projects/-/serviceAccounts/my-service-account-1@example.iam.gserviceaccount.com",
+		"projects/-/serviceAccounts/my-service-account-2@example.iam.gserviceaccount.com",
+	}
+	delegatesString := fmt.Sprintf(`["%s","%s"]`, delegates[0], delegates[1])
+
+	// There are no ENVs for this provider argument
+
+	context := map[string]interface{}{
+		"impersonate_service_account_delegates": delegatesString,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		// No PreCheck for checking ENVs
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFwProvider_impersonate_service_account_delegatesInProviderBlock(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_provider_config_plugin_framework.default", "impersonate_service_account_delegates.#", fmt.Sprintf("%d", len(delegates))),
+					resource.TestCheckResourceAttr("data.google_provider_config_plugin_framework.default", "impersonate_service_account_delegates.0", delegates[0]),
+					resource.TestCheckResourceAttr("data.google_provider_config_plugin_framework.default", "impersonate_service_account_delegates.1", delegates[1]),
+				),
+			},
+		},
+	})
+}
+
+func testAccFwProvider_impersonate_service_account_delegates_emptyListUsage(t *testing.T) {
+
+	context := map[string]interface{}{
+		"impersonate_service_account_delegates": "[]", // empty array
+		"random_suffix":                         acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		// No PreCheck for checking ENVs
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFwProvider_impersonate_service_account_delegates_testProvisioning(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_provider_config_plugin_framework.default", "impersonate_service_account_delegates.#", "0"),
+				),
+				// No error expected as empty array is ignored
+			},
+		},
+	})
+}
+
+// testAccFwProvider_impersonate_service_account_delegatesInProviderBlock allows setting the impersonate_service_account_delegates argument in a provider block.
+func testAccFwProvider_impersonate_service_account_delegatesInProviderBlock(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+provider "google" {
+	impersonate_service_account_delegates = %{impersonate_service_account_delegates}
+}
+
+data "google_provider_config_plugin_framework" "default" {}
+
+output "impersonate_service_account_delegates" {
+  value = data.google_provider_config_plugin_framework.default.impersonate_service_account_delegates
+  sensitive = true
+}
+`, context)
+}
+
+// testAccFwProvider_impersonate_service_account_delegates_testProvisioning allows setting the impersonate_service_account_delegates argument in a provider block
+// and testing its impact on provisioning a resource
+func testAccFwProvider_impersonate_service_account_delegates_testProvisioning(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+provider "google" {
+	impersonate_service_account_delegates = %{impersonate_service_account_delegates}
+}
+
+data "google_provider_config_plugin_framework" "default" {}
+
+resource "google_pubsub_topic" "example" {
+  name = "tf-test-%{random_suffix}"
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/fwprovider/framework_provider_impersonate_service_account_test.go
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider_impersonate_service_account_test.go
@@ -125,7 +125,6 @@ provider "google" {
 }
 
 data "google_provider_config_plugin_framework" "default" {}
-
 `, context)
 }
 
@@ -134,6 +133,5 @@ data "google_provider_config_plugin_framework" "default" {}
 func testAccFwProvider_impersonate_service_account_inEnvsOnly(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_provider_config_plugin_framework" "default" {}
-
 `, context)
 }

--- a/mmv1/third_party/terraform/fwtransport/framework_config.go.tmpl
+++ b/mmv1/third_party/terraform/fwtransport/framework_config.go.tmpl
@@ -37,6 +37,7 @@ type FrameworkProviderConfig struct {
 	Credentials                types.String
 	AccessToken                types.String
 	ImpersonateServiceAccount  types.String
+	ImpersonateServiceAccountDelegates types.List
 	// End temporary
 
 	BillingProject             types.String
@@ -107,6 +108,7 @@ func (p *FrameworkProviderConfig) LoadAndValidateFramework(ctx context.Context, 
 	p.Credentials = data.Credentials
 	p.AccessToken = data.AccessToken
 	p.ImpersonateServiceAccount = data.ImpersonateServiceAccount
+	p.ImpersonateServiceAccountDelegates = data.ImpersonateServiceAccountDelegates
 	// End temporary
 
 	// Copy values from the ProviderModel struct containing data about the provider configuration (present only when responsing to ConfigureProvider rpc calls)

--- a/mmv1/third_party/terraform/provider/provider_impersonate_service_account_delegates_test.go
+++ b/mmv1/third_party/terraform/provider/provider_impersonate_service_account_delegates_test.go
@@ -127,6 +127,14 @@ resource "google_pubsub_topic" "example" {
 }
 
 func testAccSdkProvider_impersonate_service_account_delegates_testViaFailure_1(context map[string]interface{}) string {
+
+	// This test config sets up the ability to use impersonate_service_account_delegates
+	//    The 'base service account' is the service account that credentials supplied via ENVs is linked to.
+	//    The 'delegate service account' is google_service_account.default_1
+	//        The base SA is given roles/iam.serviceAccountTokenCreator on the delegate SA via google_service_account_iam_member.token_1
+	//    The 'target service account' is google_service_account.default_2
+	//        The delegate SA is given roles/iam.serviceAccountTokenCreator on the target SA via google_service_account_iam_member.token_2
+
 	return acctest.Nprintf(`
 // This will succeed due to the Terraform identity having necessary permissions
 resource "google_pubsub_topic" "ok" {
@@ -163,9 +171,14 @@ resource "google_service_account_iam_member" "token_2" {
 }
 
 func testAccSdkProvider_impersonate_service_account_delegates_testViaFailure_2(context map[string]interface{}) string {
-	return testAccSdkProvider_impersonate_service_account_delegates_testViaFailure_1(context) + acctest.Nprintf(`
+	// See comments in testAccSdkProvider_impersonate_service_account_delegates_testViaFailure_1, about how the config
+	// sets up the ability to use impersonate_service_account_delegates.
 
-// Use impersonate_service_account_delegates
+	// Here in testAccSdkProvider_impersonate_service_account_delegates_testViaFailure_2 we:
+	//    Pass the base service account to google.impersonation implicitly via `credentials` (ENVs in the test environment)
+	//    Set the target service account as `impersonate_service_account`
+	//    Set the delegate service account(s) in `impersonate_service_account_delegates`
+	return testAccSdkProvider_impersonate_service_account_delegates_testViaFailure_1(context) + acctest.Nprintf(`
 provider "google" {
   alias = "impersonation"
   impersonate_service_account = google_service_account.default_2.email

--- a/mmv1/third_party/terraform/provider/provider_impersonate_service_account_delegates_test.go
+++ b/mmv1/third_party/terraform/provider/provider_impersonate_service_account_delegates_test.go
@@ -171,7 +171,6 @@ provider "google" {
   impersonate_service_account = google_service_account.default_2.email
   impersonate_service_account_delegates = [
     google_service_account.default_1.email,
-    google_service_account.default_2.email,
   ]
 }
 

--- a/mmv1/third_party/terraform/provider/provider_impersonate_service_account_delegates_test.go
+++ b/mmv1/third_party/terraform/provider/provider_impersonate_service_account_delegates_test.go
@@ -1,0 +1,184 @@
+package provider_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccFwProvider_impersonate_service_account_delegates(t *testing.T) {
+	testCases := map[string]func(t *testing.T){
+		// Configuring the provider using inputs
+		//     There are no environment variables for this field
+		"impersonate_service_account_delegates can be set in config": testAccSdkProvider_impersonate_service_account_delegates_setInConfig,
+
+		// Schema-level validation
+		"when impersonate_service_account_delegates is set to an empty list in the config the value IS ignored": testAccSdkProvider_impersonate_service_account_delegates_emptyListUsage,
+
+		// Usage
+		"impersonate_service_account_delegates controls which service account is used for actions": testAccSdkProvider_impersonate_service_account_delegates_usage,
+	}
+
+	for name, tc := range testCases {
+		// shadow the tc variable into scope so that when
+		// the loop continues, if t.Run hasn't executed tc(t)
+		// yet, we don't have a race condition
+		// see https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			tc(t)
+		})
+	}
+}
+
+func testAccSdkProvider_impersonate_service_account_delegates_setInConfig(t *testing.T) {
+	acctest.SkipIfVcr(t) // Test doesn't interact with API
+
+	delegates := []string{
+		"projects/-/serviceAccounts/my-service-account-1@example.iam.gserviceaccount.com",
+		"projects/-/serviceAccounts/my-service-account-2@example.iam.gserviceaccount.com",
+	}
+	delegatesString := fmt.Sprintf(`["%s","%s"]`, delegates[0], delegates[1])
+
+	// There are no ENVs for this provider argument
+
+	context := map[string]interface{}{
+		"random_suffix":                         acctest.RandString(t, 10),
+		"impersonate_service_account_delegates": delegatesString,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		// No PreCheck for checking ENVs
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSdkProvider_impersonate_service_account_delegates_testProvisioning(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_provider_config_sdk.default", "impersonate_service_account_delegates.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSdkProvider_impersonate_service_account_delegates_emptyListUsage(t *testing.T) {
+	acctest.SkipIfVcr(t) // Test doesn't interact with API
+
+	context := map[string]interface{}{
+		"random_suffix":                         acctest.RandString(t, 10),
+		"impersonate_service_account_delegates": "[]",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		// No PreCheck for checking ENVs
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSdkProvider_impersonate_service_account_delegates_testProvisioning(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_provider_config_sdk.default", "impersonate_service_account_delegates.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSdkProvider_impersonate_service_account_delegates_usage(t *testing.T) {
+	acctest.SkipIfVcr(t) // Test doesn't interact with API
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		// No PreCheck for checking ENVs
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSdkProvider_impersonate_service_account_delegates_testViaFailure_1(context),
+			},
+			{
+				// This needs to be split into a second step as impersonate_service_account_delegates does
+				// not tolerate unknown values
+				Config:      testAccSdkProvider_impersonate_service_account_delegates_testViaFailure_2(context),
+				ExpectError: regexp.MustCompile("Error creating Topic: googleapi: Error 403: User not authorized"),
+			},
+		},
+	})
+}
+
+// testAccSdkProvider_impersonate_service_account_delegates_testProvisioning allows setting the impersonate_service_account_delegates argument in a provider block
+// and testing its impact on provisioning a resource
+func testAccSdkProvider_impersonate_service_account_delegates_testProvisioning(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+provider "google" {
+	impersonate_service_account_delegates = %{impersonate_service_account_delegates}
+}
+
+data "google_provider_config_sdk" "default" {}
+
+resource "google_pubsub_topic" "example" {
+  name = "tf-test-%{random_suffix}"
+}
+`, context)
+}
+
+func testAccSdkProvider_impersonate_service_account_delegates_testViaFailure_1(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+// This will succeed due to the Terraform identity having necessary permissions
+resource "google_pubsub_topic" "ok" {
+  name = "tf-test-%{random_suffix}-ok"
+}
+
+//  Create a first service account and ensure the Terraform identity can make tokens for it
+resource "google_service_account" "default_1" {
+  account_id   = "tf-test-%{random_suffix}-1"
+  display_name = "Acceptance test impersonated service account"
+}
+
+data "google_client_openid_userinfo" "me" {
+}
+
+resource "google_service_account_iam_member" "token_1" {
+  service_account_id = google_service_account.default_1.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${data.google_client_openid_userinfo.me.email}"
+}
+
+//  Create a second service account and ensure the first service account can make tokens for it
+resource "google_service_account" "default_2" {
+  account_id   = "tf-test-%{random_suffix}-2"
+  display_name = "Acceptance test impersonated service account"
+}
+
+resource "google_service_account_iam_member" "token_2" {
+  service_account_id = google_service_account.default_2.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.default_1.email}"
+}
+`, context)
+}
+
+func testAccSdkProvider_impersonate_service_account_delegates_testViaFailure_2(context map[string]interface{}) string {
+	return testAccSdkProvider_impersonate_service_account_delegates_testViaFailure_1(context) + acctest.Nprintf(`
+
+// Use impersonate_service_account_delegates
+provider "google" {
+  alias = "impersonation"
+  impersonate_service_account = google_service_account.default_2.email
+  impersonate_service_account_delegates = [
+    google_service_account.default_1.email,
+    google_service_account.default_2.email,
+  ]
+}
+
+// This will fail due to the impersonated service account not having any permissions
+resource "google_pubsub_topic" "fail" {
+  provider = google.impersonation
+  name = "tf-test-%{random_suffix}-fail"
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/provider/provider_impersonate_service_account_test.go
+++ b/mmv1/third_party/terraform/provider/provider_impersonate_service_account_test.go
@@ -145,7 +145,6 @@ provider "google" {
 }
 
 data "google_provider_config_sdk" "default" {}
-
 `, context)
 }
 
@@ -154,7 +153,6 @@ data "google_provider_config_sdk" "default" {}
 func testAccSdkProvider_impersonate_service_account_inEnvsOnly(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_provider_config_sdk" "default" {}
-
 `, context)
 }
 


### PR DESCRIPTION
To be merged after https://github.com/GoogleCloudPlatform/magic-modules/pull/11641

This PR adds acceptance tests for usage of `impersonate_service_account_delegates` that demonstrate:

- how the provider behaves when provider configuration arguments come from different sources ( config vs ENVs)
    - _There are no ENVs for `impersonate_service_account_delegates`_ 
- schema-level validation that's in place, e.g. handling of empty arrays
    -  _Empty arrays are silently tolerated_
- use cases: how does this argument impact the providers behaviour in plan/apply


**Note: this PR does not include testing usage of impersonate_service_account_delegates when using PF-implemented resource/data source as doing this in the context of Firebase (the only service with PF-implemented stuff) is very complex.**

---

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
