### PR TITLE
Add existing_reservations to google_compute_region_commitment

### DIFF
--- a/mmv1/products/compute/RegionCommitment.yaml
+++ b/mmv1/products/compute/RegionCommitment.yaml
@@ -203,3 +203,8 @@ properties:
       The default value is false if not specified.
       If the field is set to true, the commitment will be automatically renewed for either
       one or three years according to the terms of the existing commitment.
+  - !ruby/object:Api::Type::String
+    name: 'existingReservations'
+    default_from_api: true
+    description: |
+      Specifies the already existing reservations to attach to the Commitment.


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/17473

Adds support to attach an existing reservation to a commitment.

```release-note:enhancement
compute: added 'existing_reservations' field to 'google_compute_region_commitment' resource
```
