### PR TITLE
Dataproc: Make `internal_ip_only` a computed, not defaulted, field. Always send it when specified.

### DIFF
--- a/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
+++ b/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
@@ -915,7 +915,7 @@ func BootstrapSubnetForDataprocBatches(t *testing.T, subnetName string, networkN
 	subnetOptions := map[string]interface{}{
 		"privateIpGoogleAccess": true,
 	}
-	return BootstrapSubnetWithOverrides(t, subnetName, networkName, subnetOptions)
+	return bootstrapSubnetWithOverrides(t, subnetName, networkName, subnetOptions, "10.78.0.0/20")
 }
 
 func BootstrapSubnet(t *testing.T, subnetName string, networkName string) string {
@@ -930,6 +930,10 @@ func BootstrapSubnetWithFirewallForDataprocBatches(t *testing.T, testId string, 
 }
 
 func BootstrapSubnetWithOverrides(t *testing.T, subnetName string, networkName string, subnetOptions map[string]interface{}) string {
+	return bootstrapSubnetWithOverrides(t, subnetName, networkName, subnetOptions, "10.77.0.0/20")
+}
+
+func bootstrapSubnetWithOverrides(t *testing.T, subnetName string, networkName string, subnetOptions map[string]interface{}, ipCidrRange string) string {
 	projectID := envvar.GetTestProjectFromEnv()
 	region := envvar.GetTestRegionFromEnv()
 

--- a/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
+++ b/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
@@ -959,7 +959,7 @@ func bootstrapSubnetWithOverrides(t *testing.T, subnetName string, networkName s
 			"name":        subnetName,
 			"region ":     region,
 			"network":     networkUrl,
-			"ipCidrRange": "10.78.0.0/20",
+			"ipCidrRange": ipCidrRange,
 		}
 
 		if len(subnetOptions) != 0 {

--- a/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
+++ b/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
@@ -955,7 +955,7 @@ func BootstrapSubnetWithOverrides(t *testing.T, subnetName string, networkName s
 			"name":        subnetName,
 			"region ":     region,
 			"network":     networkUrl,
-			"ipCidrRange": "10.77.0.0/20",
+			"ipCidrRange": "10.78.0.0/20",
 		}
 
 		if len(subnetOptions) != 0 {

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
@@ -650,9 +650,9 @@ func ResourceDataprocCluster() *schema.Resource {
 									"internal_ip_only": {
 										Type:         schema.TypeBool,
 										Optional:     true,
+										Computed:     true,
 										AtLeastOneOf: gceClusterConfigKeys,
 										ForceNew:     true,
-										Default:      false,
 										Description:  `By default, clusters are not restricted to internal IP addresses, and will have ephemeral external IP addresses assigned to each instance. If set to true, all instances in the cluster will only have internal IP addresses. Note: Private Google Access (also known as privateIpGoogleAccess) must be enabled on the subnetwork that the cluster will be launched in.`,
 									},
 

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
@@ -58,15 +58,19 @@ func TestAccDataprocCluster_missingZoneGlobalRegion2(t *testing.T) {
 func TestAccDataprocCluster_basic(t *testing.T) {
 	t.Parallel()
 
-	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
+	var cluster dataproc.Cluster
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_basic(rnd),
+				Config: testAccDataprocCluster_basic(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.basic", &cluster),
 
@@ -112,7 +116,7 @@ func TestAccDataprocVirtualCluster_basic(t *testing.T) {
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
 	pid := envvar.GetTestProjectFromEnv()
-	version := "3.1-dataproc-7"
+	version := "3.5-dataproc-19"
 	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
 	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
@@ -122,7 +126,7 @@ func TestAccDataprocVirtualCluster_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocVirtualCluster_basic(pid, rnd, networkName, subnetworkName),
+				Config: testAccDataprocVirtualCluster_basic(pid, rnd, networkName, subnetworkName, version),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.virtual_cluster", &cluster),
 
@@ -426,15 +430,18 @@ func TestAccDataprocCluster_updatable(t *testing.T) {
 	t.Parallel()
 
 	rnd := acctest.RandString(t, 10)
-	var cluster dataproc.Cluster
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
+	var cluster dataproc.Cluster
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_updatable(rnd, 2, 1),
+				Config: testAccDataprocCluster_updatable(rnd, subnetworkName, 2, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.updatable", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.master_config.0.num_instances", "1"),
@@ -442,7 +449,7 @@ func TestAccDataprocCluster_updatable(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.preemptible_worker_config.0.num_instances", "1")),
 			},
 			{
-				Config: testAccDataprocCluster_updatable(rnd, 2, 0),
+				Config: testAccDataprocCluster_updatable(rnd, subnetworkName, 2, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.updatable", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.master_config.0.num_instances", "1"),
@@ -450,7 +457,7 @@ func TestAccDataprocCluster_updatable(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.preemptible_worker_config.0.num_instances", "0")),
 			},
 			{
-				Config: testAccDataprocCluster_updatable(rnd, 3, 2),
+				Config: testAccDataprocCluster_updatable(rnd, subnetworkName, 3, 2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.master_config.0.num_instances", "1"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.worker_config.0.num_instances", "3"),
@@ -514,6 +521,10 @@ func TestAccDataprocCluster_spotWithInstanceFlexibilityPolicy(t *testing.T) {
 	t.Parallel()
 
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	var cluster dataproc.Cluster
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -521,7 +532,7 @@ func TestAccDataprocCluster_spotWithInstanceFlexibilityPolicy(t *testing.T) {
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_spotWithInstanceFlexibilityPolicy(rnd),
+				Config: testAccDataprocCluster_spotWithInstanceFlexibilityPolicy(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.spot_with_instance_flexibility_policy", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.spot_with_instance_flexibility_policy", "cluster_config.0.preemptible_worker_config.0.preemptibility", "SPOT"),
@@ -538,6 +549,10 @@ func TestAccDataprocCluster_spotWithAuxiliaryNodeGroups(t *testing.T) {
 
 	project := envvar.GetTestProjectFromEnv()
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	var cluster dataproc.Cluster
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -545,7 +560,7 @@ func TestAccDataprocCluster_spotWithAuxiliaryNodeGroups(t *testing.T) {
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withAuxiliaryNodeGroups(rnd),
+				Config: testAccDataprocCluster_withAuxiliaryNodeGroups(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_auxiliary_node_groups", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.roles.0", "DRIVER"),
@@ -1046,22 +1061,26 @@ func TestAccDataprocCluster_withMetastoreConfig(t *testing.T) {
 	msName_basic := fmt.Sprintf("projects/%s/locations/us-central1/services/%s", pid, basicServiceId)
 	msName_update := fmt.Sprintf("projects/%s/locations/us-central1/services/%s", pid, updateServiceId)
 
-	var cluster dataproc.Cluster
 	clusterName := "tf-test-" + acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
+	var cluster dataproc.Cluster
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withMetastoreConfig(clusterName, basicServiceId),
+				Config: testAccDataprocCluster_withMetastoreConfig(clusterName, subnetworkName, basicServiceId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_metastore_config", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_metastore_config", "cluster_config.0.metastore_config.0.dataproc_metastore_service", msName_basic),
 				),
 			},
 			{
-				Config: testAccDataprocCluster_withMetastoreConfig_update(clusterName, updateServiceId),
+				Config: testAccDataprocCluster_withMetastoreConfig_update(clusterName, subnetworkName, updateServiceId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_metastore_config", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_metastore_config", "cluster_config.0.metastore_config.0.dataproc_metastore_service", msName_update),
@@ -1323,16 +1342,22 @@ resource "google_dataproc_cluster" "basic" {
 `, rnd)
 }
 
-func testAccDataprocCluster_basic(rnd string) string {
+func testAccDataprocCluster_basic(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "basic" {
   name   = "tf-test-dproc-%s"
   region = "us-central1"
+
+  cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+  }
 }
-`, rnd)
+`, rnd, subnetworkName)
 }
 
-func testAccDataprocVirtualCluster_basic(projectID, rnd, networkName, subnetworkName string) string {
+func testAccDataprocVirtualCluster_basic(projectID, rnd, networkName, subnetworkName, version string) string {
 	return fmt.Sprintf(`
 data "google_project" "project" {
   project_id = "%s"
@@ -1376,7 +1401,7 @@ resource "google_dataproc_cluster" "virtual_cluster" {
 		kubernetes_namespace = "tf-test-dproc-%s"
 		kubernetes_software_config {
 		  component_version = {
-			"SPARK": "3.1-dataproc-7",
+			"SPARK": "%s",
 		  }
 		}
 		gke_cluster_config {
@@ -1391,7 +1416,7 @@ resource "google_dataproc_cluster" "virtual_cluster" {
 	  }
 	}
   }
-`, projectID, rnd, networkName, subnetworkName, projectID, rnd, rnd, rnd, rnd, rnd, rnd)
+`, projectID, rnd, networkName, subnetworkName, projectID, rnd, rnd, rnd, rnd, rnd, version, rnd)
 }
 
 func testAccCheckDataprocGkeClusterNodePoolsHaveRoles(cluster *dataproc.Cluster, roles ...string) func(s *terraform.State) error {
@@ -1424,6 +1449,8 @@ resource "google_dataproc_cluster" "accelerated_cluster" {
     }
 
     master_config {
+      # The default machine family is n2, which does not support (most) accelerators.
+      machine_type = "n1-standard-2"
       accelerators {
         accelerator_type  = "%s"
         accelerator_count = "1"
@@ -1431,6 +1458,8 @@ resource "google_dataproc_cluster" "accelerated_cluster" {
     }
 
     worker_config {
+      # The default machine family is n2, which does not support (most) accelerators.
+      machine_type = "n1-standard-2"
       accelerators {
         accelerator_type  = "%s"
         accelerator_count = "1"
@@ -1635,7 +1664,7 @@ resource "google_compute_node_template" "nodetmpl" {
     tfacc = "test"
   }
 
-  node_type = "n1-node-96-624"
+  node_type = "n2-node-80-640"
 
   cpu_overcommit_type = "ENABLED"
 }
@@ -1793,7 +1822,7 @@ resource "google_dataproc_cluster" "with_init_action" {
 `, bucket, rnd, objName, objName, rnd, subnetworkName)
 }
 
-func testAccDataprocCluster_updatable(rnd string, w, p int) string {
+func testAccDataprocCluster_updatable(rnd, subnetworkName string, w, p int) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "updatable" {
   name   = "tf-test-dproc-%s"
@@ -1801,6 +1830,10 @@ resource "google_dataproc_cluster" "updatable" {
   graceful_decommission_timeout = "0.2s"
 
   cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+
     master_config {
       num_instances = "1"
       machine_type  = "e2-medium"
@@ -1825,7 +1858,7 @@ resource "google_dataproc_cluster" "updatable" {
     }
   }
 }
-`, rnd, w, p)
+`, rnd, subnetworkName, w, p)
 }
 
 func testAccDataprocCluster_nonPreemptibleSecondary(rnd, subnetworkName string) string {
@@ -1906,13 +1939,17 @@ resource "google_dataproc_cluster" "spot_secondary" {
 	`, rnd, subnetworkName)
 }
 
-func testAccDataprocCluster_spotWithInstanceFlexibilityPolicy(rnd string) string {
+func testAccDataprocCluster_spotWithInstanceFlexibilityPolicy(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "spot_with_instance_flexibility_policy" {
   name   = "tf-test-dproc-%s"
   region = "us-central1"
 
   cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+
     master_config {
       num_instances = "1"
       machine_type  = "e2-medium"
@@ -1944,16 +1981,20 @@ resource "google_dataproc_cluster" "spot_with_instance_flexibility_policy" {
     }
   }
 }
-	`, rnd)
+	`, rnd, subnetworkName)
 }
 
-func testAccDataprocCluster_withAuxiliaryNodeGroups(rnd string) string {
+func testAccDataprocCluster_withAuxiliaryNodeGroups(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_auxiliary_node_groups" {
   name   = "tf-test-dproc-%s"
   region = "us-central1"
 
   cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+
     master_config {
       num_instances = "1"
       machine_type  = "e2-medium"
@@ -1993,7 +2034,7 @@ resource "google_dataproc_cluster" "with_auxiliary_node_groups" {
     }
   }
 }
-	`, rnd)
+	`, rnd, subnetworkName)
 }
 
 func testAccDataprocCluster_withStagingBucketOnly(bucketName string) string {
@@ -2351,6 +2392,9 @@ resource "google_dataproc_cluster" "with_net_ref_by_name" {
 
     gce_cluster_config {
       network = google_compute_network.dataproc_network.name
+      # The network we are creating does not have private Google access, so it
+      # cannot support internal IPs only.
+      internal_ip_only = false
     }
   }
 }
@@ -2378,6 +2422,9 @@ resource "google_dataproc_cluster" "with_net_ref_by_url" {
 
     gce_cluster_config {
       network = google_compute_network.dataproc_network.self_link
+      # The network we are creating does not have private Google access, so it
+      # cannot support internal IPs only.
+      internal_ip_only = false
     }
   }
 }
@@ -2507,13 +2554,16 @@ resource "google_dataproc_autoscaling_policy" "asp" {
 `, rnd, subnetworkName, rnd)
 }
 
-func testAccDataprocCluster_withMetastoreConfig(clusterName, serviceId string) string {
+func testAccDataprocCluster_withMetastoreConfig(clusterName, subnetworkName, serviceId string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_metastore_config" {
   name                  = "%s"
   region                = "us-central1"
 
   cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
     metastore_config {
       dataproc_metastore_service = google_dataproc_metastore_service.ms.name
     }
@@ -2535,16 +2585,19 @@ resource "google_dataproc_metastore_service" "ms" {
     version = "3.1.2"
   }
 }
-`, clusterName, serviceId)
+`, clusterName, subnetworkName, serviceId)
 }
 
-func testAccDataprocCluster_withMetastoreConfig_update(clusterName, serviceId string) string {
+func testAccDataprocCluster_withMetastoreConfig_update(clusterName, subnetworkName, serviceId string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_metastore_config" {
   name                  = "%s"
   region                = "us-central1"
 
   cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
     metastore_config {
       dataproc_metastore_service = google_dataproc_metastore_service.ms.name
     }
@@ -2566,6 +2619,6 @@ resource "google_dataproc_metastore_service" "ms" {
     version = "3.1.2"
   }
 }
-`, clusterName, serviceId)
+`, clusterName, subnetworkName, serviceId)
 }
 

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
@@ -1804,7 +1804,7 @@ resource "google_dataproc_cluster" "with_init_action" {
     }
 
     master_config {
-      machine_type = "e2-medium"
+      machine_type = "n1-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -1836,7 +1836,7 @@ resource "google_dataproc_cluster" "updatable" {
 
     master_config {
       num_instances = "1"
-      machine_type  = "e2-medium"
+      machine_type  = "n1-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -1844,7 +1844,7 @@ resource "google_dataproc_cluster" "updatable" {
 
     worker_config {
       num_instances = "%d"
-      machine_type  = "e2-medium"
+      machine_type  = "n1-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -1874,7 +1874,7 @@ resource "google_dataproc_cluster" "non_preemptible_secondary" {
 
     master_config {
       num_instances = "1"
-      machine_type  = "e2-medium"
+      machine_type  = "n1-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -1882,7 +1882,7 @@ resource "google_dataproc_cluster" "non_preemptible_secondary" {
   
     worker_config {
       num_instances = "2"
-      machine_type  = "e2-medium"
+      machine_type  = "n1-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -1913,7 +1913,7 @@ resource "google_dataproc_cluster" "spot_secondary" {
 
     master_config {
       num_instances = "1"
-      machine_type  = "e2-medium"
+      machine_type  = "n1-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -1921,7 +1921,7 @@ resource "google_dataproc_cluster" "spot_secondary" {
 
     worker_config {
       num_instances = "2"
-      machine_type  = "e2-medium"
+      machine_type  = "n1-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -1952,7 +1952,7 @@ resource "google_dataproc_cluster" "spot_with_instance_flexibility_policy" {
 
     master_config {
       num_instances = "1"
-      machine_type  = "e2-medium"
+      machine_type  = "n1-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -1960,7 +1960,7 @@ resource "google_dataproc_cluster" "spot_with_instance_flexibility_policy" {
 
     worker_config {
       num_instances = "2"
-      machine_type  = "e2-medium"
+      machine_type  = "n1-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -1997,7 +1997,7 @@ resource "google_dataproc_cluster" "with_auxiliary_node_groups" {
 
     master_config {
       num_instances = "1"
-      machine_type  = "e2-medium"
+      machine_type  = "n1-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -2005,7 +2005,7 @@ resource "google_dataproc_cluster" "with_auxiliary_node_groups" {
 
     worker_config {
       num_instances = "2"
-      machine_type  = "e2-medium"
+      machine_type  = "n1-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -2081,7 +2081,7 @@ resource "google_dataproc_cluster" "with_bucket" {
     }
 
     master_config {
-      machine_type = "e2-medium"
+      machine_type = "n1-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -2115,7 +2115,7 @@ resource "google_dataproc_cluster" "with_bucket" {
     }
 
     master_config {
-      machine_type = "e2-medium"
+      machine_type = "n1-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -2305,7 +2305,7 @@ resource "google_dataproc_cluster" "with_service_account" {
     }
 
     master_config {
-      machine_type = "e2-medium"
+      machine_type = "n1-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -2384,7 +2384,7 @@ resource "google_dataproc_cluster" "with_net_ref_by_name" {
     }
 
     master_config {
-      machine_type = "e2-medium"
+      machine_type = "n1-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
@@ -2414,7 +2414,7 @@ resource "google_dataproc_cluster" "with_net_ref_by_url" {
     }
 
     master_config {
-      machine_type = "e2-medium"
+      machine_type = "n1-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
@@ -1073,14 +1073,14 @@ func TestAccDataprocCluster_withMetastoreConfig(t *testing.T) {
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withMetastoreConfig(clusterName, subnetworkName, basicServiceId),
+				Config: testAccDataprocCluster_withMetastoreConfig(pid, clusterName, subnetworkName, basicServiceId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_metastore_config", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_metastore_config", "cluster_config.0.metastore_config.0.dataproc_metastore_service", msName_basic),
 				),
 			},
 			{
-				Config: testAccDataprocCluster_withMetastoreConfig_update(clusterName, subnetworkName, updateServiceId),
+				Config: testAccDataprocCluster_withMetastoreConfig_update(pid, clusterName, subnetworkName, updateServiceId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_metastore_config", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_metastore_config", "cluster_config.0.metastore_config.0.dataproc_metastore_service", msName_update),
@@ -2554,7 +2554,7 @@ resource "google_dataproc_autoscaling_policy" "asp" {
 `, rnd, subnetworkName, rnd)
 }
 
-func testAccDataprocCluster_withMetastoreConfig(clusterName, subnetworkName, serviceId string) string {
+func testAccDataprocCluster_withMetastoreConfig(projectName, clusterName, subnetworkName, serviceId string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_metastore_config" {
   name                  = "%s"
@@ -2584,11 +2584,17 @@ resource "google_dataproc_metastore_service" "ms" {
   hive_metastore_config {
     version = "3.1.2"
   }
+
+  network_config {
+    consumers {
+      subnetwork = "projects/%s/regions/us-central1/subnetworks/%s"
+    }
+  }
 }
-`, clusterName, subnetworkName, serviceId)
+`, clusterName, subnetworkName, serviceId, projectName, subnetworkName)
 }
 
-func testAccDataprocCluster_withMetastoreConfig_update(clusterName, subnetworkName, serviceId string) string {
+func testAccDataprocCluster_withMetastoreConfig_update(projectName, clusterName, subnetworkName, serviceId string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_metastore_config" {
   name                  = "%s"
@@ -2618,7 +2624,13 @@ resource "google_dataproc_metastore_service" "ms" {
   hive_metastore_config {
     version = "3.1.2"
   }
+
+  network_config {
+    consumers {
+      subnetwork = "projects/%s/regions/us-central1/subnetworks/%s"
+    }
+  }
 }
-`, clusterName, subnetworkName, serviceId)
+`, clusterName, subnetworkName, serviceId, projectName, subnetworkName)
 }
 

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
@@ -60,7 +60,7 @@ func TestAccDataprocCluster_basic(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster-internal", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	var cluster dataproc.Cluster
@@ -78,7 +78,7 @@ func TestAccDataprocCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("google_dataproc_cluster.basic", "cluster_config.0.bucket"),
 
 					// Default behavior is for Dataproc to not use only internal IP addresses
-					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.internal_ip_only", "false"),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.internal_ip_only", "true"),
 
 					// Expect 1 master instances with computed values
 					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.master_config.#", "1"),
@@ -431,7 +431,7 @@ func TestAccDataprocCluster_updatable(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster-internal", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	var cluster dataproc.Cluster
@@ -522,7 +522,7 @@ func TestAccDataprocCluster_spotWithInstanceFlexibilityPolicy(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster-internal", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	var cluster dataproc.Cluster
@@ -550,7 +550,7 @@ func TestAccDataprocCluster_spotWithAuxiliaryNodeGroups(t *testing.T) {
 	project := envvar.GetTestProjectFromEnv()
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster-internal", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	var cluster dataproc.Cluster
@@ -1063,7 +1063,7 @@ func TestAccDataprocCluster_withMetastoreConfig(t *testing.T) {
 
 	clusterName := "tf-test-" + acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster-internal", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	var cluster dataproc.Cluster

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
@@ -1352,6 +1352,16 @@ resource "google_dataproc_cluster" "basic" {
     gce_cluster_config {
       subnetwork = "%s"
     }
+
+    master_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
+    }
+
+    worker_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
+    }
   }
 }
 `, rnd, subnetworkName)
@@ -1537,6 +1547,16 @@ resource "google_dataproc_cluster" "basic" {
         enable_vtpm                 = true
       }
     }
+
+    master_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
+    }
+
+    worker_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
+    }
   }
 }
 `, rnd, rnd, rnd, rnd)
@@ -1557,6 +1577,16 @@ resource "google_dataproc_cluster" "basic" {
       }
       tags = ["my-tag", "your-tag", "our-tag", "their-tag"]
     }
+
+    master_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
+    }
+
+    worker_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
+    }
   }
 }
 `, rnd, subnetworkName)
@@ -1572,12 +1602,16 @@ resource "google_dataproc_cluster" "with_min_num_instances" {
     gce_cluster_config {
       subnetwork = "%s"
     }
-    master_config{
+    master_config {
       num_instances=1
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
     }
-    worker_config{
+    worker_config {
       num_instances = 3
       min_num_instances = 2
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
     }
   }
 }
@@ -1637,6 +1671,15 @@ resource "google_dataproc_cluster" "basic" {
     gce_cluster_config {
       subnetwork = "%s"
     }
+
+    master_config {
+      machine_type  = "n1-standard-2"
+    }
+
+    worker_config {
+      machine_type  = "n1-standard-2"
+    }
+
     dataproc_metric_config {
       metrics {
         metric_source = "HDFS"
@@ -1713,6 +1756,9 @@ resource "google_dataproc_cluster" "single_node_cluster" {
       override_properties = {
         "dataproc:dataproc.allow.zero.workers" = "true"
       }
+    }
+    master_config {
+      machine_type  = "n1-standard-2"
     }
   }
 }
@@ -2134,6 +2180,16 @@ resource "google_dataproc_cluster" "with_labels" {
     gce_cluster_config {
       subnetwork = "%s"
     }
+
+    master_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
+    }
+
+    worker_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
+    }
   }
 
   labels = {
@@ -2151,6 +2207,16 @@ resource "google_dataproc_cluster" "with_labels" {
   cluster_config {
     gce_cluster_config {
       subnetwork = "%s"
+    }
+
+    master_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
+    }
+
+    worker_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
     }
   }
 
@@ -2170,6 +2236,16 @@ resource "google_dataproc_cluster" "with_labels" {
     gce_cluster_config {
       subnetwork = "%s"
     }
+
+    master_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
+    }
+
+    worker_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
+    }
   }
 }
 `, rnd, subnetworkName)
@@ -2184,6 +2260,16 @@ resource "google_dataproc_cluster" "with_endpoint_config" {
 	cluster_config {
     gce_cluster_config {
       subnetwork = "%s"
+    }
+
+    master_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
+    }
+
+    worker_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
     }
 
 		endpoint_config {
@@ -2205,6 +2291,16 @@ resource "google_dataproc_cluster" "with_image_version" {
       subnetwork = "%s"
     }
 
+    master_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
+    }
+
+    worker_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
+    }
+
     software_config {
       image_version = "%s"
     }
@@ -2222,6 +2318,16 @@ resource "google_dataproc_cluster" "with_opt_components" {
   cluster_config {
     gce_cluster_config {
       subnetwork = "%s"
+    }
+
+    master_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
+    }
+
+    worker_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
     }
 
     software_config {
@@ -2243,6 +2349,16 @@ resource "google_dataproc_cluster" "with_lifecycle_config" {
       subnetwork = "%s"
     }
 
+    master_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
+    }
+
+    worker_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
+    }
+
     lifecycle_config {
       idle_delete_ttl = "%s"
     }
@@ -2260,6 +2376,16 @@ resource "google_dataproc_cluster" "with_lifecycle_config" {
  cluster_config {
   gce_cluster_config {
       subnetwork = "%s"
+    }
+
+    master_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
+    }
+
+    worker_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
     }
 
    lifecycle_config {
@@ -2471,6 +2597,16 @@ resource "google_dataproc_cluster" "kerb" {
       subnetwork = "%s"
     }
 
+    master_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
+    }
+
+    worker_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
+    }
+
     security_config {
       kerberos_config {
         root_principal_password_uri = google_storage_bucket_object.password.self_link
@@ -2491,6 +2627,16 @@ resource "google_dataproc_cluster" "basic" {
   cluster_config {
     gce_cluster_config {
       subnetwork = "%s"
+    }
+
+    master_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
+    }
+
+    worker_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
     }
 
     autoscaling_config {
@@ -2529,6 +2675,16 @@ resource "google_dataproc_cluster" "basic" {
       subnetwork = "%s"
     }
 
+    master_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
+    }
+
+    worker_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
+    }
+
     autoscaling_config {
       policy_uri = ""
     }
@@ -2563,6 +2719,14 @@ resource "google_dataproc_cluster" "with_metastore_config" {
   cluster_config {
     gce_cluster_config {
       subnetwork = "%s"
+    }
+    master_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
+    }
+    worker_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
     }
     metastore_config {
       dataproc_metastore_service = google_dataproc_metastore_service.ms.name
@@ -2603,6 +2767,14 @@ resource "google_dataproc_cluster" "with_metastore_config" {
   cluster_config {
     gce_cluster_config {
       subnetwork = "%s"
+    }
+    master_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
+    }
+    worker_config {
+      # The Terraform testing projects have a lot more n1 quota than anything else.
+      machine_type = "n1-standard-2"
     }
     metastore_config {
       dataproc_metastore_service = google_dataproc_metastore_service.ms.name

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
@@ -1449,10 +1449,6 @@ resource "google_dataproc_cluster" "accelerated_cluster" {
   region = "us-central1"
 
   cluster_config {
-    software_config {
-      image_version = "2.0.35-debian10"
-    }
-
     gce_cluster_config {
       subnetwork = "%s"
       zone = "%s"
@@ -1725,9 +1721,6 @@ resource "google_dataproc_cluster" "basic" {
   region = "us-central1"
 
   cluster_config {
-    software_config {
-      image_version = "2.0.35-debian10"
-    }
     gce_cluster_config {
       subnetwork = "%s"
       zone = "us-central1-f"
@@ -1843,7 +1836,6 @@ resource "google_dataproc_cluster" "with_init_action" {
 
     # Keep the costs down with smallest config we can get away with
     software_config {
-      image_version = "2.0.35-debian10"
       override_properties = {
         "dataproc:dataproc.allow.zero.workers" = "true"
       }
@@ -2120,7 +2112,6 @@ resource "google_dataproc_cluster" "with_bucket" {
 
     # Keep the costs down with smallest config we can get away with
     software_config {
-      image_version = "2.0.35-debian10"
       override_properties = {
         "dataproc:dataproc.allow.zero.workers" = "true"
       }
@@ -2154,7 +2145,6 @@ resource "google_dataproc_cluster" "with_bucket" {
 
     # Keep the costs down with smallest config we can get away with
     software_config {
-      image_version = "2.0.35-debian10"
       override_properties = {
         "dataproc:dataproc.allow.zero.workers" = "true"
       }
@@ -2424,7 +2414,6 @@ resource "google_dataproc_cluster" "with_service_account" {
   cluster_config {
     # Keep the costs down with smallest config we can get away with
     software_config {
-      image_version = "2.0.35-debian10"
       override_properties = {
         "dataproc:dataproc.allow.zero.workers" = "true"
       }

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job_test.go.tmpl
@@ -862,12 +862,11 @@ resource "google_dataproc_cluster" "basic" {
   cluster_config {
     # Keep the costs down with smallest config we can get away with
     software_config {
-      image_version = "2.0.35-debian10"
+      # 2.1 removes Presto in favor of Trino. So use 2.0 for the Presto test.
+      image_version = "2.0"
       override_properties = {
         "dataproc:dataproc.allow.zero.workers" = "true"
       }
-      # 2.1 removes Presto in favor of Trino. So use 2.0 for the Presto test.
-      image_version = "2.0"
       optional_components = ["PRESTO"]
     }
 

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job_test.go.tmpl
@@ -50,7 +50,7 @@ func TestAccDataprocJob_updatable(t *testing.T) {
 	rnd := acctest.RandString(t, 10)
 	jobId := fmt.Sprintf("dproc-update-job-id-%s", rnd)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -83,7 +83,7 @@ func TestAccDataprocJob_PySpark(t *testing.T) {
 	rnd := acctest.RandString(t, 10)
 	jobId := fmt.Sprintf("dproc-custom-job-id-%s", rnd)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -125,7 +125,7 @@ func TestAccDataprocJob_Spark(t *testing.T) {
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -161,7 +161,7 @@ func TestAccDataprocJob_Hadoop(t *testing.T) {
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -197,7 +197,7 @@ func TestAccDataprocJob_Hive(t *testing.T) {
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -233,7 +233,7 @@ func TestAccDataprocJob_Pig(t *testing.T) {
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -269,7 +269,7 @@ func TestAccDataprocJob_SparkSql(t *testing.T) {
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -305,7 +305,7 @@ func TestAccDataprocJob_Presto(t *testing.T) {
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job_test.go.tmpl
@@ -50,7 +50,7 @@ func TestAccDataprocJob_updatable(t *testing.T) {
 	rnd := acctest.RandString(t, 10)
 	jobId := fmt.Sprintf("dproc-update-job-id-%s", rnd)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster-internal", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -83,7 +83,7 @@ func TestAccDataprocJob_PySpark(t *testing.T) {
 	rnd := acctest.RandString(t, 10)
 	jobId := fmt.Sprintf("dproc-custom-job-id-%s", rnd)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster-internal", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -125,7 +125,7 @@ func TestAccDataprocJob_Spark(t *testing.T) {
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster-internal", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -161,7 +161,7 @@ func TestAccDataprocJob_Hadoop(t *testing.T) {
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster-internal", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -197,7 +197,7 @@ func TestAccDataprocJob_Hive(t *testing.T) {
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster-internal", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -233,7 +233,7 @@ func TestAccDataprocJob_Pig(t *testing.T) {
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster-internal", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -269,7 +269,7 @@ func TestAccDataprocJob_SparkSql(t *testing.T) {
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster-internal", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -305,7 +305,7 @@ func TestAccDataprocJob_Presto(t *testing.T) {
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster-internal", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job_test.go.tmpl
@@ -307,7 +307,7 @@ func TestAccDataprocJob_Presto(t *testing.T) {
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
 	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster-internal", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
-	
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
@@ -866,6 +866,8 @@ resource "google_dataproc_cluster" "basic" {
       override_properties = {
         "dataproc:dataproc.allow.zero.workers" = "true"
       }
+      # 2.1 removes Presto in favor of Trino. So use 2.0 for the Presto test.
+      image_version = "2.0"
       optional_components = ["PRESTO"]
     }
 


### PR DESCRIPTION
Make `internal_ip_only` of `google_dataproc_cluster` a computed, not defaulted, field. Always send it when specified by the user.

The 'default' value for this field is determined on Dataproc's servers, based on the image version used. Users can still provide a value to override the default, but if the user does not provide the value, then the value generated by Dataproc's servers should be used.

This is being done because the server-side default changed between Dataproc image versions < 2.1 and >= 2.2, from `true` to `false` respectively. 

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


Fixes https://github.com/hashicorp/terraform-provider-google/issues/19522.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
dataproc: Changed `google_dataproc_cluster` `internal_ip_only` field to computed and always sent if specified.
```
