### PR TITLE
feat: promote service scaling to GA in cloudrunv2 Service resource

### DIFF
--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -322,7 +322,6 @@ properties:
     item_type: Api::Type::String
   - !ruby/object:Api::Type::NestedObject
     name: 'scaling'
-    min_version: beta
     description: |
       Scaling settings that apply to the whole service
     properties:

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.erb
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.erb
@@ -971,8 +971,109 @@ resource "google_cloud_run_v2_service" "default" {
 `, context)
 }
 
-<% unless version == 'ga' -%>
 func TestAccCloudRunV2Service_cloudrunv2ServiceWithServiceMinInstances(t *testing.T) {
+  t.Parallel()
+  context := map[string]interface{} {
+    "random_suffix" : acctest.RandString(t, 10),
+  }
+  acctest.VcrTest(t, resource.TestCase {
+    PreCheck: func() { acctest.AccTestPreCheck(t)},
+    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+    CheckDestroy: testAccCheckCloudRunV2ServiceDestroyProducer(t),
+    Steps: []resource.TestStep{
+       {
+        Config: testAccCloudRunV2Service_cloudrunv2ServiceWithMinInstances(context),
+      },
+      {
+        ResourceName: "google_cloud_run_v2_service.default",
+        ImportState: true,
+        ImportStateVerify: true,
+        ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "launch_stage", "deletion_protection"},
+      },
+      {
+        Config: testAccCloudRunV2Service_cloudrunv2ServiceWithNoMinInstances(context),
+      },
+      {
+        ResourceName: "google_cloud_run_v2_service.default",
+        ImportState: true,
+        ImportStateVerify: true,
+        ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "launch_stage", "deletion_protection"},
+      },
+
+    }, 
+  })
+}
+
+func testAccCloudRunV2Service_cloudrunv2ServiceWithNoMinInstances(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_cloud_run_v2_service" "default" {
+  name     = "tf-test-cloudrun-service%{random_suffix}"
+  description = "description creating"
+  location = "us-central1"
+  deletion_protection = false
+  annotations = {
+    generated-by = "magic-modules"
+  }
+  ingress = "INGRESS_TRAFFIC_ALL"
+  labels = {
+    label-1 = "value-1"
+  }
+  client = "client-1"
+  client_version = "client-version-1"
+  template {
+    containers {
+      name = "container-1"
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+      }
+    }
+  lifecycle {
+    ignore_changes = [
+      launch_stage,
+    ]
+  }
+}
+
+`, context)
+}
+func testAccCloudRunV2Service_cloudrunv2ServiceWithMinInstances(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_cloud_run_v2_service" "default" {
+  name     = "tf-test-cloudrun-service%{random_suffix}"
+  description = "description creating"
+  location = "us-central1"
+  deletion_protection = false
+  annotations = {
+    generated-by = "magic-modules"
+  }
+  ingress = "INGRESS_TRAFFIC_ALL"
+  labels = {
+    label-1 = "value-1"
+  }
+  client = "client-1"
+  client_version = "client-version-1"
+  scaling {
+    min_instance_count = 1
+  }
+  template {
+    containers {
+      name = "container-1"
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+  }
+  lifecycle {
+    ignore_changes = [
+      launch_stage,
+    ]
+  }
+}
+
+`, context)
+}
+
+
+<% unless version == 'ga' -%>
+
+func TestAccCloudRunV2Service_cloudrunv2ServiceWithDefaultUriDisabled(t *testing.T) {
   t.Parallel()
   context := map[string]interface{} {
     "random_suffix" : acctest.RandString(t, 10),
@@ -1005,38 +1106,6 @@ func TestAccCloudRunV2Service_cloudrunv2ServiceWithServiceMinInstances(t *testin
   })
 }
 
-func testAccCloudRunV2Service_cloudrunv2ServiceWithNoMinInstances(context map[string]interface{}) string {
-	return acctest.Nprintf(`
-resource "google_cloud_run_v2_service" "default" {
-  name     = "tf-test-cloudrun-service%{random_suffix}"
-  description = "description creating"
-  location = "us-central1"
-  deletion_protection = false
-  launch_stage = "BETA"
-  annotations = {
-    generated-by = "magic-modules"
-  }
-  ingress = "INGRESS_TRAFFIC_ALL"
-  labels = {
-    label-1 = "value-1"
-  }
-  client = "client-1"
-  client_version = "client-version-1"
-  template {
-    containers {
-      name = "container-1"
-      image = "us-docker.pkg.dev/cloudrun/container/hello"
-      }
-    }
-  lifecycle {
-    ignore_changes = [
-      launch_stage,
-    ]
-  }
-}
-
-`, context)
-}
 func testAccCloudRunV2Service_cloudrunv2ServiceWithMinInstancesAndDefaultUriDisabled(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_cloud_run_v2_service" "default" {
@@ -1073,6 +1142,7 @@ resource "google_cloud_run_v2_service" "default" {
 
 `, context)
 }
+
 <% end -%>
 
 <% unless version == 'ga' -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Promote service-level scaling to GA in cloudrunv2 Service resource.

This is an annotation in v1 so no change is needed there.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudrunv2: promoted service-level `scaling` field in the `google_cloud_run_v2_service` resource to GA
```
