### PR TITLE
Fix removing `host_error_timeout_seconds` that was broken due to an API bug

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.erb
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.erb
@@ -167,6 +167,13 @@ func expandScheduling(v interface{}) (*compute.Scheduling, error) {
 <% unless version == 'ga' -%>
 	if v, ok := original["host_error_timeout_seconds"]; ok {
 		scheduling.HostErrorTimeoutSeconds = int64(v.(int))
+		//host_error_timeout_seconds doesn't get removed correctly due to an API bug on instances.SetScheduling.
+		//We need to set it to NullFields as a workaround because nil is rounded to 0
+		if v == 0 || v == nil {
+			scheduling.NullFields = append(scheduling.NullFields, "HostErrorTimeoutSeconds")
+		} else {
+			scheduling.ForceSendFields = append(scheduling.ForceSendFields, "HostErrorTimeoutSeconds")
+		}
 	}
 
 	if v, ok := original["maintenance_interval"]; ok {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.erb
@@ -1491,13 +1491,25 @@ func TestAccComputeInstance_hostErrorTimeoutSecconds(t *testing.T) {
 	context_1 := map[string]interface{}{
 		"instance_name":          fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
 		"zone":                   "us-central1-a",
-		"host_error_timeout_sec": 90,
+		"host_error_timeout_sec": "host_error_timeout_seconds = 90",
 	}
 
 	context_2 := map[string]interface{}{
 		"instance_name":          context_1["instance_name"],
 		"zone":                   context_1["zone"],
-		"host_error_timeout_sec": 120,
+		"host_error_timeout_sec": "host_error_timeout_seconds = 120",
+	}
+
+	context_3 := map[string]interface{}{
+		"instance_name":          context_1["instance_name"],
+		"zone":                   context_1["zone"],
+		"host_error_timeout_sec": "host_error_timeout_seconds = null",
+	}
+
+	context_4 := map[string]interface{}{
+		"instance_name":          context_1["instance_name"],
+		"zone":                   context_1["zone"],
+		"host_error_timeout_sec": "host_error_timeout_seconds = 0",
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -1521,6 +1533,22 @@ func TestAccComputeInstance_hostErrorTimeoutSecconds(t *testing.T) {
 				),
 			},
 			computeInstanceImportStep(context_2["zone"].(string), context_2["instance_name"].(string), []string{}),
+			{
+				Config: testAccComputeInstance_hostErrorTimeoutSeconds(context_3),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "scheduling.0.host_error_timeout_seconds", "0"),
+				),
+			},
+			computeInstanceImportStep(context_3["zone"].(string), context_3["instance_name"].(string), []string{}),
+			{
+				Config: testAccComputeInstance_hostErrorTimeoutSeconds(context_4),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "scheduling.0.host_error_timeout_seconds", "0"),
+				),
+			},
+			computeInstanceImportStep(context_4["zone"].(string), context_4["instance_name"].(string), []string{}),
 		},
 	})
 }
@@ -8240,7 +8268,8 @@ resource "google_compute_instance" "foobar" {
     network = "default"
   }
   scheduling {
-    host_error_timeout_seconds = %{host_error_timeout_sec}
+    %{host_error_timeout_sec}
+	automatic_restart = true
   }
 }`, context)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
references https://github.com/GoogleCloudPlatform/magic-modules/pull/11652

When this parameter is removed or set to null it couldn't be removed because the instances.SetScheduling API method doesn't remove parameters that are not mentioned in the request (contrary to for example instances.Update). `null` cannot be sent directly in the request on an `Int` field because it's rounded to 0 in go. 

So this is a workaround to clear the field when a user removes it's value and `0` or `nil` in go is taken as `null` in the API
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: `host_error_timeout_seconds` can now be set to null on `google_compute_instance`
```
