### PR TITLE
gkehub: remove `google_gke_hub_membership` deprecated `description` field from example

### DIFF
--- a/mmv1/templates/terraform/examples/gkehub_feature_multi_cluster_ingress.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkehub_feature_multi_cluster_ingress.tf.tmpl
@@ -11,7 +11,6 @@ resource "google_gke_hub_membership" "membership" {
       resource_link = "//container.googleapis.com/${google_container_cluster.cluster.id}"
     }
   }
-  description = "Membership"
 }
 
 resource "google_gke_hub_feature" "feature" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Removes the [deprecated](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/gke_hub_membership#description) `description` field from `google_gke_hub_membership` in an [example](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/gke_hub_feature#example-usage---gkehub-feature-multi-cluster-ingress) to avoid confusion. The field is not used in any other examples.


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
gkehub: remove `google_gke_hub_membership` deprecated `description` field from example
```
