### PR TITLE
Make reader accept provider blocks in tests

### DIFF
--- a/tools/test-reader/reader/reader.go
+++ b/tools/test-reader/reader/reader.go
@@ -329,6 +329,10 @@ func readConfigStr(configStr string) (Step, error) {
 				LabelNames: []string{"name"},
 			},
 			{
+				Type:       "provider",
+				LabelNames: []string{"name"},
+			},
+			{
 				Type: "locals",
 			},
 		},

--- a/tools/test-reader/reader/testdata/service/covered_resource_test.go
+++ b/tools/test-reader/reader/testdata/service/covered_resource_test.go
@@ -37,6 +37,9 @@ resource "covered_resource" "resource" {
 
 func testAccCoveredResource_update() string {
 	return `
+provider "google" {
+  region = "us-central1"
+}
 resource "covered_resource" "resource" {
   field_two {
     field_three = "value-two"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Test reader was crashing when it encountered provider blocks, now it will just ignore them.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
