### PR TITLE
Terraform support for best path selection

### DIFF
--- a/mmv1/products/compute/Network.yaml
+++ b/mmv1/products/compute/Network.yaml
@@ -65,6 +65,27 @@ examples:
       network_name: 'vpc-network'
     test_env_vars:
       project: 'PROJECT_NAME'
+  - name: 'network_bgp_best_path_selection_mode'
+    primary_resource_id: 'vpc_network'
+    min_version: 'beta'
+    vars:
+      network_name: 'vpc-network'
+    test_env_vars:
+      project: 'PROJECT_NAME'
+  - name: 'network_bgp_best_path_selection_mode_standard'
+    primary_resource_id: 'vpc_network'
+    min_version: 'beta'
+    vars:
+      network_name: 'vpc-network'
+    test_env_vars:
+      project: 'PROJECT_NAME'
+  - name: 'network_bgp_best_path_selection_mode_standard_custom_fields'
+    primary_resource_id: 'vpc_network'
+    min_version: 'beta'
+    vars:
+      network_name: 'vpc-network'
+    test_env_vars:
+      project: 'PROJECT_NAME'
 virtual_fields:
   - name: 'delete_default_routes_on_create'
     description: |
@@ -144,6 +165,39 @@ properties:
         enum_values:
           - 'REGIONAL'
           - 'GLOBAL'
+      - name: 'bgpBestPathSelectionMode'
+        type: Enum
+        description: |
+         The BGP best selection algorithm to be employed. MODE can be LEGACY or STANDARD.
+        min_version: 'beta'
+        default_from_api: true
+        update_url: 'projects/{{project}}/global/networks/{{name}}'
+        update_verb: 'PATCH'
+        enum_values:
+          - 'LEGACY'
+          - 'STANDARD'
+      - name: 'bgpAlwaysCompareMed'
+        type: Boolean
+        description: |
+         Enables/disables the comparison of MED across routes with different Neighbor ASNs.
+         This value can only be set if the --bgp-best-path-selection-mode is STANDARD
+        min_version: 'beta'
+        required: false
+        default_from_api: true
+        update_url: 'projects/{{project}}/global/networks/{{name}}'
+        update_verb: 'PATCH'
+      - name: 'bgpInterRegionCost'
+        type: Enum
+        description: |
+         Choice of the behavior of inter-regional cost and MED in the BPS algorithm.
+        min_version: 'beta'
+        required: false
+        default_from_api: true
+        update_url: 'projects/{{project}}/global/networks/{{name}}'
+        update_verb: 'PATCH'
+        enum_values:
+          - 'DEFAULT'
+          - 'ADD_COST_TO_MED'
   - name: 'mtu'
     type: Integer
     description: |

--- a/mmv1/products/compute/Route.yaml
+++ b/mmv1/products/compute/Route.yaml
@@ -228,6 +228,24 @@ properties:
     description: |
       URL to a Network that should handle matching packets.
     output: true
+  - name: 'nextHopOrigin'
+    type: String
+    description: |
+      Indicates the origin of the route. Can be IGP (Interior Gateway Protocol), EGP (Exterior Gateway Protocol), or INCOMPLETE.
+    min_version: 'beta'
+    output: true
+  - name: 'nextHopMed'
+    type: String
+    description: |
+      Multi-Exit Discriminator, a BGP route metric that indicates the desirability of a particular route in a network.
+    min_version: 'beta'
+    output: true
+  - name: 'nextHopInterRegionCost'
+    type: String
+    description: |
+      Internal fixed region-to-region cost that Google Cloud calculates based on factors such as network performance, distance, and available bandwidth between regions.
+    min_version: 'beta'
+    output: true
   - name: 'nextHopIlb'
     type: String
     description: |

--- a/mmv1/templates/terraform/examples/network_bgp_best_path_selection_mode.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_bgp_best_path_selection_mode.tf.tmpl
@@ -1,0 +1,5 @@
+resource "google_compute_network" "{{$.PrimaryResourceId}}" {
+  project                                   = "{{index $.TestEnvVars "project"}}"
+  name                                      = "{{index $.Vars "network_name"}}"
+  routing_mode                              = "GLOBAL"
+}

--- a/mmv1/templates/terraform/examples/network_bgp_best_path_selection_mode.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_bgp_best_path_selection_mode.tf.tmpl
@@ -1,4 +1,5 @@
 resource "google_compute_network" "{{$.PrimaryResourceId}}" {
+  provider                                  = google-beta
   project                                   = "{{index $.TestEnvVars "project"}}"
   name                                      = "{{index $.Vars "network_name"}}"
   routing_mode                              = "GLOBAL"

--- a/mmv1/templates/terraform/examples/network_bgp_best_path_selection_mode_standard.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_bgp_best_path_selection_mode_standard.tf.tmpl
@@ -1,0 +1,6 @@
+resource "google_compute_network" "{{$.PrimaryResourceId}}" {
+  project                                   = "{{index $.TestEnvVars "project"}}"
+  name                                      = "{{index $.Vars "network_name"}}"
+  routing_mode                              = "GLOBAL"
+  bgp_best_path_selection_mode              = "STANDARD"
+}

--- a/mmv1/templates/terraform/examples/network_bgp_best_path_selection_mode_standard.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_bgp_best_path_selection_mode_standard.tf.tmpl
@@ -1,4 +1,5 @@
 resource "google_compute_network" "{{$.PrimaryResourceId}}" {
+  provider                                  = google-beta
   project                                   = "{{index $.TestEnvVars "project"}}"
   name                                      = "{{index $.Vars "network_name"}}"
   routing_mode                              = "GLOBAL"

--- a/mmv1/templates/terraform/examples/network_bgp_best_path_selection_mode_standard_custom_fields.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_bgp_best_path_selection_mode_standard_custom_fields.tf.tmpl
@@ -1,0 +1,8 @@
+resource "google_compute_network" "{{$.PrimaryResourceId}}" {
+  project                                   = "{{index $.TestEnvVars "project"}}"
+  name                                      = "{{index $.Vars "network_name"}}"
+  routing_mode                              = "GLOBAL"
+  bgp_best_path_selection_mode              = "STANDARD"
+  bgp_always_compare_med                    = true
+  bgp_inter_region_cost                     = ADD_COST_TO_MED
+}

--- a/mmv1/templates/terraform/examples/network_bgp_best_path_selection_mode_standard_custom_fields.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_bgp_best_path_selection_mode_standard_custom_fields.tf.tmpl
@@ -1,8 +1,9 @@
 resource "google_compute_network" "{{$.PrimaryResourceId}}" {
+  provider                                  = google-beta
   project                                   = "{{index $.TestEnvVars "project"}}"
   name                                      = "{{index $.Vars "network_name"}}"
   routing_mode                              = "GLOBAL"
   bgp_best_path_selection_mode              = "STANDARD"
   bgp_always_compare_med                    = true
-  bgp_inter_region_cost                     = ADD_COST_TO_MED
+  bgp_inter_region_cost                     = "ADD_COST_TO_MED"
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_test.go.tmpl
@@ -112,6 +112,115 @@ func TestAccComputeNetwork_routingModeAndUpdate(t *testing.T) {
 	})
 }
 
+{{ if ne $.TargetVersionName `ga` -}}
+func TestAccComputeNetwork_bgpBestPathSelectionModeAndUpdate(t *testing.T) {
+   t.Parallel()
+
+   var network compute.Network
+   suffixName := acctest.RandString(t, 10)
+   networkName := fmt.Sprintf("tf-best-bgp-path-selection-mode-%s", suffixName)
+
+   acctest.VcrTest(t, resource.TestCase{
+       PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+       ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+       CheckDestroy:             testAccCheckComputeNetworkDestroyProducer(t),
+       Steps: []resource.TestStep{
+           {
+               Config: testAccComputeNetwork_best_bgp_path_selection_mode(networkName, "LEGACY"),
+               Check: resource.ComposeTestCheckFunc(
+                   testAccCheckComputeNetworkExists(
+                       t, "google_compute_network.acc_network_bgp_best_path_selection_mode", &network),
+                   resource.TestCheckResourceAttr(
+					   "google_compute_network.acc_network_bgp_best_path_selection_mode", "RoutingConfig.BgpBestPathSelectionMode", "LEGACY"),
+               ),
+           },
+           // Test updating the best bgp path selection field (only updatable field).
+           {
+               Config: testAccComputeNetwork_best_bgp_path_selection_mode(networkName, "STANDARD"),
+               Check: resource.ComposeTestCheckFunc(
+                   testAccCheckComputeNetworkExists(
+                       t, "google_compute_network.acc_network_bgp_best_path_selection_mode", &network),
+                   resource.TestCheckResourceAttr(
+					   "google_compute_network.acc_network_bgp_best_path_selection_mode", "RoutingConfig.BgpBestPathSelectionMode", "STANDARD"),
+               ),
+           },
+       },
+   })
+}
+
+
+func TestAccComputeNetwork_bgpAlwaysCompareMedAndUpdate(t *testing.T) {
+   t.Parallel()
+
+   var network compute.Network
+   suffixName := acctest.RandString(t, 10)
+   networkName := fmt.Sprintf("tf-bgp-always-compare-med-%s", suffixName)
+
+   acctest.VcrTest(t, resource.TestCase{
+       PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+       ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+       CheckDestroy:             testAccCheckComputeNetworkDestroyProducer(t),
+       Steps: []resource.TestStep{
+           {
+               Config: testAccComputeNetwork_bgp_always_compare_med(networkName, false),
+               Check: resource.ComposeTestCheckFunc(
+                   testAccCheckComputeNetworkExists(
+                       t, "google_compute_network.acc_network_bgp_always_compare_med", &network),
+                   testAccCheckComputeNetworkHasBgpAlwaysCompareMed(
+                       t, "google_compute_network.acc_network_bgp_always_compare_med", &network, false),
+               ),
+           },
+           // Test updating the bgpAlwaysCompareMed field (only updatable field).
+           {
+               Config: testAccComputeNetwork_bgp_always_compare_med(networkName, true),
+               Check: resource.ComposeTestCheckFunc(
+                   testAccCheckComputeNetworkExists(
+                       t, "google_compute_network.acc_network_bgp_always_compare_med", &network),
+                   testAccCheckComputeNetworkHasBgpAlwaysCompareMed(
+                       t, "google_compute_network.acc_network_bgp_always_compare_med", &network, true),
+               ),
+           },
+       },
+   })
+}
+
+
+func TestAccComputeNetwork_bgpInterRegionCostAndUpdate(t *testing.T) {
+   t.Parallel()
+
+   var network compute.Network
+   suffixName := acctest.RandString(t, 10)
+   networkName := fmt.Sprintf("tf-bgp-inter-region-cost-%s", suffixName)
+
+   acctest.VcrTest(t, resource.TestCase{
+       PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+       ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+       CheckDestroy:             testAccCheckComputeNetworkDestroyProducer(t),
+       Steps: []resource.TestStep{
+           {
+               Config: testAccComputeNetwork_bgp_inter_region_cost(networkName, "DEFAULT"),
+               Check: resource.ComposeTestCheckFunc(
+                   testAccCheckComputeNetworkExists(
+                       t, "google_compute_network.acc_network_bgp_inter_region_cost", &network),
+                   testAccCheckComputeNetworkHasBgpInterRegionCost(
+                       t, "google_compute_network.acc_network_bgp_inter_region_cost", &network, "DEFAULT"),
+               ),
+           },
+           // Test updating the bgpInterRegionCost field (only updatable field).
+           {
+               Config: testAccComputeNetwork_bgp_inter_region_cost(networkName, "ADD_COST_TO_MED"),
+               Check: resource.ComposeTestCheckFunc(
+                   testAccCheckComputeNetworkExists(
+                       t, "google_compute_network.acc_network_bgp_inter_region_cost", &network),
+                   testAccCheckComputeNetworkHasBgpInterRegionCost(
+                       t, "google_compute_network.acc_network_bgp_inter_region_cost", &network, "ADD_COST_TO_MED"),
+               ),
+           },
+       },
+   })
+}
+{{- end }}
+
 func TestAccComputeNetwork_numericId(t *testing.T) {
 	t.Parallel()
 	suffixName := acctest.RandString(t, 10)
@@ -166,6 +275,63 @@ func TestAccComputeNetwork_default_routing_mode(t *testing.T) {
 		},
 	})
 }
+
+{{ if ne $.TargetVersionName `ga` -}}
+func TestAccComputeNetwork_default_bgp_best_path_selection_mode(t *testing.T) {
+   t.Parallel()
+
+   var network compute.Network
+   suffixName := acctest.RandString(t, 10)
+   networkName := fmt.Sprintf("tf-test-bgp-best-path-selection-default-routes-%s", suffixName)
+
+   expectedBgpBestPathSelection := "LEGACY"
+
+   acctest.VcrTest(t, resource.TestCase{
+       PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+       ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+       CheckDestroy:             testAccCheckComputeNetworkDestroyProducer(t),
+       Steps: []resource.TestStep{
+           {
+               Config: testAccComputeNetwork_basic(networkName),
+               Check: resource.ComposeTestCheckFunc(
+                   testAccCheckComputeNetworkExists(
+                       t, "google_compute_network.bar", &network),
+                   resource.TestCheckResourceAttr(
+					   "google_compute_network.acc_network_bgp_best_path_selection_mode", "RoutingConfig.BgpBestPathSelectionMode", expectedBgpBestPathSelection),
+               ),
+           },
+       },
+   })
+}
+
+
+func TestAccComputeNetwork_default_bgp_always_compare_med(t *testing.T) {
+   t.Parallel()
+
+   var network compute.Network
+   suffixName := acctest.RandString(t, 10)
+   networkName := fmt.Sprintf("tf-test-bgp-always-comapre-med-default-routes-%s", suffixName)
+
+   expectedBgpAlwaysCompareMed := false
+
+   acctest.VcrTest(t, resource.TestCase{
+       PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+       ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+       CheckDestroy:             testAccCheckComputeNetworkDestroyProducer(t),
+       Steps: []resource.TestStep{
+           {
+               Config: testAccComputeNetwork_best_bgp_path_selection_mode(networkName, "STANDARD"),
+               Check: resource.ComposeTestCheckFunc(
+                   testAccCheckComputeNetworkExists(
+                       t, "google_compute_network.acc_network_bgp_best_path_selection_mode", &network),
+                   testAccCheckComputeNetworkHasBgpAlwaysCompareMed(
+                       t, "google_compute_network.acc_network_bgp_best_path_selection_mode", &network, expectedBgpAlwaysCompareMed),
+               ),
+           },
+       },
+   })
+}
+{{- end }}
 
 func TestAccComputeNetwork_networkDeleteDefaultRoute(t *testing.T) {
 	t.Parallel()
@@ -372,6 +538,67 @@ func testAccCheckComputeNetworkHasRoutingMode(t *testing.T, n string, network *c
 	}
 }
 
+{{ if ne $.TargetVersionName `ga` -}}
+func testAccCheckComputeNetworkHasBgpAlwaysCompareMed(t *testing.T, n string, network *compute.Network, bgpAlwaysCompareMed bool) resource.TestCheckFunc {
+   return func(s *terraform.State) error {
+       config := acctest.GoogleProviderConfig(t)
+
+       rs, ok := s.RootModule().Resources[n]
+       if !ok {
+           return fmt.Errorf("Not found: %s", n)
+       }
+
+       if rs.Primary.Attributes["bgp_always_compare_med"] == "" {
+           return fmt.Errorf("BGP always compare med  not found on resource")
+       }
+
+       found, err := config.NewComputeClient(config.UserAgent).Networks.Get(
+           config.Project, network.Name).Do()
+       if err != nil {
+           return err
+       }
+
+       foundBgpAlwaysCompareMed := found.RoutingConfig.BgpAlwaysCompareMed
+
+       if foundBgpAlwaysCompareMed != bgpAlwaysCompareMed {
+           return fmt.Errorf("Expected BGP always compare med %t to match actual BGP always compare med %t", bgpAlwaysCompareMed, foundBgpAlwaysCompareMed)
+       }
+
+       return nil
+   }
+}
+
+
+func testAccCheckComputeNetworkHasBgpInterRegionCost(t *testing.T, n string, network *compute.Network, bgpInterRegionCost string) resource.TestCheckFunc {
+   return func(s *terraform.State) error {
+       config := acctest.GoogleProviderConfig(t)
+
+       rs, ok := s.RootModule().Resources[n]
+       if !ok {
+           return fmt.Errorf("Not found: %s", n)
+       }
+
+       if rs.Primary.Attributes["bgp_inter_region_cost"] == "" {
+           return fmt.Errorf("BGP inter region cost  not found on resource")
+       }
+
+       found, err := config.NewComputeClient(config.UserAgent).Networks.Get(
+           config.Project, network.Name).Do()
+       if err != nil {
+           return err
+       }
+
+       foundBgpInterRegionCost := found.RoutingConfig.BgpInterRegionCost
+
+       if foundBgpInterRegionCost != bgpInterRegionCost {
+           return fmt.Errorf("Expected BGP always compare med %s to match actual BGP always compare med %s", bgpInterRegionCost, foundBgpInterRegionCost)
+       }
+
+       return nil
+   }
+}
+{{- end }}
+
 func testAccCheckComputeNetworkHasNetworkFirewallPolicyEnforcementOrder(t *testing.T, n string, network *compute.Network, order string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
@@ -436,6 +663,40 @@ resource "google_compute_network" "acc_network_routing_mode" {
 }
 `, networkName, routingMode)
 }
+
+{{ if ne $.TargetVersionName `ga` -}}
+func testAccComputeNetwork_best_bgp_path_selection_mode(networkName, bgpBestPathSelection string) string {
+   return fmt.Sprintf(`
+resource "google_compute_network" "acc_network_bgp_best_path_selection_mode" {
+ name         = "%s"
+ routing_mode = "GLOBAL"
+ bgp_best_path_selection_mode = "%s"
+}
+`, networkName, bgpBestPathSelection)
+}
+
+func testAccComputeNetwork_bgp_always_compare_med(networkName string, bgpAlwaysComapreMed bool) string {
+   return fmt.Sprintf(`
+resource "google_compute_network" "acc_network_bgp_always_compare_med" {
+ name         = "%s"
+ routing_mode = "GLOBAL"
+ bgp_best_path_selection_mode = "STANDARD"
+ bgp_always_compare_med = %t
+}
+`, networkName, bgpAlwaysComapreMed)
+}
+
+func testAccComputeNetwork_bgp_inter_region_cost(networkName, bgpInterRegionCost string) string {
+   return fmt.Sprintf(`
+resource "google_compute_network" "acc_network_bgp_inter_region_cost" {
+ name         = "%s"
+ routing_mode = "GLOBAL"
+ bgp_best_path_selection_mode = "STANDARD"
+ bgp_inter_region_cost = "%s"
+}
+`, networkName, bgpInterRegionCost)
+}
+{{- end }}
 
 func testAccComputeNetwork_deleteDefaultRoute(networkName string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_test.go.tmpl
@@ -122,30 +122,29 @@ func TestAccComputeNetwork_bgpBestPathSelectionModeAndUpdate(t *testing.T) {
 
    acctest.VcrTest(t, resource.TestCase{
        PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-       ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+       ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
        CheckDestroy:             testAccCheckComputeNetworkDestroyProducer(t),
        Steps: []resource.TestStep{
            {
-               Config: testAccComputeNetwork_best_bgp_path_selection_mode(networkName, "LEGACY"),
-               Check: resource.ComposeTestCheckFunc(
-                   testAccCheckComputeNetworkExists(
-                       t, "google_compute_network.acc_network_bgp_best_path_selection_mode", &network),
-                   resource.TestCheckResourceAttr(
-					   "google_compute_network.acc_network_bgp_best_path_selection_mode", "RoutingConfig.BgpBestPathSelectionMode", "LEGACY"),
-               ),
-           },
-           // Test updating the best bgp path selection field (only updatable field).
-           {
-               Config: testAccComputeNetwork_best_bgp_path_selection_mode(networkName, "STANDARD"),
-               Check: resource.ComposeTestCheckFunc(
-                   testAccCheckComputeNetworkExists(
-                       t, "google_compute_network.acc_network_bgp_best_path_selection_mode", &network),
-                   resource.TestCheckResourceAttr(
-					   "google_compute_network.acc_network_bgp_best_path_selection_mode", "RoutingConfig.BgpBestPathSelectionMode", "STANDARD"),
-               ),
+				Config: testAccComputeNetwork_best_bgp_path_selection_mode(networkName, "LEGACY"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeNetworkExists(
+						t, "google_compute_network.acc_network_bgp_best_path_selection_mode", &network),
+					testAccCheckComputeNetworkHasBgpBestPathSelectionMode(t, "google_compute_network.acc_network_bgp_best_path_selection_mode", &network, "LEGACY"),
+				),
+			},
+			// Test updating the best bgp path selection field (only updatable field).
+			{
+				Config: testAccComputeNetwork_best_bgp_path_selection_mode(networkName, "STANDARD"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeNetworkExists(
+						t, "google_compute_network.acc_network_bgp_best_path_selection_mode", &network),
+					testAccCheckComputeNetworkHasBgpBestPathSelectionMode(t, "google_compute_network.acc_network_bgp_best_path_selection_mode", &network, "STANDARD"),
+				),
+			},
            },
        },
-   })
+   )
 }
 
 
@@ -158,7 +157,7 @@ func TestAccComputeNetwork_bgpAlwaysCompareMedAndUpdate(t *testing.T) {
 
    acctest.VcrTest(t, resource.TestCase{
        PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-       ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+       ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
        CheckDestroy:             testAccCheckComputeNetworkDestroyProducer(t),
        Steps: []resource.TestStep{
            {
@@ -194,7 +193,7 @@ func TestAccComputeNetwork_bgpInterRegionCostAndUpdate(t *testing.T) {
 
    acctest.VcrTest(t, resource.TestCase{
        PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-       ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+       ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
        CheckDestroy:             testAccCheckComputeNetworkDestroyProducer(t),
        Steps: []resource.TestStep{
            {
@@ -278,30 +277,29 @@ func TestAccComputeNetwork_default_routing_mode(t *testing.T) {
 
 {{ if ne $.TargetVersionName `ga` -}}
 func TestAccComputeNetwork_default_bgp_best_path_selection_mode(t *testing.T) {
-   t.Parallel()
+	t.Parallel()
 
-   var network compute.Network
-   suffixName := acctest.RandString(t, 10)
-   networkName := fmt.Sprintf("tf-test-bgp-best-path-selection-default-routes-%s", suffixName)
+	var network compute.Network
+	suffixName := acctest.RandString(t, 10)
+	networkName := fmt.Sprintf("tf-test-bgp-best-path-selection-default-routes-%s", suffixName)
 
-   expectedBgpBestPathSelection := "LEGACY"
+	expectedBgpBestPathSelection := "LEGACY"
 
-   acctest.VcrTest(t, resource.TestCase{
-       PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-       ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-       CheckDestroy:             testAccCheckComputeNetworkDestroyProducer(t),
-       Steps: []resource.TestStep{
-           {
-               Config: testAccComputeNetwork_basic(networkName),
-               Check: resource.ComposeTestCheckFunc(
-                   testAccCheckComputeNetworkExists(
-                       t, "google_compute_network.bar", &network),
-                   resource.TestCheckResourceAttr(
-					   "google_compute_network.acc_network_bgp_best_path_selection_mode", "RoutingConfig.BgpBestPathSelectionMode", expectedBgpBestPathSelection),
-               ),
-           },
-       },
-   })
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckComputeNetworkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeBetaNetwork_basic(networkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeNetworkExists(
+						t, "google_compute_network.bar", &network),
+					testAccCheckComputeNetworkHasBgpBestPathSelectionMode(t, "google_compute_network.bar", &network, expectedBgpBestPathSelection),
+				),
+			},
+		},
+	})
 }
 
 
@@ -316,7 +314,7 @@ func TestAccComputeNetwork_default_bgp_always_compare_med(t *testing.T) {
 
    acctest.VcrTest(t, resource.TestCase{
        PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-       ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+       ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
        CheckDestroy:             testAccCheckComputeNetworkDestroyProducer(t),
        Steps: []resource.TestStep{
            {
@@ -539,6 +537,35 @@ func testAccCheckComputeNetworkHasRoutingMode(t *testing.T, n string, network *c
 }
 
 {{ if ne $.TargetVersionName `ga` -}}
+func testAccCheckComputeNetworkHasBgpBestPathSelectionMode(t *testing.T, n string, network *compute.Network, bgpBestPathSelectionMode string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := acctest.GoogleProviderConfig(t)
+
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.Attributes["bgp_always_compare_med"] == "" {
+			return fmt.Errorf("BGP always compare med  not found on resource")
+		}
+
+		found, err := config.NewComputeClient(config.UserAgent).Networks.Get(
+			config.Project, network.Name).Do()
+		if err != nil {
+			return err
+		}
+
+		foundBgpBestPathSelectionMode := found.RoutingConfig.BgpBestPathSelectionMode
+
+		if bgpBestPathSelectionMode != foundBgpBestPathSelectionMode {
+			return fmt.Errorf("Expected BGP always compare med %s to match actual BGP always compare med %s", bgpBestPathSelectionMode, foundBgpBestPathSelectionMode)
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckComputeNetworkHasBgpAlwaysCompareMed(t *testing.T, n string, network *compute.Network, bgpAlwaysCompareMed bool) resource.TestCheckFunc {
    return func(s *terraform.State) error {
        config := acctest.GoogleProviderConfig(t)
@@ -567,7 +594,6 @@ func testAccCheckComputeNetworkHasBgpAlwaysCompareMed(t *testing.T, n string, ne
        return nil
    }
 }
-
 
 func testAccCheckComputeNetworkHasBgpInterRegionCost(t *testing.T, n string, network *compute.Network, bgpInterRegionCost string) resource.TestCheckFunc {
    return func(s *terraform.State) error {
@@ -665,9 +691,20 @@ resource "google_compute_network" "acc_network_routing_mode" {
 }
 
 {{ if ne $.TargetVersionName `ga` -}}
+func testAccComputeBetaNetwork_basic(networkName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "bar" {
+  provider 				  = google-beta
+  name                    = "%s"
+  auto_create_subnetworks = true
+}
+`, networkName)
+}
+
 func testAccComputeNetwork_best_bgp_path_selection_mode(networkName, bgpBestPathSelection string) string {
    return fmt.Sprintf(`
 resource "google_compute_network" "acc_network_bgp_best_path_selection_mode" {
+ provider     = google-beta
  name         = "%s"
  routing_mode = "GLOBAL"
  bgp_best_path_selection_mode = "%s"
@@ -678,6 +715,7 @@ resource "google_compute_network" "acc_network_bgp_best_path_selection_mode" {
 func testAccComputeNetwork_bgp_always_compare_med(networkName string, bgpAlwaysComapreMed bool) string {
    return fmt.Sprintf(`
 resource "google_compute_network" "acc_network_bgp_always_compare_med" {
+ provider     = google-beta
  name         = "%s"
  routing_mode = "GLOBAL"
  bgp_best_path_selection_mode = "STANDARD"
@@ -689,6 +727,7 @@ resource "google_compute_network" "acc_network_bgp_always_compare_med" {
 func testAccComputeNetwork_bgp_inter_region_cost(networkName, bgpInterRegionCost string) string {
    return fmt.Sprintf(`
 resource "google_compute_network" "acc_network_bgp_inter_region_cost" {
+ provider     = google-beta
  name         = "%s"
  routing_mode = "GLOBAL"
  bgp_best_path_selection_mode = "STANDARD"


### PR DESCRIPTION
 **Modified the following beta fields in google_compute_network Gateway resource (b/343562168)**
- gateway_ip_version (enum): Added new enum field "bgp_best_path_selection_mode" with possible values Legacy and Standard
- bgp_bps_always_compare_med (bool): Added new bool field
- gateway_ip_version (bgp_bps_inter_region_cost): Added new enum field "bgp_bps_inter_region_cost" with possible values Default and Add-cost-to-med

 **3 new beta output fields for google_compute_router_status for best_routes & best_routes_for_router fields**
- gateway_ip_version (enum): Added new enum field "bgp_best_path_selection_mode" with possible values Legacy and Standard
- route.next_hop_origin
- route.next_hop_med
- route.next_hop_inter_region_cost
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `bgp_best_path_selection_mode `,`bgp_bps_always_compare_med` and `bgp_bps_inter_region_cost ` fields to `google_compute_network` resource
```

```release-note:enhancement
compute: added `next_hop_origin `,`next_hop_med ` and `next_hop_inter_region_cost ` output fields to `google_compute_route` resource
```
