### PR TITLE
container: fix storage pool resource names in test

### DIFF
--- a/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
+++ b/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go
@@ -1176,7 +1176,14 @@ func BootstrapComputeStoragePool(t *testing.T, storagePoolName, storagePoolType 
 	if err != nil {
 		t.Fatalf("Error getting storage pool %s: %s", storagePoolName, err)
 	}
-	return storagePool.SelfLink
+
+	storagePoolResourceName, err := tpgresource.GetRelativePath(storagePool.SelfLink)
+
+	if err != nil {
+		t.Fatal("Failed to extract Storage Pool resource name from URL.")
+	}
+
+	return storagePoolResourceName
 }
 
 func SetupProjectsAndGetAccessToken(org, billing, pid, service string, config *transport_tpg.Config) (string, error) {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -11697,11 +11697,7 @@ func TestAccContainerCluster_storagePoolsWithNodePool(t *testing.T) {
 	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 	location := envvar.GetTestZoneFromEnv()
 
-	storagePoolNameURL := acctest.BootstrapComputeStoragePool(t, "basic-1", "hyperdisk-balanced")
-	storagePoolResourceName, err := extractSPName(storagePoolNameURL)
-	if err != nil {
-		t.Fatal("Failed to extract Storage Pool resource name from URL.")
-	}
+	storagePoolResourceName := acctest.BootstrapComputeStoragePool(t, "basic-1", "hyperdisk-balanced")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -11754,11 +11750,7 @@ func TestAccContainerCluster_storagePoolsWithNodeConfig(t *testing.T) {
 	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 	location := envvar.GetTestZoneFromEnv()
 
-	storagePoolNameURL := acctest.BootstrapComputeStoragePool(t, "basic-1", "hyperdisk-balanced")
-	storagePoolResourceName, err := extractSPName(storagePoolNameURL)
-	if err != nil {
-		t.Fatal("Failed to extract Storage Pool resource name from URL.")
-	}
+	storagePoolResourceName := acctest.BootstrapComputeStoragePool(t, "basic-1", "hyperdisk-balanced")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -11798,17 +11790,6 @@ resource "google_container_cluster" "storage_pools_with_node_config" {
   }
 }
 `, cluster, location, networkName, subnetworkName, storagePoolResourceName)
-}
-
-func extractSPName(url string) (string, error) {
-    re := regexp.MustCompile(`https://www\.googleapis\.com/compute/beta/(projects/[^"]+)`)
-    matches := re.FindStringSubmatch(url)
-
-    if len(matches) > 1 {
-        return matches[1], nil
-    } else {
-        return "", fmt.Errorf("no match found")
-    }
 }
 
 func TestAccContainerCluster_withAutopilotGcpFilestoreCsiDriver(t *testing.T) {

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -4960,11 +4960,7 @@ func TestAccContainerNodePool_storagePools(t *testing.T) {
 	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 	location := envvar.GetTestZoneFromEnv()
 
-	storagePoolNameURL := acctest.BootstrapComputeStoragePool(t, "basic-1", "hyperdisk-balanced")
-	storagePoolResourceName, err := extractSPName(storagePoolNameURL)
-	if err != nil {
-		t.Fatal("Failed to extract Storage Pool resource name from URL.")
-	}
+	storagePoolResourceName := acctest.BootstrapComputeStoragePool(t, "basic-1", "hyperdisk-balanced")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -5024,11 +5020,8 @@ func TestAccContainerNodePool_withMachineDiskStoragePoolsUpdate(t *testing.T) {
 	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 	location := envvar.GetTestZoneFromEnv()
 
-	storagePoolNameURL := acctest.BootstrapComputeStoragePool(t, "basic-1", "hyperdisk-balanced")
-	storagePoolResourceName, err := extractSPName(storagePoolNameURL)
-	if err != nil {
-		t.Fatal("Failed to extract Storage Pool resource name from URL.")
-	}
+	storagePoolResourceName := acctest.BootstrapComputeStoragePool(t, "basic-1", "hyperdisk-balanced")
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
@@ -5084,10 +5077,10 @@ resource "google_container_node_pool" "np" {
   initial_node_count = 2
 
   node_config {
-	machine_type    = "c3-standard-4"
-    disk_size_gb    = 50
-    disk_type       = "hyperdisk-balanced"
-	storage_pools = ["%[5]s"]
+    machine_type  = "c3-standard-4"
+    disk_size_gb  = 50
+    disk_type     = "hyperdisk-balanced"
+    storage_pools = ["%[5]s"]
   }
 }
 `, cluster, np, networkName, subnetworkName, storagePoolResourceName, location)


### PR DESCRIPTION
Came across this when working on #11826

Tests such as
`TestAccContainerNodePool_withDiskMachineAndStoragePoolUpdate` seem to be failing, possibly due to being promoted from beta to v1

Rather than update the regex in extractSP, use
`tpgresource.GetRelativePath()` and return that from the bootstrap method, as mentioned here:
https://github.com/GoogleCloudPlatform/magic-modules/pull/11391#discussion_r1750588141

See #11391 and #11598

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
