### PR TITLE
pubsub: fix permadiff with configuring an empty retry_policy.

### DIFF
--- a/mmv1/products/pubsub/Subscription.yaml
+++ b/mmv1/products/pubsub/Subscription.yaml
@@ -471,6 +471,8 @@ properties:
           A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s".
         default_from_api: true
         diff_suppress_func: 'tpgresource.DurationDiffSuppress'
+    send_empty_value: true
+    allow_empty_object: true
   - name: 'enableMessageOrdering'
     type: Boolean
     description: |

--- a/mmv1/third_party/terraform/services/pubsub/resource_pubsub_subscription_test.go
+++ b/mmv1/third_party/terraform/services/pubsub/resource_pubsub_subscription_test.go
@@ -36,6 +36,30 @@ func TestAccPubsubSubscription_emptyTTL(t *testing.T) {
 	})
 }
 
+func TestAccPubsubSubscription_emptyRetryPolicy(t *testing.T) {
+	t.Parallel()
+
+	topic := fmt.Sprintf("tf-test-topic-%s", acctest.RandString(t, 10))
+	subscription := fmt.Sprintf("tf-test-sub-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckPubsubSubscriptionDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPubsubSubscription_emptyRetryPolicy(topic, subscription),
+			},
+			{
+				ResourceName:      "google_pubsub_subscription.foo",
+				ImportStateId:     subscription,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccPubsubSubscription_basic(t *testing.T) {
 	t.Parallel()
 
@@ -490,6 +514,22 @@ resource "google_pubsub_subscription" "foo" {
     ttl = ""
   }
   enable_message_ordering    = false
+}
+`, topic, subscription)
+}
+
+func testAccPubsubSubscription_emptyRetryPolicy(topic, subscription string) string {
+	return fmt.Sprintf(`
+resource "google_pubsub_topic" "foo" {
+  name = "%s"
+}
+
+resource "google_pubsub_subscription" "foo" {
+  name  = "%s"
+  topic = google_pubsub_topic.foo.id
+
+  retry_policy {
+  }
 }
 `, topic, subscription)
 }

--- a/mmv1/third_party/tgc/tests/data/example_pubsub_subscription.json
+++ b/mmv1/third_party/tgc/tests/data/example_pubsub_subscription.json
@@ -48,6 +48,7 @@
         "pushConfig": {
           "pushEndpoint": "https://example.com/push"
         },
+        "retryPolicy": null,
         "topic": "projects/{{.Provider.project}}/topics/example-pubsub-topic"
       }
     }

--- a/mmv1/third_party/tgc/tests/data/example_pubsub_subscription_iam_binding.json
+++ b/mmv1/third_party/tgc/tests/data/example_pubsub_subscription_iam_binding.json
@@ -20,6 +20,7 @@
         "pushConfig": {
           "pushEndpoint": "https://example.com/push"
         },
+        "retryPolicy": null,
         "topic": "projects/{{.Provider.project}}/topics/example-pubsub-topic"
       }
     },

--- a/mmv1/third_party/tgc/tests/data/example_pubsub_subscription_iam_member.json
+++ b/mmv1/third_party/tgc/tests/data/example_pubsub_subscription_iam_member.json
@@ -20,6 +20,7 @@
         "pushConfig": {
           "pushEndpoint": "https://example.com/push"
         },
+        "retryPolicy": null,
         "topic": "projects/{{.Provider.project}}/topics/example-pubsub-topic"
       }
     },

--- a/mmv1/third_party/tgc/tests/data/example_pubsub_subscription_iam_policy.json
+++ b/mmv1/third_party/tgc/tests/data/example_pubsub_subscription_iam_policy.json
@@ -20,6 +20,7 @@
         "pushConfig": {
           "pushEndpoint": "https://example.com/push"
         },
+        "retryPolicy": null,
         "topic": "projects/{{.Provider.project}}/topics/example-pubsub-topic"
       }
     },


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/18016

The permadiff arises when users specify an empty retry policy as `retry_policy: {}` in their config, but the empty value doesn't get sent to the API and the API subsequently doesn't return a `retry_policy` in the response. By setting `send_empty_value: true` on the `retry_policy` property, we ensure that the API recognizes the user-configured value.

Similar fixes for other resource properties will be investigated and sent in separate PRs.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
pubsub: fix permadiff with configuring an empty `retry_policy`.
```
