### PR TITLE
Added template func to colorize text

### DIFF
--- a/.ci/magician/cmd/templates.go
+++ b/.ci/magician/cmd/templates.go
@@ -1,0 +1,12 @@
+package cmd
+
+import (
+	"fmt"
+)
+
+func color(color, text string) string {
+	if color == "" || text == "" {
+		return text
+	}
+	return fmt.Sprintf("$\\textcolor{%s}{\\textsf{%s}}$", color, text)
+}

--- a/.ci/magician/cmd/templates/vcr/record_replay.tmpl
+++ b/.ci/magician/cmd/templates/vcr/record_replay.tmpl
@@ -1,10 +1,10 @@
 {{- if gt (len .RecordingResult.PassedTests) 0 -}}
-$\textcolor{green}{\textsf{Tests passed during RECORDING mode:}}$
+{{color "green" "Tests passed during RECORDING mode:"}}
 {{range .RecordingResult.PassedTests}}`{{.}}`[[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-{{$.PRNumber}}/artifacts/{{$.BuildID}}/recording/{{.}}.log)]
 {{end}}
 
 {{- if gt (len .ReplayingAfterRecordingResult.FailedTests ) 0 -}}
-$\textcolor{red}{\textsf{Tests failed when rerunning REPLAYING mode:}}$
+{{color "red" "Tests failed when rerunning REPLAYING mode:"}}
 {{range .ReplayingAfterRecordingResult.FailedTests}}`{{.}}`[[Error message](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-{{$.PRNumber}}/artifacts/{{$.BuildID}}/build-log/replaying_build_after_recording/{{.}}_replaying_test.log)] [[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-{{$.PRNumber}}/artifacts/{{$.BuildID}}/replaying_after_recording/{{.}}.log)]
 {{end}}
 
@@ -13,19 +13,19 @@ Tests failed due to non-determinism or randomness when the VCR replayed the resp
 Please fix these to complete your PR. If you believe these test failures to be incorrect or unrelated to your change, or if you have any questions, please raise the concern with your reviewer.
 
 {{else}}
-$\textcolor{green}{\textsf{No issues found for passed tests after REPLAYING rerun.}}$
+{{color "green" "No issues found for passed tests after REPLAYING rerun."}}
 {{end}}{{/* end of if gt (len .ReplayingAfterRecordingResult.FailedTests ) 0 */}}
 ---
 {{end}}{{/* end of if gt (len .RecordingResult.PassedTests) 0 */}}
 
 {{if gt (len .RecordingResult.FailedTests) 0 -}}
-$\textcolor{red}{\textsf{Tests failed during RECORDING mode:}}$
+{{color "red" "Tests failed during RECORDING mode:"}}
 {{range .RecordingResult.FailedTests}}`{{.}}`[[Error message](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-{{$.PRNumber}}/artifacts/{{$.BuildID}}/build-log/recording_build/{{.}}_recording_test.log)] [[Debug log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-{{$.PRNumber}}/artifacts/{{$.BuildID}}/recording/{{.}}.log)]
 {{end}}
 {{end}} {{- /* end of if gt (len .RecordingResult.FailedTests) 0 */ -}}
 
-{{if .HasTerminatedTests}}$\textcolor{red}{\textsf{Several tests got terminated during RECORDING mode.}}${{end}}
-{{if .RecordingErr}}$\textcolor{red}{\textsf{Errors occurred during RECORDING mode. Please fix them to complete your PR.}}${{end}}
-{{if .AllRecordingPassed}}$\textcolor{green}{\textsf{All tests passed!}}${{end}}
+{{if .HasTerminatedTests}}{{color "red" "Several tests got terminated during RECORDING mode."}}{{end}}
+{{if .RecordingErr}}{{color "red" "Errors occurred during RECORDING mode. Please fix them to complete your PR."}}{{end}}
+{{if .AllRecordingPassed}}{{color "green" "All tests passed!"}}{{end}}
 
 View the [build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-{{.PRNumber}}/artifacts/{{.BuildID}}/build-log/recording_test.log) or the [debug log](https://console.cloud.google.com/storage/browser/ci-vcr-logs/beta/refs/heads/auto-pr-{{.PRNumber}}/artifacts/{{.BuildID}}/recording) for each test

--- a/.ci/magician/cmd/templates/vcr/without_replay_failed_tests.tmpl
+++ b/.ci/magician/cmd/templates/vcr/without_replay_failed_tests.tmpl
@@ -1,7 +1,7 @@
 {{- if .ReplayingErr -}}
-$\textcolor{red}{\textsf{Errors occurred during REPLAYING mode. Please fix them to complete your PR.}}$
+{{color "red" "Errors occurred during REPLAYING mode. Please fix them to complete your PR."}}
 {{- else -}}
-$\textcolor{green}{\textsf{All tests passed!}}$
+{{color "green" "All tests passed!"}}
 {{- end}}
 
 View the [build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-{{.PRNumber}}/artifacts/{{.BuildID}}/build-log/replaying_test.log)

--- a/.ci/magician/cmd/templates_test.go
+++ b/.ci/magician/cmd/templates_test.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestColor(t *testing.T) {
+	cases := []struct {
+		name  string
+		color string
+		text  string
+		want  string
+	}{
+		{
+			name:  "red",
+			color: "red",
+			text:  "Test text",
+			want:  "$\\textcolor{red}{\\textsf{Test text}}$",
+		},
+		{
+			name: "green",
+			color: "green",
+			text: "Test text",
+			want: "$\\textcolor{green}{\\textsf{Test text}}$",
+		},
+		{
+			name: "empty color",
+			text: "Test text",
+			want: "Test text",
+		},
+		{
+			name:  "empty text",
+			color: "green",
+			want:  "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := color(tc.color, tc.text)
+			if got != tc.want {
+				t.Errorf("color(%s, %s) got %s; want %s", tc.color, tc.text, got, tc.want)
+			}
+		})
+	}
+}

--- a/.ci/magician/cmd/test_terraform_vcr.go
+++ b/.ci/magician/cmd/test_terraform_vcr.go
@@ -477,6 +477,7 @@ func formatComment(fileName string, tmplText string, data any) (string, error) {
 	funcs := template.FuncMap{
 		"join": strings.Join,
 		"add":  func(i, j int) int { return i + j },
+		"color": color,
 	}
 	tmpl, err := template.New(fileName).Funcs(funcs).Parse(tmplText)
 	if err != nil {


### PR DESCRIPTION
This is a preparatory step for https://github.com/hashicorp/terraform-provider-google/issues/19301 since it will allow us to easily change the method we use to colorize text everywhere at once

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
