### PR TITLE
Add fields to support stateful cookie-based affinity

### DIFF
--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -1312,9 +1312,9 @@ properties:
         description: |
           Lifetime of the cookie.
         at_least_one_of:
-          - 'http_cookie.0.ttl'
-          - 'http_cookie.0.name'
-          - 'http_cookie.0.path'
+          - 'strong_session_affinity_cookie.0.ttl'
+          - 'strong_session_affinity_cookie.0.name'
+          - 'strong_session_affinity_cookie.0.path'
         properties:
           - name: 'seconds'
             type: Integer
@@ -1334,17 +1334,17 @@ properties:
         description: |
           Name of the cookie.
         at_least_one_of:
-          - 'http_cookie.0.ttl'
-          - 'http_cookie.0.name'
-          - 'http_cookie.0.path'
+          - 'strong_session_affinity_cookie.0.ttl'
+          - 'strong_session_affinity_cookie.0.name'
+          - 'strong_session_affinity_cookie.0.path'
       - name: 'path'
         type: String
         description: |
           Path to set for the cookie.
         at_least_one_of:
-          - 'http_cookie.0.ttl'
-          - 'http_cookie.0.name'
-          - 'http_cookie.0.path'
+          - 'strong_session_affinity_cookie.0.ttl'
+          - 'strong_session_affinity_cookie.0.name'
+          - 'strong_session_affinity_cookie.0.path'
   - name: 'timeoutSec'
     type: Integer
     description: |

--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -106,6 +106,12 @@ examples:
     vars:
       backend_service_name: 'backend-service'
       health_check_name: 'health-check'
+  - name: 'backend_service_stateful_session_affinity'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      backend_service_name: 'backend-service'
+      health_check_name: 'health-check'
   - name: 'backend_service_network_endpoint'
     primary_resource_id: 'default'
     min_version: 'beta'
@@ -1295,6 +1301,50 @@ properties:
       - 'GENERATED_COOKIE'
       - 'HEADER_FIELD'
       - 'HTTP_COOKIE'
+      - 'STRONG_COOKIE_AFFINITY'
+  - name: 'strongSessionAffinityCookie'
+    type: NestedObject
+    description: |
+      Describes the HTTP cookie used for stateful session affinity. This field is applicable and required if the sessionAffinity is set to STRONG_COOKIE_AFFINITY.
+    properties:
+      - name: 'ttl'
+        type: NestedObject
+        description: |
+          Lifetime of the cookie.
+        at_least_one_of:
+          - 'http_cookie.0.ttl'
+          - 'http_cookie.0.name'
+          - 'http_cookie.0.path'
+        properties:
+          - name: 'seconds'
+            type: Integer
+            description: |
+              Span of time at a resolution of a second.
+              Must be from 0 to 315,576,000,000 inclusive.
+            required: true
+          - name: 'nanos'
+            type: Integer
+            description: |
+              Span of time that's a fraction of a second at nanosecond
+              resolution. Durations less than one second are represented
+              with a 0 seconds field and a positive nanos field. Must
+              be from 0 to 999,999,999 inclusive.
+      - name: 'name'
+        type: String
+        description: |
+          Name of the cookie.
+        at_least_one_of:
+          - 'http_cookie.0.ttl'
+          - 'http_cookie.0.name'
+          - 'http_cookie.0.path'
+      - name: 'path'
+        type: String
+        description: |
+          Path to set for the cookie.
+        at_least_one_of:
+          - 'http_cookie.0.ttl'
+          - 'http_cookie.0.name'
+          - 'http_cookie.0.path'
   - name: 'timeoutSec'
     type: Integer
     description: |

--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -96,6 +96,12 @@ examples:
     vars:
       region_backend_service_name: 'region-service'
       health_check_name: 'rbs-health-check'
+  - name: 'region_backend_service_ilb_stateful_session_affinity'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      region_backend_service_name: 'region-service'
+      health_check_name: 'rbs-health-check'
   - name: 'region_backend_service_balancing_mode'
     primary_resource_id: 'default'
     vars:
@@ -1151,6 +1157,50 @@ properties:
       - 'HEADER_FIELD'
       - 'HTTP_COOKIE'
       - 'CLIENT_IP_NO_DESTINATION'
+      - 'STRONG_COOKIE_AFFINITY'
+  - name: 'strongSessionAffinityCookie'
+    type: NestedObject
+    description: |
+      Describes the HTTP cookie used for stateful session affinity. This field is applicable and required if the sessionAffinity is set to STRONG_COOKIE_AFFINITY.
+    properties:
+      - name: 'ttl'
+        type: NestedObject
+        description: |
+          Lifetime of the cookie.
+        at_least_one_of:
+          - 'http_cookie.0.ttl'
+          - 'http_cookie.0.name'
+          - 'http_cookie.0.path'
+        properties:
+          - name: 'seconds'
+            type: Integer
+            description: |
+              Span of time at a resolution of a second.
+              Must be from 0 to 315,576,000,000 inclusive.
+            required: true
+          - name: 'nanos'
+            type: Integer
+            description: |
+              Span of time that's a fraction of a second at nanosecond
+              resolution. Durations less than one second are represented
+              with a 0 seconds field and a positive nanos field. Must
+              be from 0 to 999,999,999 inclusive.
+      - name: 'name'
+        type: String
+        description: |
+          Name of the cookie.
+        at_least_one_of:
+          - 'http_cookie.0.ttl'
+          - 'http_cookie.0.name'
+          - 'http_cookie.0.path'
+      - name: 'path'
+        type: String
+        description: |
+          Path to set for the cookie.
+        at_least_one_of:
+          - 'http_cookie.0.ttl'
+          - 'http_cookie.0.name'
+          - 'http_cookie.0.path'
   - name: 'connectionTrackingPolicy'
     type: NestedObject
     description: |

--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -1168,9 +1168,9 @@ properties:
         description: |
           Lifetime of the cookie.
         at_least_one_of:
-          - 'http_cookie.0.ttl'
-          - 'http_cookie.0.name'
-          - 'http_cookie.0.path'
+          - 'strong_session_affinity_cookie.0.ttl'
+          - 'strong_session_affinity_cookie.0.name'
+          - 'strong_session_affinity_cookie.0.path'
         properties:
           - name: 'seconds'
             type: Integer
@@ -1190,17 +1190,17 @@ properties:
         description: |
           Name of the cookie.
         at_least_one_of:
-          - 'http_cookie.0.ttl'
-          - 'http_cookie.0.name'
-          - 'http_cookie.0.path'
+          - 'strong_session_affinity_cookie.0.ttl'
+          - 'strong_session_affinity_cookie.0.name'
+          - 'strong_session_affinity_cookie.0.path'
       - name: 'path'
         type: String
         description: |
           Path to set for the cookie.
         at_least_one_of:
-          - 'http_cookie.0.ttl'
-          - 'http_cookie.0.name'
-          - 'http_cookie.0.path'
+          - 'strong_session_affinity_cookie.0.ttl'
+          - 'strong_session_affinity_cookie.0.name'
+          - 'strong_session_affinity_cookie.0.path'
   - name: 'connectionTrackingPolicy'
     type: NestedObject
     description: |

--- a/mmv1/templates/terraform/examples/backend_service_stateful_session_affinity.tf.tmpl
+++ b/mmv1/templates/terraform/examples/backend_service_stateful_session_affinity.tf.tmpl
@@ -1,0 +1,26 @@
+resource "google_compute_backend_service" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+
+  name                  = "{{index $.Vars "backend_service_name"}}"
+  health_checks         = [google_compute_health_check.health_check.id]
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  locality_lb_policy    = "RING_HASH"
+  session_affinity      = "STRONG_COOKIE_AFFINITY"
+  
+  strong_session_affinity_cookie {
+     ttl {
+       seconds = 11
+       nanos   = 1111
+     }
+     name = "mycookie"
+   }   
+}
+
+resource "google_compute_health_check" "health_check" {
+  provider = google-beta
+
+  name = "{{index $.Vars "health_check_name"}}"
+  http_health_check {
+    port = 80
+  }
+}

--- a/mmv1/templates/terraform/examples/region_backend_service_ilb_stateful_session_affinity.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_backend_service_ilb_stateful_session_affinity.tf.tmpl
@@ -1,0 +1,27 @@
+resource "google_compute_region_backend_service" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+
+  region = "us-central1"
+  name = "{{index $.Vars "region_backend_service_name"}}"
+  health_checks = [google_compute_health_check.health_check.id]
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  locality_lb_policy = "RING_HASH"
+  session_affinity = "STRONG_COOKIE_AFFINITY"
+  protocol = "HTTP"
+  
+  strong_session_affinity_cookie {
+    ttl {
+      seconds = 11
+      nanos = 1111
+    }
+    name = "mycookie"
+  }  
+}
+
+resource "google_compute_health_check" "health_check" {
+  provider = google-beta
+  name               = "{{index $.Vars "health_check_name"}}"
+  http_health_check {
+    port = 80
+  }
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add Terraform support for configuring stateful cookie-based affinity. It is added to both backend service and regional backend service. Connections bearing the same cookie will be served by the same backend VM while that VM remains healthy, as long as the cookie has not expired.
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/19647

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

- Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes.
- [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran make test and make lint to ensure it passes unit and linter tests.
- Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests). - read only field
- [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added enum STATEFUL_COOKIE_AFFINITY and `strong_session_affinity_cookie` field to `google_compute_backend_service` and `google_compute_region_backend_service` resource
```
