### PR TITLE
Add TeamCity testing project for ephemeral resources feature branch, clean up imports

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
@@ -7,7 +7,6 @@
 
 package builds
 
-import DefaultTerraformCoreVersion
 import jetbrains.buildServer.configs.kotlin.BuildSteps
 import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
 

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_triggers.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_triggers.kt
@@ -36,7 +36,8 @@ class NightlyTriggerConfiguration(
 fun Triggers.runNightly(config: NightlyTriggerConfiguration) {
 
     schedule{
-        enabled = config.nightlyTestsEnabled
+        // enabled = config.nightlyTestsEnabled
+        enabled = false
         branchFilter = "+:" + config.branch // returns "+:/refs/heads/nightly-test" if default
         triggerBuild = always() // Run build even if no new commits/pending changes
         withPendingChangesOnly = false

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_triggers.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_triggers.kt
@@ -36,8 +36,7 @@ class NightlyTriggerConfiguration(
 fun Triggers.runNightly(config: NightlyTriggerConfiguration) {
 
     schedule{
-        // enabled = config.nightlyTestsEnabled
-        enabled = false
+        enabled = config.nightlyTestsEnabled
         branchFilter = "+:" + config.branch // returns "+:/refs/heads/nightly-test" if default
         triggerBuild = always() // Run build even if no new commits/pending changes
         withPendingChangesOnly = false

--- a/mmv1/third_party/terraform/.teamcity/components/projects/feature_branches/FEATURE-BRANCH-ephemeral-resource.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/feature_branches/FEATURE-BRANCH-ephemeral-resource.kt
@@ -41,7 +41,7 @@ fun featureBranchEphemeralResourcesSubProject(allConfig: AllContextParameters): 
     val packageName = "resourcemanager" // All ephemeral resources will be in the resourcemanager package
     val vcrConfig = getVcrAcceptanceTestConfig(allConfig) // Reused below for both MM testing build configs
     val trigger  = NightlyTriggerConfiguration(
-        branch = featureBranchEphemeralResources // triggered builds must test the feature branch
+        branch = "refs/heads/$featureBranchEphemeralResources" // triggered builds must test the feature branch
     )
 
 

--- a/mmv1/third_party/terraform/.teamcity/components/projects/feature_branches/FEATURE-BRANCH-ephemeral-resource.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/feature_branches/FEATURE-BRANCH-ephemeral-resource.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// This file is maintained in the GoogleCloudPlatform/magic-modules repository and copied into the downstream provider repositories. Any changes to this file in the downstream will be overwritten.
+
+package projects.feature_branches
+
+import ProviderNameBeta
+import ProviderNameGa
+import SharedResourceNameBeta
+import SharedResourceNameGa
+import SharedResourceNameVcr
+import builds.*
+import generated.ServicesListBeta
+import generated.ServicesListGa
+import jetbrains.buildServer.configs.kotlin.Project
+import replaceCharsId
+import vcs_roots.HashiCorpVCSRootBeta
+import vcs_roots.HashiCorpVCSRootGa
+import vcs_roots.ModularMagicianVCSRootBeta
+import vcs_roots.ModularMagicianVCSRootGa
+
+const val featureBranchEphemeralResources = "FEATURE-BRANCH-ephemeral-resource"
+const val EphemeralResourcesTfCoreVersion = "1.10.0-alpha20240926" // TODO - update with correct release
+
+// featureBranchEphemeralResourcesSubProject creates a project just for testing ephemeral resources.
+// We know that all ephemeral resources we're adding are part of the Resource Manager service, so we only include those builds.
+// We create builds for testing the resourcemanager service:
+//    - Against the GA hashicorp repo
+//    - Against the GA modular-magician repo
+//    - Against the Beta hashicorp repo
+//    - Against the Beta modular-magician repo
+// These resemble existing projects present in TeamCity, but these all use a more recent version of Terraform including
+// the new ephemeral values feature.
+fun featureBranchEphemeralResourcesSubProject(allConfig: AllContextParameters): Project {
+
+    val projectId = replaceCharsId(featureBranchEphemeralResources)
+
+    val packageName = "resourcemanager" // All ephemeral resources will be in the resourcemanager package
+    val vcrConfig = getVcrAcceptanceTestConfig(allConfig) // Reused below for both MM testing build configs
+    val trigger  = NightlyTriggerConfiguration(
+        branch = featureBranchEphemeralResources // triggered builds must test the feature branch
+    )
+
+
+    // GA
+    val gaConfig = getGaAcceptanceTestConfig(allConfig)
+    // How to make only build configuration to the relevant package(s)
+    val resourceManagerPackageGa = ServicesListGa.getValue(packageName)
+
+    // Enable testing using hashicorp/terraform-provider-google
+    var parentId = "${projectId}_HC_GA"
+    val buildConfigHashiCorpGa = BuildConfigurationForSinglePackage(packageName, resourceManagerPackageGa.getValue("path"), "Ephemeral resources in $packageName (GA provider, HashiCorp downstream)", ProviderNameGa, parentId, HashiCorpVCSRootGa, listOf(SharedResourceNameGa), gaConfig)
+    buildConfigHashiCorpGa.addTrigger(trigger)
+
+    // Enable testing using modular-magician/terraform-provider-google
+    parentId = "${projectId}_MM_GA"
+    val buildConfigModularMagicianGa = BuildConfigurationForSinglePackage(packageName, resourceManagerPackageGa.getValue("path"), "Ephemeral resources in $packageName (GA provider, MM upstream)", ProviderNameGa, parentId, ModularMagicianVCSRootGa, listOf(SharedResourceNameVcr), vcrConfig)
+
+    // Beta
+    val betaConfig = getBetaAcceptanceTestConfig(allConfig)
+    val resourceManagerPackageBeta = ServicesListBeta.getValue(packageName)
+
+    // Enable testing using hashicorp/terraform-provider-google-beta
+    parentId = "${projectId}_HC_BETA"
+    val buildConfigHashiCorpBeta = BuildConfigurationForSinglePackage(packageName, resourceManagerPackageBeta.getValue("path"), "Ephemeral resources in $packageName (Beta provider, HashiCorp downstream)", ProviderNameBeta, parentId, HashiCorpVCSRootBeta, listOf(SharedResourceNameBeta), betaConfig)
+    buildConfigHashiCorpBeta.addTrigger(trigger)
+
+    // Enable testing using modular-magician/terraform-provider-google-beta
+    parentId = "${projectId}_MM_BETA"
+    val buildConfigModularMagicianBeta = BuildConfigurationForSinglePackage(packageName, resourceManagerPackageBeta.getValue("path"), "Ephemeral resources in $packageName (Beta provider, MM upstream)", ProviderNameBeta, parentId, ModularMagicianVCSRootBeta, listOf(SharedResourceNameVcr), vcrConfig)
+
+    val allBuildConfigs = listOf(buildConfigHashiCorpGa, buildConfigModularMagicianGa, buildConfigHashiCorpBeta, buildConfigModularMagicianBeta)
+
+    // Make these builds use a 1.10.0-ish version of TF core
+    allBuildConfigs.forEach{ b ->
+        b.overrideTerraformCoreVersion(EphemeralResourcesTfCoreVersion)
+    }
+
+    return Project{
+        id(projectId)
+        name = featureBranchEphemeralResources
+        description = "Subproject for testing feature branch $featureBranchEphemeralResources"
+
+        // Register all build configs in the project
+        allBuildConfigs.forEach{ b ->
+            buildType(b)
+        }
+
+        params {
+            readOnlySettings()
+        }
+    }
+}

--- a/mmv1/third_party/terraform/.teamcity/components/projects/feature_branches/FEATURE-BRANCH-ephemeral-resource.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/feature_branches/FEATURE-BRANCH-ephemeral-resource.kt
@@ -58,6 +58,7 @@ fun featureBranchEphemeralResourcesSubProject(allConfig: AllContextParameters): 
     // Enable testing using modular-magician/terraform-provider-google
     parentId = "${projectId}_MM_GA"
     val buildConfigModularMagicianGa = BuildConfigurationForSinglePackage(packageName, resourceManagerPackageGa.getValue("path"), "Ephemeral resources in $packageName (GA provider, MM upstream)", ProviderNameGa, parentId, ModularMagicianVCSRootGa, listOf(SharedResourceNameVcr), vcrConfig)
+    // No trigger added here (MM upstream is manual only)
 
     // Beta
     val betaConfig = getBetaAcceptanceTestConfig(allConfig)
@@ -71,13 +72,18 @@ fun featureBranchEphemeralResourcesSubProject(allConfig: AllContextParameters): 
     // Enable testing using modular-magician/terraform-provider-google-beta
     parentId = "${projectId}_MM_BETA"
     val buildConfigModularMagicianBeta = BuildConfigurationForSinglePackage(packageName, resourceManagerPackageBeta.getValue("path"), "Ephemeral resources in $packageName (Beta provider, MM upstream)", ProviderNameBeta, parentId, ModularMagicianVCSRootBeta, listOf(SharedResourceNameVcr), vcrConfig)
+    // No trigger added here (MM upstream is manual only)
 
+
+    // ------
+
+    // Make all builds use a 1.10.0-ish version of TF core
     val allBuildConfigs = listOf(buildConfigHashiCorpGa, buildConfigModularMagicianGa, buildConfigHashiCorpBeta, buildConfigModularMagicianBeta)
-
-    // Make these builds use a 1.10.0-ish version of TF core
     allBuildConfigs.forEach{ b ->
         b.overrideTerraformCoreVersion(EphemeralResourcesTfCoreVersion)
     }
+
+    // ------
 
     return Project{
         id(projectId)

--- a/mmv1/third_party/terraform/.teamcity/components/projects/reused/mm_upstream.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/reused/mm_upstream.kt
@@ -14,12 +14,7 @@ import ServiceSweeperCronName
 import ServiceSweeperManualName
 import SharedResourceNameVcr
 import builds.*
-import generated.PackagesListBeta
-import generated.PackagesListGa
-import generated.ServicesListBeta
-import generated.ServicesListGa
-import generated.SweepersListBeta
-import generated.SweepersListGa
+import generated.*
 import jetbrains.buildServer.configs.kotlin.BuildType
 import jetbrains.buildServer.configs.kotlin.Project
 import jetbrains.buildServer.configs.kotlin.vcs.GitVcsRoot

--- a/mmv1/third_party/terraform/.teamcity/components/projects/reused/vcr_recording.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/reused/vcr_recording.kt
@@ -9,7 +9,8 @@ package projects.reused
 
 import SharedResourceNameVcr
 import VcrRecordingProjectId
-import builds.*
+import builds.AccTestConfiguration
+import builds.VcrDetails
 import jetbrains.buildServer.configs.kotlin.Project
 import jetbrains.buildServer.configs.kotlin.vcs.GitVcsRoot
 import replaceCharsId

--- a/mmv1/third_party/terraform/.teamcity/components/projects/root_project.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/root_project.kt
@@ -18,6 +18,7 @@ import generated.ServicesListBeta
 import generated.ServicesListGa
 import jetbrains.buildServer.configs.kotlin.Project
 import jetbrains.buildServer.configs.kotlin.sharedResource
+import projects.feature_branches.featureBranchEphemeralResourcesSubProject
 
 // googleCloudRootProject returns a root project that contains a subprojects for the GA and Beta version of the
 // Google provider. There are also resources to help manage the test projects used for acceptance tests.
@@ -61,6 +62,10 @@ fun googleCloudRootProject(allConfig: AllContextParameters): Project {
         subProject(googleSubProjectGa(allConfig))
         subProject(googleSubProjectBeta(allConfig))
         subProject(projectSweeperSubProject(allConfig))
+
+        // Feature branch-testing projects - these will be added and removed as needed
+        subProject(featureBranchEphemeralResourcesSubProject(allConfig))
+
 
         params {
             readOnlySettings()

--- a/mmv1/third_party/terraform/.teamcity/settings.kts
+++ b/mmv1/third_party/terraform/.teamcity/settings.kts
@@ -5,9 +5,9 @@
 
 // This file is maintained in the GoogleCloudPlatform/magic-modules repository and copied into the downstream provider repositories. Any changes to this file in the downstream will be overwritten.
 
-import projects.googleCloudRootProject
 import builds.AllContextParameters
 import jetbrains.buildServer.configs.kotlin.*
+import projects.googleCloudRootProject
 
 version = "2024.03"
 

--- a/mmv1/third_party/terraform/.teamcity/tests/FEATURE-BRANCH-ephemeral-resource.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/FEATURE-BRANCH-ephemeral-resource.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// This file is maintained in the GoogleCloudPlatform/magic-modules repository and copied into the downstream provider repositories. Any changes to this file in the downstream will be overwritten.
+
+package tests
+
+import jetbrains.buildServer.configs.kotlin.triggers.ScheduleTrigger
+import org.junit.Assert
+import org.junit.Test
+import projects.feature_branches.featureBranchEphemeralResources
+import projects.googleCloudRootProject
+
+class FeatureBranchEphemeralResourcesSubProject {
+    @Test
+    fun checkProjectSetup() {
+        val root = googleCloudRootProject(testContextParameters())
+
+        // Find feature branch project
+        var project = getSubProject(root, featureBranchEphemeralResources)
+
+        // Make assertions about builds in the feature branch testing project
+        project.buildTypes.forEach{bt ->
+            Assert.assertTrue(
+                "Build configuration `${bt.name}` should contain at least one trigger",
+                bt.triggers.items.isNotEmpty()
+            )
+            // Look for at least one CRON trigger
+            var found: Boolean = false
+            lateinit var schedulingTrigger: ScheduleTrigger
+            for (item in bt.triggers.items){
+                if (item.type == "schedulingTrigger") {
+                    schedulingTrigger = item as ScheduleTrigger
+                    found = true
+                    break
+                }
+            }
+
+            Assert.assertTrue(
+                "Build configuration `${bt.name}` should contain a CRON/'schedulingTrigger' trigger",
+                found
+            )
+
+            // Check that triggered builds are being run on the feature branch
+            var isCorrectBranch: Boolean = schedulingTrigger.branchFilter == "+:refs/heads/${featureBranchEphemeralResources}"
+
+            Assert.assertTrue(
+                "Build configuration `${bt.name}` is using the ${featureBranchEphemeralResources} branch filter;",
+                isCorrectBranch
+            )
+        }
+    }
+}

--- a/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
@@ -8,9 +8,9 @@
 package tests
 
 import ProjectSweeperName
-import ServiceSweeperName
 import ServiceSweeperCronName
 import ServiceSweeperManualName
+import ServiceSweeperName
 import jetbrains.buildServer.configs.kotlin.BuildType
 import jetbrains.buildServer.configs.kotlin.Project
 import jetbrains.buildServer.configs.kotlin.triggers.ScheduleTrigger

--- a/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/sweepers.kt
@@ -136,7 +136,7 @@ class SweeperTests {
 
         // Find Project sweeper project's build
         val projectSweeperProject = getSubProject(root, projectSweeperProjectName)
-        val projectSweeper: BuildType = getBuildFromProject(projectSweeperProject!!, ProjectSweeperName)
+        val projectSweeper: BuildType = getBuildFromProject(projectSweeperProject, ProjectSweeperName)
         
         // Check only one schedule trigger is on the builds in question
         assertTrue(sweeperGa.triggers.items.size == 1)


### PR DESCRIPTION
## Adding projects in our TeamCity environment for testing ephemeral resources

This project will:
- Use a more recent Terraform binary version that contains the ephemeral feature
    - See `EphemeralResourcesTfCoreVersion`
- Have builds only for services were we're adding ephemeral resources
- Have builds that allow using the hashicorp and modular-magician owned repos (can test PRs pre-merge)
- CRON triggers to schedule builds (that use the hashicorp repo) every night

## Preview of the changes


**Here is a test project where this PR's config is deployed: https://hashicorp.teamcity.com/project/TerraformProviders_TerraformProviderGoogleSarahCheckingEphemeralTesting?mode=builds**


This is what the new addition to TeamCity will look like - we only need to test the resourcemanager package as all ephemeral resources we want to add are in that package:


<img width="880" alt="Screenshot 2024-10-03 at 21 15 35" src="https://github.com/user-attachments/assets/da66decb-b257-4c2c-8510-75139789dd95">

Here's a look at the trigger set on the builds using the HashiCorp-owned repos:


<img width="1309" alt="Screenshot 2024-10-03 at 21 18 53" src="https://github.com/user-attachments/assets/8139b1c4-0aa5-44f8-9461-e75b0e1f7b2d">

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
