### PR TITLE
Revert the promotion of Port Mapping NEGs from GA to Beta

### DIFF
--- a/mmv1/products/compute/RegionNetworkEndpoint.yaml
+++ b/mmv1/products/compute/RegionNetworkEndpoint.yaml
@@ -80,6 +80,7 @@ examples:
       network_name: 'network'
   - name: 'region_network_endpoint_portmap'
     primary_resource_id: 'region_network_endpoint_portmap'
+    min_version: 'beta'
     vars:
       network_name: 'network'
       subnetwork_name: 'subnetwork'
@@ -139,6 +140,7 @@ properties:
     type: Integer
     description: |
       Client destination port for the `GCE_VM_IP_PORTMAP` NEG.
+    min_version: 'beta'
     custom_flatten: 'templates/terraform/custom_flatten/float64_to_int.go.tmpl'
   - name: 'instance'
     type: ResourceRef
@@ -147,3 +149,4 @@ properties:
       This is required for network endpoints of type GCE_VM_IP_PORTMAP.
     resource: 'Instance'
     imports: 'name'
+    min_version: 'beta'

--- a/mmv1/products/compute/RegionNetworkEndpointGroup.yaml
+++ b/mmv1/products/compute/RegionNetworkEndpointGroup.yaml
@@ -99,6 +99,7 @@ examples:
       network_name: 'network'
   - name: 'region_network_endpoint_group_portmap'
     primary_resource_id: 'region_network_endpoint_group_portmap'
+    min_version: 'beta'
     vars:
       network_name: 'network'
       subnetwork_name: 'subnetwork'

--- a/mmv1/templates/terraform/examples/region_network_endpoint_group_portmap.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_network_endpoint_group_portmap.tf.tmpl
@@ -5,10 +5,12 @@ resource "google_compute_region_network_endpoint_group" "{{$.PrimaryResourceId}}
   subnetwork            = google_compute_subnetwork.default.id
 
   network_endpoint_type = "GCE_VM_IP_PORTMAP"
+  provider              = google-beta
 }
 
 resource "google_compute_network" "default" {
   name                    = "{{index $.Vars "network_name"}}"
+  provider              = google-beta
 }
 
 resource "google_compute_subnetwork" "default" {
@@ -16,4 +18,5 @@ resource "google_compute_subnetwork" "default" {
   ip_cidr_range = "10.0.0.0/16"
   region        = "us-central1"
   network       = google_compute_network.default.id
+  provider              = google-beta
 }

--- a/mmv1/templates/terraform/examples/region_network_endpoint_portmap.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_network_endpoint_portmap.tf.tmpl
@@ -1,6 +1,7 @@
 resource "google_compute_network" "default" {
   name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = false
+  provider           = google-beta
 }
 
 resource "google_compute_subnetwork" "default" {
@@ -8,6 +9,7 @@ resource "google_compute_subnetwork" "default" {
   ip_cidr_range = "10.0.0.0/16"
   region        = "us-central1"
   network       = google_compute_network.default.id
+  provider           = google-beta
 }
 
 resource "google_compute_region_network_endpoint_group" default {
@@ -17,6 +19,7 @@ resource "google_compute_region_network_endpoint_group" default {
   subnetwork            = google_compute_subnetwork.default.id
 
   network_endpoint_type = "GCE_VM_IP_PORTMAP"
+  provider           = google-beta
 }
 
 resource "google_compute_region_network_endpoint" "{{$.PrimaryResourceId}}" {
@@ -26,11 +29,13 @@ resource "google_compute_region_network_endpoint" "{{$.PrimaryResourceId}}" {
   port       = 80
   ip_address = google_compute_instance.default.network_interface[0].network_ip
   client_destination_port = 8080
+  provider           = google-beta
 }
 
 data "google_compute_image" "my_image" {
   family  = "debian-11"
   project = "debian-cloud"
+  provider           = google-beta
 }
 
 resource "google_compute_instance" "default" {
@@ -49,4 +54,5 @@ resource "google_compute_instance" "default" {
     access_config {
     }
   }
+  provider           = google-beta
 }

--- a/mmv1/templates/terraform/pre_delete/compute_region_network_endpoint.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/compute_region_network_endpoint.go.tmpl
@@ -27,6 +27,7 @@ if fqdnProp != "" {
   toDelete["fqdn"] = fqdnProp
 }
 
+<% unless version == 'ga' -%>
 // Instance
 instanceProp, err := expandNestedComputeRegionNetworkEndpointInstance(d.Get("instance"), d, config)
 if err != nil {
@@ -44,6 +45,7 @@ if err != nil {
 if clientDestinationPortProp != "" && d.Get("client_destination_port").(int) > 0 {
   toDelete["clientDestinationPort"] = clientDestinationPortProp
 }
+<% end -%>
 
 obj = map[string]interface{}{
 	"networkEndpoints": []map[string]interface{}{toDelete},

--- a/mmv1/templates/terraform/pre_delete/compute_region_network_endpoint.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/compute_region_network_endpoint.go.tmpl
@@ -27,7 +27,7 @@ if fqdnProp != "" {
   toDelete["fqdn"] = fqdnProp
 }
 
-<% unless version == 'ga' -%>
+{{- if ne $.TargetVersionName "ga" }}
 // Instance
 instanceProp, err := expandNestedComputeRegionNetworkEndpointInstance(d.Get("instance"), d, config)
 if err != nil {
@@ -45,7 +45,7 @@ if err != nil {
 if clientDestinationPortProp != "" && d.Get("client_destination_port").(int) > 0 {
   toDelete["clientDestinationPort"] = clientDestinationPortProp
 }
-<% end -%>
+{{- end }}
 
 obj = map[string]interface{}{
 	"networkEndpoints": []map[string]interface{}{toDelete},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_network_endpoint_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_network_endpoint_test.go.tmpl
@@ -143,7 +143,7 @@ resource "google_compute_region_network_endpoint" "add2" {
 `, context) + testAccComputeRegionNetworkEndpoint_noRegionNetworkEndpoints(context)
 }
 
-<% unless version == 'ga' -%>
+{{- if ne $.TargetVersionName "ga" }}
 
 func TestAccComputeRegionNetworkEndpoint_regionNetworkEndpointPortmapExample(t *testing.T) {
 	t.Parallel()
@@ -245,7 +245,7 @@ resource "google_compute_region_network_endpoint" "region_network_endpoint_portm
 }
 `, context) + testAccComputeRegionNetworkEndpoint_regionNetworkEndpointPortmapNoEndpointExample(context)
 }
-<% end -%>
+{{- end }}
 
 func testAccComputeRegionNetworkEndpoint_noRegionNetworkEndpoints(context map[string]interface{}) string {
 	return acctest.Nprintf(`

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_network_endpoint_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_network_endpoint_test.go.tmpl
@@ -143,6 +143,8 @@ resource "google_compute_region_network_endpoint" "add2" {
 `, context) + testAccComputeRegionNetworkEndpoint_noRegionNetworkEndpoints(context)
 }
 
+<% unless version == 'ga' -%>
+
 func TestAccComputeRegionNetworkEndpoint_regionNetworkEndpointPortmapExample(t *testing.T) {
 	t.Parallel()
 
@@ -155,7 +157,7 @@ func TestAccComputeRegionNetworkEndpoint_regionNetworkEndpointPortmapExample(t *
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccComputeRegionNetworkEndpoint_regionNetworkEndpointPortmapExample(context),
@@ -182,6 +184,7 @@ func testAccComputeRegionNetworkEndpoint_regionNetworkEndpointPortmapNoEndpointE
 resource "google_compute_network" "default" {
   name                    = "network%{random_suffix}"
   auto_create_subnetworks = false
+  provider           = google-beta
 }
 
 resource "google_compute_subnetwork" "default" {
@@ -189,6 +192,7 @@ resource "google_compute_subnetwork" "default" {
   ip_cidr_range = "10.0.0.0/16"
   region        = "us-central1"
   network       = google_compute_network.default.id
+  provider           = google-beta
 }
 
 resource "google_compute_region_network_endpoint_group" default {
@@ -198,11 +202,13 @@ resource "google_compute_region_network_endpoint_group" default {
   subnetwork            = google_compute_subnetwork.default.id
 
   network_endpoint_type = "GCE_VM_IP_PORTMAP"
+  provider           = google-beta
 }
 
 data "google_compute_image" "my_image" {
   family  = "debian-11"
   project = "debian-cloud"
+  provider           = google-beta
 }
 
 resource "google_compute_instance" "default" {
@@ -221,6 +227,7 @@ resource "google_compute_instance" "default" {
     access_config {
     }
   }
+  provider           = google-beta
 }
 `, context)
 }
@@ -234,9 +241,11 @@ resource "google_compute_region_network_endpoint" "region_network_endpoint_portm
   port       = 80
   ip_address = google_compute_instance.default.network_interface[0].network_ip
   client_destination_port = 8080
+  provider           = google-beta
 }
 `, context) + testAccComputeRegionNetworkEndpoint_regionNetworkEndpointPortmapNoEndpointExample(context)
 }
+<% end -%>
 
 func testAccComputeRegionNetworkEndpoint_noRegionNetworkEndpoints(context map[string]interface{}) string {
 	return acctest.Nprintf(`


### PR DESCRIPTION
Revert the PR https://github.com/GoogleCloudPlatform/magic-modules/pull/11771 

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: promoted `client_destination_port` and `instance` fields in `google_compute_region_network_endpoint` resource to GA (revert)
```
