### PR TITLE
Handle location tag bindings of removed resources

### DIFF
--- a/mmv1/third_party/terraform/services/tags/resource_tags_location_tag_bindings.go.tmpl
+++ b/mmv1/third_party/terraform/services/tags/resource_tags_location_tag_bindings.go.tmpl
@@ -7,8 +7,10 @@ import (
 	"strings"
 	"time"
 
+    "github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+	"google.golang.org/api/googleapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -180,7 +182,7 @@ func resourceTagsLocationTagBindingRead(d *schema.ResourceData, meta interface{}
 		UserAgent: userAgent,
 	})
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("TagsLocationTagBinding %q", d.Id()))
+		return transport_tpg.HandleNotFoundError(transformTagsLocationTagBindingReadError(err), d, fmt.Sprintf("TagsLocationTagBinding %q", d.Id()))
 	}
 	log.Printf("[DEBUG] Skipping res with name for import = %#v,)", res)
 
@@ -195,7 +197,7 @@ func resourceTagsLocationTagBindingRead(d *schema.ResourceData, meta interface{}
 		for pageToken != "" {
 			url, err = transport_tpg.AddQueryParams(url, map[string]string{"pageToken": fmt.Sprintf("%s", res["nextPageToken"])})
 			if err != nil {
-				return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("TagsLocationTagBinding %q", d.Id()))
+				return transport_tpg.HandleNotFoundError(transformTagsLocationTagBindingReadError(err), d, fmt.Sprintf("TagsLocationTagBinding %q", d.Id()))
 			}
 			resp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 				Config: config,
@@ -385,4 +387,28 @@ func resourceTagsLocationTagBindingFindNestedObjectInList(d *schema.ResourceData
 		return idx, item, nil
 	}
 	return -1, nil, nil
+}
+
+func transformTagsLocationTagBindingReadError(err error) error {
+    if gErr, ok := errwrap.GetType(err, &googleapi.Error{}).(*googleapi.Error); ok && gErr.Code == 403 {
+        for _, detail := range gErr.Details {
+            if detailMap, ok := detail.(map[string]interface{}); ok {
+                if detailType, ok := detailMap["@type"].(string); ok && detailType == "type.googleapis.com/google.rpc.ResourceInfo" {
+                    if description, ok := detailMap["description"].(string); ok && strings.Contains(description, "(or the resource may not exist in this location)") {
+                        // This error occurs when either the tag binding parent does not exist, or permission is denied. It is
+                        // deliberately ambiguous so that existence information is not revealed to the caller. However, for
+                        // the Read function, we can only assume that the membership does not exist, and proceed with attempting
+                        // other operations. Since HandleNotFoundError(...) expects an error code of 404 when a resource does not
+                        // exist, to get the desired behavior, we modify the error code to be 404.
+                        gErr.Code = 404
+                    }
+                }
+            }
+        }
+
+        log.Printf("[DEBUG] Transformed TagsLocationTagBinding error")
+        return gErr
+    }
+
+    return err
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Currently, the `google_tags_location_tag_binding` resource will cause any plans to fail whenever the resource (`parent`) it was for is deleted outside of Terraform. Specifically, it results in errors like these during the read operation:

```
│ Error: Error when reading or editing TagsLocationTagBinding "<some-id>": googleapi: Error 403: The caller does not have permission
│ Details:
│ [
│   {
│     "@type": "type.googleapis.com/google.rpc.ResourceInfo",
│     "description": "permission [storage.buckets.listTagBindings] required (or the resource may not exist in this location)",
│     "resourceName": "//storage.googleapis.com/projects/_/buckets/<bucket-name>"
│   }
│ ]
│
│   with google_tags_location_tag_binding.binding,
│   on main.tf line 24, in resource "google_tags_location_tag_binding" "binding":
│   24: resource "google_tags_location_tag_binding" "binding" {
│
╵
```

The correct Terraform behavior would be that it recognizes this resource has been removed and drops it from the state. This PR implements that behavior, allowing plan operations to succeed even when the related resource was removed externally.

I tested the change successfully against my own test files, as well as the [reproduction snippet](https://gist.github.com/alexjmoore/0bfb62718f872e6fb72e73dedda2ca3e) from the linked issue. 

Fixes hashicorp/terraform-provider-google#15928.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
tags:  removed `google_tags_location_tag_binding` resource from the Terraform state when its parent resource has been removed outside of Terraform
```
