### PR TITLE
Enable update in apigee reference

### DIFF
--- a/mmv1/products/apigee/EnvReferences.yaml
+++ b/mmv1/products/apigee/EnvReferences.yaml
@@ -24,7 +24,6 @@ base_url: '{{env_id}}/references'
 self_link: '{{env_id}}/references/{{name}}'
 create_url: '{{env_id}}/references/'
 delete_url: '{{env_id}}/references/{{name}}'
-immutable: true
 import_format:
   - '{{env_id}}/references/{{name}}'
   - '{{env_id}}/{{name}}'
@@ -78,4 +77,3 @@ properties:
     description: |
       Required. The id of the resource to which this reference refers. Must be the id of a resource that exists in the parent environment and is of the given resourceType.
     required: true
-    immutable: true

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_env_references_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_env_references_test.go
@@ -111,15 +111,22 @@ resource "google_apigee_environment" "apigee_environment" {
 }
 
 resource "google_apigee_env_keystore" "apigee_environment_keystore_1" {
-  name       = "tf-test-keystore%{random_suffix}"
+  name       = "tf-test-keystore1%{random_suffix}"
   env_id     = google_apigee_environment.apigee_environment.id
 }
 
 resource "google_apigee_env_references" "apigee_environment_reference" {
   env_id         = google_apigee_environment.apigee_environment.id
-  name           = "tf-test-reference%{random_suffix}"
+  name           = "tf-test-reference"
   resource_type  = "KeyStore"
   refers         = google_apigee_env_keystore.apigee_environment_keystore_1.name
+  depends_on = [google_apigee_env_keystore.apigee_environment_keystore_1]
+}
+
+resource "google_apigee_env_keystore" "apigee_environment_keystore_2" {
+  name       = "tf-test-keystore2%{random_suffix}"
+  env_id     = google_apigee_environment.apigee_environment.id
+  depends_on = [google_apigee_env_references.apigee_environment_reference]
 }
 `, context)
 }
@@ -190,15 +197,22 @@ resource "google_apigee_environment" "apigee_environment" {
 }
 
 resource "google_apigee_env_keystore" "apigee_environment_keystore_2" {
-  name       = "tf-test-keystore%{random_suffix}"
+  name       = "tf-test-keystore2%{random_suffix}"
   env_id     = google_apigee_environment.apigee_environment.id
 }
 
 resource "google_apigee_env_references" "apigee_environment_reference" {
   env_id         = google_apigee_environment.apigee_environment.id
-  name           = "tf-test-reference%{random_suffix}"
+  name           = "tf-test-reference"
   resource_type  = "KeyStore"
   refers         = google_apigee_env_keystore.apigee_environment_keystore_2.name
+  depends_on = [google_apigee_env_keystore.apigee_environment_keystore_2]
+}
+
+resource "google_apigee_env_keystore" "apigee_environment_keystore_1" {
+  name       = "tf-test-keystore1%{random_suffix}"
+  env_id     = google_apigee_environment.apigee_environment.id
+  depends_on = [google_apigee_env_references.apigee_environment_reference]
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_env_references_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_env_references_test.go
@@ -117,7 +117,7 @@ resource "google_apigee_env_keystore" "apigee_environment_keystore_1" {
 
 resource "google_apigee_env_references" "apigee_environment_reference" {
   env_id         = google_apigee_environment.apigee_environment.id
-  name           = "tf-test-reference"
+  name           = "tf-test-reference%{random_suffix}"
   resource_type  = "KeyStore"
   refers         = google_apigee_env_keystore.apigee_environment_keystore_1.name
   depends_on = [google_apigee_env_keystore.apigee_environment_keystore_1]
@@ -203,7 +203,7 @@ resource "google_apigee_env_keystore" "apigee_environment_keystore_2" {
 
 resource "google_apigee_env_references" "apigee_environment_reference" {
   env_id         = google_apigee_environment.apigee_environment.id
-  name           = "tf-test-reference"
+  name           = "tf-test-reference%{random_suffix}"
   resource_type  = "KeyStore"
   refers         = google_apigee_env_keystore.apigee_environment_keystore_2.name
   depends_on = [google_apigee_env_keystore.apigee_environment_keystore_2]

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_env_references_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_env_references_test.go
@@ -1,0 +1,204 @@
+package apigee_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccApigeeEnvReferences_apigeeEnvironmentReferenceTest_Update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"random_suffix":   acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckApigeeEnvReferencesDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigeeEnvReferences_apigeeEnvironmentReferenceTest_full(context),
+			},
+			{
+				ResourceName:            "google_apigee_env_references.apigee_environment_reference",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"env_id"},
+			},
+			{
+				Config: testAccApigeeEnvReferences_apigeeEnvironmentReferenceTest_update(context),
+			},
+			{
+				ResourceName:            "google_apigee_env_references.apigee_environment_reference",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"env_id"},
+			},
+		},
+	})
+}
+
+func testAccApigeeEnvReferences_apigeeEnvironmentReferenceTest_full(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
+}
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+}
+
+resource "google_project_service" "servicenetworking" {
+  project = google_project.project.project_id
+  service = "servicenetworking.googleapis.com"
+  depends_on = [google_project_service.apigee]
+}
+
+resource "google_project_service" "compute" {
+  project = google_project.project.project_id
+  service = "compute.googleapis.com"
+  depends_on = [google_project_service.servicenetworking]
+}
+
+resource "google_compute_network" "apigee_network" {
+  name       = "apigee-network"
+  project    = google_project.project.project_id
+  depends_on = [google_project_service.compute]
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+  project       = google_project.project.project_id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+  depends_on              = [google_project_service.servicenetworking]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = google_project.project.project_id
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on         = [
+    google_service_networking_connection.apigee_vpc_connection,
+    google_project_service.apigee,
+  ]
+}
+
+resource "google_apigee_environment" "apigee_environment_reference" {
+  org_id       = google_apigee_organization.apigee_org.id
+  name         = "tf-test%{random_suffix}"
+  description  = "Apigee Environment"
+  display_name = "environment-1"
+}
+
+resource "google_apigee_env_keystore" "apigee_environment_keystore_1" {
+  name       = "tf-test-keystore%{random_suffix}"
+  env_id     = google_apigee_environment.apigee_environment_reference.id
+}
+
+resource "google_apigee_env_references" "apigee_environment_reference" {
+  env_id         = google_apigee_environment.apigee_environment_reference.id
+  name           = "reference_test"
+  resource_type  = "KeyStore"
+  refers         = google_apigee_env_keystore.apigee_environment_keystore_1.name
+}
+`, context)
+}
+
+func testAccApigeeEnvReferences_apigeeEnvironmentReferenceTest_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
+}
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+}
+
+resource "google_project_service" "servicenetworking" {
+  project = google_project.project.project_id
+  service = "servicenetworking.googleapis.com"
+  depends_on = [google_project_service.apigee]
+}
+
+resource "google_project_service" "compute" {
+  project = google_project.project.project_id
+  service = "compute.googleapis.com"
+  depends_on = [google_project_service.servicenetworking]
+}
+
+resource "google_compute_network" "apigee_network" {
+  name       = "apigee-network"
+  project    = google_project.project.project_id
+  depends_on = [google_project_service.compute]
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+  project       = google_project.project.project_id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+  depends_on              = [google_project_service.servicenetworking]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = google_project.project.project_id
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on         = [
+    google_service_networking_connection.apigee_vpc_connection,
+    google_project_service.apigee,
+  ]
+}
+
+resource "google_apigee_environment" "apigee_environment_reference" {
+  org_id       = google_apigee_organization.apigee_org.id
+  name         = "tf-test%{random_suffix}"
+  description  = "Apigee Environment"
+  display_name = "environment-1"
+}
+
+resource "google_apigee_env_keystore" "apigee_environment_keystore_2" {
+  name       = "tf-test-keystore%{random_suffix}"
+  env_id     = google_apigee_environment.apigee_environment_reference.id
+}
+
+resource "google_apigee_env_references" "apigee_environment_reference" {
+  env_id         = google_apigee_environment.apigee_environment_reference.id
+  name           = "reference_test"
+  resource_type  = "KeyStore"
+  refers         = google_apigee_env_keystore.apigee_environment_keystore_2.name
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_env_references_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_env_references_test.go
@@ -117,7 +117,7 @@ resource "google_apigee_env_keystore" "apigee_environment_keystore_1" {
 
 resource "google_apigee_env_references" "apigee_environment_reference" {
   env_id         = google_apigee_environment.apigee_environment.id
-  name           = "reference_test"
+  name           = "tf-test-reference%{random_suffix}"
   resource_type  = "KeyStore"
   refers         = google_apigee_env_keystore.apigee_environment_keystore_1.name
 }
@@ -196,7 +196,7 @@ resource "google_apigee_env_keystore" "apigee_environment_keystore_2" {
 
 resource "google_apigee_env_references" "apigee_environment_reference" {
   env_id         = google_apigee_environment.apigee_environment.id
-  name           = "reference_test"
+  name           = "tf-test-reference%{random_suffix}"
   resource_type  = "KeyStore"
   refers         = google_apigee_env_keystore.apigee_environment_keystore_2.name
 }

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_env_references_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_env_references_test.go
@@ -103,7 +103,7 @@ resource "google_apigee_organization" "apigee_org" {
   ]
 }
 
-resource "google_apigee_environment" "apigee_environment_reference" {
+resource "google_apigee_environment" "apigee_environment" {
   org_id       = google_apigee_organization.apigee_org.id
   name         = "tf-test%{random_suffix}"
   description  = "Apigee Environment"
@@ -112,11 +112,11 @@ resource "google_apigee_environment" "apigee_environment_reference" {
 
 resource "google_apigee_env_keystore" "apigee_environment_keystore_1" {
   name       = "tf-test-keystore%{random_suffix}"
-  env_id     = google_apigee_environment.apigee_environment_reference.id
+  env_id     = google_apigee_environment.apigee_environment.id
 }
 
 resource "google_apigee_env_references" "apigee_environment_reference" {
-  env_id         = google_apigee_environment.apigee_environment_reference.id
+  env_id         = google_apigee_environment.apigee_environment.id
   name           = "reference_test"
   resource_type  = "KeyStore"
   refers         = google_apigee_env_keystore.apigee_environment_keystore_1.name
@@ -182,7 +182,7 @@ resource "google_apigee_organization" "apigee_org" {
   ]
 }
 
-resource "google_apigee_environment" "apigee_environment_reference" {
+resource "google_apigee_environment" "apigee_environment" {
   org_id       = google_apigee_organization.apigee_org.id
   name         = "tf-test%{random_suffix}"
   description  = "Apigee Environment"
@@ -191,11 +191,11 @@ resource "google_apigee_environment" "apigee_environment_reference" {
 
 resource "google_apigee_env_keystore" "apigee_environment_keystore_2" {
   name       = "tf-test-keystore%{random_suffix}"
-  env_id     = google_apigee_environment.apigee_environment_reference.id
+  env_id     = google_apigee_environment.apigee_environment.id
 }
 
 resource "google_apigee_env_references" "apigee_environment_reference" {
-  env_id         = google_apigee_environment.apigee_environment_reference.id
+  env_id         = google_apigee_environment.apigee_environment.id
   name           = "reference_test"
   resource_type  = "KeyStore"
   refers         = google_apigee_env_keystore.apigee_environment_keystore_2.name

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_env_references_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_env_references_test.go
@@ -52,6 +52,7 @@ resource "google_project" "project" {
   name            = "tf-test%{random_suffix}"
   org_id          = "%{org_id}"
   billing_account = "%{billing_account}"
+  deletion_policy = "DELETE"
 }
 
 resource "google_project_service" "apigee" {
@@ -138,6 +139,7 @@ resource "google_project" "project" {
   name            = "tf-test%{random_suffix}"
   org_id          = "%{org_id}"
   billing_account = "%{billing_account}"
+  deletion_policy = "DELETE"
 }
 
 resource "google_project_service" "apigee" {


### PR DESCRIPTION
Add update capability to allow the reference to be updated without needing to recreate the entire resource.

Update API : https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.environments.references/update

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
apigee: added update support for `google_apigee_env_references`
```