### PR TITLE
Fix labels related tests

### DIFF
--- a/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.tmpl
@@ -421,7 +421,7 @@ func TestAccCloudRunService_withProviderDefaultLabels(t *testing.T) {
 
           resource.TestCheckResourceAttr("google_cloud_run_service.default", "metadata.0.annotations.%", "1"),
 					resource.TestCheckResourceAttr("google_cloud_run_service.default", "metadata.0.annotations.generated-by", "magic-modules"),
-          resource.TestCheckResourceAttr("google_cloud_run_service.default", "metadata.0.effective_annotations.%", "6"),
+          resource.TestCheckResourceAttr("google_cloud_run_service.default", "metadata.0.effective_annotations.%", "7"),
 				),
 			},
 			{
@@ -447,7 +447,7 @@ func TestAccCloudRunService_withProviderDefaultLabels(t *testing.T) {
 
           resource.TestCheckResourceAttr("google_cloud_run_service.default", "metadata.0.annotations.%", "1"),
 					resource.TestCheckResourceAttr("google_cloud_run_service.default", "metadata.0.annotations.generated-by", "magic-modules-update"),
-          resource.TestCheckResourceAttr("google_cloud_run_service.default", "metadata.0.effective_annotations.%", "6"),
+          resource.TestCheckResourceAttr("google_cloud_run_service.default", "metadata.0.effective_annotations.%", "7"),
 				),
 			},
 			{
@@ -506,7 +506,7 @@ func TestAccCloudRunService_withProviderDefaultLabels(t *testing.T) {
 					resource.TestCheckResourceAttr("google_cloud_run_service.default", "metadata.0.effective_labels.%", "1"),
 
           resource.TestCheckNoResourceAttr("google_cloud_run_service.default", "metadata.0.annotations.%"),
-          resource.TestCheckResourceAttr("google_cloud_run_service.default", "metadata.0.effective_annotations.%", "5"),
+          resource.TestCheckResourceAttr("google_cloud_run_service.default", "metadata.0.effective_annotations.%", "6"),
 				),
 			},
 			{
@@ -545,8 +545,11 @@ func TestAccCloudRunServiceMigration_withLabels(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_cloud_run_service.default", "metadata.0.labels.%", "2"),
 					resource.TestCheckResourceAttr("google_cloud_run_service.default", "metadata.0.effective_labels.%", "3"),
-					resource.TestCheckResourceAttr("google_cloud_run_service.default", "metadata.0.annotations.%", "1"),
-					resource.TestCheckResourceAttr("google_cloud_run_service.default", "metadata.0.effective_annotations.%", "6"),
+					// A new system annotation is added by the API around 08/28/2024,
+					// and the current service annotation filter doesn't work for this new annotation during the migration,
+					// so it is treated as the user defined annotation.
+					resource.TestCheckResourceAttr("google_cloud_run_service.default", "metadata.0.annotations.%", "2"),
+					resource.TestCheckResourceAttr("google_cloud_run_service.default", "metadata.0.effective_annotations.%", "7"),
 				),
 			},
 		},

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -11554,11 +11554,12 @@ func TestAccContainerCluster_withProviderDefaultLabels(t *testing.T) {
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "resource_labels.%", "1"),
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "resource_labels.created-by", "terraform"),
 
-					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.%", "2"),
+					// goog-terraform-provisioned: true is added
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.%", "3"),
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.default_key1", "default_value1"),
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.created-by", "terraform"),
 
-					resource.TestCheckResourceAttr("google_container_cluster.primary", "effective_labels.%", "2"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "effective_labels.%", "3"),
 				),
 			},
 			{
@@ -11574,11 +11575,12 @@ func TestAccContainerCluster_withProviderDefaultLabels(t *testing.T) {
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "resource_labels.created-by", "terraform"),
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.default_key1", "value1"),
 
-					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.%", "2"),
+					// goog-terraform-provisioned: true is added
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.%", "3"),
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.default_key1", "value1"),
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.created-by", "terraform"),
 
-					resource.TestCheckResourceAttr("google_container_cluster.primary", "effective_labels.%", "2"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "effective_labels.%", "3"),
 				),
 			},
 			{
@@ -11592,11 +11594,12 @@ func TestAccContainerCluster_withProviderDefaultLabels(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "resource_labels.%", "0"),
 
-					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.%", "2"),
+					// goog-terraform-provisioned: true is added
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.%", "3"),
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.default_key1", "default_value1"),
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.created-by", "terraform"),
 
-					resource.TestCheckResourceAttr("google_container_cluster.primary", "effective_labels.%", "2"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "effective_labels.%", "3"),
 				),
 			},
 			{
@@ -11609,8 +11612,8 @@ func TestAccContainerCluster_withProviderDefaultLabels(t *testing.T) {
 				Config: testAccContainerCluster_basic(clusterName, networkName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "resource_labels.%", "0"),
-					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.%", "0"),
-					resource.TestCheckResourceAttr("google_container_cluster.primary", "effective_labels.%", "0"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "terraform_labels.%", "1"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "effective_labels.%", "1"),
 				),
 			},
 			{

--- a/mmv1/third_party/terraform/services/dataflow/resource_dataflow_job_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataflow/resource_dataflow_job_test.go.tmpl
@@ -364,7 +364,8 @@ func TestAccDataflowJob_withProviderDefaultLabels(t *testing.T) {
 				Config: testAccDataflowJob_zone(bucket, job, zone),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckNoResourceAttr("google_dataflow_job.big_data", "labels.%"),
-					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.%", "3"),
+					// goog-terraform-provisioned: true is added
+					resource.TestCheckResourceAttr("google_dataflow_job.big_data", "effective_labels.%", "4"),
 				),
 			},
 			{


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Passed tests:

[TestAccCloudRunService_withProviderDefaultLabels](https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_GoogleCloud_GOOGLE_BETA_MMUPSTREAMTESTS_GOOGLEBETA_PACKAGE_CLOUDRUN/242446?buildTab=tests)

[TestAccCloudRunServiceMigration_withLabels](https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_GoogleCloud_GOOGLE_BETA_MMUPSTREAMTESTS_GOOGLEBETA_PACKAGE_CLOUDRUN/242449?buildTab=tests)

[TestAccContainerCluster_withProviderDefaultLabels](https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_GoogleCloud_GOOGLE_BETA_MMUPSTREAMTESTS_GOOGLEBETA_PACKAGE_CONTAINER/242447?buildTab=tests)

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
