### PR TITLE
Handle service account casing in google_bigquery_dataset_access

### DIFF
--- a/mmv1/products/bigquery/DatasetAccess.yaml
+++ b/mmv1/products/bigquery/DatasetAccess.yaml
@@ -134,6 +134,7 @@ properties:
       - 'routine'
     diff_suppress_func: 'resourceBigQueryDatasetAccessIamMemberDiffSuppress'
     custom_expand: 'templates/terraform/custom_expand/string_to_lower_case.go.tmpl'
+    custom_flatten: 'templates/terraform/custom_flatten/string_to_lower_case.go.tmpl'
   - name: 'groupByEmail'
     type: String
     description: An email address of a Google Group to grant access to.
@@ -148,6 +149,7 @@ properties:
       - 'routine'
     diff_suppress_func: 'resourceBigQueryDatasetAccessIamMemberDiffSuppress'
     custom_expand: 'templates/terraform/custom_expand/string_to_lower_case.go.tmpl'
+    custom_flatten: 'templates/terraform/custom_flatten/string_to_lower_case.go.tmpl'
   - name: 'domain'
     type: String
     description: |

--- a/mmv1/templates/terraform/custom_flatten/string_to_lower_case.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/string_to_lower_case.go.tmpl
@@ -1,0 +1,19 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2024 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+  if v == nil {
+    return nil
+  }
+
+  return strings.ToLower(v.(string))
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/19547.

A follow-up to https://github.com/GoogleCloudPlatform/magic-modules/pull/11477. Service account names come back from the `GET` API in their original capitalization instead of being normalized to lower-case so need to be specifically handled.

There isn't a good way to add a unit test organically since `google_service_account` only allows lower-case names and the error came from customers creating upper-case service accounts outside of Terraform.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigquery: fixed an error which could occur with service account field values containing non-lower-case characters in `google_bigquery_dataset_access`
```
