### PR TITLE
Set `config_sync.enabled` field to `true` to fix broken tests

### DIFF
--- a/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.tmpl
@@ -108,6 +108,7 @@ resource "google_gke_hub_feature_membership" "feature_member_1" {
   configmanagement {
     version = "1.18.2"
     config_sync {
+      enabled = true
       source_format = "hierarchy"
       git {
         sync_repo   = "https://github.com/GoogleCloudPlatform/magic-modules"
@@ -125,6 +126,7 @@ resource "google_gke_hub_feature_membership" "feature_member_2" {
   configmanagement {
     version = "1.18.2"
     config_sync {
+      enabled = true
       source_format = "hierarchy"
       git {
         sync_repo   = "https://github.com/terraform-providers/terraform-provider-google"
@@ -176,6 +178,7 @@ resource "google_gke_hub_feature_membership" "feature_member_2" {
   configmanagement {
     version = "1.18.2"
     config_sync {
+      enabled = true
       source_format = "hierarchy"
       git {
         sync_repo   = "https://github.com/terraform-providers/terraform-provider-google-beta"
@@ -214,6 +217,7 @@ resource "google_gke_hub_feature_membership" "feature_member_2" {
   configmanagement {
     version = "1.18.2"
     config_sync {
+      enabled = true
       source_format = "unstructured"
       git {
         sync_repo   = "https://github.com/terraform-providers/terraform-provider-google-beta"
@@ -242,6 +246,7 @@ resource "google_gke_hub_feature_membership" "feature_member_3" {
   configmanagement {
     version = "1.18.2"
     config_sync {
+      enabled = true
       source_format = "hierarchy"
       git {
         sync_repo   = "https://github.com/hashicorp/terraform"
@@ -424,6 +429,7 @@ resource "google_gke_hub_feature_membership" "feature_member" {
   configmanagement {
     version = "1.18.2"
     config_sync {
+      enabled = true
       git {
         sync_repo      = "https://github.com/hashicorp/terraform"
         https_proxy    = "https://example.com"
@@ -490,6 +496,7 @@ resource "google_gke_hub_feature_membership" "feature_member" {
   configmanagement {
     version = "1.18.2"
     config_sync {
+      enabled = true
       git {
         sync_repo      = "https://github.com/hashicorp/terraform"
         https_proxy    = "https://example.com"
@@ -562,6 +569,7 @@ resource "google_gke_hub_feature_membership" "feature_member" {
   configmanagement {
     version = "1.18.2"
     config_sync {
+      enabled = true
       git {
         sync_repo   = "https://github.com/hashicorp/terraform"
         secret_type = "none"
@@ -651,6 +659,7 @@ resource "google_gke_hub_feature_membership" "feature_member" {
   configmanagement {
     version = "1.18.2"
     config_sync {
+      enabled = true
       source_format = "unstructured"
       oci {
         sync_repo = "us-central1-docker.pkg.dev/sample-project/config-repo/config-sync-gke:latest"
@@ -700,6 +709,7 @@ resource "google_gke_hub_feature_membership" "feature_member" {
   configmanagement {
     version = "1.18.2"
     config_sync {
+      enabled = true
       source_format = "hierarchy"
       oci {
         sync_repo = "us-central1-docker.pkg.dev/sample-project/config-repo/config-sync-gke:latest"


### PR DESCRIPTION
Terraform google provider v5.41.0 (released on Aug 12, 2024) introduced a new field `config_sync.enabled` to the google_gke_hub_feature_membership resource. The default value of this field is false. However, when the field is omitted from the Terraform resource, Terraform sets the field to false in the ACM Hub API explicitly. This issue causes the Terraform users to fail to install Config Sync unless they set the new field to true explicitly.

To mitigate this issue, we enhanced the Hub CLH to throw an error if Config Sync is explicitly disabled and the Git or OCI configuration is set.

Our Terraform users need to set the new field to true explicitly to install Config Sync from v5.41.0. For existing CS installations, upgrading from Terraform versions prior to v5.41.0 to versions >= v5.41.0 does not break users, and does not uninstall Config Sync.

part of https://github.com/hashicorp/terraform-provider-google/issues/14591. 

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
