### PR TITLE
Update documentation to list `global` as the only supported location for logging resource `LogScope`

### DIFF
--- a/mmv1/products/logging/LogScope.yaml
+++ b/mmv1/products/logging/LogScope.yaml
@@ -52,8 +52,7 @@ parameters:
   - name: 'location'
     type: String
     description:
-      'The location of the resource. The supported locations are: global,
-      us-central1, us-east1, us-west1, asia-east1, europe-west1.'
+      'The location of the resource. The only supported location is global so far.'
     url_param_only: true
     immutable: true
     default_from_api: true


### PR DESCRIPTION

Only updating the public doc to make `global` the only supported location for logging resource LogScope.

We only support global for logging resource LogScope, so updating the public doc to reflect that.
The error handling will be added in a follow up PR since a test is broken by a different service and I'm not able to test it.

Error: 
google-beta/services/compute/data_source_google_compute_region_instance_group_manager.go:28:30: undefined: tpgresource.ParseRegionalInstanceGroupManagersFieldValue
make: *** [GNUmakefile:29: vet] Error 1

```release-note:none
```
