### PR TITLE
Add TeamCity project for testing v7.0.0 feature branch

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/projects/feature_branches/FEATURE-BRANCH-major-release-7.0.0.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/feature_branches/FEATURE-BRANCH-major-release-7.0.0.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// This file is controlled by MMv1, any changes made here will be overwritten
+
+package projects.feature_branches
+
+import ProviderNameBeta
+import ProviderNameGa
+import builds.*
+import jetbrains.buildServer.configs.kotlin.Project
+import jetbrains.buildServer.configs.kotlin.vcs.GitVcsRoot
+import projects.reused.nightlyTests
+import replaceCharsId
+
+const val branchName = "FEATURE-BRANCH-major-release-7.0.0"
+
+// VCS Roots specifically for pulling code from the feature branches in the downstream repos
+
+object HashicorpVCSRootGa_featureBranchMajorRelease700: GitVcsRoot({
+    name = "VCS root for the hashicorp/terraform-provider-${ProviderNameGa} repo @ refs/heads/${branchName}"
+    url = "https://github.com/hashicorp/terraform-provider-${ProviderNameGa}"
+    branch = "refs/heads/${branchName}"
+    branchSpec = """
+        +:(refs/heads/*)
+        -:refs/pulls/*
+    """.trimIndent()
+})
+
+object HashicorpVCSRootBeta_featureBranchMajorRelease700: GitVcsRoot({
+    name = "VCS root for the hashicorp/terraform-provider-${ProviderNameBeta} repo @ refs/heads/${branchName}"
+    url = "https://github.com/hashicorp/terraform-provider-${ProviderNameBeta}"
+    branch = "refs/heads/${branchName}"
+    branchSpec = """
+        +:(refs/heads/*)
+        -:refs/pulls/*
+    """.trimIndent()
+})
+
+fun featureBranchMajorRelease700_Project(allConfig: AllContextParameters): Project {
+
+    val projectId = replaceCharsId(branchName)
+    val gaProjectId = replaceCharsId(projectId + "_GA")
+    val betaProjectId= replaceCharsId(projectId + "_BETA")
+
+    // Get config for using the GA and Beta identities
+    val gaConfig = getGaAcceptanceTestConfig(allConfig)
+    val betaConfig = getBetaAcceptanceTestConfig(allConfig)
+
+    return Project{
+        id(projectId)
+        name = "7.0.0 Major Release Testing"
+        description = "Subproject for testing feature branch $branchName"
+
+        // Register feature branch-specific VCS roots in the project
+        vcsRoot(HashicorpVCSRootGa_featureBranchMajorRelease700)
+        vcsRoot(HashicorpVCSRootBeta_featureBranchMajorRelease700)
+
+        // Nested Nightly Test project that uses hashicorp/terraform-provider-google
+        subProject(
+            Project{
+                id(gaProjectId)
+                name = "Google"
+                subProject(
+                    nightlyTests(
+                        gaProjectId,
+                        ProviderNameGa,
+                        HashicorpVCSRootGa_featureBranchMajorRelease700,
+                        gaConfig,
+                        NightlyTriggerConfiguration(
+                            branch = "refs/heads/${branchName}", // Make triggered builds use the feature branch
+                            daysOfWeek = "5"     // Thursday for GA, TeamCity numbers days Sun=1...Sat=7
+                        ), 
+                    )
+                )
+            }
+        )
+
+        // Nested Nightly Test project that uses hashicorp/terraform-provider-google-beta
+        subProject(
+            Project {
+                id(betaProjectId)
+                name = "Google Beta"
+                subProject(
+                    nightlyTests(
+                        betaProjectId,
+                        ProviderNameBeta,
+                        HashicorpVCSRootBeta_featureBranchMajorRelease700,
+                        betaConfig,
+                        NightlyTriggerConfiguration(
+                            branch = "refs/heads/${branchName}", // Make triggered builds use the feature branch
+                            daysOfWeek="6"       // Friday for Beta, TeamCity numbers days Sun=1...Sat=7
+                        ),
+                    )
+                )
+            }
+        )
+
+        params {
+            readOnlySettings()
+        }
+    }
+}

--- a/mmv1/third_party/terraform/.teamcity/components/projects/google_beta_subproject.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/google_beta_subproject.kt
@@ -32,7 +32,7 @@ fun googleSubProjectBeta(allConfig: AllContextParameters): Project {
         description = "Subproject containing builds for testing the Beta version of the Google provider"
 
         // Nightly Test project that uses hashicorp/terraform-provider-google-beta
-        subProject(nightlyTests(betaId, ProviderNameBeta, HashiCorpVCSRootBeta, betaConfig, NightlyTriggerConfiguration()))
+        subProject(nightlyTests(betaId, ProviderNameBeta, HashiCorpVCSRootBeta, betaConfig, NightlyTriggerConfiguration(daysOfWeek="1-5,7"))) // All nights except Friday (6) for Beta; feature branch testing happens on Fridays and TeamCity numbers days Sun=1...Sat=7
 
         // MM Upstream project that uses modular-magician/terraform-provider-google-beta
         subProject(mmUpstream(betaId, ProviderNameBeta, ModularMagicianVCSRootBeta, HashiCorpVCSRootBeta, vcrConfig, NightlyTriggerConfiguration()))

--- a/mmv1/third_party/terraform/.teamcity/components/projects/google_ga_subproject.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/google_ga_subproject.kt
@@ -31,7 +31,7 @@ fun googleSubProjectGa(allConfig: AllContextParameters): Project {
         description = "Subproject containing builds for testing the GA version of the Google provider"
 
         // Nightly Test project that uses hashicorp/terraform-provider-google
-        subProject(nightlyTests(gaId, ProviderNameGa, HashiCorpVCSRootGa, gaConfig, NightlyTriggerConfiguration()))
+        subProject(nightlyTests(gaId, ProviderNameGa, HashiCorpVCSRootGa, gaConfig, NightlyTriggerConfiguration(daysOfWeek="1-4,6-7"))) // All nights except Thursday (5) for GA; feature branch testing happens on Thursdays and TeamCity numbers days Sun=1...Sat=7
 
         // MM Upstream project that uses modular-magician/terraform-provider-google
         subProject(mmUpstream(gaId, ProviderNameGa, ModularMagicianVCSRootGa, HashiCorpVCSRootGa, vcrConfig, NightlyTriggerConfiguration()))

--- a/mmv1/third_party/terraform/.teamcity/components/projects/root_project.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/root_project.kt
@@ -18,6 +18,7 @@ import generated.ServicesListBeta
 import generated.ServicesListGa
 import jetbrains.buildServer.configs.kotlin.Project
 import jetbrains.buildServer.configs.kotlin.sharedResource
+import projects.feature_branches.featureBranchMajorRelease700_Project
 
 // googleCloudRootProject returns a root project that contains a subprojects for the GA and Beta version of the
 // Google provider. There are also resources to help manage the test projects used for acceptance tests.
@@ -61,6 +62,9 @@ fun googleCloudRootProject(allConfig: AllContextParameters): Project {
         subProject(googleSubProjectGa(allConfig))
         subProject(googleSubProjectBeta(allConfig))
         subProject(projectSweeperSubProject(allConfig))
+
+        // Feature branch testing
+        subProject(featureBranchMajorRelease700_Project(allConfig)) // FEATURE-BRANCH-major-release-7.0.0
 
         params {
             readOnlySettings()


### PR DESCRIPTION
An example PR showing how to add a new project in TeamCity for testing a major release branch

This project would:
- Test the GA version of the feature branch on Thursdays
- Test the Beta version of the feature branch on Fridays

The changes also make the 'regular' nightly tests not run on those two days.


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
