### PR TITLE
Add unit tests for the VCR request matcher function

### DIFF
--- a/mmv1/third_party/terraform/acctest/vcr_utils.go
+++ b/mmv1/third_party/terraform/acctest/vcr_utils.go
@@ -347,13 +347,13 @@ func HandleVCRConfiguration(ctx context.Context, testName string, rndTripper htt
 		return pollInterval, rndTripper, diags
 	}
 	// Defines how VCR will match requests to responses.
-	rec.SetMatcher(NewMatcherFunc(ctx))
+	rec.SetMatcher(NewVcrMatcherFunc(ctx))
 
 	return pollInterval, rec, diags
 }
 
-// NewMatcherFunc returns a function used for matching HTTP requests with data recorded in VCR cassettes
-func NewMatcherFunc(ctx context.Context) func(r *http.Request, i cassette.Request) bool {
+// NewVcrMatcherFunc returns a function used for matching HTTP requests with data recorded in VCR cassettes
+func NewVcrMatcherFunc(ctx context.Context) func(r *http.Request, i cassette.Request) bool {
 	return func(r *http.Request, i cassette.Request) bool {
 		// Default matcher compares method and URL only
 		if !cassette.DefaultMatcher(r, i) {

--- a/mmv1/third_party/terraform/acctest/vcr_utils.go
+++ b/mmv1/third_party/terraform/acctest/vcr_utils.go
@@ -347,7 +347,14 @@ func HandleVCRConfiguration(ctx context.Context, testName string, rndTripper htt
 		return pollInterval, rndTripper, diags
 	}
 	// Defines how VCR will match requests to responses.
-	rec.SetMatcher(func(r *http.Request, i cassette.Request) bool {
+	rec.SetMatcher(NewMatcherFunc(ctx))
+
+	return pollInterval, rec, diags
+}
+
+// NewMatcherFunc returns a function used for matching HTTP requests with data recorded in VCR cassettes
+func NewMatcherFunc(ctx context.Context) func(r *http.Request, i cassette.Request) bool {
+	return func(r *http.Request, i cassette.Request) bool {
 		// Default matcher compares method and URL only
 		if !cassette.DefaultMatcher(r, i) {
 			return false
@@ -377,19 +384,17 @@ func HandleVCRConfiguration(ctx context.Context, testName string, rndTripper htt
 		if strings.Contains(contentType, "application/json") {
 			var reqJson, cassetteJson interface{}
 			if err := json.Unmarshal([]byte(reqBody), &reqJson); err != nil {
-				tflog.Debug(ctx, fmt.Sprintf("Failed to unmarshall request json: %v", err))
+				tflog.Debug(ctx, fmt.Sprintf("Failed to unmarshal request json: %v", err))
 				return false
 			}
 			if err := json.Unmarshal([]byte(i.Body), &cassetteJson); err != nil {
-				tflog.Debug(ctx, fmt.Sprintf("Failed to unmarshall cassette json: %v", err))
+				tflog.Debug(ctx, fmt.Sprintf("Failed to unmarshal cassette json: %v", err))
 				return false
 			}
 			return reflect.DeepEqual(reqJson, cassetteJson)
 		}
 		return false
-	})
-
-	return pollInterval, rec, diags
+	}
 }
 
 // MuxedProviders configures the providers, thus, if we want the providers to be configured

--- a/mmv1/third_party/terraform/acctest/vcr_utils_test.go
+++ b/mmv1/third_party/terraform/acctest/vcr_utils_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 )
 
-func TestNewMatcherFunc_canDetectMatches(t *testing.T) {
+func TestNewVcrMatcherFunc_canDetectMatches(t *testing.T) {
 
 	// Same description used to make both structs being compared,
 	// so everything should be determined as a match
@@ -46,7 +46,7 @@ func TestNewMatcherFunc_canDetectMatches(t *testing.T) {
 			ctx := context.Background()
 			req := prepareHttpRequest(tc)
 			cassetteReq := prepareCassetteRequest(tc)
-			matcher := acctest.NewMatcherFunc(ctx)
+			matcher := acctest.NewVcrMatcherFunc(ctx)
 
 			// Act - use matcher
 			matchDetected := matcher(req, cassetteReq)
@@ -59,7 +59,7 @@ func TestNewMatcherFunc_canDetectMatches(t *testing.T) {
 	}
 }
 
-func TestNewMatcherFunc_canDetectMismatches(t *testing.T) {
+func TestNewVcrMatcherFunc_canDetectMismatches(t *testing.T) {
 
 	cases := map[string]struct {
 		httpRequest     requestDescription
@@ -105,7 +105,7 @@ func TestNewMatcherFunc_canDetectMismatches(t *testing.T) {
 			ctx := context.Background()
 			req := prepareHttpRequest(tc.httpRequest)
 			cassetteReq := prepareCassetteRequest(tc.cassetteRequest)
-			matcher := acctest.NewMatcherFunc(ctx)
+			matcher := acctest.NewVcrMatcherFunc(ctx)
 
 			// Act - use matcher
 			matchDetected := matcher(req, cassetteReq)

--- a/mmv1/third_party/terraform/acctest/vcr_utils_test.go
+++ b/mmv1/third_party/terraform/acctest/vcr_utils_test.go
@@ -102,6 +102,48 @@ func TestNewVcrMatcherFunc_canDetectMismatches(t *testing.T) {
 		httpRequest     requestDescription
 		cassetteRequest requestDescription
 	}{
+		"requests using different schemes": {
+			httpRequest: requestDescription{
+				scheme: "http",
+				method: "GET",
+				host:   "example.com",
+				path:   "foobar",
+			},
+			cassetteRequest: requestDescription{
+				scheme: "https",
+				method: "GET",
+				host:   "example.com",
+				path:   "foobar",
+			},
+		},
+		"requests using different hosts": {
+			httpRequest: requestDescription{
+				scheme: "https",
+				method: "GET",
+				host:   "example.com",
+				path:   "foobar",
+			},
+			cassetteRequest: requestDescription{
+				scheme: "https",
+				method: "GET",
+				host:   "google.com",
+				path:   "foobar",
+			},
+		},
+		"requests using different paths": {
+			httpRequest: requestDescription{
+				scheme: "https",
+				method: "GET",
+				host:   "example.com",
+				path:   "foobar1",
+			},
+			cassetteRequest: requestDescription{
+				scheme: "https",
+				method: "GET",
+				host:   "example.com",
+				path:   "foobar2",
+			},
+		},
 		"requests with different methods": {
 			httpRequest: requestDescription{
 				scheme: "https",

--- a/mmv1/third_party/terraform/acctest/vcr_utils_test.go
+++ b/mmv1/third_party/terraform/acctest/vcr_utils_test.go
@@ -1,0 +1,164 @@
+package acctest_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/dnaeon/go-vcr/cassette"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestNewMatcherFunc_canDetectMatches(t *testing.T) {
+
+	// Same description used to make both structs being compared,
+	// so everything should be determined as a match
+	cases := map[string]requestDescription{
+		"matching POST requests with empty body": {
+			scheme: "https",
+			method: "POST",
+			host:   "example.com",
+			path:   "foobar",
+			body:   "{}",
+		},
+		"matching POST requests with body": {
+			scheme: "https",
+			method: "POST",
+			host:   "example.com",
+			path:   "foobar",
+			body:   "{\"field\":\"value\"}",
+		},
+		"matching GET requests": {
+			scheme: "https",
+			method: "GET",
+			host:   "example.com",
+			path:   "foobar",
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			// Make matcher
+			ctx := context.Background()
+			req := prepareHttpRequest(tc)
+			cassetteReq := prepareCassetteRequest(tc)
+			matcher := acctest.NewMatcherFunc(ctx)
+
+			// Act - use matcher
+			matchDetected := matcher(req, cassetteReq)
+
+			// Assert match
+			if !matchDetected {
+				t.Fatalf("expected matcher to match the requests")
+			}
+		})
+	}
+}
+
+func TestNewMatcherFunc_canDetectMismatches(t *testing.T) {
+
+	cases := map[string]struct {
+		httpRequest     requestDescription
+		cassetteRequest requestDescription
+	}{
+		"different methods": {
+			httpRequest: requestDescription{
+				scheme: "https",
+				method: "POST",
+				host:   "example.com",
+				path:   "foobar",
+				body:   "{}",
+			},
+			cassetteRequest: requestDescription{
+				scheme: "https",
+				method: "PUT",
+				host:   "example.com",
+				path:   "foobar",
+				body:   "{}",
+			},
+		},
+		"different bodies": {
+			httpRequest: requestDescription{
+				scheme: "https",
+				method: "POST",
+				host:   "example.com",
+				path:   "foobar",
+				body:   "{\"field\":\"value is ABCDEFG\"}",
+			},
+			cassetteRequest: requestDescription{
+				scheme: "https",
+				method: "POST",
+				host:   "example.com",
+				path:   "foobar",
+				body:   "{\"field\":\"value is MNLOP\"}",
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			// Make matcher
+			ctx := context.Background()
+			req := prepareHttpRequest(tc.httpRequest)
+			cassetteReq := prepareCassetteRequest(tc.cassetteRequest)
+			matcher := acctest.NewMatcherFunc(ctx)
+
+			// Act - use matcher
+			matchDetected := matcher(req, cassetteReq)
+
+			// Assert match
+			if matchDetected {
+				t.Fatalf("expected matcher to not match the requests")
+			}
+		})
+	}
+}
+
+type requestDescription struct {
+	scheme string
+	method string
+	host   string
+	path   string
+	body   string
+}
+
+func prepareHttpRequest(d requestDescription) *http.Request {
+	url := &url.URL{
+		Scheme: d.scheme,
+		Host:   d.host,
+		Path:   d.path,
+	}
+
+	req := &http.Request{
+		Method: d.method,
+		URL:    url,
+	}
+
+	// Conditionally set a body
+	if d.body != "" {
+		body := io.NopCloser(bytes.NewBufferString(d.body))
+		req.Body = body
+	}
+
+	return req
+}
+
+func prepareCassetteRequest(d requestDescription) cassette.Request {
+	fullUrl := fmt.Sprintf("%s://%s/%s", d.scheme, d.host, d.path)
+
+	req := cassette.Request{
+		Method: d.method,
+		URL:    fullUrl,
+	}
+
+	// Conditionally set a body
+	if d.body != "" {
+		req.Body = d.body
+	}
+
+	return req
+}

--- a/mmv1/third_party/terraform/acctest/vcr_utils_test.go
+++ b/mmv1/third_party/terraform/acctest/vcr_utils_test.go
@@ -226,7 +226,6 @@ func TestNewVcrMatcherFunc_ignoresDifferentUserAgents(t *testing.T) {
 	cases := map[string]struct {
 		httpRequest     requestDescription
 		cassetteRequest requestDescription
-		expectMatch     bool
 	}{
 		"GET requests with different useragents are matched": {
 			httpRequest: requestDescription{
@@ -247,7 +246,6 @@ func TestNewVcrMatcherFunc_ignoresDifferentUserAgents(t *testing.T) {
 					"User-Agent": "user-agent-CASSETTE",
 				},
 			},
-			expectMatch: true,
 		},
 		"POST requests with identical bodies and different useragents are matched": {
 			httpRequest: requestDescription{
@@ -270,7 +268,6 @@ func TestNewVcrMatcherFunc_ignoresDifferentUserAgents(t *testing.T) {
 					"User-Agent": "user-agent-CASSETTE",
 				},
 			},
-			expectMatch: true,
 		},
 		"POST requests with reordered but matching bodies and different useragents are matched if Content-Type contains 'application/json'": {
 			httpRequest: requestDescription{
@@ -295,7 +292,6 @@ func TestNewVcrMatcherFunc_ignoresDifferentUserAgents(t *testing.T) {
 					"Content-Type": "application/json",
 				},
 			},
-			expectMatch: true,
 		},
 	}
 
@@ -311,7 +307,7 @@ func TestNewVcrMatcherFunc_ignoresDifferentUserAgents(t *testing.T) {
 			matchDetected := matcher(req, cassetteReq)
 
 			// Assert match
-			if matchDetected != tc.expectMatch {
+			if !matchDetected {
 				t.Fatalf("expected matcher to match the requests")
 			}
 		})

--- a/mmv1/third_party/terraform/acctest/vcr_utils_test.go
+++ b/mmv1/third_party/terraform/acctest/vcr_utils_test.go
@@ -119,11 +119,12 @@ func TestNewVcrMatcherFunc_canDetectMismatches(t *testing.T) {
 }
 
 type requestDescription struct {
-	scheme string
-	method string
-	host   string
-	path   string
-	body   string
+	scheme  string
+	method  string
+	host    string
+	path    string
+	body    string
+	headers map[string]string
 }
 
 func prepareHttpRequest(d requestDescription) *http.Request {
@@ -143,6 +144,13 @@ func prepareHttpRequest(d requestDescription) *http.Request {
 		body := io.NopCloser(bytes.NewBufferString(d.body))
 		req.Body = body
 	}
+	// Conditionally set headers
+	if len(d.headers) > 0 {
+		req.Header = http.Header{}
+		for k, v := range d.headers {
+			req.Header.Set(k, v)
+		}
+	}
 
 	return req
 }
@@ -158,6 +166,13 @@ func prepareCassetteRequest(d requestDescription) cassette.Request {
 	// Conditionally set a body
 	if d.body != "" {
 		req.Body = d.body
+	}
+	// Conditionally set headers
+	if len(d.headers) > 0 {
+		req.Headers = http.Header{}
+		for k, v := range d.headers {
+			req.Headers.Add(k, v)
+		}
 	}
 
 	return req


### PR DESCRIPTION
Part of https://github.com/hashicorp/terraform-provider-google/issues/19685

This PR adds tests for the logic used to match a request a provider wants to make to the request data recorded in cassettes.

From the tests, it looks like upgrading the version of Terraform used for VCR tests (TF version impacts User-Agent values) does not impact matching. This is because the User-Agent header doesn't appear to be used at all in the matching logic.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:note
provider: minor refactoring of how we run acceptance tests in VCR mode
```
