### PR TITLE
Mark location of logging LogScope to be global by default and output only

### DIFF
--- a/mmv1/products/logging/LogScope.yaml
+++ b/mmv1/products/logging/LogScope.yaml
@@ -55,7 +55,8 @@ parameters:
       'The location of the resource. The only supported location is global so far.'
     url_param_only: true
     immutable: true
-    default_from_api: true
+    output: true
+    default_value: 'global'
 properties:
   - name: 'name'
     type: String

--- a/mmv1/templates/terraform/examples/logging_log_scope_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/logging_log_scope_basic.tf.tmpl
@@ -1,6 +1,5 @@
 resource "google_logging_log_scope" "{{$.PrimaryResourceId}}" {
     parent         = "projects/{{index $.TestEnvVars "project"}}"
-    location       = "global"
     name           = "projects/{{index $.TestEnvVars "project"}}/locations/global/logScopes/{{index $.Vars "log_scope_name"}}"
     resource_names = [
         "projects/{{index $.TestEnvVars "project"}}",


### PR DESCRIPTION
Mark location of logging LogScope to be global by default and output only to prevent overwriting it to a different value by users.

```release-note:none
```
