### PR TITLE
Speed up goimports usage

### DIFF
--- a/mmv1/main.go
+++ b/mmv1/main.go
@@ -56,6 +56,8 @@ var yamlTempMode = flag.Bool("yaml-temp", false, "copy text over from ruby yaml 
 var handwrittenTempFiles = flag.String("handwritten-temp", "", "copy specific handwritten files over from .erb to go .tmpl.temp comma separated")
 var templateTempFiles = flag.String("template-temp", "", "copy specific templates over from .erb to go .tmpl.temp comma separated")
 
+var showImportDiffs = flag.Bool("show-import-diffs", false, "write go import diffs to stdout")
+
 func main() {
 
 	flag.Parse()
@@ -193,6 +195,8 @@ func main() {
 	if generateCode {
 		providerToGenerate.CompileCommonFiles(*outputPath, productsForVersion, "")
 	}
+
+	provider.FixImports(*outputPath, *showImportDiffs)
 }
 
 func GenerateProduct(productChannel chan string, providerToGenerate provider.Provider, productsForVersionChannel chan *api.Product, startTime time.Time, productsToGenerate []string, resourceToGenerate, overrideDirectory string, generateCode, generateDocs bool) {

--- a/mmv1/provider/template_data.go
+++ b/mmv1/provider/template_data.go
@@ -15,6 +15,7 @@ package provider
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"go/format"
 	"log"
@@ -22,6 +23,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"text/template"
 
@@ -47,6 +49,8 @@ var GA_VERSION = "ga"
 var BETA_VERSION = "beta"
 var ALPHA_VERSION = "alpha"
 var PRIVATE_VERSION = "private"
+
+var goimportFiles sync.Map
 
 func NewTemplateData(outputFolder string, versionName string) *TemplateData {
 	td := TemplateData{OutputFolder: outputFolder, VersionName: versionName}
@@ -208,19 +212,14 @@ func (td *TemplateData) GenerateFile(filePath, templatePath string, input any, g
 		} else {
 			sourceByte = formattedByte
 		}
+		if !strings.Contains(templatePath, "third_party/terraform") {
+			goimportFiles.Store(filePath, struct{}{})
+		}
 	}
 
 	err = os.WriteFile(filePath, sourceByte, 0644)
 	if err != nil {
 		glog.Exit(err)
-	}
-
-	if goFormat && !strings.Contains(templatePath, "third_party/terraform") {
-		cmd := exec.Command("goimports", "-w", filepath.Base(filePath))
-		cmd.Dir = filepath.Dir(filePath)
-		if err := cmd.Run(); err != nil {
-			log.Fatal(err)
-		}
 	}
 }
 
@@ -231,6 +230,44 @@ func (td *TemplateData) ImportPath() string {
 		return "internal/terraform-next/google-private"
 	}
 	return "github.com/hashicorp/terraform-provider-google-beta/google-beta"
+}
+
+func FixImports(outputPath string, dumpDiffs bool) {
+	log.Printf("Fixing go import paths")
+
+	baseArgs := []string{"-w"}
+	if dumpDiffs {
+		baseArgs = []string{"-d", "-w"}
+	}
+
+	// -w and -d are mutually exclusive; if dumpDiffs is requested we need to run twice.
+	for _, base := range baseArgs {
+		hasFiles := false
+		args := []string{base}
+		goimportFiles.Range(func(filePath, _ any) bool {
+			p, err := filepath.Rel(outputPath, filePath.(string))
+			if err != nil {
+				log.Fatal(err)
+			}
+			args = append(args, p)
+			hasFiles = true
+			return true
+		})
+
+		if hasFiles {
+			cmd := exec.Command("goimports", args...)
+			cmd.Dir = outputPath
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				var exitErr *exec.ExitError
+				if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+					glog.Error(string(exitErr.Stderr))
+				}
+				log.Fatal(err)
+			}
+		}
+	}
 }
 
 type TestInput struct {

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -35,8 +35,12 @@ import (
 
     "fmt"
     "log"
+    "net/http"
     "reflect"
-{{- if and (not $.Immutable) ($.UpdateMask) }}
+{{- if $.SupportsIndirectUserProjectOverride }}
+    "regexp"
+{{- end }}
+{{- if or (and (not $.Immutable) ($.UpdateMask)) $.LegacyLongFormProject }}
     "strings"
 {{- end }}
     "time"


### PR DESCRIPTION
Now that the go compiler is live I've started toying with bazel, and the extra time that `goimports` adds to each compile run is irking me. This PR speeds things up by running `goimports` once as a last compilation step rather than running it for each generated source file.

`goimports` performs two functions for us: removing imports that are declared but not used, and adding imports that are used but not declared. The former is fast, the latter is slow - like, a couple of orders of magnitude slower than the former. The difference exists because removing imports requires parsing only the go file that's being fixed, while adding imports potentially parses every go file in the project, the standard library, and in your `GOPATH`.  `goimports` has an internal cache that avoids some repetitive parsing, and by using a single execution that runs over all of the generated files at once we're able to leverage that cache.

Here's some example timings on my M1 Macbook Pro. Before:

```
$ time make provider VERSION=beta OUTPUT_PATH="../terraform-provider-google-beta"
real	1m1.976s
user	1m33.130s
sys	2m37.034s

$ time make provider VERSION=ga OUTPUT_PATH="../terraform-provider-google"
real	1m0.521s
user	1m23.280s
sys	2m25.612s
```

After:

```
$ time make provider VERSION=beta OUTPUT_PATH="../terraform-provider-google-beta"
real	0m24.659s
user	0m38.855s
sys	0m18.785s

$ time make provider VERSION=ga OUTPUT_PATH="../terraform-provider-google"
real	0m22.059s
user	0m36.664s
sys	0m19.448s
```

YMMV of course, and full builds benefit a lot more than single product builds.

Ultimately the best way to speed up the compiler will be to include all imports that we're using, and the change to `resource.go.tmpl` picks the lowest hanging fruit (for context, 10 seconds of the speed up on my machine came from just those five lines). The new `--show-import-diffs` flag is useful for identifying the files that need import fixes.

```release-note:none
```
