### PR TITLE
Adding replication field for Filestore Instance

### DIFF
--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -336,20 +336,6 @@ properties:
       resource, see the `google_tags_tag_value` resource.
     immutable: true
     ignore_read: true
-  - name: 'tags'
-    type: KeyValuePairs
-    description: |
-      A map of resource manager tags. Resource manager tag keys
-      and values have the same definition as resource manager
-      tags. Keys must be in the format tagKeys/{tag_key_id},
-      and values are in the format tagValues/456. The field is
-      ignored when empty. The field is immutable and causes
-      resource replacement when mutated. This field is only set
-      at create time and modifying this field after creation
-      will trigger recreation. To apply tags to an existing
-      resource, see the `google_tags_tag_value` resource.
-    immutable: true
-    ignore_read: true
   - name: 'initialReplication'
     api_name: replication
     type: NestedObject

--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -336,3 +336,79 @@ properties:
       resource, see the `google_tags_tag_value` resource.
     immutable: true
     ignore_read: true
+  - name: 'initialReplication'
+    api_name: replication
+    type: NestedObject
+    description: |
+      Replication configuration, once set, this cannot be updated.
+    url_param_only: true
+    immutable: true
+    properties:
+      - name: 'role'
+        type: Enum
+        description: |
+          The replication role.
+        default_value: "STANDBY"
+        enum_values:
+          - 'ROLE_UNSPECIFIED'
+          - 'ACTIVE'
+          - 'STANDBY'
+      - name: 'replicas'
+        type: Array
+        description: |
+          The replication role.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'peerInstance'
+              type: String
+              description: |
+                The peer instance.
+              required: true
+  - name: 'effectiveReplication'
+    api_name: replication
+    type: NestedObject
+    output: true
+    description: |
+       Output only fields for replication configuration
+    properties:
+      - name: 'replicas'
+        type: Array
+        description: |
+          The replication role.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'state'
+              type: Enum
+              description: |
+                Output only. The replica state
+              output: true
+            - name: 'stateReasons'
+              type: Array
+              description: |
+                Output only. Additional information about the replication state, if available.
+              output: true
+              item_type:
+                type: Enum
+            - name: 'lastActiveSyncTime'
+              type: String
+              description: |
+                Output only. The timestamp of the latest replication snapshot taken on the active instance and is already replicated safely.
+                A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits.
+                Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z"
+              output: true
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags. Resource manager tag keys
+      and values have the same definition as resource manager
+      tags. Keys must be in the format tagKeys/{tag_key_id},
+      and values are in the format tagValues/456. The field is
+      ignored when empty. The field is immutable and causes
+      resource replacement when mutated. This field is only set
+      at create time and modifying this field after creation
+      will trigger recreation. To apply tags to an existing
+      resource, see the `google_tags_tag_value` resource.
+    immutable: true
+    ignore_read: true

--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -341,6 +341,7 @@ properties:
     type: NestedObject
     description: |
       Replication configuration, once set, this cannot be updated.
+      Addtionally this should be specified on the replica instance only, indicating the active as the peer_instance
     url_param_only: true
     immutable: true
     properties:
@@ -370,7 +371,7 @@ properties:
     type: NestedObject
     output: true
     description: |
-       Output only fields for replication configuration
+       Output only fields for replication configuration.
     properties:
       - name: 'replicas'
         type: Array

--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -336,6 +336,20 @@ properties:
       resource, see the `google_tags_tag_value` resource.
     immutable: true
     ignore_read: true
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags. Resource manager tag keys
+      and values have the same definition as resource manager
+      tags. Keys must be in the format tagKeys/{tag_key_id},
+      and values are in the format tagValues/456. The field is
+      ignored when empty. The field is immutable and causes
+      resource replacement when mutated. This field is only set
+      at create time and modifying this field after creation
+      will trigger recreation. To apply tags to an existing
+      resource, see the `google_tags_tag_value` resource.
+    immutable: true
+    ignore_read: true
   - name: 'initialReplication'
     api_name: replication
     type: NestedObject
@@ -398,17 +412,3 @@ properties:
                 A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits.
                 Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z"
               output: true
-  - name: 'tags'
-    type: KeyValuePairs
-    description: |
-      A map of resource manager tags. Resource manager tag keys
-      and values have the same definition as resource manager
-      tags. Keys must be in the format tagKeys/{tag_key_id},
-      and values are in the format tagValues/456. The field is
-      ignored when empty. The field is immutable and causes
-      resource replacement when mutated. This field is only set
-      at create time and modifying this field after creation
-      will trigger recreation. To apply tags to an existing
-      resource, see the `google_tags_tag_value` resource.
-    immutable: true
-    ignore_read: true

--- a/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
+++ b/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
@@ -434,33 +434,6 @@ func TestAccFilestoreInstance_tags(t *testing.T) {
 		},
 	})
 }
-func TestAccFilestoreInstance_replication(t *testing.T) {
-	t.Parallel()
-
-	context := map[string]interface{}{
-		"random_suffix": acctest.RandString(t, 10),
-		"location_1"   : "us-central1",
-		"location_2"   : "us-west1",
-		"tier"         : "ENTERPRISE",
-	}
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckFilestoreInstanceDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFilestoreInstance_replication(context),
-			},
-			{
-				ResourceName:      "google_filestore_instance.replica-instance",
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{"zone","initial_replication"},
-
-			},
-		},
-	})
-}
 
 func testAccFileInstanceTags(name string, tags map[string]string) string {
 	r := fmt.Sprintf(`
@@ -486,6 +459,33 @@ tags = {`, name)
 
 	l += fmt.Sprintf("}\n}")
 	return r + l
+}
+
+func TestAccFilestoreInstance_replication(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"location_1":    "us-central1",
+		"location_2":    "us-west1",
+		"tier":          "ENTERPRISE",
+	}
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckFilestoreInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFilestoreInstance_replication(context),
+			},
+			{
+				ResourceName:            "google_filestore_instance.replica-instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"zone", "initial_replication"},
+			},
+		},
+	})
 }
 
 func testAccFilestoreInstance_replication(context map[string]interface{}) string {

--- a/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
+++ b/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
@@ -524,10 +524,10 @@ resource "google_filestore_instance" "replica-instance" {
   }
 
   initial_replication {
-	replicas {
-	  peer_instance = google_filestore_instance.instance.id
-	     }
-	}
+    replicas {
+      peer_instance = google_filestore_instance.instance.id
+    }
+  }
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
+++ b/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
@@ -434,6 +434,33 @@ func TestAccFilestoreInstance_tags(t *testing.T) {
 		},
 	})
 }
+func TestAccFilestoreInstance_replication(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"location_1"   : "us-central1",
+		"location_2"   : "us-west1",
+		"tier"         : "ENTERPRISE",
+	}
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckFilestoreInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFilestoreInstance_replication(context),
+			},
+			{
+				ResourceName:      "google_filestore_instance.replica-instance",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"zone","initial_replication"},
+
+			},
+		},
+	})
+}
 
 func testAccFileInstanceTags(name string, tags map[string]string) string {
 	r := fmt.Sprintf(`
@@ -459,4 +486,48 @@ tags = {`, name)
 
 	l += fmt.Sprintf("}\n}")
 	return r + l
+}
+
+func testAccFilestoreInstance_replication(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_filestore_instance" "instance" {
+  name             = "tf-instance-%{random_suffix}"
+  location         = "%{location_1}"
+  tier             = "%{tier}"
+  description      = "An instance created during testing."
+
+  file_shares {
+    capacity_gb    = 1024
+    name           = "share"
+  }
+
+  networks {
+    network        = "default"
+    modes          = ["MODE_IPV4"]
+  }
+}
+
+resource "google_filestore_instance" "replica-instance" {
+  name          	= "tf-rinstance-%{random_suffix}"
+  location      	= "%{location_2}"
+  tier          	= "%{tier}"
+  description   	= "An replica instance created during testing."
+
+  file_shares {	
+    capacity_gb 	= 1024
+    name            = "share"
+  }
+
+  networks {
+    network         = "default"
+    modes           = ["MODE_IPV4"]
+  }
+
+  initial_replication {
+	replicas {
+	  peer_instance = google_filestore_instance.instance.id
+	     }
+	}
+}
+`, context)
 }


### PR DESCRIPTION
Adding replication field for resource_filestore_instance


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.


```release-note:enhancement
filestore: added `initial_replication` field for peer instance configuration and `effective_replication` output for replication configuration output to `google_filestore_instance`
```
