### PR TITLE
Fix whitespace diffs on logging_sink exclusion filters

### DIFF
--- a/mmv1/third_party/terraform/services/logging/resource_logging_sink.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_sink.go
@@ -63,9 +63,10 @@ func resourceLoggingSinkSchema() map[string]*schema.Schema {
 						Description: `A description of this exclusion.`,
 					},
 					"filter": {
-						Type:        schema.TypeString,
-						Required:    true,
-						Description: `An advanced logs filter that matches the log entries to be excluded. By using the sample function, you can exclude less than 100% of the matching log entries`,
+						Type:             schema.TypeString,
+						Required:         true,
+						DiffSuppressFunc: OptionalSurroundingSpacesSuppress,
+						Description:      `An advanced logs filter that matches the log entries to be excluded. By using the sample function, you can exclude less than 100% of the matching log entries`,
 					},
 					"disabled": {
 						Type:        schema.TypeBool,


### PR DESCRIPTION
The top-level `filter` resource already has `OptionalSurroundingSpacesSuppress`, but the filter on `exclusions` does not causing unnecessary diffs when there only difference is leading/trailing whitespace, common because of the use of HEREDOC on this attribute.

```release-note:bug
logging: fixed the whitespace permadiff on `exclusions.filter` field in `google_logging_billing_account_sink`, `google_logging_folder_sink`, `google_logging_organization_sink` and `google_logging_project_sink` resources
```