### PR TITLE
added provisioned_throughput to instance_template and regional_instance_template

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
@@ -178,7 +178,15 @@ func ResourceComputeInstanceTemplate() *schema.Resource {
 							Optional:    true,
 							ForceNew:    true,
 							Computed:    true,
-							Description: `Indicates how many IOPS to provision for the disk. This sets the number of I/O operations per second that the disk can handle. Values must be between 10,000 and 120,000. For more details, see the [Extreme persistent disk documentation](https://cloud.google.com/compute/docs/disks/extreme-persistent-disk).`,
+							Description: `Indicates how many IOPS to provision for the disk. This sets the number of I/O operations per second that the disk can handle. For more details, see the [Extreme persistent disk documentation](https://cloud.google.com/compute/docs/disks/extreme-persistent-disk) or the [Hyperdisk documentation](https://cloud.google.com/compute/docs/disks/hyperdisks) depending on the selected disk_type.`,
+						},
+
+						"provisioned_throughput": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							ForceNew:    true,
+							Computed:    true,
+							Description: `Indicates how much throughput to provision for the disk, in MB/s. This sets the amount of data that can be read or written from the disk per second. For more details, see the [Hyperdisk documentation](https://cloud.google.com/compute/docs/disks/hyperdisks).`,
 						},
 
 						"resource_manager_tags": {
@@ -1233,7 +1241,7 @@ func buildDisks(d *schema.ResourceData, config *transport_tpg.Config) ([]*comput
 		}
 		if v, ok := d.GetOk(prefix + ".source"); ok {
 			disk.Source = v.(string)
-			conflicts := []string{"disk_size_gb", "disk_name", "disk_type", "provisioned_iops", "source_image", "source_snapshot", "labels"}
+			conflicts := []string{"disk_size_gb", "disk_name", "disk_type", "provisioned_iops", "provisioned_throughput", "source_image", "source_snapshot", "labels"}
 			for _, conflict := range conflicts {
 				if _, ok := d.GetOk(prefix + "." + conflict); ok {
 					return nil, fmt.Errorf("Cannot use `source` with any of the fields in %s", conflicts)
@@ -1255,6 +1263,9 @@ func buildDisks(d *schema.ResourceData, config *transport_tpg.Config) ([]*comput
 			}
 			if v, ok := d.GetOk(prefix + ".provisioned_iops"); ok {
 				disk.InitializeParams.ProvisionedIops = int64(v.(int))
+			}
+			if v, ok := d.GetOk(prefix + ".provisioned_throughput"); ok {
+				disk.InitializeParams.ProvisionedThroughput = int64(v.(int))
 			}
 			if _, ok := d.GetOk(prefix + ".resource_manager_tags"); ok {
 				disk.InitializeParams.ResourceManagerTags = tpgresource.ExpandStringMap(d, prefix + ".resource_manager_tags")
@@ -1520,6 +1531,12 @@ func diskCharacteristicsFromMap(m map[string]interface{}) diskCharacteristics {
 		// use strings to compare for simplicity.
 		dc.provisionedIops = fmt.Sprintf("%v", v)
 	}
+	
+	if v := m["provisioned_throughput"]; v != nil {
+		// Terraform and GCP return ints as different types (int vs int64), so just
+		// use strings to compare for simplicity.
+		dc.provisionedThroughput = fmt.Sprintf("%v", v)
+	}
 
 	return dc
 }
@@ -1545,6 +1562,7 @@ func flattenDisk(disk *compute.AttachedDisk, configDisk map[string]any, defaultP
 		}
 		diskMap["disk_type"] = disk.InitializeParams.DiskType
 		diskMap["provisioned_iops"] = disk.InitializeParams.ProvisionedIops
+		diskMap["provisioned_throughput"] = disk.InitializeParams.ProvisionedThroughput
 		diskMap["disk_name"] = disk.InitializeParams.DiskName
 		diskMap["labels"] = disk.InitializeParams.Labels
 		// The API does not return a disk size value for scratch disks. They are largely only one size,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.tmpl
@@ -404,6 +404,26 @@ func TestAccComputeInstanceTemplate_diskIops(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstanceTemplate_diskIopsThroughput(t *testing.T) {
+	t.Parallel()
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceTemplate_diskIopsThroughput(acctest.RandString(t, 10)),
+			},
+			{
+				ResourceName:      "google_compute_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccComputeInstanceTemplate_subnet_auto(t *testing.T) {
 	t.Parallel()
 
@@ -2910,6 +2930,37 @@ resource "google_compute_instance_template" "foobar" {
     disk_size_gb     = 100
     boot             = true
     provisioned_iops = 10000
+    labels = {
+      foo = "bar"
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+`, suffix)
+}
+
+func testAccComputeInstanceTemplate_diskIopsThroughput(suffix string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%s"
+  machine_type = "e2-medium"
+
+  disk {
+    source_image           = data.google_compute_image.my_image.self_link
+    auto_delete            = true
+    disk_size_gb           = 100
+    boot                   = true
+    disk_type   		   = "hyperdisk-throughput"
+    provisioned_iops       = 10000
+    provisioned_throughput = 1024
     labels = {
       foo = "bar"
     }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
@@ -155,7 +155,15 @@ func ResourceComputeRegionInstanceTemplate() *schema.Resource {
 							Optional:    true,
 							ForceNew:    true,
 							Computed:    true,
-							Description: `Indicates how many IOPS to provision for the disk. This sets the number of I/O operations per second that the disk can handle. Values must be between 10,000 and 120,000. For more details, see the [Extreme persistent disk documentation](https://cloud.google.com/compute/docs/disks/extreme-persistent-disk).`,
+							Description: `Indicates how many IOPS to provision for the disk. This sets the number of I/O operations per second that the disk can handle. For more details, see the [Extreme persistent disk documentation](https://cloud.google.com/compute/docs/disks/extreme-persistent-disk) or the [Hyperdisk documentation](https://cloud.google.com/compute/docs/disks/hyperdisks) depending on the selected disk_type.`,
+						},
+
+						"provisioned_throughput": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							ForceNew:    true,
+							Computed:    true,
+							Description: `Indicates how much throughput to provision for the disk, in MB/s. This sets the amount of data that can be read or written from the disk per second. For more details, see the [Hyperdisk documentation](https://cloud.google.com/compute/docs/disks/hyperdisks).`,
 						},
 
 						"resource_manager_tags": {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
@@ -303,6 +303,26 @@ func TestAccComputeRegionInstanceTemplate_diskIops(t *testing.T) {
 	})
 }
 
+func TestAccComputeRegionInstanceTemplate_diskIopsThroughput(t *testing.T) {
+	t.Parallel()
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_diskIopsThroughput(acctest.RandString(t, 10)),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccComputeRegionInstanceTemplate_subnet_auto(t *testing.T) {
 	t.Parallel()
 
@@ -2270,6 +2290,37 @@ resource "google_compute_region_instance_template" "foobar" {
     disk_size_gb     = 100
     boot             = true
     provisioned_iops = 10000
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+`, suffix)
+}
+
+func testAccComputeRegionInstanceTemplate_diskIopsThroughput(suffix string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%s"
+  machine_type = "e2-medium"
+  region      = "us-central1"
+
+  disk {
+    source_image        = data.google_compute_image.my_image.self_link
+    auto_delete   
+         = true
+    disk_size_gb        = 100   
+
+    boot                = true
+    disk_type           = "hyperdisk-throughput"
+    provisioned_iops    = 10000
+    provisioned_throughput = 1024
   }
 
   network_interface {


### PR DESCRIPTION
Added the option to configure provisioned_throughput for regional and global instance_templates similar to PR#8528. Both provisioned_iops and provisioned_throughput can be used to customise hyperdisks, so I also updated the wording of provisioned_iops so it isn't exclusively referring to PD extreme.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
