### PR TITLE
Allow for setting `desired_status` to different values than "RUNNING" on creation of `google_compute_instance`

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -1272,7 +1272,6 @@ be from 0 to 999,999,999 inclusive.`,
 				},
 				suppressEmptyGuestAcceleratorDiff,
 			),
-			desiredStatusDiff,
 			validateSubnetworkProject,
 			forceNewIfNetworkIPNotUpdatable,
 			tpgresource.SetLabelsDiff,
@@ -1462,10 +1461,36 @@ func getAllStatusBut(status string) []string {
 	return computeInstanceStatus
 }
 
-func waitUntilInstanceHasDesiredStatus(config *transport_tpg.Config, d *schema.ResourceData) error {
-	desiredStatus := d.Get("desired_status").(string)
+func changeInstanceStatusOnCreation(config *transport_tpg.Config, d *schema.ResourceData, project, zone, status, userAgent string) error {
+	var op *compute.Operation
+	var err error
+	if status == "RUNNING" {
+		return nil
+	} else if status == "TERMINATED" {
+		op, err = config.NewComputeClient(userAgent).Instances.Stop(project, zone, d.Get("name").(string)).Do()
+	} else if status == "SUSPENDED" {
+		op, err = config.NewComputeClient(userAgent).Instances.Suspend(project, zone, d.Get("name").(string)).Do()
+	}
+	if err != nil {
+		return fmt.Errorf("Error changing instance status after creation: %s", err)
+	}
 
-	if desiredStatus != "" {
+	waitErr := ComputeOperationWaitTime(config, op, project, "changing instance status", userAgent, d.Timeout(schema.TimeoutCreate))
+	if waitErr != nil {
+		d.SetId("")
+		return waitErr
+	}
+
+	err = waitUntilInstanceHasDesiredStatus(config, d, status)
+	if err != nil {
+		return fmt.Errorf("Error waiting for status: %s", err)
+	}
+
+	return nil
+}
+
+func waitUntilInstanceHasDesiredStatus(config *transport_tpg.Config, d *schema.ResourceData, status string) error {
+	if status != "" {
 		stateRefreshFunc := func() (interface{}, string, error) {
 			instance, err := getInstance(config, d)
 			if err != nil || instance == nil {
@@ -1476,9 +1501,9 @@ func waitUntilInstanceHasDesiredStatus(config *transport_tpg.Config, d *schema.R
 		}
 		stateChangeConf := retry.StateChangeConf{
 			Delay:      5 * time.Second,
-			Pending:    getAllStatusBut(desiredStatus),
+			Pending:    getAllStatusBut(status),
 			Refresh:    stateRefreshFunc,
-			Target:     []string{desiredStatus},
+			Target:     []string{status},
 			Timeout:    d.Timeout(schema.TimeoutUpdate),
 			MinTimeout: 2 * time.Second,
 		}
@@ -1486,7 +1511,7 @@ func waitUntilInstanceHasDesiredStatus(config *transport_tpg.Config, d *schema.R
 
 		if err != nil {
 			return fmt.Errorf(
-				"Error waiting for instance to reach desired status %s: %s", desiredStatus, err)
+				"Error waiting for instance to reach desired status %s: %s", status, err)
 		}
 	}
 
@@ -1553,9 +1578,14 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	}
 	{{- end }}
 
-	err = waitUntilInstanceHasDesiredStatus(config, d)
+	err = waitUntilInstanceHasDesiredStatus(config, d, "RUNNING")
 	if err != nil {
 		return fmt.Errorf("Error waiting for status: %s", err)
+	}
+
+	err = changeInstanceStatusOnCreation(config, d, project, zone.Name, d.Get("desired_status").(string), userAgent)
+	if err != nil {
+		return fmt.Errorf("Error changing instance status after creation: %s", err)
 	}
 
 	return resourceComputeInstanceRead(d, meta)
@@ -2890,25 +2920,6 @@ func suppressEmptyGuestAcceleratorDiff(_ context.Context, d *schema.ResourceDiff
 		if err := d.Clear("guest_accelerator"); err != nil {
 			return err
 		}
-	}
-
-	return nil
-}
-
-// return an error if the desired_status field is set to a value other than RUNNING on Create.
-func desiredStatusDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
-	// when creating an instance, name is not set
-	oldName, _ := diff.GetChange("name")
-
-	if oldName == nil || oldName == "" {
-		_, newDesiredStatus := diff.GetChange("desired_status")
-
-		if newDesiredStatus == nil || newDesiredStatus == "" {
-			return nil
-		} else if newDesiredStatus != "RUNNING" {
-			return fmt.Errorf("When creating an instance, desired_status can only accept RUNNING value")
-		}
-		return nil
 	}
 
 	return nil

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -1583,7 +1583,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 
 	if val, ok := d.GetOk("desired_status"); ok {
 		if val.(string) != "RUNNING" {
-			err = changeInstanceStatusOnCreation(config, d, project, zone.Name, d.Get("desired_status").(string), userAgent)
+			err = changeInstanceStatusOnCreation(config, d, project, zone.Name, val.(string), userAgent)
 			if err != nil {
 				return fmt.Errorf("Error changing instance status after creation: %s", err)
 			}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -1464,9 +1464,7 @@ func getAllStatusBut(status string) []string {
 func changeInstanceStatusOnCreation(config *transport_tpg.Config, d *schema.ResourceData, project, zone, status, userAgent string) error {
 	var op *compute.Operation
 	var err error
-	if status == "RUNNING" {
-		return nil
-	} else if status == "TERMINATED" {
+	if status == "TERMINATED" {
 		op, err = config.NewComputeClient(userAgent).Instances.Stop(project, zone, d.Get("name").(string)).Do()
 	} else if status == "SUSPENDED" {
 		op, err = config.NewComputeClient(userAgent).Instances.Suspend(project, zone, d.Get("name").(string)).Do()
@@ -1583,9 +1581,13 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error waiting for status: %s", err)
 	}
 
-	err = changeInstanceStatusOnCreation(config, d, project, zone.Name, d.Get("desired_status").(string), userAgent)
-	if err != nil {
-		return fmt.Errorf("Error changing instance status after creation: %s", err)
+	if val, ok := d.GetOk("desired_status"); ok {
+		if val.(string) != "RUNNING" {
+			err = changeInstanceStatusOnCreation(config, d, project, zone.Name, d.Get("desired_status").(string), userAgent)
+			if err != nil {
+				return fmt.Errorf("Error changing instance status after creation: %s", err)
+			}
+		}
 	}
 
 	return resourceComputeInstanceRead(d, meta)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -2287,27 +2287,80 @@ func TestAccComputeInstance_enableDisplay(t *testing.T) {
 	})
 }
 
-func TestAccComputeInstance_desiredStatusOnCreation(t *testing.T) {
+func TestAccComputeInstance_desiredStatusTerminatedOnCreation(t *testing.T) {
 	t.Parallel()
 
 	var instance compute.Instance
-	var instanceName = fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	context_1 := map[string]interface{}{
+		"instance_name":  fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"zone":           "us-central1-a",
+		"desired_status": "TERMINATED",
+	}
+
+	context_2 := map[string]interface{}{
+		"instance_name":  context_1["instance_name"],
+		"zone":           context_1["zone"],
+		"desired_status": "RUNNING",
+	}
 
 	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy: testAccCheckComputeInstanceDestroyProducer(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccComputeInstance_machineType_desiredStatus_allowStoppingForUpdate(instanceName, "e2-medium", "TERMINATED", false),
-				ExpectError: regexp.MustCompile("When creating an instance, desired_status can only accept RUNNING value"),
+				Config: testAccComputeInstance_desiredStatusOnCreation(context_1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceHasStatus(&instance, context_1["desired_status"].(string)),
+				),
 			},
 			{
-				Config: testAccComputeInstance_machineType_desiredStatus_allowStoppingForUpdate(instanceName, "e2-medium", "RUNNING", false),
+				Config: testAccComputeInstance_desiredStatusOnCreation(context_2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(
-						t, "google_compute_instance.foobar", &instance),
-					testAccCheckComputeInstanceHasStatus(&instance, "RUNNING"),
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceHasStatus(&instance, context_2["desired_status"].(string)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeInstance_desiredStatusSuspendedOnCreation(t *testing.T) {
+	t.Parallel()
+
+	var instance compute.Instance
+
+	context_1 := map[string]interface{}{
+		"instance_name":  fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"zone":           "us-central1-a",
+		"desired_status": "SUSPENDED",
+	}
+
+	context_2 := map[string]interface{}{
+		"instance_name":  context_1["instance_name"],
+		"zone":           context_1["zone"],
+		"desired_status": "RUNNING",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_desiredStatusOnCreation(context_1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceHasStatus(&instance, context_1["desired_status"].(string)),
+				),
+			},
+			{
+				Config: testAccComputeInstance_desiredStatusOnCreation(context_2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceHasStatus(&instance, context_2["desired_status"].(string)),
 				),
 			},
 		},
@@ -8935,6 +8988,33 @@ resource "google_compute_instance" "foobar" {
 	}
 }
 `, instance)
+}
+
+func testAccComputeInstance_desiredStatusOnCreation(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+	name           = "%{instance_name}"
+	machine_type   = "e2-medium"
+	zone           = "%{zone}"
+
+	boot_disk {
+		initialize_params{
+			image = "${data.google_compute_image.my_image.self_link}"
+		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+
+	desired_status = "%{desired_status}"
+}
+`, context)
 }
 
 func testAccComputeInstance_resourcePolicyCollocate(instance, suffix string) string {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
closes https://github.com/hashicorp/terraform-provider-google/issues/16586
- added the feature
- added tests for it
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: `desired_status` on google_compute_instance can now be set to `TERMINATED` or `SUSPENDED` on instance creation
```
