### PR TITLE
Fix the issue of unpopulated fields in the terraform state for the `google_secret_manager_secrets` datasource

### DIFF
--- a/mmv1/third_party/terraform/services/secretmanager/data_source_secret_manager_secrets.go
+++ b/mmv1/third_party/terraform/services/secretmanager/data_source_secret_manager_secrets.go
@@ -144,17 +144,21 @@ func flattenSecretManagerSecretsSecrets(v interface{}, d *schema.ResourceData, c
 			continue
 		}
 		transformed = append(transformed, map[string]interface{}{
-			"replication":     flattenSecretManagerSecretReplication(original["replication"], d, config),
-			"annotations":     flattenSecretManagerSecretAnnotations(original["annotations"], d, config),
-			"expire_time":     flattenSecretManagerSecretExpireTime(original["expireTime"], d, config),
-			"labels":          flattenSecretManagerSecretLabels(original["labels"], d, config),
-			"rotation":        flattenSecretManagerSecretRotation(original["rotation"], d, config),
-			"topics":          flattenSecretManagerSecretTopics(original["topics"], d, config),
-			"version_aliases": flattenSecretManagerSecretVersionAliases(original["versionAliases"], d, config),
-			"create_time":     flattenSecretManagerSecretCreateTime(original["createTime"], d, config),
-			"name":            flattenSecretManagerSecretName(original["name"], d, config),
-			"project":         getDataFromName(original["name"], 1),
-			"secret_id":       getDataFromName(original["name"], 3),
+			"replication":           flattenSecretManagerSecretReplication(original["replication"], d, config),
+			"annotations":           flattenSecretManagerSecretEffectiveAnnotations(original["annotations"], d, config),
+			"effective_annotations": flattenSecretManagerSecretEffectiveAnnotations(original["annotations"], d, config),
+			"expire_time":           flattenSecretManagerSecretExpireTime(original["expireTime"], d, config),
+			"labels":                flattenSecretManagerSecretEffectiveLabels(original["labels"], d, config),
+			"effective_labels":      flattenSecretManagerSecretEffectiveLabels(original["labels"], d, config),
+			"terraform_labels":      flattenSecretManagerSecretEffectiveLabels(original["labels"], d, config),
+			"rotation":              flattenSecretManagerSecretRotation(original["rotation"], d, config),
+			"topics":                flattenSecretManagerSecretTopics(original["topics"], d, config),
+			"version_aliases":       flattenSecretManagerSecretVersionAliases(original["versionAliases"], d, config),
+			"version_destroy_ttl":   flattenSecretManagerSecretVersionDestroyTtl(original["versionDestroyTtl"], d, config),
+			"create_time":           flattenSecretManagerSecretCreateTime(original["createTime"], d, config),
+			"name":                  flattenSecretManagerSecretName(original["name"], d, config),
+			"project":               getDataFromName(original["name"], 1),
+			"secret_id":             getDataFromName(original["name"], 3),
 		})
 	}
 	return transformed

--- a/mmv1/third_party/terraform/services/secretmanager/data_source_secret_manager_secrets_test.go
+++ b/mmv1/third_party/terraform/services/secretmanager/data_source_secret_manager_secrets_test.go
@@ -30,11 +30,8 @@ func TestAccDataSourceSecretManagerSecrets_basic(t *testing.T) {
 						"data.google_secret_manager_secrets.foo",
 						"google_secret_manager_secret.foo",
 						map[string]struct{}{
-							"id":               {},
-							"project":          {},
-							"effective_labels": {},
-							"labels":           {},
-							"terraform_labels": {},
+							"id":      {},
+							"project": {},
 						},
 					),
 				),
@@ -59,6 +56,16 @@ resource "google_secret_manager_secret" "foo" {
       }
     }
   }
+
+  labels = {
+    label = "my-label"
+  }
+
+  annotations = {
+    key1 = "value1"
+  }
+
+  version_destroy_ttl = "360000s"
 }
 
 data "google_secret_manager_secrets" "foo" {
@@ -89,11 +96,8 @@ func TestAccDataSourceSecretManagerSecrets_filter(t *testing.T) {
 						"google_secret_manager_secret.foo",
 						"google_secret_manager_secret.bar",
 						map[string]struct{}{
-							"id":               {},
-							"project":          {},
-							"effective_labels": {},
-							"labels":           {},
-							"terraform_labels": {},
+							"id":      {},
+							"project": {},
 						},
 					),
 				),
@@ -118,6 +122,14 @@ resource "google_secret_manager_secret" "foo" {
       }
     }
   }
+
+  labels = {
+    label = "my-label"
+  }
+
+  annotations = {
+    key1 = "value1"
+  }
 }
 
 resource "google_secret_manager_secret" "bar" {
@@ -129,6 +141,14 @@ resource "google_secret_manager_secret" "bar" {
         location = "us-east5"
       }
     }
+  }
+
+  labels = {
+    label= "my-label2"
+  }
+
+  annotations = {
+    key1 = "value1" 
   }
 }
 

--- a/mmv1/third_party/terraform/website/docs/d/secret_manager_secrets.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/secret_manager_secrets.html.markdown
@@ -43,6 +43,8 @@ exported:
 
 * `version_aliases` - Mapping from version alias to version name.
 
+* `version_destroy_ttl` - The version destroy ttl for the secret version.
+
 * `topics` -
   A list of up to 10 Pub/Sub topics to which messages are published when control plane operations are called on the secret or its versions.
   Structure is [documented below](#nested_topics).


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fix the issue of unpopulated fields like `labels`, `annotations` and `version_destroy_ttl` in the terraform state for the `google_secret_manager_secrets` datasource.
I think this might be due to the [new annotations model](https://github.com/GoogleCloudPlatform/magic-modules/pull/8931) and [labels model](https://github.com/GoogleCloudPlatform/magic-modules/pull/9000) which changed the existing flatteners for the annotations and the labels fields. For the `version_destroy_ttl` field, I added the flattening as this field was introduced later on.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
secretmanager: fixed the issue of unpopulated fields `labels`, `annotations` and `version_destroy_ttl` in the terraform state for the `google_secret_manager_secrets` datasource
```
