### PR TITLE
fix: Make key handle sweepable

### DIFF
--- a/mmv1/products/kms/KeyHandle.yaml
+++ b/mmv1/products/kms/KeyHandle.yaml
@@ -54,7 +54,8 @@ examples:
     primary_resource_id: 'example-keyhandle'
     min_version: 'beta'
     vars:
-      key_project_name: 'key-proj'
+      folder_name: 'my-folder'
+      key_project_name: 'res-proj'
       resource_project_name: 'resources'
     test_env_vars:
       org_id: 'ORG_ID'

--- a/mmv1/products/kms/KeyHandle.yaml
+++ b/mmv1/products/kms/KeyHandle.yaml
@@ -55,8 +55,8 @@ examples:
     min_version: 'beta'
     vars:
       folder_name: 'my-folder'
-      key_project_name: 'res-proj'
-      resource_project_name: 'resources'
+      key_project_name: 'key-proj'
+      resource_project_name: 'res-proj'
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'

--- a/mmv1/templates/terraform/examples/kms_key_handle_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/kms_key_handle_basic.tf.tmpl
@@ -1,7 +1,7 @@
 # Create Folder in GCP Organization
 resource "google_folder" "autokms_folder" {
   provider     = google-beta
-  display_name = "folder-example"
+  display_name = "{{index $.Vars "folder_name"}}"
   parent       = "organizations/{{index $.TestEnvVars "org_id"}}"
   deletion_protection = false
 }
@@ -89,7 +89,7 @@ resource "time_sleep" "wait_autokey_config" {
 resource "google_kms_key_handle" "{{$.PrimaryResourceId}}" {
   provider               = google-beta
   project                = google_project.resource_project.project_id
-  name                   = "example-key-handle" 
+  name                   = "tf-test-key-handle"
   location               = "global"
   resource_type_selector = "storage.googleapis.com/Bucket"
   depends_on             = [time_sleep.wait_autokey_config]


### PR DESCRIPTION
Make key handle and resource project name sweepable too.

Go template version of https://github.com/GoogleCloudPlatform/magic-modules/pull/11693 PR

<!-- AUTOCHANGELOG for Downstream PRs.

-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
