### PR TITLE
Make dataform tests use bootstrapped KMS keys, use non-authoritative IAM resources

### DIFF
--- a/mmv1/products/dataform/Repository.yaml
+++ b/mmv1/products/dataform/Repository.yaml
@@ -48,6 +48,9 @@ examples:
       secret_name: 'my-secret'
       key_ring_name: 'example-key-ring'
       crypto_key_name: 'example-crypto-key-name'
+    test_vars_overrides:
+      key_ring_name: 'acctest.BootstrapKMSKeyInLocation(t, "us-central1").KeyRing.Name'
+      crypto_key_name: 'tpgresource.GetResourceNameFromSelfLink(acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name)'
     # This example is used in the docs to address this issue
     # See : https://github.com/hashicorp/terraform-provider-google/issues/17335
     exclude_test: true
@@ -60,8 +63,10 @@ examples:
       dataform_repository_name: 'dataform_repository'
       data: 'secret-data'
       secret_name: 'my-secret'
-      key_ring_name: 'example-key-ring'
       crypto_key_name: 'example-crypto-key-name'
+    test_vars_overrides:
+      key_ring_name: 'acctest.BootstrapKMSKeyInLocation(t, "us-central1").KeyRing.Name'
+      crypto_key_name: 'tpgresource.GetResourceNameFromSelfLink(acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name)'
     # Although the Terraform config can be applied without error, the connection between Dataform and the SourceRepo aren't yet functional
     # See : https://github.com/hashicorp/terraform-provider-google/issues/17335
     # See : https://issuetracker.google.com/issues/287850319

--- a/mmv1/products/dataform/Repository.yaml
+++ b/mmv1/products/dataform/Repository.yaml
@@ -63,6 +63,7 @@ examples:
       dataform_repository_name: 'dataform_repository'
       data: 'secret-data'
       secret_name: 'my-secret'
+      key_ring_name: 'example-key-ring'
       crypto_key_name: 'example-crypto-key-name'
     test_vars_overrides:
       key_ring_name: 'acctest.BootstrapKMSKeyInLocation(t, "us-central1").KeyRing.Name'

--- a/mmv1/templates/terraform/examples/dataform_repository.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataform_repository.tf.tmpl
@@ -14,29 +14,20 @@ resource "google_secret_manager_secret_version" "secret_version" {
   secret_data = "{{index $.Vars "data"}}"
 }
 
-resource "google_kms_key_ring" "keyring" {
-  provider = google-beta
-  
-  name     = "{{index $.Vars "key_ring_name"}}"
-  location = "us-central1"
-}
-
-resource "google_kms_crypto_key" "example_key" {
+data "google_kms_crypto_key" "example_key" {
   provider = google-beta
   
   name            = "{{index $.Vars "crypto_key_name"}}"
-  key_ring        = google_kms_key_ring.keyring.id
+  key_ring        = "{{index $.Vars "key_ring_name"}}"
 }
 
-resource "google_kms_crypto_key_iam_binding" "crypto_key_binding" {
+resource "google_kms_crypto_key_iam_member" "crypto_key_member" {
   provider = google-beta
 
-  crypto_key_id = google_kms_crypto_key.example_key.id
+  crypto_key_id = data.google_kms_crypto_key.example_key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  members = [
-    "serviceAccount:service-${data.google_project.project.number}@gcp-sa-dataform.iam.gserviceaccount.com",
-  ]
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-dataform.iam.gserviceaccount.com"
 }
 
 resource "google_dataform_repository" "{{$.PrimaryResourceId}}" {
@@ -44,7 +35,7 @@ resource "google_dataform_repository" "{{$.PrimaryResourceId}}" {
   name = "{{index $.Vars "dataform_repository_name"}}"
   display_name = "{{index $.Vars "dataform_repository_name"}}"
   npmrc_environment_variables_secret_version = google_secret_manager_secret_version.secret_version.id
-  kms_key_name = google_kms_crypto_key.example_key.id
+  kms_key_name = data.google_kms_crypto_key.example_key.id
 
   labels = {
     label_foo1 = "label-bar1"
@@ -63,6 +54,6 @@ resource "google_dataform_repository" "{{$.PrimaryResourceId}}" {
   }
 
   depends_on = [
-    google_kms_crypto_key_iam_binding.crypto_key_binding
+    google_kms_crypto_key_iam_member.crypto_key_member
   ]
 }

--- a/mmv1/templates/terraform/examples/dataform_repository.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataform_repository.tf.tmpl
@@ -21,14 +21,10 @@ data "google_kms_crypto_key" "example_key" {
   key_ring        = "{{index $.Vars "key_ring_name"}}"
 }
 
-resource "google_kms_crypto_key_iam_member" "crypto_key_member" {
-  provider = google-beta
-
-  crypto_key_id = data.google_kms_crypto_key.example_key.id
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-
-  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-dataform.iam.gserviceaccount.com"
-}
+# Permissions are already provisioned for the default Dataform Serivce Account in the test projects
+#   - Service account `service-YOUR_PROJECT_NUMBER@gcp-sa-dataform.iam.gserviceaccount.com`
+#   - Needs the role roles/cloudkms.cryptoKeyEncrypterDecrypter
+#   - On the KMS key used by the Repository
 
 resource "google_dataform_repository" "{{$.PrimaryResourceId}}" {
   provider = google-beta

--- a/mmv1/templates/terraform/examples/dataform_repository_with_cloudsource_repo.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataform_repository_with_cloudsource_repo.tf.tmpl
@@ -23,29 +23,20 @@ resource "google_secret_manager_secret_version" "secret_version" {
   secret_data = "{{index $.Vars "data"}}"
 }
 
-resource "google_kms_key_ring" "keyring" {
-  provider = google-beta
-  
-  name     = "{{index $.Vars "key_ring_name"}}"
-  location = "us-central1"
-}
-
-resource "google_kms_crypto_key" "example_key" {
+data "google_kms_crypto_key" "example_key" {
   provider = google-beta
   
   name            = "{{index $.Vars "crypto_key_name"}}"
-  key_ring        = google_kms_key_ring.keyring.id
+  key_ring        = "{{index $.Vars "key_ring_name"}}"
 }
 
-resource "google_kms_crypto_key_iam_binding" "crypto_key_binding" {
+resource "google_kms_crypto_key_iam_member" "crypto_key_member" {
   provider = google-beta
 
-  crypto_key_id = google_kms_crypto_key.example_key.id
+  crypto_key_id = data.google_kms_crypto_key.example_key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  members = [
-    "serviceAccount:service-${data.google_project.project.number}@gcp-sa-dataform.iam.gserviceaccount.com",
-  ]
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-dataform.iam.gserviceaccount.com"
 }
 
 resource "google_dataform_repository" "{{$.PrimaryResourceId}}" {
@@ -53,7 +44,7 @@ resource "google_dataform_repository" "{{$.PrimaryResourceId}}" {
   name = "{{index $.Vars "dataform_repository_name"}}"
   display_name = "{{index $.Vars "dataform_repository_name"}}"
   npmrc_environment_variables_secret_version = google_secret_manager_secret_version.secret_version.id
-  kms_key_name = google_kms_crypto_key.example_key.id
+  kms_key_name = data.google_kms_crypto_key.example_key.id
 
   labels = {
     label_foo1 = "label-bar1"
@@ -72,6 +63,6 @@ resource "google_dataform_repository" "{{$.PrimaryResourceId}}" {
   }
 
   depends_on = [
-    google_kms_crypto_key_iam_binding.crypto_key_binding
+    google_kms_crypto_key_iam_member.crypto_key_member
   ]
 }

--- a/mmv1/templates/terraform/examples/dataform_repository_with_cloudsource_repo.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataform_repository_with_cloudsource_repo.tf.tmpl
@@ -30,15 +30,10 @@ data "google_kms_crypto_key" "example_key" {
   key_ring        = "{{index $.Vars "key_ring_name"}}"
 }
 
-resource "google_kms_crypto_key_iam_member" "crypto_key_member" {
-  provider = google-beta
-
-  crypto_key_id = data.google_kms_crypto_key.example_key.id
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-
-  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-dataform.iam.gserviceaccount.com"
-}
-
+# Permissions are already provisioned for the default Dataform Serivce Account in the test projects
+#   - Service account `service-YOUR_PROJECT_NUMBER@gcp-sa-dataform.iam.gserviceaccount.com`
+#   - Needs the role roles/cloudkms.cryptoKeyEncrypterDecrypter
+#   - On the KMS key used by the Repository
 resource "google_dataform_repository" "{{$.PrimaryResourceId}}" {
   provider = google-beta
   name = "{{index $.Vars "dataform_repository_name"}}"


### PR DESCRIPTION

Fixes https://github.com/hashicorp/terraform-provider-google/issues/19734



<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
