### PR TITLE
Skip Custom Ski CA test for Private CA

### DIFF
--- a/mmv1/products/privateca/CertificateAuthority.yaml
+++ b/mmv1/products/privateca/CertificateAuthority.yaml
@@ -128,6 +128,8 @@ examples:
       'deletion_protection': 'false'
     ignore_read_extra:
       - 'deletion_protection'
+    # Signing custom keys requires a service account which does not exist for the terraform testing project
+    exclude_test: true
     # Multiple IAM bindings on the same key cause non-determinism
     skip_vcr: true
 virtual_fields:


### PR DESCRIPTION
This PR will skip a Example test which has been consistently failing. It is dependent on a service account which would need to be created for it to run successfully.

https://github.com/hashicorp/terraform-provider-google/issues/17979


<!-- AUTOCHANGELOG for Downstream PRs.

    - release-note:none
-->
