### PR TITLE
Force send internal_ip_only

### DIFF
--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
@@ -2177,6 +2177,7 @@ func expandGceClusterConfig(d *schema.ResourceData, config *transport_tpg.Config
 	}
 	if v, ok := cfg["internal_ip_only"]; ok {
 		conf.InternalIpOnly = v.(bool)
+		conf.ForceSendFields = append(conf.ForceSendFields, "InternalIpOnly")
 	}
 	if v, ok := cfg["metadata"]; ok {
 		conf.Metadata = tpgresource.ConvertStringMap(v.(map[string]interface{}))

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
@@ -13,10 +13,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/hashicorp/terraform-provider-google-beta/google-beta/acctest"
-	"github.com/hashicorp/terraform-provider-google-beta/google-beta/envvar"
-	"github.com/hashicorp/terraform-provider-google-beta/google-beta/tpgresource"
-	transport_tpg "github.com/hashicorp/terraform-provider-google-beta/google-beta/transport"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 	"google.golang.org/api/googleapi"
 
@@ -2568,3 +2568,4 @@ resource "google_dataproc_metastore_service" "ms" {
 }
 `, clusterName, serviceId)
 }
+

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
@@ -13,10 +13,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	"github.com/hashicorp/terraform-provider-google/google/envvar"
-	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
-	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+	"github.com/hashicorp/terraform-provider-google-beta/google-beta/acctest"
+	"github.com/hashicorp/terraform-provider-google-beta/google-beta/envvar"
+	"github.com/hashicorp/terraform-provider-google-beta/google-beta/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google-beta/google-beta/transport"
 
 	"google.golang.org/api/googleapi"
 
@@ -28,7 +28,7 @@ func TestAccDataprocCluster_missingZoneGlobalRegion1(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:  func() { acctest.AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
@@ -44,7 +44,7 @@ func TestAccDataprocCluster_missingZoneGlobalRegion2(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:  func() { acctest.AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
@@ -559,7 +559,6 @@ func TestAccDataprocCluster_spotWithAuxiliaryNodeGroups(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.node_group_config.0.accelerators.0.accelerator_count", "1"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group_id", "node-group-id"),
 					testAccCheckDataprocAuxiliaryNodeGroupAccelerator(&cluster, project),
-
 				),
 			},
 		},
@@ -707,7 +706,7 @@ func TestAccDataprocCluster_withServiceAcc(t *testing.T) {
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"time": {},
 		},
-		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
+		CheckDestroy: testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataprocCluster_withServiceAcc(sa, rnd, subnetworkName),
@@ -827,13 +826,13 @@ func TestAccDataprocCluster_withLifecycleConfigAutoDeletion(t *testing.T) {
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withLifecycleConfigAutoDeletionTime(rnd, now.Add(time.Hour * 10).Format(fmtString), subnetworkName),
+				Config: testAccDataprocCluster_withLifecycleConfigAutoDeletionTime(rnd, now.Add(time.Hour*10).Format(fmtString), subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_lifecycle_config", &cluster),
 				),
 			},
 			{
-				Config: testAccDataprocCluster_withLifecycleConfigAutoDeletionTime(rnd, now.Add(time.Hour * 20).Format(fmtString), subnetworkName),
+				Config: testAccDataprocCluster_withLifecycleConfigAutoDeletionTime(rnd, now.Add(time.Hour*20).Format(fmtString), subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_lifecycle_config", &cluster),
 				),
@@ -1046,7 +1045,7 @@ func TestAccDataprocCluster_withMetastoreConfig(t *testing.T) {
 	updateServiceId := "tf-test-metastore-srv-update-" + acctest.RandString(t, 10)
 	msName_basic := fmt.Sprintf("projects/%s/locations/us-central1/services/%s", pid, basicServiceId)
 	msName_update := fmt.Sprintf("projects/%s/locations/us-central1/services/%s", pid, updateServiceId)
-	
+
 	var cluster dataproc.Cluster
 	clusterName := "tf-test-" + acctest.RandString(t, 10)
 	acctest.VcrTest(t, resource.TestCase{
@@ -1058,8 +1057,7 @@ func TestAccDataprocCluster_withMetastoreConfig(t *testing.T) {
 				Config: testAccDataprocCluster_withMetastoreConfig(clusterName, basicServiceId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_metastore_config", &cluster),
-					resource.TestCheckResourceAttr("google_dataproc_cluster.with_metastore_config", "cluster_config.0.metastore_config.0.dataproc_metastore_service",msName_basic),
-					
+					resource.TestCheckResourceAttr("google_dataproc_cluster.with_metastore_config", "cluster_config.0.metastore_config.0.dataproc_metastore_service", msName_basic),
 				),
 			},
 			{
@@ -1067,7 +1065,6 @@ func TestAccDataprocCluster_withMetastoreConfig(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_metastore_config", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_metastore_config", "cluster_config.0.metastore_config.0.dataproc_metastore_service", msName_update),
-					
 				),
 			},
 		},
@@ -1417,6 +1414,10 @@ resource "google_dataproc_cluster" "accelerated_cluster" {
   region = "us-central1"
 
   cluster_config {
+    software_config {
+      image_version = "2.0.35-debian10"
+    }
+
     gce_cluster_config {
       subnetwork = "%s"
       zone = "%s"
@@ -1652,6 +1653,9 @@ resource "google_dataproc_cluster" "basic" {
   region = "us-central1"
 
   cluster_config {
+    software_config {
+      image_version = "2.0.35-debian10"
+    }
     gce_cluster_config {
       subnetwork = "%s"
       zone = "us-central1-f"
@@ -1764,6 +1768,7 @@ resource "google_dataproc_cluster" "with_init_action" {
 
     # Keep the costs down with smallest config we can get away with
     software_config {
+      image_version = "2.0.35-debian10"
       override_properties = {
         "dataproc:dataproc.allow.zero.workers" = "true"
       }
@@ -2028,6 +2033,7 @@ resource "google_dataproc_cluster" "with_bucket" {
 
     # Keep the costs down with smallest config we can get away with
     software_config {
+      image_version = "2.0.35-debian10"
       override_properties = {
         "dataproc:dataproc.allow.zero.workers" = "true"
       }
@@ -2061,6 +2067,7 @@ resource "google_dataproc_cluster" "with_bucket" {
 
     # Keep the costs down with smallest config we can get away with
     software_config {
+      image_version = "2.0.35-debian10"
       override_properties = {
         "dataproc:dataproc.allow.zero.workers" = "true"
       }
@@ -2250,6 +2257,7 @@ resource "google_dataproc_cluster" "with_service_account" {
   cluster_config {
     # Keep the costs down with smallest config we can get away with
     software_config {
+      image_version = "2.0.35-debian10"
       override_properties = {
         "dataproc:dataproc.allow.zero.workers" = "true"
       }
@@ -2560,4 +2568,3 @@ resource "google_dataproc_metastore_service" "ms" {
 }
 `, clusterName, serviceId)
 }
-

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job_test.go.tmpl
@@ -862,6 +862,7 @@ resource "google_dataproc_cluster" "basic" {
   cluster_config {
     # Keep the costs down with smallest config we can get away with
     software_config {
+      image_version = "2.0.35-debian10"
       override_properties = {
         "dataproc:dataproc.allow.zero.workers" = "true"
       }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This overrides the server-side default and keeps our default of false.
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/19522
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/19424

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
dataproc: fixed a bug in `google_dataproc_cluster` that prevented creation of clusters with `internal_ip_only` set to false
```
