### PR TITLE
Proposal: use embedded structs to add GetProject methods to PF-implemented resources & data sources

### DIFF
--- a/mmv1/third_party/terraform/fwresource/data_source_with_configure.go
+++ b/mmv1/third_party/terraform/fwresource/data_source_with_configure.go
@@ -1,0 +1,34 @@
+package fwresource
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+type dataSourceConfigurer interface {
+	Configure(context.Context, datasource.ConfigureRequest, *datasource.ConfigureResponse)
+}
+
+type DataSourceWithConfigure struct {
+	Config *transport_tpg.Config
+}
+
+func (ds *DataSourceWithConfigure) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+	p, ok := req.ProviderData.(*transport_tpg.Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *transport_tpg.Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	ds.Config = p
+}

--- a/mmv1/third_party/terraform/fwresource/resource_with_configure.go
+++ b/mmv1/third_party/terraform/fwresource/resource_with_configure.go
@@ -1,0 +1,34 @@
+package fwresource
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+type resourceConfigurer interface {
+	Configure(context.Context, resource.ConfigureRequest, *resource.ConfigureResponse)
+}
+
+type ResourceWithConfigure struct {
+	Config *transport_tpg.Config
+}
+
+func (r *ResourceWithConfigure) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+	p, ok := req.ProviderData.(*transport_tpg.Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *transport_tpg.Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.Config = p
+}

--- a/mmv1/third_party/terraform/fwresource/with_get_project.go
+++ b/mmv1/third_party/terraform/fwresource/with_get_project.go
@@ -1,0 +1,39 @@
+package fwresource
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+type ProjectGetter interface {
+	GetProject(types.String, *transport_tpg.Config, *diag.Diagnostics) types.String
+}
+
+type WithGetProject struct {
+}
+
+// GetProject determines whether to use a project value from the resource/data source config or the provider-default project
+func (w *WithGetProject) GetProject(resourceProject types.String, config *transport_tpg.Config, diags *diag.Diagnostics) types.String {
+	// Prevent panic if nil pointer
+	if config == nil {
+		diags.AddError("nil pointer encountered in fwresource.GetProject", "Please report this issue to the provider developers")
+		return types.String{}
+	}
+
+	if !(resourceProject.IsNull() || resourceProject.IsUnknown() || resourceProject.ValueString() == "") {
+		return resourceProject
+	}
+
+	if config.Project != "" {
+		return types.StringValue(config.Project)
+	}
+
+	diags.AddAttributeError(
+		path.Root("project"),
+		"missing required field project",
+		"this resource/data source requires a project argument set either in the resource/data block or provided as a provider-level default",
+	)
+	return types.String{}
+}

--- a/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_android_app_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_android_app_config.go.tmpl
@@ -30,7 +30,7 @@ func NewGoogleFirebaseAndroidAppConfigDataSource() datasource.DataSource {
 
 // GoogleFirebaseAndroidAppConfigDataSource defines the data source implementation
 type GoogleFirebaseAndroidAppConfigDataSource struct {
-	client         *firebase.Service
+	fwresource.DataSourceWithConfigure
 	providerConfig *transport_tpg.Config
 }
 
@@ -84,28 +84,6 @@ func (d *GoogleFirebaseAndroidAppConfigDataSource) Schema(ctx context.Context, r
 			},
 		},
 	}
-}
-
-func (d *GoogleFirebaseAndroidAppConfigDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	// Prevent panic if the provider has not been configured.
-	if req.ProviderData == nil {
-		return
-	}
-
-	p, ok := req.ProviderData.(*transport_tpg.Config)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *transport_tpg.Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-		return
-	}
-
-	d.client = p.NewFirebaseClient(ctx, p.UserAgent)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	d.providerConfig = p
 }
 
 func (d *GoogleFirebaseAndroidAppConfigDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {

--- a/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_android_app_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_android_app_config.go.tmpl
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/fwmodels"
 	"github.com/hashicorp/terraform-provider-google/google/fwresource"
 	"github.com/hashicorp/terraform-provider-google/google/fwtransport"
-	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 // Ensure the implementation satisfies the expected interfaces
@@ -31,7 +30,7 @@ func NewGoogleFirebaseAndroidAppConfigDataSource() datasource.DataSource {
 // GoogleFirebaseAndroidAppConfigDataSource defines the data source implementation
 type GoogleFirebaseAndroidAppConfigDataSource struct {
 	fwresource.DataSourceWithConfigure
-	providerConfig *transport_tpg.Config
+	fwresource.WithGetProject
 }
 
 type GoogleFirebaseAndroidAppConfigModel struct {
@@ -103,15 +102,18 @@ func (d *GoogleFirebaseAndroidAppConfigDataSource) Read(ctx context.Context, req
 	}
 
 	// Use provider_meta to set User-Agent
-	d.client.UserAgent = fwtransport.GenerateFrameworkUserAgentString(metaData, d.client.UserAgent)
+	userAgent := fwtransport.GenerateFrameworkUserAgentString(metaData, d.Config.UserAgent)
 
-	data.Project = fwresource.GetProjectFramework(data.Project, types.StringValue(d.providerConfig.Project), &resp.Diagnostics)
+	// Check if provider-default value(s) need to be used
+	project := d.GetProject(data.Project, d.Config, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	data.Project = project
 
 	// GET Request
-	service := firebase.NewProjectsAndroidAppsService(d.client)
+	client := d.Config.NewFirebaseClient(ctx, userAgent)
+	service := firebase.NewProjectsAndroidAppsService(client)
 	appName := fmt.Sprintf("projects/%s/androidApps/%s/config", data.Project.ValueString(), data.AppId.ValueString())
 	clientResp, err := service.GetConfig(appName).Do()
 	if err != nil {

--- a/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_android_app_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_android_app_config.go.tmpl
@@ -132,8 +132,6 @@ func (d *GoogleFirebaseAndroidAppConfigDataSource) Read(ctx context.Context, req
 		return
 	}
 
-
-
 	// GET Request
 	service := firebase.NewProjectsAndroidAppsService(d.client)
 	appName := fmt.Sprintf("projects/%s/androidApps/%s/config", data.Project.ValueString(), data.AppId.ValueString())

--- a/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_apple_app_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_apple_app_config.go.tmpl
@@ -30,7 +30,7 @@ func NewGoogleFirebaseAppleAppConfigDataSource() datasource.DataSource {
 
 // GoogleFirebaseAppleAppConfigDataSource defines the data source implementation
 type GoogleFirebaseAppleAppConfigDataSource struct {
-	client         *firebase.Service
+	fwresource.DataSourceWithConfigure
 	providerConfig *transport_tpg.Config
 }
 
@@ -84,28 +84,6 @@ func (d *GoogleFirebaseAppleAppConfigDataSource) Schema(ctx context.Context, req
 			},
 		},
 	}
-}
-
-func (d *GoogleFirebaseAppleAppConfigDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	// Prevent panic if the provider has not been configured.
-	if req.ProviderData == nil {
-		return
-	}
-
-	p, ok := req.ProviderData.(*transport_tpg.Config)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *transport_tpg.Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-		return
-	}
-
-	d.client = p.NewFirebaseClient(ctx, p.UserAgent)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	d.providerConfig = p
 }
 
 func (d *GoogleFirebaseAppleAppConfigDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {

--- a/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_apple_app_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_apple_app_config.go.tmpl
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/fwmodels"
 	"github.com/hashicorp/terraform-provider-google/google/fwresource"
 	"github.com/hashicorp/terraform-provider-google/google/fwtransport"
-	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 // Ensure the implementation satisfies the expected interfaces
@@ -31,7 +30,7 @@ func NewGoogleFirebaseAppleAppConfigDataSource() datasource.DataSource {
 // GoogleFirebaseAppleAppConfigDataSource defines the data source implementation
 type GoogleFirebaseAppleAppConfigDataSource struct {
 	fwresource.DataSourceWithConfigure
-	providerConfig *transport_tpg.Config
+	fwresource.WithGetProject
 }
 
 type GoogleFirebaseAppleAppConfigModel struct {
@@ -103,15 +102,18 @@ func (d *GoogleFirebaseAppleAppConfigDataSource) Read(ctx context.Context, req d
 	}
 
 	// Use provider_meta to set User-Agent
-	d.client.UserAgent = fwtransport.GenerateFrameworkUserAgentString(metaData, d.client.UserAgent)
+	userAgent := fwtransport.GenerateFrameworkUserAgentString(metaData, d.Config.UserAgent)
 
-	data.Project = fwresource.GetProjectFramework(data.Project, types.StringValue(d.providerConfig.Project), &resp.Diagnostics)
+	// Check if provider-default value(s) need to be used
+	project := d.GetProject(data.Project, d.Config, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	data.Project = project
 
 	// GET Request
-	service := firebase.NewProjectsIosAppsService(d.client)
+	client := d.Config.NewFirebaseClient(ctx, userAgent)
+	service := firebase.NewProjectsIosAppsService(client)
 	appName := fmt.Sprintf("projects/%s/iosApps/%s/config", data.Project.ValueString(), data.AppId.ValueString())
 	clientResp, err := service.GetConfig(appName).Do()
 	if err != nil {

--- a/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_web_app_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_web_app_config.go.tmpl
@@ -30,7 +30,7 @@ func NewGoogleFirebaseWebAppConfigDataSource() datasource.DataSource {
 
 // GoogleFirebaseWebAppConfigDataSource defines the data source implementation
 type GoogleFirebaseWebAppConfigDataSource struct {
-	client         *firebase.Service
+	fwresource.DataSourceWithConfigure
 	providerConfig *transport_tpg.Config
 }
 
@@ -131,28 +131,6 @@ func (d *GoogleFirebaseWebAppConfigDataSource) Schema(ctx context.Context, req d
 			},
 		},
 	}
-}
-
-func (d *GoogleFirebaseWebAppConfigDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	// Prevent panic if the provider has not been configured.
-	if req.ProviderData == nil {
-		return
-	}
-
-	p, ok := req.ProviderData.(*transport_tpg.Config)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *transport_tpg.Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-		return
-	}
-
-	d.client = p.NewFirebaseClient(ctx, p.UserAgent)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	d.providerConfig = p
 }
 
 func (d *GoogleFirebaseWebAppConfigDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {

--- a/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_web_app_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_web_app_config.go.tmpl
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/fwmodels"
 	"github.com/hashicorp/terraform-provider-google/google/fwresource"
 	"github.com/hashicorp/terraform-provider-google/google/fwtransport"
-	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 // Ensure the implementation satisfies the expected interfaces
@@ -31,7 +30,7 @@ func NewGoogleFirebaseWebAppConfigDataSource() datasource.DataSource {
 // GoogleFirebaseWebAppConfigDataSource defines the data source implementation
 type GoogleFirebaseWebAppConfigDataSource struct {
 	fwresource.DataSourceWithConfigure
-	providerConfig *transport_tpg.Config
+	fwresource.WithGetProject
 }
 
 type GoogleFirebaseWebAppConfigModel struct {
@@ -150,15 +149,18 @@ func (d *GoogleFirebaseWebAppConfigDataSource) Read(ctx context.Context, req dat
 	}
 
 	// Use provider_meta to set User-Agent
-	d.client.UserAgent = fwtransport.GenerateFrameworkUserAgentString(metaData, d.client.UserAgent)
+	userAgent := fwtransport.GenerateFrameworkUserAgentString(metaData, d.Config.UserAgent)
 
-	data.Project = fwresource.GetProjectFramework(data.Project, types.StringValue(d.providerConfig.Project), &resp.Diagnostics)
+	// Check if provider-default value(s) need to be used
+	project := d.GetProject(data.Project, d.Config, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	data.Project = project
 
 	// GET Request
-	service := firebase.NewProjectsWebAppsService(d.client)
+	client := d.Config.NewFirebaseClient(ctx, userAgent)
+	service := firebase.NewProjectsWebAppsService(client)
 	appName := fmt.Sprintf("projects/%s/webApps/%s/config", data.Project.ValueString(), data.WebAppId.ValueString())
 	clientResp, err := service.GetConfig(appName).Do()
 	if err != nil {


### PR DESCRIPTION
Blocked by muxing fixes PR (this PR contains that PR's commits)

# Background

Dating from the time of the original muxing in 2023 there is [a function called **GetProjectFramework**](https://github.com/hashicorp/terraform-provider-google-beta/blob/c56e8bfea58d081d0e236e9630f5b2baa4820e80/google-beta/fwresource/field_helpers.go#L21) that's used to determine whether to take the `project` value from a resource argument or from the provider default.

```go
// GetProject reads the "project" field from the given resource and falls
// back to the provider's value if not given. If the provider's value is not
// given, an error is returned.
func GetProjectFramework(rVal, pVal types.String, diags *diag.Diagnostics) types.String {
	return getProjectFromFrameworkSchema("project", rVal, pVal, diags)
}

func getProjectFromFrameworkSchema(projectSchemaField string, rVal, pVal types.String, diags *diag.Diagnostics) types.String {
	if !rVal.IsNull() && rVal.ValueString() != "" {
		return rVal
	}

	if !pVal.IsNull() && pVal.ValueString() != "" {
		return pVal
	}

	diags.AddError("required field is not set", fmt.Sprintf("%s is not set", projectSchemaField))
	return types.String{}
}
```

This was written to heavily mimic [the original, SDKv2 equivalent **GetProject**](https://github.com/hashicorp/terraform-provider-google-beta/blob/c56e8bfea58d081d0e236e9630f5b2baa4820e80/google-beta/tpgresource/utils.go#L86) function. This function needed a 'schema field' argument because the first argument was `*schema.ResourceData`, the entire data for a resource. The function needed instructions on what key-value pair to look for and retrieve from that data structure: 

```go
// GetProject reads the "project" field from the given resource data and falls
// back to the provider's value if not given. If the provider's value is not
// given, an error is returned.
func GetProject(d TerraformResourceData, config *transport_tpg.Config) (string, error) {
	return GetProjectFromSchema("project", d, config)
}

func GetProjectFromSchema(projectSchemaField string, d TerraformResourceData, config *transport_tpg.Config) (string, error) {
	res, ok := d.GetOk(projectSchemaField)
	if ok && projectSchemaField != "" {
		return res.(string), nil
	}
	if config.Project != "" {
		return config.Project, nil
	}
	return "", fmt.Errorf("%s: required field is not set", projectSchemaField)
}
```

# My opinion

Mimicking the original SDK code when implementing a plugin-framework version of this logic doesn't make sense, as a resource's data is no longer stored as a map[string]interface{} matching a schema which can be queried with string keys. Instead the data is read into a struct annotated with struct tags that link fields to config values. For example:

```go
type GoogleFirebaseAppleAppConfigModel struct {
	Id                 types.String `tfsdk:"id"`
	AppId              types.String `tfsdk:"app_id"`
	ConfigFilename     types.String `tfsdk:"config_filename"`
	ConfigFileContents types.String `tfsdk:"config_file_contents"`
	Project            types.String `tfsdk:"project"`
}
```

Given this, there isn't any sense passing in the string `"project"` to `getProjectFromFrameworkSchema` above. And if you remove that part of a logic you end up with a generic function that compares two arguments using the new type system and then return the first one that isn't unknown, null, or `""`.

I don't think we want a generic 'compare two values' function as we want the function to be able to provide feedback to the user via errors and warnings if no suitable value is found. A generic function cannot tell the user what value is missing.

This led me to thinking that we should implement logic specifically for retrieving the `project` value

# This PR

In this PR I propose that we add a new embeddable struct that allows adding a new method `GetProject` to resources and data sources. This method will return either the resource's project argument, the provider-default project, or an error as feedback to the user.

The calling code that defines the custom model for that resource (e.g. GoogleFirebaseAppleAppConfigModel above) has the responsibility of needing to provide the correct field from the resource model struct as an argument. This replaces the use of `"project"` in the SDK version.

Because the method is specific to `project`, we can include feedback about which field has missing information.

An open question is whether we have any resources/data sources currently where a project ID is supplied by a field called something other than `project`. If not, we can hardcode the function to raise an error about `project` being unset. If there are special resources that use other fields for project we can update the logic so that the field name is stored in the resource model struct and accessed from there. However, setting the custom project schema field name in that struct is something that would need to happen in a non-standardised (see https://github.com/GoogleCloudPlatform/magic-modules/pull/11924) Configure function.


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
