### PR TITLE
Add missing test for `data.google_firebase_web_app_config`, clean up plugin-framework Firebase code a bit

### DIFF
--- a/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_android_app_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_android_app_config.go.tmpl
@@ -75,6 +75,7 @@ func (d *GoogleFirebaseAndroidAppConfigDataSource) Schema(ctx context.Context, r
 				Computed:            true,
 			},
 
+			// This is included for backwards compatibility with the original, SDK-implemented data source.
 			"id": schema.StringAttribute{
 				Description:         "Firebase Android App Config identifier",
 				MarkdownDescription: "Firebase Android App Config identifier",
@@ -116,25 +117,26 @@ func (d *GoogleFirebaseAndroidAppConfigDataSource) Read(ctx context.Context, req
 		return
 	}
 
-	d.client.UserAgent = fwtransport.GenerateFrameworkUserAgentString(metaData, d.client.UserAgent)
-
-	client := firebase.NewProjectsAndroidAppsService(d.client)
-
 	// Read Terraform configuration data into the model
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
+	// Use provider_meta to set User-Agent
+	d.client.UserAgent = fwtransport.GenerateFrameworkUserAgentString(metaData, d.client.UserAgent)
+
 	data.Project = fwresource.GetProjectFramework(data.Project, d.project, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	appName := fmt.Sprintf("projects/%s/androidApps/%s/config", data.Project.ValueString(), data.AppId.ValueString())
-	data.Id = types.StringValue(appName)
 
-	clientResp, err := client.GetConfig(appName).Do()
+
+	// GET Request
+	service := firebase.NewProjectsAndroidAppsService(d.client)
+	appName := fmt.Sprintf("projects/%s/androidApps/%s/config", data.Project.ValueString(), data.AppId.ValueString())
+	clientResp, err := service.GetConfig(appName).Do()
 	if err != nil {
 		fwtransport.HandleDatasourceNotFoundError(ctx, err, &resp.State, fmt.Sprintf("dataSourceFirebaseAndroidAppConfig %q", data.AppId.ValueString()), &resp.Diagnostics)
 		if resp.Diagnostics.HasError() {
@@ -144,6 +146,8 @@ func (d *GoogleFirebaseAndroidAppConfigDataSource) Read(ctx context.Context, req
 
 	tflog.Trace(ctx, "read firebase android app config data source")
 
+	// Put data in model
+	data.Id = types.StringValue(appName)
 	data.ConfigFilename = types.StringValue(clientResp.ConfigFilename)
 	data.ConfigFileContents = types.StringValue(clientResp.ConfigFileContents)
 

--- a/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_apple_app_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_apple_app_config.go.tmpl
@@ -75,6 +75,7 @@ func (d *GoogleFirebaseAppleAppConfigDataSource) Schema(ctx context.Context, req
 				Computed:            true,
 			},
 
+			// This is included for backwards compatibility with the original, SDK-implemented data source.
 			"id": schema.StringAttribute{
 				Description:         "Firebase Apple App Config identifier",
 				MarkdownDescription: "Firebase Apple App Config identifier",
@@ -116,25 +117,24 @@ func (d *GoogleFirebaseAppleAppConfigDataSource) Read(ctx context.Context, req d
 		return
 	}
 
-	d.client.UserAgent = fwtransport.GenerateFrameworkUserAgentString(metaData, d.client.UserAgent)
-
-	client := firebase.NewProjectsIosAppsService(d.client)
-
 	// Read Terraform configuration data into the model
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
+	// Use provider_meta to set User-Agent
+	d.client.UserAgent = fwtransport.GenerateFrameworkUserAgentString(metaData, d.client.UserAgent)
+
 	data.Project = fwresource.GetProjectFramework(data.Project, d.project, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
+	// GET Request
+	service := firebase.NewProjectsIosAppsService(d.client)
 	appName := fmt.Sprintf("projects/%s/iosApps/%s/config", data.Project.ValueString(), data.AppId.ValueString())
-	data.Id = types.StringValue(appName)
-
-	clientResp, err := client.GetConfig(appName).Do()
+	clientResp, err := service.GetConfig(appName).Do()
 	if err != nil {
 		fwtransport.HandleDatasourceNotFoundError(ctx, err, &resp.State, fmt.Sprintf("dataSourceFirebaseAppleAppConfig %q", data.AppId.ValueString()), &resp.Diagnostics)
 		if resp.Diagnostics.HasError() {
@@ -144,6 +144,8 @@ func (d *GoogleFirebaseAppleAppConfigDataSource) Read(ctx context.Context, req d
 
 	tflog.Trace(ctx, "read firebase apple app config data source")
 
+	// Put data in model
+	data.Id = types.StringValue(appName)
 	data.ConfigFilename = types.StringValue(clientResp.ConfigFilename)
 	data.ConfigFileContents = types.StringValue(clientResp.ConfigFileContents)
 

--- a/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_web_app_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_web_app_config.go.tmpl
@@ -87,17 +87,17 @@ func (d *GoogleFirebaseWebAppConfigDataSource) Schema(ctx context.Context, req d
 			},
 
 			"location_id": schema.StringAttribute{
-				Description:         "The ID of the project's default GCP resource location. The location is one of the available GCP resource locations. " +
-					"This field is omitted if the default GCP resource location has not been finalized yet. To set your project's "	+
+				Description: "The ID of the project's default GCP resource location. The location is one of the available GCP resource locations. " +
+					"This field is omitted if the default GCP resource location has not been finalized yet. To set your project's " +
 					"default GCP resource location, call defaultLocation.finalize after you add Firebase services to your project.",
 				MarkdownDescription: "The ID of the project's default GCP resource location. The location is one of the available GCP resource locations. " +
-					"This field is omitted if the default GCP resource location has not been finalized yet. To set your project's "	+
+					"This field is omitted if the default GCP resource location has not been finalized yet. To set your project's " +
 					"default GCP resource location, call defaultLocation.finalize after you add Firebase services to your project.",
-				Computed:            true,
+				Computed: true,
 			},
 
 			"measurement_id": schema.StringAttribute{
-				Description:         "The unique Google-assigned identifier of the Google Analytics web stream associated with the Firebase Web App. " +
+				Description: "The unique Google-assigned identifier of the Google Analytics web stream associated with the Firebase Web App. " +
 					"Firebase SDKs use this ID to interact with Google Analytics APIs. " +
 					"This field is only present if the App is linked to a web stream in a Google Analytics App + Web property. " +
 					"Learn more about this ID and Google Analytics web streams in the Analytics documentation. " +
@@ -107,7 +107,7 @@ func (d *GoogleFirebaseWebAppConfigDataSource) Schema(ctx context.Context, req d
 					"This field is only present if the App is linked to a web stream in a Google Analytics App + Web property. " +
 					"Learn more about this ID and Google Analytics web streams in the Analytics documentation. " +
 					"To generate a measurementId and link the Web App with a Google Analytics web stream, call projects.addGoogleAnalytics.",
-				Computed:            true,
+				Computed: true,
 			},
 
 			"messaging_sender_id": schema.StringAttribute{
@@ -122,6 +122,7 @@ func (d *GoogleFirebaseWebAppConfigDataSource) Schema(ctx context.Context, req d
 				Computed:            true,
 			},
 
+			// This is included for backwards compatibility with the original, SDK-implemented data source.
 			"id": schema.StringAttribute{
 				Description:         "Firebase Web App Config identifier",
 				MarkdownDescription: "Firebase Web App Config identifier",
@@ -163,25 +164,24 @@ func (d *GoogleFirebaseWebAppConfigDataSource) Read(ctx context.Context, req dat
 		return
 	}
 
-	d.client.UserAgent = fwtransport.GenerateFrameworkUserAgentString(metaData, d.client.UserAgent)
-
-	client := firebase.NewProjectsWebAppsService(d.client)
-
 	// Read Terraform configuration data into the model
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
+	// Use provider_meta to set User-Agent
+	d.client.UserAgent = fwtransport.GenerateFrameworkUserAgentString(metaData, d.client.UserAgent)
+
 	data.Project = fwresource.GetProjectFramework(data.Project, d.project, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
+	// GET Request
+	service := firebase.NewProjectsWebAppsService(d.client)
 	appName := fmt.Sprintf("projects/%s/webApps/%s/config", data.Project.ValueString(), data.WebAppId.ValueString())
-	data.Id = data.WebAppId
-
-	clientResp, err := client.GetConfig(appName).Do()
+	clientResp, err := service.GetConfig(appName).Do()
 	if err != nil {
 		fwtransport.HandleDatasourceNotFoundError(ctx, err, &resp.State, fmt.Sprintf("dataSourceFirebaseWebAppConfig %q", data.WebAppId.ValueString()), &resp.Diagnostics)
 		if resp.Diagnostics.HasError() {
@@ -191,6 +191,8 @@ func (d *GoogleFirebaseWebAppConfigDataSource) Read(ctx context.Context, req dat
 
 	tflog.Trace(ctx, "read firebase web app config data source")
 
+	// Put data in model
+	data.Id = data.WebAppId
 	data.ApiKey = types.StringValue(clientResp.ApiKey)
 	data.AuthDomain = types.StringValue(clientResp.AuthDomain)
 	data.DatabaseUrl = types.StringValue(clientResp.DatabaseURL)

--- a/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_web_app_config_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_web_app_config_test.go.tmpl
@@ -1,0 +1,50 @@
+package firebase_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccDataSourceGoogleFirebaseWebAppConfig(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project_id":   envvar.GetTestProjectFromEnv(),
+		"display_name": "tf_test Display Name WebApp DataSource",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		CheckDestroy: testAccCheckFirebaseWebAppDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+				Config:                   testAccDataSourceGoogleFirebaseWebAppConfig(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.google_firebase_web_app_config.my_app_config", "api_key"),
+					resource.TestCheckResourceAttrSet("data.google_firebase_web_app_config.my_app_config", "auth_domain"),
+					resource.TestCheckResourceAttrSet("data.google_firebase_web_app_config.my_app_config", "database_url"),
+					resource.TestCheckResourceAttrSet("data.google_firebase_web_app_config.my_app_config", "storage_bucket"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleFirebaseWebAppConfig(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_firebase_web_app" "my_app" {
+  project = "%{project_id}"
+  display_name = "%{display_name}"
+}
+
+data "google_firebase_web_app_config" "my_app_config" {
+  web_app_id = google_firebase_web_app.my_app.app_id
+}
+`, context)
+}
+{{- end }}

--- a/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_web_app_config_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_web_app_config_test.go.tmpl
@@ -10,8 +10,9 @@ import (
 )
 
 func TestAccDataSourceGoogleFirebaseWebAppConfig(t *testing.T) {
+	// TODO: https://github.com/hashicorp/terraform-provider-google/issues/14158
+	acctest.SkipIfVcr(t)
 	t.Parallel()
-
 	context := map[string]interface{}{
 		"project_id":   envvar.GetTestProjectFromEnv(),
 		"display_name": "tf_test Display Name WebApp DataSource",


### PR DESCRIPTION
This PR:
* adds a missing test for the Firebase data sources in the provider
* slightly refactors existing Firebases data sources that have been migrated to the plugin-framework
    * doesn't impact function, instead structures the code differently and adds new comments



<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
