### PR TITLE
Use subnets with `privateIpGoogleAccess: true` in tests, as is required when u…

### DIFF
--- a/mmv1/third_party/terraform/services/dataproc/iam_dataproc_cluster_test.go
+++ b/mmv1/third_party/terraform/services/dataproc/iam_dataproc_cluster_test.go
@@ -17,7 +17,7 @@ func TestAccDataprocClusterIamBinding(t *testing.T) {
 	role := "roles/editor"
 
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	importId := fmt.Sprintf("projects/%s/regions/%s/clusters/%s %s",
@@ -63,7 +63,7 @@ func TestAccDataprocClusterIamMember(t *testing.T) {
 	role := "roles/editor"
 
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	importId := fmt.Sprintf("projects/%s/regions/%s/clusters/%s %s serviceAccount:%s",
@@ -105,7 +105,7 @@ func TestAccDataprocClusterIamPolicy(t *testing.T) {
 	role := "roles/editor"
 
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	importId := fmt.Sprintf("projects/%s/regions/%s/clusters/%s",

--- a/mmv1/third_party/terraform/services/dataproc/iam_dataproc_job_test.go
+++ b/mmv1/third_party/terraform/services/dataproc/iam_dataproc_job_test.go
@@ -18,7 +18,7 @@ func TestAccDataprocJobIamBinding(t *testing.T) {
 	role := "roles/editor"
 
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	importId := fmt.Sprintf("projects/%s/regions/%s/jobs/%s %s",
@@ -61,7 +61,7 @@ func TestAccDataprocJobIamMember(t *testing.T) {
 	role := "roles/editor"
 
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	importId := fmt.Sprintf("projects/%s/regions/%s/jobs/%s %s serviceAccount:%s",
@@ -98,7 +98,7 @@ func TestAccDataprocJobIamPolicy(t *testing.T) {
 	role := "roles/editor"
 
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	importId := fmt.Sprintf("projects/%s/regions/%s/jobs/%s",

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
@@ -58,15 +58,19 @@ func TestAccDataprocCluster_missingZoneGlobalRegion2(t *testing.T) {
 func TestAccDataprocCluster_basic(t *testing.T) {
 	t.Parallel()
 
-	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "gke-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
+	var cluster dataproc.Cluster
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_basic(rnd),
+				Config: testAccDataprocCluster_basic(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.basic", &cluster),
 
@@ -426,15 +430,18 @@ func TestAccDataprocCluster_updatable(t *testing.T) {
 	t.Parallel()
 
 	rnd := acctest.RandString(t, 10)
-	var cluster dataproc.Cluster
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
+	var cluster dataproc.Cluster
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_updatable(rnd, 2, 1),
+				Config: testAccDataprocCluster_updatable(rnd, subnetworkName, 2, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.updatable", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.master_config.0.num_instances", "1"),
@@ -442,7 +449,7 @@ func TestAccDataprocCluster_updatable(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.preemptible_worker_config.0.num_instances", "1")),
 			},
 			{
-				Config: testAccDataprocCluster_updatable(rnd, 2, 0),
+				Config: testAccDataprocCluster_updatable(rnd, subnetworkName, 2, 0),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.updatable", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.master_config.0.num_instances", "1"),
@@ -450,7 +457,7 @@ func TestAccDataprocCluster_updatable(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.preemptible_worker_config.0.num_instances", "0")),
 			},
 			{
-				Config: testAccDataprocCluster_updatable(rnd, 3, 2),
+				Config: testAccDataprocCluster_updatable(rnd, subnetworkName, 3, 2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.master_config.0.num_instances", "1"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.worker_config.0.num_instances", "3"),
@@ -514,6 +521,10 @@ func TestAccDataprocCluster_spotWithInstanceFlexibilityPolicy(t *testing.T) {
 	t.Parallel()
 
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	var cluster dataproc.Cluster
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -521,7 +532,7 @@ func TestAccDataprocCluster_spotWithInstanceFlexibilityPolicy(t *testing.T) {
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_spotWithInstanceFlexibilityPolicy(rnd),
+				Config: testAccDataprocCluster_spotWithInstanceFlexibilityPolicy(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.spot_with_instance_flexibility_policy", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.spot_with_instance_flexibility_policy", "cluster_config.0.preemptible_worker_config.0.preemptibility", "SPOT"),
@@ -538,6 +549,10 @@ func TestAccDataprocCluster_spotWithAuxiliaryNodeGroups(t *testing.T) {
 
 	project := envvar.GetTestProjectFromEnv()
 	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
 	var cluster dataproc.Cluster
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -545,7 +560,7 @@ func TestAccDataprocCluster_spotWithAuxiliaryNodeGroups(t *testing.T) {
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withAuxiliaryNodeGroups(rnd),
+				Config: testAccDataprocCluster_withAuxiliaryNodeGroups(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_auxiliary_node_groups", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_auxiliary_node_groups", "cluster_config.0.auxiliary_node_groups.0.node_group.0.roles.0", "DRIVER"),
@@ -1050,15 +1065,19 @@ func TestAccDataprocCluster_withMetastoreConfig(t *testing.T) {
 	msName_basic := fmt.Sprintf("projects/%s/locations/us-central1/services/%s", pid, basicServiceId)
 	msName_update := fmt.Sprintf("projects/%s/locations/us-central1/services/%s", pid, updateServiceId)
 	
-	var cluster dataproc.Cluster
 	clusterName := "tf-test-" + acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
+	var cluster dataproc.Cluster
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withMetastoreConfig(clusterName, basicServiceId),
+				Config: testAccDataprocCluster_withMetastoreConfig(clusterName, subnetworkName, basicServiceId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_metastore_config", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_metastore_config", "cluster_config.0.metastore_config.0.dataproc_metastore_service",msName_basic),
@@ -1066,7 +1085,7 @@ func TestAccDataprocCluster_withMetastoreConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDataprocCluster_withMetastoreConfig_update(clusterName, updateServiceId),
+				Config: testAccDataprocCluster_withMetastoreConfig_update(clusterName, subnetworkName, updateServiceId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_metastore_config", &cluster),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_metastore_config", "cluster_config.0.metastore_config.0.dataproc_metastore_service", msName_update),
@@ -1329,13 +1348,19 @@ resource "google_dataproc_cluster" "basic" {
 `, rnd)
 }
 
-func testAccDataprocCluster_basic(rnd string) string {
+func testAccDataprocCluster_basic(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "basic" {
   name   = "tf-test-dproc-%s"
   region = "us-central1"
+
+  cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+  }
 }
-`, rnd)
+`, rnd, subnetworkName)
 }
 
 func testAccDataprocVirtualCluster_basic(projectID, rnd, networkName, subnetworkName string) string {
@@ -1382,7 +1407,7 @@ resource "google_dataproc_cluster" "virtual_cluster" {
 		kubernetes_namespace = "tf-test-dproc-%s"
 		kubernetes_software_config {
 		  component_version = {
-			"SPARK": "3.1-dataproc-7",
+			"SPARK": "latest",
 		  }
 		}
 		gke_cluster_config {
@@ -1426,6 +1451,8 @@ resource "google_dataproc_cluster" "accelerated_cluster" {
     }
 
     master_config {
+      # The default machine family is n2, which does not support (most) accelerators.
+      machine_type = 'n1-standard-2'
       accelerators {
         accelerator_type  = "%s"
         accelerator_count = "1"
@@ -1433,6 +1460,8 @@ resource "google_dataproc_cluster" "accelerated_cluster" {
     }
 
     worker_config {
+      # The default machine family is n2, which does not support (most) accelerators.
+      machine_type = 'n1-standard-2'
       accelerators {
         accelerator_type  = "%s"
         accelerator_count = "1"
@@ -1637,7 +1666,7 @@ resource "google_compute_node_template" "nodetmpl" {
     tfacc = "test"
   }
 
-  node_type = "n1-node-96-624"
+  node_type = "n2-node-80-640"
 
   cpu_overcommit_type = "ENABLED"
 }
@@ -1791,7 +1820,7 @@ resource "google_dataproc_cluster" "with_init_action" {
 `, bucket, rnd, objName, objName, rnd, subnetworkName)
 }
 
-func testAccDataprocCluster_updatable(rnd string, w, p int) string {
+func testAccDataprocCluster_updatable(rnd, subnetworkName string, w, p int) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "updatable" {
   name   = "tf-test-dproc-%s"
@@ -1799,6 +1828,10 @@ resource "google_dataproc_cluster" "updatable" {
   graceful_decommission_timeout = "0.2s"
 
   cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+
     master_config {
       num_instances = "1"
       machine_type  = "e2-medium"
@@ -1823,7 +1856,7 @@ resource "google_dataproc_cluster" "updatable" {
     }
   }
 }
-`, rnd, w, p)
+`, rnd, subnetworkName, w, p)
 }
 
 func testAccDataprocCluster_nonPreemptibleSecondary(rnd, subnetworkName string) string {
@@ -1872,6 +1905,12 @@ resource "google_dataproc_cluster" "spot_secondary" {
   region = "us-central1"
 
   cluster_config {
+    # TODO(harwayne): Remove once internal_ip_only is respected properly. Until
+    # then, force the Dataproc version to have internal_ip_only false.
+    software_config {
+      image_version = "2.2"
+    }
+
     gce_cluster_config {
       subnetwork = "%s"
     }
@@ -1904,13 +1943,17 @@ resource "google_dataproc_cluster" "spot_secondary" {
 	`, rnd, subnetworkName)
 }
 
-func testAccDataprocCluster_spotWithInstanceFlexibilityPolicy(rnd string) string {
+func testAccDataprocCluster_spotWithInstanceFlexibilityPolicy(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "spot_with_instance_flexibility_policy" {
   name   = "tf-test-dproc-%s"
   region = "us-central1"
 
   cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+
     master_config {
       num_instances = "1"
       machine_type  = "e2-medium"
@@ -1942,16 +1985,20 @@ resource "google_dataproc_cluster" "spot_with_instance_flexibility_policy" {
     }
   }
 }
-	`, rnd)
+	`, rnd, subnetworkName)
 }
 
-func testAccDataprocCluster_withAuxiliaryNodeGroups(rnd string) string {
+func testAccDataprocCluster_withAuxiliaryNodeGroups(rnd, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_auxiliary_node_groups" {
   name   = "tf-test-dproc-%s"
   region = "us-central1"
 
   cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+
     master_config {
       num_instances = "1"
       machine_type  = "e2-medium"
@@ -1991,7 +2038,7 @@ resource "google_dataproc_cluster" "with_auxiliary_node_groups" {
     }
   }
 }
-	`, rnd)
+	`, rnd, subnetworkName)
 }
 
 func testAccDataprocCluster_withStagingBucketOnly(bucketName string) string {
@@ -2332,6 +2379,11 @@ resource "google_dataproc_cluster" "with_net_ref_by_name" {
 
     # Keep the costs down with smallest config we can get away with
     software_config {
+      # TODO(harwayne): Remove once 'internal_ip_only: false' is sent to Dataproc servers.
+      # Until then, use an earlier version of Dataproc that does not default to internal IP
+      # addresses.
+      image_version = "2.1"
+
       override_properties = {
         "dataproc:dataproc.allow.zero.workers" = "true"
       }
@@ -2346,6 +2398,9 @@ resource "google_dataproc_cluster" "with_net_ref_by_name" {
 
     gce_cluster_config {
       network = google_compute_network.dataproc_network.name
+      # The network we are creating does not have private Google access, so it
+      # cannot support internal IPs only.
+      internal_ip_only = false
     }
   }
 }
@@ -2359,6 +2414,11 @@ resource "google_dataproc_cluster" "with_net_ref_by_url" {
 
     # Keep the costs down with smallest config we can get away with
     software_config {
+      # TODO(harwayne): Remove once 'internal_ip_only: false' is sent to Dataproc servers.
+      # Until then, use an earlier version of Dataproc that does not default to internal IP
+      # addresses.
+      image_version = "2.1"
+
       override_properties = {
         "dataproc:dataproc.allow.zero.workers" = "true"
       }
@@ -2373,6 +2433,9 @@ resource "google_dataproc_cluster" "with_net_ref_by_url" {
 
     gce_cluster_config {
       network = google_compute_network.dataproc_network.self_link
+      # The network we are creating does not have private Google access, so it
+      # cannot support internal IPs only.
+      internal_ip_only = false
     }
   }
 }
@@ -2417,6 +2480,13 @@ resource "google_dataproc_cluster" "kerb" {
   cluster_config {
     gce_cluster_config {
       subnetwork = "%s"
+    }
+
+    # TODO(harwayne): Remove once 'internal_ip_only' is a computed field. Until then,
+    # use an earlier version of Dataproc that does not default to internal IP
+    # addresses.
+    software_config {
+      image_version = "2.1"
     }
 
     security_config {
@@ -2502,13 +2572,16 @@ resource "google_dataproc_autoscaling_policy" "asp" {
 `, rnd, subnetworkName, rnd)
 }
 
-func testAccDataprocCluster_withMetastoreConfig(clusterName, serviceId string) string {
+func testAccDataprocCluster_withMetastoreConfig(clusterName, subnetworkName, serviceId string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_metastore_config" {
   name                  = "%s"
   region                = "us-central1"
 
   cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
     metastore_config {
       dataproc_metastore_service = google_dataproc_metastore_service.ms.name
     }
@@ -2530,16 +2603,19 @@ resource "google_dataproc_metastore_service" "ms" {
     version = "3.1.2"
   }
 }
-`, clusterName, serviceId)
+`, clusterName, subnetworkName, serviceId)
 }
 
-func testAccDataprocCluster_withMetastoreConfig_update(clusterName, serviceId string) string {
+func testAccDataprocCluster_withMetastoreConfig_update(clusterName, subnetworkName, serviceId string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_metastore_config" {
   name                  = "%s"
   region                = "us-central1"
 
   cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
     metastore_config {
       dataproc_metastore_service = google_dataproc_metastore_service.ms.name
     }
@@ -2561,6 +2637,6 @@ resource "google_dataproc_metastore_service" "ms" {
     version = "3.1.2"
   }
 }
-`, clusterName, serviceId)
+`, clusterName, subnetworkName, serviceId)
 }
 

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
@@ -114,7 +114,7 @@ func TestAccDataprocVirtualCluster_basic(t *testing.T) {
 	pid := envvar.GetTestProjectFromEnv()
 	version := "3.1-dataproc-7"
 	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "gke-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -155,7 +155,7 @@ func TestAccDataprocCluster_withAccelerators(t *testing.T) {
 	acceleratorType := "nvidia-tesla-t4"
 	zone := "us-central1-c"
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -261,7 +261,7 @@ func TestAccDataprocCluster_withMetadataAndTags(t *testing.T) {
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -289,7 +289,7 @@ func TestAccDataprocCluster_withMinNumInstances(t *testing.T) {
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -315,7 +315,7 @@ func TestAccDataprocCluster_withReservationAffinity(t *testing.T) {
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -343,7 +343,7 @@ func TestAccDataprocCluster_withDataprocMetricConfig(t *testing.T) {
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -372,7 +372,7 @@ func TestAccDataprocCluster_withNodeGroupAffinity(t *testing.T) {
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -397,7 +397,7 @@ func TestAccDataprocCluster_singleNodeCluster(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	var cluster dataproc.Cluster
@@ -465,7 +465,7 @@ func TestAccDataprocCluster_nonPreemptibleSecondary(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	var cluster dataproc.Cluster
 
@@ -490,7 +490,7 @@ func TestAccDataprocCluster_spotSecondary(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	var cluster dataproc.Cluster
 
@@ -574,7 +574,7 @@ func TestAccDataprocCluster_withStagingBucket(t *testing.T) {
 	clusterName := fmt.Sprintf("tf-test-dproc-%s", rnd)
 	bucketName := fmt.Sprintf("%s-bucket", clusterName)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -609,7 +609,7 @@ func TestAccDataprocCluster_withTempBucket(t *testing.T) {
 	clusterName := fmt.Sprintf("tf-test-dproc-%s", rnd)
 	bucketName := fmt.Sprintf("%s-temp-bucket", clusterName)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -643,7 +643,7 @@ func TestAccDataprocCluster_withInitAction(t *testing.T) {
 	bucketName := fmt.Sprintf("tf-test-dproc-%s-init-bucket", rnd)
 	objectName := "msg.txt"
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -670,7 +670,7 @@ func TestAccDataprocCluster_withConfigOverrides(t *testing.T) {
 	rnd := acctest.RandString(t, 10)
 	var cluster dataproc.Cluster
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -696,7 +696,7 @@ func TestAccDataprocCluster_withServiceAcc(t *testing.T) {
 	saEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", sa, envvar.GetTestProjectFromEnv())
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	var cluster dataproc.Cluster
@@ -733,7 +733,10 @@ func TestAccDataprocCluster_withImageVersion(t *testing.T) {
 	rnd := acctest.RandString(t, 10)
 	version := "2.0.35-debian10"
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	// The image version is before 2.2, so does not need private IP access, but we
+	// are giving private IP access for consistency with the other tests. And so
+	// that when this is upgraded to a new version of Dataproc it will work.
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	var cluster dataproc.Cluster
@@ -758,7 +761,7 @@ func TestAccDataprocCluster_withOptionalComponents(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	var cluster dataproc.Cluster
 
@@ -783,7 +786,7 @@ func TestAccDataprocCluster_withLifecycleConfigIdleDeleteTtl(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	var cluster dataproc.Cluster
 
@@ -817,7 +820,7 @@ func TestAccDataprocCluster_withLifecycleConfigAutoDeletion(t *testing.T) {
 	now := time.Now()
 	fmtString := "2006-01-02T15:04:05.072Z"
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	var cluster dataproc.Cluster
@@ -847,7 +850,7 @@ func TestAccDataprocCluster_withLabels(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	var cluster dataproc.Cluster
 
@@ -933,7 +936,7 @@ func TestAccDataprocCluster_withEndpointConfig(t *testing.T) {
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -958,7 +961,7 @@ func TestAccDataprocCluster_KMS(t *testing.T) {
 	rnd := acctest.RandString(t, 10)
 	kms := acctest.BootstrapKMSKey(t)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	if acctest.BootstrapPSARole(t, "service-", "compute-system", "roles/cloudkms.cryptoKeyEncrypterDecrypter") {
@@ -987,7 +990,7 @@ func TestAccDataprocCluster_withKerberos(t *testing.T) {
 	rnd := acctest.RandString(t, 10)
 	kms := acctest.BootstrapKMSKey(t)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	var cluster dataproc.Cluster
@@ -1011,7 +1014,7 @@ func TestAccDataprocCluster_withAutoscalingPolicy(t *testing.T) {
 
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	var cluster dataproc.Cluster

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_job_test.go.tmpl
@@ -50,7 +50,7 @@ func TestAccDataprocJob_updatable(t *testing.T) {
 	rnd := acctest.RandString(t, 10)
 	jobId := fmt.Sprintf("dproc-update-job-id-%s", rnd)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -83,7 +83,7 @@ func TestAccDataprocJob_PySpark(t *testing.T) {
 	rnd := acctest.RandString(t, 10)
 	jobId := fmt.Sprintf("dproc-custom-job-id-%s", rnd)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -125,7 +125,7 @@ func TestAccDataprocJob_Spark(t *testing.T) {
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -161,7 +161,7 @@ func TestAccDataprocJob_Hadoop(t *testing.T) {
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -197,7 +197,7 @@ func TestAccDataprocJob_Hive(t *testing.T) {
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -233,7 +233,7 @@ func TestAccDataprocJob_Pig(t *testing.T) {
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -269,7 +269,7 @@ func TestAccDataprocJob_SparkSql(t *testing.T) {
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -305,7 +305,7 @@ func TestAccDataprocJob_Presto(t *testing.T) {
 	var job dataproc.Job
 	rnd := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	subnetworkName := acctest.BootstrapSubnetForDataprocBatches(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
 	
 	acctest.VcrTest(t, resource.TestCase{


### PR DESCRIPTION
Use subnets with `privateIpGoogleAccess: true` in tests, as is required when using the now default `internal_ip_only: true` (as of Dataproc 2.2).

Note that this is a Test only chang.e

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
