### PR TITLE
Set google_service_account IAM-related fields during plan stage

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account.go
@@ -326,13 +326,13 @@ func resourceGoogleServiceAccountImport(d *schema.ResourceData, meta interface{}
 }
 
 func resourceGoogleServiceAccountPlanOutputs(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
-	if !d.HasChange("account_id") {
+	if d.Get("email") != "" || d.Get("member") != "" {
 		return nil
 	}
 
 	aid := d.Get("account_id")
 	proj := d.Get("project")
-	if aid != nil && proj != nil {
+	if aid != "" && proj != "" {
 		email := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", aid, proj)
 		if err := d.SetNew("email", email); err != nil {
 			return fmt.Errorf("error setting email: %s", err)

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account.go
@@ -3,6 +3,7 @@ package resourcemanager
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -347,6 +348,12 @@ func ResourceServiceAccountCustomDiffFunc(diff tpgresource.TerraformResourceDiff
 	return nil
 }
 func resourceServiceAccountCustomDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	if config.UniverseDomain != "" && config.UniverseDomain != "googleapis.com" {
+		log.Printf("[WARN] The UniverseDomain is set to %q. Skipping resourceServiceAccountCustomDiff", config.UniverseDomain)
+		return nil
+	}
+
 	// separate func to allow unit testing
 	return ResourceServiceAccountCustomDiffFunc(diff)
 }

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account.go
@@ -331,8 +331,8 @@ func ResourceServiceAccountCustomDiffFunc(diff tpgresource.TerraformResourceDiff
 		return nil
 	}
 
-	aid := diff.Get("account_id")
-	proj := diff.Get("project")
+	aid := diff.Get("account_id").(string)
+	proj := diff.Get("project").(string)
 	if aid == "" || proj == "" {
 		return nil
 	}
@@ -348,9 +348,8 @@ func ResourceServiceAccountCustomDiffFunc(diff tpgresource.TerraformResourceDiff
 	return nil
 }
 func resourceServiceAccountCustomDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
-	config := meta.(*transport_tpg.Config)
-	if config.UniverseDomain != "" && config.UniverseDomain != "googleapis.com" {
-		log.Printf("[WARN] The UniverseDomain is set to %q. Skipping resourceServiceAccountCustomDiff", config.UniverseDomain)
+	if ud := transport_tpg.GetUniverseDomainFromMeta(meta); ud != "googleapis.com" {
+		log.Printf("[WARN] The UniverseDomain is set to %q. Skipping resourceServiceAccountCustomDiff", ud)
 		return nil
 	}
 

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account_test.go
@@ -308,6 +308,9 @@ func TestResourceServiceAccountCustomDiff(t *testing.T) {
 
 	accountId := "a" + acctest.RandString(t, 10)
 	project := envvar.GetTestProjectFromEnv()
+	if project == "" {
+		project = "test-project"
+	}
 	expectedEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", accountId, project)
 	expectedMember := "serviceAccount:" + expectedEmail
 

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account_test.go
@@ -319,7 +319,6 @@ func TestResourceServiceAccountCustomDiff(t *testing.T) {
 		name       string
 		before     map[string]interface{}
 		after      map[string]interface{}
-		result     map[string]interface{}
 		wantEmail  string
 		wantMember string
 	}{
@@ -390,10 +389,10 @@ func TestResourceServiceAccountCustomDiff(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc.result = maps.Clone(tc.after)
+		result := maps.Clone(tc.after)
 		if tc.wantEmail != "" || tc.wantMember != "" {
-			tc.result["email"] = tc.wantEmail
-			tc.result["member"] = tc.wantMember
+			result["email"] = tc.wantEmail
+			result["member"] = tc.wantMember
 		}
 		t.Run(tc.name, func(t *testing.T) {
 			diff := &tpgresource.ResourceDiffMock{
@@ -402,8 +401,8 @@ func TestResourceServiceAccountCustomDiff(t *testing.T) {
 				Schema: tpgresourcemanager.ResourceGoogleServiceAccount().Schema,
 			}
 			tpgresourcemanager.ResourceServiceAccountCustomDiffFunc(diff)
-			if d := cmp.Diff(tc.result, diff.After); d != "" {
-				t.Fatalf("got unexpected change: %v expected: %v", diff.After, tc.result)
+			if d := cmp.Diff(result, diff.After); d != "" {
+				t.Fatalf("got unexpected change: %v expected: %v", diff.After, result)
 			}
 		})
 	}

--- a/mmv1/third_party/terraform/tpgresource/resource_test_utils.go
+++ b/mmv1/third_party/terraform/tpgresource/resource_test_utils.go
@@ -79,6 +79,7 @@ type ResourceDiffMock struct {
 	Before     map[string]interface{}
 	After      map[string]interface{}
 	Cleared    map[string]interface{}
+	Schema     map[string]*schema.Schema
 	IsForceNew bool
 }
 
@@ -110,6 +111,32 @@ func (d *ResourceDiffMock) Clear(key string) error {
 
 func (d *ResourceDiffMock) ForceNew(key string) error {
 	d.IsForceNew = true
+	return nil
+}
+
+func (d *ResourceDiffMock) SetNew(key string, value interface{}) error {
+	if len(d.Schema) > 0 {
+		if err := d.checkKey(key, "SetNew"); err != nil {
+			return err
+		}
+	}
+
+	d.After[key] = value
+	return nil
+}
+
+func (d *ResourceDiffMock) checkKey(key, caller string) error {
+	var schema *schema.Schema
+	s, ok := d.Schema[key]
+	if ok {
+		schema = s
+	}
+	if schema == nil {
+		return fmt.Errorf("%s: invalid key: %s", caller, key)
+	}
+	if !schema.Computed {
+		return fmt.Errorf("%s only operates on computed keys - %s is not one", caller, key)
+	}
 	return nil
 }
 

--- a/mmv1/third_party/terraform/tpgresource/utils.go
+++ b/mmv1/third_party/terraform/tpgresource/utils.go
@@ -54,6 +54,7 @@ type TerraformResourceDiff interface {
 	GetOk(string) (interface{}, bool)
 	Clear(string) error
 	ForceNew(string) error
+	SetNew(string, interface{}) error
 }
 
 // Contains functions that don't really belong anywhere else.

--- a/mmv1/third_party/terraform/transport/config.go.tmpl
+++ b/mmv1/third_party/terraform/transport/config.go.tmpl
@@ -1352,3 +1352,11 @@ func GetRegionFromRegionSelfLink(selfLink string) string {
 	}
 	return selfLink
 }
+
+func GetUniverseDomainFromMeta(meta interface{}) string {
+	config := meta.(*Config)
+	if config.UniverseDomain != "" && config.UniverseDomain != "googleapis.com" {
+		return "googleapis.com"
+	}
+	return config.UniverseDomain
+}

--- a/mmv1/third_party/terraform/transport/config.go.tmpl
+++ b/mmv1/third_party/terraform/transport/config.go.tmpl
@@ -1355,7 +1355,7 @@ func GetRegionFromRegionSelfLink(selfLink string) string {
 
 func GetUniverseDomainFromMeta(meta interface{}) string {
 	config := meta.(*Config)
-	if config.UniverseDomain != "" && config.UniverseDomain != "googleapis.com" {
+	if config.UniverseDomain == "" {
 		return "googleapis.com"
 	}
 	return config.UniverseDomain

--- a/mmv1/third_party/tgc/tests/data/example_container_cluster.json
+++ b/mmv1/third_party/tgc/tests/data/example_container_cluster.json
@@ -46,7 +46,8 @@
                     "oauthScopes": [
                         "https://www.googleapis.com/auth/cloud-platform"
                     ],
-                    "preemptible": true
+                    "preemptible": true,
+                    "serviceAccount": "service-account-cc@{{.Provider.project}}.iam.gserviceaccount.com"
                 },
                 "location": "us-central1",
                 "management": {

--- a/mmv1/third_party/tgc/tests/data/example_google_composer_environment.json
+++ b/mmv1/third_party/tgc/tests/data/example_google_composer_environment.json
@@ -7,7 +7,7 @@
                 {
                     "role": "roles/composer.worker",
                     "members": [
-                        ""
+                        "serviceAccount:composer-new-account@{{.Provider.project}}.iam.gserviceaccount.com"
                     ]
                 }
             ]


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This sets the IAM-related fields on `google_service_account` with CustomizeDiff so they won't be "known after apply" and can be used to set IAM rules in a single TF run. I couldn't find any existing issues around it, but it has been a thorn in my side for a while.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
resourcemanager: made `google_service_account` `email` and `member` fields available during plan
```
