### PR TITLE
Update forward_ssh_connectivity.private_key to be mutable

### DIFF
--- a/mmv1/products/datastream/ConnectionProfile.yaml
+++ b/mmv1/products/datastream/ConnectionProfile.yaml
@@ -404,7 +404,6 @@ properties:
         type: String
         description: |
           SSH private key.
-        immutable: true
         sensitive: true
         conflicts:
           - forward_ssh_connectivity.0.password

--- a/mmv1/third_party/terraform/services/datastream/resource_datastream_connection_profile_test.go
+++ b/mmv1/third_party/terraform/services/datastream/resource_datastream_connection_profile_test.go
@@ -17,8 +17,8 @@ func TestAccDatastreamConnectionProfile_update(t *testing.T) {
 		"random_suffix": acctest.RandString(t, 10),
 	}
 
-	// random_pass_1 := acctest.RandString(t, 10)
-	// random_pass_2 := acctest.RandString(t, 10)
+	random_pass_1 := acctest.RandString(t, 10)
+	random_pass_2 := acctest.RandString(t, 10)
 
 	pubkey1, privkey1, _ := acctest2.RandSSHKeyPair("ssh-acceptance-test")
 	pubkey2, privkey2, _ := acctest2.RandSSHKeyPair("ssh-acceptance-test")
@@ -34,51 +34,51 @@ func TestAccDatastreamConnectionProfile_update(t *testing.T) {
 		},
 		CheckDestroy: testAccCheckDatastreamConnectionProfileDestroyProducer(t),
 		Steps: []resource.TestStep{
-			// {
-			// 	Config: testAccDatastreamConnectionProfile_update(context),
-			// },
-			// {
-			// 	ResourceName:            "google_datastream_connection_profile.default",
-			// 	ImportState:             true,
-			// 	ImportStateVerify:       true,
-			// 	ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "create_without_validation"},
-			// },
-			// {
-			// 	Config: testAccDatastreamConnectionProfile_update2(context, true),
-			// },
-			// {
-			// 	ResourceName:            "google_datastream_connection_profile.default",
-			// 	ImportState:             true,
-			// 	ImportStateVerify:       true,
-			// 	ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "create_without_validation", "postgresql_profile.0.password"},
-			// },
-			// {
-			// 	// Disable prevent_destroy
-			// 	Config: testAccDatastreamConnectionProfile_update2(context, false),
-			// },
-			// {
-			// 	Config: testAccDatastreamConnectionProfile_mySQLUpdate(context, true, random_pass_1),
-			// },
-			// {
-			// 	ResourceName:            "google_datastream_connection_profile.mysql_con_profile",
-			// 	ImportState:             true,
-			// 	ImportStateVerify:       true,
-			// 	ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "create_without_validation", "mysql_profile.0.password"},
-			// },
-			// {
-			// 	// run once more to update the password. it should update it in-place
-			// 	Config: testAccDatastreamConnectionProfile_mySQLUpdate(context, true, random_pass_2),
-			// },
-			// {
-			// 	ResourceName:            "google_datastream_connection_profile.mysql_con_profile",
-			// 	ImportState:             true,
-			// 	ImportStateVerify:       true,
-			// 	ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "create_without_validation", "mysql_profile.0.password"},
-			// },
-			// {
-			// 	// Disable prevent_destroy
-			// 	Config: testAccDatastreamConnectionProfile_mySQLUpdate(context, false, random_pass_2),
-			// },
+			{
+				Config: testAccDatastreamConnectionProfile_update(context),
+			},
+			{
+				ResourceName:            "google_datastream_connection_profile.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "create_without_validation"},
+			},
+			{
+				Config: testAccDatastreamConnectionProfile_update2(context, true),
+			},
+			{
+				ResourceName:            "google_datastream_connection_profile.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "create_without_validation", "postgresql_profile.0.password"},
+			},
+			{
+				// Disable prevent_destroy
+				Config: testAccDatastreamConnectionProfile_update2(context, false),
+			},
+			{
+				Config: testAccDatastreamConnectionProfile_mySQLUpdate(context, true, random_pass_1),
+			},
+			{
+				ResourceName:            "google_datastream_connection_profile.mysql_con_profile",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "create_without_validation", "mysql_profile.0.password"},
+			},
+			{
+				// run once more to update the password. it should update it in-place
+				Config: testAccDatastreamConnectionProfile_mySQLUpdate(context, true, random_pass_2),
+			},
+			{
+				ResourceName:            "google_datastream_connection_profile.mysql_con_profile",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "create_without_validation", "mysql_profile.0.password"},
+			},
+			{
+				// Disable prevent_destroy
+				Config: testAccDatastreamConnectionProfile_mySQLUpdate(context, false, random_pass_2),
+			},
 			{
 				Config: testAccDatastreamConnectionProfile_SSHKey_Update(context, true, random_privkey_1, pubkey1),
 			},

--- a/mmv1/third_party/terraform/services/datastream/resource_datastream_connection_profile_test.go
+++ b/mmv1/third_party/terraform/services/datastream/resource_datastream_connection_profile_test.go
@@ -1,10 +1,11 @@
 package datastream_test
 
 import (
-	"testing"
-
+	acctest2 "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"strings"
+	"testing"
 )
 
 func TestAccDatastreamConnectionProfile_update(t *testing.T) {
@@ -16,11 +17,14 @@ func TestAccDatastreamConnectionProfile_update(t *testing.T) {
 		"random_suffix": acctest.RandString(t, 10),
 	}
 
-	random_pass_1 := acctest.RandString(t, 10)
-	random_pass_2 := acctest.RandString(t, 10)
+	// random_pass_1 := acctest.RandString(t, 10)
+	// random_pass_2 := acctest.RandString(t, 10)
 
-	random_key_1 := acctest.RandString(t, 10)
-	random_key_2 := acctest.RandString(t, 10)
+	pubkey1, privkey1, _ := acctest2.RandSSHKeyPair("ssh-acceptance-test")
+	pubkey2, privkey2, _ := acctest2.RandSSHKeyPair("ssh-acceptance-test")
+
+	random_privkey_1 := strings.ReplaceAll(privkey1, "\n", "\\n")
+	random_privkey_2 := strings.ReplaceAll(privkey2, "\n", "\\n")
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -30,72 +34,72 @@ func TestAccDatastreamConnectionProfile_update(t *testing.T) {
 		},
 		CheckDestroy: testAccCheckDatastreamConnectionProfileDestroyProducer(t),
 		Steps: []resource.TestStep{
+			// {
+			// 	Config: testAccDatastreamConnectionProfile_update(context),
+			// },
+			// {
+			// 	ResourceName:            "google_datastream_connection_profile.default",
+			// 	ImportState:             true,
+			// 	ImportStateVerify:       true,
+			// 	ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "create_without_validation"},
+			// },
+			// {
+			// 	Config: testAccDatastreamConnectionProfile_update2(context, true),
+			// },
+			// {
+			// 	ResourceName:            "google_datastream_connection_profile.default",
+			// 	ImportState:             true,
+			// 	ImportStateVerify:       true,
+			// 	ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "create_without_validation", "postgresql_profile.0.password"},
+			// },
+			// {
+			// 	// Disable prevent_destroy
+			// 	Config: testAccDatastreamConnectionProfile_update2(context, false),
+			// },
+			// {
+			// 	Config: testAccDatastreamConnectionProfile_mySQLUpdate(context, true, random_pass_1),
+			// },
+			// {
+			// 	ResourceName:            "google_datastream_connection_profile.mysql_con_profile",
+			// 	ImportState:             true,
+			// 	ImportStateVerify:       true,
+			// 	ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "create_without_validation", "mysql_profile.0.password"},
+			// },
+			// {
+			// 	// run once more to update the password. it should update it in-place
+			// 	Config: testAccDatastreamConnectionProfile_mySQLUpdate(context, true, random_pass_2),
+			// },
+			// {
+			// 	ResourceName:            "google_datastream_connection_profile.mysql_con_profile",
+			// 	ImportState:             true,
+			// 	ImportStateVerify:       true,
+			// 	ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "create_without_validation", "mysql_profile.0.password"},
+			// },
+			// {
+			// 	// Disable prevent_destroy
+			// 	Config: testAccDatastreamConnectionProfile_mySQLUpdate(context, false, random_pass_2),
+			// },
 			{
-				Config: testAccDatastreamConnectionProfile_update(context),
-			},
-			{
-				ResourceName:            "google_datastream_connection_profile.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"connection_profile_id", "location"},
-			},
-			{
-				Config: testAccDatastreamConnectionProfile_update2(context, true),
-			},
-			{
-				ResourceName:            "google_datastream_connection_profile.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "postgresql_profile.0.password"},
-			},
-			{
-				// Disable prevent_destroy
-				Config: testAccDatastreamConnectionProfile_update2(context, false),
-			},
-			{
-				Config: testAccDatastreamConnectionProfile_mySQLUpdate(context, true, random_pass_1),
-			},
-			{
-				ResourceName:            "google_datastream_connection_profile.mysql_con_profile",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "mysql_profile.0.password"},
-			},
-			{
-				// run once more to update the password. it should update it in-place
-				Config: testAccDatastreamConnectionProfile_mySQLUpdate(context, true, random_pass_2),
-			},
-			{
-				ResourceName:            "google_datastream_connection_profile.mysql_con_profile",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "mysql_profile.0.password"},
-			},
-			{
-				// Disable prevent_destroy
-				Config: testAccDatastreamConnectionProfile_mySQLUpdate(context, false, random_pass_2),
-			},
-			{
-				Config: testAccDatastreamConnectionProfile_SSHKey_Update(context, true, random_key_1),
+				Config: testAccDatastreamConnectionProfile_SSHKey_Update(context, true, random_privkey_1, pubkey1),
 			},
 			{
 				ResourceName:            "google_datastream_connection_profile.ssh_connectivity_profile",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "forward_ssh_connectivity.0.private_key"},
+				ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "create_without_validation", "forward_ssh_connectivity.0.private_key"},
 			},
 			{
 
-				Config: testAccDatastreamConnectionProfile_SSHKey_Update(context, true, random_key_2),
+				Config: testAccDatastreamConnectionProfile_SSHKey_Update(context, true, random_privkey_2, pubkey2),
 			},
 			{
 				ResourceName:            "google_datastream_connection_profile.ssh_connectivity_profile",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "forward_ssh_connectivity.0.private_key"},
+				ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "create_without_validation", "forward_ssh_connectivity.0.private_key"},
 			},
 			{
-				Config: testAccDatastreamConnectionProfile_SSHKey_Update(context, false, random_key_2),
+				Config: testAccDatastreamConnectionProfile_SSHKey_Update(context, false, random_privkey_2, pubkey2),
 			},
 		},
 	})
@@ -273,7 +277,7 @@ resource "google_datastream_connection_profile" "mysql_con_profile" {
 `, context)
 }
 
-func testAccDatastreamConnectionProfile_SSHKey_Update(context map[string]interface{}, preventDestroy bool, private_key string) string {
+func testAccDatastreamConnectionProfile_SSHKey_Update(context map[string]interface{}, preventDestroy bool, private_key string, public_key string) string {
 	context["lifecycle_block"] = ""
 	if preventDestroy {
 		context["lifecycle_block"] = `
@@ -281,8 +285,8 @@ func testAccDatastreamConnectionProfile_SSHKey_Update(context map[string]interfa
             prevent_destroy = true
         }`
 	}
-
 	context["private_key"] = private_key
+	context["public_key"] = public_key
 
 	return acctest.Nprintf(`
 resource "google_sql_database_instance" "instance" {
@@ -319,41 +323,70 @@ resource "google_sql_database_instance" "instance" {
         deletion_protection  = "false"
     }
     
-    resource "google_sql_database" "db" {
+resource "google_sql_database" "db" {
         instance = google_sql_database_instance.instance.name
         name     = "db"
     }
-    
-    resource "random_password" "pwd" {
-        length = 16
-        special = false
-    }
-    
-    resource "google_sql_user" "user" {
+ 
+resource "google_sql_user" "user" {
         name = "user"
         instance = google_sql_database_instance.instance.name
-        password = random_password.pwd.result
+        password = "Ckrw75FbtmKrTKCtWPFJS54cTdbGC8D82rJwp3gV"
     }
+
+resource "google_compute_instance" "default" {
+		name         = "test-bastion"
+		machine_type = "e2-small"
+		zone         = "us-central1-a"
+		boot_disk {
+			initialize_params {
+			image = "debian-11-bullseye-v20241009"
+		  }
+		}
+
+		network_interface {
+		  network = "default"
+		  access_config {
+
+		  }
+		}
+		metadata = {
+		  "ssh-keys" = "${google_sql_user.user.name}:%{public_key}"
+		}
+	  }
+  
+resource "google_compute_firewall" "ssh" {
+		name = "tf-test-%{random_suffix}"
+		allow {
+		  ports    = ["22"]
+		  protocol = "tcp"
+		}
+		direction     = "INGRESS"
+		network       = "default"
+		priority      = 1000
+		source_ranges = ["0.0.0.0/0"]
+		target_tags   = ["ssh"]
+}
 
 resource "google_datastream_connection_profile" "ssh_connectivity_profile" {
-    display_name          = "Source connection profile"
-    location              = "us-central1"
-    connection_profile_id = "tf-test-mysql-profile%{random_suffix}"
+        display_name          = "Source connection profile"
+        location              = "us-central1"
+        connection_profile_id = "tf-test-mysql-profile%{random_suffix}"
 
-    postgresql_profile {
-        hostname = google_sql_database_instance.instance.public_ip_address
-        username = google_sql_user.user.name
-        password = google_sql_user.user.password
-        database = google_sql_database.db.name
-    }
+    	postgresql_profile {
+        	hostname = google_sql_database_instance.instance.public_ip_address
+        	username = google_sql_user.user.name
+        	password = google_sql_user.user.password
+        	database = google_sql_database.db.name
+    	}
 
-    forward_ssh_connectivity {
-        hostname = google_sql_database_instance.instance.public_ip_address
-        username = google_sql_user.user.name
-        port     = 22
-        private_key = "%{private_key}"
-    }
-    %{lifecycle_block}
+    	forward_ssh_connectivity {
+        	hostname = google_compute_instance.default.network_interface.0.access_config.0.nat_ip
+        	username = google_sql_user.user.name
+        	port     = 5432
+        	private_key = "%{private_key}"
+    	}
+    	%{lifecycle_block}
 }
 `, context)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This prevents the connection profile from failing permanently (needing to be re-created) when the forward ssh connectivity private key is updated. 
Fixes https://github.com/hashicorp/terraform-provider-google/issues/18999

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note: enhancement
datastream: updated `private_key`to be mutable in `google_datastream_connection_profile` resource.
```
