### PR TITLE
NCC Producer VPC Spoke resource added

### DIFF
--- a/mmv1/products/networkconnectivity/Spoke.yaml
+++ b/mmv1/products/networkconnectivity/Spoke.yaml
@@ -277,7 +277,7 @@ properties:
         immutable: true
       - name: producerNetwork
         type: String
-        description: ga
+        description: The URI of the Producer VPC.
         output: true
         immutable: true
       - name: includeExportRanges

--- a/mmv1/products/networkconnectivity/Spoke.yaml
+++ b/mmv1/products/networkconnectivity/Spoke.yaml
@@ -86,7 +86,6 @@ examples:
       interconnect_attachment_name: 'partner-interconnect1'
       interconnect_attachment_spoke_name: 'interconnect-attachment-spoke'
   - name: 'network_connectivity_spoke_linked_producer_vpc_network_basic'
-    config_path: "{{override_path}}/examples/network_connectivity_spoke_linked_producer_vpc_network_basic.tf.erb"
     primary_resource_id: 'primary'
     vars:
       network_name: "net-spoke"
@@ -284,12 +283,14 @@ properties:
         type: Array
         description: IP ranges allowed to be included from peering.
         immutable: true
-        item_type: Api::Type::String
+        item_type: 
+          type: String
       - name: excludeExportRanges
         type: Array
         description: IP ranges encompassing the subnets to be excluded from peering.
         immutable: true
-        item_type: Api::Type::String
+        item_type:
+          type: String
   - name: 'uniqueId'
     type: String
     description: Output only. The Google-generated UUID for the spoke. This value is unique across all spoke resources. If a spoke is deleted and another with the same name is created, the new spoke is assigned a different unique_id.

--- a/mmv1/products/networkconnectivity/Spoke.yaml
+++ b/mmv1/products/networkconnectivity/Spoke.yaml
@@ -284,7 +284,7 @@ properties:
         type: Array
         description: IP ranges allowed to be included from peering.
         immutable: true
-        item_type: 
+        item_type:
           type: String
       - name: excludeExportRanges
         type: Array

--- a/mmv1/products/networkconnectivity/Spoke.yaml
+++ b/mmv1/products/networkconnectivity/Spoke.yaml
@@ -85,6 +85,15 @@ examples:
       router_name: 'external-vpn-gateway'
       interconnect_attachment_name: 'partner-interconnect1'
       interconnect_attachment_spoke_name: 'interconnect-attachment-spoke'
+  - name: 'network_connectivity_spoke_linked_producer_vpc_network_basic'
+    config_path: "{{override_path}}/examples/network_connectivity_spoke_linked_producer_vpc_network_basic.tf.erb"
+    primary_resource_id: 'primary'
+    vars:
+      network_name: "net-spoke"
+      global_name: 'test-address'
+      hub_name: "hub-basic"
+      spoke_name: "vpc-spoke"
+      producer_spoke_name: "producer-spoke"
 parameters:
   - name: 'location'
     type: String
@@ -128,6 +137,7 @@ properties:
       - linked_interconnect_attachments
       - linked_router_appliance_instances
       - linked_vpc_network
+      - linked_producer_vpc_network
     properties:
       - name: 'uris'
         type: Array
@@ -156,6 +166,7 @@ properties:
       - linked_vpn_tunnels
       - linked_router_appliance_instances
       - linked_vpc_network
+      - linked_producer_vpc_network
     properties:
       - name: 'uris'
         type: Array
@@ -184,6 +195,7 @@ properties:
       - linked_interconnect_attachments
       - linked_vpn_tunnels
       - linked_vpc_network
+      - linked_producer_vpc_network
     properties:
       - name: 'instances'
         type: Array
@@ -223,6 +235,7 @@ properties:
       - linked_interconnect_attachments
       - linked_router_appliance_instances
       - linked_vpn_tunnels
+      - linked_producer_vpc_network
     properties:
       - name: 'uri'
         type: String
@@ -242,6 +255,41 @@ properties:
         immutable: true
         item_type:
           type: String
+  - name: linkedProducerVpcNetwork
+    description: Producer VPC network that is associated with the spoke.
+    immutable: true
+    conflicts:
+      - linked_interconnect_attachments
+      - linked_router_appliance_instances
+      - linked_vpn_tunnels
+      - linked_vpc_network
+    properties:
+      - name: network
+        type: String
+        description: The URI of the Service Consumer VPC that the Producer VPC is peered with.
+        required: true
+        immutable: true
+        diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+      - name: peering
+        type: String
+        description: The name of the VPC peering between the Service Consumer VPC and the Producer VPC (defined in the Tenant project) which is added to the NCC hub. This peering must be in ACTIVE state.
+        required: true
+        immutable: true
+      - name: producerNetwork
+        type: String
+        description: ga
+        output: true
+        immutable: true
+      - name: includeExportRanges
+        type: Array
+        description: IP ranges allowed to be included from peering.
+        immutable: true
+        item_type: Api::Type::String
+      - name: excludeExportRanges
+        type: Array
+        description: IP ranges encompassing the subnets to be excluded from peering.
+        immutable: true
+        item_type: Api::Type::String
   - name: 'uniqueId'
     type: String
     description: Output only. The Google-generated UUID for the spoke. This value is unique across all spoke resources. If a spoke is deleted and another with the same name is created, the new spoke is assigned a different unique_id.

--- a/mmv1/products/networkconnectivity/Spoke.yaml
+++ b/mmv1/products/networkconnectivity/Spoke.yaml
@@ -255,6 +255,7 @@ properties:
         item_type:
           type: String
   - name: linkedProducerVpcNetwork
+    type: NestedObject
     description: Producer VPC network that is associated with the spoke.
     immutable: true
     conflicts:

--- a/mmv1/templates/terraform/examples/network_connectivity_spoke_linked_producer_vpc_network_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_connectivity_spoke_linked_producer_vpc_network_basic.tf.tmpl
@@ -1,10 +1,10 @@
 resource "google_compute_network" "network" {
-  name                    = "<%= ctx[:vars]['network_name'] %>"
+  name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_global_address" "address" {
-  name          = "<%= ctx[:vars]['global_name'] %>"
+  name          = "{{index $.Vars "global_name"}}"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
@@ -18,11 +18,11 @@ resource "google_service_networking_connection" "peering" {
 }
 
 resource "google_network_connectivity_hub" "basic_hub" {
-  name = "<%= ctx[:vars]['hub_name'] %>"
+  name = "{{index $.Vars "hub_name"}}"
 }
 
 resource "google_network_connectivity_spoke" "linked_vpc_spoke"  {
-  name     = "<%= ctx[:vars]['spoke_name'] %>"
+  name     = "{{index $.Vars "spoke_name"}}"
   location = "global"
   hub      = google_network_connectivity_hub.basic_hub.id
   linked_vpc_network {
@@ -31,7 +31,7 @@ resource "google_network_connectivity_spoke" "linked_vpc_spoke"  {
 }
 
 resource "google_network_connectivity_spoke" "primary"  {
-  name        = "<%= ctx[:vars]['producer_spoke_name'] %>"
+  name        = "{{index $.Vars "producer_spoke_name"}}"
   location    = "global"
   description = "A sample spoke with a linked router appliance instance"
   labels = {

--- a/mmv1/templates/terraform/examples/network_connectivity_spoke_linked_producer_vpc_network_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_connectivity_spoke_linked_producer_vpc_network_basic.tf.tmpl
@@ -1,0 +1,50 @@
+resource "google_compute_network" "network" {
+  name                    = "<%= ctx[:vars]['network_name'] %>"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_global_address" "address" {
+  name          = "<%= ctx[:vars]['global_name'] %>"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.network.id
+}
+
+resource "google_service_networking_connection" "peering" {
+  network                 = google_compute_network.network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.address.name]
+}
+
+resource "google_network_connectivity_hub" "basic_hub" {
+  name = "<%= ctx[:vars]['hub_name'] %>"
+}
+
+resource "google_network_connectivity_spoke" "linked_vpc_spoke"  {
+  name     = "<%= ctx[:vars]['spoke_name'] %>"
+  location = "global"
+  hub      = google_network_connectivity_hub.basic_hub.id
+  linked_vpc_network {
+    uri = google_compute_network.network.self_link
+  }
+}
+
+resource "google_network_connectivity_spoke" "primary"  {
+  name        = "<%= ctx[:vars]['producer_spoke_name'] %>"
+  location    = "global"
+  description = "A sample spoke with a linked router appliance instance"
+  labels = {
+    label-one = "value-one"
+  }
+  hub         = google_network_connectivity_hub.basic_hub.id
+  linked_producer_vpc_network {
+    network = google_compute_network.network.name
+    peering = google_service_networking_connection.peering.peering
+    exclude_export_ranges = [
+    "198.51.100.0/24",
+    "10.10.0.0/16"
+    ]
+  }
+  depends_on  = [google_network_connectivity_spoke.linked_vpc_spoke]
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Moved changes from private-overrides. Removing private-overrides code in: https://cloud-internal-review.git.corp.google.com/c/cloud-graphite-eng/magic-modules-private-overrides/+/48671

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
networkconnectivity: added `linked_producer_vpc_network` field to `google_network_connectivity_spoke` resource
```
