### PR TITLE
Add example of a Workload Identity Pool configuration for GitHub Actions

### DIFF
--- a/mmv1/products/iambeta/WorkloadIdentityPoolProvider.yaml
+++ b/mmv1/products/iambeta/WorkloadIdentityPoolProvider.yaml
@@ -59,6 +59,11 @@ examples:
     vars:
       workload_identity_pool_id: 'example-pool'
       workload_identity_pool_provider_id: 'example-prvdr'
+  - name: 'iam_workload_identity_pool_provider_github_actions'
+    primary_resource_id: 'example'
+    vars:
+      workload_identity_pool_id: 'example-pool'
+      workload_identity_pool_provider_id: 'example-prvdr'
   - name: 'iam_workload_identity_pool_provider_oidc_basic'
     primary_resource_id: 'example'
     vars:

--- a/mmv1/templates/terraform/examples/iam_workload_identity_pool_provider_github_actions.tf.tmpl
+++ b/mmv1/templates/terraform/examples/iam_workload_identity_pool_provider_github_actions.tf.tmpl
@@ -1,0 +1,26 @@
+resource "google_iam_workload_identity_pool" "pool" {
+  workload_identity_pool_id = "{{index $.Vars "workload_identity_pool_id"}}"
+}
+
+resource "google_iam_workload_identity_pool_provider" "{{$.PrimaryResourceId}}" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.pool.workload_identity_pool_id
+  workload_identity_pool_provider_id = "{{index $.Vars "workload_identity_pool_provider_id"}}"
+  display_name                       = "Name of provider"
+  description                        = "GitHub Actions identity pool provider for automated test"
+  disabled                           = true
+  attribute_condition = <<EOT
+    assertion.repository_owner_id == "123456789" &&
+    attribute.repository == "gh-org/gh-repo" &&
+    assertion.ref == "refs/heads/main" &&
+    assertion.ref_type == "branch"
+EOT
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.actor"      = "assertion.actor"
+    "attribute.aud"        = "assertion.aud"
+    "attribute.repository" = "assertion.repository"
+  }
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}


### PR DESCRIPTION
A security check was recently enabled in GCP which prevents [insecure workload identity pools](https://cloud.google.com/iam/docs/best-practices-for-using-workload-identity-federation#multi-tenant-attribute-conditions) from being created for certain providers. This check requires an `attribute_condition` to specified when creating an OIDC provider for GitHub Actions. [GCP documentation](https://cloud.google.com/iam/docs/workload-identity-federation-with-deployment-pipelines#github-actions_2) already explains how to configure a provider for GitHub Actions, but it would also be helpful to provide an example for Terraform users.


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
