### PR TITLE
Add major release number to `dev` ua

### DIFF
--- a/mmv1/third_party/terraform/version/version.go
+++ b/mmv1/third_party/terraform/version/version.go
@@ -2,5 +2,5 @@ package version
 
 var (
 	// ProviderVersion is set during the release process to the release version of the binary
-	ProviderVersion = "dev"
+	ProviderVersion = "dev6"
 )


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Based on the acc replacement in https://github.com/hashicorp/terraform-provider-google/blob/270d18f71bc6dd721d14235d4dd30693c483d033/GNUmakefile#L17-L18 the release system should be resilient, but we should check it (I think you'll have to?)

A large number of `4.X` releases were misattributed to `dev`, which makes it difficult to tell private build and Registry provider useragents apart. `hashicorp/terraform` uses a VERSION file updated with every release (https://github.com/hashicorp/terraform/blob/main/version/VERSION) while other providers use `dev`, like ourselves. Using just the major version should give enough fidelity to classify private builds while also not requiring too frequent of updates.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
