### PR TITLE
Add producer VPC spokes support to google_network_connectivity_spoke

### DIFF
--- a/mmv1/products/networkconnectivity/Spoke.yaml
+++ b/mmv1/products/networkconnectivity/Spoke.yaml
@@ -126,6 +126,7 @@ properties:
     immutable: true
     conflicts:
       - linked_interconnect_attachments
+      - linked_producer_vpc_network
       - linked_router_appliance_instances
       - linked_vpc_network
     properties:
@@ -154,6 +155,7 @@ properties:
     immutable: true
     conflicts:
       - linked_vpn_tunnels
+      - linked_producer_vpc_network
       - linked_router_appliance_instances
       - linked_vpc_network
     properties:
@@ -176,12 +178,53 @@ properties:
           The only allowed value for now is "ALL_IPV4_RANGES".
         item_type:
           type: String
+  - name: 'linkedProducerVpcNetwork'
+    type: NestedObject
+    description: Producer VPC network that is associated with the spoke.
+    immutable: true
+    min_version: beta
+    conflicts:
+      - linked_interconnect_attachments
+      - linked_router_appliance_instances
+      - linked_vpn_tunnels
+      - linked_vpc_network
+    properties:
+      - name: 'network'
+        type: String
+        description: VPC network that contains the peering to the Producer VPC
+        min_version: beta
+        required: true
+        immutable: true
+        diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+      - name: 'peering'
+        type: String
+        description: |
+          name of the peering between the VPC network and the Producer
+          VPC. Only `servicenetworking-googleapis-com` is supported.
+        min_version: beta
+        required: true
+        immutable: true
+      - name: 'excludeExportRanges'
+        type: Array
+        description: the IP address ranges to be excluded from exporting to the hub.
+        min_version: beta
+        immutable: true
+        item_type:
+          type: String
+      - name: 'includeExportRanges'
+        type: Array
+        description: the IP address ranges to be included when exporting to the hub
+        min_version: beta
+        immutable: true
+        item_type:
+          type: String
   - name: 'linkedRouterApplianceInstances'
     type: NestedObject
     description: The URIs of linked Router appliance resources
     immutable: true
     conflicts:
       - linked_interconnect_attachments
+      - linked_producer_vpc_network
       - linked_vpn_tunnels
       - linked_vpc_network
     properties:
@@ -221,6 +264,7 @@ properties:
     immutable: true
     conflicts:
       - linked_interconnect_attachments
+      - linked_producer_vpc_network
       - linked_router_appliance_instances
       - linked_vpn_tunnels
     properties:

--- a/mmv1/products/networkconnectivity/Spoke.yaml
+++ b/mmv1/products/networkconnectivity/Spoke.yaml
@@ -85,6 +85,14 @@ examples:
       router_name: 'external-vpn-gateway'
       interconnect_attachment_name: 'partner-interconnect1'
       interconnect_attachment_spoke_name: 'interconnect-attachment-spoke'
+  - name: 'network_connectivity_spoke_linked_producer_vpc_network'
+    primary_resource_id: 'producer'
+    vars:
+      network_name: 'net'
+      hub_name: 'hub'
+      range_name: 'psa-range'
+      consumer_vpc_spoke_name: 'consumer-vpc-spoke'
+      producer_vpc_spoke_name: 'producer-vpc-spoke'
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/networkconnectivity/product.yaml
+++ b/mmv1/products/networkconnectivity/product.yaml
@@ -17,5 +17,7 @@ display_name: 'Network Connectivity'
 versions:
   - name: 'ga'
     base_url: 'https://networkconnectivity.googleapis.com/v1/'
+  - name: 'beta'
+    base_url: 'https://networkconnectivity.googleapis.com/v1beta/'
 scopes:
   - 'https://www.googleapis.com/auth/cloud-platform'

--- a/mmv1/templates/terraform/examples/network_connectivity_spoke_linked_producer_vpc_network.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_connectivity_spoke_linked_producer_vpc_network.tf.tmpl
@@ -1,0 +1,59 @@
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "{{index $.Vars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_connectivity_hub" "hub" {
+  provider    = google-beta
+  name        = "{{index $.Vars "hub_name"}}"
+}
+
+# reserve private range for service networking
+resource "google_compute_global_address" "range" {
+  provider      = google-beta
+  name          = "{{index $.Vars "range_name"}}"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.network.id
+}
+
+# create service networking connection
+resource "google_service_networking_connection" "default" {
+  provider                = google-beta
+  network                 = google_compute_network.network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.range.name]
+}
+
+# attach the consumer VPC to the hub
+resource "google_network_connectivity_spoke" "consumer" {
+  provider = google-beta
+  name     = "{{index $.Vars "consumer_vpc_spoke_name"}}"
+  location = "global"
+  hub      = google_network_connectivity_hub.hub.id
+  linked_vpc_network {
+    uri = google_compute_network.network.id
+  }
+}
+
+# attach the producer VPC to the hub
+resource "google_network_connectivity_spoke" "{{$.PrimaryResourceId}}"  {
+  provider = google-beta
+  name     = "{{index $.Vars "producer_vpc_spoke_name"}}"
+  location = "global"
+  hub      = google_network_connectivity_hub.hub.id
+  linked_producer_vpc_network {
+    exclude_export_ranges = ["10.10.0.0/16"]
+    include_export_ranges = ["10.0.0.0/8"]
+    network = google_compute_network.network.id
+    peering = google_service_networking_connection.default.peering
+  }
+
+  # producer vpc spoke can only be attached after attaching the
+  # consumer vpc
+  depends_on = [    
+    google_network_connectivity_spoke.consumer
+  ]
+}


### PR DESCRIPTION
Add support for [producer VPC spokes](https://cloud.google.com/network-connectivity/docs/network-connectivity-center/concepts/producer-vpc-spokes-overview#whats_next) to the NCC spoke resource

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
networkconnectivity: added `linked_vpc_producer_network` field to `google_network_connectivity_spoke`
```
