### PR TITLE
Add `creation_timestamp` field to `google_compute_instance` and template resources

### DIFF
--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance.go.tmpl
@@ -3,9 +3,9 @@ package compute
 import (
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func DataSourceGoogleComputeInstance() *schema.Resource {
@@ -23,7 +23,7 @@ func DataSourceGoogleComputeInstance() *schema.Resource {
 
 func dataSourceGoogleComputeInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
-	userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {
 		return err
 	}
@@ -201,6 +201,9 @@ func dataSourceGoogleComputeInstanceRead(d *schema.ResourceData, meta interface{
 	}
 	if err := d.Set("name", instance.Name); err != nil {
 		return fmt.Errorf("Error setting name: %s", err)
+	}
+	if err := d.Set("creation_timestamp", instance.CreationTimestamp); err != nil {
+		return fmt.Errorf("Error setting creation_timestamp: %s", err)
 	}
 	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, tpgresource.GetResourceNameFromSelfLink(instance.Zone), instance.Name))
 	return nil

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -1177,6 +1177,12 @@ be from 0 to 999,999,999 inclusive.`,
 				Description: `The server-assigned unique identifier of this instance.`,
 			},
 
+			"creation_timestamp": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Creation timestamp in RFC3339 text format.`,
+			},
+
 			"label_fingerprint": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -1802,6 +1808,9 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	}
 	if err := d.Set("instance_id", fmt.Sprintf("%d", instance.Id)); err != nil {
 		return fmt.Errorf("Error setting instance_id: %s", err)
+	}
+	if err := d.Set("creation_timestamp", instance.CreationTimestamp); err != nil {
+		return fmt.Errorf("Error setting creation_timestamp: %s", err)
 	}
 	if err := d.Set("project", project); err != nil {
 		return fmt.Errorf("Error setting project: %s", err)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
@@ -823,6 +823,13 @@ be from 0 to 999,999,999 inclusive.`,
 				Description: `A special URI of the created resource that uniquely identifies this instance template.`,
 			},
 
+			"creation_timestamp": {
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Computed:    true,
+				Description: `Creation timestamp in RFC3339 text format.`,
+			},
+
 			"service_account": {
 				Type:        schema.TypeList,
 				MaxItems:    1,
@@ -1799,6 +1806,9 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 	}
 	if err = d.Set("self_link_unique", fmt.Sprintf("%v?uniqueId=%v", instanceTemplate.SelfLink, instanceTemplate.Id)); err != nil {
 		return fmt.Errorf("Error setting self_link_unique: %s", err)
+	}
+	if err = d.Set("creation_timestamp", instanceTemplate.CreationTimestamp); err != nil {
+		return fmt.Errorf("Error setting creation_timestamp: %s", err)
 	}
 	if err = d.Set("name", instanceTemplate.Name); err != nil {
 		return fmt.Errorf("Error setting name: %s", err)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
@@ -775,6 +775,13 @@ be from 0 to 999,999,999 inclusive.`,
 				Description: `The URI of the created resource.`,
 			},
 
+			"creation_timestamp": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The time at which the instance was created in RFC 3339 format.`,
+			},
+
 			"service_account": {
 				Type:        schema.TypeList,
 				MaxItems:    1,
@@ -1297,6 +1304,9 @@ func resourceComputeRegionInstanceTemplateRead(d *schema.ResourceData, meta inte
 	}
 	if err = d.Set("self_link", instanceTemplate["selfLink"]); err != nil {
 		return fmt.Errorf("Error setting self_link: %s", err)
+	}
+	if err := d.Set("creation_timestamp", instanceTemplate["creationTimestamp"]); err != nil {
+		return fmt.Errorf("Error setting creation_timestamp: %s", err)
 	}
 	if err = d.Set("name", instanceTemplate["name"]); err != nil {
 		return fmt.Errorf("Error setting name: %s", err)

--- a/mmv1/third_party/terraform/website/docs/d/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance.html.markdown
@@ -73,6 +73,8 @@ The following arguments are supported:
 
 * `instance_id` - The server-assigned unique identifier of this instance.
 
+* `creation_timestamp` - Creation timestamp in RFC3339 text format.
+
 * `metadata_fingerprint` - The unique fingerprint of the metadata.
 
 * `self_link` - The URI of the created resource.

--- a/mmv1/third_party/terraform/website/docs/d/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance_template.html.markdown
@@ -318,6 +318,8 @@ The `disk_encryption_key` block supports:
 
 * `id` - an identifier for the resource with format `projects/{{project}}/global/instanceTemplates/{{name}}`
 
+* `creation_timestamp` - Creation timestamp in RFC3339 text format.
+
 * `metadata_fingerprint` - The unique fingerprint of the metadata.
 
 * `self_link` - The URI of the created resource.

--- a/mmv1/third_party/terraform/website/docs/d/compute_region_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_region_instance_template.html.markdown
@@ -302,6 +302,8 @@ The `disk_encryption_key` block supports:
 
 * `id` - an identifier for the resource with format `projects/{{project}}/regions/{{region}}/instanceTemplates/{{name}}`
 
+* `creation_timestamp` - Creation timestamp in RFC3339 text format.
+
 * `metadata_fingerprint` - The unique fingerprint of the metadata.
 
 * `self_link` - The URI of the created resource.

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -588,6 +588,8 @@ exported:
 
 * `id` - an identifier for the resource with format `projects/{{project}}/zones/{{zone}}/instances/{{name}}`
 
+* `creation_timestamp` - Creation timestamp in RFC3339 text format.
+
 * `instance_id` - The server-assigned unique identifier of this instance.
 
 * `metadata_fingerprint` - The unique fingerprint of the metadata.

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -733,6 +733,8 @@ exported:
 
 * `id` - an identifier for the resource with format `projects/{{project}}/global/instanceTemplates/{{name}}`
 
+* `creation_timestamp` - Creation timestamp in RFC3339 text format.
+
 * `metadata_fingerprint` - The unique fingerprint of the metadata.
 
 * `self_link` - The URI of the created resource.

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
@@ -693,6 +693,8 @@ exported:
 
 * `id` - an identifier for the resource with format `projects/{{project}}/regions/{{region}}/instanceTemplates/{{name}}`
 
+* `creation_timestamp` - Creation timestamp in RFC3339 text format.
+
 * `metadata_fingerprint` - The unique fingerprint of the metadata.
 
 * `self_link` - The URI of the created resource.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
closes https://github.com/hashicorp/terraform-provider-google/issues/15663

- added field `creation_timestamp` to
  - google_compute_instance
  - google_compute_instance_template
  - google_compute_region_instance_template
- added data source support (templates didn't need a change because they use the Read function from the resource)
- added doc changes

This is an output only field. Please LMK if you want it tested somehow.
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhacement
compute: added `creation_timestamp` field to `google_compute_instance`, `google_compute_instance_template`, `google_compute_region_instance_template`
```
