### PR TITLE
Clarify data source attached_disk documentation

### DIFF
--- a/mmv1/third_party/terraform/website/docs/d/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance.html.markdown
@@ -139,7 +139,7 @@ The following arguments are supported:
 
 <a name="nested_attached_disk"></a>The `attached_disk` block supports:
 
-* `source` - The name or self_link of the disk attached to this instance.
+* `source` - The self_link of the disk attached to this instance.
 
 * `device_name` - Name with which the attached disk is accessible
     under `/dev/disk/by-id/`


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

closes: https://github.com/hashicorp/terraform-provider-google/issues/15718

This patch clarifies that the `source` field of `attached_disk` data source in the `google_compute_instance` which always is `self_link` and cannot be name.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
Clarifies that the `source` field of `attached_disk` data source in the `google_compute_instance` which always is `self_link` and cannot be name.
```
