### PR TITLE
Fix TestAccGKEHubFeatureMembership_gkehubFeatureAcmUpdate

### DIFF
--- a/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.tmpl
@@ -31,6 +31,9 @@ func TestAccGKEHubFeatureMembership_gkehubFeatureAcmUpdate(t *testing.T) {
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
 		CheckDestroy:             testAccCheckGKEHubFeatureDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -97,7 +100,7 @@ resource "google_gke_hub_feature" "feature" {
   labels = {
     foo = "bar"
   }
-  depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_gke_hub_feature_membership" "feature_member_1" {
@@ -148,7 +151,7 @@ resource "google_gke_hub_feature" "feature" {
   labels = {
     foo = "changed"
   }
-  depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_gke_hub_feature_membership" "feature_member_1" {
@@ -206,7 +209,7 @@ resource "google_gke_hub_feature" "feature" {
   labels = {
     foo = "changed"
   }
-  depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_gke_hub_feature_membership" "feature_member_2" {
@@ -228,7 +231,7 @@ resource "google_gke_hub_feature_membership" "feature_member_2" {
       enabled = true
       audit_interval_seconds = "9"
       exemptable_namespaces = ["different", "1234"]
-      template_library_installed = false
+      template_library_installed = true
     }
     hierarchy_controller {
       enable_hierarchical_resource_quota = true
@@ -285,9 +288,6 @@ resource "google_gke_hub_feature_membership" "feature_member_4" {
     }
   }
 }
-
-
-
 `, context)
 }
 
@@ -301,7 +301,7 @@ resource "google_gke_hub_feature" "feature" {
   labels = {
     foo = "changed"
   }
-  depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_gke_hub_feature_membership" "feature_member_3" {
@@ -336,6 +336,9 @@ func TestAccGKEHubFeatureMembership_gkehubFeatureAcmAllFields(t *testing.T) {
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
 		CheckDestroy:             testAccCheckGKEHubFeatureDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -394,7 +397,7 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection = false
-  depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_gke_hub_membership" "membership" {
@@ -418,7 +421,7 @@ resource "google_gke_hub_feature" "feature" {
   labels = {
     foo = "bar"
   }
-  depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_gke_hub_feature_membership" "feature_member" {
@@ -461,7 +464,7 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection = false
-  depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_gke_hub_membership" "membership" {
@@ -485,7 +488,7 @@ resource "google_gke_hub_feature" "feature" {
   labels = {
     foo = "bar"
   }
-  depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_gke_hub_feature_membership" "feature_member" {
@@ -529,7 +532,7 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection = false
-  depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub, google_project_service.acm]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_gke_hub_membership" "membership" {
@@ -553,7 +556,7 @@ resource "google_gke_hub_feature" "feature" {
   labels = {
     foo = "bar"
   }
-  depends_on = [google_project_service.mci, google_project_service.container, google_project_service.container, google_project_service.gkehub]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_service_account" "feature_sa" {
@@ -594,6 +597,9 @@ func TestAccGKEHubFeatureMembership_gkehubFeatureAcmOci(t *testing.T) {
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
 		CheckDestroy:             testAccCheckGKEHubFeatureDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -643,7 +649,7 @@ resource "google_gke_hub_feature" "feature" {
   labels = {
     foo = "bar"
   }
-  depends_on = [google_project_service.container, google_project_service.gkehub]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_service_account" "feature_sa" {
@@ -693,7 +699,7 @@ resource "google_gke_hub_feature" "feature" {
   labels = {
     foo = "bar"
   }
-  depends_on = [google_project_service.container, google_project_service.gkehub]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_service_account" "feature_sa" {
@@ -743,7 +749,7 @@ resource "google_gke_hub_feature" "feature" {
   labels = {
     foo = "bar"
   }
-  depends_on = [google_project_service.container, google_project_service.gkehub]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_service_account" "feature_sa" {
@@ -785,6 +791,9 @@ func TestAccGKEHubFeatureMembership_gkehubFeatureMesh(t *testing.T) {
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
 		CheckDestroy:             testAccCheckGKEHubFeatureDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -832,7 +841,7 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection = false
-  depends_on = [google_project_service.container, google_project_service.gkehub]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_gke_hub_membership" "membership" {
@@ -856,7 +865,7 @@ resource "google_gke_hub_feature" "feature" {
   labels = {
     foo = "bar"
   }
-  depends_on = [google_project_service.container, google_project_service.gkehub, google_project_service.mesh]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_service_account" "feature_sa" {
@@ -885,7 +894,7 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection = false
-  depends_on = [google_project_service.container, google_project_service.gkehub]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_gke_hub_membership" "membership" {
@@ -909,7 +918,7 @@ resource "google_gke_hub_feature" "feature" {
   labels = {
     foo = "bar"
   }
-  depends_on = [google_project_service.container, google_project_service.gkehub, google_project_service.mesh]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_service_account" "feature_sa" {
@@ -937,7 +946,7 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   deletion_protection = false
-  depends_on = [google_project_service.container, google_project_service.gkehub]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_gke_hub_membership" "membership" {
@@ -961,7 +970,7 @@ resource "google_gke_hub_feature" "feature" {
   labels = {
     foo = "bar"
   }
-  depends_on = [google_project_service.container, google_project_service.gkehub, google_project_service.mesh]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_service_account" "feature_sa" {
@@ -995,6 +1004,9 @@ func TestAccGKEHubFeatureMembership_gkehubFeaturePolicyController(t *testing.T) 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
 		CheckDestroy:             testAccCheckGKEHubFeatureDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -1040,7 +1052,7 @@ resource "google_gke_hub_feature" "feature" {
   project = google_project.project.project_id
   name = "policycontroller"
   location = "global"
-  depends_on = [google_project_service.container, google_project_service.gkehub, google_project_service.poco]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_gke_hub_feature_membership" "feature_member" {
@@ -1066,7 +1078,7 @@ resource "google_gke_hub_feature" "feature" {
   project = google_project.project.project_id
   name = "policycontroller"
   location = "global"
-  depends_on = [google_project_service.container, google_project_service.gkehub, google_project_service.poco]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_gke_hub_feature_membership" "feature_member" {
@@ -1137,7 +1149,7 @@ resource "google_gke_hub_feature" "feature" {
   project = google_project.project.project_id
   name = "policycontroller"
   location = "global"
-  depends_on = [google_project_service.container, google_project_service.gkehub, google_project_service.poco]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_gke_hub_feature_membership" "feature_member" {
@@ -1189,7 +1201,7 @@ resource "google_container_cluster" "primary" {
   initial_node_count = 1
   project = google_project.project.project_id
   deletion_protection = false
-  depends_on = [google_project_service.container, google_project_service.container, google_project_service.gkehub]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_container_cluster" "secondary" {
@@ -1198,7 +1210,7 @@ resource "google_container_cluster" "secondary" {
   initial_node_count = 1
   project = google_project.project.project_id
   deletion_protection = false
-  depends_on = [google_project_service.container, google_project_service.container, google_project_service.gkehub]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_container_cluster" "tertiary" {
@@ -1207,7 +1219,7 @@ resource "google_container_cluster" "tertiary" {
   initial_node_count = 1
   project = google_project.project.project_id
   deletion_protection = false
-  depends_on = [google_project_service.container, google_project_service.container, google_project_service.gkehub]
+  depends_on = [time_sleep.wait_120s]
 }
 
 
@@ -1217,7 +1229,7 @@ resource "google_container_cluster" "quarternary" {
   initial_node_count = 1
   project = google_project.project.project_id
   deletion_protection = false
-  depends_on = [google_project_service.container, google_project_service.container, google_project_service.gkehub]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_gke_hub_membership" "membership" {
@@ -1281,7 +1293,7 @@ resource "google_compute_network" "testnetwork" {
     project                 = google_project.project.project_id
     name                    = "testnetwork"
     auto_create_subnetworks = true
-    depends_on = [google_project_service.compute]
+    depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_container_cluster" "container_acmoci" {
@@ -1291,7 +1303,7 @@ resource "google_container_cluster" "container_acmoci" {
   network = google_compute_network.testnetwork.self_link
   project = google_project.project.project_id
   deletion_protection = false
-  depends_on = [google_project_service.container, google_project_service.container, google_project_service.gkehub]
+  depends_on = [time_sleep.wait_120s]
 }
 
 resource "google_gke_hub_membership" "membership_acmoci" {
@@ -1406,6 +1418,22 @@ resource "google_project_service" "gkehub" {
   project = google_project.project.project_id
   service = "gkehub.googleapis.com"
   disable_on_destroy = false
+}
+
+// It needs waiting until the API services are really activated.
+resource "time_sleep" "wait_120s" {
+  create_duration = "120s"
+  depends_on = [
+    google_project_service.anthos,
+    google_project_service.mesh,
+    google_project_service.mci,
+    google_project_service.acm,
+    google_project_service.poco,
+    google_project_service.mcsd,
+    google_project_service.compute,
+    google_project_service.container,
+    google_project_service.gkehub,
+  ]
 }
 `, context)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
part of https://github.com/hashicorp/terraform-provider-google/issues/14591

1. The API side doesn't support the deletion of PoCo config in ACM, so keep `template_library_installed  = true`. The details are in https://b.corp.google.com/issues/284514917#comment12

This change will fix the [perma-diff](https://github.com/hashicorp/terraform-provider-google/issues/14591#issuecomment-2327578415) in the field `template_library_installed`
2. Sometimes the test fails because the services are not activated, so add the sleep to wait.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
