### PR TITLE
Add computed to node_config.kubelet_config & node_pool_auto_config.node_kubelet_config

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -814,6 +814,7 @@ func schemaNodePoolAutoConfigNodeKubeletConfig() *schema.Schema {
   return &schema.Schema{
 		Type:        schema.TypeList,
 		Optional:    true,
+		Computed:    true,
 		MaxItems:    1,
 		Description: `Node kubelet configs.`,
 		Elem: &schema.Resource{

--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -595,6 +595,7 @@ func schemaNodeConfig() *schema.Schema {
 				"kubelet_config": {
 					Type:     schema.TypeList,
 					Optional: true,
+					Computed: true,
 					MaxItems: 1,
 					Description: `Node kubelet configs.`,
 					Elem: &schema.Resource{


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/19792

Support for the `node_config.kubelet_config.insecure_kubelet_readonly_port_enabled` field was added in https://github.com/GoogleCloudPlatform/magic-modules/pull/11573 and was marked Computed. `node_config` itself is also Computed, however `node_config.kubelet_config` is not.

This means that: 
  - A configuration that does not specify `node_config` is not affected
  - A configuration that specifies `node_config` but not `node_config.kubelet_config` **is affected**
  - A configuration that specifies `node_config.kubelet_config` is not affected.

This caused numerous failing tests for us, however, not all the tests we would have expected to fail based on those criteria.~I haven't determined another trigger condition so I suspect it's a partial rollout of a serialisation change.~ This was confirmed as a rollout in https://github.com/hashicorp/terraform-provider-google/issues/19792#issuecomment-2405836119.

`kubelet_config` appears in multiple other locations, `node_pool_defaults.node_config_defaults.insecure_kubelet_readonly_port_enabled` and `node_pool_auto_config.node_kubelet_config.insecure_kubelet_readonly_port_enabled`
  - `node_pool_defaults.node_config_defaults` has the same problem, as it is not Computed while `node_pool_defaults` and `insecure_kubelet_readonly_port_enabled` are. However, sending just `node_pool_defaults {}` already triggers the same issue with another field (`logging_variant`). Ideally we'd make `node_config_defaults` Required, but I'm not sure about the impact on autopilot. I'll file a bug.
  - I don't expect a default value to be set for `node_pool_auto_config.node_kubelet_config.insecure_kubelet_readonly_port_enabled` but I've set `node_pool_auto_config.node_kubelet_config` to `Computed` anyways since it could exhibit the same issue and I would not want to have to deal with the same problem _again_. I may cut the change if I can confirm it will never get a default (but I'm not guaranteed / unlikely to find that answer before shipping the change)

The update part of the original issue (`Error: googleapi: Error 400: At least one of ['node_version', <snip>, 'max_run_duration'] must be specified.`) is because we [used `ForceSendFields` with a `nil` `KubeletConfig` value](https://github.com/hashicorp/terraform-provider-google-beta/blob/4699748cee90655d692077aa3936edf261c82892/google-beta/services/container/resource_container_node_pool.go#L1824-L1826), which does nothing. We had to set  `KubeletConfig` to `&container.KubeletConfig{}` in that block. `NullFields` would be correct for a patch in theory, but this is a PUT / customish update and the JSON null still triggers the API error.

After this change we can no longer trigger that specific update message. I'll still clean up that callsite / any similarly structured ones to ensure we send an empty struct properly if we do hit them, but in a separate change.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: fixed a diff triggered by a new API-side default value for `node_config.0.kubelet_config.0.insecure_kubelet_readonly_port_enabled`. Terraform will now accept server-specified values for `node_config.0.kubelet_config` when it is not defined in configuration and will not detect drift. Note that this means that removing the value from configuration will now preserve old settings instead of reverting the old settings.
```

```release-note:enhancement
container: `google_container_cluster` will now accept server-specified values for `node_pool_auto_config.0.node_kubelet_config` when it is not defined in configuration and will not detect drift. Note that this means that removing the value from configuration will now preserve old settings instead of reverting the old settings.
```
