### PR TITLE
Deprecate google_notebooks_location since it is not an actual resource

### DIFF
--- a/mmv1/products/notebooks/Location.yaml
+++ b/mmv1/products/notebooks/Location.yaml
@@ -15,6 +15,7 @@
 name: 'Location'
 kind: 'compute#zone'
 description: 'Represents a Location resource.'
+exclude: true
 readonly: true
 docs:
 base_url: 'projects/{{project}}/locations'

--- a/mmv1/products/notebooks/Location.yaml
+++ b/mmv1/products/notebooks/Location.yaml
@@ -15,7 +15,9 @@
 name: 'Location'
 kind: 'compute#zone'
 description: 'Represents a Location resource.'
-exclude: true
+deprecation_message: >-
+  `google_notebooks_location` is deprecated and will be removed in a future major release.
+  This resource is not functional.
 readonly: true
 docs:
 base_url: 'projects/{{project}}/locations'


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This was added in https://github.com/GoogleCloudPlatform/magic-modules/pull/3620

I believe it was meant to only be used for ResourceRefs of the other resources, and not to be an actual resource itself. I was not able to find working create/delete endpoints, the resource is not used in any tests, and there are no issues referencing it. I also tried to provision the resource locally, and received a 404:

```
google_notebooks_location.loc: Creating...
╷
│ Error: Error creating Location: googleapi: got HTTP response code 404 with body: <!DOCTYPE html>
│ <html lang=en>
│   <meta charset=utf-8>
│   <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
│   <title>Error 404 (Not Found)!!1</title>
│   <style>
│     *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
│   </style>
│   <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
│   <p><b>404.</b> <ins>That’s an error.</ins>
│   <p>The requested URL <code>/v1/projects/ryanoaksnightly2/locations?alt=json</code> was not found on this server.  <ins>That’s all we know.</ins>
```


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:deprecation
notebooks: deprecated non-functional `google_notebooks_location` resource
```
