### PR TITLE
Send empty GKE objects explicitly

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
@@ -1759,6 +1759,7 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 					d.Get(prefix + "node_config.0.workload_metadata_config")),
 			}
 			if req.WorkloadMetadataConfig == nil {
+				req.WorkloadMetadataConfig = &container.WorkloadMetadataConfig{}
 				req.ForceSendFields = []string{"WorkloadMetadataConfig"}
 			}
 			updateF := func() error {
@@ -1826,6 +1827,7 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 					d.Get(prefix + "node_config.0.kubelet_config")),
 			}
 			if req.KubeletConfig == nil {
+				req.KubeletConfig = &container.NodeKubeletConfig{}
 				req.ForceSendFields = []string{"KubeletConfig"}
 			}
 			updateF := func() error {
@@ -1859,6 +1861,7 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 					d.Get(prefix + "node_config.0.linux_node_config")),
 			}
 			if req.LinuxNodeConfig == nil {
+				req.LinuxNodeConfig = &container.LinuxNodeConfig{}
 				req.ForceSendFields = []string{"LinuxNodeConfig"}
 			}
 			updateF := func() error {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This change is mainly just to correct some currently misleading code- 2/3 of these fields are Computed and can't actually trigger this check (at least in reasonable circumstances) and `linux_node_config` still has a permadiff afterwards. This does mean that updates that remove `linux_node_config` that also include other changes will move on to the other changes so it at least has some user benefit, in addition to stopping the misleading snippet from propagating. This _could be_ valid for some blocks, just not the one where is still happens!

Followup to https://github.com/GoogleCloudPlatform/magic-modules/pull/11971

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: `node_config.linux_config`, `node_config.workload_metadata_config` and `node_config.kubelet_config` will now successfully send empty messages to the API when `terraform plan` indicates they are being removed, rather than null, which caused an error. The sole reliable case is `node_config.linux_config` when the block is removed, where there will still be a permadiff, but the update request that's triggered will no longer error and other changes displayed in the plan should go through.
```
