### PR TITLE
Fix deletion_protection fields specified as strings

### DIFF
--- a/mmv1/templates/terraform/examples/bigquery_connection_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/bigquery_connection_basic.tf.tmpl
@@ -6,7 +6,7 @@ resource "google_sql_database_instance" "instance" {
 		tier = "db-f1-micro"
 	}
 
-    deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+    deletion_protection  = {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_sql_database" "db" {

--- a/mmv1/templates/terraform/examples/bigquery_connection_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/bigquery_connection_full.tf.tmpl
@@ -6,7 +6,7 @@ resource "google_sql_database_instance" "instance" {
 		tier = "db-f1-micro"
 	}
 
-    deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+    deletion_protection  = {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_sql_database" "db" {

--- a/mmv1/templates/terraform/examples/bigquery_connection_sql_with_cmek.tf.tmpl
+++ b/mmv1/templates/terraform/examples/bigquery_connection_sql_with_cmek.tf.tmpl
@@ -7,7 +7,7 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-f1-micro"
   }
 
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_sql_database" "db" {

--- a/mmv1/templates/terraform/examples/bigtable_app_profile_anycluster.tf.tmpl
+++ b/mmv1/templates/terraform/examples/bigtable_app_profile_anycluster.tf.tmpl
@@ -19,7 +19,7 @@ resource "google_bigtable_instance" "instance" {
     storage_type = "HDD"
   }
 
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_bigtable_app_profile" "ap" {

--- a/mmv1/templates/terraform/examples/bigtable_app_profile_data_boost.tf.tmpl
+++ b/mmv1/templates/terraform/examples/bigtable_app_profile_data_boost.tf.tmpl
@@ -7,7 +7,7 @@ resource "google_bigtable_instance" "instance" {
     storage_type = "SSD"
   }
 
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_bigtable_app_profile" "ap" {

--- a/mmv1/templates/terraform/examples/bigtable_app_profile_multicluster.tf.tmpl
+++ b/mmv1/templates/terraform/examples/bigtable_app_profile_multicluster.tf.tmpl
@@ -19,7 +19,7 @@ resource "google_bigtable_instance" "instance" {
     storage_type = "HDD"
   }
 
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_bigtable_app_profile" "ap" {

--- a/mmv1/templates/terraform/examples/bigtable_app_profile_priority.tf.tmpl
+++ b/mmv1/templates/terraform/examples/bigtable_app_profile_priority.tf.tmpl
@@ -7,7 +7,7 @@ resource "google_bigtable_instance" "instance" {
     storage_type = "HDD"
   }
 
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_bigtable_app_profile" "ap" {

--- a/mmv1/templates/terraform/examples/bigtable_app_profile_singlecluster.tf.tmpl
+++ b/mmv1/templates/terraform/examples/bigtable_app_profile_singlecluster.tf.tmpl
@@ -7,7 +7,7 @@ resource "google_bigtable_instance" "instance" {
     storage_type = "HDD"
   }
 
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_bigtable_app_profile" "ap" {

--- a/mmv1/templates/terraform/examples/cloud_run_service_sql.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloud_run_service_sql.tf.tmpl
@@ -28,5 +28,5 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-f1-micro"
   }
 
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/cloudrunv2_job_sql.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloudrunv2_job_sql.tf.tmpl
@@ -66,5 +66,5 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-f1-micro"
   }
 
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/cloudrunv2_service_sql.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_sql.tf.tmpl
@@ -76,5 +76,5 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-f1-micro"
   }
 
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_deletion_protection.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_deletion_protection.tf.tmpl
@@ -3,7 +3,7 @@ resource "google_dataproc_metastore_service" "{{$.PrimaryResourceId}}" {
     location            = "us-central1"
     port                = 9080
     tier                = "DEVELOPER"
-    deletion_protection = "{{index $.Vars "deletion_protection"}}"
+    deletion_protection = {{index $.Vars "deletion_protection"}}
   
     maintenance_window {
       hour_of_day = 2
@@ -18,4 +18,3 @@ resource "google_dataproc_metastore_service" "{{$.PrimaryResourceId}}" {
       env = "test"
     }
   }
-  

--- a/mmv1/templates/terraform/examples/datastream_connection_profile_postgres.tf.tmpl
+++ b/mmv1/templates/terraform/examples/datastream_connection_profile_postgres.tf.tmpl
@@ -30,7 +30,7 @@ resource "google_sql_database_instance" "instance" {
         }
     }
 
-    deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+    deletion_protection  = {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_sql_database" "db" {

--- a/mmv1/templates/terraform/examples/datastream_connection_profile_postgresql_private_connection.tf.tmpl
+++ b/mmv1/templates/terraform/examples/datastream_connection_profile_postgresql_private_connection.tf.tmpl
@@ -49,7 +49,7 @@ resource "google_sql_database_instance" "instance" {
         }
     }
 
-    deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+    deletion_protection  = {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_sql_database" "db" {

--- a/mmv1/templates/terraform/examples/datastream_connection_profile_sql_server.tf.tmpl
+++ b/mmv1/templates/terraform/examples/datastream_connection_profile_sql_server.tf.tmpl
@@ -3,7 +3,7 @@ resource "google_sql_database_instance" "instance" {
     database_version    = "SQLSERVER_2019_STANDARD"
     region              = "us-central1"
     root_password       = "{{index $.Vars "sql_server_root_password"}}"
-    deletion_protection = "{{index $.Vars "deletion_protection"}}"
+    deletion_protection = {{index $.Vars "deletion_protection"}}
 
     settings {
         tier = "db-custom-2-4096"

--- a/mmv1/templates/terraform/examples/datastream_stream_sql_server.tf.tmpl
+++ b/mmv1/templates/terraform/examples/datastream_stream_sql_server.tf.tmpl
@@ -3,7 +3,7 @@ resource "google_sql_database_instance" "instance" {
     database_version    = "SQLSERVER_2019_STANDARD"
     region              = "us-central1"
     root_password       = "{{index $.Vars "sql_server_root_password"}}"
-    deletion_protection = "{{index $.Vars "deletion_protection"}}"
+    deletion_protection = {{index $.Vars "deletion_protection"}}
 
     settings {
         tier = "db-custom-2-4096"

--- a/mmv1/templates/terraform/examples/datastream_stream_sql_server_change_tables.tf.tmpl
+++ b/mmv1/templates/terraform/examples/datastream_stream_sql_server_change_tables.tf.tmpl
@@ -3,7 +3,7 @@ resource "google_sql_database_instance" "instance" {
     database_version    = "SQLSERVER_2019_STANDARD"
     region              = "us-central1"
     root_password       = "{{index $.Vars "sql_server_root_password"}}"
-    deletion_protection = "{{index $.Vars "deletion_protection"}}"
+    deletion_protection = {{index $.Vars "deletion_protection"}}
 
     settings {
         tier = "db-custom-2-4096"

--- a/mmv1/templates/terraform/examples/dns_managed_zone_private_gke.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dns_managed_zone_private_gke.tf.tmpl
@@ -64,5 +64,5 @@ resource "google_container_cluster" "cluster-1" {
     cluster_secondary_range_name  = google_compute_subnetwork.subnetwork-1.secondary_ip_range[0].range_name
     services_secondary_range_name = google_compute_subnetwork.subnetwork-1.secondary_ip_range[1].range_name
   }
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/dns_response_policy_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dns_response_policy_basic.tf.tmpl
@@ -52,7 +52,7 @@ resource "google_container_cluster" "cluster-1" {
     cluster_secondary_range_name  = google_compute_subnetwork.subnetwork-1.secondary_ip_range[0].range_name
     services_secondary_range_name = google_compute_subnetwork.subnetwork-1.secondary_ip_range[1].range_name
   }
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_dns_response_policy" "{{$.PrimaryResourceId}}" {

--- a/mmv1/templates/terraform/examples/firebasehosting_customdomain_cloud_run.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firebasehosting_customdomain_cloud_run.tf.tmpl
@@ -19,7 +19,7 @@ resource "google_cloud_run_v2_service" "default" {
     }
   }
 
-  deletion_protection = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection = {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_firebase_hosting_version" "default" {

--- a/mmv1/templates/terraform/examples/firebasehosting_version_cloud_run.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firebasehosting_version_cloud_run.tf.tmpl
@@ -19,7 +19,7 @@ resource "google_cloud_run_v2_service" "default" {
     }
   }
 
-  deletion_protection = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection = {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_firebase_hosting_version" "default" {

--- a/mmv1/templates/terraform/examples/gkebackup_backupplan_autopilot.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkebackup_backupplan_autopilot.tf.tmpl
@@ -12,7 +12,7 @@ resource "google_container_cluster" "primary" {
       enabled = true
     }
   }
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
   network       = "{{index $.Vars "network_name"}}"
   subnetwork    = "{{index $.Vars "subnetwork_name"}}"
 }

--- a/mmv1/templates/terraform/examples/gkebackup_backupplan_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkebackup_backupplan_basic.tf.tmpl
@@ -10,7 +10,7 @@ resource "google_container_cluster" "primary" {
       enabled = true
     }
   }
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
   network       = "{{index $.Vars "network_name"}}"
   subnetwork    = "{{index $.Vars "subnetwork_name"}}"
 }

--- a/mmv1/templates/terraform/examples/gkebackup_backupplan_cmek.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkebackup_backupplan_cmek.tf.tmpl
@@ -10,7 +10,7 @@ resource "google_container_cluster" "primary" {
       enabled = true
     }
   }
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
   network       = "{{index $.Vars "network_name"}}"
   subnetwork    = "{{index $.Vars "subnetwork_name"}}"
 }

--- a/mmv1/templates/terraform/examples/gkebackup_backupplan_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkebackup_backupplan_full.tf.tmpl
@@ -10,7 +10,7 @@ resource "google_container_cluster" "primary" {
       enabled = true
     }
   }
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
   network       = "{{index $.Vars "network_name"}}"
   subnetwork    = "{{index $.Vars "subnetwork_name"}}"
 }

--- a/mmv1/templates/terraform/examples/gkebackup_backupplan_permissive.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkebackup_backupplan_permissive.tf.tmpl
@@ -10,7 +10,7 @@ resource "google_container_cluster" "primary" {
       enabled = true
     }
   }
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
   network       = "{{index $.Vars "network_name"}}"
   subnetwork    = "{{index $.Vars "subnetwork_name"}}"
 }

--- a/mmv1/templates/terraform/examples/gkebackup_backupplan_rpo_daily_window.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkebackup_backupplan_rpo_daily_window.tf.tmpl
@@ -10,7 +10,7 @@ resource "google_container_cluster" "primary" {
       enabled = true
     }
   }
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
   network       = "{{index $.Vars "network_name"}}"
   subnetwork    = "{{index $.Vars "subnetwork_name"}}"
 }

--- a/mmv1/templates/terraform/examples/gkebackup_backupplan_rpo_weekly_window.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkebackup_backupplan_rpo_weekly_window.tf.tmpl
@@ -10,7 +10,7 @@ resource "google_container_cluster" "primary" {
       enabled = true
     }
   }
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
   network       = "{{index $.Vars "network_name"}}"
   subnetwork    = "{{index $.Vars "subnetwork_name"}}"
 }

--- a/mmv1/templates/terraform/examples/gkebackup_restoreplan_all_cluster_resources.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkebackup_restoreplan_all_cluster_resources.tf.tmpl
@@ -10,7 +10,7 @@ resource "google_container_cluster" "primary" {
       enabled = true
     }
   }
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
   network       = "{{index $.Vars "network_name"}}"
   subnetwork    = "{{index $.Vars "subnetwork_name"}}"
 }

--- a/mmv1/templates/terraform/examples/gkebackup_restoreplan_all_namespaces.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkebackup_restoreplan_all_namespaces.tf.tmpl
@@ -10,7 +10,7 @@ resource "google_container_cluster" "primary" {
       enabled = true
     }
   }
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
   network       = "{{index $.Vars "network_name"}}"
   subnetwork    = "{{index $.Vars "subnetwork_name"}}"
 }

--- a/mmv1/templates/terraform/examples/gkebackup_restoreplan_gitops_mode.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkebackup_restoreplan_gitops_mode.tf.tmpl
@@ -10,7 +10,7 @@ resource "google_container_cluster" "primary" {
       enabled = true
     }
   }
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
   network       = "{{index $.Vars "network_name"}}"
   subnetwork    = "{{index $.Vars "subnetwork_name"}}"
 }

--- a/mmv1/templates/terraform/examples/gkebackup_restoreplan_protected_application.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkebackup_restoreplan_protected_application.tf.tmpl
@@ -10,7 +10,7 @@ resource "google_container_cluster" "primary" {
       enabled = true
     }
   }
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
   network       = "{{index $.Vars "network_name"}}"
   subnetwork    = "{{index $.Vars "subnetwork_name"}}"
 }

--- a/mmv1/templates/terraform/examples/gkebackup_restoreplan_rename_namespace.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkebackup_restoreplan_rename_namespace.tf.tmpl
@@ -10,7 +10,7 @@ resource "google_container_cluster" "primary" {
       enabled = true
     }
   }
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
   network       = "{{index $.Vars "network_name"}}"
   subnetwork    = "{{index $.Vars "subnetwork_name"}}"
 }

--- a/mmv1/templates/terraform/examples/gkebackup_restoreplan_restore_order.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkebackup_restoreplan_restore_order.tf.tmpl
@@ -10,7 +10,7 @@ resource "google_container_cluster" "primary" {
       enabled = true
     }
   }
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
   network       = "{{index $.Vars "network_name"}}"
   subnetwork    = "{{index $.Vars "subnetwork_name"}}"
 }

--- a/mmv1/templates/terraform/examples/gkebackup_restoreplan_rollback_namespace.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkebackup_restoreplan_rollback_namespace.tf.tmpl
@@ -10,7 +10,7 @@ resource "google_container_cluster" "primary" {
       enabled = true
     }
   }
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
   network       = "{{index $.Vars "network_name"}}"
   subnetwork    = "{{index $.Vars "subnetwork_name"}}"
 }

--- a/mmv1/templates/terraform/examples/gkebackup_restoreplan_second_transformation.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkebackup_restoreplan_second_transformation.tf.tmpl
@@ -10,7 +10,7 @@ resource "google_container_cluster" "primary" {
       enabled = true
     }
   }
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
   network       = "{{index $.Vars "network_name"}}"
   subnetwork    = "{{index $.Vars "subnetwork_name"}}"
 }

--- a/mmv1/templates/terraform/examples/gkebackup_restoreplan_volume_res.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkebackup_restoreplan_volume_res.tf.tmpl
@@ -10,7 +10,7 @@ resource "google_container_cluster" "primary" {
       enabled = true
     }
   }
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
   network       = "{{index $.Vars "network_name"}}"
   subnetwork    = "{{index $.Vars "subnetwork_name"}}"
 }

--- a/mmv1/templates/terraform/examples/gkehub_membership_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkehub_membership_basic.tf.tmpl
@@ -2,7 +2,7 @@ resource "google_container_cluster" "primary" {
   name               = "{{index $.Vars "cluster_name"}}"
   location           = "us-central1-a"
   initial_node_count = 1
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
   network       = "{{index $.Vars "network_name"}}"
   subnetwork    = "{{index $.Vars "subnetwork_name"}}"
 }

--- a/mmv1/templates/terraform/examples/gkehub_membership_binding_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkehub_membership_binding_basic.tf.tmpl
@@ -2,7 +2,7 @@ resource "google_container_cluster" "primary" {
   name               = "{{index $.Vars "cluster_name"}}"
   location           = "us-central1-a"
   initial_node_count = 1
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
   network       = "{{index $.Vars "network_name"}}"
   subnetwork    = "{{index $.Vars "subnetwork_name"}}"
 }

--- a/mmv1/templates/terraform/examples/gkehub_membership_issuer.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkehub_membership_issuer.tf.tmpl
@@ -5,7 +5,7 @@ resource "google_container_cluster" "primary" {
   workload_identity_config {
     workload_pool = "{{index $.TestEnvVars "project"}}.svc.id.goog"
   }
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
   network       = "{{index $.Vars "network_name"}}"
   subnetwork    = "{{index $.Vars "subnetwork_name"}}"
 }

--- a/mmv1/templates/terraform/examples/gkehub_membership_rbac_role_binding_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkehub_membership_rbac_role_binding_basic.tf.tmpl
@@ -3,7 +3,7 @@ resource "google_container_cluster" "primary" {
   name               = "{{index $.Vars "cluster_name"}}"
   location           = "us-central1-a"
   initial_node_count = 1
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
   network       = "{{index $.Vars "network_name"}}"
   subnetwork    = "{{index $.Vars "subnetwork_name"}}"
 }

--- a/mmv1/templates/terraform/examples/instance_group_named_port_gke.tf.tmpl
+++ b/mmv1/templates/terraform/examples/instance_group_named_port_gke.tf.tmpl
@@ -38,5 +38,5 @@ resource "google_container_cluster" "my_cluster" {
     cluster_ipv4_cidr_block  = "/19"
     services_ipv4_cidr_block = "/22"
   }
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/network_peering_routes_config_gke.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_peering_routes_config_gke.tf.tmpl
@@ -49,5 +49,5 @@ resource "google_container_cluster" "private_cluster" {
     cluster_secondary_range_name  = google_compute_subnetwork.container_subnetwork.secondary_ip_range[0].range_name
     services_secondary_range_name = google_compute_subnetwork.container_subnetwork.secondary_ip_range[1].range_name
   }
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/privateca_certificate_authority_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/privateca_certificate_authority_basic.tf.tmpl
@@ -4,7 +4,7 @@ resource "google_privateca_certificate_authority" "{{$.PrimaryResourceId}}" {
   pool = "{{index $.Vars "pool_name"}}"
   certificate_authority_id = "{{index $.Vars "certificate_authority_id"}}"
   location = "{{index $.Vars "pool_location"}}"
-  deletion_protection = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection = {{index $.Vars "deletion_protection"}}
   config {
     subject_config {
       subject {

--- a/mmv1/templates/terraform/examples/privateca_certificate_authority_byo_key.tf.tmpl
+++ b/mmv1/templates/terraform/examples/privateca_certificate_authority_byo_key.tf.tmpl
@@ -21,7 +21,7 @@ resource "google_privateca_certificate_authority" "{{$.PrimaryResourceId}}" {
   pool = "{{index $.Vars "pool_name"}}"
   certificate_authority_id = "{{index $.Vars "certificate_authority_id"}}"
   location = "{{index $.Vars "pool_location"}}"
-  deletion_protection = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection = {{index $.Vars "deletion_protection"}}
   key_spec {
     cloud_kms_key_version = "{{index $.Vars "kms_key_name"}}/cryptoKeyVersions/1"
   }

--- a/mmv1/templates/terraform/examples/privateca_certificate_authority_custom_ski.tf.tmpl
+++ b/mmv1/templates/terraform/examples/privateca_certificate_authority_custom_ski.tf.tmpl
@@ -4,7 +4,7 @@ resource "google_privateca_certificate_authority" "{{$.PrimaryResourceId}}" {
   pool = "{{index $.Vars "pool_name"}}"
   certificate_authority_id = "{{index $.Vars "certificate_authority_id"}}"
   location = "{{index $.Vars "pool_location"}}"
-  deletion_protection = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection = {{index $.Vars "deletion_protection"}}
   config {
     subject_config {
       subject {

--- a/mmv1/templates/terraform/examples/privateca_certificate_authority_subordinate.tf.tmpl
+++ b/mmv1/templates/terraform/examples/privateca_certificate_authority_subordinate.tf.tmpl
@@ -45,7 +45,7 @@ resource "google_privateca_certificate_authority" "{{$.PrimaryResourceId}}" {
   pool = "{{index $.Vars "pool_name"}}"
   certificate_authority_id = "{{index $.Vars "certificate_authority_id"}}-sub"
   location = "{{index $.Vars "pool_location"}}"
-  deletion_protection = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection = {{index $.Vars "deletion_protection"}}
   subordinate_config {
     certificate_authority = google_privateca_certificate_authority.root-ca.name
   }

--- a/mmv1/templates/terraform/examples/spanner_backup_schedule_daily_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/spanner_backup_schedule_daily_full.tf.tmpl
@@ -13,7 +13,7 @@ resource "google_spanner_database" "database" {
     "CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)",
     "CREATE TABLE t2 (t2 INT64 NOT NULL,) PRIMARY KEY(t2)",
   ]
-  deletion_protection = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection = {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_spanner_backup_schedule" "{{$.PrimaryResourceId}}" {

--- a/mmv1/templates/terraform/examples/spanner_backup_schedule_daily_incremental.tf.tmpl
+++ b/mmv1/templates/terraform/examples/spanner_backup_schedule_daily_incremental.tf.tmpl
@@ -14,7 +14,7 @@ resource "google_spanner_database" "database" {
     "CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)",
     "CREATE TABLE t2 (t2 INT64 NOT NULL,) PRIMARY KEY(t2)",
   ]
-  deletion_protection = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection = {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_spanner_backup_schedule" "{{$.PrimaryResourceId}}" {

--- a/mmv1/templates/terraform/examples/sql_database_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_database_basic.tf.tmpl
@@ -12,5 +12,5 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-f1-micro"
   }
 
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_database_deletion_policy.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_database_deletion_policy.tf.tmpl
@@ -13,5 +13,5 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-g1-small"
   }
 
-  deletion_protection  = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_database_instance_my_sql.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_database_instance_my_sql.tf.tmpl
@@ -5,7 +5,7 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
   settings {
     tier = "db-n1-standard-2"
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }
 
 resource "random_password" "pwd" {

--- a/mmv1/templates/terraform/examples/sql_database_instance_postgres.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_database_instance_postgres.tf.tmpl
@@ -6,7 +6,7 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
   settings {
     tier = "db-custom-2-7680"
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }
 
 resource "random_password" "pwd" {

--- a/mmv1/templates/terraform/examples/sql_database_instance_sqlserver.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_database_instance_sqlserver.tf.tmpl
@@ -6,7 +6,7 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
   settings {
     tier = "db-custom-2-7680"
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }
 
 resource "random_password" "pwd" {

--- a/mmv1/templates/terraform/examples/sql_instance_cmek.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_instance_cmek.tf.tmpl
@@ -33,7 +33,7 @@ resource "google_sql_database_instance" "mysql_instance_with_cmek" {
   settings {
     tier = "db-n1-standard-2"
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_sql_database_instance" "postgres_instance_with_cmek" {
@@ -45,7 +45,7 @@ resource "google_sql_database_instance" "postgres_instance_with_cmek" {
   settings {
     tier = "db-custom-2-7680"
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
@@ -58,5 +58,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
   settings {
     tier = "db-custom-2-7680"
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_instance_ha.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_instance_ha.tf.tmpl
@@ -11,7 +11,7 @@ resource "google_sql_database_instance" "mysql_instance_ha" {
       start_time         = "20:55"
     }
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_sql_database_instance" "postgres_instance_ha" {
@@ -27,7 +27,7 @@ resource "google_sql_database_instance" "postgres_instance_ha" {
       start_time                     = "20:55"
     }
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
@@ -43,5 +43,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
       start_time         = "20:55"
     }
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_instance_iam_condition.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_instance_iam_condition.tf.tmpl
@@ -33,5 +33,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
   settings {
     tier = "db-n1-standard-2"
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_instance_pitr.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_instance_pitr.tf.tmpl
@@ -11,7 +11,7 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
       transaction_log_retention_days = "3"
     }
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_sql_database_instance" "postgres_instance_pitr" {
@@ -27,5 +27,5 @@ resource "google_sql_database_instance" "postgres_instance_pitr" {
       transaction_log_retention_days = "3"
     }
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_instance_ssl_cert.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_instance_ssl_cert.tf.tmpl
@@ -8,7 +8,7 @@ resource "google_sql_database_instance" "mysql_instance" {
       ssl_mode = "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
     }
   }
-  deletion_protection = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection = {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_sql_ssl_cert" "mysql_client_cert" {
@@ -26,7 +26,7 @@ resource "google_sql_database_instance" "postgres_instance" {
       ssl_mode = "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
     }
   }
-  deletion_protection = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection = {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_sql_ssl_cert" "postgres_client_cert" {
@@ -45,5 +45,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
       ssl_mode = "ENCRYPTED_ONLY"
     }
   }
-  deletion_protection = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection = {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_mysql_instance_authorized_network.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_mysql_instance_authorized_network.tf.tmpl
@@ -12,5 +12,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
       }
     }
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_mysql_instance_backup.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_mysql_instance_backup.tf.tmpl
@@ -10,5 +10,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
       start_time                     = "20:55"
     }
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_mysql_instance_backup_location.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_mysql_instance_backup_location.tf.tmpl
@@ -9,5 +9,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
       location                       = "asia-northeast1"
     }
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_mysql_instance_backup_retention.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_mysql_instance_backup_retention.tf.tmpl
@@ -12,5 +12,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
       }
     }
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_mysql_instance_clone.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_mysql_instance_clone.tf.tmpl
@@ -5,7 +5,7 @@ resource "google_sql_database_instance" "source" {
   settings {
     tier = "db-n1-standard-2"
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
@@ -15,5 +15,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
   clone {
     source_instance_name = google_sql_database_instance.source.id
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_mysql_instance_flags.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_mysql_instance_flags.tf.tmpl
@@ -18,5 +18,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
     disk_type             = "PD_SSD"
     tier         = "db-n1-standard-2"
   }
-  deletion_protection = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection = {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_mysql_instance_public_ip.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_mysql_instance_public_ip.tf.tmpl
@@ -18,5 +18,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
     }
     tier = "db-custom-4-26624"
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_mysql_instance_pvp.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_mysql_instance_pvp.tf.tmpl
@@ -13,5 +13,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
       enable_password_policy = true
     }
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_mysql_instance_replica.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_mysql_instance_replica.tf.tmpl
@@ -9,7 +9,7 @@ resource "google_sql_database_instance" "primary" {
       binary_log_enabled = "true"
     }
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
@@ -27,5 +27,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
     availability_type = "ZONAL"
     disk_size         = "100"
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_postgres_instance_authorized_network.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_postgres_instance_authorized_network.tf.tmpl
@@ -12,5 +12,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
       }
     }
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_postgres_instance_backup.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_postgres_instance_backup.tf.tmpl
@@ -9,5 +9,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
       start_time                     = "20:55"
     }
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_postgres_instance_backup_location.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_postgres_instance_backup_location.tf.tmpl
@@ -9,5 +9,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
       location                       = "us-central1"
     }
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_postgres_instance_backup_retention.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_postgres_instance_backup_retention.tf.tmpl
@@ -12,5 +12,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
       }
     }
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_postgres_instance_clone.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_postgres_instance_clone.tf.tmpl
@@ -5,7 +5,7 @@ resource "google_sql_database_instance" "source" {
   settings {
     tier = "db-n1-standard-2"
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
@@ -15,5 +15,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
   clone {
     source_instance_name = google_sql_database_instance.source.id
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_postgres_instance_flags.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_postgres_instance_flags.tf.tmpl
@@ -13,5 +13,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
     }
     tier = "db-custom-2-7680"
   }
-  deletion_protection = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection = {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_postgres_instance_public_ip.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_postgres_instance_public_ip.tf.tmpl
@@ -16,5 +16,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
     }
     tier = "db-custom-2-7680"
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_postgres_instance_pvp.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_postgres_instance_pvp.tf.tmpl
@@ -14,5 +14,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
       enable_password_policy = true
     }
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_postgres_instance_replica.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_postgres_instance_replica.tf.tmpl
@@ -8,7 +8,7 @@ resource "google_sql_database_instance" "primary" {
       enabled            = "true"
     }
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
@@ -26,5 +26,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
     availability_type = "ZONAL"
     disk_size         = "100"
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_sqlserver_instance_authorized_network.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_sqlserver_instance_authorized_network.tf.tmpl
@@ -13,5 +13,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
       }
     }
   }
-  deletion_protection = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection = {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_sqlserver_instance_backup.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_sqlserver_instance_backup.tf.tmpl
@@ -10,5 +10,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
       start_time                     = "20:55"
     }
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_sqlserver_instance_backup_location.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_sqlserver_instance_backup_location.tf.tmpl
@@ -10,5 +10,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
       location                       = "us-central1"
     }
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_sqlserver_instance_backup_retention.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_sqlserver_instance_backup_retention.tf.tmpl
@@ -13,5 +13,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
       }
     }
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_sqlserver_instance_clone.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_sqlserver_instance_clone.tf.tmpl
@@ -6,7 +6,7 @@ resource "google_sql_database_instance" "source" {
   settings {
     tier = "db-custom-2-7680"
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
@@ -17,5 +17,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
   clone {
     source_instance_name = google_sql_database_instance.source.id
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_sqlserver_instance_flags.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_sqlserver_instance_flags.tf.tmpl
@@ -18,5 +18,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
     }
     tier = "db-custom-2-7680"
   }
-  deletion_protection = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection = {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_sqlserver_instance_public_ip.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_sqlserver_instance_public_ip.tf.tmpl
@@ -17,5 +17,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
       ipv4_enabled = true
     }
   }
-  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+  deletion_protection =  {{index $.Vars "deletion_protection"}}
 }

--- a/mmv1/templates/terraform/examples/sql_sqlserver_instance_replica.tf.tmpl
+++ b/mmv1/templates/terraform/examples/sql_sqlserver_instance_replica.tf.tmpl
@@ -9,7 +9,7 @@ resource "google_sql_database_instance" "primary" {
       enabled = "true"
     }
   }
-  deletion_protection = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection = {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
@@ -27,5 +27,5 @@ resource "google_sql_database_instance" "{{$.PrimaryResourceId}}" {
     availability_type = "ZONAL"
     disk_size         = "100"
   }
-  deletion_protection = "{{index $.Vars "deletion_protection"}}"
+  deletion_protection = {{index $.Vars "deletion_protection"}}
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Part of https://github.com/hashicorp/terraform-provider-google/issues/19747

These happen to work because of Terraform's particularly aggressive type coercion, but our docs should specify the true types where possible. This will turn some entries from `""` to `` (blank). Working on correcting for those in a followup change, I'll probably gate submission of this on finishing those (and merging both PRs independently will have no merge conflicts, but combine to correct all the pages due to a helpful-for-once cross merge).

I thought these might have been introduced during the Go rewrite, but turns out they werent! They were like that in Ruby too.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
