### PR TITLE
fix doc for Datastream Postgres connection profile

### DIFF
--- a/mmv1/templates/terraform/examples/datastream_stream_postgresql.tf.tmpl
+++ b/mmv1/templates/terraform/examples/datastream_stream_postgresql.tf.tmpl
@@ -5,7 +5,7 @@ resource "google_datastream_connection_profile" "source" {
 
     postgresql_profile {
         hostname = "hostname"
-        port     = 3306
+        port     = 5432
         username = "user"
         password = "pass"
         database = "postgres"


### PR DESCRIPTION
In terraform documentation for Datastream, the port configuration for the PostgreSQL connection profile is set to 3306 (which is the default for MySQL DBs). Updated it to PostgreSQL default port `5432`

Relevant link: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/datastream_stream#example-usage---datastream-stream-postgresql

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
