### PR TITLE
Add documentation for google_privileged_access_manager_entitlement data source

### DIFF
--- a/mmv1/third_party/terraform/website/docs/d/privileged_access_manager_entitlement.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/privileged_access_manager_entitlement.html.markdown
@@ -1,0 +1,37 @@
+---
+subcategory: "Privileged Access Manager"
+description: |-
+  Get information about a Google Cloud Privileged Access Manager Entitlement.
+---
+
+# google_privileged_access_manager_entitlement
+
+Use this data source to get information about a Google Cloud Privileged Access Manager Entitlement.
+
+To get more information about Privileged Access Manager, see:
+
+* [API Documentation](https://cloud.google.com/iam/docs/reference/pam/rest)
+* How-to guides
+  * [Official documentation](https://cloud.google.com/iam/docs/pam-overview)
+
+## Example Usage
+
+```hcl
+data "google_privileged_access_manager_entitlement" "my-entitlement" {
+  parent  = "projects/my-project"
+  location = "global"
+  entitlement_id = "my-entitlement"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `parent` - (Required) The project or folder or organization that contains the resource. Format: projects/{project-id|project-number} or folders/{folder-number}  or organizations/{organization-number}
+* `location` - (Required) The region of the Entitlement resource.
+* `entitlement_id` - (Required) ID of the Entitlement resource. This is the last part of the Entitlement's full name which is of the format `{parent}/locations/{location}/entitlements/{entitlement_id}`.
+
+## Attribute Reference
+
+See [google_privileged_access_manager_entitlement](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/privileged_access_manager_entitlement#argument-reference) for details of the available attributes.


### PR DESCRIPTION
The data source itself was added in https://github.com/GoogleCloudPlatform/magic-modules/pull/11588.

Followed https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/handwritten-docs-style-guide.md for writing this documentation.

Previewed using Hashicorp registry doc preview tool:
![image](https://github.com/user-attachments/assets/9cc88c24-ae56-4a03-90c2-c397efbe2a97)

```release-note:none
```
