### PR TITLE
Added redirectOptions and headerAction fields to compute SecurityPolicyRule

### DIFF
--- a/mmv1/products/compute/SecurityPolicyRule.yaml
+++ b/mmv1/products/compute/SecurityPolicyRule.yaml
@@ -453,6 +453,39 @@ properties:
         description: |
           Can only be specified if the action for the rule is "rate_based_ban".
           If specified, determines the time (in seconds) the traffic will continue to be banned by the rate limit after the rate falls below the threshold.
+  - name: 'redirectOptions'
+    type: NestedObject
+    description: |
+      Parameters defining the redirect action. Cannot be specified for any other actions. This field is only supported in Global Security Policies of type CLOUD_ARMOR.
+    properties:
+      - name: 'type'
+        type: String
+        description: |
+          Type of the redirect action.
+      - name: 'target'
+        type: String
+        description: |
+          Target for the redirect action. This is required if the type is EXTERNAL_302 and cannot be specified for GOOGLE_RECAPTCHA.
+  - name: 'headerAction'
+    type: NestedObject
+    description: |
+      Optional, additional actions that are performed on headers. This field is only supported in Global Security Policies of type CLOUD_ARMOR.
+    properties:
+      - name: 'requestHeadersToAdds'
+        type: Array
+        description: |
+          The list of request headers to add or overwrite if they're already present.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'headerName'
+              type: String
+              description: |
+                The name of the header to set.
+            - name: 'headerValue'
+              type: String
+              description: |
+                The value to set the named header to.
   - name: 'preview'
     type: Boolean
     description: |

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_rule_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_rule_test.go.tmpl
@@ -401,7 +401,7 @@ func TestAccComputeSecurityPolicyRule_withHeadAction(t *testing.T) {
 		"header_value": fmt.Sprintf("tf-test-header-value-%s", acctest.RandString(t, 10)),
 	}
 
-  contextUpdate := map[string]interface{}{
+	contextUpdate := map[string]interface{}{
 		"sp_name":      context["sp_name"],
 		"header_name":  fmt.Sprintf("tf-test-header-name-update-%s", acctest.RandString(t, 10)),
 		"header_value": fmt.Sprintf("tf-test-header-value-update-%s", acctest.RandString(t, 10)),

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_rule_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_rule_test.go.tmpl
@@ -360,6 +360,102 @@ func TestAccComputeSecurityPolicyRule_modifyExprOptions(t *testing.T) {
 	})
 }
 
+func TestAccComputeSecurityPolicyRule_withRedirectOptionsUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeSecurityPolicyRuleDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSecurityPolicyRule_withRedirectOptionsRecaptcha(context),
+			},
+			{
+				ResourceName:      "google_compute_security_policy_rule.policy_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeSecurityPolicyRule_withRedirectOptionsExternal(context),
+			},
+			{
+				ResourceName:      "google_compute_security_policy_rule.policy_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeSecurityPolicyRule_withHeadAction(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"sp_name":      fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+    "header_name":  fmt.Sprintf("tf-test-header-name-%s", acctest.RandString(t, 10)),
+    "header_value": fmt.Sprintf("tf-test-header-value-%s", acctest.RandString(t, 10)),
+	}
+
+  contextUpdate := map[string]interface{}{
+		"sp_name":      context["sp_name"],
+    "header_name":  fmt.Sprintf("tf-test-header-name-update-%s", acctest.RandString(t, 10)),
+    "header_value": fmt.Sprintf("tf-test-header-value-update-%s", acctest.RandString(t, 10)),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeSecurityPolicyRuleDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSecurityPolicyRule_withoutHeadAction(context),
+			},
+			{
+				ResourceName:      "google_compute_security_policy_rule.policy_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeSecurityPolicyRule_withHeadAction(context),
+			},
+			{
+				ResourceName:      "google_compute_security_policy_rule.policy_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeSecurityPolicyRule_withHeadAction(contextUpdate),
+			},
+			{
+				ResourceName:      "google_compute_security_policy_rule.policy_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeSecurityPolicyRule_withMultipleHeaders(context),
+			},
+			{
+				ResourceName:      "google_compute_security_policy_rule.policy_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeSecurityPolicyRule_withoutHeadAction(context),
+			},
+			{
+				ResourceName:      "google_compute_security_policy_rule.policy_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccComputeSecurityPolicyRule_preBasicUpdate(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_security_policy" "default" {
@@ -1045,6 +1141,139 @@ resource "google_compute_security_policy_rule" "policy_rule" {
           "placeholder-recaptcha-session-site-key-1"
         ]
       }
+    }
+  }
+}
+`, context)
+}
+
+func testAccComputeSecurityPolicyRule_withRedirectOptionsRecaptcha(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_security_policy" "default" {
+  name        = "tf-test%{random_suffix}"
+  description = "basic global security policy"
+}
+
+resource "google_compute_security_policy_rule" "policy_rule" {
+  security_policy = google_compute_security_policy.default.name
+  action          = "redirect"
+  priority        = "100"
+  match {
+    versioned_expr = "SRC_IPS_V1"
+    config {
+      src_ip_ranges = ["*"]
+    }
+  }
+  redirect_options {
+    type = "GOOGLE_RECAPTCHA"
+  }
+}
+`, context)
+}
+
+func testAccComputeSecurityPolicyRule_withRedirectOptionsExternal(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_security_policy" "default" {
+  name        = "tf-test%{random_suffix}"
+  description = "basic global security policy"
+}
+
+resource "google_compute_security_policy_rule" "policy_rule" {
+  security_policy = google_compute_security_policy.default.name
+  action          = "redirect"
+  priority        = "100"
+  match {
+    versioned_expr = "SRC_IPS_V1"
+    config {
+      src_ip_ranges = ["*"]
+    }
+  }
+  redirect_options {
+    type = "EXTERNAL_302"
+    target = "https://example.com"
+  }
+}
+`, context)
+}
+
+func testAccComputeSecurityPolicyRule_withoutHeadAction(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_security_policy" "default" {
+  name        = "%{sp_name}"
+  description = "basic global security policy"
+}
+
+resource "google_compute_security_policy_rule" "policy_rule" {
+  security_policy = google_compute_security_policy.default.name
+  action   = "allow"
+  priority = "1000"
+  match {
+    expr {
+      expression = "request.path.matches(\"/login.html\") && token.recaptcha_session.score < 0.2"
+    }
+  }
+}
+`, context)
+}
+
+func testAccComputeSecurityPolicyRule_withHeadAction(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_security_policy" "default" {
+  name        = "%{sp_name}"
+  description = "basic global security policy"
+}
+
+resource "google_compute_security_policy_rule" "policy_rule" {
+  security_policy = google_compute_security_policy.default.name
+  action   = "allow"
+  priority = "1000"
+  match {
+    expr {
+      expression = "request.path.matches(\"/login.html\") && token.recaptcha_session.score < 0.2"
+    }
+  }
+
+  header_action {
+    request_headers_to_adds {
+      header_name  = "%{header_name}"
+      header_value = "%{header_value}"
+    }
+  }
+}
+`, context)
+}
+
+func testAccComputeSecurityPolicyRule_withMultipleHeaders(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_security_policy" "default" {
+  name        = "%{sp_name}"
+  description = "basic global security policy"
+}
+
+resource "google_compute_security_policy_rule" "policy_rule" {
+  security_policy = google_compute_security_policy.default.name
+  action   = "allow"
+  priority = "1000"
+  match {
+    expr {
+      expression = "request.path.matches(\"/login.html\") && token.recaptcha_session.score < 0.2"
+    }
+  }
+
+  header_action {
+    request_headers_to_adds {
+      header_name  = "reCAPTCHA-Warning"
+      header_value = "high"
+    }
+
+    request_headers_to_adds {
+      header_name  = "X-Hello"
+      header_value = "World"
+    }
+
+    request_headers_to_adds {
+      header_name  = "X-Resource"
+      header_value = "test"
     }
   }
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_rule_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_rule_test.go.tmpl
@@ -397,14 +397,14 @@ func TestAccComputeSecurityPolicyRule_withHeadAction(t *testing.T) {
 
 	context := map[string]interface{}{
 		"sp_name":      fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
-    "header_name":  fmt.Sprintf("tf-test-header-name-%s", acctest.RandString(t, 10)),
-    "header_value": fmt.Sprintf("tf-test-header-value-%s", acctest.RandString(t, 10)),
+		"header_name":  fmt.Sprintf("tf-test-header-name-%s", acctest.RandString(t, 10)),
+		"header_value": fmt.Sprintf("tf-test-header-value-%s", acctest.RandString(t, 10)),
 	}
 
   contextUpdate := map[string]interface{}{
 		"sp_name":      context["sp_name"],
-    "header_name":  fmt.Sprintf("tf-test-header-name-update-%s", acctest.RandString(t, 10)),
-    "header_value": fmt.Sprintf("tf-test-header-value-update-%s", acctest.RandString(t, 10)),
+		"header_name":  fmt.Sprintf("tf-test-header-name-update-%s", acctest.RandString(t, 10)),
+		"header_value": fmt.Sprintf("tf-test-header-value-update-%s", acctest.RandString(t, 10)),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds support for the fields `header_action` and `redirect_options` to the resource `google_compute_security_policy_rule`.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/19805

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `header_action` and `redirect_options` fields  to `google_compute_security_policy_rule` resource
```
