### PR TITLE
Fix TestAccComputeRegionNetworkEndpointGroup_regionNetworkEndpointGroupAppengineExample

### DIFF
--- a/mmv1/templates/terraform/examples/region_network_endpoint_group_appengine.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_network_endpoint_group_appengine.tf.tmpl
@@ -65,6 +65,7 @@ resource "google_app_engine_flexible_app_version" "{{$.PrimaryResourceId}}" {
 resource "google_storage_bucket" "{{$.PrimaryResourceId}}" {
   name     = "{{index $.Vars "neg_name"}}"
   location = "US"
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_bucket_object" "{{$.PrimaryResourceId}}" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fixes https://github.com/hashicorp/terraform-provider-google/issues/16170

After discussed with the service team, the reason for the internal error is that on the API side one behavior has changed with the resource `google_storage_bucket` resource, that now for the test requires `uniform_bucket_level_access = true`. 

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
