### PR TITLE
Add cai_base_url fields for resources that need them

### DIFF
--- a/mmv1/products/deploymentmanager/product.yaml
+++ b/mmv1/products/deploymentmanager/product.yaml
@@ -17,5 +17,6 @@ display_name: 'Cloud Deployment Manager'
 versions:
   - name: 'ga'
     base_url: 'https://www.googleapis.com/deploymentmanager/v2/'
+    cai_base_url: 'https://deploymentmanager.googleapis.com/v2/'
 scopes:
   - 'https://www.googleapis.com/auth/cloud-platform'

--- a/mmv1/products/secretmanagerregional/product.yaml
+++ b/mmv1/products/secretmanagerregional/product.yaml
@@ -18,7 +18,9 @@ display_name: 'Secret Manager'
 versions:
   - name: 'ga'
     base_url: 'https://secretmanager.{{location}}.rep.googleapis.com/v1/'
+    cai_base_url: 'https://secretmanager.googleapis.com/v1/'
   - name: 'beta'
     base_url: 'https://secretmanager.{{location}}.rep.googleapis.com/v1/'
+    cai_base_url: 'https://secretmanager.googleapis.com/v1/'
 scopes:
   - 'https://www.googleapis.com/auth/cloud-platform'

--- a/mmv1/products/siteverification/product.yaml
+++ b/mmv1/products/siteverification/product.yaml
@@ -17,5 +17,6 @@ display_name: 'Site Verification'
 versions:
   - name: 'ga'
     base_url: 'https://www.googleapis.com/siteVerification/v1/'
+    cai_base_url: 'https://siteverification.googleapis.com/v1/'
 scopes:
   - 'https://www.googleapis.com/auth/siteverification'


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

I believe these services all need the `cai_base_url` field to be specified, because of how their url is formatted. However, I don't know enough about this mechanism to know if it is actually correct (and what will change as a result).

Within the context of API matching, these were discovered to be services where we did not have a matching API name, which is what prompted the correction (we use `cai_base_url` as an override for matching if it is specified).

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
fix cai_base_url values for some resources that have base urls that do not match their service domain name
```
