### PR TITLE
[DataprocGdc] Add Terraform support for Dataproc on GDC resources

### DIFF
--- a/mmv1/products/dataprocgdc/ServiceInstance.yaml
+++ b/mmv1/products/dataprocgdc/ServiceInstance.yaml
@@ -1,0 +1,114 @@
+base_url: projects/{{project}}/locations/{{location}}/serviceInstances
+create_url: projects/{{project}}/locations/{{location}}/serviceInstances?serviceInstanceId={{service_instance_id}}
+self_link: projects/{{project}}/locations/{{location}}/serviceInstances/{{service_instance_id}}
+id_format: projects/{{project}}/locations/{{location}}/serviceInstances/{{service_instance_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/serviceInstances/{{service_instance_id}}
+name: ServiceInstance
+description: A service instance is an instance of the Dataproc operator running on a GDC cluster.
+autogen_async: true
+properties:
+  - name: gdceCluster
+    type: NestedObject
+    properties:
+      - name: gdceCluster
+        type: String
+        description: 'Required. Gdce cluster resource id. '
+        required: true
+    description: 'Gdce cluster information. '
+  - name: name
+    type: String
+    description: 'Identifier. The name of the service instance. '
+    output: true
+  - name: uid
+    type: String
+    description: "System generated unique identifier for this service instance,
+      formatted as\nUUID4. "
+    output: true
+  - name: displayName
+    type: String
+    description: 'User-provided human-readable name to be used in user interfaces. '
+  - name: createTime
+    type: String
+    description: 'The timestamp when the resource was created. '
+    output: true
+  - name: updateTime
+    type: String
+    description: 'The timestamp when the resource was most recently updated. '
+    output: true
+  - name: requestedState
+    type: String
+    description: "The intended state to which the service instance is reconciling.
+      \n Possible values:\n STATE_UNSPECIFIED\nCREATING\nACTIVE\nDISCONNECTED\nDELETING\nSTOPPING\nSTOPPED\nSTARTING\nUPDATING\nFAILED"
+    output: true
+  - name: state
+    type: String
+    description: "The current state. \n Possible values:\n STATE_UNSPECIFIED\nCREATING\nACTIVE\nDISCONNECTED\nDELETING\nSTOPPING\nSTOPPED\nSTARTING\nUPDATING\nFAILED"
+    output: true
+  - name: reconciling
+    type: Boolean
+    description: "Whether the service instance is currently reconciling.\nTrue
+      if the current state of the resource does not match the\nintended state, and the
+      system is working to reconcile them, whether\nor not the change was user initiated.\nRequired
+      by aip.dev/128#reconciliation "
+    output: true
+  - name: labels
+    type: KeyValueLabels
+    output:
+    api_name:
+    description: "The labels to associate with this service instance. Labels
+      may be used for\nfiltering and billing tracking. "
+    min_version:
+    ignore_write:
+    update_verb:
+    update_url:
+    immutable:
+  - name: sparkServiceInstanceConfig
+    type: NestedObject
+    properties: []
+    description: 'Spark-specific service instance configuration. '
+  - name: stateMessage
+    type: String
+    description: 'A message explaining the current state. '
+    output: true
+  - name: serviceAccount
+    type: String
+    description: 'Requested service account to associate with ServiceInstance. '
+  - name: effectiveServiceAccount
+    type: String
+    description: "Effective service account associated with ServiceInstance.
+      This will be\nthe service_account if specified. Otherwise, it will be an automatically\ncreated
+      per-resource P4SA that also automatically has Fleet Workload\nIdentity bindings
+      applied. "
+    output: true
+parameters:
+  - name: location
+    type: String
+    description: 'Resource ID segment making up resource `name`. It identifies the resource
+      within its parent collection as described in https://google.aip.dev/122. See documentation
+      for resource type `dataprocgdc.googleapis.com/SparkApplication`. '
+    url_param_only: true
+    required: true
+    immutable: true
+  - name: serviceInstanceId
+    type: String
+    description: "Required. Id of the requesting object\nIf auto-generating Id server-side,
+      remove this field and\nservice_instance_id from the method_signature of Create
+      RPC "
+    url_param_only: true
+    required: true
+    immutable: true
+async:
+  actions: ['create', 'delete']
+  type: OpAsync
+  operation:
+    base_url: "{{op_id}}"
+immutable: true
+examples:
+  - name: "dataprocgdc_serviceinstance"
+    primary_resource_id: "service-instance"
+    vars:
+      service_instance_id: "tf-e2e-service-instance"
+      project: "my-project"
+    test_vars_overrides:
+      'project': '"gdce-cluster-monitoring"'

--- a/mmv1/products/dataprocgdc/ServiceInstance.yaml
+++ b/mmv1/products/dataprocgdc/ServiceInstance.yaml
@@ -1,100 +1,40 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: ServiceInstance
+description: A service instance is an instance of the Dataproc operator running on a GDC cluster.
+references:
+  guides:
+    'Dataproc Intro': 'https://cloud.google.com/dataproc/'
+  api: 'https://cloud.google.com/dataproc-gdc/docs/reference/rest/v1/projects.locations.serviceInstances'
 base_url: projects/{{project}}/locations/{{location}}/serviceInstances
 create_url: projects/{{project}}/locations/{{location}}/serviceInstances?serviceInstanceId={{service_instance_id}}
 self_link: projects/{{project}}/locations/{{location}}/serviceInstances/{{service_instance_id}}
 id_format: projects/{{project}}/locations/{{location}}/serviceInstances/{{service_instance_id}}
 import_format:
   - projects/{{project}}/locations/{{location}}/serviceInstances/{{service_instance_id}}
-name: ServiceInstance
-description: A service instance is an instance of the Dataproc operator running on a GDC cluster.
 autogen_async: true
-properties:
-  - name: gdceCluster
-    type: NestedObject
-    properties:
-      - name: gdceCluster
-        type: String
-        description: 'Required. Gdce cluster resource id. '
-        required: true
-    description: 'Gdce cluster information. '
-  - name: name
-    type: String
-    description: 'Identifier. The name of the service instance. '
-    output: true
-  - name: uid
-    type: String
-    description: "System generated unique identifier for this service instance,
-      formatted as\nUUID4. "
-    output: true
-  - name: displayName
-    type: String
-    description: 'User-provided human-readable name to be used in user interfaces. '
-  - name: createTime
-    type: String
-    description: 'The timestamp when the resource was created. '
-    output: true
-  - name: updateTime
-    type: String
-    description: 'The timestamp when the resource was most recently updated. '
-    output: true
-  - name: requestedState
-    type: String
-    description: "The intended state to which the service instance is reconciling.
-      \n Possible values:\n STATE_UNSPECIFIED\nCREATING\nACTIVE\nDISCONNECTED\nDELETING\nSTOPPING\nSTOPPED\nSTARTING\nUPDATING\nFAILED"
-    output: true
-  - name: state
-    type: String
-    description: "The current state. \n Possible values:\n STATE_UNSPECIFIED\nCREATING\nACTIVE\nDISCONNECTED\nDELETING\nSTOPPING\nSTOPPED\nSTARTING\nUPDATING\nFAILED"
-    output: true
-  - name: reconciling
-    type: Boolean
-    description: "Whether the service instance is currently reconciling.\nTrue
-      if the current state of the resource does not match the\nintended state, and the
-      system is working to reconcile them, whether\nor not the change was user initiated.\nRequired
-      by aip.dev/128#reconciliation "
-    output: true
-  - name: labels
-    type: KeyValueLabels
-    output:
-    api_name:
-    description: "The labels to associate with this service instance. Labels
-      may be used for\nfiltering and billing tracking. "
-    min_version:
-    ignore_write:
-    update_verb:
-    update_url:
-    immutable:
-  - name: sparkServiceInstanceConfig
-    type: NestedObject
-    properties: []
-    description: 'Spark-specific service instance configuration. '
-  - name: stateMessage
-    type: String
-    description: 'A message explaining the current state. '
-    output: true
-  - name: serviceAccount
-    type: String
-    description: 'Requested service account to associate with ServiceInstance. '
-  - name: effectiveServiceAccount
-    type: String
-    description: "Effective service account associated with ServiceInstance.
-      This will be\nthe service_account if specified. Otherwise, it will be an automatically\ncreated
-      per-resource P4SA that also automatically has Fleet Workload\nIdentity bindings
-      applied. "
-    output: true
 parameters:
   - name: location
     type: String
-    description: 'Resource ID segment making up resource `name`. It identifies the resource
-      within its parent collection as described in https://google.aip.dev/122. See documentation
-      for resource type `dataprocgdc.googleapis.com/SparkApplication`. '
+    description: 'Location of the resource. '
     url_param_only: true
     required: true
     immutable: true
   - name: serviceInstanceId
     type: String
-    description: "Required. Id of the requesting object\nIf auto-generating Id server-side,
-      remove this field and\nservice_instance_id from the method_signature of Create
-      RPC "
+    description: "Id of the service instance."
     url_param_only: true
     required: true
     immutable: true
@@ -112,3 +52,88 @@ examples:
       project: "my-project"
     test_vars_overrides:
       'project': '"gdce-cluster-monitoring"'
+properties:
+  - name: gdceCluster
+    type: NestedObject
+    properties:
+      - name: gdceCluster
+        type: String
+        description: 'Gdce cluster resource id. '
+        required: true
+    description: 'Gdce cluster information. '
+  - name: name
+    type: String
+    description: 'Identifier. The name of the service instance. '
+    output: true
+  - name: uid
+    type: String
+    description: "System generated unique identifier for this service instance,
+      formatted as UUID4. "
+    output: true
+  - name: displayName
+    type: String
+    description: 'User-provided human-readable name to be used in user interfaces. '
+  - name: createTime
+    type: String
+    description: 'The timestamp when the resource was created. '
+    output: true
+  - name: updateTime
+    type: String
+    description: 'The timestamp when the resource was most recently updated. '
+    output: true
+  - name: requestedState
+    type: String
+    description: |
+      The intended state to which the service instance is reconciling. Possible values:
+      * `CREATING`
+      * `ACTIVE`
+      * `DISCONNECTED`
+      * `DELETING`
+      * `STOPPING`
+      * `STOPPED`
+      * `STARTING`
+      * `UPDATING`
+      * `FAILED`
+    output: true
+  - name: state
+    type: String
+    description: |
+      The current state. Possible values:
+      * `CREATING`
+      * `ACTIVE`
+      * `DISCONNECTED`
+      * `DELETING`
+      * `STOPPING`
+      * `STOPPED`
+      * `STARTING`
+      * `UPDATING`
+      * `FAILED`
+    output: true
+  - name: reconciling
+    type: Boolean
+    description: "Whether the service instance is currently reconciling. True
+      if the current state of the resource does not match the intended state, and the
+      system is working to reconcile them, whether or not the change was user initiated."
+    output: true
+  - name: labels
+    type: KeyValueLabels
+    description: "The labels to associate with this service instance. Labels
+      may be used for filtering and billing tracking. "
+  - name: sparkServiceInstanceConfig
+    type: NestedObject
+    properties: []
+    description: 'Spark-specific service instance configuration. '
+  - name: stateMessage
+    type: String
+    description: 'A message explaining the current state. '
+    output: true
+  - name: serviceAccount
+    type: String
+    description: 'Requested service account to associate with ServiceInstance. '
+  - name: effectiveServiceAccount
+    type: String
+    description: "Effective service account associated with ServiceInstance.
+      This will be the service_account if specified. Otherwise, it will be an automatically created
+      per-resource P4SA that also automatically has Fleet Workload. Identity bindings
+      applied. "
+    output: true

--- a/mmv1/products/dataprocgdc/product.yaml
+++ b/mmv1/products/dataprocgdc/product.yaml
@@ -1,0 +1,9 @@
+--- !ruby/object:Api::Product
+versions:
+  - !ruby/object:Api::Product::Version
+    base_url: https://dataprocgdc.googleapis.com/v1/
+    name: ga
+name: DataprocGdc
+display_name: Dataproc on GDC
+scopes:
+  - https://www.googleapis.com/auth/cloud-platform

--- a/mmv1/products/dataprocgdc/product.yaml
+++ b/mmv1/products/dataprocgdc/product.yaml
@@ -1,9 +1,21 @@
---- !ruby/object:Api::Product
-versions:
-  - !ruby/object:Api::Product::Version
-    base_url: https://dataprocgdc.googleapis.com/v1/
-    name: ga
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
 name: DataprocGdc
 display_name: Dataproc on GDC
+versions:
+  - name: ga
+    base_url: https://dataprocgdc.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform

--- a/mmv1/templates/terraform/examples/dataprocgdc_serviceinstance.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataprocgdc_serviceinstance.tf.tmpl
@@ -5,7 +5,7 @@ resource "google_dataproc_gdc_service_instance" "{{$.PrimaryResourceId}}" {
   gdce_cluster {
       gdce_cluster = "projects/gdce-cluster-monitoring/locations/us-west2/clusters/gdce-prism-prober-ord106"
   }
-  display_name = "A service instance for a Terraform create test"
+  display_name = "A service instance"
   labels = {
     "test-label": "label-value"
   }

--- a/mmv1/templates/terraform/examples/dataprocgdc_serviceinstance.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataprocgdc_serviceinstance.tf.tmpl
@@ -1,0 +1,14 @@
+resource "google_dataproc_gdc_service_instance" "{{$.PrimaryResourceId}}" {
+  service_instance_id = "{{index $.Vars "service_instance_id"}}"
+  project         = "{{index $.Vars "project"}}"
+  location        = "us-west2"
+  gdce_cluster {
+      gdce_cluster = "projects/gdce-cluster-monitoring/locations/us-west2/clusters/gdce-prism-prober-ord106"
+  }
+  display_name = "A service instance for a Terraform create test"
+  labels = {
+    "test-label": "label-value"
+  }
+  service_account = "dataprocgdc-cep-workflows@gdce-cluster-monitoring.iam.gserviceaccount.com"
+}
+

--- a/mmv1/third_party/terraform/.teamcity/components/inputs/services_beta.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/inputs/services_beta.kt
@@ -296,6 +296,11 @@ var ServicesListBeta = mapOf(
         "displayName" to "Dataproc",
         "path" to "./google-beta/services/dataproc"
     ),
+    "dataprocgdc" to mapOf(
+        "name" to "dataprocgdc",
+        "displayName" to "Dataproc on GDC",
+        "path" to "./google-beta/services/dataprocgdc"
+    ),
     "dataprocmetastore" to mapOf(
         "name" to "dataprocmetastore",
         "displayName" to "Dataprocmetastore",

--- a/mmv1/third_party/terraform/.teamcity/components/inputs/services_ga.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/inputs/services_ga.kt
@@ -296,6 +296,11 @@ var ServicesListGa = mapOf(
         "displayName" to "Dataproc",
         "path" to "./google/services/dataproc"
     ),
+    "dataprocgdc" to mapOf(
+        "name" to "dataprocgdc",
+        "displayName" to "Dataproc on GDC",
+        "path" to "./google/services/dataprocgdc"
+    ),
     "dataprocmetastore" to mapOf(
         "name" to "dataprocmetastore",
         "displayName" to "Dataprocmetastore",


### PR DESCRIPTION
This PR adds support for Dataproc on GDC API Service Instances to the GCP Terraform provider. 

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_dataproc_gdc_service_instance`
```