### PR TITLE
compute: Validate stopping for update in plan stage

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -709,6 +709,90 @@ func flattenEnableDisplay(displayDevice *compute.DisplayDevice) interface{} {
 	return displayDevice.EnableDisplay
 }
 
+func hasNetworkInterfaceChanged(d tpgresource.TerraformResourceDiff) bool {
+	oldCount, newCount := d.GetChange("network_interface.#")
+	if oldCount.(int) != newCount.(int) {
+		return true
+	}
+
+	//Check if force new is required for network IP
+	for i := 0; i < newCount.(int); i++ {
+		prefix := fmt.Sprintf("network_interface.%d", i)
+		networkKey := prefix + ".network"
+		oldN, newN := d.GetChange(networkKey)
+		subnetworkKey := prefix + ".subnetwork"
+		oldS, newS := d.GetChange(subnetworkKey)
+		subnetworkProjectKey := prefix + ".subnetwork_project"
+		networkIPKey := prefix + ".network_ip"
+		if d.HasChange(networkIPKey) && d.Get(networkIPKey).(string) != "" {
+			if tpgresource.CompareSelfLinkOrResourceName("", oldS.(string), newS.(string), nil) && !d.HasChange(subnetworkProjectKey) && tpgresource.CompareSelfLinkOrResourceName("", oldN.(string), newN.(string), nil) {
+				return false
+			}
+		}
+	}
+
+	for i := 0; i < newCount.(int); i++ {
+		prefix := fmt.Sprintf("network_interface.%d", i)
+		networkKey := prefix + ".network"
+		oldN, newN := d.GetChange(networkKey)
+		if !tpgresource.CompareSelfLinkOrResourceName("", oldN.(string), newN.(string), nil) {
+			return true
+		}
+
+		subnetworkKey := prefix + ".subnetwork"
+		oldS, newS := d.GetChange(subnetworkKey)
+		if !tpgresource.CompareSelfLinkOrResourceName("", oldS.(string), newS.(string), nil) {
+			return true
+		}
+
+		subnetworkProjectKey := prefix + ".subnetwork_project"
+		if d.HasChange(subnetworkProjectKey) {
+			return true
+		}
+
+		networkIPKey := prefix + ".network_ip"
+		if d.HasChange(networkIPKey) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasKeysInListChanged(d tpgresource.TerraformResourceDiff, keysList []string) bool {
+	for _, key := range keysList {
+		if d.HasChange(key) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasServiceAccountChanged(oServiceAccount, newServiceAccount []interface{}) bool {
+	if len(oServiceAccount) != len(newServiceAccount) {
+		return true
+	} else if len(oServiceAccount) == 1 {
+		// service_account has MaxItems: 1
+		// scopes is a required field and so will always be set
+		oScopes := oServiceAccount[0].(map[string]interface{})["scopes"].(*schema.Set)
+		nScopes := newServiceAccount[0].(map[string]interface{})["scopes"].(*schema.Set)
+		if oScopes.Equal(nScopes) {
+			return false
+		}
+
+		// new values might be aliases, so we need to check if canonicals are equal
+		if len(nScopes.List()) == 0 {
+			return true
+		}
+		for index, value := range nScopes.List() {
+			if tpgresource.CanonicalizeServiceScope(value.(string)) != oScopes.List()[index].(string) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // Node affinity updates require a reboot
 func schedulingHasChangeRequiringReboot(d *schema.ResourceData) bool {
 	o, n := d.GetChange("scheduling")

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -106,6 +106,44 @@ var (
 		"shielded_instance_config.0.enable_vtpm",
 		"shielded_instance_config.0.enable_integrity_monitoring",
 	}
+
+	forceNewKeys = []string{
+		"boot_disk.0.auto_delete",
+		"boot_disk.0.device_name",
+		"boot_disk.0.disk_encryption_key_raw",
+		"boot_disk.0.kms_key_self_link",
+		"boot_disk.0.mode",
+		"boot_disk.0.source",
+		"boot_disk.0.initialize_params.0.size",
+		"boot_disk.0.initialize_params.0.type",
+		"boot_disk.0.initialize_params.0.labels",
+		"boot_disk.0.initialize_params.0.resource_manager_tags",
+		"boot_disk.0.initialize_params.0.provisioned_iops",
+		"boot_disk.0.initialize_params.0.provisioned_throughput",
+		"boot_disk.0.initialize_params.0.enable_confidential_compute",
+		"boot_disk.0.initialize_params.0.storage_pool",
+		"boot_disk.0.initialize_params.0.resource_policies",
+		"name",
+		"network_interface.0.nic_type",
+		"network_interface.0.ipv6_access_config.external_ipv6",
+		"network_interface.0.ipv6_access_config.external_ipv6_prefix_length",
+		"network_interface.0.ipv6_access_config.name",
+		"network_interface.0.queue_count",
+		"network_performance_config.0.total_egress_bandwidth_tier",
+		"guest_accelerator.0.count",
+		"guest_accelerator.0.type",
+		"params",
+		"metadata_startup_script",
+		"project",
+		"scratch_disk",
+		"confidential_instance_config",
+		"zone",
+		"hostname",
+		"reservation_affinity.0.type",
+		"reservation_affinity.0.specific_reservation.key",
+		"reservation_affinity.0.specific_reservation.values",
+		"key_revocation_action_type",
+	}
 )
 
 // This checks if the project provided in subnetwork's self_link matches
@@ -167,6 +205,54 @@ func forceNewIfNetworkIPNotUpdatableFunc(d tpgresource.TerraformResourceDiff) er
 				}
 			}
 		}
+	}
+
+	return nil
+}
+
+func validateStoppingForUpdate(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	// separate func to allow unit testing
+	return validateStoppingForUpdateFunc(d)
+}
+
+// Validate if machine allows for stopping instance for update when it's needed
+func validateStoppingForUpdateFunc(d tpgresource.TerraformResourceDiff) error {
+	// Do not check StoppingForUpdate when force new is triggered
+	if hasKeysInListChanged(d, forceNewKeys) {
+		return nil
+	}
+
+	// d.HasChange("service_account") is oversensitive: see https://github.com/hashicorp/terraform/issues/17411
+	// Until that's fixed, manually check whether there is a change.
+	oServiceAccount, nServiceAccount := d.GetChange("service_account")
+	oList := oServiceAccount.([]interface{})
+	nList := nServiceAccount.([]interface{})
+	scopesChange := hasServiceAccountChanged(oList, nList)
+
+	schedulingChange := false
+	o, n := d.GetChange("scheduling")
+	oSlice, oOk := o.([]interface{})
+	nSlice, nOk := n.([]interface{})
+	if oOk && len(oSlice) > 0 && nOk && len(nSlice) > 0 {
+		oScheduling := oSlice[0].(map[string]interface{})
+		newScheduling := nSlice[0].(map[string]interface{})
+		schedulingChange = hasNodeAffinitiesChanged(oScheduling, newScheduling)
+	}
+
+	oType, nType := d.GetChange("machine_type")
+	machineTypeChange := !tpgresource.CompareResourceNames("", oType.(string), nType.(string), nil)
+
+	needToStopInstanceBeforeUpdating := scopesChange || schedulingChange || machineTypeChange || hasNetworkInterfaceChanged(d) || d.HasChange("service_account.0.email") || d.HasChange("min_cpu_platform") || d.HasChange("enable_display") || d.HasChange("shielded_instance_config") || d.HasChange("advanced_machine_features")
+
+	allowUpdate := d.Get("allow_stopping_for_update").(bool)
+	currentStatus := d.Get("current_status").(string)
+	desiredStatus := d.Get("desired_status").(string)
+
+	if !(allowUpdate) && needToStopInstanceBeforeUpdating && currentStatus == "RUNNING" && desiredStatus != "TERMINATED" {
+		return fmt.Errorf("Changing the machine_type, min_cpu_platform, service_account, enable_display, shielded_instance_config, scheduling.node_affinities, scheduling.max_run_duration " +
+			"or network_interface.[#d].(network/subnetwork/subnetwork_project) or advanced_machine_features on a started instance requires stopping it. " +
+			"To acknowledge this, please set allow_stopping_for_update = true in your config. " +
+			"You can also stop it by setting desiredStatus = \"TERMINATED\", but the instance will not be restarted after the update.")
 	}
 
 	return nil
@@ -1304,6 +1390,7 @@ be from 0 to 999,999,999 inclusive.`,
 			),
 			validateSubnetworkProject,
 			forceNewIfNetworkIPNotUpdatable,
+			validateStoppingForUpdate,
 			tpgresource.SetLabelsDiff,
 		),
 		UseJSONNumber: true,
@@ -2486,16 +2573,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 	o, n := d.GetChange("service_account")
 	oList := o.([]interface{})
 	nList := n.([]interface{})
-	scopesChange := false
-	if len(oList) != len(nList) {
-		scopesChange = true
-	} else if len(oList) == 1 {
-		// service_account has MaxItems: 1
-		// scopes is a required field and so will always be set
-		oScopes := oList[0].(map[string]interface{})["scopes"].(*schema.Set)
-		nScopes := nList[0].(map[string]interface{})["scopes"].(*schema.Set)
-		scopesChange = !oScopes.Equal(nScopes)
-	}
+	scopesChange := hasServiceAccountChanged(oList, nList)
 
 	if d.HasChange("deletion_protection") {
 		nDeletionProtection := d.Get("deletion_protection").(bool)
@@ -2589,13 +2667,6 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 	if needToStopInstanceBeforeUpdating {
 		statusBeforeUpdate := instance.Status
 		desiredStatus := d.Get("desired_status").(string)
-
-		if statusBeforeUpdate == "RUNNING" && desiredStatus != "TERMINATED" && !d.Get("allow_stopping_for_update").(bool) {
-			return fmt.Errorf("Changing the machine_type, min_cpu_platform, service_account, enable_display, shielded_instance_config, scheduling.node_affinities, scheduling.max_run_duration " +
-				"or network_interface.[#d].(network/subnetwork/subnetwork_project) or advanced_machine_features on a started instance requires stopping it. " +
-				"To acknowledge this, please set allow_stopping_for_update = true in your config. " +
-				"You can also stop it by setting desired_status = \"TERMINATED\", but the instance will not be restarted after the update.")
-		}
 
 		if statusBeforeUpdate != "TERMINATED" {
 			op, err := config.NewComputeClient(userAgent).Instances.Stop(project, zone, instance.Name).Do()

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -1253,7 +1253,7 @@ func TestAccComputeInstance_serviceAccount(t *testing.T) {
 						"https://www.googleapis.com/auth/userinfo.email"),
 				),
 			},
-			computeInstanceImportStep("us-central1-a", instanceName, []string{}),
+			computeInstanceImportStep("us-central1-a", instanceName, []string{"allow_stopping_for_update"}),
 		},
 	})
 }
@@ -1277,7 +1277,7 @@ func TestAccComputeInstance_noServiceAccount(t *testing.T) {
 					testAccCheckComputeInstanceNoServiceAccount(&instance),
 				),
 			},
-			computeInstanceImportStep("us-central1-a", instanceName, []string{}),
+			computeInstanceImportStep("us-central1-a", instanceName, []string{"allow_stopping_for_update"}),
 		},
 	})
 }
@@ -6848,6 +6848,7 @@ resource "google_compute_instance" "foobar" {
   name         = "%s"
   machine_type = "e2-medium"
   zone         = "us-central1-a"
+  allow_stopping_for_update = true
 
   boot_disk {
     initialize_params {
@@ -6881,6 +6882,7 @@ resource "google_compute_instance" "foobar" {
   name         = "%s"
   machine_type = "e2-medium"
   zone         = "us-central1-a"
+  allow_stopping_for_update = true
 
   boot_disk {
     initialize_params {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This patch moves the `allowUpdate` check from the apply stage to the plan stage. Covers all configuration changes that require an instance to be stopped. It also adds new helper functions for checking network configuration changes and service account changes.

This patch is covered by existing acceptance tests: `TestAccComputeInstance_updateRunning_desiredStatusRunning_notAllowStoppingForUpdate` `TestAccComputeInstance_updateRunning_desiredStatusNotSet_notAllowStoppingForUpdate`

* Add new customdiff `validateStoppingForUpdate`
* Add new helper functions
  * `hasServiceAccountChanged`
  * `hasNetworkInterfaceChanged`
* Delete `allowUpdate` check from apply stage
* Refactor scopeChange check using the new helper function in apply stage

Closes: https://github.com/hashicorp/terraform-provider-google/issues/4076

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: validate stopping for update in plan stage
```
