### PR TITLE
Make the appengine service name sweepable in the test compute region network endpoint

### DIFF
--- a/mmv1/templates/terraform/examples/region_network_endpoint_group_appengine.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_network_endpoint_group_appengine.tf.tmpl
@@ -11,7 +11,7 @@ resource "google_compute_region_network_endpoint_group" "{{$.PrimaryResourceId}}
 
 resource "google_app_engine_flexible_app_version" "{{$.PrimaryResourceId}}" {
   version_id = "v1"
-  service    = "appengine-network-endpoint-group"
+  service    = "{{index $.Vars "neg_name"}}"
   runtime    = "nodejs"
   flexible_runtime_settings {
     operating_system = "ubuntu22"

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.tmpl
@@ -14,6 +14,7 @@ import (
 )
 
 func TestAccAppEngineFlexibleAppVersion_update(t *testing.T) {
+// test
 	t.Skip("https://github.com/hashicorp/terraform-provider-google/issues/18239")
 	t.Parallel()
 

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.tmpl
@@ -14,7 +14,6 @@ import (
 )
 
 func TestAccAppEngineFlexibleAppVersion_update(t *testing.T) {
-// test
 	t.Skip("https://github.com/hashicorp/terraform-provider-google/issues/18239")
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
part of https://github.com/hashicorp/terraform-provider-google/issues/16170

Make the appengine service name sweepable in the test TestAccComputeRegionNetworkEndpointGroup_regionNetworkEndpointGroupAppengineExample


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
