### PR TITLE
Add autoscale settings to external clusters

### DIFF
--- a/mmv1/products/vmwareengine/Cluster.yaml
+++ b/mmv1/products/vmwareengine/Cluster.yaml
@@ -149,3 +149,119 @@ properties:
             If zero is provided max value from `nodeType.availableCustomCoreCounts` will be used.
             Once the customer is created then corecount cannot be changed.
           default_value: 0
+  - name: 'autoscalingSettings'
+    type: NestedObject
+    description: |
+      Configuration of the autoscaling applied to this cluster
+    properties:
+      - name: 'autoscalingPolicies'
+        type: Map
+        required: true
+        description: |
+          The map with autoscaling policies applied to the cluster.
+          The key is the identifier of the policy.
+          It must meet the following requirements:
+            * Only contains 1-63 alphanumeric characters and hyphens
+            * Begins with an alphabetical character
+            * Ends with a non-hyphen character
+            * Not formatted as a UUID
+            * Complies with [RFC 1034](https://datatracker.ietf.org/doc/html/rfc1034) (section 3.5)
+
+          Currently there map must contain only one element
+          that describes the autoscaling policy for compute nodes.
+        key_name: 'autoscale_policy_id'
+        key_description: 'The key is the identifier of the policy.'
+        value_type:
+          name: AutoscalingPolicy
+          type: NestedObject
+          properties:
+            - name: 'nodeTypeId'
+              type: String
+              required: true
+              description: |
+                The canonical identifier of the node type to add or remove.
+            - name: 'scaleOutSize'
+              type: Integer
+              required: true
+              description: |
+                Number of nodes to add to a cluster during a scale-out operation.
+                Must be divisible by 2 for stretched clusters.
+            - name: 'minNodeCount'
+              type: Integer
+              description: |
+                Minimum number of nodes of the given type in a cluster.
+                The number is coerced to the minimum number of nodes of any type in the cluster.
+            - name: 'maxNodeCount'
+              type: Integer
+              description: |
+                Maximum number of nodes of the given type in a cluster.
+                The number is coerced to the maximum number of nodes of any type in the cluster.
+            - name: 'cpuThresholds'
+              type: NestedObject
+              description: |
+                Utilization thresholds pertaining to CPU utilization.
+              properties:
+                - name: 'scaleOut'
+                  type: Integer
+                  description: |
+                    The utilization triggering the scale-out operation in percent.
+                - name: 'scaleIn'
+                  type: Integer
+                  description: |
+                    The utilization triggering the scale-in operation in percent.
+            - name: 'grantedMemoryThresholds'
+              type: NestedObject
+              description: |
+                Utilization thresholds pertaining to amount of granted memory.
+              properties:
+                - name: 'scaleOut'
+                  type: Integer
+                  description: |
+                    The utilization triggering the scale-out operation in percent.
+                - name: 'scaleIn'
+                  type: Integer
+                  description: |
+                    The utilization triggering the scale-in operation in percent.
+            - name: 'consumedMemoryThresholds'
+              type: NestedObject
+              description: |
+                Utilization thresholds pertaining to amount of consumed memory. 
+              properties:
+                - name: 'scaleOut'
+                  type: Integer
+                  description: |
+                    The utilization triggering the scale-out operation in percent.
+                - name: 'scaleIn'
+                  type: Integer
+                  description: |
+                    The utilization triggering the scale-in operation in percent.                 
+            - name: 'storageThresholds'
+              type: NestedObject
+              description: |
+                Utilization thresholds pertaining to amount of consumed storage.
+              properties:
+                - name: 'scaleOut'
+                  type: Integer
+                  description: |
+                    The utilization triggering the scale-out operation in percent.
+                - name: 'scaleIn'
+                  type: Integer
+                  description: |
+                    The utilization triggering the scale-in operation in percent.
+      - name: 'minClusterNodeCount'
+        type: Integer
+        description: |
+          Minimum number of nodes of any type in a cluster.
+          If not specified the default limits apply.
+      - name: 'maxClusterNodeCount'
+        type: Integer
+        description: |
+          Maximum number of nodes of any type in a cluster.
+          If not specified the default limits apply.
+      - name: 'coolDownPeriod'
+        type: String
+        description: |
+          The minimum duration between consecutive autoscale operations.
+          It starts once addition or removal of nodes is fully completed.
+          Defaults to 30m if not specified. 
+          Cool down period must be in whole minutes (for example, 30m, 31m, 50m).

--- a/mmv1/products/vmwareengine/Cluster.yaml
+++ b/mmv1/products/vmwareengine/Cluster.yaml
@@ -225,7 +225,7 @@ properties:
             - name: 'consumedMemoryThresholds'
               type: NestedObject
               description: |
-                Utilization thresholds pertaining to amount of consumed memory. 
+                Utilization thresholds pertaining to amount of consumed memory.
               properties:
                 - name: 'scaleOut'
                   type: Integer
@@ -234,7 +234,7 @@ properties:
                 - name: 'scaleIn'
                   type: Integer
                   description: |
-                    The utilization triggering the scale-in operation in percent.                 
+                    The utilization triggering the scale-in operation in percent.
             - name: 'storageThresholds'
               type: NestedObject
               description: |
@@ -263,5 +263,5 @@ properties:
         description: |
           The minimum duration between consecutive autoscale operations.
           It starts once addition or removal of nodes is fully completed.
-          Defaults to 30m if not specified. 
+          Defaults to 30m if not specified.
           Cool down period must be in whole minutes (for example, 30m, 31m, 50m).

--- a/mmv1/products/vmwareengine/PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/PrivateCloud.yaml
@@ -218,6 +218,122 @@ properties:
             type: String
             description: |
               Additional zone for a higher level of availability and load balancing.
+      - name: 'autoscalingSettings'
+        type: NestedObject
+        description: |
+          Configuration of the autoscaling applied to this cluster
+        properties:
+          - name: 'autoscalingPolicies'
+            type: Map
+            required: true
+            description: |
+              The map with autoscaling policies applied to the cluster.
+              The key is the identifier of the policy.
+              It must meet the following requirements:
+               * Only contains 1-63 alphanumeric characters and hyphens
+               * Begins with an alphabetical character
+               * Ends with a non-hyphen character
+               * Not formatted as a UUID
+               * Complies with [RFC 1034](https://datatracker.ietf.org/doc/html/rfc1034) (section 3.5)
+
+              Currently there map must contain only one element
+              that describes the autoscaling policy for compute nodes.
+            key_name: 'autoscale_policy_id'
+            key_description: 'The key is the identifier of the policy.'
+            value_type:
+              name: AutoscalingPolicy
+              type: NestedObject
+              properties:
+                - name: 'nodeTypeId'
+                  type: String
+                  required: true
+                  description: |
+                    The canonical identifier of the node type to add or remove.
+                - name: 'scaleOutSize'
+                  type: Integer
+                  required: true
+                  description: |
+                    Number of nodes to add to a cluster during a scale-out operation.
+                    Must be divisible by 2 for stretched clusters.
+                - name: 'minNodeCount'
+                  type: Integer
+                  description: |
+                    Minimum number of nodes of the given type in a cluster.
+                    The number is coerced to the minimum number of nodes of any type in the cluster.
+                - name: 'maxNodeCount'
+                  type: Integer
+                  description: |
+                    Maximum number of nodes of the given type in a cluster.
+                    The number is coerced to the maximum number of nodes of any type in the cluster.
+                - name: 'cpuThresholds'
+                  type: NestedObject
+                  description: |
+                    Utilization thresholds pertaining to CPU utilization.
+                  properties:
+                    - name: 'scaleOut'
+                      type: Integer
+                      description: |
+                        The utilization triggering the scale-out operation in percent.
+                    - name: 'scaleIn'
+                      type: Integer
+                      description: |
+                        The utilization triggering the scale-in operation in percent.
+                - name: 'grantedMemoryThresholds'
+                  type: NestedObject
+                  description: |
+                    Utilization thresholds pertaining to amount of granted memory.
+                  properties:
+                    - name: 'scaleOut'
+                      type: Integer
+                      description: |
+                        The utilization triggering the scale-out operation in percent.
+                    - name: 'scaleIn'
+                      type: Integer
+                      description: |
+                        The utilization triggering the scale-in operation in percent.
+                - name: 'consumedMemoryThresholds'
+                  type: NestedObject
+                  description: |
+                    Utilization thresholds pertaining to amount of consumed memory. 
+                  properties:
+                    - name: 'scaleOut'
+                      type: Integer
+                      description: |
+                        The utilization triggering the scale-out operation in percent.
+                    - name: 'scaleIn'
+                      type: Integer
+                      description: |
+                        The utilization triggering the scale-in operation in percent.                 
+                - name: 'storageThresholds'
+                  type: NestedObject
+                  description: |
+                    Utilization thresholds pertaining to amount of consumed storage.
+                  properties:
+                    - name: 'scaleOut'
+                      type: Integer
+                      description: |
+                        The utilization triggering the scale-out operation in percent.
+                    - name: 'scaleIn'
+                      type: Integer
+                      description: |
+                        The utilization triggering the scale-in operation in percent.
+          - name: 'minClusterNodeCount'
+            type: Integer
+            description: |
+              Minimum number of nodes of any type in a cluster.
+              If not specified the default limits apply.
+          - name: 'maxClusterNodeCount'
+            type: Integer
+            description: |
+              Maximum number of nodes of any type in a cluster.
+              If not specified the default limits apply.
+          - name: 'coolDownPeriod'
+            type: String
+            description: |
+              The minimum duration between consecutive autoscale operations.
+              It starts once addition or removal of nodes is fully completed.
+              Defaults to 30m if not specified. 
+              Cool down period must be in whole minutes (for example, 30m, 31m, 50m).
   - name: 'hcx'
     type: NestedObject
     description: |

--- a/mmv1/templates/terraform/examples/vmware_engine_cluster_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/vmware_engine_cluster_full.tf.tmpl
@@ -24,6 +24,30 @@ resource "google_vmwareengine_private_cloud" "cluster-pc" {
       node_count   = 3
       custom_core_count = 32
     }
+    autoscaling_settings {
+      autoscaling_policies {
+        autoscale_policy_id = "autoscaling-policy"
+        node_type_id = "standard-72"
+        scale_out_size = 1
+        min_node_count = 3 
+        max_node_count = 8
+        cpu_thresholds {
+          scale_out = 75
+          scale_in = 15
+        }
+        consumed_memory_thresholds {
+          scale_out = 85
+          scale_in = 10
+        }
+        storage_thresholds {
+          scale_out = 79
+          scale_in = 20
+        }
+      }
+      min_cluster_node_count = 3
+      max_cluster_node_count = 8
+      cool_down_period = "1800s"
+    }
   }
 }
 

--- a/mmv1/templates/terraform/examples/vmware_engine_private_cloud_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/vmware_engine_private_cloud_full.tf.tmpl
@@ -14,6 +14,30 @@ resource "google_vmwareengine_private_cloud" "{{$.PrimaryResourceId}}" {
       node_count   = 1
       custom_core_count = 32
     }
+    autoscaling_settings {
+      autoscaling_policies {
+        autoscale_policy_id = "autoscaling-policy"
+        node_type_id = "standard-72"
+        scale_out_size = 1
+        min_node_count = 3 
+        max_node_count = 8
+        cpu_thresholds {
+          scale_out = 80
+          scale_in = 10
+        }
+        consumed_memory_thresholds {
+          scale_out = 90
+          scale_in = 10
+        }
+        storage_thresholds {
+          scale_out = 80
+          scale_in = 20
+        }
+      }
+      min_cluster_node_count = 3
+      max_cluster_node_count = 8
+      cool_down_period = "1800s"
+    }
   }
   deletion_delay_hours = 0
   send_deletion_delay_hours_if_zero = true

--- a/mmv1/templates/terraform/post_update/private_cloud.go.tmpl
+++ b/mmv1/templates/terraform/post_update/private_cloud.go.tmpl
@@ -15,10 +15,12 @@ clusterObj := make(map[string]interface{})
 
 if v, ok := d.GetOkExists("management_cluster"); !tpgresource.IsEmptyValue(reflect.ValueOf(mgmtClusterProp)) && (ok || !reflect.DeepEqual(v, mgmtClusterProp)) {
   clusterObj["nodeTypeConfigs"] = mgmtMap["nodeTypeConfigs"]
+  clusterObj["autoscalingSettings"] = mgmtMap["autoscalingSettings"]
 }
 
 if d.HasChange("management_cluster") {
   clusterUpdateMask = append(clusterUpdateMask, "nodeTypeConfigs.*.nodeCount")
+  clusterUpdateMask = append(clusterUpdateMask, "autoscalingSettings")
 }
 
 clusterPatchUrl, err := transport_tpg.AddQueryParams(clusterUrl, map[string]string{"updateMask": strings.Join(clusterUpdateMask, ",")})

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_test.go
@@ -129,7 +129,7 @@ data "google_vmwareengine_cluster" "ds" {
 `, context)
 }
 
-func testVmwareEngineClusterConfigWithAutoscaleSettings(context map[string]interface{}, nodeCount int) string {
+func testVmwareEngineClusterUpdateConfig(context map[string]interface{}, nodeCount int) string {
 	context["node_count"] = nodeCount
 	return acctest.Nprintf(`
 resource "google_vmwareengine_network" "cluster-nw" {

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_cluster_test.go
@@ -46,7 +46,7 @@ func TestAccVmwareengineCluster_vmwareEngineClusterUpdate(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"parent", "name"},
 			},
 			{
-				Config: testVmwareEngineClusterConfig(context, 4), // expand the cluster
+				Config: testVmwareEngineClusterUpdateConfig(context, 4), // expand the cluster
 			},
 			{
 				ResourceName:            "google_vmwareengine_cluster.vmw-engine-ext-cluster",
@@ -104,6 +104,92 @@ resource "google_vmwareengine_cluster" "vmw-engine-ext-cluster" {
     node_count   = %{node_count}
     custom_core_count = 32
   }
+	autoscaling_settings {
+		autoscaling_policies {
+			autoscale_policy_id = "autoscaling-policy"
+			node_type_id = "standard-72"
+			scale_out_size = 1
+			min_node_count = 3 
+			max_node_count = 8
+			storage_thresholds {
+				scale_out = 80
+				scale_in = 20
+			}
+		}
+		min_cluster_node_count = 3
+		max_cluster_node_count = 8
+		cool_down_period = "1800s"
+	}
+}
+
+data "google_vmwareengine_cluster" "ds" {
+  name = google_vmwareengine_cluster.vmw-engine-ext-cluster.name
+  parent = google_vmwareengine_private_cloud.cluster-pc.id
+}
+`, context)
+}
+
+func testVmwareEngineClusterConfigWithAutoscaleSettings(context map[string]interface{}, nodeCount int) string {
+	context["node_count"] = nodeCount
+	return acctest.Nprintf(`
+resource "google_vmwareengine_network" "cluster-nw" {
+  name        = "tf-test-cluster-nw%{random_suffix}"
+  location    = "global"
+  type        = "STANDARD"
+  description = "PC network description."
+}
+
+resource "google_vmwareengine_private_cloud" "cluster-pc" {
+  location    = "%{region}-b"
+  name        = "tf-test-cluster-pc%{random_suffix}"
+  description = "Sample test PC."
+  deletion_delay_hours = 0
+  send_deletion_delay_hours_if_zero = true
+  network_config {
+    management_cidr       = "192.168.10.0/24"
+    vmware_engine_network = google_vmwareengine_network.cluster-nw.id
+  }
+  management_cluster {
+    cluster_id = "tf-test-mgmt-cluster%{random_suffix}"
+    node_type_configs {
+      node_type_id = "standard-72"
+      node_count   = 3
+    }
+  }
+}
+
+resource "google_vmwareengine_cluster" "vmw-engine-ext-cluster" {
+  name = "tf-test-ext-cluster%{random_suffix}"
+  parent =  google_vmwareengine_private_cloud.cluster-pc.id
+  node_type_configs {
+    node_type_id = "standard-72"
+    node_count   = %{node_count}
+    custom_core_count = 32
+  }
+	autoscaling_settings {
+		autoscaling_policies {
+			autoscale_policy_id = "autoscaling-policy"
+			node_type_id = "standard-72"
+			scale_out_size = 2
+			min_node_count = 3 
+			max_node_count = 10
+			cpu_thresholds {
+				scale_out = 75
+				scale_in = 15
+			}
+			consumed_memory_thresholds {
+				scale_out = 85
+				scale_in = 10
+			}
+			storage_thresholds {
+				scale_out = 79
+				scale_in = 20
+        }
+		}
+		min_cluster_node_count = 3
+		max_cluster_node_count = 10
+		cool_down_period = "3600s"
+	}
 }
 
 data "google_vmwareengine_cluster" "ds" {

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
 package vmwareengine_test
 
 import (
@@ -55,7 +57,27 @@ func TestAccVmwareenginePrivateCloud_vmwareEnginePrivateCloudUpdate(t *testing.T
 			},
 
 			{
-				Config: testVmwareenginePrivateCloudUpdateConfig(context),
+				Config: testVmwareenginePrivateCloudUpdateNodeConfig(context),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores(
+						"data.google_vmwareengine_private_cloud.ds",
+						"google_vmwareengine_private_cloud.vmw-engine-pc",
+						map[string]struct{}{
+							"type":                              {},
+							"deletion_delay_hours":              {},
+							"send_deletion_delay_hours_if_zero": {},
+						}),
+				),
+			},
+			{
+				ResourceName:            "google_vmwareengine_private_cloud.vmw-engine-pc",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "name", "update_time", "type", "deletion_delay_hours", "send_deletion_delay_hours_if_zero"},
+			},
+
+			{
+				Config: testVmwareenginePrivateCloudUpdateAutoscaleConfig(context),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores(
 						"data.google_vmwareengine_private_cloud.ds",
@@ -134,8 +156,12 @@ func testVmwareenginePrivateCloudCreateConfig(context map[string]interface{}) st
 	return testVmwareenginePrivateCloudConfig(context, "sample description", "TIME_LIMITED", 1, 1) + testVmwareengineVcenterNSXCredentailsConfig(context)
 }
 
-func testVmwareenginePrivateCloudUpdateConfig(context map[string]interface{}) string {
+func testVmwareenginePrivateCloudUpdateNodeConfig(context map[string]interface{}) string {
 	return testVmwareenginePrivateCloudConfig(context, "sample updated description", "STANDARD", 3, 8) + testVmwareengineVcenterNSXCredentailsConfig(context)
+}
+
+func testVmwareenginePrivateCloudUpdateAutoscaleConfig(context map[string]interface{}) string {
+	return testVmwareenginePrivateCloudAutoscaleConfig(context, "sample updated description", "STANDARD", 3, 8) + testVmwareengineVcenterNSXCredentailsConfig(context)
 }
 
 func testVmwareenginePrivateCloudDelayedDeleteConfig(context map[string]interface{}) string {
@@ -143,15 +169,15 @@ func testVmwareenginePrivateCloudDelayedDeleteConfig(context map[string]interfac
 }
 
 func testVmwareenginePrivateCloudUndeleteConfig(context map[string]interface{}) string {
-	return testVmwareenginePrivateCloudConfig(context, "sample updated description", "STANDARD", 3, 0) + testVmwareengineVcenterNSXCredentailsConfig(context)
+	return testVmwareenginePrivateCloudAutoscaleConfig(context, "sample updated description", "STANDARD", 3, 0) + testVmwareengineVcenterNSXCredentailsConfig(context)
 }
 
 func testVmwareengineSubnetImportConfig(context map[string]interface{}) string {
-	return testVmwareenginePrivateCloudConfig(context, "sample updated description", "STANDARD", 3, 0) + testVmwareengineSubnetConfig(context, "192.168.1.0/26")
+	return testVmwareenginePrivateCloudAutoscaleConfig(context, "sample updated description", "STANDARD", 3, 0) + testVmwareengineSubnetConfig(context, "192.168.1.0/26")
 }
 
 func testVmwareengineSubnetUpdateConfig(context map[string]interface{}) string {
-	return testVmwareenginePrivateCloudConfig(context, "sample updated description", "STANDARD", 3, 0) + testVmwareengineSubnetConfig(context, "192.168.2.0/26")
+	return testVmwareenginePrivateCloudAutoscaleConfig(context, "sample updated description", "STANDARD", 3, 0) + testVmwareengineSubnetConfig(context, "192.168.2.0/26")
 }
 
 func testVmwareenginePrivateCloudConfig(context map[string]interface{}, description, pcType string, nodeCount, delayHours int) string {
@@ -184,6 +210,70 @@ resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
       node_type_id = "standard-72"
       node_count = "%{node_count}"
       custom_core_count = 32
+    }
+  }
+}
+
+data "google_vmwareengine_private_cloud" "ds" {
+	location = "%{region}-b"
+	name = "tf-test-sample-pc%{random_suffix}"
+	depends_on = [
+   	google_vmwareengine_private_cloud.vmw-engine-pc,
+  ]
+}
+`, context)
+}
+
+func testVmwareenginePrivateCloudAutoscaleConfig(context map[string]interface{}, description, pcType string, nodeCount, delayHours int) string {
+	context["node_count"] = nodeCount
+	context["delay_hrs"] = delayHours
+	context["description"] = description
+	context["type"] = pcType
+	return acctest.Nprintf(`
+resource "google_vmwareengine_network" "vmw-engine-nw" {
+  name              = "tf-test-pc-nw-%{random_suffix}"
+  location          = "global"
+  type              = "STANDARD"
+  description       = "PC network description."
+}
+
+resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
+  location = "%{region}-b"
+  name = "tf-test-sample-pc%{random_suffix}"
+  description = "%{description}"
+  type = "%{type}"
+  deletion_delay_hours = "%{delay_hrs}"
+  send_deletion_delay_hours_if_zero = true
+  network_config {
+    management_cidr = "192.168.0.0/24"
+    vmware_engine_network = google_vmwareengine_network.vmw-engine-nw.id
+  }
+  management_cluster {
+    cluster_id = "tf-test-sample-mgmt-cluster-custom-core-count%{random_suffix}"
+    node_type_configs {
+      node_type_id = "standard-72"
+      node_count = "%{node_count}"
+      custom_core_count = 32
+    }
+    autoscaling_settings {
+      autoscaling_policies {
+        autoscale_policy_id = "autoscaling-policy"
+        node_type_id = "standard-72"
+        scale_out_size = 1
+        min_node_count = 3 
+        max_node_count = 8
+        cpu_thresholds {
+          scale_out = 80
+          scale_in = 10
+        }
+        storage_thresholds {
+          scale_out = 80
+          scale_in = 20
+        }
+      }
+      min_cluster_node_count = 3
+      max_cluster_node_count = 8
+      cool_down_period = "1800s"
     }
   }
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add terraform support for autoscaling in pc external clusters

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
vmwareengine: added `autoscaling_setttings` to `google_vmwareengine_cluster` resource
```
