### PR TITLE
Add autoscaling settings to pc management cluster

### DIFF
--- a/mmv1/products/vmwareengine/PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/PrivateCloud.yaml
@@ -236,7 +236,7 @@ properties:
                * Not formatted as a UUID
                * Complies with [RFC 1034](https://datatracker.ietf.org/doc/html/rfc1034) (section 3.5)
 
-              Currently there map must contain only one element
+              Currently the map must contain only one element
               that describes the autoscaling policy for compute nodes.
             key_name: 'autoscale_policy_id'
             key_description: 'The key is the identifier of the policy.'

--- a/mmv1/products/vmwareengine/PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/PrivateCloud.yaml
@@ -223,6 +223,7 @@ properties:
         type: NestedObject
         description: |
           Configuration of the autoscaling applied to this cluster
+          You must have a minimum of 3 nodes in your PC to add autoscaling settings
           Currently, autoscale settings can be updated for management cluster only during updation
           PC creation does not support autoscale settings for now
         properties:

--- a/mmv1/products/vmwareengine/PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/PrivateCloud.yaml
@@ -67,7 +67,7 @@ examples:
       management_cluster_id: 'sample-mgmt-cluster'
     test_env_vars:
       region: 'REGION'
- # update tests will take care of create and update. PC creation is expensive and node reservation is required.
+      # update tests will take care of create and update. PC creation is expensive and node reservation is required.
     exclude_test: true
   - name: 'vmware_engine_private_cloud_full'
     primary_resource_id: 'vmw-engine-pc'
@@ -77,7 +77,7 @@ examples:
       management_cluster_id: 'sample-mgmt-cluster'
     test_env_vars:
       region: 'REGION'
- # update tests will take care of create and update. PC creation is expensive and node reservation is required.
+    # update tests will take care of create and update. PC creation is expensive and node reservation is required.
     exclude_test: true
 virtual_fields:
   - name: 'deletion_delay_hours'
@@ -294,7 +294,7 @@ properties:
                 - name: 'consumedMemoryThresholds'
                   type: NestedObject
                   description: |
-                    Utilization thresholds pertaining to amount of consumed memory. 
+                    Utilization thresholds pertaining to amount of consumed memory.
                   properties:
                     - name: 'scaleOut'
                       type: Integer
@@ -303,7 +303,7 @@ properties:
                     - name: 'scaleIn'
                       type: Integer
                       description: |
-                        The utilization triggering the scale-in operation in percent.                 
+                        The utilization triggering the scale-in operation in percent.
                 - name: 'storageThresholds'
                   type: NestedObject
                   description: |
@@ -332,7 +332,7 @@ properties:
             description: |
               The minimum duration between consecutive autoscale operations.
               It starts once addition or removal of nodes is fully completed.
-              Defaults to 30m if not specified. 
+              Defaults to 30m if not specified.
               Cool down period must be in whole minutes (for example, 30m, 31m, 50m).
   - name: 'hcx'
     type: NestedObject

--- a/mmv1/products/vmwareengine/PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/PrivateCloud.yaml
@@ -304,19 +304,20 @@ properties:
             type: Integer
             description: |
               Minimum number of nodes of any type in a cluster.
-              If not specified the default limits apply.
+              Mandatory for successful addition of autoscaling settings in cluster.
           - name: 'maxClusterNodeCount'
             type: Integer
             description: |
               Maximum number of nodes of any type in a cluster.
-              If not specified the default limits apply.
+              Mandatory for successful addition of autoscaling settings in cluster.
           - name: 'coolDownPeriod'
             type: String
             description: |
               The minimum duration between consecutive autoscale operations.
               It starts once addition or removal of nodes is fully completed.
-              Defaults to 30m if not specified.
+              Minimum cool down period is 30m.
               Cool down period must be in whole minutes (for example, 30m, 31m, 50m).
+              Mandatory for successful addition of autoscaling settings in cluster.
   - name: 'hcx'
     type: NestedObject
     description: |

--- a/mmv1/products/vmwareengine/PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/PrivateCloud.yaml
@@ -218,6 +218,122 @@ properties:
             type: String
             description: |
               Additional zone for a higher level of availability and load balancing.
+      - name: 'autoscalingSettings'
+        type: NestedObject
+        description: |
+          Configuration of the autoscaling applied to this cluster
+        properties:
+          - name: 'autoscalingPolicies'
+            type: Map
+            required: true
+            description: |
+              The map with autoscaling policies applied to the cluster.
+              The key is the identifier of the policy.
+              It must meet the following requirements:
+               * Only contains 1-63 alphanumeric characters and hyphens
+               * Begins with an alphabetical character
+               * Ends with a non-hyphen character
+               * Not formatted as a UUID
+               * Complies with [RFC 1034](https://datatracker.ietf.org/doc/html/rfc1034) (section 3.5)
+
+              Currently there map must contain only one element
+              that describes the autoscaling policy for compute nodes.
+            key_name: 'autoscale_policy_id'
+            key_description: 'The key is the identifier of the policy.'
+            value_type:
+              name: AutoscalingPolicy
+              type: NestedObject
+              properties:
+                - name: 'nodeTypeId'
+                  type: String
+                  required: true
+                  description: |
+                    The canonical identifier of the node type to add or remove.
+                - name: 'scaleOutSize'
+                  type: Integer
+                  required: true
+                  description: |
+                    Number of nodes to add to a cluster during a scale-out operation.
+                    Must be divisible by 2 for stretched clusters.
+                - name: 'minNodeCount'
+                  type: Integer
+                  description: |
+                    Minimum number of nodes of the given type in a cluster.
+                    The number is coerced to the minimum number of nodes of any type in the cluster.
+                - name: 'maxNodeCount'
+                  type: Integer
+                  description: |
+                    Maximum number of nodes of the given type in a cluster.
+                    The number is coerced to the maximum number of nodes of any type in the cluster.
+                - name: 'cpuThresholds'
+                  type: NestedObject
+                  description: |
+                    Utilization thresholds pertaining to CPU utilization.
+                  properties:
+                    - name: 'scaleOut'
+                      type: Integer
+                      description: |
+                        The utilization triggering the scale-out operation in percent.
+                    - name: 'scaleIn'
+                      type: Integer
+                      description: |
+                        The utilization triggering the scale-in operation in percent.
+                - name: 'grantedMemoryThresholds'
+                  type: NestedObject
+                  description: |
+                    Utilization thresholds pertaining to amount of granted memory.
+                  properties:
+                    - name: 'scaleOut'
+                      type: Integer
+                      description: |
+                        The utilization triggering the scale-out operation in percent.
+                    - name: 'scaleIn'
+                      type: Integer
+                      description: |
+                        The utilization triggering the scale-in operation in percent.
+                - name: 'consumedMemoryThresholds'
+                  type: NestedObject
+                  description: |
+                    Utilization thresholds pertaining to amount of consumed memory. 
+                  properties:
+                    - name: 'scaleOut'
+                      type: Integer
+                      description: |
+                        The utilization triggering the scale-out operation in percent.
+                    - name: 'scaleIn'
+                      type: Integer
+                      description: |
+                        The utilization triggering the scale-in operation in percent.                 
+                - name: 'storageThresholds'
+                  type: NestedObject
+                  description: |
+                    Utilization thresholds pertaining to amount of consumed storage.
+                  properties:
+                    - name: 'scaleOut'
+                      type: Integer
+                      description: |
+                        The utilization triggering the scale-out operation in percent.
+                    - name: 'scaleIn'
+                      type: Integer
+                      description: |
+                        The utilization triggering the scale-in operation in percent.
+          - name: 'minClusterNodeCount'
+            type: Integer
+            description: |
+              Minimum number of nodes of any type in a cluster.
+              If not specified the default limits apply.
+          - name: 'maxClusterNodeCount'
+            type: Integer
+            description: |
+              Maximum number of nodes of any type in a cluster.
+              If not specified the default limits apply.
+          - name: 'coolDownPeriod'
+            type: String
+            description: |
+              The minimum duration between consecutive autoscale operations.
+              It starts once addition or removal of nodes is fully completed.
+              Defaults to 30m if not specified. 
+              Cool down period must be in whole minutes (for example, 30m, 31m, 50m).
   - name: 'hcx'
     type: NestedObject
     description: |

--- a/mmv1/products/vmwareengine/PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/PrivateCloud.yaml
@@ -222,6 +222,8 @@ properties:
         type: NestedObject
         description: |
           Configuration of the autoscaling applied to this cluster
+          Currently, autoscale settings can be updated for management cluster only during updation
+          PC creation does not support autoscale settings for now
         properties:
           - name: 'autoscalingPolicies'
             type: Map

--- a/mmv1/products/vmwareengine/PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/PrivateCloud.yaml
@@ -262,10 +262,12 @@ properties:
                   properties:
                     - name: 'scaleOut'
                       type: Integer
+                      required: true
                       description: |
                         The utilization triggering the scale-out operation in percent.
                     - name: 'scaleIn'
                       type: Integer
+                      required: true
                       description: |
                         The utilization triggering the scale-in operation in percent.
                 - name: 'consumedMemoryThresholds'
@@ -275,10 +277,12 @@ properties:
                   properties:
                     - name: 'scaleOut'
                       type: Integer
+                      required: true
                       description: |
                         The utilization triggering the scale-out operation in percent.
                     - name: 'scaleIn'
                       type: Integer
+                      required: true
                       description: |
                         The utilization triggering the scale-in operation in percent.
                 - name: 'storageThresholds'
@@ -288,10 +292,12 @@ properties:
                   properties:
                     - name: 'scaleOut'
                       type: Integer
+                      required: true
                       description: |
                         The utilization triggering the scale-out operation in percent.
                     - name: 'scaleIn'
                       type: Integer
+                      required: true
                       description: |
                         The utilization triggering the scale-in operation in percent.
           - name: 'minClusterNodeCount'

--- a/mmv1/products/vmwareengine/PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/PrivateCloud.yaml
@@ -255,33 +255,10 @@ properties:
                   description: |
                     Number of nodes to add to a cluster during a scale-out operation.
                     Must be divisible by 2 for stretched clusters.
-                - name: 'minNodeCount'
-                  type: Integer
-                  description: |
-                    Minimum number of nodes of the given type in a cluster.
-                    The number is coerced to the minimum number of nodes of any type in the cluster.
-                - name: 'maxNodeCount'
-                  type: Integer
-                  description: |
-                    Maximum number of nodes of the given type in a cluster.
-                    The number is coerced to the maximum number of nodes of any type in the cluster.
                 - name: 'cpuThresholds'
                   type: NestedObject
                   description: |
                     Utilization thresholds pertaining to CPU utilization.
-                  properties:
-                    - name: 'scaleOut'
-                      type: Integer
-                      description: |
-                        The utilization triggering the scale-out operation in percent.
-                    - name: 'scaleIn'
-                      type: Integer
-                      description: |
-                        The utilization triggering the scale-in operation in percent.
-                - name: 'grantedMemoryThresholds'
-                  type: NestedObject
-                  description: |
-                    Utilization thresholds pertaining to amount of granted memory.
                   properties:
                     - name: 'scaleOut'
                       type: Integer

--- a/mmv1/products/vmwareengine/PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/PrivateCloud.yaml
@@ -223,7 +223,7 @@ properties:
         type: NestedObject
         description: |
           Configuration of the autoscaling applied to this cluster
-          You must have a minimum of 3 nodes in your PC to add autoscaling settings
+          Private cloud must have a minimum of 3 nodes to add autoscale settings
         properties:
           - name: 'autoscalingPolicies'
             type: Map

--- a/mmv1/products/vmwareengine/PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/PrivateCloud.yaml
@@ -224,8 +224,6 @@ properties:
         description: |
           Configuration of the autoscaling applied to this cluster
           You must have a minimum of 3 nodes in your PC to add autoscaling settings
-          Currently, autoscale settings can be updated for management cluster only during updation
-          PC creation does not support autoscale settings for now
         properties:
           - name: 'autoscalingPolicies'
             type: Map

--- a/mmv1/products/vmwareengine/PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/PrivateCloud.yaml
@@ -52,6 +52,7 @@ custom_code:
   update_encoder: 'templates/terraform/update_encoder/private_cloud.go.tmpl'
   decoder: 'templates/terraform/decoders/private_cloud.go.tmpl'
   pre_create: 'templates/terraform/pre_create/vmwareengine_private_cloud.go.tmpl'
+  post_create: 'templates/terraform/post_create/private_cloud.go.tmpl'
   post_delete: 'templates/terraform/post_delete/private_cloud.go.tmpl'
   post_update: 'templates/terraform/post_update/private_cloud.go.tmpl'
   pre_delete: 'templates/terraform/pre_delete/vmwareengine_private_cloud.go.tmpl'

--- a/mmv1/templates/terraform/examples/vmware_engine_private_cloud_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/vmware_engine_private_cloud_full.tf.tmpl
@@ -23,19 +23,19 @@ resource "google_vmwareengine_private_cloud" "{{$.PrimaryResourceId}}" {
         max_node_count = 8
         cpu_thresholds {
           scale_out = 80
-          scale_in = 10
+          scale_in  = 15
+        }
+				granted_memory_thresholds {
+				  scale_out = 80
+          scale_in  = 25
+        }
+        consumed_memory_thresholds {
+          scale_out = 75
+          scale_in  = 20
         }
         storage_thresholds {
           scale_out = 80
-          scale_in = 20
-        }
-        consumed_memory_thresholds {
-          scale_in  = 75
-          scale_out = 20
-        }
-        granted_memory_thresholds {
-          scale_in  = 80
-          scale_out = 25
+          scale_in  = 20
         }
       }
       min_cluster_node_count = 3

--- a/mmv1/templates/terraform/examples/vmware_engine_private_cloud_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/vmware_engine_private_cloud_full.tf.tmpl
@@ -25,13 +25,17 @@ resource "google_vmwareengine_private_cloud" "{{$.PrimaryResourceId}}" {
           scale_out = 80
           scale_in = 10
         }
-        consumed_memory_thresholds {
-          scale_out = 90
-          scale_in = 10
-        }
         storage_thresholds {
           scale_out = 80
           scale_in = 20
+        }
+        consumed_memory_thresholds {
+          scale_in  = 75
+          scale_out = 20
+        }
+        granted_memory_thresholds {
+          scale_in  = 80
+          scale_out = 25
         }
       }
       min_cluster_node_count = 3

--- a/mmv1/templates/terraform/examples/vmware_engine_private_cloud_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/vmware_engine_private_cloud_full.tf.tmpl
@@ -14,6 +14,30 @@ resource "google_vmwareengine_private_cloud" "{{$.PrimaryResourceId}}" {
       node_count   = 1
       custom_core_count = 32
     }
+    autoscaling_settings {
+      autoscaling_policies {
+        autoscale_policy_id = "autoscaling-policy"
+        node_type_id = "standard-72"
+        scale_out_size = 1
+        min_node_count = 3 
+        max_node_count = 8
+        cpu_thresholds {
+          scale_out = 80
+          scale_in = 10
+        }
+        consumed_memory_thresholds {
+          scale_out = 90
+          scale_in = 10
+        }
+        storage_thresholds {
+          scale_out = 80
+          scale_in = 20
+        }
+      }
+      min_cluster_node_count = 3
+      max_cluster_node_count = 8
+      cool_down_period = "1800s"
+    }
   }
   deletion_delay_hours = 0
   send_deletion_delay_hours_if_zero = true

--- a/mmv1/templates/terraform/examples/vmware_engine_private_cloud_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/vmware_engine_private_cloud_full.tf.tmpl
@@ -19,15 +19,9 @@ resource "google_vmwareengine_private_cloud" "{{$.PrimaryResourceId}}" {
         autoscale_policy_id = "autoscaling-policy"
         node_type_id = "standard-72"
         scale_out_size = 1
-        min_node_count = 3
-        max_node_count = 8
         cpu_thresholds {
           scale_out = 80
           scale_in  = 15
-        }
-				granted_memory_thresholds {
-				  scale_out = 80
-          scale_in  = 25
         }
         consumed_memory_thresholds {
           scale_out = 75

--- a/mmv1/templates/terraform/examples/vmware_engine_private_cloud_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/vmware_engine_private_cloud_full.tf.tmpl
@@ -19,7 +19,7 @@ resource "google_vmwareengine_private_cloud" "{{$.PrimaryResourceId}}" {
         autoscale_policy_id = "autoscaling-policy"
         node_type_id = "standard-72"
         scale_out_size = 1
-        min_node_count = 3 
+        min_node_count = 3
         max_node_count = 8
         cpu_thresholds {
           scale_out = 80

--- a/mmv1/templates/terraform/post_create/private_cloud.go.tmpl
+++ b/mmv1/templates/terraform/post_create/private_cloud.go.tmpl
@@ -1,0 +1,54 @@
+mgmtClusterProp, err := expandVmwareenginePrivateCloudManagementCluster(d.Get("management_cluster"), d, config)
+if v, ok := d.GetOkExists("management_cluster"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, mgmtClusterProp)) {
+		obj["managementCluster"] = mgmtClusterProp
+}
+
+mgmtMap := mgmtClusterProp.(map[string]interface{})
+parentUrl, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}VmwareengineBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/privateClouds/{{"{{"}}name{{"}}"}}")
+if err != nil {
+  return err
+}
+
+clusterUrl := fmt.Sprintf("%s/clusters/%s", parentUrl, mgmtMap["clusterId"])
+clusterUpdateMask := []string{}
+clusterObj := make(map[string]interface{})
+
+if v, ok := d.GetOkExists("management_cluster"); !tpgresource.IsEmptyValue(reflect.ValueOf(mgmtClusterProp)) && (ok || !reflect.DeepEqual(v, mgmtClusterProp)) {
+  clusterObj["autoscalingSettings"] = mgmtMap["autoscalingSettings"]
+}
+
+if d.HasChange("management_cluster") {
+  clusterUpdateMask = append(clusterUpdateMask, "autoscalingSettings")
+}
+
+clusterPatchUrl, err := transport_tpg.AddQueryParams(clusterUrl, map[string]string{"updateMask": strings.Join(clusterUpdateMask, ",")})
+if err != nil {
+  return err
+}
+
+// check if there is anything to update to avoid API call if not required.
+if len(clusterUpdateMask) > 0 {
+    res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+      Config:    config,
+      Method:    "PATCH",
+      Project:   billingProject,
+      RawURL:    clusterPatchUrl,
+      UserAgent: userAgent,
+      Body:      clusterObj,
+      Timeout:   d.Timeout(schema.TimeoutUpdate),
+    })
+
+    if err != nil {
+      return fmt.Errorf("Error updating magament cluster %q: %s", d.Id(), err)
+    } else {
+      log.Printf("[DEBUG] Finished updating magament cluster %q: %#v", d.Id(), res)
+    }
+
+    err = VmwareengineOperationWaitTime(
+      config, res, project, "Updating Managment Cluster", userAgent,
+      d.Timeout(schema.TimeoutUpdate))
+
+    if err != nil {
+      return err
+    }
+}

--- a/mmv1/templates/terraform/post_update/private_cloud.go.tmpl
+++ b/mmv1/templates/terraform/post_update/private_cloud.go.tmpl
@@ -15,10 +15,12 @@ clusterObj := make(map[string]interface{})
 
 if v, ok := d.GetOkExists("management_cluster"); !tpgresource.IsEmptyValue(reflect.ValueOf(mgmtClusterProp)) && (ok || !reflect.DeepEqual(v, mgmtClusterProp)) {
   clusterObj["nodeTypeConfigs"] = mgmtMap["nodeTypeConfigs"]
+  clusterObj["autoscalingSettings"] = mgmtMap["autoscalingSettings"]
 }
 
 if d.HasChange("management_cluster") {
   clusterUpdateMask = append(clusterUpdateMask, "nodeTypeConfigs.*.nodeCount")
+  clusterUpdateMask = append(clusterUpdateMask, "autoscalingSettings")
 }
 
 clusterPatchUrl, err := transport_tpg.AddQueryParams(clusterUrl, map[string]string{"updateMask": strings.Join(clusterUpdateMask, ",")})

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
@@ -260,7 +260,7 @@ resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
         autoscale_policy_id = "autoscaling-policy"
         node_type_id = "standard-72"
         scale_out_size = 1
-        min_node_count = 3 
+        min_node_count = 3
         max_node_count = 8
         cpu_thresholds {
           scale_out = 80

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
@@ -151,7 +151,7 @@ func TestAccVmwareenginePrivateCloud_vmwareEnginePrivateCloudUpdate(t *testing.T
 }
 
 func testVmwareenginePrivateCloudCreateConfig(context map[string]interface{}) string {
-	return testVmwareenginePrivateCloudConfig(context, "sample description", "TIME_LIMITED", 1, 1) + testVmwareengineVcenterNSXCredentailsConfig(context)
+	return testVmwareenginePrivateCloudConfig(context, "sample description", "STANDARD", 3, 8) + testVmwareengineVcenterNSXCredentailsConfig(context)
 }
 
 func testVmwareenginePrivateCloudUpdateNodeConfig(context map[string]interface{}) string {
@@ -208,6 +208,20 @@ resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
       node_type_id = "standard-72"
       node_count = "%{node_count}"
       custom_core_count = 32
+    }
+		autoscaling_settings {
+      autoscaling_policies {
+        autoscale_policy_id = "autoscaling-policy"
+        node_type_id = "standard-72"
+        scale_out_size = 1
+        storage_thresholds {
+          scale_out = 60
+          scale_in  = 20
+        }
+      }
+      min_cluster_node_count = 3
+      max_cluster_node_count = 8
+      cool_down_period = "1800s"
     }
   }
 }

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
@@ -1,5 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
 package vmwareengine_test
 
 import (

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
@@ -264,19 +264,19 @@ resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
         max_node_count = 8
         cpu_thresholds {
           scale_out = 80
-          scale_in = 10
+          scale_in  = 15
+        }
+				granted_memory_thresholds {
+				  scale_out = 80
+          scale_in  = 25
+        }
+        consumed_memory_thresholds {
+          scale_out = 75
+          scale_in  = 20
         }
         storage_thresholds {
           scale_out = 80
-          scale_in = 20
-        }
-        consumed_memory_thresholds {
-          scale_in  = 75
-          scale_out = 20
-        }
-        granted_memory_thresholds {
-          scale_in  = 80
-          scale_out = 25
+          scale_in  = 20
         }
       }
       min_cluster_node_count = 3

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
@@ -260,15 +260,9 @@ resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
         autoscale_policy_id = "autoscaling-policy"
         node_type_id = "standard-72"
         scale_out_size = 1
-        min_node_count = 3
-        max_node_count = 8
         cpu_thresholds {
           scale_out = 80
           scale_in  = 15
-        }
-				granted_memory_thresholds {
-				  scale_out = 80
-          scale_in  = 25
         }
         consumed_memory_thresholds {
           scale_out = 75

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
@@ -270,6 +270,14 @@ resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
           scale_out = 80
           scale_in = 20
         }
+        consumed_memory_thresholds {
+          scale_in  = 75
+          scale_out = 20
+        }
+        granted_memory_thresholds {
+          scale_in  = 80
+          scale_out = 25
+        }
       }
       min_cluster_node_count = 3
       max_cluster_node_count = 8

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_private_cloud_test.go
@@ -1,3 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
 package vmwareengine_test
 
 import (
@@ -55,7 +57,27 @@ func TestAccVmwareenginePrivateCloud_vmwareEnginePrivateCloudUpdate(t *testing.T
 			},
 
 			{
-				Config: testVmwareenginePrivateCloudUpdateConfig(context),
+				Config: testVmwareenginePrivateCloudUpdateNodeConfig(context),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores(
+						"data.google_vmwareengine_private_cloud.ds",
+						"google_vmwareengine_private_cloud.vmw-engine-pc",
+						map[string]struct{}{
+							"type":                              {},
+							"deletion_delay_hours":              {},
+							"send_deletion_delay_hours_if_zero": {},
+						}),
+				),
+			},
+			{
+				ResourceName:            "google_vmwareengine_private_cloud.vmw-engine-pc",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "name", "update_time", "type", "deletion_delay_hours", "send_deletion_delay_hours_if_zero"},
+			},
+
+			{
+				Config: testVmwareenginePrivateCloudUpdateAutoscaleConfig(context),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores(
 						"data.google_vmwareengine_private_cloud.ds",
@@ -134,8 +156,12 @@ func testVmwareenginePrivateCloudCreateConfig(context map[string]interface{}) st
 	return testVmwareenginePrivateCloudConfig(context, "sample description", "TIME_LIMITED", 1, 1) + testVmwareengineVcenterNSXCredentailsConfig(context)
 }
 
-func testVmwareenginePrivateCloudUpdateConfig(context map[string]interface{}) string {
+func testVmwareenginePrivateCloudUpdateNodeConfig(context map[string]interface{}) string {
 	return testVmwareenginePrivateCloudConfig(context, "sample updated description", "STANDARD", 3, 8) + testVmwareengineVcenterNSXCredentailsConfig(context)
+}
+
+func testVmwareenginePrivateCloudUpdateAutoscaleConfig(context map[string]interface{}) string {
+	return testVmwareenginePrivateCloudAutoscaleConfig(context, "sample updated description", "STANDARD", 3, 8) + testVmwareengineVcenterNSXCredentailsConfig(context)
 }
 
 func testVmwareenginePrivateCloudDelayedDeleteConfig(context map[string]interface{}) string {
@@ -143,15 +169,15 @@ func testVmwareenginePrivateCloudDelayedDeleteConfig(context map[string]interfac
 }
 
 func testVmwareenginePrivateCloudUndeleteConfig(context map[string]interface{}) string {
-	return testVmwareenginePrivateCloudConfig(context, "sample updated description", "STANDARD", 3, 0) + testVmwareengineVcenterNSXCredentailsConfig(context)
+	return testVmwareenginePrivateCloudAutoscaleConfig(context, "sample updated description", "STANDARD", 3, 0) + testVmwareengineVcenterNSXCredentailsConfig(context)
 }
 
 func testVmwareengineSubnetImportConfig(context map[string]interface{}) string {
-	return testVmwareenginePrivateCloudConfig(context, "sample updated description", "STANDARD", 3, 0) + testVmwareengineSubnetConfig(context, "192.168.1.0/26")
+	return testVmwareenginePrivateCloudAutoscaleConfig(context, "sample updated description", "STANDARD", 3, 0) + testVmwareengineSubnetConfig(context, "192.168.1.0/26")
 }
 
 func testVmwareengineSubnetUpdateConfig(context map[string]interface{}) string {
-	return testVmwareenginePrivateCloudConfig(context, "sample updated description", "STANDARD", 3, 0) + testVmwareengineSubnetConfig(context, "192.168.2.0/26")
+	return testVmwareenginePrivateCloudAutoscaleConfig(context, "sample updated description", "STANDARD", 3, 0) + testVmwareengineSubnetConfig(context, "192.168.2.0/26")
 }
 
 func testVmwareenginePrivateCloudConfig(context map[string]interface{}, description, pcType string, nodeCount, delayHours int) string {
@@ -184,6 +210,70 @@ resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
       node_type_id = "standard-72"
       node_count = "%{node_count}"
       custom_core_count = 32
+    }
+  }
+}
+
+data "google_vmwareengine_private_cloud" "ds" {
+	location = "%{region}-b"
+	name = "tf-test-sample-pc%{random_suffix}"
+	depends_on = [
+   	google_vmwareengine_private_cloud.vmw-engine-pc,
+  ]
+}
+`, context)
+}
+
+func testVmwareenginePrivateCloudAutoscaleConfig(context map[string]interface{}, description, pcType string, nodeCount, delayHours int) string {
+	context["node_count"] = nodeCount
+	context["delay_hrs"] = delayHours
+	context["description"] = description
+	context["type"] = pcType
+	return acctest.Nprintf(`
+resource "google_vmwareengine_network" "vmw-engine-nw" {
+  name              = "tf-test-pc-nw-%{random_suffix}"
+  location          = "global"
+  type              = "STANDARD"
+  description       = "PC network description."
+}
+
+resource "google_vmwareengine_private_cloud" "vmw-engine-pc" {
+  location = "%{region}-b"
+  name = "tf-test-sample-pc%{random_suffix}"
+  description = "%{description}"
+  type = "%{type}"
+  deletion_delay_hours = "%{delay_hrs}"
+  send_deletion_delay_hours_if_zero = true
+  network_config {
+    management_cidr = "192.168.0.0/24"
+    vmware_engine_network = google_vmwareengine_network.vmw-engine-nw.id
+  }
+  management_cluster {
+    cluster_id = "tf-test-sample-mgmt-cluster-custom-core-count%{random_suffix}"
+    node_type_configs {
+      node_type_id = "standard-72"
+      node_count = "%{node_count}"
+      custom_core_count = 32
+    }
+    autoscaling_settings {
+      autoscaling_policies {
+        autoscale_policy_id = "autoscaling-policy"
+        node_type_id = "standard-72"
+        scale_out_size = 1
+        min_node_count = 3 
+        max_node_count = 8
+        cpu_thresholds {
+          scale_out = 80
+          scale_in = 10
+        }
+        storage_thresholds {
+          scale_out = 80
+          scale_in = 20
+        }
+      }
+      min_cluster_node_count = 3
+      max_cluster_node_count = 8
+      cool_down_period = "1800s"
     }
   }
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add terraform support for autoscaling in pc management cluster

Private Cloud Acceptance Tests pass at [gpaste/5685698748481536](https://paste.googleplex.com/5685698748481536)


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
vmwareengine: added `autoscaling_settings` to `google_vmwareengine_private_cloud` resource
```
