### PR TITLE
Remove parallel runs for vertex_endpoint_iam tests

### DIFF
--- a/mmv1/third_party/terraform/services/vertexai/iam_vertex_endpoint_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/vertexai/iam_vertex_endpoint_test.go.tmpl
@@ -52,7 +52,7 @@ func TestAccVertexAIEndpointIamMember(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-    "network_name": acctest.BootstrapSharedServiceNetworkingConnection(t, "vertex-ai-endpoint-iam-1"),
+    "network_name": acctest.BootstrapSharedServiceNetworkingConnection(t, "vertex-ai-endpoint-iam-2"),
 		"random_suffix": acctest.RandString(t, 10),
 		"role":          "roles/viewer",
 	}
@@ -79,7 +79,7 @@ func TestAccVertexAIEndpointIamPolicy(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-    "network_name": acctest.BootstrapSharedServiceNetworkingConnection(t, "vertex-ai-endpoint-iam-1"),
+    "network_name": acctest.BootstrapSharedServiceNetworkingConnection(t, "vertex-ai-endpoint-iam-3"),
 		"random_suffix": acctest.RandString(t, 10),
 		"role":          "roles/viewer",
 	}

--- a/mmv1/third_party/terraform/services/vertexai/iam_vertex_endpoint_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/vertexai/iam_vertex_endpoint_test.go.tmpl
@@ -14,6 +14,7 @@ import (
 
 func TestAccVertexAIEndpointIamBinding(t *testing.T) {
 	// t.Parallel()
+	// See https://github.com/hashicorp/terraform-provider-google/issues/18932
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),

--- a/mmv1/third_party/terraform/services/vertexai/iam_vertex_endpoint_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/vertexai/iam_vertex_endpoint_test.go.tmpl
@@ -16,6 +16,7 @@ func TestAccVertexAIEndpointIamBinding(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
+    "network_name": acctest.BootstrapSharedServiceNetworkingConnection(t, "vertex-ai-endpoint-iam-1"),
 		"random_suffix": acctest.RandString(t, 10),
 		"role":          "roles/viewer",
 	}
@@ -51,6 +52,7 @@ func TestAccVertexAIEndpointIamMember(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
+    "network_name": acctest.BootstrapSharedServiceNetworkingConnection(t, "vertex-ai-endpoint-iam-1"),
 		"random_suffix": acctest.RandString(t, 10),
 		"role":          "roles/viewer",
 	}
@@ -77,6 +79,7 @@ func TestAccVertexAIEndpointIamPolicy(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
+    "network_name": acctest.BootstrapSharedServiceNetworkingConnection(t, "vertex-ai-endpoint-iam-1"),
 		"random_suffix": acctest.RandString(t, 10),
 		"role":          "roles/viewer",
 	}
@@ -140,7 +143,7 @@ resource "google_compute_global_address" "vertex_range" {
 }
 
 resource "google_compute_network" "vertex_network" {
-  name       = "tf-test-network-name%{random_suffix}"
+  name       = "%{network_name}"
 }
 
 data "google_project" "project" {}
@@ -187,7 +190,7 @@ resource "google_compute_global_address" "vertex_range" {
 }
 
 resource "google_compute_network" "vertex_network" {
-  name       = "tf-test-network-name%{random_suffix}"
+  name       = "%{network_name}"
 }
 
 data "google_project" "project" {}
@@ -249,7 +252,7 @@ resource "google_compute_global_address" "vertex_range" {
 }
 
 resource "google_compute_network" "vertex_network" {
-  name       = "tf-test-network-name%{random_suffix}"
+  name       = "%{network_name}"
 }
 
 data "google_project" "project" {}
@@ -298,7 +301,7 @@ resource "google_compute_global_address" "vertex_range" {
 }
 
 resource "google_compute_network" "vertex_network" {
-  name       = "tf-test-network-name%{random_suffix}"
+  name       = "%{network_name}"
 }
 
 data "google_project" "project" {}
@@ -345,7 +348,7 @@ resource "google_compute_global_address" "vertex_range" {
 }
 
 resource "google_compute_network" "vertex_network" {
-  name       = "tf-test-network-name%{random_suffix}"
+  name       = "%{network_name}"
 }
 
 data "google_project" "project" {}

--- a/mmv1/third_party/terraform/services/vertexai/iam_vertex_endpoint_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/vertexai/iam_vertex_endpoint_test.go.tmpl
@@ -122,14 +122,14 @@ resource "google_vertex_ai_endpoint" "endpoint" {
   labels       = {
     label-one = "value-one"
   }
-  network      = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.vertex_network.name}"
+  network      = "projects/${data.google_project.project.number}/global/networks/${data.google_compute_network.vertex_network.name}"
   depends_on   = [
     google_service_networking_connection.vertex_vpc_connection
   ]
 }
 
 resource "google_service_networking_connection" "vertex_vpc_connection" {
-  network                 = google_compute_network.vertex_network.id
+  network                 = data.google_compute_network.vertex_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.vertex_range.name]
 }
@@ -139,10 +139,10 @@ resource "google_compute_global_address" "vertex_range" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 24
-  network       = google_compute_network.vertex_network.id
+  network       = data.google_compute_network.vertex_network.id
 }
 
-resource "google_compute_network" "vertex_network" {
+data "google_compute_network" "vertex_network" {
   name       = "%{network_name}"
 }
 
@@ -169,14 +169,14 @@ resource "google_vertex_ai_endpoint" "endpoint" {
   labels       = {
     label-one = "value-one"
   }
-  network      = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.vertex_network.name}"
+  network      = "projects/${data.google_project.project.number}/global/networks/${data.google_compute_network.vertex_network.name}"
   depends_on   = [
     google_service_networking_connection.vertex_vpc_connection
   ]
 }
 
 resource "google_service_networking_connection" "vertex_vpc_connection" {
-  network                 = google_compute_network.vertex_network.id
+  network                 = data.google_compute_network.vertex_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.vertex_range.name]
 }
@@ -186,10 +186,10 @@ resource "google_compute_global_address" "vertex_range" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 24
-  network       = google_compute_network.vertex_network.id
+  network       = data.google_compute_network.vertex_network.id
 }
 
-resource "google_compute_network" "vertex_network" {
+data "google_compute_network" "vertex_network" {
   name       = "%{network_name}"
 }
 
@@ -231,14 +231,14 @@ resource "google_vertex_ai_endpoint" "endpoint" {
   labels       = {
     label-one = "value-one"
   }
-  network      = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.vertex_network.name}"
+  network      = "projects/${data.google_project.project.number}/global/networks/${data.google_compute_network.vertex_network.name}"
   depends_on   = [
     google_service_networking_connection.vertex_vpc_connection
   ]
 }
 
 resource "google_service_networking_connection" "vertex_vpc_connection" {
-  network                 = google_compute_network.vertex_network.id
+  network                 = data.google_compute_network.vertex_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.vertex_range.name]
 }
@@ -248,10 +248,10 @@ resource "google_compute_global_address" "vertex_range" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 24
-  network       = google_compute_network.vertex_network.id
+  network       = data.google_compute_network.vertex_network.id
 }
 
-resource "google_compute_network" "vertex_network" {
+data "google_compute_network" "vertex_network" {
   name       = "%{network_name}"
 }
 
@@ -280,14 +280,14 @@ resource "google_vertex_ai_endpoint" "endpoint" {
   labels       = {
     label-one = "value-one"
   }
-  network      = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.vertex_network.name}"
+  network      = "projects/${data.google_project.project.number}/global/networks/${data.google_compute_network.vertex_network.name}"
   depends_on   = [
     google_service_networking_connection.vertex_vpc_connection
   ]
 }
 
 resource "google_service_networking_connection" "vertex_vpc_connection" {
-  network                 = google_compute_network.vertex_network.id
+  network                 = data.google_compute_network.vertex_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.vertex_range.name]
 }
@@ -297,10 +297,10 @@ resource "google_compute_global_address" "vertex_range" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 24
-  network       = google_compute_network.vertex_network.id
+  network       = data.google_compute_network.vertex_network.id
 }
 
-resource "google_compute_network" "vertex_network" {
+data "google_compute_network" "vertex_network" {
   name       = "%{network_name}"
 }
 
@@ -327,14 +327,14 @@ resource "google_vertex_ai_endpoint" "endpoint" {
   labels       = {
     label-one = "value-one"
   }
-  network      = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.vertex_network.name}"
+  network      = "projects/${data.google_project.project.number}/global/networks/${data.google_compute_network.vertex_network.name}"
   depends_on   = [
     google_service_networking_connection.vertex_vpc_connection
   ]
 }
 
 resource "google_service_networking_connection" "vertex_vpc_connection" {
-  network                 = google_compute_network.vertex_network.id
+  network                 = data.google_compute_network.vertex_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.vertex_range.name]
 }
@@ -344,10 +344,10 @@ resource "google_compute_global_address" "vertex_range" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 24
-  network       = google_compute_network.vertex_network.id
+  network       = data.google_compute_network.vertex_network.id
 }
 
-resource "google_compute_network" "vertex_network" {
+data "google_compute_network" "vertex_network" {
   name       = "%{network_name}"
 }
 

--- a/mmv1/third_party/terraform/services/vertexai/iam_vertex_endpoint_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/vertexai/iam_vertex_endpoint_test.go.tmpl
@@ -13,10 +13,9 @@ import (
 )
 
 func TestAccVertexAIEndpointIamBinding(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	context := map[string]interface{}{
-    "network_name": acctest.BootstrapSharedServiceNetworkingConnection(t, "vertex-ai-endpoint-iam-1"),
 		"random_suffix": acctest.RandString(t, 10),
 		"role":          "roles/viewer",
 	}
@@ -49,10 +48,9 @@ func TestAccVertexAIEndpointIamBinding(t *testing.T) {
 }
 
 func TestAccVertexAIEndpointIamMember(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	context := map[string]interface{}{
-    "network_name": acctest.BootstrapSharedServiceNetworkingConnection(t, "vertex-ai-endpoint-iam-2"),
 		"random_suffix": acctest.RandString(t, 10),
 		"role":          "roles/viewer",
 	}
@@ -76,10 +74,9 @@ func TestAccVertexAIEndpointIamMember(t *testing.T) {
 }
 
 func TestAccVertexAIEndpointIamPolicy(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	context := map[string]interface{}{
-    "network_name": acctest.BootstrapSharedServiceNetworkingConnection(t, "vertex-ai-endpoint-iam-3"),
 		"random_suffix": acctest.RandString(t, 10),
 		"role":          "roles/viewer",
 	}
@@ -122,14 +119,14 @@ resource "google_vertex_ai_endpoint" "endpoint" {
   labels       = {
     label-one = "value-one"
   }
-  network      = "projects/${data.google_project.project.number}/global/networks/${data.google_compute_network.vertex_network.name}"
+  network      = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.vertex_network.name}"
   depends_on   = [
     google_service_networking_connection.vertex_vpc_connection
   ]
 }
 
 resource "google_service_networking_connection" "vertex_vpc_connection" {
-  network                 = data.google_compute_network.vertex_network.id
+  network                 = google_compute_network.vertex_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.vertex_range.name]
 }
@@ -139,11 +136,11 @@ resource "google_compute_global_address" "vertex_range" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 24
-  network       = data.google_compute_network.vertex_network.id
+  network       = google_compute_network.vertex_network.id
 }
 
-data "google_compute_network" "vertex_network" {
-  name       = "%{network_name}"
+resource "google_compute_network" "vertex_network" {
+  name       = "tf-test-network-name%{random_suffix}"
 }
 
 data "google_project" "project" {}
@@ -169,14 +166,14 @@ resource "google_vertex_ai_endpoint" "endpoint" {
   labels       = {
     label-one = "value-one"
   }
-  network      = "projects/${data.google_project.project.number}/global/networks/${data.google_compute_network.vertex_network.name}"
+  network      = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.vertex_network.name}"
   depends_on   = [
     google_service_networking_connection.vertex_vpc_connection
   ]
 }
 
 resource "google_service_networking_connection" "vertex_vpc_connection" {
-  network                 = data.google_compute_network.vertex_network.id
+  network                 = google_compute_network.vertex_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.vertex_range.name]
 }
@@ -186,11 +183,11 @@ resource "google_compute_global_address" "vertex_range" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 24
-  network       = data.google_compute_network.vertex_network.id
+  network       = google_compute_network.vertex_network.id
 }
 
-data "google_compute_network" "vertex_network" {
-  name       = "%{network_name}"
+resource "google_compute_network" "vertex_network" {
+  name       = "tf-test-network-name%{random_suffix}"
 }
 
 data "google_project" "project" {}
@@ -231,14 +228,14 @@ resource "google_vertex_ai_endpoint" "endpoint" {
   labels       = {
     label-one = "value-one"
   }
-  network      = "projects/${data.google_project.project.number}/global/networks/${data.google_compute_network.vertex_network.name}"
+  network      = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.vertex_network.name}"
   depends_on   = [
     google_service_networking_connection.vertex_vpc_connection
   ]
 }
 
 resource "google_service_networking_connection" "vertex_vpc_connection" {
-  network                 = data.google_compute_network.vertex_network.id
+  network                 = google_compute_network.vertex_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.vertex_range.name]
 }
@@ -248,11 +245,11 @@ resource "google_compute_global_address" "vertex_range" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 24
-  network       = data.google_compute_network.vertex_network.id
+  network       = google_compute_network.vertex_network.id
 }
 
-data "google_compute_network" "vertex_network" {
-  name       = "%{network_name}"
+resource "google_compute_network" "vertex_network" {
+  name       = "tf-test-network-name%{random_suffix}"
 }
 
 data "google_project" "project" {}
@@ -280,14 +277,14 @@ resource "google_vertex_ai_endpoint" "endpoint" {
   labels       = {
     label-one = "value-one"
   }
-  network      = "projects/${data.google_project.project.number}/global/networks/${data.google_compute_network.vertex_network.name}"
+  network      = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.vertex_network.name}"
   depends_on   = [
     google_service_networking_connection.vertex_vpc_connection
   ]
 }
 
 resource "google_service_networking_connection" "vertex_vpc_connection" {
-  network                 = data.google_compute_network.vertex_network.id
+  network                 = google_compute_network.vertex_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.vertex_range.name]
 }
@@ -297,11 +294,11 @@ resource "google_compute_global_address" "vertex_range" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 24
-  network       = data.google_compute_network.vertex_network.id
+  network       = google_compute_network.vertex_network.id
 }
 
-data "google_compute_network" "vertex_network" {
-  name       = "%{network_name}"
+resource "google_compute_network" "vertex_network" {
+  name       = "tf-test-network-name%{random_suffix}"
 }
 
 data "google_project" "project" {}
@@ -327,14 +324,14 @@ resource "google_vertex_ai_endpoint" "endpoint" {
   labels       = {
     label-one = "value-one"
   }
-  network      = "projects/${data.google_project.project.number}/global/networks/${data.google_compute_network.vertex_network.name}"
+  network      = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.vertex_network.name}"
   depends_on   = [
     google_service_networking_connection.vertex_vpc_connection
   ]
 }
 
 resource "google_service_networking_connection" "vertex_vpc_connection" {
-  network                 = data.google_compute_network.vertex_network.id
+  network                 = google_compute_network.vertex_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.vertex_range.name]
 }
@@ -344,11 +341,11 @@ resource "google_compute_global_address" "vertex_range" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 24
-  network       = data.google_compute_network.vertex_network.id
+  network       = google_compute_network.vertex_network.id
 }
 
-data "google_compute_network" "vertex_network" {
-  name       = "%{network_name}"
+resource "google_compute_network" "vertex_network" {
+  name       = "tf-test-network-name%{random_suffix}"
 }
 
 data "google_project" "project" {}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
There are 3 flaky different vertex endpoint iam tests failing for the same reason. Looks like for each endpoint only one network is permitted. Remove parallel runs for the tests and see if it fixes the problem.

Note: These tests always pass in VCR.
fixes https://github.com/hashicorp/terraform-provider-google/issues/18932

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
