### PR TITLE
Change backupvault force-delete behavior: have two separate parameters for different deletion scenarios.

### DIFF
--- a/mmv1/products/backupdr/BackupVault.yaml
+++ b/mmv1/products/backupdr/BackupVault.yaml
@@ -23,7 +23,7 @@ create_url: 'projects/{{project}}/locations/{{location}}/backupVaults?backupVaul
 update_url: 'projects/{{project}}/locations/{{location}}/backupVaults/{{backup_vault_id}}?force={{force_update}}'
 update_verb: 'PATCH'
 update_mask: true
-delete_url: 'projects/{{project}}/locations/{{location}}/backupVaults/{{backup_vault_id}}?force={{ignore_inactive_datasources}}&ignoreBackupPlanReferences={{ignore_backup_plan_references}}&allowMissing={{allow_missing}}'
+delete_url: 'projects/{{project}}/locations/{{location}}/backupVaults/{{backup_vault_id}}'
 import_format:
   - 'projects/{{project}}/locations/{{location}}/backupVaults/{{backup_vault_id}}'
 timeouts:
@@ -45,6 +45,8 @@ async:
     path: 'error'
     message: 'message'
 custom_code:
+  !ruby/object:Provider::Terraform::CustomCode
+  pre_delete: 'templates/terraform/pre_delete/backup_dr_backup_vault.go.tmpl'
 examples:
   - name: 'backup_dr_backup_vault_full'
     primary_resource_id: 'backup-vault-test'
@@ -75,6 +77,14 @@ parameters:
         the restriction against conflicting retention periods. This conflict may occur when the
         expiration schedule defined by the associated backup plan is shorter than the minimum
         retention set by the backup vault.
+    min_version: 'beta'
+    url_param_only: true
+    default_value: false
+  - name: 'force-delete'
+    type: Boolean
+    description: |
+       If set, the following restrictions against deletion of the backup vault instance can be overridden:
+          * deletion of a backup vault instance containing no backups, but still containing empty datasources.
     min_version: 'beta'
     url_param_only: true
     default_value: false

--- a/mmv1/products/backupdr/BackupVault.yaml
+++ b/mmv1/products/backupdr/BackupVault.yaml
@@ -23,7 +23,7 @@ create_url: 'projects/{{project}}/locations/{{location}}/backupVaults?backupVaul
 update_url: 'projects/{{project}}/locations/{{location}}/backupVaults/{{backup_vault_id}}?force={{force_update}}'
 update_verb: 'PATCH'
 update_mask: true
-delete_url: 'projects/{{project}}/locations/{{location}}/backupVaults/{{backup_vault_id}}?force={{force_delete}}&allowMissing={{allow_missing}}'
+delete_url: 'projects/{{project}}/locations/{{location}}/backupVaults/{{backup_vault_id}}?force={{ignore_inactive_datasources}}&ignoreBackupPlanReferences={{ignore_backup_plan_references}}&allowMissing={{allow_missing}}'
 import_format:
   - 'projects/{{project}}/locations/{{location}}/backupVaults/{{backup_vault_id}}'
 timeouts:
@@ -78,11 +78,18 @@ parameters:
     min_version: 'beta'
     url_param_only: true
     default_value: false
-  - name: 'force_delete'
+  - name: 'ignore_inactive_datasources'
     type: Boolean
     description: |
        If set, the following restrictions against deletion of the backup vault instance can be overridden:
           * deletion of a backup vault instance containing no backups, but still containing empty datasources.
+    min_version: 'beta'
+    url_param_only: true
+    default_value: false
+  - name: 'ignore_backup_plan_references'
+    type: Boolean
+    description: |
+       If set, the following restrictions against deletion of the backup vault instance can be overridden:
           * deletion of a backup vault instance that is being referenced by an active backup plan.
     min_version: 'beta'
     url_param_only: true

--- a/mmv1/products/backupdr/BackupVault.yaml
+++ b/mmv1/products/backupdr/BackupVault.yaml
@@ -80,12 +80,6 @@ parameters:
     min_version: 'beta'
     url_param_only: true
     default_value: false
-  - name: 'force_delete'
-    type: Boolean
-    description: |
-       If set, the following restrictions against deletion of the backup vault instance can be overridden:
-          * deletion of a backup vault instance containing no backups, but still containing empty datasources.
-    min_version: 'beta'
   - name: 'ignore_inactive_datasources'
     type: Boolean
     description: |

--- a/mmv1/products/backupdr/BackupVault.yaml
+++ b/mmv1/products/backupdr/BackupVault.yaml
@@ -80,14 +80,12 @@ parameters:
     min_version: 'beta'
     url_param_only: true
     default_value: false
-  - name: 'force-delete'
+  - name: 'force_delete'
     type: Boolean
     description: |
        If set, the following restrictions against deletion of the backup vault instance can be overridden:
           * deletion of a backup vault instance containing no backups, but still containing empty datasources.
     min_version: 'beta'
-    url_param_only: true
-    default_value: false
   - name: 'ignore_inactive_datasources'
     type: Boolean
     description: |

--- a/mmv1/products/backupdr/BackupVault.yaml
+++ b/mmv1/products/backupdr/BackupVault.yaml
@@ -89,9 +89,8 @@ parameters:
     min_version: 'beta'
     url_param_only: true
     default_value: false
-    deprecation_message: '`force_delete` is deprecated and will be removed in a future major release. Use ignore_inactive_datasources` instead.'
-    exactly_one_of:
-      - 'force_delete'
+    deprecation_message: '`force_delete` is deprecated and will be removed in a future major release. Use `ignore_inactive_datasources` instead.'
+    conflicts:
       - 'ignore_inactive_datasources'
   - name: 'ignore_inactive_datasources'
     type: Boolean
@@ -101,9 +100,8 @@ parameters:
     min_version: 'beta'
     url_param_only: true
     default_value: false
-    exactly_one_of:
+    conflicts:
       - 'force_delete'
-      - 'ignore_inactive_datasources'
   - name: 'ignore_backup_plan_references'
     type: Boolean
     description: |

--- a/mmv1/products/backupdr/BackupVault.yaml
+++ b/mmv1/products/backupdr/BackupVault.yaml
@@ -80,6 +80,19 @@ parameters:
     min_version: 'beta'
     url_param_only: true
     default_value: false
+  - name: 'force_delete'
+    type: Boolean
+    description: |
+       If set, the following restrictions against deletion of the backup vault instance can be overridden:
+          * deletion of a backup vault instance containing no backups, but still containing empty datasources.
+          * deletion of a backup vault instance that is being referenced by an active backup plan.
+    min_version: 'beta'
+    url_param_only: true
+    default_value: false
+    deprecation_message: '`force_delete` is deprecated and will be removed in a future major release. Use ignore_inactive_datasources` instead.'
+    exactly_one_of:
+      - 'force_delete'
+      - 'ignore_inactive_datasources'
   - name: 'ignore_inactive_datasources'
     type: Boolean
     description: |
@@ -88,6 +101,9 @@ parameters:
     min_version: 'beta'
     url_param_only: true
     default_value: false
+    exactly_one_of:
+      - 'force_delete'
+      - 'ignore_inactive_datasources'
   - name: 'ignore_backup_plan_references'
     type: Boolean
     description: |

--- a/mmv1/templates/terraform/examples/backup_dr_backup_vault_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/backup_dr_backup_vault_full.tf.tmpl
@@ -13,6 +13,7 @@ resource "google_backup_dr_backup_vault" "{{$.PrimaryResourceId}}" {
     annotations2 = "baz1"
   }
   force_update = "true"
-  force_delete = "true"
+  ignore_inactive_datasources = "true"
+  ignore_backup_plan_references = "true"
   allow_missing = "true"
 }

--- a/mmv1/templates/terraform/pre_delete/backup_dr_backup_vault.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/backup_dr_backup_vault.go.tmpl
@@ -1,0 +1,18 @@
+if v, ok := d.GetOk("ignore_inactive_datasources"); ok {
+    url, err = transport_tpg.AddQueryParams(url, map[string]string{"force": fmt.Sprintf("%v", v)})
+    if err != nil {
+        return err
+    }
+}
+if v, ok := d.GetOk("ignore_backup_plan_references"); ok {
+    url, err = transport_tpg.AddQueryParams(url, map[string]string{"ignoreBackupPlanReferences": fmt.Sprintf("%v", v)})
+    if err != nil {
+        return err
+    }
+}
+if v, ok := d.GetOk("allow_missing"); ok {
+    url, err = transport_tpg.AddQueryParams(url, map[string]string{"allowMissing": fmt.Sprintf("%v", v)})
+    if err != nil {
+        return err
+    }
+}

--- a/mmv1/templates/terraform/pre_delete/backup_dr_backup_vault.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/backup_dr_backup_vault.go.tmpl
@@ -1,4 +1,10 @@
-if v, ok := d.GetOk("ignore_inactive_datasources"); ok {
+if v, ok := d.GetOk("ignore_inactive_datasources") ; ok {
+    url, err = transport_tpg.AddQueryParams(url, map[string]string{"force": fmt.Sprintf("%v", v)})
+    if err != nil {
+        return err
+    }
+}
+if v, ok := d.GetOk("force_delete") ; ok {
     url, err = transport_tpg.AddQueryParams(url, map[string]string{"force": fmt.Sprintf("%v", v)})
     if err != nil {
         return err

--- a/mmv1/third_party/terraform/services/backupdr/resource_backup_dr_backup_vault_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/backupdr/resource_backup_dr_backup_vault_test.go.tmpl
@@ -66,7 +66,7 @@ resource "google_backup_dr_backup_vault" "backup-vault-test" {
   }
   force_update = "true"
   ignore_inactive_datasources = "true"
-  ignore_backup_plan_reference = "true"
+  ignore_backup_plan_references = "true"
   allow_missing = "true"
 }
 `, context)
@@ -91,7 +91,7 @@ resource "google_backup_dr_backup_vault" "backup-vault-test" {
   }
   force_update = "true"
   ignore_inactive_datasources = "true"
-  ignore_backup_plan_reference = "true"
+  ignore_backup_plan_references = "true"
   allow_missing = "true"
 }
 `, context)

--- a/mmv1/third_party/terraform/services/backupdr/resource_backup_dr_backup_vault_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/backupdr/resource_backup_dr_backup_vault_test.go.tmpl
@@ -32,7 +32,7 @@ func TestAccBackupDRBackupVault_fullUpdate(t *testing.T) {
 				ResourceName:            "google_backup_dr_backup_vault.backup-vault-test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_missing", "annotations", "backup_vault_id", "force_delete", "force_update", "labels", "location", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"allow_missing", "annotations", "backup_vault_id", "ignore_inactive_datasources", "ignore_backup_plan_references", "force_update", "labels", "location", "terraform_labels"},
 			},
 			{
 				Config: testAccBackupDRBackupVault_fullUpdate(context),
@@ -41,7 +41,7 @@ func TestAccBackupDRBackupVault_fullUpdate(t *testing.T) {
 				ResourceName:            "google_backup_dr_backup_vault.backup-vault-test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_missing", "annotations", "backup_vault_id", "force_delete", "force_update", "labels", "location", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"allow_missing", "annotations", "backup_vault_id", "ignore_inactive_datasources", "ignore_backup_plan_references", "force_update", "labels", "location", "terraform_labels"},
 			},
 		},
 	})
@@ -65,7 +65,8 @@ resource "google_backup_dr_backup_vault" "backup-vault-test" {
 	annotations2 = "baz"
   }
   force_update = "true"
-  force_delete = "true"
+  ignore_inactive_datasources = "true"
+  ignore_backup_plan_reference = "true"
   allow_missing = "true"
 }
 `, context)
@@ -89,7 +90,8 @@ resource "google_backup_dr_backup_vault" "backup-vault-test" {
 	annotations2 = "baz1"
   }
   force_update = "true"
-  force_delete = "true"
+  ignore_inactive_datasources = "true"
+  ignore_backup_plan_reference = "true"
   allow_missing = "true"
 }
 `, context)

--- a/mmv1/third_party/terraform/services/backupdr/resource_backup_dr_backup_vault_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/backupdr/resource_backup_dr_backup_vault_test.go.tmpl
@@ -32,7 +32,7 @@ func TestAccBackupDRBackupVault_fullUpdate(t *testing.T) {
 				ResourceName:            "google_backup_dr_backup_vault.backup-vault-test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_missing", "annotations", "backup_vault_id", "ignore_inactive_datasources", "ignore_backup_plan_references", "force_update", "labels", "location", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"allow_missing", "annotations", "backup_vault_id", "force_delete", "force_update", "ignore_backup_plan_references", "ignore_inactive_datasources", "labels", "location", "terraform_labels"},
 			},
 			{
 				Config: testAccBackupDRBackupVault_fullUpdate(context),
@@ -41,7 +41,7 @@ func TestAccBackupDRBackupVault_fullUpdate(t *testing.T) {
 				ResourceName:            "google_backup_dr_backup_vault.backup-vault-test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_missing", "annotations", "backup_vault_id", "ignore_inactive_datasources", "ignore_backup_plan_references", "force_update", "labels", "location", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"allow_missing", "annotations", "backup_vault_id", "force_delete", "force_update", "ignore_backup_plan_references", "ignore_inactive_datasources", "labels", "location", "terraform_labels"},
 			},
 		},
 	})


### PR DESCRIPTION
```release-note: deprecation
backupdr: deprecated `force_delete` on `google_backup_dr_backup_vault`. Use `ignore_inactive_datasources` instead (beta)
```
```release-note: enhancement
backupdr: added `ignore_inactive_datasources` and `ignore_backup_plan_references` fields to `google_backup_dr_backup_vault` resource (beta)
```
