### PR TITLE
docs: update run-tests note format

### DIFF
--- a/docs/content/develop/test/run-tests.md
+++ b/docs/content/develop/test/run-tests.md
@@ -62,8 +62,7 @@ aliases:
     make testacc TEST=./google/services/container TESTARGS='-run=TestAccContainerNodePool'
     ```
 
-> [!NOTE]
-> Acceptance tests create actual infrastructure which can incur costs. Acceptance tests may not clean up after themselves if interrupted, so you may want to check for stray resources and / or billing charges.
+> **Note:** Acceptance tests create actual infrastructure which can incur costs. Acceptance tests may not clean up after themselves if interrupted, so you may want to check for stray resources and / or billing charges.
 
 1. Optional: Save verbose test output (including API requests and responses) to a file for analysis.
 
@@ -95,8 +94,7 @@ aliases:
     ```bash
     make testacc TEST=./google-beta/services/container TESTARGS='-run=TestAccContainerNodePool'
     ```
-> [!NOTE]
-> Acceptance tests create actual infrastructure which can incur costs. Acceptance tests may not clean up after themselves if interrupted, so you may want to check for stray resources and / or billing charges.
+> **Note:** Acceptance tests create actual infrastructure which can incur costs. Acceptance tests may not clean up after themselves if interrupted, so you may want to check for stray resources and / or billing charges.
 
 1. Optional: Save verbose test output to a file for analysis.
 


### PR DESCRIPTION
Fixes note added in #11475 to work within Hugo and match other notes. As I'd worried, the GH flavor markdown didn't end up rendering properly on the regular site.

Screenshot from https://googlecloudplatform.github.io/magic-modules/develop/test/run-tests/
<img width="695" alt="image" src="https://github.com/user-attachments/assets/32d65753-828d-4bc2-9e3d-400b0ad8b240">

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
