### PR TITLE
Magician vcr eap cmd

### DIFF
--- a/.ci/magician/cmd/test_eap_vcr.go
+++ b/.ci/magician/cmd/test_eap_vcr.go
@@ -1,232 +1,112 @@
 package cmd
 
 import (
+	_ "embed"
 	"fmt"
+	"magician/exec"
+	"magician/provider"
+	"magician/vcr"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
-	"text/template"
 
 	"github.com/spf13/cobra"
-
-	"magician/exec"
-	"magician/github"
-	"magician/provider"
-	"magician/source"
-	"magician/vcr"
-
-	_ "embed"
 )
 
-var (
-	//go:embed templates/vcr/test_analytics.tmpl
-	testsAnalyticsTmplText string
-	//go:embed templates/vcr/non_exercised_tests.tmpl
-	nonExercisedTestsTmplText string
-	//go:embed templates/vcr/with_replay_failed_tests.tmpl
-	withReplayFailedTestsTmplText string
-	//go:embed templates/vcr/without_replay_failed_tests.tmpl
-	withoutReplayFailedTestsTmplText string
-	//go:embed templates/vcr/record_replay.tmpl
-	recordReplayTmplText string
-)
-
-var ttvEnvironmentVariables = [...]string{
+var tevEnvironmentVariables = [...]string{
+	"GEN_PATH",
 	"GOCACHE",
 	"GOPATH",
-	"GOOGLE_BILLING_ACCOUNT",
-	"GOOGLE_CUST_ID",
-	"GOOGLE_IDENTITY_USER",
-	"GOOGLE_MASTER_BILLING_ACCOUNT",
-	"GOOGLE_ORG",
-	"GOOGLE_ORG_2",
-	"GOOGLE_ORG_DOMAIN",
-	"GOOGLE_PROJECT",
-	"GOOGLE_PROJECT_NUMBER",
 	"GOOGLE_REGION",
-	"GOOGLE_SERVICE_ACCOUNT",
-	"GOOGLE_PUBLIC_AVERTISED_PREFIX_DESCRIPTION",
 	"GOOGLE_ZONE",
+	"ORG_ID",
+	"GOOGLE_PROJECT",
+	"GOOGLE_BILLING_ACCOUNT",
+	"GOOGLE_ORG",
+	"GOOGLE_ORG_DOMAIN",
+	"GOOGLE_PROJECT_NUMBER",
+	"GOOGLE_USE_DEFAULT_CREDENTIALS",
+	"GOOGLE_IMPERSONATE_SERVICE_ACCOUNT",
+	"KOKORO_ARTIFACTS_DIR",
 	"HOME",
+	"MODIFIED_FILE_PATH",
 	"PATH",
-	"SA_KEY",
 	"USER",
 }
 
-type analytics struct {
-	ReplayingResult  vcr.Result
-	RunFullVCR       bool
-	AffectedServices []string
-}
-
-type nonExercisedTests struct {
-	NotRunBetaTests []string
-	NotRunGATests   []string
-}
-
-type withReplayFailedTests struct {
-	ReplayingResult vcr.Result
-}
-
-type withoutReplayFailedTests struct {
-	ReplayingErr error
-	LogBucket    string
-	Version      string
-	Head         string
-	BuildID      string
-}
-
-type recordReplay struct {
-	RecordingResult               vcr.Result
-	ReplayingAfterRecordingResult vcr.Result
-	HasTerminatedTests            bool
-	RecordingErr                  error
-	AllRecordingPassed            bool
-	LogBucket                     string
-	Version                       string
-	Head                          string
-	BuildID                       string
-}
-
-var testTerraformVCRCmd = &cobra.Command{
-	Use:   "test-terraform-vcr",
-	Short: "Run vcr tests for affected packages",
-	Long: `This command runs on new pull requests to replay VCR cassettes and re-record failing cassettes.
+var testEAPVCRCmd = &cobra.Command{
+	Use:   "test-eap-vcr",
+	Short: "Run vcr tests for affected packages in EAP",
+	Long: `This command runs on new change lists to replay VCR cassettes and re-record failing cassettes.
 
 It expects the following arguments:
-	1. PR number
-	2. SHA of the latest magic-modules commit
-	3. Build ID
-	4. Project ID where Cloud Builds are located
-	5. Build step number
-	
+	1. Change number
+
+
 The following environment variables are required:
-` + listTTVEnvironmentVariables(),
+` + listTEVEnvironmentVariables(),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		env := make(map[string]string, len(ttvEnvironmentVariables))
-		for _, ev := range ttvEnvironmentVariables {
+		env := make(map[string]string, len(tevEnvironmentVariables))
+		for _, ev := range tevEnvironmentVariables {
 			val, ok := os.LookupEnv(ev)
 			if !ok {
 				return fmt.Errorf("did not provide %s environment variable", ev)
 			}
 			env[ev] = val
 		}
-
-		for _, tokenName := range []string{"GITHUB_TOKEN_DOWNSTREAMS", "GITHUB_TOKEN_MAGIC_MODULES"} {
-			val, ok := lookupGithubTokenOrFallback(tokenName)
-			if !ok {
-				return fmt.Errorf("did not provide %s or GITHUB_TOKEN environment variable", tokenName)
-			}
-			env[tokenName] = val
-		}
-
-		baseBranch := os.Getenv("BASE_BRANCH")
-		if baseBranch == "" {
-			baseBranch = "main"
-		}
-
-		gh := github.NewClient(env["GITHUB_TOKEN_MAGIC_MODULES"])
 		rnr, err := exec.NewRunner()
 		if err != nil {
-			return fmt.Errorf("error creating a runner: %w", err)
+			return err
 		}
-		ctlr := source.NewController(env["GOPATH"], "modular-magician", env["GITHUB_TOKEN_DOWNSTREAMS"], rnr)
-
 		vt, err := vcr.NewTester(env, "ci-vcr-cassettes", "ci-vcr-logs", rnr)
 		if err != nil {
-			return fmt.Errorf("error creating VCR tester: %w", err)
+			return err
 		}
-
-		if len(args) != 5 {
-			return fmt.Errorf("wrong number of arguments %d, expected 5", len(args))
-		}
-
-		return execTestTerraformVCR(args[0], args[1], args[2], args[3], args[4], baseBranch, gh, rnr, ctlr, vt)
+		return execTestEAPVCR(args[0], env["GEN_PATH"], env["KOKORO_ARTIFACTS_DIR"], env["MODIFIED_FILE_PATH"], rnr, vt)
 	},
 }
 
-func listTTVEnvironmentVariables() string {
+func listTEVEnvironmentVariables() string {
 	var result string
-	for i, ev := range ttvEnvironmentVariables {
+	for i, ev := range tevEnvironmentVariables {
 		result += fmt.Sprintf("\t%2d. %s\n", i+1, ev)
 	}
 	return result
 }
 
-func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, baseBranch string, gh GithubClient, rnr ExecRunner, ctlr *source.Controller, vt *vcr.Tester) error {
-	newBranch := "auto-pr-" + prNumber
-	oldBranch := newBranch + "-old"
-
-	tpgRepo := &source.Repo{
-		Name:   "terraform-provider-google",
-		Owner:  "modular-magician",
-		Branch: newBranch,
-	}
-	tpgbRepo := &source.Repo{
-		Name:   "terraform-provider-google-beta",
-		Owner:  "modular-magician",
-		Branch: newBranch,
-	}
-	// Initialize repos
-	for _, repo := range []*source.Repo{tpgRepo, tpgbRepo} {
-		ctlr.SetPath(repo)
-		if err := ctlr.Clone(repo); err != nil {
-			return fmt.Errorf("error cloning repo: %w", err)
-		}
-		if err := ctlr.Fetch(repo, oldBranch); err != nil {
-			return fmt.Errorf("failed to fetch old branch: %w", err)
-		}
-		changedFiles, err := ctlr.DiffNameOnly(repo, oldBranch, newBranch)
-		if err != nil {
-			return fmt.Errorf("failed to compute name-only diff: %w", err)
-		}
-		repo.ChangedFiles = changedFiles
-		repo.UnifiedZeroDiff, err = ctlr.DiffUnifiedZero(repo, oldBranch, newBranch)
-		if err != nil {
-			return fmt.Errorf("failed to compute unified=0 diff: %w", err)
-		}
+func execTestEAPVCR(changeNumber, genPath, kokoroArtifactsDir, modifiedFilePath string, rnr ExecRunner, vt *vcr.Tester) error {
+	vt.SetRepoPath(provider.Alpha, genPath)
+	if err := rnr.PushDir(genPath); err != nil {
+		return fmt.Errorf("error changing to gen path: %w", err)
 	}
 
-	vt.SetRepoPath(provider.Beta, tpgbRepo.Path)
-
-	if err := rnr.PushDir(tpgbRepo.Path); err != nil {
-		return fmt.Errorf("error changing to tpgbRepo dir: %w", err)
+	changedFiles, err := rnr.Run("git", []string{"diff", "--name-only"}, nil)
+	if err != nil {
+		return fmt.Errorf("error diffing gen path: %w", err)
 	}
 
-	services, runFullVCR := modifiedPackages(tpgbRepo.ChangedFiles, provider.Beta)
+	services, runFullVCR := modifiedPackages(strings.Split(changedFiles, "\n"), provider.Alpha)
 	if len(services) == 0 && !runFullVCR {
 		fmt.Println("Skipping tests: No go files or test fixtures changed")
 		return nil
 	}
 	fmt.Println("Running tests: Go files or test fixtures changed")
 
-	if err := vt.FetchCassettes(provider.Beta, baseBranch, newBranch); err != nil {
+	head := "auto-cl-" + changeNumber
+	if err := vt.FetchCassettes(provider.Alpha, "main", head); err != nil {
 		return fmt.Errorf("error fetching cassettes: %w", err)
 	}
-
-	buildStatusTargetURL := fmt.Sprintf("https://console.cloud.google.com/cloud-build/builds;region=global/%s;step=%s?project=%s", buildID, buildStep, projectID)
-	if err := gh.PostBuildStatus(prNumber, "VCR-test", "pending", buildStatusTargetURL, mmCommitSha); err != nil {
-		return fmt.Errorf("error posting pending status: %w", err)
-	}
-
-	replayingResult, testDirs, replayingErr := runReplaying(runFullVCR, provider.Beta, services, vt)
-	testState := "success"
-	if replayingErr != nil {
-		testState = "failure"
-	}
-
+	replayingResult, testDirs, replayingErr := runReplaying(runFullVCR, provider.Alpha, services, vt)
 	if err := vt.UploadLogs(vcr.UploadLogsOptions{
-		Head:    newBranch,
-		BuildID: buildID,
+		Head:    head,
 		Mode:    vcr.Replaying,
-		Version: provider.Beta,
+		Version: provider.Alpha,
 	}); err != nil {
 		return fmt.Errorf("error uploading replaying logs: %w", err)
 	}
 
-	if hasPanics, err := handlePanics(prNumber, buildID, buildStatusTargetURL, mmCommitSha, replayingResult, vcr.Replaying, gh); err != nil {
+	if hasPanics, err := handleEAPVCRPanics(head, kokoroArtifactsDir, modifiedFilePath, replayingResult, vcr.Replaying, rnr); err != nil {
 		return fmt.Errorf("error handling panics: %w", err)
 	} else if hasPanics {
 		return nil
@@ -234,7 +114,9 @@ func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, 
 
 	var servicesArr []string
 	for s := range services {
-		servicesArr = append(servicesArr, s)
+		if _, ok := allowedAlphaServices[s]; ok {
+			servicesArr = append(servicesArr, s)
+		}
 	}
 	analyticsData := analytics{
 		ReplayingResult:  replayingResult,
@@ -245,29 +127,17 @@ func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, 
 	if err != nil {
 		return fmt.Errorf("error formatting test_analytics comment: %w", err)
 	}
-
-	notRunBeta, notRunGa := notRunTests(tpgRepo.UnifiedZeroDiff, tpgbRepo.UnifiedZeroDiff, replayingResult)
-
-	nonExercisedTestsData := nonExercisedTests{
-		NotRunBetaTests: notRunBeta,
-		NotRunGATests:   notRunGa,
-	}
-	nonExercisedTestsComment, err := formatNonExercisedTests(nonExercisedTestsData)
-	if err != nil {
-		return fmt.Errorf("error formatting non exercised tests comment: %w", err)
-	}
-
 	if len(replayingResult.FailedTests) > 0 {
 		withReplayFailedTestsData := withReplayFailedTests{
 			ReplayingResult: replayingResult,
 		}
+
 		withReplayFailedTestsComment, err := formatWithReplayFailedTests(withReplayFailedTestsData)
 		if err != nil {
 			return fmt.Errorf("error formatting action taken comment: %w", err)
 		}
-
-		comment := strings.Join([]string{testsAnalyticsComment, nonExercisedTestsComment, withReplayFailedTestsComment}, "\n")
-		if err := gh.PostComment(prNumber, comment); err != nil {
+		comment := strings.Join([]string{testsAnalyticsComment, withReplayFailedTestsComment}, "\n")
+		if err := postGerritComment(kokoroArtifactsDir, modifiedFilePath, comment, rnr); err != nil {
 			return fmt.Errorf("error posting comment: %w", err)
 		}
 
@@ -277,261 +147,103 @@ func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, 
 			TestDirs: testDirs,
 			Tests:    replayingResult.FailedTests,
 		})
-		if recordingErr != nil {
-			testState = "failure"
-		} else {
-			testState = "success"
-		}
 
-		if err := vt.UploadCassettes(newBranch, provider.Beta); err != nil {
-			return fmt.Errorf("error uploading cassettes: %w", err)
-		}
-
-		if err := vt.UploadLogs(vcr.UploadLogsOptions{
-			Head:     newBranch,
-			BuildID:  buildID,
-			Parallel: true,
-			Mode:     vcr.Recording,
-			Version:  provider.Beta,
-		}); err != nil {
-			return fmt.Errorf("error uploading recording logs: %w", err)
-		}
-
-		if hasPanics, err := handlePanics(prNumber, buildID, buildStatusTargetURL, mmCommitSha, recordingResult, vcr.Recording, gh); err != nil {
+		if hasPanics, err := handleEAPVCRPanics(head, kokoroArtifactsDir, modifiedFilePath, recordingResult, vcr.Recording, rnr); err != nil {
 			return fmt.Errorf("error handling panics: %w", err)
 		} else if hasPanics {
 			return nil
 		}
-
 		replayingAfterRecordingResult := vcr.Result{}
-		var replayingAfterRecordingErr error
 		if len(recordingResult.PassedTests) > 0 {
-			replayingAfterRecordingResult, replayingAfterRecordingErr = vt.RunParallel(vcr.RunOptions{
+			replayingAfterRecordingResult, _ = vt.RunParallel(vcr.RunOptions{
 				Mode:     vcr.Replaying,
-				Version:  provider.Beta,
+				Version:  provider.Alpha,
 				TestDirs: testDirs,
 				Tests:    recordingResult.PassedTests,
 			})
-			if replayingAfterRecordingErr != nil {
-				testState = "failure"
-			}
-
 			if err := vt.UploadLogs(vcr.UploadLogsOptions{
-				Head:           newBranch,
-				BuildID:        buildID,
-				AfterRecording: true,
+				Head:           head,
 				Parallel:       true,
-				Mode:           vcr.Replaying,
-				Version:        provider.Beta,
+				AfterRecording: true,
+				Mode:           vcr.Recording,
+				Version:        provider.Alpha,
 			}); err != nil {
 				return fmt.Errorf("error uploading recording logs: %w", err)
 			}
-
 		}
-
 		hasTerminatedTests := (len(recordingResult.PassedTests) + len(recordingResult.FailedTests)) < len(replayingResult.FailedTests)
 		allRecordingPassed := len(recordingResult.FailedTests) == 0 && !hasTerminatedTests && recordingErr == nil
-
 		recordReplayData := recordReplay{
 			RecordingResult:               recordingResult,
 			ReplayingAfterRecordingResult: replayingAfterRecordingResult,
 			RecordingErr:                  recordingErr,
 			HasTerminatedTests:            hasTerminatedTests,
 			AllRecordingPassed:            allRecordingPassed,
-			LogBucket:                     "ci-vcr-logs",
-			Version:                       provider.Beta.String(),
-			Head:                          newBranch,
-			BuildID:                       buildID,
 		}
 		recordReplayComment, err := formatRecordReplay(recordReplayData)
 		if err != nil {
 			return fmt.Errorf("error formatting record replay comment: %w", err)
 		}
-		if err := gh.PostComment(prNumber, recordReplayComment); err != nil {
+		if err := postGerritComment(kokoroArtifactsDir, modifiedFilePath, recordReplayComment, rnr); err != nil {
 			return fmt.Errorf("error posting comment: %w", err)
 		}
-
 	} else { //  len(replayingResult.FailedTests) == 0
 		withoutReplayFailedTestsData := withoutReplayFailedTests{
 			ReplayingErr: replayingErr,
-			Head:         newBranch,
-			LogBucket:    "ci-vcr-logs",
-			BuildID:      buildID,
 		}
 		withoutReplayFailedTestsComment, err := formatWithoutReplayFailedTests(withoutReplayFailedTestsData)
 		if err != nil {
 			return fmt.Errorf("error formatting action taken comment: %w", err)
 		}
-
-		comment := strings.Join([]string{testsAnalyticsComment, nonExercisedTestsComment, withoutReplayFailedTestsComment}, "\n")
-		if err := gh.PostComment(prNumber, comment); err != nil {
+		comment := strings.Join([]string{testsAnalyticsComment, withoutReplayFailedTestsComment}, "\n")
+		if err := postGerritComment(kokoroArtifactsDir, modifiedFilePath, comment, rnr); err != nil {
 			return fmt.Errorf("error posting comment: %w", err)
 		}
-	}
-
-	if err := gh.PostBuildStatus(prNumber, "VCR-test", testState, buildStatusTargetURL, mmCommitSha); err != nil {
-		return fmt.Errorf("error posting build status: %w", err)
 	}
 	return nil
 }
 
-var addedTestsRegexp = regexp.MustCompile(`(?m)^\+func (TestAcc\w+)\(t \*testing.T\) {`)
-
-func notRunTests(gaDiff, betaDiff string, result vcr.Result) ([]string, []string) {
-	fmt.Println("Checking for new acceptance tests that were not run")
-	addedGaTests := addedTestsRegexp.FindAllStringSubmatch(gaDiff, -1)
-	addedBetaTests := addedTestsRegexp.FindAllStringSubmatch(betaDiff, -1)
-
-	if len(addedGaTests) == 0 && len(addedBetaTests) == 0 {
-		return []string{}, []string{}
-	}
-
-	// Consider tests "run" only if they passed or failed.
-	runTests := map[string]struct{}{}
-	for _, t := range result.PassedTests {
-		runTests[t] = struct{}{}
-	}
-	for _, t := range result.FailedTests {
-		runTests[t] = struct{}{}
-	}
-
-	notRunBeta := []string{}
-	for _, t := range addedBetaTests {
-		if _, ok := runTests[t[1]]; !ok {
-			notRunBeta = append(notRunBeta, t[1])
-		}
-	}
-	// Always count GA-only tests because we never run GA tests
-	notRunGa := []string{}
-	addedBetaTestsMap := map[string]struct{}{}
-	for _, t := range addedBetaTests {
-		addedBetaTestsMap[t[1]] = struct{}{}
-	}
-	for _, t := range addedGaTests {
-		if _, ok := addedBetaTestsMap[t[1]]; !ok {
-			notRunGa = append(notRunGa, t[1])
-		}
-	}
-
-	sort.Strings(notRunBeta)
-	sort.Strings(notRunGa)
-	return notRunBeta, notRunGa
+var allowedAlphaServices = map[string]struct{}{
+	"accesscontextmanager":      {},
+	"cloudbuild":                {},
+	"compute":                   {},
+	"dataprocgdc":               {},
+	"healthcare":                {},
+	"looker":                    {},
+	"osconfig":                  {},
+	"saasmanagement":            {},
+	"stackdriver":               {},
+	"tpuv2":                     {},
+	"workstations":              {},
+	"bigquery":                  {},
+	"cloudbuildv2":              {},
+	"contactcenteraiplatform":   {},
+	"gkeonprem":                 {},
+	"kms":                       {},
+	"netapp":                    {},
+	"remotebuildexecutionadmin": {},
+	"spanner":                   {},
+	"storageinsights":           {},
+	"vmwareengine":              {},
 }
 
-func modifiedPackages(changedFiles []string, version provider.Version) (map[string]struct{}, bool) {
-	var goFiles []string
-	for _, line := range changedFiles {
-		if strings.HasSuffix(line, ".go") || strings.Contains(line, "test-fixtures") || strings.HasSuffix(line, "go.mod") || strings.HasSuffix(line, "go.sum") {
-			goFiles = append(goFiles, line)
-		}
-	}
-	services := make(map[string]struct{})
-	runFullVCR := false
-	for _, file := range goFiles {
-		if strings.HasPrefix(file, version.ProviderName()+"/services/") {
-			fileParts := strings.Split(file, "/")
-			services[fileParts[2]] = struct{}{}
-		} else if file == version.ProviderName()+"/provider/provider_mmv1_resources.go" || file == version.ProviderName()+"/provider/provider_dcl_resources.go" {
-			fmt.Println("ignore changes in ", file)
-		} else {
-			fmt.Println("run full tests ", file)
-			runFullVCR = true
-			break
-		}
-	}
-	return services, runFullVCR
-}
-
-func runReplaying(runFullVCR bool, version provider.Version, services map[string]struct{}, vt *vcr.Tester) (vcr.Result, []string, error) {
-	result := vcr.Result{}
-	var testDirs []string
-	var replayingErr error
-	if runFullVCR {
-		fmt.Println("runReplaying: full VCR tests")
-		result, replayingErr = vt.Run(vcr.RunOptions{
-			Mode:    vcr.Replaying,
-			Version: version,
-		})
-	} else if len(services) > 0 {
-		fmt.Printf("runReplaying: %d specific services: %v\n", len(services), services)
-		for service := range services {
-			servicePath := "./" + filepath.Join(version.ProviderName(), "services", service)
-			testDirs = append(testDirs, servicePath)
-			fmt.Println("run VCR tests in ", service)
-			serviceResult, serviceReplayingErr := vt.Run(vcr.RunOptions{
-				Mode:     vcr.Replaying,
-				Version:  version,
-				TestDirs: []string{servicePath},
-			})
-			if serviceReplayingErr != nil {
-				replayingErr = serviceReplayingErr
-			}
-			result.PassedTests = append(result.PassedTests, serviceResult.PassedTests...)
-			result.SkippedTests = append(result.SkippedTests, serviceResult.SkippedTests...)
-			result.FailedTests = append(result.FailedTests, serviceResult.FailedTests...)
-			result.Panics = append(result.Panics, serviceResult.Panics...)
-		}
-	} else {
-		fmt.Println("runReplaying: no impacted services")
-	}
-
-	return result, testDirs, replayingErr
-}
-
-func handlePanics(prNumber, buildID, buildStatusTargetURL, mmCommitSha string, result vcr.Result, mode vcr.Mode, gh GithubClient) (bool, error) {
+func handleEAPVCRPanics(head, kokoroArtifactsDir, modifiedFilePath string, result vcr.Result, mode vcr.Mode, rnr ExecRunner) (bool, error) {
 	if len(result.Panics) > 0 {
-		comment := color("red", fmt.Sprintf("The provider crashed while running the VCR tests in %s mode\n", mode.Upper()))
-		comment += fmt.Sprintf(`Please fix it to complete your PR.
-View the [build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-%s/artifacts/%s/build-log/%s_test.log)`, prNumber, buildID, mode.Lower())
-		if err := gh.PostComment(prNumber, comment); err != nil {
+		comment := fmt.Sprintf(`The provider crashed while running the VCR tests in %s mode.
+Please fix it to complete your CL
+View the [build log](https://storage.cloud.google.com/ci-vcr-logs/alpha/refs/heads/%s/build-log/%s_test.log)`, mode.Upper(), head, mode.Lower())
+		if err := postGerritComment(kokoroArtifactsDir, modifiedFilePath, comment, rnr); err != nil {
 			return true, fmt.Errorf("error posting comment: %v", err)
-		}
-		if err := gh.PostBuildStatus(prNumber, "VCR-test", "failure", buildStatusTargetURL, mmCommitSha); err != nil {
-			return true, fmt.Errorf("error posting failure status: %v", err)
 		}
 		return true, nil
 	}
 	return false, nil
 }
 
+func postGerritComment(kokoroArtifactsDir, modifiedFilePath, comment string, rnr ExecRunner) error {
+	return rnr.AppendFile(filepath.Join(kokoroArtifactsDir, "gerrit_comments.json"), fmt.Sprintf("\n{path: \"%s\", message: \"%s\"}", modifiedFilePath, comment))
+}
+
 func init() {
-	rootCmd.AddCommand(testTerraformVCRCmd)
-}
-
-func formatComment(fileName string, tmplText string, data any) (string, error) {
-	funcs := template.FuncMap{
-		"join":  strings.Join,
-		"add":   func(i, j int) int { return i + j },
-		"color": color,
-	}
-	tmpl, err := template.New(fileName).Funcs(funcs).Parse(tmplText)
-	if err != nil {
-		panic(fmt.Sprintf("Unable to parse %s: %s", fileName, err))
-	}
-	sb := new(strings.Builder)
-	err = tmpl.Execute(sb, data)
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(sb.String()), nil
-}
-
-func formatTestsAnalytics(data analytics) (string, error) {
-	return formatComment("test_analytics.tmpl", testsAnalyticsTmplText, data)
-}
-
-func formatNonExercisedTests(data nonExercisedTests) (string, error) {
-	return formatComment("non_exercised_tests.tmpl", nonExercisedTestsTmplText, data)
-}
-
-func formatWithReplayFailedTests(data withReplayFailedTests) (string, error) {
-	return formatComment("with_replay_failed_tests.tmpl", withReplayFailedTestsTmplText, data)
-}
-
-func formatWithoutReplayFailedTests(data withoutReplayFailedTests) (string, error) {
-	return formatComment("without_replay_failed_tests.tmpl", withoutReplayFailedTestsTmplText, data)
-}
-
-func formatRecordReplay(data recordReplay) (string, error) {
-	return formatComment("record_replay.tmpl", recordReplayTmplText, data)
+	rootCmd.AddCommand(testEAPVCRCmd)
 }

--- a/.ci/magician/cmd/test_eap_vcr.go
+++ b/.ci/magician/cmd/test_eap_vcr.go
@@ -114,7 +114,7 @@ func execTestEAPVCR(changeNumber, genPath, kokoroArtifactsDir, modifiedFilePath 
 
 	var servicesArr []string
 	for s := range services {
-		if _, ok := allowedAlphaServices[s]; ok {
+		if _, ok := allowedPrivateServices[s]; ok {
 			servicesArr = append(servicesArr, s)
 		}
 	}
@@ -208,28 +208,31 @@ func execTestEAPVCR(changeNumber, genPath, kokoroArtifactsDir, modifiedFilePath 
 	return nil
 }
 
-var allowedAlphaServices = map[string]struct{}{
+var allowedPrivateServices = map[string]struct{}{
 	"accesscontextmanager":      {},
-	"cloudbuild":                {},
-	"compute":                   {},
-	"dataprocgdc":               {},
-	"healthcare":                {},
-	"looker":                    {},
-	"osconfig":                  {},
-	"saasmanagement":            {},
-	"stackdriver":               {},
-	"tpuv2":                     {},
-	"workstations":              {},
-	"bigquery":                  {},
+	"chronicle":                 {},
 	"cloudbuildv2":              {},
 	"contactcenteraiplatform":   {},
 	"gkeonprem":                 {},
 	"kms":                       {},
 	"netapp":                    {},
+	"oracledatabase":            {},
 	"remotebuildexecutionadmin": {},
 	"spanner":                   {},
 	"storageinsights":           {},
 	"vmwareengine":              {},
+	"bigquery":                  {},
+	"cloudbuild":                {},
+	"compute":                   {},
+	"dataprocgdc":               {},
+	"healthcare":                {},
+	"managedkafka":              {},
+	"networksecurity":           {},
+	"osconfig":                  {},
+	"saasmanagement":            {},
+	"stackdriver":               {},
+	"tpuv2":                     {},
+	"workstations":              {},
 }
 
 func handleEAPVCRPanics(head, kokoroArtifactsDir, modifiedFilePath string, result vcr.Result, mode vcr.Mode, rnr ExecRunner) (bool, error) {

--- a/.ci/magician/cmd/test_eap_vcr.go
+++ b/.ci/magician/cmd/test_eap_vcr.go
@@ -114,9 +114,7 @@ func execTestEAPVCR(changeNumber, genPath, kokoroArtifactsDir, modifiedFilePath 
 
 	var servicesArr []string
 	for s := range services {
-		if _, ok := allowedPrivateServices[s]; ok {
-			servicesArr = append(servicesArr, s)
-		}
+		servicesArr = append(servicesArr, s)
 	}
 	analyticsData := analytics{
 		ReplayingResult:  replayingResult,
@@ -206,33 +204,6 @@ func execTestEAPVCR(changeNumber, genPath, kokoroArtifactsDir, modifiedFilePath 
 		}
 	}
 	return nil
-}
-
-var allowedPrivateServices = map[string]struct{}{
-	"accesscontextmanager":      {},
-	"chronicle":                 {},
-	"cloudbuildv2":              {},
-	"contactcenteraiplatform":   {},
-	"gkeonprem":                 {},
-	"kms":                       {},
-	"netapp":                    {},
-	"oracledatabase":            {},
-	"remotebuildexecutionadmin": {},
-	"spanner":                   {},
-	"storageinsights":           {},
-	"vmwareengine":              {},
-	"bigquery":                  {},
-	"cloudbuild":                {},
-	"compute":                   {},
-	"dataprocgdc":               {},
-	"healthcare":                {},
-	"managedkafka":              {},
-	"networksecurity":           {},
-	"osconfig":                  {},
-	"saasmanagement":            {},
-	"stackdriver":               {},
-	"tpuv2":                     {},
-	"workstations":              {},
 }
 
 func handleEAPVCRPanics(head, kokoroArtifactsDir, modifiedFilePath string, result vcr.Result, mode vcr.Mode, rnr ExecRunner) (bool, error) {

--- a/.ci/magician/cmd/test_eap_vcr.go
+++ b/.ci/magician/cmd/test_eap_vcr.go
@@ -231,7 +231,8 @@ func handleEAPVCRPanics(head, kokoroArtifactsDir, modifiedFilePath string, resul
 	if len(result.Panics) > 0 {
 		comment := fmt.Sprintf(`The provider crashed while running the VCR tests in %s mode.
 Please fix it to complete your CL
-View the [build log](https://storage.cloud.google.com/ci-vcr-logs/alpha/refs/heads/%s/build-log/%s_test.log)`, mode.Upper(), head, mode.Lower())
+View the [build log](https://storage.cloud.google.com/ci-vcr-logs/%s/refs/heads/%s/build-log/%s_test.log)`,
+			provider.Private.String(), mode.Upper(), head, mode.Lower())
 		if err := postGerritComment(kokoroArtifactsDir, modifiedFilePath, comment, rnr); err != nil {
 			return true, fmt.Errorf("error posting comment: %v", err)
 		}

--- a/.ci/magician/cmd/test_eap_vcr.go
+++ b/.ci/magician/cmd/test_eap_vcr.go
@@ -68,6 +68,8 @@ The following environment variables are required:
 			val, ok := os.LookupEnv(ev)
 			if ok {
 				env[ev] = val
+			} else {
+				fmt.Printf("🟡 Did not provide %s environment variable\n", ev)
 			}
 		}
 

--- a/.ci/magician/cmd/test_eap_vcr.go
+++ b/.ci/magician/cmd/test_eap_vcr.go
@@ -148,11 +148,16 @@ func execTestEAPVCR(changeNumber, genPath, kokoroArtifactsDir, modifiedFilePath 
 			Tests:    replayingResult.FailedTests,
 		})
 
+		if err := vt.UploadCassettes(head, provider.Private); err != nil {
+			return fmt.Errorf("error uploading cassettes: %w", err)
+		}
+
 		if hasPanics, err := handleEAPVCRPanics(head, kokoroArtifactsDir, modifiedFilePath, recordingResult, vcr.Recording, rnr); err != nil {
 			return fmt.Errorf("error handling panics: %w", err)
 		} else if hasPanics {
 			return nil
 		}
+
 		replayingAfterRecordingResult := vcr.Result{}
 		if len(recordingResult.PassedTests) > 0 {
 			replayingAfterRecordingResult, _ = vt.RunParallel(vcr.RunOptions{

--- a/.ci/magician/cmd/test_eap_vcr.go
+++ b/.ci/magician/cmd/test_eap_vcr.go
@@ -164,10 +164,14 @@ func execTestEAPVCR(changeNumber, genPath, kokoroArtifactsDir, modifiedFilePath 
 
 		recordingResult, recordingErr := vt.RunParallel(vcr.RunOptions{
 			Mode:     vcr.Recording,
-			Version:  provider.Beta,
+			Version:  provider.Private,
 			TestDirs: testDirs,
 			Tests:    replayingResult.FailedTests,
 		})
+
+		if recordingErr != nil {
+			fmt.Println("error during recording:", recordingErr)
+		}
 
 		if err := vt.UploadCassettes(head, provider.Private); err != nil {
 			return fmt.Errorf("error uploading cassettes: %w", err)
@@ -205,6 +209,9 @@ func execTestEAPVCR(changeNumber, genPath, kokoroArtifactsDir, modifiedFilePath 
 			RecordingErr:                  recordingErr,
 			HasTerminatedTests:            hasTerminatedTests,
 			AllRecordingPassed:            allRecordingPassed,
+			LogBucket:                     "ci-vcr-logs",
+			Version:                       provider.Private.String(),
+			Head:                          head,
 		}
 		recordReplayComment, err := formatRecordReplay(recordReplayData)
 		if err != nil {

--- a/.ci/magician/cmd/test_eap_vcr.go
+++ b/.ci/magician/cmd/test_eap_vcr.go
@@ -1,0 +1,537 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"text/template"
+
+	"github.com/spf13/cobra"
+
+	"magician/exec"
+	"magician/github"
+	"magician/provider"
+	"magician/source"
+	"magician/vcr"
+
+	_ "embed"
+)
+
+var (
+	//go:embed templates/vcr/test_analytics.tmpl
+	testsAnalyticsTmplText string
+	//go:embed templates/vcr/non_exercised_tests.tmpl
+	nonExercisedTestsTmplText string
+	//go:embed templates/vcr/with_replay_failed_tests.tmpl
+	withReplayFailedTestsTmplText string
+	//go:embed templates/vcr/without_replay_failed_tests.tmpl
+	withoutReplayFailedTestsTmplText string
+	//go:embed templates/vcr/record_replay.tmpl
+	recordReplayTmplText string
+)
+
+var ttvEnvironmentVariables = [...]string{
+	"GOCACHE",
+	"GOPATH",
+	"GOOGLE_BILLING_ACCOUNT",
+	"GOOGLE_CUST_ID",
+	"GOOGLE_IDENTITY_USER",
+	"GOOGLE_MASTER_BILLING_ACCOUNT",
+	"GOOGLE_ORG",
+	"GOOGLE_ORG_2",
+	"GOOGLE_ORG_DOMAIN",
+	"GOOGLE_PROJECT",
+	"GOOGLE_PROJECT_NUMBER",
+	"GOOGLE_REGION",
+	"GOOGLE_SERVICE_ACCOUNT",
+	"GOOGLE_PUBLIC_AVERTISED_PREFIX_DESCRIPTION",
+	"GOOGLE_ZONE",
+	"HOME",
+	"PATH",
+	"SA_KEY",
+	"USER",
+}
+
+type analytics struct {
+	ReplayingResult  vcr.Result
+	RunFullVCR       bool
+	AffectedServices []string
+}
+
+type nonExercisedTests struct {
+	NotRunBetaTests []string
+	NotRunGATests   []string
+}
+
+type withReplayFailedTests struct {
+	ReplayingResult vcr.Result
+}
+
+type withoutReplayFailedTests struct {
+	ReplayingErr error
+	LogBucket    string
+	Version      string
+	Head         string
+	BuildID      string
+}
+
+type recordReplay struct {
+	RecordingResult               vcr.Result
+	ReplayingAfterRecordingResult vcr.Result
+	HasTerminatedTests            bool
+	RecordingErr                  error
+	AllRecordingPassed            bool
+	LogBucket                     string
+	Version                       string
+	Head                          string
+	BuildID                       string
+}
+
+var testTerraformVCRCmd = &cobra.Command{
+	Use:   "test-terraform-vcr",
+	Short: "Run vcr tests for affected packages",
+	Long: `This command runs on new pull requests to replay VCR cassettes and re-record failing cassettes.
+
+It expects the following arguments:
+	1. PR number
+	2. SHA of the latest magic-modules commit
+	3. Build ID
+	4. Project ID where Cloud Builds are located
+	5. Build step number
+	
+The following environment variables are required:
+` + listTTVEnvironmentVariables(),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		env := make(map[string]string, len(ttvEnvironmentVariables))
+		for _, ev := range ttvEnvironmentVariables {
+			val, ok := os.LookupEnv(ev)
+			if !ok {
+				return fmt.Errorf("did not provide %s environment variable", ev)
+			}
+			env[ev] = val
+		}
+
+		for _, tokenName := range []string{"GITHUB_TOKEN_DOWNSTREAMS", "GITHUB_TOKEN_MAGIC_MODULES"} {
+			val, ok := lookupGithubTokenOrFallback(tokenName)
+			if !ok {
+				return fmt.Errorf("did not provide %s or GITHUB_TOKEN environment variable", tokenName)
+			}
+			env[tokenName] = val
+		}
+
+		baseBranch := os.Getenv("BASE_BRANCH")
+		if baseBranch == "" {
+			baseBranch = "main"
+		}
+
+		gh := github.NewClient(env["GITHUB_TOKEN_MAGIC_MODULES"])
+		rnr, err := exec.NewRunner()
+		if err != nil {
+			return fmt.Errorf("error creating a runner: %w", err)
+		}
+		ctlr := source.NewController(env["GOPATH"], "modular-magician", env["GITHUB_TOKEN_DOWNSTREAMS"], rnr)
+
+		vt, err := vcr.NewTester(env, "ci-vcr-cassettes", "ci-vcr-logs", rnr)
+		if err != nil {
+			return fmt.Errorf("error creating VCR tester: %w", err)
+		}
+
+		if len(args) != 5 {
+			return fmt.Errorf("wrong number of arguments %d, expected 5", len(args))
+		}
+
+		return execTestTerraformVCR(args[0], args[1], args[2], args[3], args[4], baseBranch, gh, rnr, ctlr, vt)
+	},
+}
+
+func listTTVEnvironmentVariables() string {
+	var result string
+	for i, ev := range ttvEnvironmentVariables {
+		result += fmt.Sprintf("\t%2d. %s\n", i+1, ev)
+	}
+	return result
+}
+
+func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, baseBranch string, gh GithubClient, rnr ExecRunner, ctlr *source.Controller, vt *vcr.Tester) error {
+	newBranch := "auto-pr-" + prNumber
+	oldBranch := newBranch + "-old"
+
+	tpgRepo := &source.Repo{
+		Name:   "terraform-provider-google",
+		Owner:  "modular-magician",
+		Branch: newBranch,
+	}
+	tpgbRepo := &source.Repo{
+		Name:   "terraform-provider-google-beta",
+		Owner:  "modular-magician",
+		Branch: newBranch,
+	}
+	// Initialize repos
+	for _, repo := range []*source.Repo{tpgRepo, tpgbRepo} {
+		ctlr.SetPath(repo)
+		if err := ctlr.Clone(repo); err != nil {
+			return fmt.Errorf("error cloning repo: %w", err)
+		}
+		if err := ctlr.Fetch(repo, oldBranch); err != nil {
+			return fmt.Errorf("failed to fetch old branch: %w", err)
+		}
+		changedFiles, err := ctlr.DiffNameOnly(repo, oldBranch, newBranch)
+		if err != nil {
+			return fmt.Errorf("failed to compute name-only diff: %w", err)
+		}
+		repo.ChangedFiles = changedFiles
+		repo.UnifiedZeroDiff, err = ctlr.DiffUnifiedZero(repo, oldBranch, newBranch)
+		if err != nil {
+			return fmt.Errorf("failed to compute unified=0 diff: %w", err)
+		}
+	}
+
+	vt.SetRepoPath(provider.Beta, tpgbRepo.Path)
+
+	if err := rnr.PushDir(tpgbRepo.Path); err != nil {
+		return fmt.Errorf("error changing to tpgbRepo dir: %w", err)
+	}
+
+	services, runFullVCR := modifiedPackages(tpgbRepo.ChangedFiles, provider.Beta)
+	if len(services) == 0 && !runFullVCR {
+		fmt.Println("Skipping tests: No go files or test fixtures changed")
+		return nil
+	}
+	fmt.Println("Running tests: Go files or test fixtures changed")
+
+	if err := vt.FetchCassettes(provider.Beta, baseBranch, newBranch); err != nil {
+		return fmt.Errorf("error fetching cassettes: %w", err)
+	}
+
+	buildStatusTargetURL := fmt.Sprintf("https://console.cloud.google.com/cloud-build/builds;region=global/%s;step=%s?project=%s", buildID, buildStep, projectID)
+	if err := gh.PostBuildStatus(prNumber, "VCR-test", "pending", buildStatusTargetURL, mmCommitSha); err != nil {
+		return fmt.Errorf("error posting pending status: %w", err)
+	}
+
+	replayingResult, testDirs, replayingErr := runReplaying(runFullVCR, provider.Beta, services, vt)
+	testState := "success"
+	if replayingErr != nil {
+		testState = "failure"
+	}
+
+	if err := vt.UploadLogs(vcr.UploadLogsOptions{
+		Head:    newBranch,
+		BuildID: buildID,
+		Mode:    vcr.Replaying,
+		Version: provider.Beta,
+	}); err != nil {
+		return fmt.Errorf("error uploading replaying logs: %w", err)
+	}
+
+	if hasPanics, err := handlePanics(prNumber, buildID, buildStatusTargetURL, mmCommitSha, replayingResult, vcr.Replaying, gh); err != nil {
+		return fmt.Errorf("error handling panics: %w", err)
+	} else if hasPanics {
+		return nil
+	}
+
+	var servicesArr []string
+	for s := range services {
+		servicesArr = append(servicesArr, s)
+	}
+	analyticsData := analytics{
+		ReplayingResult:  replayingResult,
+		RunFullVCR:       runFullVCR,
+		AffectedServices: sort.StringSlice(servicesArr),
+	}
+	testsAnalyticsComment, err := formatTestsAnalytics(analyticsData)
+	if err != nil {
+		return fmt.Errorf("error formatting test_analytics comment: %w", err)
+	}
+
+	notRunBeta, notRunGa := notRunTests(tpgRepo.UnifiedZeroDiff, tpgbRepo.UnifiedZeroDiff, replayingResult)
+
+	nonExercisedTestsData := nonExercisedTests{
+		NotRunBetaTests: notRunBeta,
+		NotRunGATests:   notRunGa,
+	}
+	nonExercisedTestsComment, err := formatNonExercisedTests(nonExercisedTestsData)
+	if err != nil {
+		return fmt.Errorf("error formatting non exercised tests comment: %w", err)
+	}
+
+	if len(replayingResult.FailedTests) > 0 {
+		withReplayFailedTestsData := withReplayFailedTests{
+			ReplayingResult: replayingResult,
+		}
+		withReplayFailedTestsComment, err := formatWithReplayFailedTests(withReplayFailedTestsData)
+		if err != nil {
+			return fmt.Errorf("error formatting action taken comment: %w", err)
+		}
+
+		comment := strings.Join([]string{testsAnalyticsComment, nonExercisedTestsComment, withReplayFailedTestsComment}, "\n")
+		if err := gh.PostComment(prNumber, comment); err != nil {
+			return fmt.Errorf("error posting comment: %w", err)
+		}
+
+		recordingResult, recordingErr := vt.RunParallel(vcr.RunOptions{
+			Mode:     vcr.Recording,
+			Version:  provider.Beta,
+			TestDirs: testDirs,
+			Tests:    replayingResult.FailedTests,
+		})
+		if recordingErr != nil {
+			testState = "failure"
+		} else {
+			testState = "success"
+		}
+
+		if err := vt.UploadCassettes(newBranch, provider.Beta); err != nil {
+			return fmt.Errorf("error uploading cassettes: %w", err)
+		}
+
+		if err := vt.UploadLogs(vcr.UploadLogsOptions{
+			Head:     newBranch,
+			BuildID:  buildID,
+			Parallel: true,
+			Mode:     vcr.Recording,
+			Version:  provider.Beta,
+		}); err != nil {
+			return fmt.Errorf("error uploading recording logs: %w", err)
+		}
+
+		if hasPanics, err := handlePanics(prNumber, buildID, buildStatusTargetURL, mmCommitSha, recordingResult, vcr.Recording, gh); err != nil {
+			return fmt.Errorf("error handling panics: %w", err)
+		} else if hasPanics {
+			return nil
+		}
+
+		replayingAfterRecordingResult := vcr.Result{}
+		var replayingAfterRecordingErr error
+		if len(recordingResult.PassedTests) > 0 {
+			replayingAfterRecordingResult, replayingAfterRecordingErr = vt.RunParallel(vcr.RunOptions{
+				Mode:     vcr.Replaying,
+				Version:  provider.Beta,
+				TestDirs: testDirs,
+				Tests:    recordingResult.PassedTests,
+			})
+			if replayingAfterRecordingErr != nil {
+				testState = "failure"
+			}
+
+			if err := vt.UploadLogs(vcr.UploadLogsOptions{
+				Head:           newBranch,
+				BuildID:        buildID,
+				AfterRecording: true,
+				Parallel:       true,
+				Mode:           vcr.Replaying,
+				Version:        provider.Beta,
+			}); err != nil {
+				return fmt.Errorf("error uploading recording logs: %w", err)
+			}
+
+		}
+
+		hasTerminatedTests := (len(recordingResult.PassedTests) + len(recordingResult.FailedTests)) < len(replayingResult.FailedTests)
+		allRecordingPassed := len(recordingResult.FailedTests) == 0 && !hasTerminatedTests && recordingErr == nil
+
+		recordReplayData := recordReplay{
+			RecordingResult:               recordingResult,
+			ReplayingAfterRecordingResult: replayingAfterRecordingResult,
+			RecordingErr:                  recordingErr,
+			HasTerminatedTests:            hasTerminatedTests,
+			AllRecordingPassed:            allRecordingPassed,
+			LogBucket:                     "ci-vcr-logs",
+			Version:                       provider.Beta.String(),
+			Head:                          newBranch,
+			BuildID:                       buildID,
+		}
+		recordReplayComment, err := formatRecordReplay(recordReplayData)
+		if err != nil {
+			return fmt.Errorf("error formatting record replay comment: %w", err)
+		}
+		if err := gh.PostComment(prNumber, recordReplayComment); err != nil {
+			return fmt.Errorf("error posting comment: %w", err)
+		}
+
+	} else { //  len(replayingResult.FailedTests) == 0
+		withoutReplayFailedTestsData := withoutReplayFailedTests{
+			ReplayingErr: replayingErr,
+			Head:         newBranch,
+			LogBucket:    "ci-vcr-logs",
+			BuildID:      buildID,
+		}
+		withoutReplayFailedTestsComment, err := formatWithoutReplayFailedTests(withoutReplayFailedTestsData)
+		if err != nil {
+			return fmt.Errorf("error formatting action taken comment: %w", err)
+		}
+
+		comment := strings.Join([]string{testsAnalyticsComment, nonExercisedTestsComment, withoutReplayFailedTestsComment}, "\n")
+		if err := gh.PostComment(prNumber, comment); err != nil {
+			return fmt.Errorf("error posting comment: %w", err)
+		}
+	}
+
+	if err := gh.PostBuildStatus(prNumber, "VCR-test", testState, buildStatusTargetURL, mmCommitSha); err != nil {
+		return fmt.Errorf("error posting build status: %w", err)
+	}
+	return nil
+}
+
+var addedTestsRegexp = regexp.MustCompile(`(?m)^\+func (TestAcc\w+)\(t \*testing.T\) {`)
+
+func notRunTests(gaDiff, betaDiff string, result vcr.Result) ([]string, []string) {
+	fmt.Println("Checking for new acceptance tests that were not run")
+	addedGaTests := addedTestsRegexp.FindAllStringSubmatch(gaDiff, -1)
+	addedBetaTests := addedTestsRegexp.FindAllStringSubmatch(betaDiff, -1)
+
+	if len(addedGaTests) == 0 && len(addedBetaTests) == 0 {
+		return []string{}, []string{}
+	}
+
+	// Consider tests "run" only if they passed or failed.
+	runTests := map[string]struct{}{}
+	for _, t := range result.PassedTests {
+		runTests[t] = struct{}{}
+	}
+	for _, t := range result.FailedTests {
+		runTests[t] = struct{}{}
+	}
+
+	notRunBeta := []string{}
+	for _, t := range addedBetaTests {
+		if _, ok := runTests[t[1]]; !ok {
+			notRunBeta = append(notRunBeta, t[1])
+		}
+	}
+	// Always count GA-only tests because we never run GA tests
+	notRunGa := []string{}
+	addedBetaTestsMap := map[string]struct{}{}
+	for _, t := range addedBetaTests {
+		addedBetaTestsMap[t[1]] = struct{}{}
+	}
+	for _, t := range addedGaTests {
+		if _, ok := addedBetaTestsMap[t[1]]; !ok {
+			notRunGa = append(notRunGa, t[1])
+		}
+	}
+
+	sort.Strings(notRunBeta)
+	sort.Strings(notRunGa)
+	return notRunBeta, notRunGa
+}
+
+func modifiedPackages(changedFiles []string, version provider.Version) (map[string]struct{}, bool) {
+	var goFiles []string
+	for _, line := range changedFiles {
+		if strings.HasSuffix(line, ".go") || strings.Contains(line, "test-fixtures") || strings.HasSuffix(line, "go.mod") || strings.HasSuffix(line, "go.sum") {
+			goFiles = append(goFiles, line)
+		}
+	}
+	services := make(map[string]struct{})
+	runFullVCR := false
+	for _, file := range goFiles {
+		if strings.HasPrefix(file, version.ProviderName()+"/services/") {
+			fileParts := strings.Split(file, "/")
+			services[fileParts[2]] = struct{}{}
+		} else if file == version.ProviderName()+"/provider/provider_mmv1_resources.go" || file == version.ProviderName()+"/provider/provider_dcl_resources.go" {
+			fmt.Println("ignore changes in ", file)
+		} else {
+			fmt.Println("run full tests ", file)
+			runFullVCR = true
+			break
+		}
+	}
+	return services, runFullVCR
+}
+
+func runReplaying(runFullVCR bool, version provider.Version, services map[string]struct{}, vt *vcr.Tester) (vcr.Result, []string, error) {
+	result := vcr.Result{}
+	var testDirs []string
+	var replayingErr error
+	if runFullVCR {
+		fmt.Println("runReplaying: full VCR tests")
+		result, replayingErr = vt.Run(vcr.RunOptions{
+			Mode:    vcr.Replaying,
+			Version: version,
+		})
+	} else if len(services) > 0 {
+		fmt.Printf("runReplaying: %d specific services: %v\n", len(services), services)
+		for service := range services {
+			servicePath := "./" + filepath.Join(version.ProviderName(), "services", service)
+			testDirs = append(testDirs, servicePath)
+			fmt.Println("run VCR tests in ", service)
+			serviceResult, serviceReplayingErr := vt.Run(vcr.RunOptions{
+				Mode:     vcr.Replaying,
+				Version:  version,
+				TestDirs: []string{servicePath},
+			})
+			if serviceReplayingErr != nil {
+				replayingErr = serviceReplayingErr
+			}
+			result.PassedTests = append(result.PassedTests, serviceResult.PassedTests...)
+			result.SkippedTests = append(result.SkippedTests, serviceResult.SkippedTests...)
+			result.FailedTests = append(result.FailedTests, serviceResult.FailedTests...)
+			result.Panics = append(result.Panics, serviceResult.Panics...)
+		}
+	} else {
+		fmt.Println("runReplaying: no impacted services")
+	}
+
+	return result, testDirs, replayingErr
+}
+
+func handlePanics(prNumber, buildID, buildStatusTargetURL, mmCommitSha string, result vcr.Result, mode vcr.Mode, gh GithubClient) (bool, error) {
+	if len(result.Panics) > 0 {
+		comment := color("red", fmt.Sprintf("The provider crashed while running the VCR tests in %s mode\n", mode.Upper()))
+		comment += fmt.Sprintf(`Please fix it to complete your PR.
+View the [build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-%s/artifacts/%s/build-log/%s_test.log)`, prNumber, buildID, mode.Lower())
+		if err := gh.PostComment(prNumber, comment); err != nil {
+			return true, fmt.Errorf("error posting comment: %v", err)
+		}
+		if err := gh.PostBuildStatus(prNumber, "VCR-test", "failure", buildStatusTargetURL, mmCommitSha); err != nil {
+			return true, fmt.Errorf("error posting failure status: %v", err)
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+func init() {
+	rootCmd.AddCommand(testTerraformVCRCmd)
+}
+
+func formatComment(fileName string, tmplText string, data any) (string, error) {
+	funcs := template.FuncMap{
+		"join":  strings.Join,
+		"add":   func(i, j int) int { return i + j },
+		"color": color,
+	}
+	tmpl, err := template.New(fileName).Funcs(funcs).Parse(tmplText)
+	if err != nil {
+		panic(fmt.Sprintf("Unable to parse %s: %s", fileName, err))
+	}
+	sb := new(strings.Builder)
+	err = tmpl.Execute(sb, data)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(sb.String()), nil
+}
+
+func formatTestsAnalytics(data analytics) (string, error) {
+	return formatComment("test_analytics.tmpl", testsAnalyticsTmplText, data)
+}
+
+func formatNonExercisedTests(data nonExercisedTests) (string, error) {
+	return formatComment("non_exercised_tests.tmpl", nonExercisedTestsTmplText, data)
+}
+
+func formatWithReplayFailedTests(data withReplayFailedTests) (string, error) {
+	return formatComment("with_replay_failed_tests.tmpl", withReplayFailedTestsTmplText, data)
+}
+
+func formatWithoutReplayFailedTests(data withoutReplayFailedTests) (string, error) {
+	return formatComment("without_replay_failed_tests.tmpl", withoutReplayFailedTestsTmplText, data)
+}
+
+func formatRecordReplay(data recordReplay) (string, error) {
+	return formatComment("record_replay.tmpl", recordReplayTmplText, data)
+}

--- a/.ci/magician/cmd/test_eap_vcr.go
+++ b/.ci/magician/cmd/test_eap_vcr.go
@@ -76,7 +76,7 @@ func listTEVEnvironmentVariables() string {
 }
 
 func execTestEAPVCR(changeNumber, genPath, kokoroArtifactsDir, modifiedFilePath string, rnr ExecRunner, vt *vcr.Tester) error {
-	vt.SetRepoPath(provider.Alpha, genPath)
+	vt.SetRepoPath(provider.Private, genPath)
 	if err := rnr.PushDir(genPath); err != nil {
 		return fmt.Errorf("error changing to gen path: %w", err)
 	}
@@ -86,7 +86,7 @@ func execTestEAPVCR(changeNumber, genPath, kokoroArtifactsDir, modifiedFilePath 
 		return fmt.Errorf("error diffing gen path: %w", err)
 	}
 
-	services, runFullVCR := modifiedPackages(strings.Split(changedFiles, "\n"), provider.Alpha)
+	services, runFullVCR := modifiedPackages(strings.Split(changedFiles, "\n"), provider.Private)
 	if len(services) == 0 && !runFullVCR {
 		fmt.Println("Skipping tests: No go files or test fixtures changed")
 		return nil
@@ -94,14 +94,14 @@ func execTestEAPVCR(changeNumber, genPath, kokoroArtifactsDir, modifiedFilePath 
 	fmt.Println("Running tests: Go files or test fixtures changed")
 
 	head := "auto-cl-" + changeNumber
-	if err := vt.FetchCassettes(provider.Alpha, "main", head); err != nil {
+	if err := vt.FetchCassettes(provider.Private, "main", head); err != nil {
 		return fmt.Errorf("error fetching cassettes: %w", err)
 	}
-	replayingResult, testDirs, replayingErr := runReplaying(runFullVCR, provider.Alpha, services, vt)
+	replayingResult, testDirs, replayingErr := runReplaying(runFullVCR, provider.Private, services, vt)
 	if err := vt.UploadLogs(vcr.UploadLogsOptions{
 		Head:    head,
 		Mode:    vcr.Replaying,
-		Version: provider.Alpha,
+		Version: provider.Private,
 	}); err != nil {
 		return fmt.Errorf("error uploading replaying logs: %w", err)
 	}
@@ -157,7 +157,7 @@ func execTestEAPVCR(changeNumber, genPath, kokoroArtifactsDir, modifiedFilePath 
 		if len(recordingResult.PassedTests) > 0 {
 			replayingAfterRecordingResult, _ = vt.RunParallel(vcr.RunOptions{
 				Mode:     vcr.Replaying,
-				Version:  provider.Alpha,
+				Version:  provider.Private,
 				TestDirs: testDirs,
 				Tests:    recordingResult.PassedTests,
 			})
@@ -166,7 +166,7 @@ func execTestEAPVCR(changeNumber, genPath, kokoroArtifactsDir, modifiedFilePath 
 				Parallel:       true,
 				AfterRecording: true,
 				Mode:           vcr.Recording,
-				Version:        provider.Alpha,
+				Version:        provider.Private,
 			}); err != nil {
 				return fmt.Errorf("error uploading recording logs: %w", err)
 			}

--- a/.ci/magician/provider/version.go
+++ b/.ci/magician/provider/version.go
@@ -18,7 +18,7 @@ func (v Version) String() string {
 	case Beta:
 		return "beta"
 	case Private:
-		return "alpha"
+		return "private"
 	}
 	return "unknown"
 }

--- a/.ci/magician/vcr/tester.go
+++ b/.ci/magician/vcr/tester.go
@@ -245,17 +245,19 @@ func (vt *Tester) Run(opt RunOptions) (Result, error) {
 		"-vet=off",
 	)
 	env := map[string]string{
-		"VCR_PATH":                       cassettePath,
-		"VCR_MODE":                       opt.Mode.Upper(),
-		"ACCTEST_PARALLELISM":            strconv.Itoa(accTestParallelism),
-		"GOOGLE_CREDENTIALS":             vt.env["SA_KEY"],
-		"GOOGLE_APPLICATION_CREDENTIALS": filepath.Join(vt.baseDir, vt.saKeyPath),
-		"GOOGLE_TEST_DIRECTORY":          strings.Join(opt.TestDirs, " "),
-		"TF_LOG":                         "DEBUG",
-		"TF_LOG_SDK_FRAMEWORK":           "INFO",
-		"TF_LOG_PATH_MASK":               filepath.Join(logPath, "%s.log"),
-		"TF_ACC":                         "1",
-		"TF_SCHEMA_PANIC_ON_ERROR":       "1",
+		"VCR_PATH":                 cassettePath,
+		"VCR_MODE":                 opt.Mode.Upper(),
+		"ACCTEST_PARALLELISM":      strconv.Itoa(accTestParallelism),
+		"GOOGLE_CREDENTIALS":       vt.env["SA_KEY"],
+		"GOOGLE_TEST_DIRECTORY":    strings.Join(opt.TestDirs, " "),
+		"TF_LOG":                   "DEBUG",
+		"TF_LOG_SDK_FRAMEWORK":     "INFO",
+		"TF_LOG_PATH_MASK":         filepath.Join(logPath, "%s.log"),
+		"TF_ACC":                   "1",
+		"TF_SCHEMA_PANIC_ON_ERROR": "1",
+	}
+	if vt.saKeyPath != "" {
+		env["GOOGLE_APPLICATION_CREDENTIALS"] = filepath.Join(vt.baseDir, vt.saKeyPath)
 	}
 	for ev, val := range vt.env {
 		env[ev] = val
@@ -390,17 +392,19 @@ func (vt *Tester) runInParallel(mode Mode, version provider.Version, testDir, te
 		"-vet=off",
 	}
 	env := map[string]string{
-		"VCR_PATH":                       cassettePath,
-		"VCR_MODE":                       mode.Upper(),
-		"ACCTEST_PARALLELISM":            "1",
-		"GOOGLE_CREDENTIALS":             vt.env["SA_KEY"],
-		"GOOGLE_APPLICATION_CREDENTIALS": filepath.Join(vt.baseDir, vt.saKeyPath),
-		"GOOGLE_TEST_DIRECTORY":          testDir,
-		"TF_LOG":                         "DEBUG",
-		"TF_LOG_SDK_FRAMEWORK":           "INFO",
-		"TF_LOG_PATH_MASK":               filepath.Join(logPath, "%s.log"),
-		"TF_ACC":                         "1",
-		"TF_SCHEMA_PANIC_ON_ERROR":       "1",
+		"VCR_PATH":                 cassettePath,
+		"VCR_MODE":                 mode.Upper(),
+		"ACCTEST_PARALLELISM":      "1",
+		"GOOGLE_CREDENTIALS":       vt.env["SA_KEY"],
+		"GOOGLE_TEST_DIRECTORY":    testDir,
+		"TF_LOG":                   "DEBUG",
+		"TF_LOG_SDK_FRAMEWORK":     "INFO",
+		"TF_LOG_PATH_MASK":         filepath.Join(logPath, "%s.log"),
+		"TF_ACC":                   "1",
+		"TF_SCHEMA_PANIC_ON_ERROR": "1",
+	}
+	if vt.saKeyPath != "" {
+		env["GOOGLE_APPLICATION_CREDENTIALS"] = filepath.Join(vt.baseDir, vt.saKeyPath)
 	}
 	for ev, val := range vt.env {
 		env[ev] = val
@@ -534,6 +538,9 @@ func (vt *Tester) UploadCassettes(head string, version provider.Version) error {
 
 // Deletes the service account key.
 func (vt *Tester) Cleanup() error {
+	if vt.saKeyPath == "" {
+		return nil
+	}
 	if err := vt.rnr.RemoveAll(vt.saKeyPath); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This PR adds the command for running VCR in eap using the magician.

Merge after https://github.com/GoogleCloudPlatform/magic-modules/pull/11874

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
