### PR TITLE
Add support for ControlPlaneEndpointsConfig to GKE

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -54,7 +54,12 @@ var (
 				Type: schema.TypeBool,
 				Optional: true,
 				Computed: true,
-				Description: `Whether Kubernetes master is accessible via Google Compute Engine Public IPs.`,
+				Description: `Whether Kubernetes master is accessible via Google Compute Engine Public IPs. Defaults to false`,
+			},
+			"private_endpoint_enforcement_enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether master authorized networks is enforced on the private endpoint or not. Defaults to false.`,
 			},
 		},
 	}
@@ -1421,6 +1426,8 @@ func ResourceContainerCluster() *schema.Resource {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Computed:    true,
+				Deprecated:    "use control_plane_endpoints_config.ip_endpoints_config.authorized_networks_config instead",
+				ConflictsWith: []string{"control_plane_endpoints_config.0.ip_endpoints_config.0.authorized_networks_config"},
 				MaxItems:    1,
 				Elem:        masterAuthorizedNetworksConfig,
 				Description: `The desired configuration options for master authorized networks. Omit the nested cidr_blocks attribute to disallow external access (except the cluster node IPs, which GKE automatically whitelists).`,
@@ -1722,13 +1729,128 @@ func ResourceContainerCluster() *schema.Resource {
 				ConflictsWith: []string{"enable_autopilot"},
 			},
 
+			"control_plane_endpoints_config": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Computed:    true,
+				ConflictsWith: []string{
+					"private_cluster_config.0.enable_private_endpoint",
+					"private_cluster_config.0.private_endpoint_subnetwork",
+					"private_cluster_config.0.master_global_access_config",
+				},
+				Description: `Configuration for all of the cluster's control plane endpoints. If this is specified, then respective configured values from private_cluster_config are ignored.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"dns_endpoint_config": {
+							Type:        schema.TypeList,
+							MaxItems:    1,
+							Optional:    true,
+							Computed:    true,
+							Description: `DNS endpoint configuration.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"endpoint": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Computed:    true,
+										Description: `The cluster's DNS endpoint.`,
+									},
+									"allow_external_traffic": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Description: `Controls whether user traffic is allowed over this endpoint. Note that GCP-managed services may still use the endpoint even if this is false.`,
+									},
+								},
+							},
+						},
+						"ip_endpoints_config": {
+							Type:        schema.TypeList,
+							MaxItems:    1,
+							Optional:    true,
+							Computed:    true,
+							Description: `IP endpoints configuration.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Description: `Controls whether to allow direct IP access. When this is false, all other ip_endpoints_config values are ignored.`,
+									},
+									"enable_public_endpoint": {
+										Type:             schema.TypeBool,
+										Optional:         true,
+										DiffSuppressFunc: suppressWhenIpEndpointsDisabled,
+										ConflictsWith:    []string{"private_cluster_config.0.enable_private_endpoint"},
+										Description:      `Controls whether the control plane allows access through a public IP.`,
+									},
+									"global_access": {
+										Type:             schema.TypeBool,
+										Optional:         true,
+										DiffSuppressFunc: suppressWhenIpEndpointsDisabled,
+										ConflictsWith:    []string{"private_cluster_config.0.master_global_access_config"},
+										Description:      `Controls whether the control plane's private endpoint is accessible from sources in other regions.`,
+									},
+									"authorized_networks_config": {
+										Type:             schema.TypeList,
+										Optional:         true,
+										DiffSuppressFunc: suppressWhenIpEndpointsDisabled,
+										ConflictsWith:    []string{"master_authorized_networks_config"},
+										MaxItems:         1,
+										Description:      `Configuration of authorized networks. If enabled, restricts access to the control plane based on source IP.`,
+										Elem:             masterAuthorizedNetworksConfig,
+									},
+									"public_endpoint": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Computed:    true,
+										Description: `The external IP address of this cluster's control plane. Only populated if enabled.`,
+									},
+									"private_endpoint": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Computed:    true,
+										Description: `The internal IP address of this cluster's control plane. Only populated if enabled.`,
+									},
+									"private_endpoint_subnetwork": {
+										Type:             schema.TypeString,
+										Optional:         true,
+										DiffSuppressFunc: suppressWhenIpEndpointsDisabled,
+										ConflictsWith:    []string{"private_cluster_config.0.private_endpoint_subnetwork"},
+										Description:      `Subnet to provision the master's private endpoint during cluster. Specified in projects/*/regions/*/subnetworks/* format.`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			"network_config": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Computed:    true,
+				Description: `Configuration for cluster networking.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"default_enable_private_nodes": {
+							Type:          schema.TypeBool,
+							Optional:      true,
+							ConflictsWith: []string{"private_cluster_config.0.enable_private_nodes"},
+							Description:   `Controls whether by default nodes have private IP addresses only.`,
+						},
+					},
+				},
+			},
+
 			"private_cluster_config": {
 				Type:             schema.TypeList,
 				MaxItems:         1,
 				Optional:         true,
 				Computed:         true,
 				DiffSuppressFunc: containerClusterPrivateClusterConfigSuppress,
-				Description:      `Configuration for private clusters, clusters with private nodes.`,
+				Description:      `Configuration for private clusters, clusters with private nodes. It's recommended that new configurations use control_plane_endpoints_config for any settings that are available there.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						// enable_private_endpoint is orthogonal to private_endpoint_subnetwork.
@@ -1739,6 +1861,8 @@ func ResourceContainerCluster() *schema.Resource {
 						"enable_private_endpoint": {
 							Type:             schema.TypeBool,
 							Optional:         true,
+							Deprecated:       "use control_plane_endpoints_config.ip_endpoints_config.enable_public_endpoint instead, and note the flipped semantics",
+							ConflictsWith:    []string{"control_plane_endpoints_config"},
 							AtLeastOneOf:     privateClusterConfigKeys,
 							DiffSuppressFunc: containerClusterPrivateClusterConfigSuppress,
 							Description:      `When true, the cluster's private endpoint is used as the cluster endpoint and access through the public endpoint is disabled. When false, either endpoint can be used.`,
@@ -1746,7 +1870,8 @@ func ResourceContainerCluster() *schema.Resource {
 						"enable_private_nodes": {
 							Type:             schema.TypeBool,
 							Optional:         true,
-							ForceNew:         true,
+							Deprecated:       "use network_config.default_enable_private_nodes instead",
+							ConflictsWith:    []string{"network_config.0.default_enable_private_nodes"},
 							AtLeastOneOf:     privateClusterConfigKeys,
 							DiffSuppressFunc: containerClusterPrivateClusterConfigSuppress,
 							Description:      `Enables the private cluster feature, creating a private endpoint on the cluster. In a private cluster, nodes only have RFC 1918 private addresses and communicate with the master's private endpoint via private networking.`,
@@ -1763,20 +1888,22 @@ func ResourceContainerCluster() *schema.Resource {
 						"peering_name": {
 							Type:         schema.TypeString,
 							Computed:     true,
-							Description: `The name of the peering between this cluster and the Google owned VPC.`,
+							Description:  `The name of the peering between this cluster and the Google owned VPC.`,
 						},
 						"private_endpoint": {
 							Type:         schema.TypeString,
 							Computed:     true,
-							Description: `The internal IP address of this cluster's master endpoint.`,
+							Description:  `The internal IP address of this cluster's master endpoint.`,
 						},
 						"private_endpoint_subnetwork": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ForceNew:     true,
-							AtLeastOneOf: privateClusterConfigKeys,
+							Type:             schema.TypeString,
+							Optional:         true,
+							Deprecated:       "use control_plane_endpoints_config.ip_endpoints_config.private_endpoint_subnetwork instead",
+							ConflictsWith:    []string{"control_plane_endpoints_config"},
+							ForceNew:         true,
+							AtLeastOneOf:     privateClusterConfigKeys,
 							DiffSuppressFunc: containerClusterPrivateClusterConfigSuppress,
-							Description: `Subnetwork in cluster's network where master's endpoint will be provisioned.`,
+							Description:      `Subnetwork in cluster's network where master's endpoint will be provisioned.`,
 						},
 						"public_endpoint": {
 							Type:         schema.TypeString,
@@ -1784,12 +1911,14 @@ func ResourceContainerCluster() *schema.Resource {
 							Description: `The external IP address of this cluster's master endpoint.`,
 						},
 						"master_global_access_config": {
-							Type:         schema.TypeList,
-							MaxItems:     1,
-							Optional:     true,
-							Computed:     true,
-							AtLeastOneOf: privateClusterConfigKeys,
-							Description: "Controls cluster master global access settings.",
+							Type:          schema.TypeList,
+							MaxItems:      1,
+							Optional:      true,
+							Deprecated:    "use control_plane_endpoints_config.ip_endpoints_config.global_access instead",
+							ConflictsWith: []string{"control_plane_endpoints_config"},
+							Computed:      true,
+							AtLeastOneOf:  privateClusterConfigKeys,
+							Description:   "Controls cluster master global access settings.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"enabled": {
@@ -2345,13 +2474,13 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	cluster := &container.Cluster{
-		Name:                           clusterName,
-		InitialNodeCount:               int64(d.Get("initial_node_count").(int)),
-		MaintenancePolicy:              expandMaintenancePolicy(d, meta),
-		MasterAuthorizedNetworksConfig: expandMasterAuthorizedNetworksConfig(d.Get("master_authorized_networks_config"), d),
-		InitialClusterVersion:          d.Get("min_master_version").(string),
-		ClusterIpv4Cidr:                d.Get("cluster_ipv4_cidr").(string),
-		Description:                    d.Get("description").(string),
+		Name:                        clusterName,
+		InitialNodeCount:            int64(d.Get("initial_node_count").(int)),
+		MaintenancePolicy:           expandMaintenancePolicy(d, meta),
+		ControlPlaneEndpointsConfig: expandControlPlaneEndpointsConfig(d),
+		InitialClusterVersion:       d.Get("min_master_version").(string),
+		ClusterIpv4Cidr:             d.Get("cluster_ipv4_cidr").(string),
+		Description:                 d.Get("description").(string),
 		LegacyAbac: &container.LegacyAbac{
 			Enabled:         d.Get("enable_legacy_abac").(bool),
 			ForceSendFields: []string{"Enabled"},
@@ -2388,6 +2517,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 			DnsConfig:                            expandDnsConfig(d.Get("dns_config")),
 			GatewayApiConfig:                     expandGatewayApiConfig(d.Get("gateway_api_config")),
 			EnableMultiNetworking:                d.Get("enable_multi_networking").(bool),
+			DefaultEnablePrivateNodes:	          expandDefaultEnablePrivateNodes(d),
 {{- if ne $.TargetVersionName "ga" }}
 			EnableFqdnNetworkPolicy:              d.Get("enable_fqdn_network_policy").(bool),
 {{- end }}
@@ -2486,8 +2616,8 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		cluster.AuthenticatorGroupsConfig = expandAuthenticatorGroupsConfig(v)
 	}
 
-	if v, ok := d.GetOk("private_cluster_config"); ok {
-		cluster.PrivateClusterConfig = expandPrivateClusterConfig(v)
+	if v, ok := d.GetOk("private_cluster_config.0.master_ipv4_cidr_block"); ok {
+		cluster.PrivateClusterConfig = expandPrivateClusterConfigMasterIpv4CidrBlock(v, cluster)
 	}
 
 	if v, ok := d.GetOk("vertical_pod_autoscaling"); ok {
@@ -2537,10 +2667,6 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if err := validateNodePoolAutoConfig(cluster); err != nil {
-		return err
-	}
-
-	if err := validatePrivateClusterConfig(cluster); err != nil {
 		return err
 	}
 
@@ -2834,9 +2960,6 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	if err := d.Set("master_auth", flattenMasterAuth(cluster.MasterAuth)); err != nil {
 		return err
 	}
-	if err := d.Set("master_authorized_networks_config", flattenMasterAuthorizedNetworksConfig(cluster.MasterAuthorizedNetworksConfig)); err != nil {
-		return err
-	}
 	if err := d.Set("initial_node_count", cluster.InitialNodeCount); err != nil {
 		return fmt.Errorf("Error setting initial_node_count: %s", err)
 	}
@@ -2971,7 +3094,7 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	if err := d.Set("private_cluster_config", flattenPrivateClusterConfig(cluster.PrivateClusterConfig)); err != nil {
+	if err := flattenControlPlaneEndpointsConfig(cluster.ControlPlaneEndpointsConfig, cluster.PrivateClusterConfig, cluster.NetworkConfig, d); err != nil {
 		return err
 	}
 
@@ -3122,19 +3245,22 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	// The ClusterUpdate object that we use for most of these updates only allows updating one field at a time,
 	// so we have to make separate calls for each field that we want to update. The order here is fairly arbitrary-
 	// if the order of updating fields does matter, it is called out explicitly.
-	if d.HasChange("master_authorized_networks_config") {
-		c := d.Get("master_authorized_networks_config")
+
+	if d.HasChange("control_plane_endpoints_config") ||
+	    d.HasChange("master_authorized_networks_config") ||
+		d.HasChange("private_cluster_config.0.enable_private_endpoint") ||
+		d.HasChange("private_cluster_config.0.master_global_access_config") {
 		req := &container.UpdateClusterRequest{
 			Update: &container.ClusterUpdate{
-				DesiredMasterAuthorizedNetworksConfig: expandMasterAuthorizedNetworksConfig(c, d),
+				DesiredControlPlaneEndpointsConfig: expandControlPlaneEndpointsConfig(d),
 			},
 		}
 
-		updateF := updateFunc(req, "updating GKE cluster master authorized networks")
+		updateF := updateFunc(req, "updating GKE control plane endpoints config")
 		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
 			return err
 		}
-		log.Printf("[INFO] GKE cluster %s master authorized networks config has been updated", d.Id())
+		log.Printf("[INFO] GKE cluster %s control plane endpoints config has been updated", d.Id())
 	}
 
 	if d.HasChange("addons_config") {
@@ -3205,12 +3331,12 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		log.Printf("[INFO] GKE cluster %s's autopilot workload policy config allow_net_admin has been set to %v", d.Id(), allowed)
 	}
 
-	if d.HasChange("private_cluster_config.0.enable_private_endpoint") {
-		enabled := d.Get("private_cluster_config.0.enable_private_endpoint").(bool)
+	if d.HasChange("network_config") || d.HasChange("private_cluster_config.0.enable_private_nodes"){
+		enabled := expandDefaultEnablePrivateNodes(d)
 		req := &container.UpdateClusterRequest{
 			Update: &container.ClusterUpdate{
-				DesiredEnablePrivateEndpoint: enabled,
-				ForceSendFields:              []string{"DesiredEnablePrivateEndpoint"},
+				DesiredDefaultEnablePrivateNodes: enabled,
+				ForceSendFields:                  []string{"DesiredDefaultEnablePrivateNodes"},
 			},
 		}
 
@@ -3221,26 +3347,6 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 
 		log.Printf("[INFO] GKE cluster %s's enable private endpoint has been updated to %v", d.Id(), enabled)
-	}
-
-	if d.HasChange("private_cluster_config") && d.HasChange("private_cluster_config.0.master_global_access_config") {
-		config := d.Get("private_cluster_config.0.master_global_access_config")
-		req := &container.UpdateClusterRequest{
-			Update: &container.ClusterUpdate{
-				DesiredPrivateClusterConfig: &container.PrivateClusterConfig{
-					MasterGlobalAccessConfig: expandPrivateClusterConfigMasterGlobalAccessConfig(config),
-					ForceSendFields:          []string{"MasterGlobalAccessConfig"},
-				},
-			},
-		}
-
-		updateF := updateFunc(req, "updating master global access config")
-		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
-			return err
-		}
-
-		log.Printf("[INFO] GKE cluster %s's master global access config has been updated to %v", d.Id(), config)
 	}
 
 	if d.HasChange("binary_authorization") {
@@ -5339,7 +5445,7 @@ func expandMasterAuth(configured interface{}) *container.MasterAuth {
 	return result
 }
 
-func expandMasterAuthorizedNetworksConfig(configured interface{}, d *schema.ResourceData) *container.MasterAuthorizedNetworksConfig {
+func expandMasterAuthorizedNetworksConfig(configured interface{}) *container.MasterAuthorizedNetworksConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 {
 		return &container.MasterAuthorizedNetworksConfig{
@@ -5350,21 +5456,34 @@ func expandMasterAuthorizedNetworksConfig(configured interface{}, d *schema.Reso
 		Enabled: true,
 	}
 	if config, ok := l[0].(map[string]interface{}); ok {
-		if _, ok := config["cidr_blocks"]; ok {
-			cidrBlocks := config["cidr_blocks"].(*schema.Set).List()
-			result.CidrBlocks = make([]*container.CidrBlock, 0)
-			for _, v := range cidrBlocks {
-				cidrBlock := v.(map[string]interface{})
-				result.CidrBlocks = append(result.CidrBlocks, &container.CidrBlock{
-					CidrBlock:   cidrBlock["cidr_block"].(string),
-					DisplayName: cidrBlock["display_name"].(string),
-				})
-			}
+		if v, ok := config["cidr_blocks"]; ok {
+			result.CidrBlocks = expandManCidrBlocks(v)
 		}
-		if v, ok := d.GetOkExists("master_authorized_networks_config.0.gcp_public_cidrs_access_enabled"); ok {
+		if v, ok := config["gcp_public_cidrs_access_enabled"]; ok {
 			result.GcpPublicCidrsAccessEnabled = v.(bool)
-			result.ForceSendFields = []string{"GcpPublicCidrsAccessEnabled"}
+			result.ForceSendFields = append(result.ForceSendFields, "GcpPublicCidrsAccessEnabled")
 		}
+		if v, ok := config["private_endpoint_enforcement_enabled"]; ok {
+			result.PrivateEndpointEnforcementEnabled = v.(bool)
+			result.ForceSendFields = append(result.ForceSendFields, "PrivateEndpointEnforcementEnabled")
+		}
+	}
+	return result
+}
+
+func expandManCidrBlocks(configured interface{}) []*container.CidrBlock {
+	config, ok := configured.(*schema.Set)
+	if !ok {
+		return nil
+	}
+	cidrBlocks := config.List()
+	result := make([]*container.CidrBlock, 0)
+	for _, v := range cidrBlocks {
+		cidrBlock := v.(map[string]interface{})
+		result = append(result, &container.CidrBlock{
+			CidrBlock:   cidrBlock["cidr_block"].(string),
+			DisplayName: cidrBlock["display_name"].(string),
+		})
 	}
 	return result
 }
@@ -5408,32 +5527,132 @@ func isEnablePDCSI(cluster *container.Cluster) bool {
 	return cluster.AddonsConfig.GcePersistentDiskCsiDriverConfig.Enabled
 }
 
-func expandPrivateClusterConfig(configured interface{}) *container.PrivateClusterConfig {
-	l := configured.([]interface{})
-	if len(l) == 0 {
-		return nil
-	}
-	config := l[0].(map[string]interface{})
+// Most of the contents of PrivateClusterConfig have been deprecated and replaced by ControlPlaneEndpointsConfig.
+// This function only handles the sole remaining undeprecated field, master_ipv4_cidr_block.
+// Unfortunately, since private_cluster_config.enable_private_nodes is not marked optional, we can't just leave it
+// unset, as that would implicitly use the value false, and it must match the value of
+// network_config.default_enable_private_nodes. This function is intended to be called only during cluster creation,
+// after the network_config field is been configured. This is possible because master_ipv4_cidr_block is immutable.
+func expandPrivateClusterConfigMasterIpv4CidrBlock(configured interface{}, c *container.Cluster) *container.PrivateClusterConfig {
+	v := configured.(string)
+
 	return &container.PrivateClusterConfig{
-		EnablePrivateEndpoint:      config["enable_private_endpoint"].(bool),
-		EnablePrivateNodes:         config["enable_private_nodes"].(bool),
-		MasterIpv4CidrBlock:        config["master_ipv4_cidr_block"].(string),
-		MasterGlobalAccessConfig:   expandPrivateClusterConfigMasterGlobalAccessConfig(config["master_global_access_config"]),
-		PrivateEndpointSubnetwork:  config["private_endpoint_subnetwork"].(string),
-		ForceSendFields:            []string{"EnablePrivateEndpoint", "EnablePrivateNodes", "MasterIpv4CidrBlock", "MasterGlobalAccessConfig"},
+		MasterIpv4CidrBlock: v,
+		EnablePrivateNodes:  c.NetworkConfig.DefaultEnablePrivateNodes,
+		ForceSendFields:     []string{"MasterIpv4CidrBlock"},
 	}
 }
 
-func expandPrivateClusterConfigMasterGlobalAccessConfig(configured interface{}) *container.PrivateClusterMasterGlobalAccessConfig {
-	l := configured.([]interface{})
+func expandDefaultEnablePrivateNodes(d *schema.ResourceData) bool {
+	// Check if the config uses the deprecated private_cluster_config
+	b, ok := d.GetOk("private_cluster_config.0.enable_private_nodes")
+	if ok {
+		v, _ := b.(bool)
+		return v
+	}
+
+	v, ok := d.GetOk("network_config.0.default_enable_private_nodes")
+	if !ok {
+		return false
+	}
+	if b, ok := v.(bool); ok {
+		return b
+	}
+	return false
+}
+
+func expandControlPlaneEndpointsConfig(d *schema.ResourceData) *container.ControlPlaneEndpointsConfig {
+	cpec, hasCpec := d.GetOk("control_plane_endpoints_config")
+
+	if !hasCpec {
+		// Check if the config uses the deprecated private_cluster_config or master_authorized_networks_config
+		return expandEndpointsConfigFromLegacyConfigs(d)
+	}
+	l := cpec.([]interface{})
 	if len(l) == 0 {
 		return nil
 	}
 	config := l[0].(map[string]interface{})
-	return &container.PrivateClusterMasterGlobalAccessConfig{
-		Enabled: config["enabled"].(bool),
-		ForceSendFields:       []string{"Enabled"},
+	dns := &container.DNSEndpointConfig{}
+	dnsConfig, ok := config["dns_endpoint_config"]
+	if ok {
+		l := dnsConfig.([]interface{})
+		if len(l) != 0 {
+			config := l[0].(map[string]interface{})
+			dns.AllowExternalTraffic = config["allow_external_traffic"].(bool)
+			dns.ForceSendFields = []string{"AllowExternalTraffic"}
+		}
 	}
+
+	ip := &container.IPEndpointsConfig{}
+	ipConfig, ok := config["ip_endpoints_config"]
+	if ok {
+		l := ipConfig.([]interface{})
+		if len(l) != 0 {
+			config := l[0].(map[string]interface{})
+			ip.Enabled = config["enabled"].(bool)
+			ip.ForceSendFields = []string{"Enabled"}
+			if ip.Enabled {
+				ip.EnablePublicEndpoint = config["enable_public_endpoint"].(bool)
+				ip.GlobalAccess = config["global_access"].(bool)
+				man, hasMan := d.GetOk("master_authorized_networks_config")
+				if hasMan {
+					ip.AuthorizedNetworksConfig = expandMasterAuthorizedNetworksConfig(man)
+				} else {
+					ip.AuthorizedNetworksConfig = expandMasterAuthorizedNetworksConfig(config["authorized_networks_config"])
+				}
+				ip.PrivateEndpointSubnetwork = config["private_endpoint_subnetwork"].(string)
+				ip.ForceSendFields = []string{"Enabled", "EnablePublicEndpoint", "GlobalAccess", "PrivateEndpointSubnetwork"}
+			}
+		}
+	}
+	return &container.ControlPlaneEndpointsConfig{
+		DnsEndpointConfig: dns,
+		IpEndpointsConfig: ip,
+	}
+}
+
+func expandEndpointsConfigFromLegacyConfigs(d *schema.ResourceData) *container.ControlPlaneEndpointsConfig {
+	pcc, hasPcc := d.GetOk("private_cluster_config")
+	man, hasMan := d.GetOk("master_authorized_networks_config")
+	if !hasPcc && !hasMan {
+		return nil
+	}
+
+	cpec := &container.ControlPlaneEndpointsConfig{}
+
+	if hasPcc {
+		l := pcc.([]interface{})
+		if len(l) == 0 {
+			return nil
+		}
+		config := l[0].(map[string]interface{})
+		global_access := false
+		l = config["master_global_access_config"].([]interface{})
+		if len(l) != 0 {
+			global_access = l[0].(map[string]interface{})["enabled"].(bool)
+		}
+		cpec = &container.ControlPlaneEndpointsConfig{
+			IpEndpointsConfig: &container.IPEndpointsConfig{
+				Enabled:                   true,
+				EnablePublicEndpoint:      !config["enable_private_endpoint"].(bool),
+				GlobalAccess:              global_access,
+				PrivateEndpointSubnetwork: config["private_endpoint_subnetwork"].(string),
+				ForceSendFields:           []string{"Enabled", "EnablePublicEndpoint", "GlobalAccess", "PrivateEndpointSubnetwork"},
+			},
+		}
+	}
+
+	if hasMan {
+		if cpec.IpEndpointsConfig == nil {
+			cpec.IpEndpointsConfig = &container.IPEndpointsConfig{
+				Enabled: true,
+			}
+		}
+		cpec.IpEndpointsConfig.AuthorizedNetworksConfig = expandMasterAuthorizedNetworksConfig(man)
+	}
+
+	return cpec
 }
 
 func expandVerticalPodAutoscaling(configured interface{}) *container.VerticalPodAutoscaling {
@@ -6075,31 +6294,144 @@ func flattenAuthenticatorGroupsConfig(c *container.AuthenticatorGroupsConfig) []
 	}
 }
 
-func flattenPrivateClusterConfig(c *container.PrivateClusterConfig) []map[string]interface{} {
-	if c == nil {
+// Most of PrivateClusterConfig has moved to ControlPlaneEndpointsConfig, along with MasterAuthorizedNetworksConfig.
+// If the user configures the old private_cluster_config, we have to populate those values instead in order to maintain
+// compatibility. Everyone is strongly encouraged to drop usage of private_cluster_config and master_authorized_networks_config.
+func flattenControlPlaneEndpointsConfig(cpec *container.ControlPlaneEndpointsConfig, pcc *container.PrivateClusterConfig, nc *container.NetworkConfig, d *schema.ResourceData) error {
+	if cpec == nil {
+		return nil
+	}
+
+	// Structs are modeled as single-element lists of maps, and ResourceData doesn't list you set individual elements of a list,
+	// so we have to construct the full objects before setting them. Start with the values that are unconditionally set,
+	// and then start adding the fields that depend on where the user has configured them.
+
+	outIp := []map[string]interface{}{
+		{
+			"enabled":          cpec.IpEndpointsConfig.Enabled,
+			"public_endpoint":  cpec.IpEndpointsConfig.PublicEndpoint,
+			"private_endpoint": cpec.IpEndpointsConfig.PrivateEndpoint,
+		},
+	}
+	outPcc := []map[string]interface{}{
+		{
+			"public_endpoint":  cpec.IpEndpointsConfig.PublicEndpoint,
+			"private_endpoint": cpec.IpEndpointsConfig.PrivateEndpoint,
+		},
+	}
+	outCpec := []map[string]interface{}{
+		{
+			"dns_endpoint_config": flattenDnsEndpointConfig(cpec.DnsEndpointConfig),
+			"ip_endpoints_config": outIp,
+		},
+	}
+
+	// Most of ip_endpoints_config is being migrated from other fields on private_cluster_config.
+	// These fields are marked with ConflictsWith to prevent both from being set.
+	// These fields are generally marked Computed, so we can fill in both locations without causing
+	// unexpected diffs.
+
+	// Note that this is specifically negated, as the semantics of the fields are reversed.
+	outPcc[0]["enable_private_endpoint"] = !cpec.IpEndpointsConfig.EnablePublicEndpoint
+	outIp[0]["enable_public_endpoint"] = cpec.IpEndpointsConfig.EnablePublicEndpoint
+
+	outPcc[0]["master_global_access_config"] = []map[string]interface{}{
+		{
+			"enabled": cpec.IpEndpointsConfig.GlobalAccess,
+		},
+	}
+	outIp[0]["global_access"] = cpec.IpEndpointsConfig.GlobalAccess
+
+	outPcc[0]["private_endpoint_subnetwork"] = cpec.IpEndpointsConfig.PrivateEndpointSubnetwork
+	outIp[0]["private_endpoint_subnetwork"] = cpec.IpEndpointsConfig.PrivateEndpointSubnetwork
+
+	// default_enable_private_nodes needs to be set on private_cluster_config in the old format,
+	// otherwise it has its own network_config struct in the new format.
+	defaultEnablePrivateNodes := false
+	if nc != nil {
+		defaultEnablePrivateNodes = nc.DefaultEnablePrivateNodes
+	}
+	outPcc[0]["enable_private_nodes"] = defaultEnablePrivateNodes
+
+	if err := d.Set("network_config", []map[string]interface{}{
+		{
+			"default_enable_private_nodes": defaultEnablePrivateNodes,
+		},
+	}); err != nil {
+		return err
+	}
+
+	// MAN is configured on its own in the deprecated config.
+	if err := d.Set("master_authorized_networks_config", flattenMasterAuthorizedNetworksConfig(cpec.IpEndpointsConfig.AuthorizedNetworksConfig)); err != nil {
+		return err
+	}
+	outIp[0]["authorized_networks_config"] = flattenMasterAuthorizedNetworksConfig(cpec.IpEndpointsConfig.AuthorizedNetworksConfig)
+
+	// Only VPC Peering related fields (master_ipv4_cidr_block, peering_name) are canonically located in private_cluster_config now.
+	if pcc != nil {
+		outPcc[0]["master_ipv4_cidr_block"] = pcc.MasterIpv4CidrBlock
+		outPcc[0]["peering_name"] = pcc.PeeringName
+	}
+
+	// Now that the structs have been configured, we can set them.
+	if err := d.Set("control_plane_endpoints_config", outCpec); err != nil {
+		return err
+	}
+	if err := d.Set("private_cluster_config", outPcc); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func flattenDnsEndpointConfig(dns *container.DNSEndpointConfig) []map[string]interface{} {
+	if dns == nil {
 		return nil
 	}
 	return []map[string]interface{}{
 		{
-			"enable_private_endpoint":     c.EnablePrivateEndpoint,
-			"enable_private_nodes":        c.EnablePrivateNodes,
-			"master_ipv4_cidr_block":      c.MasterIpv4CidrBlock,
-			"master_global_access_config": flattenPrivateClusterConfigMasterGlobalAccessConfig(c.MasterGlobalAccessConfig),
-			"peering_name":                c.PeeringName,
-			"private_endpoint":            c.PrivateEndpoint,
-			"private_endpoint_subnetwork": c.PrivateEndpointSubnetwork,
-			"public_endpoint":             c.PublicEndpoint,
+			"endpoint":               dns.Endpoint,
+			"allow_external_traffic": dns.AllowExternalTraffic,
 		},
 	}
 }
 
-// Like most GKE blocks, this is not returned from the API at all when false. This causes trouble
-// for users who've set enabled = false in config as they will get a permadiff. Always setting the
-// field resolves that. We can assume if it was not returned, it's false.
-func flattenPrivateClusterConfigMasterGlobalAccessConfig(c *container.PrivateClusterMasterGlobalAccessConfig) []map[string]interface{} {
+func flattenIpEndpointsConfig(ip *container.IPEndpointsConfig) []map[string]interface{} {
+	if ip == nil {
+		return nil
+	}
+	v := []map[string]interface{}{
+		{
+			"enabled": ip.Enabled,
+			"enable_public_endpoint": ip.EnablePublicEndpoint,
+			"global_access": ip.GlobalAccess,
+			"authorized_networks_config": flattenMasterAuthorizedNetworksConfig(ip.AuthorizedNetworksConfig),
+			"private_endpoint_subnetwork": ip.PrivateEndpointSubnetwork,
+		},
+	}
+	if ip.PublicEndpoint != "" {
+		v[0]["public_endpoint"] = ip.PublicEndpoint
+	}
+	if ip.PrivateEndpoint != "" {
+		v[0]["private_endpoint"] = ip.PrivateEndpoint
+	}
+	return v
+}
+
+func flattenPrivateClusterConfigFromEndpointsConfig(ip *container.IPEndpointsConfig, nc *container.NetworkConfig) []map[string]interface{} {
+	if ip == nil {
+		return nil
+	}
 	return []map[string]interface{}{
 		{
-			"enabled": c != nil && c.Enabled,
+			"enable_private_endpoint":     !ip.EnablePublicEndpoint,
+			"enable_private_nodes":        nc.DefaultEnablePrivateNodes,
+			"master_global_access_config": []map[string]interface{}{
+				{"enabled": ip.GlobalAccess},
+			},
+			"private_endpoint":            ip.PrivateEndpoint,
+			"private_endpoint_subnetwork": ip.PrivateEndpointSubnetwork,
+			"public_endpoint":             ip.PublicEndpoint,
 		},
 	}
 }
@@ -6431,6 +6763,7 @@ func flattenMasterAuthorizedNetworksConfig(c *container.MasterAuthorizedNetworks
 	}
 	result["cidr_blocks"] = schema.NewSet(schema.HashResource(cidrBlockConfig), cidrBlocks)
 	result["gcp_public_cidrs_access_enabled"] = c.GcpPublicCidrsAccessEnabled
+	result["private_endpoint_enforcement_enabled"] = c.PrivateEndpointEnforcementEnabled
 	return []map[string]interface{}{result}
 }
 
@@ -6826,22 +7159,8 @@ func containerClusterPrivateClusterConfigSuppress(k, old, new string, d *schema.
 	return false
 }
 
-func validatePrivateClusterConfig(cluster *container.Cluster) error {
-	if cluster == nil || cluster.PrivateClusterConfig == nil {
-		return nil
-	}
-	if !cluster.PrivateClusterConfig.EnablePrivateNodes && len(cluster.PrivateClusterConfig.MasterIpv4CidrBlock) > 0 {
-		return fmt.Errorf("master_ipv4_cidr_block can only be set if enable_private_nodes is true")
-	}
-	if cluster.PrivateClusterConfig.EnablePrivateNodes && len(cluster.PrivateClusterConfig.MasterIpv4CidrBlock) == 0 {
-		if len(cluster.PrivateClusterConfig.PrivateEndpointSubnetwork) > 0 {
-			return nil
-		}
-		if cluster.Autopilot == nil || !cluster.Autopilot.Enabled {
-			return fmt.Errorf("master_ipv4_cidr_block must be set if enable_private_nodes is true")
-		}
-	}
-	return nil
+func suppressWhenIpEndpointsDisabled(k, old, new string, d *schema.ResourceData) bool {
+	return !d.Get("control_plane_endpoints_config.0.ip_endpoints_config.0.enabled").(bool)
 }
 
 // Autopilot clusters have preconfigured defaults: https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview#comparison.

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -1734,11 +1734,6 @@ func ResourceContainerCluster() *schema.Resource {
 				MaxItems:    1,
 				Optional:    true,
 				Computed:    true,
-				ConflictsWith: []string{
-					"private_cluster_config.0.enable_private_endpoint",
-					"private_cluster_config.0.private_endpoint_subnetwork",
-					"private_cluster_config.0.master_global_access_config",
-				},
 				Description: `Configuration for all of the cluster's control plane endpoints. If this is specified, then respective configured values from private_cluster_config are ignored.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -1775,7 +1770,12 @@ func ResourceContainerCluster() *schema.Resource {
 									"enabled": {
 										Type:        schema.TypeBool,
 										Optional:    true,
-										Description: `Controls whether to allow direct IP access. When this is false, all other ip_endpoints_config values are ignored.`,
+										ConflictsWith: []string{
+											"private_cluster_config.0.enable_private_endpoint",
+											"private_cluster_config.0.private_endpoint_subnetwork",
+											"private_cluster_config.0.master_global_access_config",
+										},
+										Description: `Controls whether to allow direct IP access. When this is false, all other ip_endpoints_config values are ignored. Implicitly true if private_cluster_config settings are still used.`,
 									},
 									"enable_public_endpoint": {
 										Type:             schema.TypeBool,
@@ -1862,7 +1862,10 @@ func ResourceContainerCluster() *schema.Resource {
 							Type:             schema.TypeBool,
 							Optional:         true,
 							Deprecated:       "use control_plane_endpoints_config.ip_endpoints_config.enable_public_endpoint instead, and note the flipped semantics",
-							ConflictsWith:    []string{"control_plane_endpoints_config"},
+							ConflictsWith:    []string{
+								"control_plane_endpoints_config.0.ip_endpoints_config.0.enabled",
+								"control_plane_endpoints_config.0.ip_endpoints_config.0.enable_public_endpoint",
+							},
 							AtLeastOneOf:     privateClusterConfigKeys,
 							DiffSuppressFunc: containerClusterPrivateClusterConfigSuppress,
 							Description:      `When true, the cluster's private endpoint is used as the cluster endpoint and access through the public endpoint is disabled. When false, either endpoint can be used.`,
@@ -1899,7 +1902,10 @@ func ResourceContainerCluster() *schema.Resource {
 							Type:             schema.TypeString,
 							Optional:         true,
 							Deprecated:       "use control_plane_endpoints_config.ip_endpoints_config.private_endpoint_subnetwork instead",
-							ConflictsWith:    []string{"control_plane_endpoints_config"},
+							ConflictsWith:    []string{
+								"control_plane_endpoints_config.0.ip_endpoints_config.0.enabled",
+								"control_plane_endpoints_config.0.ip_endpoints_config.0.private_endpoint_subnetwork",
+							},
 							ForceNew:         true,
 							AtLeastOneOf:     privateClusterConfigKeys,
 							DiffSuppressFunc: containerClusterPrivateClusterConfigSuppress,
@@ -1915,7 +1921,10 @@ func ResourceContainerCluster() *schema.Resource {
 							MaxItems:      1,
 							Optional:      true,
 							Deprecated:    "use control_plane_endpoints_config.ip_endpoints_config.global_access instead",
-							ConflictsWith: []string{"control_plane_endpoints_config"},
+							ConflictsWith: []string{
+								"control_plane_endpoints_config.0.ip_endpoints_config.0.enabled",
+								"control_plane_endpoints_config.0.ip_endpoints_config.0.global_access",
+							},
 							Computed:      true,
 							AtLeastOneOf:  privateClusterConfigKeys,
 							Description:   "Controls cluster master global access settings.",
@@ -5562,97 +5571,63 @@ func expandDefaultEnablePrivateNodes(d *schema.ResourceData) bool {
 }
 
 func expandControlPlaneEndpointsConfig(d *schema.ResourceData) *container.ControlPlaneEndpointsConfig {
-	cpec, hasCpec := d.GetOk("control_plane_endpoints_config")
-
-	if !hasCpec {
-		// Check if the config uses the deprecated private_cluster_config or master_authorized_networks_config
-		return expandEndpointsConfigFromLegacyConfigs(d)
-	}
-	l := cpec.([]interface{})
-	if len(l) == 0 {
-		return nil
-	}
-	config := l[0].(map[string]interface{})
 	dns := &container.DNSEndpointConfig{}
-	dnsConfig, ok := config["dns_endpoint_config"]
-	if ok {
-		l := dnsConfig.([]interface{})
-		if len(l) != 0 {
-			config := l[0].(map[string]interface{})
-			dns.AllowExternalTraffic = config["allow_external_traffic"].(bool)
-			dns.ForceSendFields = []string{"AllowExternalTraffic"}
+	if v, ok := d.GetOk("control_plane_endpoints_config.0.dns_endpoint_config.0.allow_external_traffic"); ok {
+		dns.AllowExternalTraffic = v.(bool)
+		dns.ForceSendFields = []string{"AllowExternalTraffic"}
+	}
+
+	ip := &container.IPEndpointsConfig{
+		// If ip_endpoints_config.enabled isn't configured, it will be set based on the presence of
+		// private_cluster_config fields. These are fields marked using ConflictsWith annotations, so
+		// we won't get contradictory settings.
+		ForceSendFields: []string{"Enabled"},
+	}
+	if v, ok := d.GetOk("control_plane_endpoints_config.0.ip_endpoints_config.0.enabled"); ok {
+		ip.Enabled = v.(bool)
+	}
+	if v, ok := d.GetOk("private_cluster_config.0.enable_private_endpoint"); ok {
+		ip.Enabled = true
+		ip.EnablePublicEndpoint = !v.(bool)
+		ip.ForceSendFields = append(ip.ForceSendFields, "EnablePublicEndpoint")
+	} else if v, ok := d.GetOk("control_plane_endpoints_config.0.ip_endpoints_config.0.enable_public_endpoint"); ok {
+		ip.EnablePublicEndpoint = v.(bool)
+		ip.ForceSendFields = append(ip.ForceSendFields, "EnablePublicEndpoint")
+	}
+	if v, ok := d.GetOk("private_cluster_config.0.private_endpoint_subnetwork"); ok {
+		ip.Enabled = true
+		ip.PrivateEndpointSubnetwork = v.(string)
+		ip.ForceSendFields = append(ip.ForceSendFields, "PrivateEndpointSubnetwork")
+	} else if v, ok := d.GetOk("control_plane_endpoints_config.0.ip_endpoints_config.0.private_endpoint_subnetwork"); ok {
+		ip.PrivateEndpointSubnetwork = v.(string)
+		ip.ForceSendFields = append(ip.ForceSendFields, "PrivateEndpointSubnetwork")
+	}
+	if v, ok := d.GetOk("private_cluster_config.0.master_global_access_config.0.enabled"); ok {
+		ip.Enabled = true
+		ip.GlobalAccess = v.(bool)
+		ip.ForceSendFields = append(ip.ForceSendFields, "GlobalAccess")
+	} else if v, ok := d.GetOk("control_plane_endpoints_config.0.ip_endpoints_config.0.global_access"); ok {
+		ip.GlobalAccess = v.(bool)
+		ip.ForceSendFields = append(ip.ForceSendFields, "GlobalAccess")
+	}
+	if v, ok := d.GetOk("master_authorized_networks_config"); ok {
+		ip.AuthorizedNetworksConfig = expandMasterAuthorizedNetworksConfig(v)
+	} else if v, ok := d.GetOk("control_plane_endpoints_config.0.ip_endpoints_config.0.authorized_networks_config"); ok {
+		ip.AuthorizedNetworksConfig = expandMasterAuthorizedNetworksConfig(v)
+	} else {
+		// TF doesn't have an explicit enabled field for authorized networks, it is assumed to be enabled based
+		// on whether the master_authorized_networks_conifg is present at all. The GKE API pays attention to the
+		// field presence of authorized_networks_config, so it's important to explicitly include enabled = false
+		// to allow disabling this during updates.
+		ip.AuthorizedNetworksConfig = &container.MasterAuthorizedNetworksConfig{
+			Enabled: false,
 		}
 	}
 
-	ip := &container.IPEndpointsConfig{}
-	ipConfig, ok := config["ip_endpoints_config"]
-	if ok {
-		l := ipConfig.([]interface{})
-		if len(l) != 0 {
-			config := l[0].(map[string]interface{})
-			ip.Enabled = config["enabled"].(bool)
-			ip.ForceSendFields = []string{"Enabled"}
-			if ip.Enabled {
-				ip.EnablePublicEndpoint = config["enable_public_endpoint"].(bool)
-				ip.GlobalAccess = config["global_access"].(bool)
-				man, hasMan := d.GetOk("master_authorized_networks_config")
-				if hasMan {
-					ip.AuthorizedNetworksConfig = expandMasterAuthorizedNetworksConfig(man)
-				} else {
-					ip.AuthorizedNetworksConfig = expandMasterAuthorizedNetworksConfig(config["authorized_networks_config"])
-				}
-				ip.PrivateEndpointSubnetwork = config["private_endpoint_subnetwork"].(string)
-				ip.ForceSendFields = []string{"Enabled", "EnablePublicEndpoint", "GlobalAccess", "PrivateEndpointSubnetwork"}
-			}
-		}
-	}
 	return &container.ControlPlaneEndpointsConfig{
 		DnsEndpointConfig: dns,
 		IpEndpointsConfig: ip,
 	}
-}
-
-func expandEndpointsConfigFromLegacyConfigs(d *schema.ResourceData) *container.ControlPlaneEndpointsConfig {
-	pcc, hasPcc := d.GetOk("private_cluster_config")
-	man, hasMan := d.GetOk("master_authorized_networks_config")
-	if !hasPcc && !hasMan {
-		return nil
-	}
-
-	cpec := &container.ControlPlaneEndpointsConfig{}
-
-	if hasPcc {
-		l := pcc.([]interface{})
-		if len(l) == 0 {
-			return nil
-		}
-		config := l[0].(map[string]interface{})
-		global_access := false
-		l = config["master_global_access_config"].([]interface{})
-		if len(l) != 0 {
-			global_access = l[0].(map[string]interface{})["enabled"].(bool)
-		}
-		cpec = &container.ControlPlaneEndpointsConfig{
-			IpEndpointsConfig: &container.IPEndpointsConfig{
-				Enabled:                   true,
-				EnablePublicEndpoint:      !config["enable_private_endpoint"].(bool),
-				GlobalAccess:              global_access,
-				PrivateEndpointSubnetwork: config["private_endpoint_subnetwork"].(string),
-				ForceSendFields:           []string{"Enabled", "EnablePublicEndpoint", "GlobalAccess", "PrivateEndpointSubnetwork"},
-			},
-		}
-	}
-
-	if hasMan {
-		if cpec.IpEndpointsConfig == nil {
-			cpec.IpEndpointsConfig = &container.IPEndpointsConfig{
-				Enabled: true,
-			}
-		}
-		cpec.IpEndpointsConfig.AuthorizedNetworksConfig = expandMasterAuthorizedNetworksConfig(man)
-	}
-
-	return cpec
 }
 
 func expandVerticalPodAutoscaling(configured interface{}) *container.VerticalPodAutoscaling {
@@ -6327,23 +6302,31 @@ func flattenControlPlaneEndpointsConfig(cpec *container.ControlPlaneEndpointsCon
 	}
 
 	// Most of ip_endpoints_config is being migrated from other fields on private_cluster_config.
-	// These fields are marked with ConflictsWith to prevent both from being set.
-	// These fields are generally marked Computed, so we can fill in both locations without causing
-	// unexpected diffs.
+	// These fields are marked with ConflictsWith to prevent both from being set. We need to ensure
+	// that we only set one of such fields to ensure that migration is possible without unexpected diffs.
 
 	// Note that this is specifically negated, as the semantics of the fields are reversed.
-	outPcc[0]["enable_private_endpoint"] = !cpec.IpEndpointsConfig.EnablePublicEndpoint
-	outIp[0]["enable_public_endpoint"] = cpec.IpEndpointsConfig.EnablePublicEndpoint
-
-	outPcc[0]["master_global_access_config"] = []map[string]interface{}{
-		{
-			"enabled": cpec.IpEndpointsConfig.GlobalAccess,
-		},
+	if _, ok := d.GetOk("private_cluster_config.0.enable_private_endpoint"); ok {
+		outPcc[0]["enable_private_endpoint"] = !cpec.IpEndpointsConfig.EnablePublicEndpoint
+	} else {
+		outIp[0]["enable_public_endpoint"] = cpec.IpEndpointsConfig.EnablePublicEndpoint
 	}
-	outIp[0]["global_access"] = cpec.IpEndpointsConfig.GlobalAccess
 
-	outPcc[0]["private_endpoint_subnetwork"] = cpec.IpEndpointsConfig.PrivateEndpointSubnetwork
-	outIp[0]["private_endpoint_subnetwork"] = cpec.IpEndpointsConfig.PrivateEndpointSubnetwork
+	if _, ok := d.GetOk("private_cluster_config.0.master_global_access_config.0.enabled"); ok {
+		outPcc[0]["master_global_access_config"] = []map[string]interface{}{
+			{
+				"enabled": cpec.IpEndpointsConfig.GlobalAccess,
+			},
+		}
+	} else {
+		outIp[0]["global_access"] = cpec.IpEndpointsConfig.GlobalAccess
+	}
+
+	if _, ok := d.GetOk("private_cluster_config.0.private_endpoint_subnetwork"); ok {
+		outPcc[0]["private_endpoint_subnetwork"] = cpec.IpEndpointsConfig.PrivateEndpointSubnetwork
+	} else {
+		outIp[0]["private_endpoint_subnetwork"] = cpec.IpEndpointsConfig.PrivateEndpointSubnetwork
+	}
 
 	// default_enable_private_nodes needs to be set on private_cluster_config in the old format,
 	// otherwise it has its own network_config struct in the new format.
@@ -6351,21 +6334,26 @@ func flattenControlPlaneEndpointsConfig(cpec *container.ControlPlaneEndpointsCon
 	if nc != nil {
 		defaultEnablePrivateNodes = nc.DefaultEnablePrivateNodes
 	}
-	outPcc[0]["enable_private_nodes"] = defaultEnablePrivateNodes
-
-	if err := d.Set("network_config", []map[string]interface{}{
-		{
-			"default_enable_private_nodes": defaultEnablePrivateNodes,
-		},
-	}); err != nil {
-		return err
+	if _, ok := d.GetOk("private_cluster_config.0.enable_private_nodes"); ok {
+		outPcc[0]["enable_private_nodes"] = defaultEnablePrivateNodes
+	} else {
+		if err := d.Set("network_config", []map[string]interface{}{
+			{
+				"default_enable_private_nodes": defaultEnablePrivateNodes,
+			},
+		}); err != nil {
+			return err
+		}
 	}
 
 	// MAN is configured on its own in the deprecated config.
-	if err := d.Set("master_authorized_networks_config", flattenMasterAuthorizedNetworksConfig(cpec.IpEndpointsConfig.AuthorizedNetworksConfig)); err != nil {
-		return err
+	if _, ok := d.GetOk("master_authorized_networks_config"); ok {
+		if err := d.Set("master_authorized_networks_config", flattenMasterAuthorizedNetworksConfig(cpec.IpEndpointsConfig.AuthorizedNetworksConfig)); err != nil {
+			return err
+		}
+	} else {
+		outIp[0]["authorized_networks_config"] = flattenMasterAuthorizedNetworksConfig(cpec.IpEndpointsConfig.AuthorizedNetworksConfig)
 	}
-	outIp[0]["authorized_networks_config"] = flattenMasterAuthorizedNetworksConfig(cpec.IpEndpointsConfig.AuthorizedNetworksConfig)
 
 	// Only VPC Peering related fields (master_ipv4_cidr_block, peering_name) are canonically located in private_cluster_config now.
 	if pcc != nil {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -1325,49 +1325,6 @@ func TestAccContainerCluster_withPrivateClusterConfigBasic(t *testing.T) {
 	})
 }
 
-func TestAccContainerCluster_withPrivateClusterConfigMissingCidrBlock(t *testing.T) {
-	t.Parallel()
-
-	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
-	containerNetName := fmt.Sprintf("tf-test-container-net-%s", acctest.RandString(t, 10))
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config:	testAccContainerCluster_withPrivateClusterConfigMissingCidrBlock(containerNetName, clusterName, "us-central1-a", false),
-				ExpectError: regexp.MustCompile("master_ipv4_cidr_block must be set if enable_private_nodes is true"),
-			},
-		},
-	})
-}
-
-func TestAccContainerCluster_withPrivateClusterConfigMissingCidrBlock_withAutopilot(t *testing.T) {
-	t.Parallel()
-
-	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
-	containerNetName := fmt.Sprintf("tf-test-container-net-%s", acctest.RandString(t, 10))
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config:	testAccContainerCluster_withPrivateClusterConfigMissingCidrBlock(containerNetName, clusterName, "us-central1", true),
-			},
-			{
-				ResourceName:      "google_container_cluster.with_private_cluster",
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{"deletion_protection"},
-			},
-		},
-	})
-}
-
 func TestAccContainerCluster_withPrivateClusterConfigGlobalAccessEnabledOnly(t *testing.T) {
 	t.Parallel()
 
@@ -8733,58 +8690,6 @@ resource "google_container_cluster" "with_resource_usage_export_config" {
 `, datasetId, clusterName, networkName, subnetworkName)
 }
 
-func testAccContainerCluster_withPrivateClusterConfigMissingCidrBlock(containerNetName, clusterName, location string, autopilotEnabled bool) string {
-	return fmt.Sprintf(`
-resource "google_compute_network" "container_network" {
-  name                    = "%s"
-  auto_create_subnetworks = false
-}
-
-resource "google_compute_subnetwork" "container_subnetwork" {
-  name                     = google_compute_network.container_network.name
-  network                  = google_compute_network.container_network.name
-  ip_cidr_range            = "10.0.36.0/24"
-  region                   = "us-central1"
-  private_ip_google_access = true
-
-  secondary_ip_range {
-    range_name    = "pod"
-    ip_cidr_range = "10.0.0.0/19"
-  }
-
-  secondary_ip_range {
-    range_name    = "svc"
-    ip_cidr_range = "10.0.32.0/22"
-  }
-}
-
-resource "google_container_cluster" "with_private_cluster" {
-  name               = "%s"
-  location           = "%s"
-  initial_node_count = 1
-
-  networking_mode = "VPC_NATIVE"
-  network    = google_compute_network.container_network.name
-  subnetwork = google_compute_subnetwork.container_subnetwork.name
-
-  private_cluster_config {
-    enable_private_endpoint = true
-    enable_private_nodes    = true
-  }
-
-  enable_autopilot = %t
-
-  master_authorized_networks_config {}
-
-  ip_allocation_policy {
-    cluster_secondary_range_name  = google_compute_subnetwork.container_subnetwork.secondary_ip_range[0].range_name
-    services_secondary_range_name = google_compute_subnetwork.container_subnetwork.secondary_ip_range[1].range_name
-  }
-  deletion_protection = false
-}
-`, containerNetName, clusterName, location, autopilotEnabled)
-}
-
 func testAccContainerCluster_withPrivateClusterConfig(containerNetName string, clusterName string, masterGlobalAccessEnabled bool) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "container_network" {
@@ -11842,4 +11747,418 @@ resource "google_container_cluster" "with_autopilot_gcp_filestore" {
   }
 }
 `, name)
+}
+
+func TestAccContainerCluster_migratePrivateNodes(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_migratePrivateNodesDeprecatedFormat(clusterName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "network_config.0.default_enable_private_nodes", "true"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "private_cluster_config.0.enable_private_nodes", "true"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_migratePrivateNodesNewFormat(clusterName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "network_config.0.default_enable_private_nodes", "true"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "private_cluster_config.0.enable_private_nodes", "true"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_migratePrivateNodesDeprecatedFormat(clusterName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "network_config.0.default_enable_private_nodes", "true"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "private_cluster_config.0.enable_private_nodes", "true"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+func testAccContainerCluster_migratePrivateNodesDeprecatedFormat(name string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 1
+  deletion_protection = false
+  private_cluster_config {
+    enable_private_nodes = true
+  }
+}`, name)
+}
+
+func testAccContainerCluster_migratePrivateNodesNewFormat(name string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 1
+  deletion_protection = false
+  network_config {
+    default_enable_private_nodes = true
+  }
+}`, name)
+}
+
+func TestAccContainerCluster_migratePrivateClusterConfig(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_migratePrivateClusterConfigDeprecatedFormat(clusterName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.ip_endpoints_config.0.enabled", "true"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.ip_endpoints_config.0.enable_public_endpoint", "false"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.ip_endpoints_config.0.global_access", "true"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "private_cluster_config.0.enable_private_endpoint", "true"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "private_cluster_config.0.master_global_access_config.0.enabled", "true"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_migratePrivateClusterConfigNewFormat(clusterName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.ip_endpoints_config.0.enabled", "true"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.ip_endpoints_config.0.enable_public_endpoint", "false"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.ip_endpoints_config.0.global_access", "true"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "private_cluster_config.0.enable_private_endpoint", "true"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "private_cluster_config.0.master_global_access_config.0.enabled", "true"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_migratePrivateClusterConfigDeprecatedFormat(clusterName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.ip_endpoints_config.0.enabled", "true"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.ip_endpoints_config.0.enable_public_endpoint", "false"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.ip_endpoints_config.0.global_access", "true"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "private_cluster_config.0.enable_private_endpoint", "true"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "private_cluster_config.0.master_global_access_config.0.enabled", "true"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+func testAccContainerCluster_migratePrivateClusterConfigDeprecatedFormat(name string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 1
+  deletion_protection = false
+  private_cluster_config {
+    enable_private_endpoint = true
+    master_global_access_config {
+      enabled = true
+    }
+  }
+  master_authorized_networks_config {
+    gcp_public_cidrs_access_enabled = false
+  }
+}`, name)
+}
+
+func testAccContainerCluster_migratePrivateClusterConfigNewFormat(name string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 1
+  deletion_protection = false
+  control_plane_endpoints_config {
+    ip_endpoints_config {
+      enabled = true
+      enable_public_endpoint = false
+      global_access = true
+      authorized_networks_config {
+        gcp_public_cidrs_access_enabled = false
+      }
+    }
+  }
+}`, name)
+}
+
+func TestAccContainerCluster_migrateAuthorizedNetworks(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_migrateAuthorizedNetworksDeprecatedFormat(clusterName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "master_authorized_networks_config.0.cidr_blocks.#", "1"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.ip_endpoints_config.0.authorized_networks_config.0.cidr_blocks.#", "1"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_migrateAuthorizedNetworksNewFormat(clusterName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "master_authorized_networks_config.0.cidr_blocks.#", "1"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.ip_endpoints_config.0.authorized_networks_config.0.cidr_blocks.#", "1"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_migrateAuthorizedNetworksDeprecatedFormat(clusterName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "master_authorized_networks_config.0.cidr_blocks.#", "1"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.ip_endpoints_config.0.authorized_networks_config.0.cidr_blocks.#", "1"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+func testAccContainerCluster_migrateAuthorizedNetworksDeprecatedFormat(name string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 1
+  deletion_protection = false
+  master_authorized_networks_config {
+    cidr_blocks {
+      cidr_block = "10.0.0.0/8"
+      display_name = "cidr1"
+    }
+    private_endpoint_enforcement_enabled = true
+  }
+}`, name)
+}
+
+func testAccContainerCluster_migrateAuthorizedNetworksNewFormat(name string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 1
+  deletion_protection = false
+  control_plane_endpoints_config {
+    ip_endpoints_config {
+      enabled = true
+      enable_public_endpoint = true
+      authorized_networks_config {
+        cidr_blocks {
+          cidr_block = "10.0.0.0/8"
+          display_name = "cidr1"
+        }
+        private_endpoint_enforcement_enabled = true
+      }
+    }
+  }
+}`, name)
+}
+
+func TestAccContainerCluster_withDnsEndpoint(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withDnsEndpointDisabled(clusterName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// The DNS endpoint should always be set, even if allow_external_traffic is false.
+					resource.TestCheckResourceAttrSet("google_container_cluster.primary", "control_plane_endpoints_config.0.dns_endpoint_config.0.endpoint"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.dns_endpoint_config.0.allow_external_traffic", "false"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.ip_endpoints_config.0.enabled", "true"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.ip_endpoints_config.0.enable_public_endpoint", "false"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.ip_endpoints_config.0.authorized_networks_config.#", "1"),
+					resource.TestCheckResourceAttrSet("google_container_cluster.primary", "control_plane_endpoints_config.0.ip_endpoints_config.0.private_endpoint"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.ip_endpoints_config.0.public_endpoint", ""),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "network_config.0.default_enable_private_nodes", "true"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_withDnsEndpointEnabledAndIpDisabled(clusterName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						acctest.ExpectNoDelete(),
+						plancheck.ExpectResourceAction("google_container_cluster.primary", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_container_cluster.primary", "control_plane_endpoints_config.0.dns_endpoint_config.0.endpoint"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.dns_endpoint_config.0.allow_external_traffic", "true"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.ip_endpoints_config.0.enabled", "false"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.ip_endpoints_config.0.private_endpoint", ""),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.ip_endpoints_config.0.public_endpoint", ""),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "network_config.0.default_enable_private_nodes", "true"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+func testAccContainerCluster_withDnsEndpointDisabled(name string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 1
+  deletion_protection = false
+  control_plane_endpoints_config {
+      dns_endpoint_config {
+          allow_external_traffic = false
+      }
+    ip_endpoints_config {
+      enabled = true
+      enable_public_endpoint = false
+      authorized_networks_config {
+        cidr_blocks {
+          cidr_block = "10.0.0.0/8"
+          display_name = "cidr1"
+        }
+            private_endpoint_enforcement_enabled = true
+      }
+    }
+    }
+  network_config {
+    default_enable_private_nodes = true
+  }
+}`, name)
+}
+
+func testAccContainerCluster_withDnsEndpointEnabledAndIpDisabled(name string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 1
+  deletion_protection = false
+  control_plane_endpoints_config {
+      dns_endpoint_config {
+          allow_external_traffic = true
+      }
+    ip_endpoints_config {
+      enabled = false
+      enable_public_endpoint = false
+      authorized_networks_config {
+        cidr_blocks {
+          cidr_block = "10.0.0.0/8"
+          display_name = "cidr1"
+        }
+            private_endpoint_enforcement_enabled = true
+      }
+    }
+    }
+  network_config {
+    default_enable_private_nodes = true
+  }
+}`, name)
 }


### PR DESCRIPTION
Add support for ControlPlaneEndpointsConfig to GKE.

Supports launch of unified cluster experience, including consolidation of control plane related settings, allowing toggling private nodes which previously required cluster recreation, and enablement of a new DNS based endpoint for easier cluster access.

```release-note:enhancement
container: added `control_plane_endpoints_config`, `master_authorized_networks_config.private_endpoint_enforcement_enabled`, and `network_config` fields to `cluster` resource.
```
