### PR TITLE
fix: if unable to calculate local md5 hash use old value of detect_md5hash

### DIFF
--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
@@ -138,6 +138,9 @@ func ResourceStorageBucketObject() *schema.Resource {
 					localMd5Hash := ""
 					if source, ok := d.GetOkExists("source"); ok {
 						localMd5Hash = tpgresource.GetFileMd5Hash(source.(string))
+						if localMd5Hash == "" && old != "" {
+							localMd5Hash = old
+						}
 					}
 
 					if content, ok := d.GetOkExists("content"); ok {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
if unable to calculate local md5 hash use old value of detect_md5hash

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
storage: if unable to calculate local md5 hash use old value of detect_md5hash
```
