### PR TITLE
add nil check to nodepool management flattener

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
@@ -1198,11 +1198,13 @@ func flattenNodePool(d *schema.ResourceData, config *transport_tpg.Config, np *c
 		nodePool["max_pods_per_node"] = np.MaxPodsConstraint.MaxPodsPerNode
 	}
 
-	nodePool["management"] = []map[string]interface{}{
-		{
-			"auto_repair":  np.Management.AutoRepair,
-			"auto_upgrade": np.Management.AutoUpgrade,
-		},
+	if np.Management != nil {
+		nodePool["management"] = []map[string]interface{}{
+			{
+				"auto_repair":  np.Management.AutoRepair,
+				"auto_upgrade": np.Management.AutoUpgrade,
+			},
+		}
 	}
 
 	if np.UpgradeSettings != nil {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

fixes https://github.com/hashicorp/terraform-provider-google/issues/19895

something must have changed in the backend or this must be a very rare case. This reference hasn't been touched in years

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: fixed a crash in `google_container_node_pool` caused by an occasional nil pointer
```
