### PR TITLE
Deprecate security_posture_config in google_container_attached_cluster

### DIFF
--- a/mmv1/products/containerattached/Cluster.yaml
+++ b/mmv1/products/containerattached/Cluster.yaml
@@ -360,7 +360,7 @@ properties:
     description: |
       Enable/Disable Security Posture API features for the cluster.
     default_from_api: true
-    deprecation_message: '`security_posture_config` is deprecated and will be removed in a future release.'
+    deprecation_message: '`security_posture_config` is deprecated and will be removed in a future major release.'
     properties:
       - name: 'vulnerabilityMode'
         type: Enum

--- a/mmv1/products/containerattached/Cluster.yaml
+++ b/mmv1/products/containerattached/Cluster.yaml
@@ -360,6 +360,7 @@ properties:
     description: |
       Enable/Disable Security Posture API features for the cluster.
     default_from_api: true
+    deprecation_message: '`security_posture_config` is deprecated and will be removed in a future release.'
     properties:
       - name: 'vulnerabilityMode'
         type: Enum

--- a/mmv1/third_party/terraform/services/containerattached/resource_container_attached_cluster_update_test.go
+++ b/mmv1/third_party/terraform/services/containerattached/resource_container_attached_cluster_update_test.go
@@ -118,9 +118,6 @@ resource "google_container_attached_cluster" "primary" {
       namespace = "default"
     }
   }
-  security_posture_config {
-    vulnerability_mode = "VULNERABILITY_ENTERPRISE"
-  }
 }
 `, context)
 }
@@ -168,9 +165,6 @@ resource "google_container_attached_cluster" "primary" {
       name = "new-proxy-config"
       namespace = "custom-ns"
     }
-  }
-  security_posture_config {
-    vulnerability_mode = "VULNERABILITY_DISABLED"
   }
   lifecycle {
     prevent_destroy = true
@@ -317,9 +311,6 @@ resource "google_container_attached_cluster" "primary" {
       name = "new-proxy-config"
       namespace = "custom-ns"
     }
-  }
-  security_posture_config {
-    vulnerability_mode = "VULNERABILITY_DISABLED"
   }
 }
 `, context)


### PR DESCRIPTION
and add deprecation message.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:deprecation
containerattached: deprecated `security_posture_config` field in `google_container_attached_cluster` resource
```
