### PR TITLE
Add a magician command for reassigning reviewers

### DIFF
--- a/.ci/magician/cmd/interfaces.go
+++ b/.ci/magician/cmd/interfaces.go
@@ -24,7 +24,7 @@ type GithubClient interface {
 	GetPullRequests(state, base, sort, direction string) ([]github.PullRequest, error)
 	GetPullRequestRequestedReviewers(prNumber string) ([]github.User, error)
 	GetPullRequestPreviousReviewers(prNumber string) ([]github.User, error)
-	GetPullRequestComments(prNumber) ([]github.PullRequestComment, error)
+	GetPullRequestComments(prNumber string) ([]github.PullRequestComment, error)
 	GetUserType(user string) github.UserType
 	GetTeamMembers(organization, team string) ([]github.User, error)
 	MergePullRequest(owner, repo, prNumber, commitSha string) error

--- a/.ci/magician/cmd/interfaces.go
+++ b/.ci/magician/cmd/interfaces.go
@@ -24,11 +24,13 @@ type GithubClient interface {
 	GetPullRequests(state, base, sort, direction string) ([]github.PullRequest, error)
 	GetPullRequestRequestedReviewers(prNumber string) ([]github.User, error)
 	GetPullRequestPreviousReviewers(prNumber string) ([]github.User, error)
+	GetPullRequestCommentsByUser(prNumber, login string) ([]github.PullRequestComment, error)
 	GetUserType(user string) github.UserType
 	GetTeamMembers(organization, team string) ([]github.User, error)
 	MergePullRequest(owner, repo, prNumber, commitSha string) error
 	PostBuildStatus(prNumber, title, state, targetURL, commitSha string) error
 	PostComment(prNumber, comment string) error
+	UpdateComment(prNumber, comment string, id int) error
 	RequestPullRequestReviewers(prNumber string, reviewers []string) error
 	AddLabels(prNumber string, labels []string) error
 	RemoveLabel(prNumber, label string) error

--- a/.ci/magician/cmd/interfaces.go
+++ b/.ci/magician/cmd/interfaces.go
@@ -24,7 +24,7 @@ type GithubClient interface {
 	GetPullRequests(state, base, sort, direction string) ([]github.PullRequest, error)
 	GetPullRequestRequestedReviewers(prNumber string) ([]github.User, error)
 	GetPullRequestPreviousReviewers(prNumber string) ([]github.User, error)
-	GetPullRequestCommentsByUser(prNumber, login string) ([]github.PullRequestComment, error)
+	GetPullRequestComments(prNumber) ([]github.PullRequestComment, error)
 	GetUserType(user string) github.UserType
 	GetTeamMembers(organization, team string) ([]github.User, error)
 	MergePullRequest(owner, repo, prNumber, commitSha string) error

--- a/.ci/magician/cmd/mock_github_test.go
+++ b/.ci/magician/cmd/mock_github_test.go
@@ -22,12 +22,13 @@ import (
 )
 
 type mockGithub struct {
-	pullRequest        github.PullRequest
-	userType           github.UserType
-	requestedReviewers []github.User
-	previousReviewers  []github.User
-	teamMembers        map[string][]github.User
-	calledMethods      map[string][][]any
+	pullRequest         github.PullRequest
+	userType            github.UserType
+	requestedReviewers  []github.User
+	previousReviewers   []github.User
+	pullRequestComments []github.PullRequestComment
+	teamMembers         map[string][]github.User
+	calledMethods       map[string][][]any
 }
 
 func (m *mockGithub) GetPullRequest(prNumber string) (github.PullRequest, error) {
@@ -55,6 +56,11 @@ func (m *mockGithub) GetPullRequestPreviousReviewers(prNumber string) ([]github.
 	return m.previousReviewers, nil
 }
 
+func (m *mockGithub) GetPullRequestCommentsByUser(prNumber string, login string) ([]github.PullRequestComment, error) {
+	m.calledMethods["GetPullRequestCommentsByUser"] = append(m.calledMethods["GetPullRequestCommentsByUser"], []any{prNumber, login})
+	return m.pullRequestComments, nil
+}
+
 func (m *mockGithub) GetTeamMembers(organization, team string) ([]github.User, error) {
 	m.calledMethods["GetTeamMembers"] = append(m.calledMethods["GetTeamMembers"], []any{organization, team})
 	if team == "" {
@@ -70,6 +76,11 @@ func (m *mockGithub) RequestPullRequestReviewers(prNumber string, reviewers []st
 
 func (m *mockGithub) PostComment(prNumber string, comment string) error {
 	m.calledMethods["PostComment"] = append(m.calledMethods["PostComment"], []any{prNumber, comment})
+	return nil
+}
+
+func (m *mockGithub) UpdateComment(prNumber, comment string, id int) error {
+	m.calledMethods["UpdateComment"] = append(m.calledMethods["UpdateComment"], []any{prNumber, comment, id})
 	return nil
 }
 

--- a/.ci/magician/cmd/mock_github_test.go
+++ b/.ci/magician/cmd/mock_github_test.go
@@ -57,7 +57,7 @@ func (m *mockGithub) GetPullRequestPreviousReviewers(prNumber string) ([]github.
 }
 
 func (m *mockGithub) GetPullRequestComments(prNumber string) ([]github.PullRequestComment, error) {
-	m.calledMethods["GetPullRequestComments"] = append(m.calledMethods["GetPullRequestComments"], []any{prNumber, login})
+	m.calledMethods["GetPullRequestComments"] = append(m.calledMethods["GetPullRequestComments"], []any{prNumber})
 	return m.pullRequestComments, nil
 }
 

--- a/.ci/magician/cmd/mock_github_test.go
+++ b/.ci/magician/cmd/mock_github_test.go
@@ -56,8 +56,8 @@ func (m *mockGithub) GetPullRequestPreviousReviewers(prNumber string) ([]github.
 	return m.previousReviewers, nil
 }
 
-func (m *mockGithub) GetPullRequestCommentsByUser(prNumber string, login string) ([]github.PullRequestComment, error) {
-	m.calledMethods["GetPullRequestCommentsByUser"] = append(m.calledMethods["GetPullRequestCommentsByUser"], []any{prNumber, login})
+func (m *mockGithub) GetPullRequestComments(prNumber string) ([]github.PullRequestComment, error) {
+	m.calledMethods["GetPullRequestComments"] = append(m.calledMethods["GetPullRequestComments"], []any{prNumber, login})
 	return m.pullRequestComments, nil
 }
 

--- a/.ci/magician/cmd/reassign_reviewer.go
+++ b/.ci/magician/cmd/reassign_reviewer.go
@@ -57,7 +57,7 @@ var reassignReviewerCmd = &cobra.Command{
 }
 
 func execReassignReviewer(prNumber, newPrimaryReviewer string, gh GithubClient) error {
-	comments, err := gh.GetPullRequestCommentsByUser(prNumber, "modular-magician")
+	comments, err := gh.GetPullRequestComments(prNumber)
 	if err != nil {
 		return err
 	}

--- a/.ci/magician/cmd/reassign_reviewer.go
+++ b/.ci/magician/cmd/reassign_reviewer.go
@@ -1,0 +1,92 @@
+/*
+* Copyright 2024 Google LLC. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+package cmd
+
+import (
+	"fmt"
+	"magician/github"
+
+	"github.com/spf13/cobra"
+)
+
+// reassignReviewerCmd represents the reassignReviewer command
+var reassignReviewerCmd = &cobra.Command{
+	Use:   "reassign-reviewer PR_NUMBER",
+	Short: "Reassigns primary reviewer to the given reviewer or a random reviewer if none given",
+	Long: `This command reassigns reviewers when invoked via a comment on a pull request.
+
+	The command expects the following PR details as arguments:
+	1. PR_NUMBER
+	2. REVIEWER (optional)
+
+
+	It then performs the following operations:
+	1. Updates the reviewer comment to reflect the new primary reviewer.
+	`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		prNumber := args[0]
+		fmt.Println("PR Number: ", prNumber)
+
+		githubToken, ok := lookupGithubTokenOrFallback("GITHUB_TOKEN_MAGIC_MODULES")
+		if !ok {
+			return fmt.Errorf("did not provide GITHUB_TOKEN_MAGIC_MODULES or GITHUB_TOKEN environment variable")
+		}
+		gh := github.NewClient(githubToken)
+		var newPrimaryReviewer string
+		if len(args) > 1 {
+			newPrimaryReviewer = args[1]
+		}
+		return execReassignReviewer(prNumber, newPrimaryReviewer, gh)
+	},
+}
+
+func execReassignReviewer(prNumber, newPrimaryReviewer string, gh GithubClient) error {
+	comments, err := gh.GetPullRequestCommentsByUser(prNumber, "modular-magician")
+	if err != nil {
+		return err
+	}
+
+	reviewerComment, currentReviewer := github.FindReviewerComment(comments)
+
+	if currentReviewer == "" {
+		return fmt.Errorf("no reviewer comment found in PR %s", prNumber)
+	}
+
+	if newPrimaryReviewer == "" {
+		newPrimaryReviewer = github.GetNewRandomReviewer(currentReviewer)
+	}
+
+	if currentReviewer == newPrimaryReviewer {
+		return fmt.Errorf("primary reviewer is already %s", newPrimaryReviewer)
+	}
+
+	err = gh.UpdateComment(prNumber, github.FormatReviewerComment(newPrimaryReviewer), reviewerComment.ID)
+	if err != nil {
+		return err
+	}
+
+	err = gh.RequestPullRequestReviewers(prNumber, []string{newPrimaryReviewer})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(reassignReviewerCmd)
+}

--- a/.ci/magician/cmd/reassign_reviewer.go
+++ b/.ci/magician/cmd/reassign_reviewer.go
@@ -69,14 +69,14 @@ func execReassignReviewer(prNumber, newPrimaryReviewer string, gh GithubClient) 
 		if err != nil {
 			return err
 		}
-		fmt.Println("New primary reviewer is ", newPrimaryReviewer)
 	} else {
 		newPrimaryReviewer, err = updateReviewComment(prNumber, currentReviewer, newPrimaryReviewer, reviewerComment.ID, gh)
 		if err != nil {
 			return err
 		}
-		fmt.Println("New primary reviewer is ", newPrimaryReviewer)
 	}
+
+	fmt.Println("New primary reviewer is ", newPrimaryReviewer)
 
 	err = gh.RequestPullRequestReviewers(prNumber, []string{newPrimaryReviewer})
 	if err != nil {

--- a/.ci/magician/cmd/reassign_reviewer.go
+++ b/.ci/magician/cmd/reassign_reviewer.go
@@ -44,9 +44,9 @@ var reassignReviewerCmd = &cobra.Command{
 		prNumber := args[0]
 		fmt.Println("PR Number: ", prNumber)
 
-		githubToken, ok := os.LookupEnv("GITHUB_TOKEN_MAGIC_MODULES")
+		githubToken, ok := os.LookupEnv("GITHUB_TOKEN")
 		if !ok {
-			return fmt.Errorf("did not provide GITHUB_TOKEN_MAGIC_MODULES environment variable")
+			return fmt.Errorf("did not provide GITHUB_TOKEN environment variable")
 		}
 		gh := github.NewClient(githubToken)
 		var newPrimaryReviewer string
@@ -66,11 +66,13 @@ func execReassignReviewer(prNumber, newPrimaryReviewer string, gh GithubClient) 
 	reviewerComment, currentReviewer := github.FindReviewerComment(comments)
 
 	if currentReviewer == "" {
+		fmt.Println("No reviewer comment found, creating one")
 		newPrimaryReviewer, err = createReviewComment(prNumber, newPrimaryReviewer, gh)
 		if err != nil {
 			return err
 		}
 	} else {
+		fmt.Println("Reassigning to random reviewer")
 		newPrimaryReviewer, err = updateReviewComment(prNumber, currentReviewer, newPrimaryReviewer, reviewerComment.ID, gh)
 		if err != nil {
 			return err
@@ -88,7 +90,6 @@ func execReassignReviewer(prNumber, newPrimaryReviewer string, gh GithubClient) 
 }
 
 func createReviewComment(prNumber, newPrimaryReviewer string, gh GithubClient) (string, error) {
-	fmt.Println("No reviewer comment found, creating one")
 	if newPrimaryReviewer == "" {
 		newPrimaryReviewer = github.GetRandomReviewer()
 	}
@@ -105,7 +106,6 @@ func createReviewComment(prNumber, newPrimaryReviewer string, gh GithubClient) (
 }
 
 func updateReviewComment(prNumber, currentReviewer, newPrimaryReviewer string, reviewerCommentID int, gh GithubClient) (string, error) {
-	fmt.Println("Reassigning to random reviewer")
 	if newPrimaryReviewer == "" {
 		newPrimaryReviewer = github.GetNewRandomReviewer(currentReviewer)
 	}

--- a/.ci/magician/cmd/reassign_reviewer.go
+++ b/.ci/magician/cmd/reassign_reviewer.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"magician/github"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -43,9 +44,9 @@ var reassignReviewerCmd = &cobra.Command{
 		prNumber := args[0]
 		fmt.Println("PR Number: ", prNumber)
 
-		githubToken, ok := lookupGithubTokenOrFallback("GITHUB_TOKEN_MAGIC_MODULES")
+		githubToken, ok := os.LookupEnv("GITHUB_TOKEN_MAGIC_MODULES")
 		if !ok {
-			return fmt.Errorf("did not provide GITHUB_TOKEN_MAGIC_MODULES or GITHUB_TOKEN environment variable")
+			return fmt.Errorf("did not provide GITHUB_TOKEN_MAGIC_MODULES environment variable")
 		}
 		gh := github.NewClient(githubToken)
 		var newPrimaryReviewer string

--- a/.ci/magician/cmd/request_reviewer.go
+++ b/.ci/magician/cmd/request_reviewer.go
@@ -31,11 +31,6 @@ var requestReviewerCmd = &cobra.Command{
 
 	The command expects the following pull request details as arguments:
 	1. PR Number
-	2. Commit SHA
-	3. Branch Name
-	4. Head Repo URL
-	5. Head Branch
-	6. Base Branch
 
 	It then performs the following operations:
 	1. Determines the author of the pull request

--- a/.ci/magician/github/get.go
+++ b/.ci/magician/github/get.go
@@ -38,6 +38,12 @@ type PullRequest struct {
 	MergeCommitSha string  `json:"merge_commit_sha"`
 }
 
+type PullRequestComment struct {
+	User User   `json:"user"`
+	Body string `json:"body"`
+	ID   int    `json:"id"`
+}
+
 func (gh *Client) GetPullRequest(prNumber string) (PullRequest, error) {
 	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/%s", prNumber)
 
@@ -96,6 +102,33 @@ func (gh *Client) GetPullRequestPreviousReviewers(prNumber string) ([]User, erro
 	}
 
 	return result, nil
+}
+
+func (gh *Client) GetPullRequestComments(prNumber string) ([]PullRequestComment, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/%s/comments", prNumber)
+
+	var comments []PullRequestComment
+	err := utils.RequestCall(url, "GET", gh.token, &comments, nil)
+	if err != nil {
+		return nil, err
+	}
+	return comments, nil
+}
+
+func (gh *Client) GetPullRequestCommentsByUser(prNumber, login string) ([]PullRequestComment, error) {
+	comments, err := gh.GetPullRequestComments(prNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	var filteredComments []PullRequestComment
+	for _, comment := range comments {
+		if comment.User.Login == login {
+			filteredComments = append(filteredComments, comment)
+		}
+	}
+
+	return filteredComments, nil
 }
 
 func (gh *Client) GetTeamMembers(organization, team string) ([]User, error) {

--- a/.ci/magician/github/get.go
+++ b/.ci/magician/github/get.go
@@ -18,6 +18,7 @@ package github
 import (
 	"fmt"
 	utils "magician/utility"
+	"time"
 )
 
 type User struct {
@@ -39,9 +40,10 @@ type PullRequest struct {
 }
 
 type PullRequestComment struct {
-	User User   `json:"user"`
-	Body string `json:"body"`
-	ID   int    `json:"id"`
+	User      User      `json:"user"`
+	Body      string    `json:"body"`
+	ID        int       `json:"id"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 func (gh *Client) GetPullRequest(prNumber string) (PullRequest, error) {

--- a/.ci/magician/github/get.go
+++ b/.ci/magician/github/get.go
@@ -115,22 +115,6 @@ func (gh *Client) GetPullRequestComments(prNumber string) ([]PullRequestComment,
 	return comments, nil
 }
 
-func (gh *Client) GetPullRequestCommentsByUser(prNumber, login string) ([]PullRequestComment, error) {
-	comments, err := gh.GetPullRequestComments(prNumber)
-	if err != nil {
-		return nil, err
-	}
-
-	var filteredComments []PullRequestComment
-	for _, comment := range comments {
-		if comment.User.Login == login {
-			filteredComments = append(filteredComments, comment)
-		}
-	}
-
-	return filteredComments, nil
-}
-
 func (gh *Client) GetTeamMembers(organization, team string) ([]User, error) {
 	url := fmt.Sprintf("https://api.github.com/orgs/%s/teams/%s/members", organization, team)
 

--- a/.ci/magician/github/membership.go
+++ b/.ci/magician/github/membership.go
@@ -108,6 +108,14 @@ func GetRandomReviewer() string {
 	return reviewer
 }
 
+// Return a random reviewer other than the old reviewer
+func GetNewRandomReviewer(oldReviewer string) string {
+	availableReviewers := AvailableReviewers()
+	availableReviewers = utils.Removes(availableReviewers, []string{oldReviewer})
+	reviewer := availableReviewers[rand.Intn(len(availableReviewers))]
+	return reviewer
+}
+
 func AvailableReviewers() []string {
 	return available(time.Now(), maps.Keys(reviewerRotation), onVacationReviewers)
 }

--- a/.ci/magician/github/reviewer_assignment.go
+++ b/.ci/magician/github/reviewer_assignment.go
@@ -77,6 +77,9 @@ func FindReviewerComment(comments []PullRequestComment) (PullRequestComment, str
 	for _, comment := range comments {
 		names := reviewerCommentRegex.SubexpNames()
 		matches := reviewerCommentRegex.FindStringSubmatch(comment.Body)
+		if len(matches) < len(names) {
+			continue
+		}
 		for i, name := range names {
 			if name == "reviewer" {
 				return comment, matches[i]

--- a/.ci/magician/github/reviewer_assignment.go
+++ b/.ci/magician/github/reviewer_assignment.go
@@ -83,7 +83,6 @@ func FindReviewerComment(comments []PullRequestComment) (PullRequestComment, str
 		}
 		names := reviewerCommentRegex.SubexpNames()
 		matches := reviewerCommentRegex.FindStringSubmatch(comment.Body)
-		fmt.Println(comment, matches)
 		if len(matches) < len(names) {
 			// Skip comments that don't match regex.
 			continue

--- a/.ci/magician/github/reviewer_assignment.go
+++ b/.ci/magician/github/reviewer_assignment.go
@@ -77,13 +77,15 @@ func FindReviewerComment(comments []PullRequestComment) (PullRequestComment, str
 	var newestComment PullRequestComment
 	var currentReviewer string
 	for _, comment := range comments {
-		if newestComment.CreatedAt.Before(comment.CreatedAt) {
-			// Skip comments created before the newest
+		if !newestComment.CreatedAt.IsZero() && comment.CreatedAt.Before(newestComment.CreatedAt) {
+			// Skip comments older than the newest comment.
 			continue
 		}
 		names := reviewerCommentRegex.SubexpNames()
 		matches := reviewerCommentRegex.FindStringSubmatch(comment.Body)
+		fmt.Println(comment, matches)
 		if len(matches) < len(names) {
+			// Skip comments that don't match regex.
 			continue
 		}
 		for i, name := range names {

--- a/.ci/magician/github/reviewer_assignment.go
+++ b/.ci/magician/github/reviewer_assignment.go
@@ -17,6 +17,7 @@ package github
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"text/template"
 
@@ -65,4 +66,22 @@ func FormatReviewerComment(newPrimaryReviewer string) string {
 		"reviewer": newPrimaryReviewer,
 	})
 	return sb.String()
+}
+
+var reviewerCommentRegex = regexp.MustCompile("@(?P<reviewer>[^,]*), a repository maintainer, has been assigned to review your changes.")
+
+// FindReviewerComment returns the comment which mentions the current primary reviewer and the reviewer's login,
+// or an empty comment and empty string if no such comment is found.
+// comments should only include comments by the magician in the current PR.
+func FindReviewerComment(comments []PullRequestComment) (PullRequestComment, string) {
+	for _, comment := range comments {
+		names := reviewerCommentRegex.SubexpNames()
+		matches := reviewerCommentRegex.FindStringSubmatch(comment.Body)
+		for i, name := range names {
+			if name == "reviewer" {
+				return comment, matches[i]
+			}
+		}
+	}
+	return PullRequestComment{}, ""
 }

--- a/.ci/magician/github/set.go
+++ b/.ci/magician/github/set.go
@@ -56,6 +56,23 @@ func (gh *Client) PostComment(prNumber, comment string) error {
 	return nil
 }
 
+func (gh *Client) UpdateComment(prNumber, comment string, id int) error {
+	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/comments/%d", id)
+
+	body := map[string]string{
+		"body": comment,
+	}
+
+	err := utils.RequestCall(url, "PATCH", gh.token, nil, body)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Successfully updated comment %d in pull request %s\n", id, prNumber)
+
+	return nil
+}
+
 func (gh *Client) RequestPullRequestReviewers(prNumber string, reviewers []string) error {
 	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/%s/requested_reviewers", prNumber)
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This command will allow reassigning a reviewer either to a random core contributor or to a specific one.

Currently can be invoked with
```
cd .ci/magician
go build .
./magician reassign-reviewer PR_NUMBER [REVIEWER]
```
(REVIEWER is optional, omitting will assign to a random core reviewer)

helps with https://github.com/hashicorp/terraform-provider-google/issues/19691

Remaining TODOs:
* Add a workflow that runs `reassign-reviewer` on `@modular-magician reassign-reviewer [reviewer]`
* Make the re-request reviewer workflow check the current reviewer using `FindReviewerComment`
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
