### PR TITLE
Allow proper changing of google_compute_region_instance_group_manager.distribution_policy_target_shape

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.tmpl
@@ -1164,7 +1164,7 @@ func expandDistributionPolicy(d *schema.ResourceData) *compute.DistributionPolic
     }
 	  return &compute.DistributionPolicy{Zones: distributionPolicyZoneConfigs, TargetShape: dpts}
 	}
-	return &compute.DistributionPolicy{TargetShape: dpts}
+    return &compute.DistributionPolicy{TargetShape: dpts}
 }
 
 func flattenDistributionPolicy(distributionPolicy *compute.DistributionPolicy) []string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.tmpl
@@ -633,7 +633,7 @@ func resourceComputeRegionInstanceGroupManagerCreate(d *schema.ResourceData, met
 		UpdatePolicy:                expandRegionUpdatePolicy(d.Get("update_policy").([]interface{})),
 		InstanceLifecyclePolicy:     expandInstanceLifecyclePolicy(d.Get("instance_lifecycle_policy").([]interface{})),
 		AllInstancesConfig:          expandAllInstancesConfig(nil, d.Get("all_instances_config").([]interface{})),
-		DistributionPolicy:          expandDistributionPolicy(d),
+		DistributionPolicy:          expandDistributionPolicyForCreate(d),
 		StatefulPolicy:              expandStatefulPolicy(d),
 		{{- if ne $.TargetVersionName "ga" }}
 		Params:                      expandInstanceGroupManagerParams(d),
@@ -907,7 +907,7 @@ func resourceComputeRegionInstanceGroupManagerUpdate(d *schema.ResourceData, met
 	}
 
 	if d.HasChange("distribution_policy_target_shape") {
-		updatedManager.DistributionPolicy = expandDistributionPolicy(d)
+		updatedManager.DistributionPolicy = expandDistributionPolicyForUpdate(d)
 		change = true
 	}
 
@@ -1145,14 +1145,24 @@ func flattenRegionUpdatePolicy(updatePolicy *compute.InstanceGroupManagerUpdateP
 	return results
 }
 
-func expandDistributionPolicy(d *schema.ResourceData) *compute.DistributionPolicy {
+func expandDistributionPolicyForUpdate(d *schema.ResourceData) *compute.DistributionPolicy {
+	dpts := d.Get("distribution_policy_target_shape").(string)
+	if dpts == "" {
+		return nil
+	}
+  // distributionPolicy.Zones is NOT updateable.
+  return &compute.DistributionPolicy{TargetShape: dpts}
+}
+
+func expandDistributionPolicyForCreate(d *schema.ResourceData) *compute.DistributionPolicy {
 	dpz := d.Get("distribution_policy_zones").(*schema.Set)
 	dpts := d.Get("distribution_policy_target_shape").(string)
 	if dpz.Len() == 0 && dpts == "" {
 		return nil
 	}
+	distributionPolicy := &compute.DistributionPolicy{}
 
-  if d.HasChange("distribution_policy_zones") {
+  if dpz.Len() > 0 {
     distributionPolicyZoneConfigs := make([]*compute.DistributionPolicyZoneConfiguration, 0, dpz.Len())
     for _, raw := range dpz.List() {
       data := raw.(string)
@@ -1162,9 +1172,12 @@ func expandDistributionPolicy(d *schema.ResourceData) *compute.DistributionPolic
 
       distributionPolicyZoneConfigs = append(distributionPolicyZoneConfigs, &distributionPolicyZoneConfig)
     }
-    return &compute.DistributionPolicy{Zones: distributionPolicyZoneConfigs, TargetShape: dpts}
+    distributionPolicy.Zones=distributionPolicyZoneConfigs
   }
-  return &compute.DistributionPolicy{TargetShape: dpts}
+  if dpts != "" {
+    distributionPolicy.TargetShape = dpts
+  }
+  return distributionPolicy
 }
 
 func flattenDistributionPolicy(distributionPolicy *compute.DistributionPolicy) []string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.tmpl
@@ -1152,17 +1152,19 @@ func expandDistributionPolicy(d *schema.ResourceData) *compute.DistributionPolic
 		return nil
 	}
 
-	distributionPolicyZoneConfigs := make([]*compute.DistributionPolicyZoneConfiguration, 0, dpz.Len())
-	for _, raw := range dpz.List() {
-		data := raw.(string)
-		distributionPolicyZoneConfig := compute.DistributionPolicyZoneConfiguration{
-			Zone: "zones/" + data,
-		}
+  if d.HasChange("distribution_policy_zones") {
+    distributionPolicyZoneConfigs := make([]*compute.DistributionPolicyZoneConfiguration, 0, dpz.Len())
+    for _, raw := range dpz.List() {
+      data := raw.(string)
+      distributionPolicyZoneConfig := compute.DistributionPolicyZoneConfiguration{
+        Zone: "zones/" + data,
+      }
 
-		distributionPolicyZoneConfigs = append(distributionPolicyZoneConfigs, &distributionPolicyZoneConfig)
+      distributionPolicyZoneConfigs = append(distributionPolicyZoneConfigs, &distributionPolicyZoneConfig)
+    }
+	  return &compute.DistributionPolicy{Zones: distributionPolicyZoneConfigs, TargetShape: dpts}
 	}
-
-	return &compute.DistributionPolicy{Zones: distributionPolicyZoneConfigs, TargetShape: dpts}
+	return &compute.DistributionPolicy{TargetShape: dpts}
 }
 
 func flattenDistributionPolicy(distributionPolicy *compute.DistributionPolicy) []string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.tmpl
@@ -1162,9 +1162,9 @@ func expandDistributionPolicy(d *schema.ResourceData) *compute.DistributionPolic
 
       distributionPolicyZoneConfigs = append(distributionPolicyZoneConfigs, &distributionPolicyZoneConfig)
     }
-	  return &compute.DistributionPolicy{Zones: distributionPolicyZoneConfigs, TargetShape: dpts}
-	}
-    return &compute.DistributionPolicy{TargetShape: dpts}
+    return &compute.DistributionPolicy{Zones: distributionPolicyZoneConfigs, TargetShape: dpts}
+  }
+  return &compute.DistributionPolicy{TargetShape: dpts}
 }
 
 func flattenDistributionPolicy(distributionPolicy *compute.DistributionPolicy) []string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.tmpl
@@ -312,7 +312,16 @@ func TestAccRegionInstanceGroupManager_distributionPolicy(t *testing.T) {
 		CheckDestroy:             testAccCheckRegionInstanceGroupManagerDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRegionInstanceGroupManager_distributionPolicy(template, igm, zones),
+				Config: testAccRegionInstanceGroupManager_distributionPolicyEmpty(template, igm),
+			},
+			{
+				ResourceName:            "google_compute_region_instance_group_manager.igm-basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"status"},
+			},
+			{
+				Config: testAccRegionInstanceGroupManager_distributionPolicy(template, igm),
 			},
 			{
 				ResourceName:            "google_compute_region_instance_group_manager.igm-basic",
@@ -322,6 +331,15 @@ func TestAccRegionInstanceGroupManager_distributionPolicy(t *testing.T) {
 			},
 			{
 				Config: testAccRegionInstanceGroupManager_distributionPolicyUpdate(template, igm, zones),
+			},
+			{
+				ResourceName:            "google_compute_region_instance_group_manager.igm-basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"status"},
+			},
+			{
+				Config: testAccRegionInstanceGroupManager_distributionPolicyEmpty(template, igm),
 			},
 			{
 				ResourceName:            "google_compute_region_instance_group_manager.igm-basic",
@@ -1135,7 +1153,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
 `, primaryTemplate, canaryTemplate, igm)
 }
 
-func testAccRegionInstanceGroupManager_distributionPolicy(template, igm string, zones []string) string {
+func testAccRegionInstanceGroupManager_distributionPolicyEmpty(template, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
   family  = "debian-11"
@@ -1169,8 +1187,6 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
   base_instance_name               = "tf-test-igm-basic"
   region                           = "us-central1"
   target_size                      = 2
-  distribution_policy_zones        = ["%s"]
-  distribution_policy_target_shape = "ANY"
 
   update_policy {
     instance_redistribution_type = "NONE"
@@ -1180,7 +1196,54 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
     max_unavailable_fixed        = 6
   }
 }
-`, template, igm, strings.Join(zones, "\",\""))
+`, template, igm)
+}
+
+func testAccRegionInstanceGroupManager_distributionPolicy(template, igm string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance_template" "igm-basic" {
+  name           = "%s"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+  network_interface {
+    network = "default"
+  }
+}
+
+resource "google_compute_region_instance_group_manager" "igm-basic" {
+  description = "Terraform test instance group manager"
+  name        = "%s"
+
+  version {
+    instance_template = google_compute_instance_template.igm-basic.self_link
+    name              = "primary"
+  }
+
+  base_instance_name               = "tf-test-igm-basic"
+  region                           = "us-central1"
+  target_size                      = 2
+  distribution_policy_target_shape = "BALANCED"
+
+  update_policy {
+    instance_redistribution_type = "NONE"
+    type                         = "OPPORTUNISTIC"
+    minimal_action               = "REPLACE"
+    max_surge_fixed              = 0
+    max_unavailable_fixed        = 6
+  }
+}
+`, template, igm)
 }
 
 func testAccRegionInstanceGroupManager_distributionPolicyUpdate(template, igm string, zones []string) string {


### PR DESCRIPTION
Allow proper changing of google_compute_region_instance_group_manager.distribution_policy_target_shape. Effectively - don't send the zones distribution when ONLY target shape changes.

fixes [#19891](https://github.com/hashicorp/terraform-provider-google/issues/19891)

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed an issue where immutable `distribution_zones` was incorrectly sent to the API when updating `distribution_policy_target_shape` in `google_compute_region_instance_group_manager` resource
```
