### PR TITLE
feat(monitoring_alert_policy): support notification prompts

### DIFF
--- a/mmv1/products/monitoring/AlertPolicy.yaml
+++ b/mmv1/products/monitoring/AlertPolicy.yaml
@@ -945,6 +945,16 @@ properties:
         type: String
         description: |
           If an alert policy that was active has no data for this long, any open incidents will close.
+      - name: 'notificationPrompts'
+        type: Array
+        description: |
+          Control when notifications will be sent out.
+        item_type:
+          type: Enum
+          enum_values:
+            - 'NOTIFICATION_PROMPT_UNSPECIFIED'
+            - 'OPENED'
+            - 'CLOSED'
       - name: 'notificationChannelStrategy'
         type: Array
         description: |

--- a/mmv1/third_party/terraform/services/monitoring/resource_monitoring_alert_policy_test.go
+++ b/mmv1/third_party/terraform/services/monitoring/resource_monitoring_alert_policy_test.go
@@ -399,7 +399,8 @@ resource "google_monitoring_alert_policy" "log" {
     notification_rate_limit {
       period = "300s"
     }
-    auto_close = "2000s"
+    auto_close           = "2000s"
+    notification_prompts = ["OPENED"]
   }
 
   severity     = "WARNING"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/8470

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

This PR adds support for setting notification prompts in the alert strategy for `google_monitoring_alert_policy` resource. This allows users to specify when notifications should be sent for an alert policy. For example, users can choose to send notifications only when an alert is fired, or when it is both fired and recovered. This feature was recently introduced in the Google Cloud Monitoring API and is not yet supported by the Terraform provider. See [REST API doc](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.alertPolicies#alertstrategy).

- If no value is set, `OPENED` and `CLOSED` are set by default.
- You cannot specify only `CLOSED`.
- Specifying `NOTIFICATION_PROMPT_UNSPECIFIED` will result in an error.

When only `CLOSED` is specified:

```HCL
resource "google_monitoring_alert_policy" "alert_policy" {
  display_name = "My Alert Policy"
  combiner     = "OR"
  conditions {
    display_name = "test condition"
    condition_threshold {
      filter     = "metric.type=\"compute.googleapis.com/instance/disk/write_bytes_count\" AND resource.type=\"gce_instance\""
      duration   = "60s"
      comparison = "COMPARISON_GT"
      aggregations {
        alignment_period   = "60s"
        per_series_aligner = "ALIGN_RATE"
      }
    }
  }
  alert_strategy {
    notification_prompts = ["CLOSED"]
  }
}
```

The following error is returned, so the user can identify the issue from the error message provided by the API. IMO, validation on the Terraform side isn't necessary.

```HCL
google_monitoring_alert_policy.alert_policy: Modifying... [id=projects/nagasawa-test/alertPolicies/3128142619627286892]
╷
│ Error: Error updating AlertPolicy "projects/nagasawa-test/alertPolicies/3128142619627286892": googleapi: Error 400: Field alertStrategy.notificationPrompts had an invalid value of "CLOSED": invalid notification prompts: metric-based alert policies notification prompts must be [OPENED] or [OPENED, CLOSED]
│
│   with google_monitoring_alert_policy.alert_policy,
│   on main.tf line 1, in resource "google_monitoring_alert_policy" "alert_policy":
│    1: resource "google_monitoring_alert_policy" "alert_policy" {
│
```

When `NOTIFICATION_PROMPT_UNSPECIFIED` is specified:

```HCL
resource "google_monitoring_alert_policy" "alert_policy" {
  display_name = "My Alert Policy"
  combiner     = "OR"
  conditions {
    display_name = "test condition"
    condition_threshold {
      filter     = "metric.type=\"compute.googleapis.com/instance/disk/write_bytes_count\" AND resource.type=\"gce_instance\""
      duration   = "60s"
      comparison = "COMPARISON_GT"
      aggregations {
        alignment_period   = "60s"
        per_series_aligner = "ALIGN_RATE"
      }
    }
  }
  alert_strategy {
    notification_prompts = ["NOTIFICATION_PROMPT_UNSPECIFIED"]
  }
}
```

The following error is returned. The API documentation also states **"Treated as error"**, so I'm not sure if it makes sense to allow this to be specified in Terraform.

```HCL
google_monitoring_alert_policy.alert_policy: Modifying... [id=projects/nagasawa-test/alertPolicies/3128142619627286892]
╷
│ Error: Error updating AlertPolicy "projects/nagasawa-test/alertPolicies/3128142619627286892": googleapi: Error 400: Field alertStrategy.notificationPrompts had an invalid value of "NOTIFICATION_PROMPT_UNSPECIFIED": unspecified notification prompt
│
│   with google_monitoring_alert_policy.alert_policy,
│   on main.tf line 1, in resource "google_monitoring_alert_policy" "alert_policy":
│    1: resource "google_monitoring_alert_policy" "alert_policy" {
│
╵
```

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
monitoring: added `alert_strategy.notification_prompts` field to `google_monitoring_alert_policy`
```
