### PR TITLE
Fixed SecurityPolicyRule and RegionSecurityPolicyRule resources being unable to manage the policy default rule

### DIFF
--- a/mmv1/products/compute/RegionSecurityPolicyRule.yaml
+++ b/mmv1/products/compute/RegionSecurityPolicyRule.yaml
@@ -67,6 +67,7 @@ examples:
       sec_policy_name: 'policywithmultiplerules'
   - name: 'region_security_policy_rule_default_rule'
     primary_resource_id: 'policy_rule'
+    min_version: 'beta'
     vars:
       sec_policy_name: 'policywithdefaultrule'
   - name: 'region_security_policy_rule_with_preconfigured_waf_config'

--- a/mmv1/products/compute/RegionSecurityPolicyRule.yaml
+++ b/mmv1/products/compute/RegionSecurityPolicyRule.yaml
@@ -52,6 +52,8 @@ async:
     path: 'error/errors'
     message: 'message'
 custom_code:
+  pre_create: 'templates/terraform/pre_create/region_security_policy_default_rule_update_on_create.go.tmpl'
+  pre_delete: 'templates/terraform/pre_delete/security_policy_default_rule_delete.go.tmpl'
 examples:
   - name: 'region_security_policy_rule_basic'
     primary_resource_id: 'policy_rule'
@@ -63,6 +65,10 @@ examples:
     min_version: 'beta'
     vars:
       sec_policy_name: 'policywithmultiplerules'
+  - name: 'region_security_policy_rule_default_rule'
+    primary_resource_id: 'policy_rule'
+    vars:
+      sec_policy_name: 'policywithdefaultrule'
   - name: 'region_security_policy_rule_with_preconfigured_waf_config'
     primary_resource_id: 'policy_rule'
     min_version: 'beta'

--- a/mmv1/products/compute/SecurityPolicyRule.yaml
+++ b/mmv1/products/compute/SecurityPolicyRule.yaml
@@ -51,6 +51,8 @@ async:
     path: 'error/errors'
     message: 'message'
 custom_code:
+  pre_create: 'templates/terraform/pre_create/security_policy_default_rule_update_on_create.go.tmpl'
+  pre_delete: 'templates/terraform/pre_delete/security_policy_default_rule_delete.go.tmpl'
 examples:
   - name: 'security_policy_rule_basic'
     primary_resource_id: 'policy_rule'
@@ -60,8 +62,6 @@ examples:
     primary_resource_id: 'policy_rule'
     vars:
       sec_policy_name: 'policyruletest'
-      project_id: 'PROJECT_NAME'
-    exclude_test: true
   - name: 'security_policy_rule_multiple_rules'
     primary_resource_id: 'policy_rule_one'
     vars:

--- a/mmv1/templates/terraform/examples/region_security_policy_rule_default_rule.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_security_policy_rule_default_rule.tf.tmpl
@@ -1,4 +1,5 @@
-resource "google_compute_region_security_policy" "default" { 
+resource "google_compute_region_security_policy" "default" {
+  provider    = google-beta
   region      = "us-west2"
   name        = "{{index $.Vars "sec_policy_name"}}"
   description = "basic region security policy"
@@ -6,6 +7,7 @@ resource "google_compute_region_security_policy" "default" {
 }
 
 resource "google_compute_region_security_policy_rule" "default_rule" {
+  provider        = google-beta
   region          = "us-west2"
   security_policy = google_compute_region_security_policy.default.name
   description     = "new rule"
@@ -19,7 +21,8 @@ resource "google_compute_region_security_policy_rule" "default_rule" {
   }
 }
 
-resource "google_compute_region_security_policy_rule" "{{$.PrimaryResourceId}}" {  
+resource "google_compute_region_security_policy_rule" "{{$.PrimaryResourceId}}" {
+  provider        = google-beta
   region          = "us-west2"
   security_policy = google_compute_region_security_policy.default.name
   description     = "new rule"

--- a/mmv1/templates/terraform/examples/region_security_policy_rule_default_rule.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_security_policy_rule_default_rule.tf.tmpl
@@ -1,0 +1,35 @@
+resource "google_compute_region_security_policy" "default" { 
+  region      = "us-west2"
+  name        = "{{index $.Vars "sec_policy_name"}}"
+  description = "basic region security policy"
+  type        = "CLOUD_ARMOR"
+}
+
+resource "google_compute_region_security_policy_rule" "default_rule" {
+  region          = "us-west2"
+  security_policy = google_compute_region_security_policy.default.name
+  description     = "new rule"
+  action          = "deny"
+  priority        = "2147483647"
+  match {
+    versioned_expr = "SRC_IPS_V1"
+    config {
+      src_ip_ranges = ["*"]
+    }
+  }
+}
+
+resource "google_compute_region_security_policy_rule" "{{$.PrimaryResourceId}}" {  
+  region          = "us-west2"
+  security_policy = google_compute_region_security_policy.default.name
+  description     = "new rule"
+  priority        = 100
+  match {
+    versioned_expr = "SRC_IPS_V1"
+    config {
+      src_ip_ranges = ["10.10.0.0/16"]
+    }
+  }
+  action          = "allow"
+  preview         = true
+}

--- a/mmv1/templates/terraform/examples/security_policy_rule_default_rule.tf.tmpl
+++ b/mmv1/templates/terraform/examples/security_policy_rule_default_rule.tf.tmpl
@@ -4,15 +4,10 @@ resource "google_compute_security_policy" "default" {
   type        = "CLOUD_ARMOR"
 }
 
-# A default rule is generated when creating the security_policy resource, import is needed to patch it
-# import {
-#   id = "projects/{{index $.TestEnvVars "project_id"}}/global/securityPolicies/{{index $.Vars "sec_policy_name"}}/priority/2147483647"
-#   to = google_compute_security_policy_rule.default_rule
-# }
 resource "google_compute_security_policy_rule" "default_rule" {
   security_policy = google_compute_security_policy.default.name
   description     = "default rule"
-  action          = "allow"
+  action          = "deny"
   priority        = "2147483647"
   match {
     versioned_expr = "SRC_IPS_V1"

--- a/mmv1/templates/terraform/pre_create/region_security_policy_default_rule_update_on_create.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/region_security_policy_default_rule_update_on_create.go.tmpl
@@ -1,0 +1,11 @@
+// We can't Create a default rule since one is automatically created with the policy
+rulePriority, ok := d.GetOk("priority")
+
+if ok && rulePriority.(int) == 2147483647 {
+	log.Printf("[WARN] {{$.Name}} represents a default rule, will attempt an Update instead")
+	newUrl, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/regions/{{"{{"}}region{{"}}"}}/securityPolicies/{{"{{"}}security_policy{{"}}"}}/patchRule?priority={{"{{"}}priority{{"}}"}}")
+	if err != nil {
+		return err
+	}
+	url = newUrl
+}

--- a/mmv1/templates/terraform/pre_create/security_policy_default_rule_update_on_create.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/security_policy_default_rule_update_on_create.go.tmpl
@@ -1,0 +1,11 @@
+// We can't Create a default rule since one is automatically created with the policy
+rulePriority, ok := d.GetOk("priority")
+
+if ok && rulePriority.(int) == 2147483647 {
+	log.Printf("[WARN] {{$.Name}} represents a default rule, will attempt an Update instead")
+	newUrl, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/global/securityPolicies/{{"{{"}}security_policy{{"}}"}}/patchRule?priority={{"{{"}}priority{{"}}"}}")
+	if err != nil {
+		return err
+	}
+	url = newUrl
+}

--- a/mmv1/templates/terraform/pre_delete/security_policy_default_rule_delete.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/security_policy_default_rule_delete.go.tmpl
@@ -1,0 +1,7 @@
+// The default rule of a Security Policy cannot be removed
+rulePriority, ok := d.GetOk("priority")
+
+if ok && rulePriority.(int) == 2147483647 {
+	log.Printf("[WARN] {{$.Name}} represents a default rule, skipping Delete request")
+	return nil
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_security_policy_rule_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_security_policy_rule_test.go.tmpl
@@ -67,6 +67,88 @@ resource "google_compute_region_security_policy_rule" "policy_rule" {
 `, context)
 }
 
+func TestAccComputeRegionSecurityPolicyRule_securityPolicyDefaultRule(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionSecurityPolicyRuleDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionSecurityPolicyRule_securityPolicyDefaultRuleDeny(context),
+			},
+      {
+        ResourceName:      "google_compute_region_security_policy_rule.policy_rule_default",
+        ImportState:       true,
+        ImportStateVerify: true,
+      },
+      {
+        Config: testAccComputeRegionSecurityPolicyRule_securityPolicyDefaultRuleAllow(context),
+      },
+      {
+        ResourceName:      "google_compute_region_security_policy_rule.policy_rule_default",
+        ImportState:       true,
+        ImportStateVerify: true,
+      },
+		},
+	})
+}
+
+func testAccComputeRegionSecurityPolicyRule_securityPolicyDefaultRuleDeny(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_region_security_policy" "default" {
+  region      = "us-west2"
+  name        = "tf-test%{random_suffix}"
+  description = "basic region security policy"
+  type        = "CLOUD_ARMOR"
+}
+
+resource "google_compute_region_security_policy_rule" "policy_rule_default" {
+  security_policy = google_compute_region_security_policy.default.name
+  region          = "us-west2"
+  description     = "default rule"
+  action          = "deny"
+  priority        = "2147483647"
+  match {
+    versioned_expr = "SRC_IPS_V1"
+    config {
+      src_ip_ranges = ["*"]
+    }
+  }
+}
+`, context)
+}
+
+func testAccComputeRegionSecurityPolicyRule_securityPolicyDefaultRuleAllow(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_region_security_policy" "default" {
+  region      = "us-west2"
+  name        = "tf-test%{random_suffix}"
+  description = "basic region security policy"
+  type        = "CLOUD_ARMOR"
+}
+
+resource "google_compute_region_security_policy_rule" "policy_rule_default" {
+  security_policy = google_compute_region_security_policy.default.name
+  region          = "us-west2"
+  description     = "default rule"
+  action          = "allow"
+  priority        = "2147483647"
+  match {
+    versioned_expr = "SRC_IPS_V1"
+    config {
+      src_ip_ranges = ["*"]
+    }
+  }
+}
+`, context)
+}
+
 func testAccComputeRegionSecurityPolicyRule_regionSecurityPolicyRulePostUpdate(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_region_security_policy" "default" {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_security_policy_rule_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_security_policy_rule_test.go.tmpl
@@ -82,19 +82,19 @@ func TestAccComputeRegionSecurityPolicyRule_securityPolicyDefaultRule(t *testing
 			{
 				Config: testAccComputeRegionSecurityPolicyRule_securityPolicyDefaultRuleDeny(context),
 			},
-      {
-        ResourceName:      "google_compute_region_security_policy_rule.policy_rule_default",
-        ImportState:       true,
-        ImportStateVerify: true,
-      },
-      {
-        Config: testAccComputeRegionSecurityPolicyRule_securityPolicyDefaultRuleAllow(context),
-      },
-      {
-        ResourceName:      "google_compute_region_security_policy_rule.policy_rule_default",
-        ImportState:       true,
-        ImportStateVerify: true,
-      },
+			{
+				ResourceName:      "google_compute_region_security_policy_rule.policy_rule_default",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRegionSecurityPolicyRule_securityPolicyDefaultRuleAllow(context),
+			},
+			{
+				ResourceName:      "google_compute_region_security_policy_rule.policy_rule_default",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.tmpl
@@ -162,6 +162,38 @@ func TestAccComputeSecurityPolicy_update(t *testing.T) {
 	})
 }
 
+func TestAccComputeSecurityPolicyRule_securityPolicyDefaultRule(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeSecurityPolicyRuleDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSecurityPolicyRule_securityPolicyDefaultRuleDeny(context),
+			},
+      {
+        ResourceName:      "google_compute_security_policy_rule.policy_rule_default",
+        ImportState:       true,
+        ImportStateVerify: true,
+      },
+      {
+        Config: testAccComputeSecurityPolicyRule_securityPolicyDefaultRuleAllow(context),
+      },
+      {
+        ResourceName:      "google_compute_security_policy_rule.policy_rule_default",
+        ImportState:       true,
+        ImportStateVerify: true,
+      },
+		},
+	})
+}
+
 func TestAccComputeSecurityPolicy_withAdvancedOptionsConfig(t *testing.T) {
 	t.Parallel()
 
@@ -877,6 +909,52 @@ resource "google_compute_security_policy" "policy" {
   }
 }
 `, spName)
+}
+
+func testAccComputeSecurityPolicyRule_securityPolicyDefaultRuleDeny(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_security_policy" "default" {
+  name        = "tf-test%{random_suffix}"
+  description = "basic global security policy"
+  type        = "CLOUD_ARMOR"
+}
+
+resource "google_compute_security_policy_rule" "policy_rule_default" {
+  security_policy = google_compute_security_policy.default.name
+  description     = "default rule"
+  action          = "deny"
+  priority        = "2147483647"
+  match {
+    versioned_expr = "SRC_IPS_V1"
+    config {
+      src_ip_ranges = ["*"]
+    }
+  }
+}
+`, context)
+}
+
+func testAccComputeSecurityPolicyRule_securityPolicyDefaultRuleAllow(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_security_policy" "default" {
+  name        = "tf-test%{random_suffix}"
+  description = "basic global security policy"
+  type        = "CLOUD_ARMOR"
+}
+
+resource "google_compute_security_policy_rule" "policy_rule_default" {
+  security_policy = google_compute_security_policy.default.name
+  description     = "default rule"
+  action          = "allow"
+  priority        = "2147483647"
+  match {
+    versioned_expr = "SRC_IPS_V1"
+    config {
+      src_ip_ranges = ["*"]
+    }
+  }
+}
+`, context)
 }
 
 func testAccComputeSecurityPolicy_withRuleExpr(spName string) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.tmpl
@@ -177,19 +177,19 @@ func TestAccComputeSecurityPolicyRule_securityPolicyDefaultRule(t *testing.T) {
 			{
 				Config: testAccComputeSecurityPolicyRule_securityPolicyDefaultRuleDeny(context),
 			},
-      {
-        ResourceName:      "google_compute_security_policy_rule.policy_rule_default",
-        ImportState:       true,
-        ImportStateVerify: true,
-      },
-      {
-        Config: testAccComputeSecurityPolicyRule_securityPolicyDefaultRuleAllow(context),
-      },
-      {
-        ResourceName:      "google_compute_security_policy_rule.policy_rule_default",
-        ImportState:       true,
-        ImportStateVerify: true,
-      },
+			{
+				ResourceName:      "google_compute_security_policy_rule.policy_rule_default",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeSecurityPolicyRule_securityPolicyDefaultRuleAllow(context),
+			},
+			{
+				ResourceName:      "google_compute_security_policy_rule.policy_rule_default",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds custom code to allow the `google_compute_region_security_policy_rule` and `google_compute_security_policy_rule` resources to override the default rule of their respective security policy without the need of a multi-apply import process.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/15687

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed unable to create default rule when using `google_compute_region_security_policy_rule` resource (beta)
```
```release-note:bug
compute: fixed unable to create default rule when using `google_compute_security_policy_rule` resource
```
