### PR TITLE
Fix issue with google_compute_(region_)per_instance_config.stateful.ips.ipAddress.address always having diff due to relative vs full path

### DIFF
--- a/mmv1/products/compute/PerInstanceConfig.yaml
+++ b/mmv1/products/compute/PerInstanceConfig.yaml
@@ -15,7 +15,7 @@
 name: 'PerInstanceConfig'
 description: |
   A config defined for a single managed instance that belongs to an instance group manager. It preserves the instance name
-  across instance group manager operations and can define stateful disks or metadata that are unique to the instance.
+  across instance group manager operations and can define stateful disks, ips or metadata that are unique to the instance.
 references:
   guides:
     'Official Documentation': 'https://cloud.google.com/compute/docs/instance-groups/stateful-migs#per-instance_configs'
@@ -213,6 +213,7 @@ properties:
                   type: ResourceRef
                   description: |
                     The URL of the reservation for this IP address.
+                  custom_flatten: 'templates/terraform/custom_flatten/full_to_relative_path.tmpl'
                   custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
                   resource: 'Address'
                   imports: 'selfLink'
@@ -243,6 +244,7 @@ properties:
                   type: ResourceRef
                   description: |
                     The URL of the reservation for this IP address.
+                  custom_flatten: 'templates/terraform/custom_flatten/full_to_relative_path.tmpl'
                   custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
                   resource: 'Address'
                   imports: 'selfLink'

--- a/mmv1/products/compute/PerInstanceConfig.yaml
+++ b/mmv1/products/compute/PerInstanceConfig.yaml
@@ -213,8 +213,8 @@ properties:
                   type: ResourceRef
                   description: |
                     The URL of the reservation for this IP address.
-                  custom_flatten: 'templates/terraform/custom_flatten/full_to_relative_path.tmpl'
-                  custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+                  diff_suppress_func: 'tpgresource.CompareSelfLinkRelativePaths'
+                  #custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
                   resource: 'Address'
                   imports: 'selfLink'
       - name: 'externalIp'
@@ -244,7 +244,7 @@ properties:
                   type: ResourceRef
                   description: |
                     The URL of the reservation for this IP address.
-                  custom_flatten: 'templates/terraform/custom_flatten/full_to_relative_path.tmpl'
-                  custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+                  diff_suppress_func: 'tpgresource.CompareSelfLinkRelativePaths'
+                  #custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
                   resource: 'Address'
                   imports: 'selfLink'

--- a/mmv1/products/compute/PerInstanceConfig.yaml
+++ b/mmv1/products/compute/PerInstanceConfig.yaml
@@ -214,7 +214,7 @@ properties:
                   description: |
                     The URL of the reservation for this IP address.
                   diff_suppress_func: 'tpgresource.CompareSelfLinkRelativePaths'
-                  #custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+                  custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
                   resource: 'Address'
                   imports: 'selfLink'
       - name: 'externalIp'
@@ -245,6 +245,6 @@ properties:
                   description: |
                     The URL of the reservation for this IP address.
                   diff_suppress_func: 'tpgresource.CompareSelfLinkRelativePaths'
-                  #custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+                  custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
                   resource: 'Address'
                   imports: 'selfLink'

--- a/mmv1/products/compute/RegionPerInstanceConfig.yaml
+++ b/mmv1/products/compute/RegionPerInstanceConfig.yaml
@@ -15,7 +15,7 @@
 name: 'RegionPerInstanceConfig'
 description: |
   A config defined for a single managed instance that belongs to an instance group manager. It preserves the instance name
-  across instance group manager operations and can define stateful disks or metadata that are unique to the instance.
+  across instance group manager operations and can define stateful disks, ips or metadata that are unique to the instance.
   This resource works with regional instance group managers.
 references:
   guides:
@@ -214,6 +214,7 @@ properties:
                   type: ResourceRef
                   description: |
                     The URL of the reservation for this IP address.
+                  custom_flatten: 'templates/terraform/custom_flatten/full_to_relative_path.tmpl'
                   custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
                   resource: 'Address'
                   imports: 'selfLink'
@@ -244,6 +245,7 @@ properties:
                   type: ResourceRef
                   description: |
                     The URL of the reservation for this IP address.
+                  custom_flatten: 'templates/terraform/custom_flatten/full_to_relative_path.tmpl'
                   custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
                   resource: 'Address'
                   imports: 'selfLink'

--- a/mmv1/products/compute/RegionPerInstanceConfig.yaml
+++ b/mmv1/products/compute/RegionPerInstanceConfig.yaml
@@ -214,8 +214,8 @@ properties:
                   type: ResourceRef
                   description: |
                     The URL of the reservation for this IP address.
-                  custom_flatten: 'templates/terraform/custom_flatten/full_to_relative_path.tmpl'
-                  custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+                  diff_suppress_func: 'tpgresource.CompareSelfLinkRelativePaths'
+                  #custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
                   resource: 'Address'
                   imports: 'selfLink'
       - name: 'externalIp'
@@ -245,7 +245,7 @@ properties:
                   type: ResourceRef
                   description: |
                     The URL of the reservation for this IP address.
-                  custom_flatten: 'templates/terraform/custom_flatten/full_to_relative_path.tmpl'
-                  custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+                  diff_suppress_func: 'tpgresource.CompareSelfLinkRelativePaths'
+                  #custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
                   resource: 'Address'
                   imports: 'selfLink'

--- a/mmv1/products/compute/RegionPerInstanceConfig.yaml
+++ b/mmv1/products/compute/RegionPerInstanceConfig.yaml
@@ -215,7 +215,7 @@ properties:
                   description: |
                     The URL of the reservation for this IP address.
                   diff_suppress_func: 'tpgresource.CompareSelfLinkRelativePaths'
-                  #custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+                  custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
                   resource: 'Address'
                   imports: 'selfLink'
       - name: 'externalIp'
@@ -246,6 +246,6 @@ properties:
                   description: |
                     The URL of the reservation for this IP address.
                   diff_suppress_func: 'tpgresource.CompareSelfLinkRelativePaths'
-                  #custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+                  custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
                   resource: 'Address'
                   imports: 'selfLink'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_per_instance_config_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_per_instance_config_test.go.tmpl
@@ -442,14 +442,14 @@ resource "google_compute_per_instance_config" "config_one" {
     }
     internal_ip {
       ip_address {
-        address = google_compute_address.static_internal_ip.self_link
+        address = google_compute_address.static_internal_ip.id
       }
       auto_delete    = "NEVER"
       interface_name = "nic0"
     }
     external_ip {
       ip_address {
-        address = google_compute_address.static_external_ip.self_link
+        address = google_compute_address.static_external_ip.id
       }
       auto_delete    = "NEVER"
       interface_name = "nic0"
@@ -545,14 +545,14 @@ resource "google_compute_per_instance_config" "default" {
     }
     internal_ip {
       ip_address {
-        address = google_compute_address.static_internal_ip.self_link
+        address = google_compute_address.static_internal_ip.id
       }
       auto_delete    = "NEVER"
       interface_name = "nic0"
     }
     external_ip {
       ip_address {
-        address = google_compute_address.static_external_ip.self_link
+        address = google_compute_address.static_external_ip.id
       }
       auto_delete    = "NEVER"
       interface_name = "nic0"
@@ -620,14 +620,14 @@ resource "google_compute_per_instance_config" "default" {
     }
     internal_ip {
       ip_address {
-        address = google_compute_address.static_internal_ip.self_link
+        address = google_compute_address.static_internal_ip.id
       }
       auto_delete    = "ON_PERMANENT_INSTANCE_DELETION"
       interface_name = "nic0"
     }
     external_ip {
       ip_address {
-        address = google_compute_address.static_external_ip.self_link
+        address = google_compute_address.static_external_ip.id
       }
       auto_delete    = "ON_PERMANENT_INSTANCE_DELETION"
       interface_name = "nic0"

--- a/mmv1/third_party/terraform/services/compute/resource_compute_per_instance_config_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_per_instance_config_test.go.tmpl
@@ -442,7 +442,7 @@ resource "google_compute_per_instance_config" "config_one" {
     }
     internal_ip {
       ip_address {
-        address = google_compute_address.static_internal_ip.id
+        address = google_compute_address.static_internal_ip.self_link
       }
       auto_delete    = "NEVER"
       interface_name = "nic0"
@@ -552,7 +552,7 @@ resource "google_compute_per_instance_config" "default" {
     }
     external_ip {
       ip_address {
-        address = google_compute_address.static_external_ip.id
+        address = google_compute_address.static_external_ip.self_link
       }
       auto_delete    = "NEVER"
       interface_name = "nic0"
@@ -627,7 +627,7 @@ resource "google_compute_per_instance_config" "default" {
     }
     external_ip {
       ip_address {
-        address = google_compute_address.static_external_ip.id
+        address = google_compute_address.static_external_ip.self_link
       }
       auto_delete    = "ON_PERMANENT_INSTANCE_DELETION"
       interface_name = "nic0"

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_per_instance_config_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_per_instance_config_test.go.tmpl
@@ -451,14 +451,14 @@ resource "google_compute_region_per_instance_config" "config_one" {
     }
     internal_ip {
       ip_address {
-				address = google_compute_address.static_internal_ip.self_link
+				address = google_compute_address.static_internal_ip.id
       }
       auto_delete    = "NEVER"
       interface_name = "nic0"
     }
     external_ip {
       ip_address {
-        address = google_compute_address.static_external_ip.self_link
+        address = google_compute_address.static_external_ip.id
       }
       auto_delete    = "NEVER"
       interface_name = "nic0"
@@ -555,14 +555,14 @@ resource "google_compute_region_per_instance_config" "default" {
     }
     internal_ip {
       ip_address {
-	    address = google_compute_address.static_internal_ip.self_link
+	    address = google_compute_address.static_internal_ip.id
       }
       auto_delete    = "NEVER"
       interface_name = "nic0"
     }
     external_ip {
       ip_address {
-        address = google_compute_address.static_external_ip.self_link
+        address = google_compute_address.static_external_ip.id
       }
       auto_delete    = "NEVER"
       interface_name = "nic0"
@@ -631,14 +631,14 @@ resource "google_compute_region_per_instance_config" "default" {
     }
     internal_ip {
       ip_address {
-	    address = google_compute_address.static_internal_ip.self_link
+	    address = google_compute_address.static_internal_ip.id
       }
       auto_delete    = "ON_PERMANENT_INSTANCE_DELETION"
       interface_name = "nic0"
     }
     external_ip {
       ip_address {
-        address = google_compute_address.static_external_ip.self_link
+        address = google_compute_address.static_external_ip.id
       }
       auto_delete    = "ON_PERMANENT_INSTANCE_DELETION"
       interface_name = "nic0"

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_per_instance_config_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_per_instance_config_test.go.tmpl
@@ -458,7 +458,7 @@ resource "google_compute_region_per_instance_config" "config_one" {
     }
     external_ip {
       ip_address {
-        address = google_compute_address.static_external_ip.id
+        address = google_compute_address.static_external_ip.self_link
       }
       auto_delete    = "NEVER"
       interface_name = "nic0"
@@ -555,7 +555,7 @@ resource "google_compute_region_per_instance_config" "default" {
     }
     internal_ip {
       ip_address {
-	    address = google_compute_address.static_internal_ip.id
+	    address = google_compute_address.static_internal_ip.self_link
       }
       auto_delete    = "NEVER"
       interface_name = "nic0"
@@ -631,7 +631,7 @@ resource "google_compute_region_per_instance_config" "default" {
     }
     internal_ip {
       ip_address {
-	    address = google_compute_address.static_internal_ip.id
+	    address = google_compute_address.static_internal_ip.self_link
       }
       auto_delete    = "ON_PERMANENT_INSTANCE_DELETION"
       interface_name = "nic0"

--- a/mmv1/third_party/terraform/tpgresource/self_link_helpers_test.go
+++ b/mmv1/third_party/terraform/tpgresource/self_link_helpers_test.go
@@ -2,6 +2,69 @@ package tpgresource
 
 import "testing"
 
+func TestCompareSelfLinkRelativePaths(t *testing.T) {
+	cases := map[string]struct {
+		Old, New string
+		Expect   bool
+	}{
+		"name only, same": {
+			Old:    "https://www.googleapis.com/compute/v1/projects/your-project/global/networks/a-network",
+			New:    "a-network",
+			Expect: false,
+		},
+		"name only, different": {
+			Old:    "https://www.googleapis.com/compute/v1/projects/your-project/global/networks/a-network",
+			New:    "another-network",
+			Expect: false,
+		},
+		"partial path, same": {
+			Old:    "https://www.googleapis.com/compute/v1/projects/your-project/global/networks/a-network",
+			New:    "projects/your-project/global/networks/a-network",
+			Expect: true,
+		},
+		"partial path, different name": {
+			Old:    "https://www.googleapis.com/compute/v1/projects/your-project/global/networks/a-network",
+			New:    "projects/your-project/global/networks/another-network",
+			Expect: false,
+		},
+		"partial path, different project": {
+			Old:    "https://www.googleapis.com/compute/v1/projects/your-project/global/networks/a-network",
+			New:    "projects/another-project/global/networks/a-network",
+			Expect: false,
+		},
+		"full path, different name": {
+			Old:    "https://www.googleapis.com/compute/v1/projects/your-project/global/networks/a-network",
+			New:    "https://www.googleapis.com/compute/v1/projects/your-project/global/networks/another-network",
+			Expect: false,
+		},
+		"full path, different project": {
+			Old:    "https://www.googleapis.com/compute/v1/projects/your-project/global/networks/a-network",
+			New:    "https://www.googleapis.com/compute/v1/projects/another-project/global/networks/a-network",
+			Expect: false,
+		},
+		"beta full path, same": {
+			Old:    "https://www.googleapis.com/compute/v1/projects/your-project/global/networks/a-network",
+			New:    "https://www.googleapis.com/compute/beta/projects/your-project/global/networks/a-network",
+			Expect: true,
+		},
+		"beta full path, different name": {
+			Old:    "https://www.googleapis.com/compute/v1/projects/your-project/global/networks/a-network",
+			New:    "https://www.googleapis.com/compute/beta/projects/your-project/global/networks/another-network",
+			Expect: false,
+		},
+		"beta full path, different project": {
+			Old:    "https://www.googleapis.com/compute/v1/projects/your-project/global/networks/a-network",
+			New:    "https://www.googleapis.com/compute/beta/projects/another-project/global/networks/a-network",
+			Expect: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		if CompareSelfLinkRelativePaths("", tc.Old, tc.New, nil) != tc.Expect {
+			t.Errorf("bad: %s, expected %t for old = %q and new = %q", tn, tc.Expect, tc.Old, tc.New)
+		}
+	}
+}
 func TestCompareSelfLinkOrResourceName(t *testing.T) {
 	cases := map[string]struct {
 		Old, New string


### PR DESCRIPTION
Convert the full path to 

fixes https://github.com/hashicorp/terraform-provider-google/issues/19265

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed permadiffs on stateful ip address in `google_compute_region_per_instance_config` and `google_compute_per_instance_config` resources
```
