### PR TITLE
chore(ci): remove replaying error display in log since it is too long

### DIFF
--- a/.ci/magician/cmd/templates/vcr/vcr_cassettes_update_replaying.tmpl
+++ b/.ci/magician/cmd/templates/vcr/vcr_cassettes_update_replaying.tmpl
@@ -17,7 +17,7 @@ Affected tests list:
 {{- end}}
 {{if .ReplayingErr}}
 #################################
-Errors occurred during REPLAYING mode: {{.ReplayingErr}}.
+Errors occurred during REPLAYING mode.
 #################################
 {{- end}}
 {{if .AllReplayingPassed}}

--- a/.ci/magician/cmd/vcr_cassette_update_test.go
+++ b/.ci/magician/cmd/vcr_cassette_update_test.go
@@ -49,7 +49,7 @@ func TestFormatVCRCassettesUpdateReplaying(t *testing.T) {
 					"#################################",
 					"",
 					"#################################",
-					"Errors occurred during REPLAYING mode: some error.",
+					"Errors occurred during REPLAYING mode.",
 					"#################################",
 				},
 				"\n",


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Remove replaying error display in log since it is too long

eg. [Example run](https://console.cloud.google.com/cloud-build/builds/929169f0-9808-406b-932e-40c8ecc905fc;step=0?inv=1&invt=AbfBfQ&project=graphite-docker-images)

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
