### PR TITLE
Add mmv1 metadata generation

### DIFF
--- a/mmv1/api/product.go
+++ b/mmv1/api/product.go
@@ -16,6 +16,7 @@ package api
 import (
 	"log"
 	"reflect"
+	"regexp"
 	"strings"
 	"unicode"
 
@@ -51,6 +52,10 @@ type Product struct {
 	// The base URL for the service API endpoint
 	// For example: `https://www.googleapis.com/compute/v1/`
 	BaseUrl string `yaml:"base_url,omitempty"`
+
+	// The validator "relative URI" of a resource, relative to the product
+	// base URL. Specific to defining the resource as a CAI asset.
+	CaiBaseUrl string
 
 	// A function reference designed for the rare case where you
 	// need to use retries in operation calls. Used for the service api
@@ -213,6 +218,7 @@ func (p *Product) ExistsAtVersion(name string) bool {
 
 func (p *Product) SetPropertiesBasedOnVersion(version *product.Version) {
 	p.BaseUrl = version.BaseUrl
+	p.CaiBaseUrl = version.CaiBaseUrl
 }
 
 func (p *Product) TerraformName() string {
@@ -220,6 +226,38 @@ func (p *Product) TerraformName() string {
 		return google.Underscore(p.LegacyName)
 	}
 	return google.Underscore(p.Name)
+}
+
+func (p *Product) ServiceBaseUrl() string {
+	if p.CaiBaseUrl != "" {
+		return p.CaiBaseUrl
+	}
+	return p.BaseUrl
+}
+
+func (p *Product) ServiceName() string {
+	parts := strings.Split(p.ServiceBaseUrl(), "/")
+	// remove location prefix if present
+	trimmed, _ := strings.CutPrefix(parts[2], "{{location}}-")
+	return trimmed
+}
+
+var versionRegexp = regexp.MustCompile(`^v[0-9]+|beta`)
+
+func (p *Product) ServiceVersion() string {
+	parts := strings.Split(p.ServiceBaseUrl(), "/")
+	for i := len(parts) - 1; i >= 0; i-- {
+		part := parts[i]
+		// stop when we get to the domain name
+		if strings.Contains(part, ".com") {
+			break
+		}
+		v := versionRegexp.FindString(part)
+		if v != "" {
+			return part
+		}
+	}
+	return ""
 }
 
 // ====================

--- a/mmv1/api/product_test.go
+++ b/mmv1/api/product_test.go
@@ -127,3 +127,114 @@ func TestProductVersionObjOrClosest(t *testing.T) {
 		})
 	}
 }
+
+func TestProductServiceName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		description string
+		obj         Product
+		expected    string
+	}{
+		{
+			description: "standard BaseUrl",
+			obj: Product{
+				BaseUrl: "https://abc.googleapis.com/beta/",
+			},
+			expected: "abc.googleapis.com",
+		},
+		{
+			description: "BaseUrl with locational subdomain",
+			obj: Product{
+				BaseUrl: "https://{{location}}-abc.googleapis.com/ga/",
+			},
+			expected: "abc.googleapis.com",
+		},
+		{
+			description: "BaseUrl and CaiBaseUrl",
+			obj: Product{
+				BaseUrl:    "https://abc.googleapis.com/ga/",
+				CaiBaseUrl: "https://def.googleapis.com/ga/",
+			},
+			expected: "def.googleapis.com",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+
+			if got, want := tc.obj.ServiceName(), tc.expected; got != want {
+				t.Errorf("expected %v to be %v", got, want)
+			}
+		})
+	}
+}
+
+func TestProductServiceVersion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		description string
+		obj         Product
+		expected    string
+	}{
+		{
+			description: "standard BaseUrl",
+			obj: Product{
+				BaseUrl: "https://abc.googleapis.com/v1/",
+			},
+			expected: "v1",
+		},
+		{
+			description: "BaseUrl without trailing /",
+			obj: Product{
+				BaseUrl: "https://abc.googleapis.com/v1",
+			},
+			expected: "v1",
+		},
+		{
+			description: "BaseUrl with version of beta",
+			obj: Product{
+				BaseUrl: "https://abc.googleapis.com/beta/",
+			},
+			expected: "beta",
+		},
+		{
+			description: "BaseUrl without valid version",
+			obj: Product{
+				BaseUrl: "https://abc.googleapis.com/other/",
+			},
+			expected: "",
+		},
+		{
+			description: "BaseUrl with additional value in path",
+			obj: Product{
+				BaseUrl: "https://abc.googleapis.com/compute/v1/",
+			},
+			expected: "v1",
+		},
+		{
+			description: "standard BaseUrl",
+			obj: Product{
+				BaseUrl:    "https://{{location}}-abc.googleapis.com/",
+				CaiBaseUrl: "https://abc.googleapis.com/v1/",
+			},
+			expected: "v1",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+
+			if got, want := tc.obj.ServiceVersion(), tc.expected; got != want {
+				t.Errorf("expected %v to be %v", got, want)
+			}
+		})
+	}
+}

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -492,6 +492,24 @@ func (r Resource) UserParameters() []*Type {
 	})
 }
 
+func (r Resource) ServiceVersion() string {
+	if r.CaiBaseUrl != "" {
+		return extractVersionFromBaseUrl(r.CaiBaseUrl)
+	}
+	return extractVersionFromBaseUrl(r.BaseUrl)
+}
+
+func extractVersionFromBaseUrl(baseUrl string) string {
+	parts := strings.Split(baseUrl, "/")
+	if parts[0][0] == 'v' {
+		return parts[0]
+	}
+	if parts[0] == "" && parts[1][0] == 'v' {
+		return parts[1]
+	}
+	return ""
+}
+
 // Return the user-facing properties in client tools; this ends up meaning
 // both properties and parameters but without any that are excluded due to
 // version mismatches or manual exclusion

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -501,9 +501,11 @@ func (r Resource) ServiceVersion() string {
 
 func extractVersionFromBaseUrl(baseUrl string) string {
 	parts := strings.Split(baseUrl, "/")
-	if parts[0][0] == 'v' {
+	// starts with v...
+	if parts[0] != "" && parts[0][0] == 'v' {
 		return parts[0]
 	}
+	// starts with /v...
 	if parts[0] == "" && parts[1][0] == 'v' {
 		return parts[1]
 	}

--- a/mmv1/api/resource_test.go
+++ b/mmv1/api/resource_test.go
@@ -131,3 +131,70 @@ func TestResourceNotInVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestResourceServiceVersion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		description string
+		obj         Resource
+		expected    string
+	}{
+		{
+			description: "BaseUrl does not start with a version",
+			obj: Resource{
+				BaseUrl: "test",
+			},
+			expected: "",
+		},
+		{
+			description: "BaseUrl starts with / and does not include a version",
+			obj: Resource{
+				BaseUrl: "/test",
+			},
+			expected: "",
+		},
+		{
+			description: "BaseUrl starts with a version",
+			obj: Resource{
+				BaseUrl: "v3/test",
+			},
+			expected: "v3",
+		},
+		{
+			description: "BaseUrl starts with a / followed by version",
+			obj: Resource{
+				BaseUrl: "/v3/test",
+			},
+			expected: "v3",
+		},
+		{
+			description: "CaiBaseUrl does not start with a version",
+			obj: Resource{
+				BaseUrl:    "apis/serving.knative.dev/v1/namespaces/{{project}}/services",
+				CaiBaseUrl: "projects/{{project}}/locations/{{location}}/services",
+			},
+			expected: "",
+		},
+		{
+			description: "CaiBaseUrl starts with a version",
+			obj: Resource{
+				BaseUrl:    "apis/serving.knative.dev/v1/namespaces/{{project}}/services",
+				CaiBaseUrl: "v1/projects/{{project}}/locations/{{location}}/services",
+			},
+			expected: "v1",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+
+			if got, want := tc.obj.ServiceVersion(), tc.expected; got != want {
+				t.Errorf("expected %q to be %q", got, want)
+			}
+		})
+	}
+}

--- a/mmv1/provider/template_data.go
+++ b/mmv1/provider/template_data.go
@@ -86,6 +86,14 @@ func (td *TemplateData) GenerateResourceFile(filePath string, resource api.Resou
 	td.GenerateFile(filePath, templatePath, resource, true, templates...)
 }
 
+func (td *TemplateData) GenerateMetadataFile(filePath string, resource api.Resource) {
+	templatePath := "templates/terraform/metadata.yaml.tmpl"
+	templates := []string{
+		templatePath,
+	}
+	td.GenerateFile(filePath, templatePath, resource, false, templates...)
+}
+
 func (td *TemplateData) GenerateOperationFile(filePath string, resource api.Resource) {
 	templatePath := "templates/terraform/operation.go.tmpl"
 	templates := []string{

--- a/mmv1/provider/terraform.go
+++ b/mmv1/provider/terraform.go
@@ -105,6 +105,8 @@ func (t *Terraform) GenerateObject(object api.Resource, outputFolder, productPat
 			// log.Printf("Generating %s tests", object.Name)
 			t.GenerateResourceTests(object, *templateData, outputFolder)
 			t.GenerateResourceSweeper(object, *templateData, outputFolder)
+			// log.Printf("Generating %s metadata", object.Name)
+			t.GenerateResourceMetadata(object, *templateData, outputFolder)
 		}
 	}
 
@@ -135,6 +137,16 @@ func (t *Terraform) GenerateResource(object api.Resource, templateData TemplateD
 		targetFilePath := path.Join(targetFolder, fmt.Sprintf("%s.html.markdown", t.FullResourceName(object)))
 		templateData.GenerateDocumentationFile(targetFilePath, object)
 	}
+}
+
+func (t *Terraform) GenerateResourceMetadata(object api.Resource, templateData TemplateData, outputFolder string) {
+	productName := t.Product.ApiName
+	targetFolder := path.Join(outputFolder, t.FolderName(), "services", productName)
+	if err := os.MkdirAll(targetFolder, os.ModePerm); err != nil {
+		log.Println(fmt.Errorf("error creating parent directory %v: %v", targetFolder, err))
+	}
+	targetFilePath := path.Join(targetFolder, fmt.Sprintf("resource_%s_generated_meta.yaml", t.FullResourceName(object)))
+	templateData.GenerateMetadataFile(targetFilePath, object)
 }
 
 func (t *Terraform) GenerateResourceTests(object api.Resource, templateData TemplateData, outputFolder string) {

--- a/mmv1/templates/terraform/metadata.yaml.tmpl
+++ b/mmv1/templates/terraform/metadata.yaml.tmpl
@@ -1,5 +1,5 @@
 resource: '{{ $.TerraformName }}'
 generation_type: 'mmv1'
-api_name: '{{ $.ProductMetadata.ServiceName }}'
+api_service_name: '{{ $.ProductMetadata.ServiceName }}'
 api_version: '{{ or $.ProductMetadata.ServiceVersion $.ServiceVersion }}'
 api_resource_type_kind: '{{ or $.ApiResourceTypeKind $.Name }}'

--- a/mmv1/templates/terraform/metadata.yaml.tmpl
+++ b/mmv1/templates/terraform/metadata.yaml.tmpl
@@ -1,0 +1,5 @@
+resource: '{{ $.TerraformName }}'
+generation_type: 'mmv1'
+api_name: '{{ $.ProductMetadata.ServiceName }}'
+api_version: '{{ or $.ProductMetadata.ServiceVersion $.ServiceVersion }}'
+api_resource_type_kind: '{{ or $.ApiResourceTypeKind $.Name }}'


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This adds generator code for producing metadata yaml files, which will contain information about how the TF resource maps to an API resource. These files will be committed directly to the downstream providers.

Some notes:
- `cai_base_url` is known to be a confusing name, but we're keeping it for now to minimize changes
- API versions require parsing the urls, and while they are most often specified on the service `base_url`, there are some resources that specify them on the _resource_ `base_url` (to support multiple versions within the service)

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
provider: added mmv1 metadata files
```
