### PR TITLE
Filestore protocol GA

### DIFF
--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -63,7 +63,6 @@ examples:
       instance_name: 'test-instance'
   - name: 'filestore_instance_protocol'
     primary_resource_id: 'instance'
-    min_version: 'beta'
     vars:
       instance_name: 'test-instance'
   - name: 'filestore_instance_enterprise'
@@ -126,7 +125,6 @@ properties:
       or NFSv4.1, for using NFS version 4.1 as file sharing protocol.
       NFSv4.1 can be used with HIGH_SCALE_SSD, ZONAL, REGIONAL and ENTERPRISE.
       The default is NFSv3.
-    min_version: 'beta'
     immutable: true
     custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.tmpl'
     default_value: "NFS_V3"

--- a/mmv1/templates/terraform/examples/filestore_instance_protocol.tf.tmpl
+++ b/mmv1/templates/terraform/examples/filestore_instance_protocol.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_filestore_instance" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   name     = "{{index $.Vars "instance_name"}}"
   location = "us-central1"
   tier     = "ENTERPRISE"


### PR DESCRIPTION
Since 30th September Filestore Protocol selection is now in GA. This PR allows deployment of a NFS_v4 Filestore instance without using the `google-beta` provider.
https://cloud.google.com/filestore/docs/release-notes#September_30_2024


**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
filestore: Migrated `protocol` property for `google_filestore_instance` from Beta to GA
```
