### PR TITLE
Promoted ServiceAttachment propagatedConnection fields to V1;

### DIFF
--- a/mmv1/products/compute/ServiceAttachment.yaml
+++ b/mmv1/products/compute/ServiceAttachment.yaml
@@ -169,7 +169,6 @@ properties:
           type: Integer
           description: |
             The number of consumer Network Connectivity Center spokes that the connected Private Service Connect endpoint has propagated to.
-          min_version: 'beta'
           output: true
   - name: 'targetService'
     type: String
@@ -266,5 +265,4 @@ properties:
       If the connection preference of the service attachment is ACCEPT_AUTOMATIC, the limit applies to each project that contains a connected endpoint.
 
       If unspecified, the default propagated connection limit is 250.
-    min_version: 'beta'
     default_from_api: true

--- a/mmv1/third_party/terraform/services/compute/resource_compute_service_attachment_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_service_attachment_test.go.tmpl
@@ -50,7 +50,6 @@ func TestAccComputeServiceAttachment_serviceAttachmentBasicExampleUpdate(t *test
 	})
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func TestAccComputeServiceAttachment_serviceAttachmentConnectedEndpointsOutput(t *testing.T) {
 	t.Parallel()
 
@@ -60,7 +59,7 @@ func TestAccComputeServiceAttachment_serviceAttachmentConnectedEndpointsOutput(t
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeServiceAttachmentDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -96,7 +95,6 @@ func TestAccComputeServiceAttachment_serviceAttachmentConnectedEndpointsOutput(t
 		},
 	})
 }
-{{- end }}
 
 func testAccComputeServiceAttachment_serviceAttachmentBasicExampleFork(context map[string]interface{}) string {
 	return acctest.Nprintf(`
@@ -280,7 +278,6 @@ resource "google_compute_subnetwork" "psc_ilb_nat" {
 `, context)
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func testAccComputeServiceAttachment_serviceAttachmentBasicExampleConnectedEndpointsOutput(context map[string]interface{}, preventDestroy bool) string {
 	context["lifecycle_block"] = ""
 	if preventDestroy {
@@ -292,7 +289,6 @@ func testAccComputeServiceAttachment_serviceAttachmentBasicExampleConnectedEndpo
 
 	return acctest.Nprintf(`
 resource "google_compute_service_attachment" "psc_ilb_service_attachment" {
-  provider    = google-beta
   name        = "tf-test-my-psc-ilb%{random_suffix}"
   region      = "us-west2"
   description = "A service attachment configured with Terraforms"
@@ -313,7 +309,6 @@ resource "google_compute_service_attachment" "psc_ilb_service_attachment" {
 }
 
 resource "google_compute_address" "psc_ilb_consumer_address" {
-  provider    = google-beta
   name        = "tf-test-psc-ilb-consumer-address%{random_suffix}"
   region      = "us-west2"
 
@@ -322,7 +317,6 @@ resource "google_compute_address" "psc_ilb_consumer_address" {
 }
 
 resource "google_compute_forwarding_rule" "psc_ilb_consumer" {
-  provider    = google-beta
   name        = "tf-test-psc-ilb-consumer-forwarding-rule%{random_suffix}"
   region      = "us-west2"
 
@@ -333,7 +327,6 @@ resource "google_compute_forwarding_rule" "psc_ilb_consumer" {
 }
 
 resource "google_compute_forwarding_rule" "psc_ilb_target_service" {
-  provider    = google-beta
   name        = "tf-test-producer-forwarding-rule%{random_suffix}"
   region      = "us-west2"
 
@@ -346,7 +339,6 @@ resource "google_compute_forwarding_rule" "psc_ilb_target_service" {
 }
 
 resource "google_compute_region_backend_service" "producer_service_backend" {
-  provider    = google-beta
   name        = "tf-test-producer-service%{random_suffix}"
   region      = "us-west2"
 
@@ -354,7 +346,6 @@ resource "google_compute_region_backend_service" "producer_service_backend" {
 }
 
 resource "google_compute_health_check" "producer_service_health_check" {
-  provider    = google-beta
   name        = "tf-test-producer-service-health-check%{random_suffix}"
 
   check_interval_sec = 1
@@ -365,13 +356,11 @@ resource "google_compute_health_check" "producer_service_health_check" {
 }
 
 resource "google_compute_network" "psc_ilb_network" {
-  provider = google-beta
   name = "tf-test-psc-ilb-network%{random_suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "psc_ilb_producer_subnetwork" {
-  provider    = google-beta
   name        = "tf-test-psc-ilb-producer-subnetwork%{random_suffix}"
   region      = "us-west2"
 
@@ -380,7 +369,6 @@ resource "google_compute_subnetwork" "psc_ilb_producer_subnetwork" {
 }
 
 resource "google_compute_subnetwork" "psc_ilb_nat" {
-  provider    = google-beta
   name        = "tf-test-psc-ilb-nat%{random_suffix}"
   region      = "us-west2"
 
@@ -390,7 +378,6 @@ resource "google_compute_subnetwork" "psc_ilb_nat" {
 }
 `, context)
 }
-{{- end }}
 
 func TestAccComputeServiceAttachment_serviceAttachmentBasicExampleGateway(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Promotes `propagated_connection_limit` and `connected_endpoints.propagated_connection_count` fields from the `compute_service_attachment` resource from Beta to GA. 

beta PR: https://github.com/GoogleCloudPlatform/magic-modules/pull/11625
<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `propagated_connection_limit` and `connected_endpoints.propagated_connection_count` fields to `google_compute_service_attachment` resource (ga)
```
