### PR TITLE
fix an argument in data.google_artifact_registry_docker_image example

### DIFF
--- a/mmv1/third_party/terraform/website/docs/d/artifact_registry_docker_image.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/artifact_registry_docker_image.html.markdown
@@ -23,7 +23,7 @@ resource "google_artifact_registry_repository" "my_repo" {
 data "google_artifact_registry_docker_image" "my_image" {
   location      = google_artifact_registry_repository.my_repo.location
   repository_id = google_artifact_registry_repository.my_repo.repository_id
-  image         = "my-image:my-tag"
+  image_name    = "my-image:my-tag"
 }
 
 resource "google_cloud_run_v2_service" "default" {


### PR DESCRIPTION
```release-note:bug
artifactregistry: fixed an argument in the `google_artifact_registry_docker_image` data source example
```
