### PR TITLE
promote netapp regional flex storage pool and volume to GA

### DIFF
--- a/mmv1/products/netapp/StoragePool.yaml
+++ b/mmv1/products/netapp/StoragePool.yaml
@@ -35,7 +35,6 @@ description: |
  the next apply. You can trigger a manual
  [zone switch](https://cloud.google.com/netapp/volumes/docs/configure-and-use/storage-pools/edit-or-delete-storage-pool#switch_active_and_replica_zones)
  via Terraform by swapping the value of the `zone` and `replica_zone` parameters in your HCL code.
- Note : Regional FLEX storage pool are supported in beta provider currently.
 
 references:
   guides:
@@ -161,13 +160,11 @@ properties:
       Specifies the active zone for regional Flex pools. `zone` and `replica_zone` values can be swapped to initiate a
       [zone switch](https://cloud.google.com/netapp/volumes/docs/configure-and-use/storage-pools/edit-or-delete-storage-pool#switch_active_and_replica_zones).
       If you want to create a zonal Flex pool, specify a zone name for `location` and omit `zone`.
-    min_version: 'beta'
   - name: 'replicaZone'
     type: String
     description: |
       Specifies the replica zone for regional Flex pools. `zone` and `replica_zone` values can be swapped to initiate a
       [zone switch](https://cloud.google.com/netapp/volumes/docs/configure-and-use/storage-pools/edit-or-delete-storage-pool#switch_active_and_replica_zones).
-    min_version: 'beta'
   - name: 'allowAutoTiering'
     type: Boolean
     description: |

--- a/mmv1/products/netapp/Volume.yaml
+++ b/mmv1/products/netapp/Volume.yaml
@@ -480,13 +480,11 @@ properties:
     type: String
     description: |
       Specifies the active zone for regional volume.
-    min_version: 'beta'
     output: true
   - name: 'replicaZone'
     type: String
     description: |
       Specifies the replica zone for regional volume.
-    min_version: 'beta'
     output: true
   - name: 'largeCapacity'
     type: Boolean

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_storage_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_storage_pool_test.go.tmpl
@@ -2,11 +2,8 @@ package netapp_test
 
 import (
 	"testing"
-{{- if ne $.TargetVersionName "ga" }}
 	"time"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-{{- end }}
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 )
@@ -197,7 +194,6 @@ resource "google_netapp_storage_pool" "test_pool" {
 `, context)
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func TestAccNetappStoragePool_FlexRegionalStoragePoolCreateExample_update(t *testing.T) {
 	context := map[string]interface{}{
 		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "gcnv-network-config-1", acctest.ServiceNetworkWithParentService("netapp.servicenetworking.goog")),
@@ -206,7 +202,7 @@ func TestAccNetappStoragePool_FlexRegionalStoragePoolCreateExample_update(t *tes
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckNetappStoragePoolDestroyProducer(t),
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"time": {},
@@ -247,7 +243,6 @@ func TestAccNetappStoragePool_FlexRegionalStoragePoolCreateExample_update(t *tes
 func testAccNetappStoragePool_FlexRegionalStoragePoolCreateExample_full(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_netapp_storage_pool" "test_pool" {
-  provider = google-beta
   name = "tf-test-pool%{random_suffix}"
   location = "us-east1"
   service_level = "FLEX"
@@ -263,7 +258,6 @@ resource "time_sleep" "wait_5_minutes" {
 }
 
 data "google_compute_network" "default" {
-    provider = google-beta
     name = "%{network_name}"
 }
 `, context)
@@ -272,7 +266,6 @@ data "google_compute_network" "default" {
 func testAccNetappStoragePool_FlexRegionalStoragePoolCreateExample_switchZone(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_netapp_storage_pool" "test_pool" {
-  provider = google-beta
   name = "tf-test-pool%{random_suffix}"
   location = "us-east1"
   service_level = "FLEX"
@@ -288,7 +281,6 @@ resource "time_sleep" "wait_5_minutes" {
 }
 
 data "google_compute_network" "default" {
-    provider = google-beta
     name = "%{network_name}"
 }
 `, context)
@@ -305,7 +297,6 @@ func testAccNetappStoragePool_FlexRegionalStoragePoolCreateExample_sleep_5_mins(
 func testAccNetappStoragePool_FlexRegionalStoragePoolCreateExample_switchBackZone(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_netapp_storage_pool" "test_pool" {
-  provider = google-beta
   name = "tf-test-pool%{random_suffix}"
   location = "us-east1"
   service_level = "FLEX"
@@ -321,10 +312,7 @@ resource "time_sleep" "wait_5_minutes" {
 }
 
 data "google_compute_network" "default" {
-    provider = google-beta
     name = "%{network_name}"
 }
 `, context)
 }
-
-{{ end }}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
netapp: promoted `zone` and `replica_zone` fields to GA in `google_netapp_storage_pool` resource
```

```release-note:enhancement
netapp: promoted `zone` and `replica_zone` fields to GA in `google_netapp_volume` resource
```
