### PR TITLE
TeamCity: archive debug logs if there are over 1000 of them

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_per_package.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_per_package.kt
@@ -67,13 +67,12 @@ class PackageDetails(private val packageName: String, private val displayName: S
             }
 
             steps {
-            //    setGitCommitBuildId()
-            //    tagBuildToIndicateTriggerMethod()
-            //    configureGoEnv()
-            //    downloadTerraformBinary()
-            //    runAcceptanceTests()
-            //    saveArtifactsToGCS()
-                makeDebugLogs() // Make build look like lots of tests have run, without needing to actually run tests
+                setGitCommitBuildId()
+                tagBuildToIndicateTriggerMethod()
+                configureGoEnv()
+                downloadTerraformBinary()
+                runAcceptanceTests()
+                saveArtifactsToGCS()
                 archiveArtifactsIfOverLimit() // Must be after push to GCS step, as this step impacts debug log files
             }
 

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_per_package.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_per_package.kt
@@ -7,6 +7,7 @@
 
 package builds
 
+import ArtifactRules
 import DefaultBuildTimeoutDuration
 import DefaultParallelism
 import generated.ServiceParallelism
@@ -96,7 +97,7 @@ class PackageDetails(private val packageName: String, private val displayName: S
                 workingDirectory(path)
             }
 
-            artifactRules = "%teamcity.build.checkoutDir%/debug*.txt"
+            artifactRules = ArtifactRules
 
             failureConditions {
                 errorMessage = true

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_per_package.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_per_package.kt
@@ -67,12 +67,13 @@ class PackageDetails(private val packageName: String, private val displayName: S
             }
 
             steps {
-                setGitCommitBuildId()
-                tagBuildToIndicateTriggerMethod()
-                configureGoEnv()
-                downloadTerraformBinary()
-                runAcceptanceTests()
-                saveArtifactsToGCS()
+            //    setGitCommitBuildId()
+            //    tagBuildToIndicateTriggerMethod()
+            //    configureGoEnv()
+            //    downloadTerraformBinary()
+            //    runAcceptanceTests()
+            //    saveArtifactsToGCS()
+                make1020DebugLogs() // Make build look like lots of tests have run, without needing to actually run tests
                 archiveArtifactsIfOverLimit() // Must be after push to GCS step, as this step impacts debug log files
             }
 

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_per_package.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_per_package.kt
@@ -73,7 +73,7 @@ class PackageDetails(private val packageName: String, private val displayName: S
             //    downloadTerraformBinary()
             //    runAcceptanceTests()
             //    saveArtifactsToGCS()
-                make1020DebugLogs() // Make build look like lots of tests have run, without needing to actually run tests
+                makeDebugLogs() // Make build look like lots of tests have run, without needing to actually run tests
                 archiveArtifactsIfOverLimit() // Must be after push to GCS step, as this step impacts debug log files
             }
 

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_per_package.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_per_package.kt
@@ -73,6 +73,7 @@ class PackageDetails(private val packageName: String, private val displayName: S
                 downloadTerraformBinary()
                 runAcceptanceTests()
                 saveArtifactsToGCS()
+                archiveArtifactsIfOverLimit() // Must be after push to GCS step, as this step impacts debug log files
             }
 
             features {

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_sweepers.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_sweepers.kt
@@ -7,6 +7,7 @@
 
 package builds
 
+import ArtifactRules
 import DefaultBuildTimeoutDuration
 import DefaultParallelism
 import jetbrains.buildServer.configs.kotlin.BuildType
@@ -100,7 +101,7 @@ class SweeperDetails(private val sweeperName: String, private val parentProjectN
                 workingDirectory(path)
             }
 
-            artifactRules = "%teamcity.build.checkoutDir%/debug*.txt"
+            artifactRules = ArtifactRules
 
             failureConditions {
                 errorMessage = true

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_vcr_recording.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_vcr_recording.kt
@@ -7,6 +7,7 @@
 
 package builds
 
+import ArtifactRules
 import DefaultBuildTimeoutDuration
 import DefaultParallelism
 import jetbrains.buildServer.configs.kotlin.BuildType
@@ -75,7 +76,7 @@ class VcrDetails(private val providerName: String, private val buildId: String, 
                 workingDirectory(path)
             }
 
-            artifactRules = "%teamcity.build.checkoutDir%/debug*.txt"
+            artifactRules = ArtifactRules
 
             failureConditions {
                 errorMessage = true

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
@@ -174,3 +174,55 @@ fun BuildSteps.saveArtifactsToGCS() {
         // https://youtrack.jetbrains.com/issue/KT-2425/Provide-a-way-for-escaping-the-dollar-sign-symbol-in-multiline-strings-and-string-templates
     })
 }
+
+// The S3 plugin we use to upload artifacts to S3 (enabling them to be accessed via the TeamCity UI later) has a limit of
+// 1000 artifacts to be uploaded at a time. To avoid a situation where no artifacts are uploaded as a result of exceeding this
+// limit we archive all the debug logs if they exceed 1000 for a given build.
+fun BuildSteps.archiveArtifactsIfOverLimit() {
+    step(ScriptBuildStep {
+        name = "Tasks after running nightly tests: archive artifacts(debug logs) if there are >=1000 before S3 upload"
+        scriptContent = """
+            #!/bin/bash
+            echo "Post-test step - archive artifacts(debug logs) if there are >=1000 before S3 upload"
+
+            # Get number of artifacts created
+            ARTIFACT_COUNT=$(ls %teamcity.build.checkoutDir%/debug* | wc -l | grep -o -E '[0-9]+')
+
+            if test ${'$'}ARTIFACT_COUNT -lt "1000"; then
+                echo "Found <1000 debug artifacts; we won't archive them before upload to S3"
+                exit 0
+            fi
+
+            echo "Found >=1000 debug artifacts; archiving before upload to S3"
+
+            # Make tarball of all debug logs
+            # Name should look similar to: debug-google-d2503f7-253644-TerraformProviders_GoogleCloud_GOOGLE_NIGHTLYTESTS_GOOGLE_PACKAGE_ACCESSAPPROVAL.tar.gz
+            cd %teamcity.build.checkoutDir%
+            ARCHIVE_NAME=debug-%PROVIDER_NAME%-%env.BUILD_NUMBER%-%system.teamcity.buildType.id%-archive.tar.gz
+            tar -cf $ARCHIVE_NAME ./debug*
+
+            # Fail loudly if archive not made as expected
+            if [ ! -f $ARCHIVE_NAME ]; then
+                echo "Archive file $ARCHIVE_NAME not found!"
+
+                # Allow sanity checking
+                echo "Listing contents of %teamcity.build.checkoutDir%"
+                ls
+
+                exit 1
+            fi
+
+            # Remove all debug logs. These are all .txt files due to the effects of TF_LOG_PATH_MASK.
+            rm ./debug*.txt
+
+            # Allow sanity checking
+            echo "Listing files matching the artifact rule value %teamcity.build.checkoutDir%/debug*"
+            ls debug*
+
+            echo "Finished"
+        """.trimIndent()
+        // ${'$'} is required to allow creating a script in TeamCity that contains
+        // parts like ${GIT_HASH_SHORT} without having Kotlin syntax issues. For more info see:
+        // https://youtrack.jetbrains.com/issue/KT-2425/Provide-a-way-for-escaping-the-dollar-sign-symbol-in-multiline-strings-and-string-templates
+    })
+}

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
@@ -226,27 +226,3 @@ fun BuildSteps.archiveArtifactsIfOverLimit() {
         // https://youtrack.jetbrains.com/issue/KT-2425/Provide-a-way-for-escaping-the-dollar-sign-symbol-in-multiline-strings-and-string-templates
     })
 }
-
-// Part of testing my PR - not to be merged!
-fun BuildSteps.makeDebugLogs() {
-    step(ScriptBuildStep {
-        name = "Tasks after running nightly tests: archive artifacts(debug logs) if there are >=1000 before S3 upload"
-        scriptContent = """
-            #!/bin/bash
-            echo "Making a build look like it's run >1000 tests and created >1000 debug logs"
-
-            // Folder where debug logs are made
-            cd %teamcity.build.checkoutDir%
-
-            // >1000 files that match the %teamcity.build.checkoutDir%/debug* pattern
-            touch debug-{0..10}}.txt
-
-            # Allow sanity checking
-            echo "Listing files matching the artifact rule value %teamcity.build.checkoutDir%/debug*"
-            ls debug*
-        """.trimIndent()
-        // ${'$'} is required to allow creating a script in TeamCity that contains
-        // parts like ${GIT_HASH_SHORT} without having Kotlin syntax issues. For more info see:
-        // https://youtrack.jetbrains.com/issue/KT-2425/Provide-a-way-for-escaping-the-dollar-sign-symbol-in-multiline-strings-and-string-templates
-    })
-}

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
@@ -199,11 +199,11 @@ fun BuildSteps.archiveArtifactsIfOverLimit() {
             # Name should look similar to: debug-google-d2503f7-253644-TerraformProviders_GoogleCloud_GOOGLE_NIGHTLYTESTS_GOOGLE_PACKAGE_ACCESSAPPROVAL.tar.gz
             cd %teamcity.build.checkoutDir%
             ARCHIVE_NAME=debug-%PROVIDER_NAME%-%env.BUILD_NUMBER%-%system.teamcity.buildType.id%-archive.tar.gz
-            tar -cf $ARCHIVE_NAME ./debug*
+            tar -cf ${'$'}ARCHIVE_NAME ./debug*
 
             # Fail loudly if archive not made as expected
-            if [ ! -f $ARCHIVE_NAME ]; then
-                echo "Archive file $ARCHIVE_NAME not found!"
+            if [ ! -f ${'$'}ARCHIVE_NAME ]; then
+                echo "Archive file ${'$'}ARCHIVE_NAME not found!"
 
                 # Allow sanity checking
                 echo "Listing contents of %teamcity.build.checkoutDir%"

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
@@ -137,7 +137,7 @@ fun BuildSteps.saveArtifactsToGCS() {
         name = "Tasks after running nightly tests: push artifacts(debug logs) to GCS"
         scriptContent = """
             #!/bin/bash
-            echo "Post-test step - storge artifacts(debug logs) to GCS"
+            echo "Post-test step - storage artifacts(debug logs) to GCS"
 
             # Authenticate gcloud CLI
             echo "${'$'}{GOOGLE_CREDENTIALS_GCS}" > google-account.json

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
@@ -228,7 +228,7 @@ fun BuildSteps.archiveArtifactsIfOverLimit() {
 }
 
 // Part of testing my PR - not to be merged!
-fun BuildSteps.make1020DebugLogs() {
+fun BuildSteps.makeDebugLogs() {
     step(ScriptBuildStep {
         name = "Tasks after running nightly tests: archive artifacts(debug logs) if there are >=1000 before S3 upload"
         scriptContent = """
@@ -239,7 +239,7 @@ fun BuildSteps.make1020DebugLogs() {
             cd %teamcity.build.checkoutDir%
 
             // >1000 files that match the %teamcity.build.checkoutDir%/debug* pattern
-            touch debug-{0..1050}}.txt
+            touch debug-{0..10}}.txt
 
             # Allow sanity checking
             echo "Listing files matching the artifact rule value %teamcity.build.checkoutDir%/debug*"

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
@@ -226,3 +226,27 @@ fun BuildSteps.archiveArtifactsIfOverLimit() {
         // https://youtrack.jetbrains.com/issue/KT-2425/Provide-a-way-for-escaping-the-dollar-sign-symbol-in-multiline-strings-and-string-templates
     })
 }
+
+// Part of testing my PR - not to be merged!
+fun BuildSteps.make1020DebugLogs() {
+    step(ScriptBuildStep {
+        name = "Tasks after running nightly tests: archive artifacts(debug logs) if there are >=1000 before S3 upload"
+        scriptContent = """
+            #!/bin/bash
+            echo "Making a build look like it's run >1000 tests and created >1000 debug logs"
+
+            // Folder where debug logs are made
+            cd %teamcity.build.checkoutDir%
+
+            // >1000 files that match the %teamcity.build.checkoutDir%/debug* pattern
+            touch debug-{0..1050}}.txt
+
+            # Allow sanity checking
+            echo "Listing files matching the artifact rule value %teamcity.build.checkoutDir%/debug*"
+            ls debug*
+        """.trimIndent()
+        // ${'$'} is required to allow creating a script in TeamCity that contains
+        // parts like ${GIT_HASH_SHORT} without having Kotlin syntax issues. For more info see:
+        // https://youtrack.jetbrains.com/issue/KT-2425/Provide-a-way-for-escaping-the-dollar-sign-symbol-in-multiline-strings-and-string-templates
+    })
+}

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_steps.kt
@@ -177,7 +177,7 @@ fun BuildSteps.saveArtifactsToGCS() {
 
 // The S3 plugin we use to upload artifacts to S3 (enabling them to be accessed via the TeamCity UI later) has a limit of
 // 1000 artifacts to be uploaded at a time. To avoid a situation where no artifacts are uploaded as a result of exceeding this
-// limit we archive all the debug logs if they exceed 1000 for a given build.
+// limit we archive all the debug logs if they equal or exceed 1000 for a given build.
 fun BuildSteps.archiveArtifactsIfOverLimit() {
     step(ScriptBuildStep {
         name = "Tasks after running nightly tests: archive artifacts(debug logs) if there are >=1000 before S3 upload"

--- a/mmv1/third_party/terraform/.teamcity/components/constants.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/constants.kt
@@ -46,4 +46,5 @@ const val VcrRecordingProjectId = "VCRRecording"
 
 // Artifact rules controls which artifacts are uploaded to S3
 // https://www.jetbrains.com/help/teamcity/2024.07/configuring-general-settings.html#Artifact+Paths
-const val ArtifactRules = "%teamcity.build.checkoutDir%/debug*.txt"
+// The value below lacks a file extension, to allow upload of individual .txt files or a single .tar.gz file
+const val ArtifactRules = "%teamcity.build.checkoutDir%/debug*"

--- a/mmv1/third_party/terraform/.teamcity/components/constants.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/constants.kt
@@ -43,3 +43,7 @@ const val ProjectSweeperName = "Project Sweeper"
 const val NightlyTestsProjectId = "NightlyTests"
 const val MMUpstreamProjectId = "MMUpstreamTests"
 const val VcrRecordingProjectId = "VCRRecording"
+
+// Artifact rules controls which artifacts are uploaded to S3
+// https://www.jetbrains.com/help/teamcity/2024.07/configuring-general-settings.html#Artifact+Paths
+const val ArtifactRules = "%teamcity.build.checkoutDir%/debug*.txt"

--- a/mmv1/third_party/terraform/.teamcity/tests/build_configuration_features.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/build_configuration_features.kt
@@ -51,34 +51,34 @@ class BuildConfigurationFeatureTests {
         }
     }
 
-//    @Test
-//    fun nonVCRBuildShouldHaveSaveArtifactsToGCS() {
-//        val root = googleCloudRootProject(testContextParameters())
-//
-//        // Find GA nightly test project
-//        var gaNightlyTestProject = getNestedProjectFromRoot(root, gaProjectName, nightlyTestsProjectName)
-//
-//        // Find GA MM Upstream project
-//        var gaMMUpstreamProject = getNestedProjectFromRoot(root, gaProjectName, mmUpstreamProjectName)
-//
-//        // Find Beta nightly test project
-//        var betaNightlyTestProject = getNestedProjectFromRoot(root, betaProjectName, nightlyTestsProjectName)
-//
-//        // Find Beta MM Upstream project
-//        var betaMMUpstreamProject = getNestedProjectFromRoot(root, betaProjectName, mmUpstreamProjectName)
-//
-//        (gaNightlyTestProject.buildTypes + gaMMUpstreamProject.buildTypes + betaNightlyTestProject.buildTypes + betaMMUpstreamProject.buildTypes).forEach{bt ->
-//            var found: Boolean = false
-//            for (item in bt.steps.items) {
-//                if (item.name == "Tasks after running nightly tests: push artifacts(debug logs) to GCS") {
-//                    found = true
-//                    break
-//                }
-//            }
-//            // service sweeper does not contain push artifacts to GCS step
-//            if (!bt.name.startsWith(ServiceSweeperName)) {
-//                assertTrue("Build configuration `${bt.name}` contains a build step that pushes artifacts to GCS", found)
-//            }
-//        }
-//    }
+    @Test
+    fun nonVCRBuildShouldHaveSaveArtifactsToGCS() {
+        val root = googleCloudRootProject(testContextParameters())
+
+        // Find GA nightly test project
+        var gaNightlyTestProject = getNestedProjectFromRoot(root, gaProjectName, nightlyTestsProjectName)
+
+        // Find GA MM Upstream project
+        var gaMMUpstreamProject = getNestedProjectFromRoot(root, gaProjectName, mmUpstreamProjectName)
+
+        // Find Beta nightly test project
+        var betaNightlyTestProject = getNestedProjectFromRoot(root, betaProjectName, nightlyTestsProjectName)
+
+        // Find Beta MM Upstream project
+        var betaMMUpstreamProject = getNestedProjectFromRoot(root, betaProjectName, mmUpstreamProjectName)
+
+        (gaNightlyTestProject.buildTypes + gaMMUpstreamProject.buildTypes + betaNightlyTestProject.buildTypes + betaMMUpstreamProject.buildTypes).forEach{bt ->
+            var found: Boolean = false
+            for (item in bt.steps.items) {
+                if (item.name == "Tasks after running nightly tests: push artifacts(debug logs) to GCS") {
+                    found = true
+                    break
+                }
+            }
+            // service sweeper does not contain push artifacts to GCS step
+            if (!bt.name.startsWith(ServiceSweeperName)) {
+                assertTrue("Build configuration `${bt.name}` contains a build step that pushes artifacts to GCS", found)
+            }
+        }
+    }
 }

--- a/mmv1/third_party/terraform/.teamcity/tests/build_configuration_features.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/build_configuration_features.kt
@@ -51,34 +51,34 @@ class BuildConfigurationFeatureTests {
         }
     }
 
-    @Test
-    fun nonVCRBuildShouldHaveSaveArtifactsToGCS() {
-        val root = googleCloudRootProject(testContextParameters())
-
-        // Find GA nightly test project
-        var gaNightlyTestProject = getNestedProjectFromRoot(root, gaProjectName, nightlyTestsProjectName)
-
-        // Find GA MM Upstream project
-        var gaMMUpstreamProject = getNestedProjectFromRoot(root, gaProjectName, mmUpstreamProjectName)
-
-        // Find Beta nightly test project
-        var betaNightlyTestProject = getNestedProjectFromRoot(root, betaProjectName, nightlyTestsProjectName)
-
-        // Find Beta MM Upstream project
-        var betaMMUpstreamProject = getNestedProjectFromRoot(root, betaProjectName, mmUpstreamProjectName)
-
-        (gaNightlyTestProject.buildTypes + gaMMUpstreamProject.buildTypes + betaNightlyTestProject.buildTypes + betaMMUpstreamProject.buildTypes).forEach{bt ->
-            var found: Boolean = false
-            for (item in bt.steps.items) {
-                if (item.name == "Tasks after running nightly tests: push artifacts(debug logs) to GCS") {
-                    found = true
-                    break
-                }
-            }
-            // service sweeper does not contain push artifacts to GCS step
-            if (!bt.name.startsWith(ServiceSweeperName)) {
-                assertTrue("Build configuration `${bt.name}` contains a build step that pushes artifacts to GCS", found)
-            }
-        }
-    }
+//    @Test
+//    fun nonVCRBuildShouldHaveSaveArtifactsToGCS() {
+//        val root = googleCloudRootProject(testContextParameters())
+//
+//        // Find GA nightly test project
+//        var gaNightlyTestProject = getNestedProjectFromRoot(root, gaProjectName, nightlyTestsProjectName)
+//
+//        // Find GA MM Upstream project
+//        var gaMMUpstreamProject = getNestedProjectFromRoot(root, gaProjectName, mmUpstreamProjectName)
+//
+//        // Find Beta nightly test project
+//        var betaNightlyTestProject = getNestedProjectFromRoot(root, betaProjectName, nightlyTestsProjectName)
+//
+//        // Find Beta MM Upstream project
+//        var betaMMUpstreamProject = getNestedProjectFromRoot(root, betaProjectName, mmUpstreamProjectName)
+//
+//        (gaNightlyTestProject.buildTypes + gaMMUpstreamProject.buildTypes + betaNightlyTestProject.buildTypes + betaMMUpstreamProject.buildTypes).forEach{bt ->
+//            var found: Boolean = false
+//            for (item in bt.steps.items) {
+//                if (item.name == "Tasks after running nightly tests: push artifacts(debug logs) to GCS") {
+//                    found = true
+//                    break
+//                }
+//            }
+//            // service sweeper does not contain push artifacts to GCS step
+//            if (!bt.name.startsWith(ServiceSweeperName)) {
+//                assertTrue("Build configuration `${bt.name}` contains a build step that pushes artifacts to GCS", found)
+//            }
+//        }
+//    }
 }


### PR DESCRIPTION
# Description

This PR addresses issues like in [this build](https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_GoogleCloud_GOOGLE_BETA_NIGHTLYTESTS_GOOGLEBETA_PACKAGE_COMPUTE/247615?buildTab=artifacts):

<img width="677" alt="Screenshot 2024-10-23 at 10 31 02" src="https://github.com/user-attachments/assets/377c9bc6-c673-4d61-bcb7-862003bb76b2">

The plugin used for uploading artifacts to S3 has a limit of 1000 artifacts per build. After contacting JetBrains support they suggested archiving files as a solution. The downside to this is that this would make it harder to open specific artifacts in your web browser, instead you'd need to download the entire zip/tar file, open it and then find the logs file you want.

The compromise discussed in the team chat was to archive logs only if a build exceeds the limit. This PR introduces that behaviour.

# Testing

I used this PR to create a test project in TeamCity for manual testing of the bash in the new build step. This PR has some commits from when I forced builds to create >1000 or <1000 debug*.txt files and then see how the new build step reacted.

## When there are >=1000 artifacts present

This commit https://github.com/GoogleCloudPlatform/magic-modules/pull/12083/commits/7b966a7e90c1cd48272c734931c694d21d6e5688 shows how I forced builds to look like they had >1000 debug logs.

[Here's a build in TeamCity showing the outcome](https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_SarahTesting1000artifactFix_GOOGLE_NIGHTLYTESTS_GOOGLE_PACKAGE_ACCESSAPPROVAL/253671?buildTab=log&focusLine=0&logView=flowAware&linesState=1596):

In step 1 >1000 debug files are made

<img width="1043" alt="Screenshot 2024-10-23 at 10 59 22" src="https://github.com/user-attachments/assets/00876dd0-7719-47ad-8ce8-e364b7ded5f0">


In step 2

```
21:33:51 Step 2/2: Tasks after running nightly tests: archive artifacts(debug logs) if there are >=1000 before S3 upload (Command Line)
21:33:51   Starting: /opt/teamcity-agent/temp/agentTmp/custom_script8203854418285142512
21:33:51   in directory: /opt/teamcity-agent/work/d9c38c33567f381b
21:33:51   Post-test step - archive artifacts(debug logs) if there are >=1000 before S3 upload
21:33:51   Found >=1000 debug artifacts; archiving before upload to S3
21:33:51   Listing files matching the artifact rule value /opt/teamcity-agent/work/d9c38c33567f381b/debug*
21:33:51   debug-google-1-TerraformProviders_SarahTesting1000artifactFix_GOOGLE_NIGHTLYTESTS_GOOGLE_PACKAGE_ACCESSAPPROVAL-archive.tar.gz
21:33:51   Finished
21:33:51   Process exited with code 0
```

The result is [the artifacts tab contains only that .tar.gz file](https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_SarahTesting1000artifactFix_GOOGLE_NIGHTLYTESTS_GOOGLE_PACKAGE_ACCESSAPPROVAL/253671?buildTab=artifacts&focusLine=NaN):

<img width="1096" alt="Screenshot 2024-10-23 at 11 00 48" src="https://github.com/user-attachments/assets/45772fa0-a566-4382-a36a-24f05dc10471">

## When there are <1000 artifacts present

[This build shows the opposite scenario](https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_SarahTesting1000artifactFix_GOOGLE_NIGHTLYTESTS_GOOGLE_PACKAGE_ACCESSAPPROVAL/253676?buildTab=log&focusLine=0&logView=flowAware), where I made the builds instead create only 10 debug files (https://github.com/GoogleCloudPlatform/magic-modules/pull/12083/commits/bfbca51ac54177b6bba1114a8926ae035b3ed3b2)

Step 2 now looks like this:

```
22:10:50 Step 2/2: Tasks after running nightly tests: archive artifacts(debug logs) if there are >=1000 before S3 upload (Command Line)
22:10:50   Starting: /opt/teamcity-agent/temp/agentTmp/custom_script15021977902611658096
22:10:50   in directory: /opt/teamcity-agent/work/d9c38c33567f381b
22:10:50   Post-test step - archive artifacts(debug logs) if there are >=1000 before S3 upload
22:10:50   Found <1000 debug artifacts; we won't archive them before upload to S3
22:10:50 
```

And [the artifacts tab shows](https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_SarahTesting1000artifactFix_GOOGLE_NIGHTLYTESTS_GOOGLE_PACKAGE_ACCESSAPPROVAL/253676?buildTab=artifacts&focusLine=NaN) the 10 files unchanged:

<img width="611" alt="Screenshot 2024-10-23 at 11 04 14" src="https://github.com/user-attachments/assets/482f9fde-e8be-4723-8e86-62749e6d16a6">


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
