### PR TITLE
fixed failing test TestAccSecurityCenterV2OrganizationBigQueryExport

### DIFF
--- a/mmv1/third_party/terraform/services/securitycenterv2/resource_scc_v2_organization_big_query_export_config_test.go
+++ b/mmv1/third_party/terraform/services/securitycenterv2/resource_scc_v2_organization_big_query_export_config_test.go
@@ -65,6 +65,7 @@ resource "google_bigquery_dataset" "default" {
   location                    = "US"
   default_table_expiration_ms = 3600000
   default_partition_expiration_ms = null
+  delete_contents_on_destroy  = true
 
   labels = {
     env = "default"
@@ -77,7 +78,7 @@ resource "google_bigquery_dataset" "default" {
 
 resource "time_sleep" "wait_1_minute" {
 	depends_on = [google_bigquery_dataset.default]
-	create_duration = "3m"
+	create_duration = "6m"
 }
 
 resource "google_scc_v2_organization_scc_big_query_export" "default" {
@@ -109,6 +110,7 @@ resource "google_bigquery_dataset" "default" {
   location                    = "US"
   default_table_expiration_ms = 3600000
   default_partition_expiration_ms = null
+  delete_contents_on_destroy  = true
 
   labels = {
     env = "default"

--- a/mmv1/third_party/terraform/services/securitycenterv2/resource_scc_v2_organization_big_query_exports_config_test.go
+++ b/mmv1/third_party/terraform/services/securitycenterv2/resource_scc_v2_organization_big_query_exports_config_test.go
@@ -65,6 +65,7 @@ resource "google_bigquery_dataset" "default" {
   location                    = "US"
   default_table_expiration_ms = 3600000
   default_partition_expiration_ms = null
+  delete_contents_on_destroy  = true
 
   labels = {
     env = "default"
@@ -77,7 +78,7 @@ resource "google_bigquery_dataset" "default" {
 
 resource "time_sleep" "wait_1_minute" {
 	depends_on = [google_bigquery_dataset.default]
-	create_duration = "3m"
+	create_duration = "6m"
 }
 
 resource "google_scc_v2_organization_scc_big_query_exports" "default" {
@@ -109,6 +110,7 @@ resource "google_bigquery_dataset" "default" {
   location                    = "US"
   default_table_expiration_ms = 3600000
   default_partition_expiration_ms = null
+  delete_contents_on_destroy  = true
 
   labels = {
     env = "default"


### PR DESCRIPTION
This PR aims to fix the V2 Org BQ Export Config failing test issue, raised in #[19308](https://github.com/hashicorp/terraform-provider-google/issues/19308) 
Bug link: [371061287](https://buganizer.corp.google.com/issues/371061287)
 
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
securitycenterv2: fixed flaky test TestAccSecurityCenterV2OrganizationBigQueryExportConfig_basic
```
