### PR TITLE
Remove bad timeouts from GKE tests

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -9470,11 +9470,6 @@ resource "google_container_cluster" "with_autopilot" {
   datapath_provider = "ADVANCED_DATAPATH"
 
   deletion_protection = false
-
-  timeouts {
-    create = "30m"
-    update = "40m"
-  }
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -9534,11 +9529,6 @@ resource "google_container_cluster" "with_autopilot" {
   enable_cilium_clusterwide_network_policy = true
 
   deletion_protection = false
-
-  timeouts {
-    create = "30m"
-    update = "40m"
-  }
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -10823,11 +10813,6 @@ resource "google_container_cluster" "primary" {
   network    = "%[4]s"
   subnetwork    = "%[5]s"
 
-  timeouts {
-    create = "30m"
-    update = "40m"
-  }
-
   depends_on = [time_sleep.wait_120_seconds]
 }
 `, projectID, randomSuffix, clusterName, networkName, subnetworkName)
@@ -10964,11 +10949,6 @@ resource "google_container_cluster" "with_autopilot" {
   }
   vertical_pod_autoscaling {
     enabled = true
-  }
-
-  timeouts {
-	create = "30m"
-	update = "40m"
   }
 
   depends_on = [time_sleep.wait_120_seconds]
@@ -11110,11 +11090,6 @@ resource "google_container_cluster" "with_autopilot" {
     enabled = true
   }
 
-  timeouts {
-	create = "30m"
-	update = "40m"
-  }
-
   depends_on = [time_sleep.wait_120_seconds]
 }
 `, projectID, randomSuffix, clusterName, networkName, subnetworkName)
@@ -11245,11 +11220,6 @@ resource "google_container_cluster" "with_autopilot" {
   }
   vertical_pod_autoscaling {
     enabled = true
-  }
-
-  timeouts {
-	create = "30m"
-	update = "40m"
   }
 
   depends_on = [time_sleep.wait_120_seconds]


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Our default times are 40m for create and 60m for update. Some tests made them... marginally lower? It's unclear why, I'm removing them as it's not interesting to test and is resulting in failures:

```
=== RUN   TestAccContainerCluster_enableCiliumPolicies_withAutopilot
=== PAUSE TestAccContainerCluster_enableCiliumPolicies_withAutopilot
=== CONT  TestAccContainerCluster_enableCiliumPolicies_withAutopilot
    resource_container_cluster_test.go:4599: Step 3/4 error: Error running apply: exit status 1
        Error: Error waiting for updating cilium clusterwide network policy: timeout while waiting for state to become 'DONE' (last state: 'RUNNING', timeout: 40m0s)
          with google_container_cluster.with_autopilot,
          on terraform_plugin_test.tf line 25, in resource "google_container_cluster" "with_autopilot":
          25: resource "google_container_cluster" "with_autopilot" {
--- FAIL: TestAccContainerCluster_enableCiliumPolicies_withAutopilot (3491.96s)
FAIL
```

Normally I bump defaults on these timeouts- we want to catch lost operations or similar without polling forever, but don't want users to ever hit them in practical cases- but 40 -> 60 is already the step I'd take.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
