### PR TITLE
Remove stale GKE 1.27 version references

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -8667,7 +8667,6 @@ resource "google_container_cluster" "with_pco_disabled" {
     network    = google_compute_network.container_network.name
     subnetwork = google_compute_subnetwork.container_subnetwork.name
 
-    min_master_version = "1.27"
     initial_node_count = 1
     datapath_provider = "ADVANCED_DATAPATH"
 
@@ -10299,12 +10298,14 @@ func testAccContainerCluster_autopilot_net_admin(name, networkName, subnetworkNa
 resource "google_container_cluster" "primary" {
   name             = "%s"
   location         = "us-central1"
+
+  network          = "%s"
+  subnetwork       = "%s"
+
   enable_autopilot = true
   allow_net_admin  = %t
-  min_master_version = 1.27
+
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
 }
 `, name, enabled, networkName, subnetworkName)
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -10307,7 +10307,7 @@ resource "google_container_cluster" "primary" {
 
   deletion_protection = false
 }
-`, name, enabled, networkName, subnetworkName)
+`, name, networkName, subnetworkName, enabled)
 }
 
 

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -838,7 +838,6 @@ resource "google_compute_subnetwork" "container_subnetwork" {
 resource "google_container_cluster" "cluster" {
   name               = "%s"
   location           = "us-central1-a"
-  min_master_version = "1.27"
   initial_node_count = 1
 
   network    = google_compute_network.container_network.name
@@ -2561,10 +2560,11 @@ resource "google_container_cluster" "cluster" {
   name               = "%s"
   location           = "us-central1"
   initial_node_count = 3
-  min_master_version = "1.27"
-  deletion_protection = false
-  network    = "%s"
+
+  network       = "%s"
   subnetwork    = "%s"
+
+  deletion_protection = false
 }
 
 resource "google_container_node_pool" "np" {
@@ -2587,10 +2587,11 @@ resource "google_container_cluster" "cluster" {
   name               = "%s"
   location           = "us-central1"
   initial_node_count = 3
-  min_master_version = "1.27"
-  deletion_protection = false
-  network    = "%s"
+
+  network       = "%s"
   subnetwork    = "%s"
+
+  deletion_protection = false
 }
 
 resource "google_container_node_pool" "np" {
@@ -2618,11 +2619,12 @@ resource "google_container_cluster" "cluster" {
   provider           = google.user-project-override
   name               = "%s"
   location           = "us-central1"
-  initial_node_count = 3
-  min_master_version = "1.27"
-  deletion_protection = false
-  network    = "%s"
+
+  network       = "%s"
   subnetwork    = "%s"
+
+  initial_node_count = 3
+  deletion_protection = false
 }
 
 resource "google_container_node_pool" "np" {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Addresses test failures that include `Error: googleapi: Error 400: No valid versions with the prefix "1.27" found.`

I've assumed that all of these can just have their versions stripped. If they fail for new reasons I am not going to fix them here- I'd prefer we fail for the real reason in the nightly.

Also rearrange some fields I didn't like, where `network`/`subnetwork` were after `deletion_protection`.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
