### PR TITLE
container: re-enable LB step in `TestAccContainerCluster_withAddons`

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -173,9 +173,9 @@ func TestAccContainerCluster_withAddons(t *testing.T) {
 	pid := envvar.GetTestProjectFromEnv()
 
 	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccContainerCluster_withAddons(pid, clusterName, networkName, subnetworkName),
@@ -184,7 +184,6 @@ func TestAccContainerCluster_withAddons(t *testing.T) {
 				ResourceName:            "google_container_cluster.primary",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				// TODO: clean up this list in `4.0.0`, remove both `workload_identity_config` fields (same for below)
 				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
 			},
 			{
@@ -196,16 +195,15 @@ func TestAccContainerCluster_withAddons(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
 			},
-			// Issue with cloudrun_config addon: https://github.com/hashicorp/terraform-provider-google/issues/11943
-			// {
-			// 	Config: testAccContainerCluster_withInternalLoadBalancer(pid, clusterName, networkName, subnetworkName),
-			// },
-			// {
-			// 	ResourceName:            "google_container_cluster.primary",
-			// 	ImportState:             true,
-			// 	ImportStateVerify:       true,
-			// 	ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
-			// },
+			{
+				Config: testAccContainerCluster_withInternalLoadBalancer(pid, clusterName, networkName, subnetworkName),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
+			},
 		},
 	})
 }
@@ -5605,12 +5603,12 @@ resource "google_container_cluster" "primary" {
     gce_persistent_disk_csi_driver_config {
       enabled = false
     }
-	gke_backup_agent_config {
-	  enabled = false
-	}
-	config_connector_config {
-	  enabled = false
-	}
+    gke_backup_agent_config {
+      enabled = false
+    }
+    config_connector_config {
+      enabled = false
+    }
     gcs_fuse_csi_driver_config {
       enabled = false
     }
@@ -5630,9 +5628,10 @@ resource "google_container_cluster" "primary" {
     }
 {{- end }}
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, projectID, clusterName, networkName, subnetworkName)
 }
@@ -5678,12 +5677,12 @@ resource "google_container_cluster" "primary" {
     gce_persistent_disk_csi_driver_config {
       enabled = true
     }
-  gke_backup_agent_config {
-    enabled = true
-  }
-  config_connector_config {
-    enabled = true
-  }
+    gke_backup_agent_config {
+      enabled = true
+    }
+    config_connector_config {
+      enabled = true
+    }
     gcs_fuse_csi_driver_config {
       enabled = true
     }
@@ -5709,52 +5708,53 @@ resource "google_container_cluster" "primary" {
     }
 {{- end }}
 	}
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, projectID, clusterName, networkName, subnetworkName)
 }
 
-// Issue with cloudrun_config addon: https://github.com/hashicorp/terraform-provider-google/issues/11943/
-// func testAccContainerCluster_withInternalLoadBalancer(projectID string, clusterName, networkName, subnetworkName string) string {
-// 	return fmt.Sprintf(`
-// data "google_project" "project" {
-//   project_id = "%s"
-// }
+func testAccContainerCluster_withInternalLoadBalancer(projectID string, clusterName, networkName, subnetworkName string) string {
+ 	return fmt.Sprintf(`
+data "google_project" "project" {
+  project_id = "%s"
+}
 
-// resource "google_container_cluster" "primary" {
-//   name               = "%s"
-//   location           = "us-central1-a"
-//   initial_node_count = 1
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
 
-//   min_master_version = "latest"
+  min_master_version = "latest"
 
-//   workload_identity_config {
-//     workload_pool = "${data.google_project.project.project_id}.svc.id.goog"
-//   }
+  workload_identity_config {
+    workload_pool = "${data.google_project.project.project_id}.svc.id.goog"
+  }
 
-//   addons_config {
-//     http_load_balancing {
-//       disabled = false
-//     }
-//     horizontal_pod_autoscaling {
-//       disabled = false
-//     }
-//     network_policy_config {
-//       disabled = false
-//     }
-//     cloudrun_config {
-// 	  disabled = false
-// 	  load_balancer_type = "LOAD_BALANCER_TYPE_INTERNAL"
-//     }
-//   }
-//   deletion_protection = false
-//   network    = "%s"
-//   subnetwork    = "%s"
-// }
-// `, projectID, clusterName, networkName, subnetworkName)
-// }
+  addons_config {
+    http_load_balancing {
+      disabled = false
+    }
+    horizontal_pod_autoscaling {
+      disabled = false
+    }
+    network_policy_config {
+      disabled = false
+    }
+    cloudrun_config {
+      disabled = false
+      load_balancer_type = "LOAD_BALANCER_TYPE_INTERNAL"
+    }
+  }
+  network    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
+}
+`, projectID, clusterName, networkName, subnetworkName)
+}
 
 func testAccContainerCluster_withNotificationConfig(clusterName, topic, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
- Re-enable `testAccContainerCluster_withInternalLoadBalancer` update step in `TestAccContainerCluster_withAddons` (appears to work, and [linked issue](https://github.com/hashicorp/terraform-provider-google/issues/11943) is closed). Looks like #6189 is where it was disabled.
- Add back cloudrun addon
- Remove comment about `workload_identity_config` cleanup (for 4.0.0) in `TestAccContainerCluster_withAddons` - it appears to still be needed in 6.x, unless I'm misunderstanding what it was referring to.

This originally contained many  formatting adjustments too (in 0f1a926a85a2af171b6a5b517008a30237289ea4), but I think it'll be better to do this on its own.

Essentially a revert of #6189

**Release Note Template for Downstream PRs (will be copied)**
See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
