### PR TITLE
Fix null deletion_protection values in gkebackup examples

### DIFF
--- a/mmv1/products/gkebackup/RestorePlan.yaml
+++ b/mmv1/products/gkebackup/RestorePlan.yaml
@@ -59,9 +59,9 @@ examples:
       name: 'restore-all-ns'
       network_name: 'default'
       subnetwork_name: 'default'
+      deletion_protection: 'true'
     test_env_vars:
       project: 'PROJECT_NAME'
-      deletion_protection: 'true'
     test_vars_overrides:
       'deletion_protection': 'false'
       'network_name': 'acctest.BootstrapSharedTestNetwork(t, "gke-cluster")'
@@ -74,9 +74,9 @@ examples:
       name: 'rollback-ns'
       network_name: 'default'
       subnetwork_name: 'default'
+      deletion_protection: 'true'
     test_env_vars:
       project: 'PROJECT_NAME'
-      deletion_protection: 'true'
     test_vars_overrides:
       'deletion_protection': 'false'
       'network_name': 'acctest.BootstrapSharedTestNetwork(t, "gke-cluster")'
@@ -89,9 +89,9 @@ examples:
       name: 'rollback-app'
       network_name: 'default'
       subnetwork_name: 'default'
+      deletion_protection: 'true'
     test_env_vars:
       project: 'PROJECT_NAME'
-      deletion_protection: 'true'
     test_vars_overrides:
       'deletion_protection': 'false'
       'network_name': 'acctest.BootstrapSharedTestNetwork(t, "gke-cluster")'
@@ -104,9 +104,9 @@ examples:
       name: 'all-groupkinds'
       network_name: 'default'
       subnetwork_name: 'default'
+      deletion_protection: 'true'
     test_env_vars:
       project: 'PROJECT_NAME'
-      deletion_protection: 'true'
     test_vars_overrides:
       'deletion_protection': 'false'
       'network_name': 'acctest.BootstrapSharedTestNetwork(t, "gke-cluster")'
@@ -119,9 +119,9 @@ examples:
       name: 'rename-ns'
       network_name: 'default'
       subnetwork_name: 'default'
+      deletion_protection: 'true'
     test_env_vars:
       project: 'PROJECT_NAME'
-      deletion_protection: 'true'
     test_vars_overrides:
       'deletion_protection': 'false'
       'network_name': 'acctest.BootstrapSharedTestNetwork(t, "gke-cluster")'
@@ -134,9 +134,9 @@ examples:
       name: 'transform-rule'
       network_name: 'default'
       subnetwork_name: 'default'
+      deletion_protection: 'true'
     test_env_vars:
       project: 'PROJECT_NAME'
-      deletion_protection: 'true'
     test_vars_overrides:
       'deletion_protection': 'false'
       'network_name': 'acctest.BootstrapSharedTestNetwork(t, "gke-cluster")'
@@ -149,9 +149,9 @@ examples:
       name: 'gitops-mode'
       network_name: 'default'
       subnetwork_name: 'default'
+      deletion_protection: 'true'
     test_env_vars:
       project: 'PROJECT_NAME'
-      deletion_protection: 'true'
     test_vars_overrides:
       'deletion_protection': 'false'
       'network_name': 'acctest.BootstrapSharedTestNetwork(t, "gke-cluster")'
@@ -164,9 +164,9 @@ examples:
       name: 'restore-order'
       network_name: 'default'
       subnetwork_name: 'default'
+      deletion_protection: 'true'
     test_env_vars:
       project: 'PROJECT_NAME'
-      deletion_protection: 'true'
     test_vars_overrides:
       'deletion_protection': 'false'
       'network_name': 'acctest.BootstrapSharedTestNetwork(t, "gke-cluster")'
@@ -179,9 +179,9 @@ examples:
       name: 'volume-res'
       network_name: 'default'
       subnetwork_name: 'default'
+      deletion_protection: 'true'
     test_env_vars:
       project: 'PROJECT_NAME'
-      deletion_protection: 'true'
     test_vars_overrides:
       'deletion_protection': 'false'
       'network_name': 'acctest.BootstrapSharedTestNetwork(t, "gke-cluster")'


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fix the examples that went from `""` -> `` (null) in gkebackup RestorePlan in https://github.com/GoogleCloudPlatform/magic-modules/pull/11981, unblocking submitting the PR

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
