### PR TITLE
Fix bug in Pub/Sub Subscription avroConfig which was not sending empty configurations. 

### DIFF
--- a/mmv1/products/pubsub/Subscription.yaml
+++ b/mmv1/products/pubsub/Subscription.yaml
@@ -231,15 +231,18 @@ properties:
           - 'NOT_FOUND'
       - name: 'avroConfig'
         type: NestedObject
+        send_empty_value: true
         description: |
           If set, message data will be written to Cloud Storage in Avro format.
         properties:
           - name: 'writeMetadata'
             type: Boolean
+            send_empty_value: true
             description: |
               When true, write the subscription name, messageId, publishTime, attributes, and orderingKey as additional fields in the output.
           - name: 'useTopicSchema'
             type: Boolean
+            send_empty_value: true
             description: |
               When true, the output Cloud Storage file will be serialized using the topic schema, if it exists.
       - name: 'serviceAccountEmail'

--- a/mmv1/products/pubsub/Subscription.yaml
+++ b/mmv1/products/pubsub/Subscription.yaml
@@ -232,6 +232,7 @@ properties:
       - name: 'avroConfig'
         type: NestedObject
         send_empty_value: true
+        allow_empty_object: true
         description: |
           If set, message data will be written to Cloud Storage in Avro format.
         properties:

--- a/mmv1/third_party/terraform/services/pubsub/resource_pubsub_subscription_test.go
+++ b/mmv1/third_party/terraform/services/pubsub/resource_pubsub_subscription_test.go
@@ -342,6 +342,40 @@ func TestAccPubsubSubscriptionCloudStorage_updateAvro(t *testing.T) {
 	})
 }
 
+func TestAccPubsubSubscriptionCloudStorage_updateAvroEmpty(t *testing.T) {
+	t.Parallel()
+
+	bucket := fmt.Sprintf("tf-test-bucket-%s", acctest.RandString(t, 10))
+	topic := fmt.Sprintf("tf-test-topic-%s", acctest.RandString(t, 10))
+	subscriptionShort := fmt.Sprintf("tf-test-sub-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckPubsubSubscriptionDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPubsubSubscriptionCloudStorage_basic(bucket, topic, subscriptionShort, "", "", "", 0, "", 0, "", "avro"),
+			},
+			{
+				ResourceName:      "google_pubsub_subscription.foo",
+				ImportStateId:     subscriptionShort,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccPubsubSubscriptionCloudStorage_basic(bucket, topic, subscriptionShort, "pre-", "-suffix", "YYYY-MM-DD/hh_mm_ssZ", 1000, "300s", 1000, "", "empty-avro"),
+			},
+			{
+				ResourceName:      "google_pubsub_subscription.foo",
+				ImportStateId:     subscriptionShort,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccPubsubSubscriptionCloudStorage_serviceAccount(t *testing.T) {
 	t.Parallel()
 
@@ -819,6 +853,8 @@ resource "google_storage_bucket_iam_member" "admin" {
     use_topic_schema = true
   }
 `
+	} else if outputFormat == "empty-avro" {
+		outputFormatString = `avro_config {}`
 	}
 	return fmt.Sprintf(`
 data "google_project" "project" { }

--- a/mmv1/third_party/terraform/services/pubsub/resource_pubsub_subscription_test.go
+++ b/mmv1/third_party/terraform/services/pubsub/resource_pubsub_subscription_test.go
@@ -342,7 +342,7 @@ func TestAccPubsubSubscriptionCloudStorage_updateAvro(t *testing.T) {
 	})
 }
 
-func TestAccPubsubSubscriptionCloudStorage_updateAvroEmpty(t *testing.T) {
+func TestAccPubsubSubscriptionCloudStorage_emptyAvroConfig(t *testing.T) {
 	t.Parallel()
 
 	bucket := fmt.Sprintf("tf-test-bucket-%s", acctest.RandString(t, 10))
@@ -354,15 +354,6 @@ func TestAccPubsubSubscriptionCloudStorage_updateAvroEmpty(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckPubsubSubscriptionDestroyProducer(t),
 		Steps: []resource.TestStep{
-			{
-				Config: testAccPubsubSubscriptionCloudStorage_basic(bucket, topic, subscriptionShort, "", "", "", 0, "", 0, "", "avro"),
-			},
-			{
-				ResourceName:      "google_pubsub_subscription.foo",
-				ImportStateId:     subscriptionShort,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
 			{
 				Config: testAccPubsubSubscriptionCloudStorage_basic(bucket, topic, subscriptionShort, "pre-", "-suffix", "YYYY-MM-DD/hh_mm_ssZ", 1000, "300s", 1000, "", "empty-avro"),
 			},


### PR DESCRIPTION
Fixes: hashicorp/terraform-provider-google/issues/19658

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
pubsub: fixed the issue to allow successfully configure empty `cloud_storage_config.avro_config` field in `google_pubsub_subscription`
```