### PR TITLE
Add support for specifying storage pool with name or partial url.

### DIFF
--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -496,14 +496,17 @@ properties:
   - name: 'storagePool'
     type: String
     description: |
-      The URL of the storage pool in which the new disk is created.
+      The URL or the name of the storage pool in which the new disk is created.
       For example:
       * https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/storagePools/{storagePool}
       * /projects/{project}/zones/{zone}/storagePools/{storagePool}
+      * /zones/{zone}/storagePools/{storagePool}
+      * /{storagePool}
     required: false
     immutable: true
     diff_suppress_func: 'tpgresource.CompareResourceNames'
     custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'
+    custom_expand: 'templates/terraform/custom_expand/storage_pool_full_url.tmpl'
   - name: 'accessMode'
     type: String
     description: |

--- a/mmv1/templates/terraform/constants/disk.tmpl
+++ b/mmv1/templates/terraform/constants/disk.tmpl
@@ -265,3 +265,41 @@ func suppressWindowsFamilyDiff(imageName, familyName string) bool {
 
 	return strings.Contains(updatedImageName, updatedFamilyString)
 }
+
+// ExpandStoragePoolUrl returns a full self link from a partial self link.
+func ExpandStoragePoolUrl(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (string, error) {
+	// It does not try to construct anything from empty.
+	if v == nil || v.(string) == "" {
+		return "", nil
+	}
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return "", err
+	}
+	zone, err := tpgresource.GetZone(d, config)
+	if err != nil {
+		return "", err
+	}
+	
+	formattedStr := v.(string)
+	if strings.HasPrefix(v.(string), "/") {
+		formattedStr = formattedStr[1:]
+	}
+	replacedStr := ""
+
+	if strings.HasPrefix(formattedStr, "https://") {
+		// Anything that starts with a URL scheme is assumed to be a self link worth using.
+		return formattedStr, nil
+	} else if strings.HasPrefix(formattedStr, "projects/") {
+		// If the self link references a project, we'll just stuck the compute prefix on it
+		replacedStr = config.ComputeBasePath + formattedStr
+	} else if strings.HasPrefix(formattedStr, "zones/") {
+		// For regional or zonal resources which include their region or zone, just put the project in front.
+		replacedStr = config.ComputeBasePath + "projects/" + project + "/" + formattedStr
+	} else {
+		// Anything else is assumed to be a zonal resource, with a partial link that begins with the resource name.
+		replacedStr = config.ComputeBasePath + "projects/" + project + "/zones/" + zone + "/storagePools/" + formattedStr
+	}
+	return replacedStr, nil
+}

--- a/mmv1/templates/terraform/custom_expand/storage_pool_full_url.tmpl
+++ b/mmv1/templates/terraform/custom_expand/storage_pool_full_url.tmpl
@@ -1,0 +1,15 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2024 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+  return ExpandStoragePoolUrl(v, d, config)
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.tmpl
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 {{ if eq $.TargetVersionName `ga` }}
 	"google.golang.org/api/compute/v1"
@@ -1632,6 +1634,28 @@ func TestAccComputeDisk_storagePoolSpecified(t *testing.T) {
 	})
 }
 
+func TestAccComputeDisk_storagePoolSpecified_nameOnly(t *testing.T) {
+	t.Parallel()
+
+	acctest.BootstrapComputeStoragePool(t, "basic-2", "hyperdisk-throughput")
+	diskName := fmt.Sprintf("tf-test-disk-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeDisk_storagePoolSpecified(diskName, "tf-bootstrap-storage-pool-hyperdisk-throughput-basic-2"),
+			},
+			{
+				ResourceName:      "google_compute_disk.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccComputeDisk_storagePoolSpecified(diskName, storagePoolUrl string) string {
 	return fmt.Sprintf(`
 resource "google_compute_disk" "foobar" {
@@ -1642,6 +1666,189 @@ resource "google_compute_disk" "foobar" {
   storage_pool = "%s"
 }
 `, diskName, storagePoolUrl)
+}
+
+func TestExpandStoragePoolUrl_withDataProjectAndZone(t *testing.T) {
+	config := &transport_tpg.Config{
+		ComputeBasePath: "https://www.googleapis.com/compute/v1/",
+		Project:         "other-project",
+		Zone:            "other-zone",
+	}
+
+	data := &tpgresource.ResourceDataMock{
+		FieldsInSchema: map[string]interface{}{
+			"project": "test-project",
+			"zone":    "test-zone",
+		},
+	}
+
+	name := "test-storage-pool"
+	zoneUrl := "zones/test-zone/storagePools/" + name
+	projectUrl := "projects/test-project/" + zoneUrl
+	fullUrl := config.ComputeBasePath + projectUrl
+
+	cases := []struct {
+		name     string
+		inputStr string
+	}{
+		{
+			name:     "full url",
+			inputStr: fullUrl,
+		},
+		{
+			name:     "project/{project}/zones/{zone}/storagePools/{storagePool}",
+			inputStr: projectUrl,
+		},
+		{
+			name:     "/project/{project}/zones/{zone}/storagePools/{storagePool}",
+			inputStr: "/" + projectUrl,
+		},
+		{
+			name:     "zones/{zone}/storagePools/{storagePool}",
+			inputStr: zoneUrl,
+		},
+		{
+			name:     "/zones/{zone}/storagePools/{storagePool}",
+			inputStr: "/" + zoneUrl,
+		},
+		{
+			name:     "{storagePool}",
+			inputStr: name,
+		},
+		{
+			name:     "/{storagePool}",
+			inputStr: "/" + name,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result, _ := tpgcompute.ExpandStoragePoolUrl(tc.inputStr, data, config)
+			if result != fullUrl {
+				t.Fatalf("%s does not match with expected full url: %s", result, fullUrl)
+			}
+		})
+	}
+}
+
+func TestExpandStoragePoolUrl_withConfigProjectAndZone(t *testing.T) {
+	config := &transport_tpg.Config{
+		ComputeBasePath: "https://www.googleapis.com/compute/v1/",
+		Project:         "test-project",
+		Zone:            "test-zone",
+	}
+
+	data := &tpgresource.ResourceDataMock{}
+
+	name := "test-storage-pool"
+	zoneUrl := "zones/test-zone/storagePools/" + name
+	projectUrl := "projects/test-project/" + zoneUrl
+	fullUrl := config.ComputeBasePath + projectUrl
+
+	cases := []struct {
+		name     string
+		inputStr string
+	}{
+		{
+			name:     "full url",
+			inputStr: fullUrl,
+		},
+		{
+			name:     "project/{project}/zones/{zone}/storagePools/{storagePool}",
+			inputStr: projectUrl,
+		},
+		{
+			name:     "/project/{project}/zones/{zone}/storagePools/{storagePool}",
+			inputStr: "/" + projectUrl,
+		},
+		{
+			name:     "zones/{zone}/storagePools/{storagePool}",
+			inputStr: zoneUrl,
+		},
+		{
+			name:     "/zones/{zone}/storagePools/{storagePool}",
+			inputStr: "/" + zoneUrl,
+		},
+		{
+			name:     "{storagePool}",
+			inputStr: name,
+		},
+		{
+			name:     "/{storagePool}",
+			inputStr: "/" + name,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result, _ := tpgcompute.ExpandStoragePoolUrl(tc.inputStr, data, config)
+			if result != fullUrl {
+				t.Fatalf("%s does not match with expected full url: %s", result, fullUrl)
+			}
+		})
+	}
+}
+
+func TestExpandStoragePoolUrl_noProjectAndZoneFromConfigAndData(t *testing.T) {
+	config := &transport_tpg.Config{
+		ComputeBasePath: "https://www.googleapis.com/compute/v1/",
+	}
+
+	data := &tpgresource.ResourceDataMock{}
+
+	name := "test-storage-pool"
+	zoneUrl := "zones/test-zone/storagePools/" + name
+	projectUrl := "projects/test-project/" + zoneUrl
+	fullUrl := config.ComputeBasePath + projectUrl
+
+	cases := []struct {
+		name     string
+		inputStr string
+	}{
+		{
+			name:     "full url",
+			inputStr: fullUrl,
+		},
+		{
+			name:     "project/{project}/zones/{zone}/storagePools/{storagePool}",
+			inputStr: projectUrl,
+		},
+		{
+			name:     "/project/{project}/zones/{zone}/storagePools/{storagePool}",
+			inputStr: "/" + projectUrl,
+		},
+		{
+			name:     "zones/{zone}/storagePools/{storagePool}",
+			inputStr: zoneUrl,
+		},
+		{
+			name:     "/zones/{zone}/storagePools/{storagePool}",
+			inputStr: "/" + zoneUrl,
+		},
+		{
+			name:     "{storagePool}",
+			inputStr: name,
+		},
+		{
+			name:     "/{storagePool}",
+			inputStr: "/" + name,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := tpgcompute.ExpandStoragePoolUrl(tc.inputStr, data, config)
+			if err == nil {
+				t.Fatal("Should return error when no project and zone available from config or resource data")
+			}
+		})
+	}
 }
 
 func TestAccComputeDisk_accessModeSpecified(t *testing.T) {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -3110,7 +3110,11 @@ func expandBootDisk(d *schema.ResourceData, config *transport_tpg.Config, projec
 		}
 
 		if v, ok := d.GetOk("boot_disk.0.initialize_params.0.storage_pool"); ok {
-			disk.InitializeParams.StoragePool = v.(string)
+			storagePoolUrl, err := expandStoragePool(v, d, config)
+			if err != nil {
+				return nil, fmt.Errorf("Error resolving storage pool name '%s': '%s'", v.(string), err)
+			}
+			disk.InitializeParams.StoragePool = storagePoolUrl.(string)
 		}
 	}
 
@@ -3207,6 +3211,10 @@ func flattenScratchDisk(disk *compute.AttachedDisk) map[string]interface{} {
 		"size": disk.DiskSizeGb,
 	}
 	return result
+}
+
+func expandStoragePool(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return ExpandStoragePoolUrl(v, d, config)
 }
 
 func hash256(raw string) (string, error) {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -10783,6 +10783,28 @@ func TestAccComputeInstance_bootDisk_storagePoolSpecified(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstance_bootDisk_storagePoolSpecified_nameOnly(t *testing.T) {
+	t.Parallel()
+
+	instanceName := fmt.Sprintf("tf-test-instance-%s", acctest.RandString(t, 10))
+	acctest.BootstrapComputeStoragePool(t, "basic-2", "hyperdisk-balanced")
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config:    testAccComputeInstance_bootDisk_storagePoolSpecified(instanceName, "tf-bootstrap-storage-pool-hyperdisk-balanced-basic-2", envvar.GetTestZoneFromEnv()),
+			},
+			{
+				ResourceName:      "google_compute_instance.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccComputeInstance_bootDisk_storagePoolSpecified(instanceName, storagePoolUrl, zone string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -327,10 +327,12 @@ is desired, you will need to modify your state file manually using
 * `enable_confidential_compute` - (Optional) Whether this disk is using confidential compute mode.
     Note: Only supported on hyperdisk skus, disk_encryption_key is required when setting to true.
 
-* `storage_pool` - (Optional) The URL of the storage pool in which the new disk is created.
+* `storage_pool` - (Optional) The URL or the name of the storage pool in which the new disk is created.
     For example:
     * https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/storagePools/{storagePool}
     * /projects/{project}/zones/{zone}/storagePools/{storagePool}
+    * /zones/{zone}/storagePools/{storagePool}
+    * /{storagePool}
 
 <a name="nested_scratch_disk"></a>The `scratch_disk` block supports:
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Add support for specifying storage pool with name or partial url.
Since storage pool is not a resource in Terraform, we need a new method for expanding given storage pool name or partial URL.
Added for both Disk and Instance.

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran make test and make lint to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: add support for specifying storage pool with name or partial url
```
