### PR TITLE
Add external catalog dataset options to google_bigquery_dataset beta

### DIFF
--- a/mmv1/products/bigquery/Dataset.yaml
+++ b/mmv1/products/bigquery/Dataset.yaml
@@ -93,6 +93,11 @@ examples:
     vars:
       dataset_id: 'example_dataset'
     exclude_test: true
+  - name: 'bigquery_dataset_external_catalog_dataset_options'
+    primary_resource_id: 'dataset'
+    vars:
+      dataset_id: 'example_dataset'
+    min_version: 'beta'
   - name: 'bigquery_dataset_resource_tags'
     primary_resource_id: 'dataset'
     primary_resource_name: 'fmt.Sprintf("tf_test_dataset%s", context["random_suffix"])'
@@ -401,3 +406,22 @@ properties:
       ID of the parent organization or project resource for this tag key. Tag value is expected
       to be the short name, for example "Production". See [Tag definitions](/iam/docs/tags-access-control#definitions)
       for more details.
+  - name: 'externalCatalogDatasetOptions'
+    type: NestedObject
+    description: |
+      Options defining open source compatible datasets living in the BigQuery catalog. Contains
+      metadata of open source database, schema or namespace represented by the current dataset.
+    min_version: beta
+    properties:
+      - name: 'parameters'
+        type: KeyValuePairs
+        description: |
+          A map of key value pairs defining the parameters and properties of the open source schema.
+          Maximum size of 2Mib.
+        min_version: beta
+      - name: 'defaultStorageLocationUri'
+        type: String
+        description: |
+          The storage location URI for all tables in the dataset. Equivalent to hive metastore's
+          database locationUri. Maximum length of 1024 characters.
+        min_version: beta

--- a/mmv1/templates/terraform/examples/bigquery_dataset_external_catalog_dataset_options.tf.tmpl
+++ b/mmv1/templates/terraform/examples/bigquery_dataset_external_catalog_dataset_options.tf.tmpl
@@ -1,0 +1,15 @@
+resource "google_bigquery_dataset" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+
+  dataset_id    = "{{index $.Vars "dataset_id"}}"
+  friendly_name = "test"
+  description   = "This is a test description"
+  location      = "US"
+
+  external_catalog_dataset_options {
+    parameters = {
+      "dataset_owner" = "test_dataset_owner"
+    }
+    default_storage_location_uri = "gs://test_dataset/tables"
+  }
+}

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_dataset_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_dataset_test.go.tmpl
@@ -454,6 +454,42 @@ func TestAccBigQueryDataset_bigqueryDatasetResourceTags_update(t *testing.T) {
 	})
 }
 
+{{- if ne $.TargetVersionName "ga" }}
+func TestAccBigQueryDataset_externalCatalogDatasetOptions_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckBigQueryDatasetDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryDataset_externalCatalogDatasetOptions_basic(context),
+			},
+			{
+				ResourceName:            "google_bigquery_dataset.dataset",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccBigQueryDataset_externalCatalogDatasetOptions_update(context),
+			},
+			{
+				ResourceName:            "google_bigquery_dataset.dataset",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+{{- end }}
 func testAccAddTable(t *testing.T, datasetID string, tableID string) resource.TestCheckFunc {
 	// Not actually a check, but adds a table independently of terraform
 	return func(s *terraform.State) error {
@@ -860,6 +896,46 @@ resource "google_bigquery_dataset" "dataset" {
   location                    = "EU"
 
   resource_tags = {
+  }
+}
+`, context)
+}
+
+func testAccBigQueryDataset_externalCatalogDatasetOptions_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_bigquery_dataset" "dataset" {
+  provider = google-beta
+
+  dataset_id    = "dataset%{random_suffix}"
+  friendly_name = "test"
+  description   = "This is a test description"
+  location      = "US"
+
+  external_catalog_dataset_options {
+    parameters = {
+      "dataset_owner" = "dataset_owner"
+    }
+    default_storage_location_uri = "gs://test_dataset/tables"
+  }
+}
+`, context)
+}
+
+func testAccBigQueryDataset_externalCatalogDatasetOptions_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_bigquery_dataset" "dataset" {
+  provider = google-beta
+
+  dataset_id    = "dataset%{random_suffix}"
+  friendly_name = "test"
+  description   = "This is a test description"
+  location      = "US"
+
+  external_catalog_dataset_options {
+    parameters = {
+      "new_dataset_owner" = "new_dataset_owner"
+    }
+    default_storage_location_uri = "gs://new_test_dataset/new_tables"
   }
 }
 `, context)


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Add external catalog dataset options to `google_bigquery_dataset` beta


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
bigquery: added `external_catalog_dataset_options` fields to `google_bigquery_dataset` resource (beta)
```
