### PR TITLE
gkehub: replace docs regarding ACM version with Config Sync version

### DIFF
--- a/mmv1/products/gkehub2/Feature.yaml
+++ b/mmv1/products/gkehub2/Feature.yaml
@@ -269,7 +269,7 @@ properties:
         properties:
           - name: 'version'
             type: String
-            description: 'Version of ACM installed'
+            description: 'Version of Config Sync installed'
           - name: 'management'
             type: Enum
             description: 'Set this field to MANAGEMENT_AUTOMATIC to enable Config Sync auto-upgrades, and set this field to MANAGEMENT_MANUAL or MANAGEMENT_UNSPECIFIED to disable Config Sync auto-upgrades.'
@@ -341,8 +341,8 @@ properties:
                     description: 'Period in seconds between consecutive syncs. Default: 15'
                   - name: 'version'
                     type: String
-                    description: 'Version of ACM installed'
-                    deprecation_message: 'The `configmanagement.config_sync.oci.version` field is deprecated and will be removed in a future major release. Please use `configmanagement.version` field to specify the version of ACM installed instead.'
+                    description: 'Version of Config Sync installed'
+                    deprecation_message: 'The `configmanagement.config_sync.oci.version` field is deprecated and will be removed in a future major release. Please use `configmanagement.version` field to specify the version of Config Sync installed instead.'
       - name: 'policycontroller'
         type: NestedObject
         description: Policy Controller spec

--- a/mmv1/third_party/terraform/website/docs/r/gke_hub_feature_membership.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/gke_hub_feature_membership.html.markdown
@@ -372,7 +372,7 @@ The following arguments are supported:
 
 * `version` -
   (Optional)
-  Version of ACM installed.
+  Version of Config Sync installed.
 
 * `binauthz` -
   (Optional, Deprecated)
@@ -412,13 +412,13 @@ The following arguments are supported:
   (Optional) Structure is [documented below](#nested_git).
 
 * `oci` -
-  (Optional) Supported from ACM versions 1.12.0 onwards. Structure is [documented below](#nested_oci).
+  (Optional) Supported from Config Sync versions 1.12.0 onwards. Structure is [documented below](#nested_oci).
   
   Use either `git` or `oci` config option.
 
 * `prevent_drift` -
   (Optional)
-  Supported from ACM versions 1.10.0 onwards. Set to true to enable the Config Sync admission webhook to prevent drifts. If set to "false", disables the Config Sync admission webhook and does not prevent drifts.
+  Supported from Config Sync versions 1.10.0 onwards. Set to true to enable the Config Sync admission webhook to prevent drifts. If set to "false", disables the Config Sync admission webhook and does not prevent drifts.
     
 * `source_format` -
   (Optional)


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

We are no longer specifying the ACM version but rather the Config Sync version and to avoid confusion we should update the documentation.

https://cloud.google.com/kubernetes-engine/enterprise/config-sync/docs/release-notes
(was previous https://cloud.google.com/anthos-config-management/docs/release-notes)

Sorry in advance if I misunderstood anything about the ACM/Policy Sync version, but hopefully this is the way now?

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
