### PR TITLE
refactor: update resource manager tag references

### DIFF
--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_dataset_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_dataset_test.go
@@ -782,22 +782,22 @@ data "google_project" "project" {
 }
 
 resource "google_tags_tag_key" "tag_key1" {
-  parent = "projects/${data.google_project.project.number}"
+  parent     = data.google_project.project.id
   short_name = "tf_test_tag_key1%{random_suffix}"
 }
 
 resource "google_tags_tag_value" "tag_value1" {
-  parent = "tagKeys/${google_tags_tag_key.tag_key1.name}"
+  parent = google_tags_tag_key.tag_key1.id
   short_name = "tf_test_tag_value1%{random_suffix}"
 }
 
 resource "google_tags_tag_key" "tag_key2" {
-  parent = "projects/${data.google_project.project.number}"
+  parent     = data.google_project.project.id
   short_name = "tf_test_tag_key2%{random_suffix}"
 }
 
 resource "google_tags_tag_value" "tag_value2" {
-  parent = "tagKeys/${google_tags_tag_key.tag_key2.name}"
+  parent     = google_tags_tag_key.tag_key2.id
   short_name = "tf_test_tag_value2%{random_suffix}"
 }
 
@@ -808,8 +808,8 @@ resource "google_bigquery_dataset" "dataset" {
   location                    = "EU"
 
   resource_tags = {
-    "${data.google_project.project.project_id}/${google_tags_tag_key.tag_key1.short_name}" = "${google_tags_tag_value.tag_value1.short_name}"
-    "${data.google_project.project.project_id}/${google_tags_tag_key.tag_key2.short_name}" = "${google_tags_tag_value.tag_value2.short_name}"
+    (google_tags_tag_key.tag_key1.namespaced_name) = google_tags_tag_value.tag_value1.short_name
+    (google_tags_tag_key.tag_key2.namespaced_name) = google_tags_tag_value.tag_value2.short_name
   }
 }
 `, context)
@@ -821,22 +821,22 @@ data "google_project" "project" {
 }
 
 resource "google_tags_tag_key" "tag_key1" {
-  parent = "projects/${data.google_project.project.number}"
+  parent     = data.google_project.project.id
   short_name = "tf_test_tag_key1%{random_suffix}"
 }
 
 resource "google_tags_tag_value" "tag_value1" {
-  parent = "tagKeys/${google_tags_tag_key.tag_key1.name}"
+  parent     = google_tags_tag_key.tag_key1.id
   short_name = "tf_test_tag_value1%{random_suffix}"
 }
 
 resource "google_tags_tag_key" "tag_key2" {
-  parent = "projects/${data.google_project.project.number}"
+  parent     = data.google_project.project.id
   short_name = "tf_test_tag_key2%{random_suffix}"
 }
 
 resource "google_tags_tag_value" "tag_value2" {
-  parent = "tagKeys/${google_tags_tag_key.tag_key2.name}"
+  parent     = google_tags_tag_key.tag_key2.id
   short_name = "tf_test_tag_value2%{random_suffix}"
 }
 

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
@@ -4274,7 +4274,7 @@ resource "google_tags_tag_key" "key1" {
 }
 
 resource "google_tags_tag_value" "value1" {
-  parent = "tagKeys/${google_tags_tag_key.key1.name}"
+  parent     = google_tags_tag_key.key1.id
   short_name = "%{tag_value_name1}"
 }
 
@@ -4287,7 +4287,7 @@ resource "google_bigquery_table" "test" {
   dataset_id = "${google_bigquery_dataset.test.dataset_id}"
   table_id   = "%{table_id}"
   resource_tags = {
-    "%{project_id}/${google_tags_tag_key.key1.short_name}" = "${google_tags_tag_value.value1.short_name}"
+    (google_tags_tag_key.key1.namespaced_name) = google_tags_tag_value.value1.short_name
   }
 }
 `, context)
@@ -4301,7 +4301,7 @@ resource "google_tags_tag_key" "key1" {
 }
 
 resource "google_tags_tag_value" "value1" {
-  parent = "tagKeys/${google_tags_tag_key.key1.name}"
+  parent     = google_tags_tag_key.key1.id
   short_name = "%{tag_value_name1}"
 }
 
@@ -4311,7 +4311,7 @@ resource "google_tags_tag_key" "key2" {
 }
 
 resource "google_tags_tag_value" "value2" {
-  parent = "tagKeys/${google_tags_tag_key.key2.name}"
+  parent     = google_tags_tag_key.key2.id
   short_name = "%{tag_value_name2}"
 }
 
@@ -4324,8 +4324,8 @@ resource "google_bigquery_table" "test" {
   dataset_id = "${google_bigquery_dataset.test.dataset_id}"
   table_id   = "%{table_id}"
   resource_tags = {
-    "%{project_id}/${google_tags_tag_key.key1.short_name}" = "${google_tags_tag_value.value1.short_name}"
-    "%{project_id}/${google_tags_tag_key.key2.short_name}" = "${google_tags_tag_value.value2.short_name}"
+    (google_tags_tag_key.key1.namespaced_name) = google_tags_tag_value.value1.short_name
+    (google_tags_tag_key.key2.namespaced_name) = google_tags_tag_value.value2.short_name
   }
 }
 `, context)
@@ -4339,7 +4339,7 @@ resource "google_tags_tag_key" "key1" {
 }
 
 resource "google_tags_tag_value" "value1" {
-  parent = "tagKeys/${google_tags_tag_key.key1.name}"
+  parent     = google_tags_tag_key.key1.id
   short_name = "%{tag_value_name1}"
 }
 
@@ -4349,7 +4349,7 @@ resource "google_tags_tag_key" "key2" {
 }
 
 resource "google_tags_tag_value" "value2" {
-  parent = "tagKeys/${google_tags_tag_key.key2.name}"
+  parent     = google_tags_tag_key.key2.id
   short_name = "%{tag_value_name2}"
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_test.go.tmpl
@@ -2007,8 +2007,8 @@ resource "google_tags_tag_key" "igm-key" {
 
 resource "google_tags_tag_value" "igm-value" {
   description = "Terraform test tag value."
-  parent = "tagKeys/${google_tags_tag_key.igm-key.name}"
-  short_name = "%s"
+  parent      = google_tags_tag_key.igm-key.id
+  short_name  = "%s"
 }
 
 resource "google_compute_instance_group_manager" "igm-tags" {
@@ -2025,7 +2025,7 @@ resource "google_compute_instance_group_manager" "igm-tags" {
 
   params {
     resource_manager_tags = {
-      "tagKeys/${google_tags_tag_key.igm-key.name}" = "tagValues/${google_tags_tag_value.igm-value.name}"
+      (google_tags_tag_key.igm-key.id) = google_tags_tag_value.igm-value.id
     }
   }
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.tmpl
@@ -4432,8 +4432,8 @@ resource "google_tags_tag_key" "key" {
 }
 
 resource "google_tags_tag_value" "value" {
-  parent = "tagKeys/${google_tags_tag_key.key.name}"
-  short_name = "foo%{random_suffix}"
+  parent      = google_tags_tag_key.key.id
+  short_name  = "foo%{random_suffix}"
   description = "For foo resources."
 }
 
@@ -4453,12 +4453,12 @@ resource "google_compute_instance_template" "foobar" {
     boot         = true
 
     resource_manager_tags = {
-      "tagKeys/${google_tags_tag_key.key.name}" = "tagValues/${google_tags_tag_value.value.name}"
+      (google_tags_tag_key.key.id) = google_tags_tag_value.value.id
     }
   }
 
   resource_manager_tags = {
-    "tagKeys/${google_tags_tag_key.key.name}" = "tagValues/${google_tags_tag_value.value.name}"
+    (google_tags_tag_key.key.id) = google_tags_tag_value.value.id
   }
 
   network_interface {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -5137,8 +5137,8 @@ resource "google_tags_tag_key" "key" {
 }
 
 resource "google_tags_tag_value" "value" {
-  parent = "tagKeys/${google_tags_tag_key.key.name}"
-  short_name = "foo%{random_suffix}"
+  parent      = google_tags_tag_key.key.id
+  short_name  = "foo%{random_suffix}"
   description = "For foo resources."
 }
 
@@ -5156,14 +5156,14 @@ resource "google_compute_instance" "foobar" {
     initialize_params {
       image = data.google_compute_image.my_image.self_link
       resource_manager_tags = {
-        "tagKeys/${google_tags_tag_key.key.name}" = "tagValues/${google_tags_tag_value.value.name}"
+        (google_tags_tag_key.key.id) = google_tags_tag_value.value.id
       }
     }
   }
 
   params {
     resource_manager_tags = {
-      "tagKeys/${google_tags_tag_key.key.name}" = "tagValues/${google_tags_tag_value.value.name}"
+      (google_tags_tag_key.key.id) = google_tags_tag_value.value.id
     }
   }
 
@@ -5183,8 +5183,8 @@ resource "google_tags_tag_key" "key" {
 }
 
 resource "google_tags_tag_value" "value" {
-  parent = "tagKeys/${google_tags_tag_key.key.name}"
-  short_name = "foo%{random_suffix}"
+  parent      = google_tags_tag_key.key.id
+  short_name  = "foo%{random_suffix}"
   description = "For foo resources."
 }
 
@@ -5195,8 +5195,8 @@ resource "google_tags_tag_key" "key_new" {
 }
 
 resource "google_tags_tag_value" "value_new" {
-  parent = "tagKeys/${google_tags_tag_key.key_new.name}"
-  short_name = "foonew%{random_suffix}"
+  parent      = google_tags_tag_key.key_new.id
+  short_name  = "foonew%{random_suffix}"
   description = "New value for foo resources."
 }
 
@@ -5214,15 +5214,15 @@ resource "google_compute_instance" "foobar" {
     initialize_params {
       image = data.google_compute_image.my_image.self_link
       resource_manager_tags = {
-        "tagKeys/${google_tags_tag_key.key.name}" = "tagValues/${google_tags_tag_value.value.name}"
+        (google_tags_tag_key.key.id) = google_tags_tag_value.value.id
       }
     }
   }
 
   params {
     resource_manager_tags = {
-      "tagKeys/${google_tags_tag_key.key.name}"     = "tagValues/${google_tags_tag_value.value.name}"
-      "tagKeys/${google_tags_tag_key.key_new.name}" = "tagValues/${google_tags_tag_value.value_new.name}"
+      (google_tags_tag_key.key.id)     = google_tags_tag_value.value.id
+      (google_tags_tag_key.key_new.id) = google_tags_tag_value.value_new.id
     }
   }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_firewall_policy_rule_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_firewall_policy_rule_test.go.tmpl
@@ -262,7 +262,7 @@ resource "google_compute_network_firewall_policy_rule" "primary" {
     src_threat_intelligences = ["iplist-known-malicious-ips"]
 
     src_secure_tags {
-      name = "tagValues/${google_tags_tag_value.basic_value.name}"
+      name = google_tags_tag_value.basic_value.id
     }
 
     layer4_configs {
@@ -290,7 +290,7 @@ resource "google_tags_tag_key" "basic_key" {
 
 resource "google_tags_tag_value" "basic_value" {
   description = "For valuename resources."
-  parent      = "tagKeys/${google_tags_tag_key.basic_key.name}"
+  parent      = google_tags_tag_key.basic_key.id
   short_name  = "tf-test-tagvalue-%{random_suffix}"
 }
 `, context)
@@ -340,7 +340,7 @@ resource "google_compute_network_firewall_policy_rule" "primary" {
   }
   
   target_secure_tags {
-    name = "tagValues/${google_tags_tag_value.basic_value.name}"
+    name = google_tags_tag_value.basic_value.id
   }
 }
 
@@ -361,7 +361,7 @@ resource "google_tags_tag_key" "basic_key" {
 
 resource "google_tags_tag_value" "basic_value" {
   description = "For valuename resources."
-  parent      = "tagKeys/${google_tags_tag_key.basic_key.name}"
+  parent      = google_tags_tag_key.basic_key.id
   short_name  = "tf-test-tagvalue-%{random_suffix}"
 }
 `, context)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_firewall_policy_with_rules_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_firewall_policy_with_rules_test.go.tmpl
@@ -71,7 +71,7 @@ resource "google_compute_network_firewall_policy_with_rules" "network-firewall-p
       dest_address_groups = [google_network_security_address_group.address_group_1.id]
     }
     target_secure_tag {
-      name = "tagValues/${google_tags_tag_value.secure_tag_value_1.name}"
+      name = google_tags_tag_value.secure_tag_value_1.id
     }
   }
   rule {
@@ -90,7 +90,7 @@ resource "google_compute_network_firewall_policy_with_rules" "network-firewall-p
         src_threat_intelligences = ["iplist-known-malicious-ips", "iplist-public-clouds"]
         src_address_groups = [google_network_security_address_group.address_group_1.id]
         src_secure_tag {
-          name = "tagValues/${google_tags_tag_value.secure_tag_value_1.name}"
+          name = google_tags_tag_value.secure_tag_value_1.id
         }
       }
       disabled = true
@@ -139,7 +139,7 @@ resource "google_tags_tag_key" "secure_tag_key_1" {
 resource "google_tags_tag_value" "secure_tag_value_1" {
   provider    = google-beta
   description = "Tag value"
-  parent      = "tagKeys/${google_tags_tag_key.secure_tag_key_1.name}"
+  parent      = google_tags_tag_key.secure_tag_key_1.id
   short_name  = "tf-test-tf-tag-value%{random_suffix}"
 }
 
@@ -205,7 +205,7 @@ resource "google_compute_network_firewall_policy_with_rules" "network-firewall-p
         src_threat_intelligences = ["iplist-public-clouds"]
         src_address_groups = [google_network_security_address_group.address_group_1.id]
         src_secure_tag {
-          name = "tagValues/${google_tags_tag_value.secure_tag_value_1.name}"
+          name = google_tags_tag_value.secure_tag_value_1.id
         }
       }
       disabled = false
@@ -237,7 +237,7 @@ resource "google_tags_tag_key" "secure_tag_key_1" {
 resource "google_tags_tag_value" "secure_tag_value_1" {
   provider    = google-beta
   description = "Tag value"
-  parent      = "tagKeys/${google_tags_tag_key.secure_tag_key_1.name}"
+  parent      = google_tags_tag_key.secure_tag_key_1.id
   short_name  = "tf-test-tf-tag-value%{random_suffix}"
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.tmpl
@@ -1955,8 +1955,8 @@ resource "google_tags_tag_key" "rigm-key" {
 
 resource "google_tags_tag_value" "rigm-value" {
   description = "Terraform test tag value."
-  parent = "tagKeys/${google_tags_tag_key.rigm-key.name}"
-  short_name = "%s"
+  parent      = google_tags_tag_key.rigm-key.id
+  short_name  = "%s"
 }
 
 resource "google_compute_region_instance_group_manager" "rigm-tags" {
@@ -1973,7 +1973,7 @@ resource "google_compute_region_instance_group_manager" "rigm-tags" {
 
   params {
     resource_manager_tags = {
-      "tagKeys/${google_tags_tag_key.rigm-key.name}" = "tagValues/${google_tags_tag_value.rigm-value.name}"
+      (google_tags_tag_key.rigm-key.id) = google_tags_tag_value.rigm-value.id
     }
   }
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
@@ -3832,7 +3832,7 @@ resource "google_tags_tag_key" "key" {
 }
 
 resource "google_tags_tag_value" "value" {
-  parent = "tagKeys/${google_tags_tag_key.key.name}"
+  parent = google_tags_tag_key.key.id
   short_name = "foo%{random_suffix}"
   description = "For foo resources."
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_network_firewall_policy_rule_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_network_firewall_policy_rule_test.go.tmpl
@@ -231,7 +231,7 @@ resource "google_compute_region_network_firewall_policy_rule" "primary" {
     }
 
     src_secure_tags {
-      name = "tagValues/${google_tags_tag_value.basic_value.name}"
+      name = google_tags_tag_value.basic_value.id
     }
     
     src_address_groups = [google_network_security_address_group.basic_regional_networksecurity_address_group.id]
@@ -256,7 +256,7 @@ resource "google_tags_tag_key" "basic_key" {
 
 resource "google_tags_tag_value" "basic_value" {
   description = "For valuename resources."
-  parent      = "tagKeys/${google_tags_tag_key.basic_key.name}"
+  parent      = google_tags_tag_key.basic_key.id
   short_name  = "tf-test-tagvalue-%{random_suffix}"
 }
 
@@ -309,7 +309,7 @@ resource "google_compute_region_network_firewall_policy_rule" "primary" {
   }
 
   target_secure_tags {
-    name = "tagValues/${google_tags_tag_value.basic_value.name}"
+    name = google_tags_tag_value.basic_value.id
   }
 }
 
@@ -331,7 +331,7 @@ resource "google_tags_tag_key" "basic_key" {
 
 resource "google_tags_tag_value" "basic_value" {
   description = "For valuename resources."
-  parent      = "tagKeys/${google_tags_tag_key.basic_key.name}"
+  parent      = google_tags_tag_key.basic_key.id
   short_name  = "tf-test-tagvalue-%{random_suffix}"
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_network_firewall_policy_with_rules_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_network_firewall_policy_with_rules_test.go.tmpl
@@ -72,7 +72,7 @@ resource "google_compute_region_network_firewall_policy_with_rules" "region-netw
       dest_address_groups = [google_network_security_address_group.address_group_1.id]
     }
     target_secure_tag {
-      name = "tagValues/${google_tags_tag_value.secure_tag_value_1.name}"
+      name = google_tags_tag_value.secure_tag_value_1.id
     }
   }
   rule {
@@ -92,7 +92,7 @@ resource "google_compute_region_network_firewall_policy_with_rules" "region-netw
         src_threat_intelligences = ["iplist-known-malicious-ips", "iplist-public-clouds"]
         src_address_groups = [google_network_security_address_group.address_group_1.id]
         src_secure_tag {
-          name = "tagValues/${google_tags_tag_value.secure_tag_value_1.name}"
+          name = google_tags_tag_value.secure_tag_value_1.id
         }
       }
       disabled = true
@@ -124,7 +124,7 @@ resource "google_tags_tag_key" "secure_tag_key_1" {
 resource "google_tags_tag_value" "secure_tag_value_1" {
   provider   = google-beta
   description = "Tag value"
-  parent      = "tagKeys/${google_tags_tag_key.secure_tag_key_1.name}"
+  parent      = google_tags_tag_key.secure_tag_key_1.id
   short_name  = "tf-test-tf-tag-value%{random_suffix}"
 }
 `, context)
@@ -172,7 +172,7 @@ resource "google_compute_region_network_firewall_policy_with_rules" "region-netw
         src_threat_intelligences = ["iplist-public-clouds"]
         src_address_groups = [google_network_security_address_group.address_group_1.id]
         src_secure_tag {
-          name = "tagValues/${google_tags_tag_value.secure_tag_value_1.name}"
+          name = google_tags_tag_value.secure_tag_value_1.id
         }
       }
       disabled = false
@@ -204,7 +204,7 @@ resource "google_tags_tag_key" "secure_tag_key_1" {
 resource "google_tags_tag_value" "secure_tag_value_1" {
   provider   = google-beta
   description = "Tag value"
-  parent      = "tagKeys/${google_tags_tag_key.secure_tag_key_1.name}"
+  parent      = google_tags_tag_key.secure_tag_key_1.id
   short_name  = "tf-test-tf-tag-value%{random_suffix}"
 }
 `, context)

--- a/mmv1/third_party/terraform/services/tags/resource_tags_test.go
+++ b/mmv1/third_party/terraform/services/tags/resource_tags_test.go
@@ -235,8 +235,8 @@ resource "google_tags_tag_key" "key" {
 
 resource "google_tags_tag_value" "value" {
 
-  parent = "tagKeys/${google_tags_tag_key.key.name}"
-  short_name = "foo%{random_suffix}"
+  parent      = google_tags_tag_key.key.id
+  short_name  = "foo%{random_suffix}"
   description = "For foo resources."
 }
 `, context)
@@ -284,8 +284,8 @@ resource "google_tags_tag_key" "key" {
 
 resource "google_tags_tag_value" "value" {
 
-  parent = "tagKeys/${google_tags_tag_key.key.name}"
-  short_name = "foo%{random_suffix}"
+  parent      = google_tags_tag_key.key.id
+  short_name  = "foo%{random_suffix}"
   description = "For foo resources."
 }
 `, context)
@@ -302,8 +302,8 @@ resource "google_tags_tag_key" "key" {
 
 resource "google_tags_tag_value" "value" {
 
-  parent = "tagKeys/${google_tags_tag_key.key.name}"
-  short_name = "foo%{random_suffix}"
+  parent      = google_tags_tag_key.key.id
+  short_name  = "foo%{random_suffix}"
   description = "For any foo resources."
 }
 `, context)
@@ -388,14 +388,14 @@ resource "google_tags_tag_key" "key" {
 }
 
 resource "google_tags_tag_value" "value" {
-	parent = "tagKeys/${google_tags_tag_key.key.name}"
-	short_name = "foo%{random_suffix}"
+	parent      = google_tags_tag_key.key.id
+	short_name  = "foo%{random_suffix}"
 	description = "For foo%{random_suffix} resources."
 }
 
 resource "google_tags_tag_binding" "binding" {
-	parent = "//cloudresourcemanager.googleapis.com/projects/${google_project.project.number}"
-	tag_value = "tagValues/${google_tags_tag_value.value.name}"
+	parent    = "//cloudresourcemanager.googleapis.com/projects/${google_project.project.number}"
+	tag_value = google_tags_tag_value.value.id
 }
 `, context)
 }
@@ -692,8 +692,8 @@ resource "google_tags_tag_key" "key" {
 }
 
 resource "google_tags_tag_value" "value" {
-	parent = "tagKeys/${google_tags_tag_key.key.name}"
-	short_name = "%{value_short_name}"
+	parent      = google_tags_tag_key.key.id
+	short_name  = "%{value_short_name}"
 	description = "For %{value_short_name} resources."
 }
 
@@ -714,8 +714,8 @@ resource "google_tags_tag_key" "key" {
 }
 
 resource "google_tags_tag_value" "value" {
-	parent = "tagKeys/${google_tags_tag_key.key.name}"
-	short_name = "%{value_short_name}"
+	parent      = google_tags_tag_key.key.id
+	short_name  = "%{value_short_name}"
 	description = "For %{value_short_name} resources."
 }
 
@@ -742,8 +742,8 @@ resource "google_tags_tag_key" "key" {
 }
 
 resource "google_tags_tag_value" "value" {
-	parent = "tagKeys/${google_tags_tag_key.key.name}"
-	short_name = "%{value_short_name}"
+	parent      = google_tags_tag_key.key.id
+	short_name  = "%{value_short_name}"
 	description = "For %{value_short_name} resources."
 }
 
@@ -766,8 +766,8 @@ resource "google_tags_tag_key" "key" {
 }
 
 resource "google_tags_tag_value" "value" {
-	parent = "tagKeys/${google_tags_tag_key.key.name}"
-	short_name = "%{value_short_name}"
+	parent      = google_tags_tag_key.key.id
+	short_name  = "%{value_short_name}"
 	description = "For %{value_short_name} resources."
 }
 
@@ -788,8 +788,8 @@ resource "google_tags_tag_key" "key" {
 }
 
 resource "google_tags_tag_value" "value" {
-	parent = "tagKeys/${google_tags_tag_key.key.name}"
-	short_name = "%{value_short_name}"
+	parent      = google_tags_tag_key.key.id
+	short_name  = "%{value_short_name}"
 	description = "For %{value_short_name} resources."
 }
 
@@ -842,8 +842,8 @@ resource "google_tags_tag_key" "key" {
 }
 
 resource "google_tags_tag_value" "value" {
-	parent = "tagKeys/${google_tags_tag_key.key.name}"
-	short_name = "foo%{random_suffix}"
+	parent      = google_tags_tag_key.key.id
+	short_name  = "foo%{random_suffix}"
 	description = "For foo%{random_suffix} resources."
 }
 
@@ -866,9 +866,9 @@ resource "google_cloud_run_service" "default" {
 }
   
 resource "google_tags_location_tag_binding" "binding" {
-	parent = "//run.googleapis.com/projects/${data.google_project.project.number}/locations/${google_cloud_run_service.default.location}/services/${google_cloud_run_service.default.name}"
-	tag_value = "tagValues/${google_tags_tag_value.value.name}"
-	location = "us-central1"
+	parent    = "//run.googleapis.com/projects/${data.google_project.project.number}/locations/${google_cloud_run_service.default.location}/services/${google_cloud_run_service.default.name}"
+	tag_value = google_tags_tag_value.value.id
+	location  = "us-central1"
 }
 `, context)
 }
@@ -949,27 +949,27 @@ resource "google_tags_tag_key" "key" {
 	description = "For a certain set of resources."
 }
 resource "google_tags_tag_value" "value" {
-	parent = "tagKeys/${google_tags_tag_key.key.name}"
-	short_name = "foo%{random_suffix}"
+	parent      = google_tags_tag_key.key.id
+	short_name  = "foo%{random_suffix}"
 	description = "For foo%{random_suffix} resources."
 }
 resource "google_compute_instance" "default" {
 	name         = "test-%{random_suffix}"
 	machine_type = "e2-medium"
 	zone         = "us-central1-a"
-	boot_disk {
-		initialize_params {
-			image = "debian-cloud/debian-11"
-		}
-	}
-	network_interface {
-		 network = "default"
-	}
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+  network_interface {
+    network = "default"
+  }
 }
 resource "google_tags_location_tag_binding" "binding" {
-	parent = "//compute.googleapis.com/projects/${data.google_project.project.number}/zones/us-central1-a/instances/${google_compute_instance.default.instance_id}"
-	tag_value = "tagValues/${google_tags_tag_value.value.name}"
-	location = "us-central1-a"
+	parent    = "//compute.googleapis.com/projects/${data.google_project.project.number}/zones/us-central1-a/instances/${google_compute_instance.default.instance_id}"
+	tag_value = google_tags_tag_value.value.id
+	location  = "us-central1-a"
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_config_test.go.tmpl
@@ -762,8 +762,8 @@ resource "google_tags_tag_key" "tag_key1" {
 }
 
 resource "google_tags_tag_value" "tag_value1" {
-  provider = google-beta
-  parent = "tagKeys/${google_tags_tag_key.tag_key1.name}"
+  provider   = google-beta
+  parent     = google_tags_tag_key.tag_key1.id
   short_name = "%{value_short_name}"
 }
 
@@ -1346,13 +1346,13 @@ data "google_project" "project" {
 
 resource "google_tags_tag_key" "tag_key1" {
   provider = google-beta
-  parent = "projects/${data.google_project.project.number}"
+  parent = data.google_project.project.id
   short_name = "tf_test_tag_key1%{random_suffix}"
 }
 
 resource "google_tags_tag_value" "tag_value1" {
   provider = google-beta
-  parent = "tagKeys/${google_tags_tag_key.tag_key1.name}"
+  parent = google_tags_tag_key.tag_key1.id
   short_name = "tf_test_tag_value1%{random_suffix}"
 }
 
@@ -1390,7 +1390,7 @@ resource "google_workstations_workstation_config" "default" {
       boot_disk_size_gb           = 35
       disable_public_ip_addresses = true
       vm_tags = {
-        "tagKeys/${google_tags_tag_key.tag_key1.name}" = "tagValues/${google_tags_tag_value.tag_value1.name}"
+        (google_tags_tag_key.tag_key1.id) = google_tags_tag_value.tag_value1.id
       }
     }
   }


### PR DESCRIPTION
Update the code for handwritten / templated go tests to use `foo.id` vs `"tagKeys/${foo.name}"` or `"tagValues/${foo.name}"`, and `foo.namespaced_name` vs. `"${data.google_project.project.project_id}/${foo.short_name}"`

This would be part 1: can update the resources for generated resources separately, and container_cluster will be covered in a separate PR.

Wrap map keys in parens where needed.

I tried to adjust spacing only in the affected blocks vs. doing any other terraform reformatting, except in one or two extreme cases.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
