### PR TITLE
accesscontextmanager - Fix permadiff for perimeter ingress / egress rule resources

### DIFF
--- a/mmv1/products/accesscontextmanager/ServicePerimeterDryRunEgressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterDryRunEgressPolicy.yaml
@@ -72,6 +72,7 @@ nested_query:
   is_list_of_ids: false
   modify_by_patch: true
 custom_code:
+  constants: 'templates/terraform/constants/access_context_manager.go.tmpl'
   pre_create: 'templates/terraform/pre_create/access_context_manager_dry_run_resource.go.tmpl'
   pre_update: 'templates/terraform/pre_create/access_context_manager_dry_run_resource.go.tmpl'
   pre_delete: 'templates/terraform/pre_create/access_context_manager_dry_run_resource.go.tmpl'
@@ -144,6 +145,8 @@ properties:
           if it contains a resource in this list. If * is specified for resources,
           then this `EgressTo` rule will authorize access to all resources outside
           the perimeter.
+        custom_flatten: templates/terraform/custom_flatten/accesscontextmanager_egress_policy_resources_custom_flatten.go.tmpl
+        diff_suppress_func: AccessContextManagerServicePerimeterDryRunEgressPolicyEgressToResourcesDiffSupressFunc
         item_type:
           type: String
       - name: 'externalResources'

--- a/mmv1/products/accesscontextmanager/ServicePerimeterDryRunIngressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterDryRunIngressPolicy.yaml
@@ -73,6 +73,7 @@ nested_query:
   is_list_of_ids: false
   modify_by_patch: true
 custom_code:
+  constants: 'templates/terraform/constants/access_context_manager.go.tmpl'
   pre_create: 'templates/terraform/pre_create/access_context_manager_dry_run_resource.go.tmpl'
   pre_update: 'templates/terraform/pre_create/access_context_manager_dry_run_resource.go.tmpl'
   pre_delete: 'templates/terraform/pre_create/access_context_manager_dry_run_resource.go.tmpl'
@@ -161,6 +162,8 @@ properties:
           then this `IngressTo` rule will authorize access to all
           resources inside the perimeter, provided that the request
           also matches the `operations` field.
+        custom_flatten: templates/terraform/custom_flatten/accesscontextmanager_ingress_policy_resources_custom_flatten.go.tmpl
+        diff_suppress_func: AccessContextManagerServicePerimeterDryRunIngressPolicyIngressToResourcesDiffSupressFunc
         item_type:
           type: String
       - name: 'operations'

--- a/mmv1/products/accesscontextmanager/ServicePerimeterEgressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterEgressPolicy.yaml
@@ -72,7 +72,8 @@ nested_query:
   is_list_of_ids: false
   modify_by_patch: true
 custom_code:
-  custom_import: 'templates/terraform/custom_import/access_context_manager_service_perimeter_ingress_policy.go.tmpl'
+  constants: 'templates/terraform/constants/access_context_manager.go.tmpl'
+  custom_import: 'templates/terraform/custom_import/access_context_manager_service_perimeter_egress_policy.go.tmpl'
 exclude_tgc: true
 # Skipping the sweeper due to the non-standard base_url and because this is fine-grained under ServicePerimeter
 exclude_sweeper: true
@@ -142,6 +143,8 @@ properties:
           if it contains a resource in this list. If * is specified for resources,
           then this `EgressTo` rule will authorize access to all resources outside
           the perimeter.
+        custom_flatten: templates/terraform/custom_flatten/accesscontextmanager_egress_policy_resources_custom_flatten.go.tmpl
+        diff_suppress_func: AccessContextManagerServicePerimeterEgressPolicyEgressToResourcesDiffSupressFunc
         item_type:
           type: String
       - name: 'externalResources'

--- a/mmv1/products/accesscontextmanager/ServicePerimeterIngressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterIngressPolicy.yaml
@@ -73,6 +73,7 @@ nested_query:
   is_list_of_ids: false
   modify_by_patch: true
 custom_code:
+  constants: 'templates/terraform/constants/access_context_manager.go.tmpl'
   custom_import: 'templates/terraform/custom_import/access_context_manager_service_perimeter_ingress_policy.go.tmpl'
 exclude_tgc: true
 # Skipping the sweeper due to the non-standard base_url and because this is fine-grained under ServicePerimeter
@@ -161,6 +162,8 @@ properties:
           then this `IngressTo` rule will authorize access to all
           resources inside the perimeter, provided that the request
           also matches the `operations` field.
+        custom_flatten: templates/terraform/custom_flatten/accesscontextmanager_ingress_policy_resources_custom_flatten.go.tmpl
+        diff_suppress_func: AccessContextManagerServicePerimeterIngressPolicyIngressToResourcesDiffSupressFunc
         item_type:
           type: String
       - name: 'operations'

--- a/mmv1/templates/terraform/constants/access_context_manager.go.tmpl
+++ b/mmv1/templates/terraform/constants/access_context_manager.go.tmpl
@@ -1,0 +1,41 @@
+func {{$.ResourceName}}EgressToResourcesDiffSupressFunc(_, _, _ string, d *schema.ResourceData) bool {
+    old, new := d.GetChange("egress_to.0.resources")
+
+    oldResources, err := tpgresource.InterfaceSliceToStringSlice(old)
+    if err != nil {
+        log.Printf("[ERROR] Failed to convert config value: %s", err)
+        return false
+    }
+
+    newResources, err := tpgresource.InterfaceSliceToStringSlice(new)
+    if err != nil {
+        log.Printf("[ERROR] Failed to convert config value: %s", err)
+        return false
+    }
+
+    sort.Strings(oldResources)
+    sort.Strings(newResources)
+
+    return slices.Equal(oldResources, newResources)
+}
+
+func {{$.ResourceName}}IngressToResourcesDiffSupressFunc(_, _, _ string, d *schema.ResourceData) bool {
+    old, new := d.GetChange("ingress_to.0.resources")
+
+    oldResources, err := tpgresource.InterfaceSliceToStringSlice(old)
+    if err != nil {
+        log.Printf("[ERROR] Failed to convert config value: %s", err)
+        return false
+    }
+
+    newResources, err := tpgresource.InterfaceSliceToStringSlice(new)
+    if err != nil {
+        log.Printf("[ERROR] Failed to convert config value: %s", err)
+        return false
+    }
+
+    sort.Strings(oldResources)
+    sort.Strings(newResources)
+
+    return slices.Equal(oldResources, newResources)
+}

--- a/mmv1/templates/terraform/custom_flatten/accesscontextmanager_egress_policy_resources_custom_flatten.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/accesscontextmanager_egress_policy_resources_custom_flatten.go.tmpl
@@ -1,0 +1,25 @@
+func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+    rawConfigValue := d.Get("egress_to.0.resources")
+
+    // Convert config value to []string
+    configValue, err := tpgresource.InterfaceSliceToStringSlice(rawConfigValue)
+    if err != nil {
+        log.Printf("[ERROR] Failed to convert config value: %s", err)
+        return v
+    }
+
+    // Convert v to []string
+    apiStringValue, err := tpgresource.InterfaceSliceToStringSlice(v)
+    if err != nil {
+        log.Printf("[ERROR] Failed to convert API value: %s", err)
+        return v
+    }
+
+    sortedStrings, err := tpgresource.SortStringsByConfigOrder(configValue, apiStringValue)
+    if err != nil {
+        log.Printf("[ERROR] Could not sort API response value: %s", err)
+        return v
+    }
+
+    return sortedStrings
+}

--- a/mmv1/templates/terraform/custom_flatten/accesscontextmanager_ingress_policy_resources_custom_flatten.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/accesscontextmanager_ingress_policy_resources_custom_flatten.go.tmpl
@@ -1,0 +1,25 @@
+func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+    rawConfigValue := d.Get("ingress_to.0.resources")
+
+    // Convert config value to []string
+    configValue, err := tpgresource.InterfaceSliceToStringSlice(rawConfigValue)
+    if err != nil {
+        log.Printf("[ERROR] Failed to convert config value: %s", err)
+        return v
+    }
+
+    // Convert v to []string
+    apiStringValue, err := tpgresource.InterfaceSliceToStringSlice(v)
+    if err != nil {
+        log.Printf("[ERROR] Failed to convert API value: %s", err)
+        return v
+    }
+
+    sortedStrings, err := tpgresource.SortStringsByConfigOrder(configValue, apiStringValue)
+    if err != nil {
+        log.Printf("[ERROR] Could not sort API response value: %s", err)
+        return v
+    }
+
+    return sortedStrings
+}


### PR DESCRIPTION
Add diff suppress and custom flatten to fix permadiffs for changing resource orders on the api side. Sometimes the api returns a different order for (ingressTo|egressTo).resources. This change sorts the users config and the api response to always be in the same order to prevent diffs.


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: bug
accesscontextmanager: Fixed permadiff for perimeter ingress / egress rule resources
```
