### PR TITLE
Allow for single field indexes in 'google_firestore_index' resources to support __name__ DESC indexes

### DIFF
--- a/mmv1/products/firestore/Index.yaml
+++ b/mmv1/products/firestore/Index.yaml
@@ -81,6 +81,12 @@ examples:
       database_id: 'database-id-vector'
     test_env_vars:
       project_id: 'PROJECT_NAME'
+  - name: 'firestore_index_name_descending'
+    primary_resource_id: 'my-index'
+    vars:
+      database_id: 'database-id'
+    test_env_vars:
+      project_id: 'PROJECT_NAME'
 parameters:
 properties:
   - name: 'name'
@@ -175,5 +181,6 @@ properties:
               properties:
  # Meant to be an empty object with no properties.
                 []
-    # Single field indexes _exist_, but the API only lets us manage composite ones.
-    min_size: 2
+    # Most composite indexes require at least two fields, but it is possible
+    # for a user to require a single field index such as `__name__ DESC`.
+    min_size: 1

--- a/mmv1/templates/terraform/examples/firestore_index_name_descending.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_index_name_descending.tf.tmpl
@@ -1,0 +1,20 @@
+resource "google_firestore_database" "database" {
+  project     = "{{index $.TestEnvVars "project_id"}}"
+  name        = "{{index $.Vars "database_id"}}"
+  location_id = "nam5"
+  type        = "FIRESTORE_NATIVE"
+
+  delete_protection_state = "DELETE_PROTECTION_DISABLED"
+  deletion_policy         = "DELETE"
+}
+
+resource "google_firestore_index" "{{$.PrimaryResourceId}}" {
+  project     = "{{index $.TestEnvVars "project_id"}}"
+  database   = google_firestore_database.database.name
+  collection = "atestcollection"
+
+  fields {
+    field_path = "__name__"
+    order      = "DESCENDING"
+  }
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Allow single field indexes in the google_firestore_index resource, this is to support having a descending index on the __name__ of the document.


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
firestore: allowed single field indexes to support `__name__ DESC` indexes in `google_firestore_index` resources
```
