### PR TITLE
Fix nightly test failure of `billing_project` related acceptance tests

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_billing_project_test.go
+++ b/mmv1/third_party/terraform/provider/provider_billing_project_test.go
@@ -140,8 +140,8 @@ func testAccSdkProvider_billing_project_emptyStringValidation(t *testing.T) {
 }
 
 func testAccSdkProvider_billing_project_useWithAndWithoutUserProjectOverride(t *testing.T) {
-	// Test does interact with APIs but experienced errors when run in VCR mode
-	// See: https://github.com/GoogleCloudPlatform/magic-modules/pull/11610#discussion_r1783271457
+	// Test cannot run in VCR mode due to use of aliases
+	// See: https://github.com/hashicorp/terraform-provider-google/issues/20019
 	acctest.SkipIfVcr(t)
 
 	randomString := acctest.RandString(t, 10)
@@ -186,8 +186,8 @@ func testAccSdkProvider_billing_project_useWithAndWithoutUserProjectOverride(t *
 }
 
 func testAccSdkProvider_billing_project_affectedByClientLibraryEnv(t *testing.T) {
-	// Test does interact with APIs but experienced errors when run in VCR mode
-	// See: https://github.com/GoogleCloudPlatform/magic-modules/pull/11610#issuecomment-2432649993
+	// Test cannot run in VCR mode due to use of aliases
+	// See: https://github.com/hashicorp/terraform-provider-google/issues/20019
 	acctest.SkipIfVcr(t)
 
 	randomString := acctest.RandString(t, 10)

--- a/mmv1/third_party/terraform/provider/provider_billing_project_test.go
+++ b/mmv1/third_party/terraform/provider/provider_billing_project_test.go
@@ -261,6 +261,13 @@ resource "google_project" "project" {
   billing_account = "%{billing_account}"
   deletion_policy = "DELETE"
 }
+
+resource "google_project_service" "serviceusage" {
+  project  = google_project.project.project_id
+  service  = "serviceusage.googleapis.com"
+
+  disable_on_destroy = false # Need it enabled in the project when the test disables services in post-test cleanup
+}
 `, context)
 }
 
@@ -293,16 +300,6 @@ resource "google_pubsub_topic" "example-resource-in" {
 // the PubSub API. This allows the second apply step to succeed in a test, if needed.
 func testAccSdkProvider_billing_project_useBillingProject_setupWithApiEnabled(context map[string]interface{}) string {
 	return testAccSdkProvider_billing_project_useBillingProject_setup(context) + acctest.Nprintf(`
-# Needed for post test cleanup
-  resource "google_project_service" "serviceusage" {
-  project  = google_project.project.project_id
-  service  = "serviceusage.googleapis.com"
-
-  depends_on = [
-    google_project_service.pubsub,
-    google_project_service.cloudresourcemanager
-  ]
-}
 
 # Needed for test steps to apply without error
 resource "google_project_service" "pubsub" {

--- a/mmv1/third_party/terraform/provider/provider_user_project_override_test.go
+++ b/mmv1/third_party/terraform/provider/provider_user_project_override_test.go
@@ -240,7 +240,9 @@ data "google_provider_config_sdk" "default" {}
 // - If user_project_override = false : the apply fails as the API is disabled in project-1
 // - If user_project_override = true : the apply succeeds as X-Goog-User-Project will reference project-2, where API is enabled
 func testAccProviderUserProjectOverride(t *testing.T) {
-	// Parallel fine-grained resource creation
+	// Test cannot run in VCR mode due to use of aliases
+	// See: https://github.com/hashicorp/terraform-provider-google/issues/20019
+	// And also due to the resources made out of band in acctest.SetupProjectsAndGetAccessToken
 	acctest.SkipIfVcr(t)
 	t.Parallel()
 
@@ -286,7 +288,9 @@ func testAccProviderUserProjectOverride(t *testing.T) {
 // Do the same thing as TestAccProviderUserProjectOverride, but using a resource that gets its project via
 // a reference to a different resource instead of a project field.
 func testAccProviderIndirectUserProjectOverride(t *testing.T) {
-	// Parallel fine-grained resource creation
+	// Test cannot run in VCR mode due to use of aliases
+	// See: https://github.com/hashicorp/terraform-provider-google/issues/20019
+	// And also due to the resources made out of band in acctest.SetupProjectsAndGetAccessToken
 	acctest.SkipIfVcr(t)
 	t.Parallel()
 


### PR DESCRIPTION
This PR updates the 'usage' test cases in TestAccSdkProvider_billing_project so that the newly provisioned project always has the Service Usage API enabled. This is needed to [address failures in nightly tests](https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_GoogleCloud_GOOGLE_NIGHTLYTESTS_GOOGLE_PACKAGE_PROVIDER/254854?branch=refs%2Fheads%2Fnightly-test&buildTypeTab=overview&mode=builds&hideTestsFromDependencies=false&buildTab=tests&expandedTest=build%3A%28id%3A254854%29%2Cid%3A2000000015).

This doesn't impact the acceptance tests' validity, as they only rely on the PubSub API being dis/enabled in the new project. Service Usage API doesn't impact that.


Here's the error being solved:

```
------- Stdout: -------
=== RUN   TestAccSdkProvider_billing_project
=== RUN   TestAccSdkProvider_billing_project/config_takes_precedence_over_environment_variables
=== RUN   TestAccSdkProvider_billing_project/when_billing_project_is_unset_in_the_config,_environment_variables_are_used_in_a_given_order
=== RUN   TestAccSdkProvider_billing_project/when_billing_project_is_set_to_an_empty_string_in_the_config_the_value_isn't_ignored_and_results_in_an_error
=== RUN   TestAccSdkProvider_billing_project/GOOGLE_CLOUD_QUOTA_PROJECT_environment_variable_interferes_with_the_billing_account_value_used
    testing_new.go:90: Error running post-test destroy, there may be dangling resources: exit status 1
        Error: Error when reading or editing Project Service tf-test-3svo0ueyzk/pubsub.googleapis.com: Error disabling service "pubsub.googleapis.com" for project "tf-test-3svo0ueyzk": googleapi: Error 403: Service Usage API has not been used in project tf-test-3svo0ueyzk before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/serviceusage.googleapis.com/overview?project=tf-test-3svo0ueyzk then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.
        Details:
        [
          {
            "@type": "type.googleapis.com/google.rpc.Help",
            "links": [
              {
                "description": "Google developers console API activation",
                "url": "https://console.developers.google.com/apis/api/serviceusage.googleapis.com/overview?project=tf-test-3svo0ueyzk
              }
            ]
          },
          {
            "@type": "type.googleapis.com/google.rpc.ErrorInfo",
            "domain": "googleapis.com",
            "metadata": {
              "consumer": "projects/tf-test-3svo0ueyzk",
              "service": "serviceusage.googleapis.com"
            },
            "reason": "SERVICE_DISABLED"
          }
        ]
        , accessNotConfigured
=== RUN   TestAccSdkProvider_billing_project/using_billing_account_alone_doesn't_impact_provisioning,_but_using_together_with_user_project_override_does
--- FAIL: TestAccSdkProvider_billing_project (341.69s)
    --- PASS: TestAccSdkProvider_billing_project/config_takes_precedence_over_environment_variables (10.50s)
    --- PASS: TestAccSdkProvider_billing_project/when_billing_project_is_unset_in_the_config,_environment_variables_are_used_in_a_given_order (16.22s)
    --- PASS: TestAccSdkProvider_billing_project/when_billing_project_is_set_to_an_empty_string_in_the_config_the_value_isn't_ignored_and_results_in_an_error (0.92s)
    --- FAIL: TestAccSdkProvider_billing_project/GOOGLE_CLOUD_QUOTA_PROJECT_environment_variable_interferes_with_the_billing_account_value_used (127.14s)
    --- PASS: TestAccSdkProvider_billing_project/using_billing_account_alone_doesn't_impact_provisioning,_but_using_together_with_user_project_override_does (186.92s)
FAIL
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
