### PR TITLE
Normalize GKE resource link in the example given in gkehub membership description

### DIFF
--- a/mmv1/products/gkehub/Membership.yaml
+++ b/mmv1/products/gkehub/Membership.yaml
@@ -155,7 +155,7 @@ properties:
             type: String
             description: |
               Self-link of the GCP resource for the GKE cluster.
-              For example: `//container.googleapis.com/projects/my-project/zones/us-west1-a/clusters/my-cluster`.
+              For example: `//container.googleapis.com/projects/my-project/locations/us-west1-a/clusters/my-cluster`.
               It can be at the most 1000 characters in length. If the cluster is provisioned with Terraform,
               this can be `"//container.googleapis.com/${google_container_cluster.my-cluster.id}"` or
               `google_container_cluster.my-cluster.id`.
@@ -174,6 +174,6 @@ properties:
         type: String
         description: |
           A JSON Web Token (JWT) issuer URI. `issuer` must start with `https://` and // be a valid
-          with length <2000 characters. For example: `https://container.googleapis.com/v1/projects/my-project/locations/us-west1/clusters/my-cluster` (must be `locations` rather than `zones`). If the cluster is provisioned with Terraform, this is `"https://container.googleapis.com/v1/${google_container_cluster.my-cluster.id}"`.
+          with length <2000 characters. For example: `https://container.googleapis.com/v1/projects/my-project/locations/us-west1/clusters/my-cluster`. If the cluster is provisioned with Terraform, this is `"https://container.googleapis.com/v1/${google_container_cluster.my-cluster.id}"`.
         required: true
         immutable: true


### PR DESCRIPTION
This PR changes the example for the GKE resource link in the gkehub membership resource to use `locations/` instead of `zones/`. While gkehub still supports `zones/` at the moment, the GKE resource link should be in the format `//container.googleapis.com/projects/{{project}}/locations/{{region or zone}}/clusters/{{cluster}}` for both regional and zonal clusters.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
