### PR TITLE
Add disabled attribute to service account data source

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_service_account.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_service_account.go
@@ -41,6 +41,10 @@ func DataSourceGoogleServiceAccount() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"disabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -83,6 +87,9 @@ func dataSourceGoogleServiceAccountRead(d *schema.ResourceData, meta interface{}
 	}
 	if err := d.Set("member", "serviceAccount:"+sa.Email); err != nil {
 		return fmt.Errorf("Error setting member: %s", err)
+	}
+	if err := d.Set("disabled", sa.Disabled); err != nil {
+		return fmt.Errorf("Error setting disabled: %s", err)
 	}
 
 	return nil

--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_service_account_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_service_account_test.go
@@ -29,6 +29,7 @@ func TestAccDatasourceGoogleServiceAccount_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "name"),
 					resource.TestCheckResourceAttrSet(resourceName, "display_name"),
 					resource.TestCheckResourceAttrSet(resourceName, "member"),
+					resource.TestCheckResourceAttrSet(resourceName, "disabled"),
 				),
 			},
 		},

--- a/mmv1/third_party/terraform/website/docs/d/service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/service_account.html.markdown
@@ -70,3 +70,5 @@ exported:
 * `display_name` - The display name for the service account.
 
 * `member` - The Identity of the service account in the form `serviceAccount:{email}`. This value is often used to refer to the service account in order to grant IAM permissions.
+
+* `disabled` - Whether a service account is disabled or not.


### PR DESCRIPTION
Adds the `disabled` attribute to the service account data source.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/20024

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
resourcemanager: added `disabled` to `google_service_account` datasource
```
