### PR TITLE
refactor: update resource manager tag references

### DIFF
--- a/mmv1/templates/terraform/examples/bigquery_dataset_resource_tags.tf.tmpl
+++ b/mmv1/templates/terraform/examples/bigquery_dataset_resource_tags.tf.tmpl
@@ -27,7 +27,7 @@ resource "google_bigquery_dataset" "{{$.PrimaryResourceId}}" {
   location      = "EU"
 
   resource_tags = {
-    (google_tags_tag_key.tag_key1.id) = google_tags_tag_value.tag_value1.id
-    (google_tags_tag_key.tag_key2.id) = google_tags_tag_value.tag_value2.id
+    (google_tags_tag_key.tag_key1.namespaced_name) = google_tags_tag_value.tag_value1.short_name
+    (google_tags_tag_key.tag_key2.namespaced_name) = google_tags_tag_value.tag_value2.short_name
   }
 }

--- a/mmv1/templates/terraform/examples/bigquery_dataset_resource_tags.tf.tmpl
+++ b/mmv1/templates/terraform/examples/bigquery_dataset_resource_tags.tf.tmpl
@@ -1,34 +1,33 @@
-data "google_project" "project" {
-}
+data "google_project" "project" {}
 
 resource "google_tags_tag_key" "tag_key1" {
-  parent = "projects/${data.google_project.project.number}"
+  parent     = data.google_project.project.id
   short_name = "{{index $.Vars "tag_key1"}}"
 }
 
 resource "google_tags_tag_value" "tag_value1" {
-  parent = "tagKeys/${google_tags_tag_key.tag_key1.name}"
+  parent     = google_tags_tag_key.tag_key1.id
   short_name = "{{index $.Vars "tag_value1"}}"
 }
 
 resource "google_tags_tag_key" "tag_key2" {
-  parent = "projects/${data.google_project.project.number}"
+  parent     = data.google_project.project.id
   short_name = "{{index $.Vars "tag_key2"}}"
 }
 
 resource "google_tags_tag_value" "tag_value2" {
-  parent = "tagKeys/${google_tags_tag_key.tag_key2.name}"
+  parent     = google_tags_tag_key.tag_key2.id
   short_name = "{{index $.Vars "tag_value2"}}"
 }
 
 resource "google_bigquery_dataset" "{{$.PrimaryResourceId}}" {
-  dataset_id                  = "{{index $.Vars "dataset_id"}}"
-  friendly_name               = "test"
-  description                 = "This is a test description"
-  location                    = "EU"
+  dataset_id    = "{{index $.Vars "dataset_id"}}"
+  friendly_name = "test"
+  description   = "This is a test description"
+  location      = "EU"
 
   resource_tags = {
-    "${data.google_project.project.project_id}/${google_tags_tag_key.tag_key1.short_name}" = "${google_tags_tag_value.tag_value1.short_name}"
-    "${data.google_project.project.project_id}/${google_tags_tag_key.tag_key2.short_name}" = "${google_tags_tag_value.tag_value2.short_name}"
+    (google_tags_tag_key.tag_key1.id) = google_tags_tag_value.tag_value1.id
+    (google_tags_tag_key.tag_key2.id) = google_tags_tag_value.tag_value2.id
   }
 }

--- a/mmv1/templates/terraform/examples/compute_network_firewall_policy_with_rules_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/compute_network_firewall_policy_with_rules_full.tf.tmpl
@@ -25,7 +25,7 @@ resource "google_compute_network_firewall_policy_with_rules" "{{$.PrimaryResourc
       dest_address_groups = [google_network_security_address_group.address_group_1.id]
     }
     target_secure_tag {
-      name = "tagValues/${google_tags_tag_value.secure_tag_value_1.name}"
+      name = google_tags_tag_value.secure_tag_value_1.id
     }
   }
   rule {
@@ -44,7 +44,7 @@ resource "google_compute_network_firewall_policy_with_rules" "{{$.PrimaryResourc
         src_threat_intelligences = ["iplist-known-malicious-ips", "iplist-public-clouds"]
         src_address_groups = [google_network_security_address_group.address_group_1.id]
         src_secure_tag {
-          name = "tagValues/${google_tags_tag_value.secure_tag_value_1.name}"
+          name = google_tags_tag_value.secure_tag_value_1.id
         }
       }
       disabled = true
@@ -72,7 +72,7 @@ resource "google_compute_network_firewall_policy_with_rules" "{{$.PrimaryResourc
 resource "google_network_security_address_group" "address_group_1" {
   provider    = google-beta
   name        = "{{index $.Vars "address_group_name"}}"
-  parent      = "projects/${data.google_project.project.name}"
+  parent      = data.google_project.project.id
   description = "Global address group"
   location    = "global"
   items       = ["208.80.154.224/32"]
@@ -83,7 +83,7 @@ resource "google_network_security_address_group" "address_group_1" {
 resource "google_tags_tag_key" "secure_tag_key_1" {
   provider    = google-beta
   description = "Tag key"
-  parent      = "projects/${data.google_project.project.name}"
+  parent      = data.google_project.project.id
   purpose     = "GCE_FIREWALL"
   short_name  = "{{index $.Vars "tag_key_name"}}"
   purpose_data = {
@@ -94,7 +94,7 @@ resource "google_tags_tag_key" "secure_tag_key_1" {
 resource "google_tags_tag_value" "secure_tag_value_1" {
   provider    = google-beta
   description = "Tag value"
-  parent      = "tagKeys/${google_tags_tag_key.secure_tag_key_1.name}"
+  parent      = google_tags_tag_key.secure_tag_key_1.id
   short_name  = "{{index $.Vars "tag_value_name"}}"
 }
 

--- a/mmv1/templates/terraform/examples/compute_region_network_firewall_policy_with_rules_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/compute_region_network_firewall_policy_with_rules_full.tf.tmpl
@@ -26,7 +26,7 @@ resource "google_compute_region_network_firewall_policy_with_rules" "{{$.Primary
       dest_address_groups = [google_network_security_address_group.address_group_1.id]
     }
     target_secure_tag {
-      name = "google_tags_tag_value.secure_tag_value_1.id
+      name = google_tags_tag_value.secure_tag_value_1.id
     }
   }
   rule {

--- a/mmv1/templates/terraform/examples/compute_region_network_firewall_policy_with_rules_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/compute_region_network_firewall_policy_with_rules_full.tf.tmpl
@@ -26,7 +26,7 @@ resource "google_compute_region_network_firewall_policy_with_rules" "{{$.Primary
       dest_address_groups = [google_network_security_address_group.address_group_1.id]
     }
     target_secure_tag {
-      name = "tagValues/${google_tags_tag_value.secure_tag_value_1.name}"
+      name = "google_tags_tag_value.secure_tag_value_1.id
     }
   }
   rule {
@@ -46,7 +46,7 @@ resource "google_compute_region_network_firewall_policy_with_rules" "{{$.Primary
         src_threat_intelligences = ["iplist-known-malicious-ips", "iplist-public-clouds"]
         src_address_groups = [google_network_security_address_group.address_group_1.id]
         src_secure_tag {
-          name = "tagValues/${google_tags_tag_value.secure_tag_value_1.name}"
+          name = google_tags_tag_value.secure_tag_value_1.id
         }
       }
       disabled = true
@@ -56,7 +56,7 @@ resource "google_compute_region_network_firewall_policy_with_rules" "{{$.Primary
 resource "google_network_security_address_group" "address_group_1" {
   provider  = google-beta 
   name        = "{{index $.Vars "address_group_name"}}"
-  parent      = "projects/${data.google_project.project.name}"
+  parent      = data.google_project.project.id
   description = "Regional address group"
   location    = "us-west2"
   items       = ["208.80.154.224/32"]
@@ -65,9 +65,9 @@ resource "google_network_security_address_group" "address_group_1" {
 }
 
 resource "google_tags_tag_key" "secure_tag_key_1" {
-  provider   = google-beta 
+  provider    = google-beta
   description = "Tag key"
-  parent      = "projects/${data.google_project.project.name}"
+  parent      = data.google_project.project.id
   purpose     = "GCE_FIREWALL"
   short_name  = "{{index $.Vars "tag_key_name"}}"
   purpose_data = {
@@ -76,8 +76,8 @@ resource "google_tags_tag_key" "secure_tag_key_1" {
 }
 
 resource "google_tags_tag_value" "secure_tag_value_1" {
-  provider   = google-beta 
+  provider    = google-beta
   description = "Tag value"
-  parent      = "tagKeys/${google_tags_tag_key.secure_tag_key_1.name}"
+  parent      = google_tags_tag_key.secure_tag_key_1.id
   short_name  = "{{index $.Vars "tag_value_name"}}"
 }

--- a/mmv1/templates/terraform/examples/dlp_discovery_config_actions.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dlp_discovery_config_actions.tf.tmpl
@@ -1,96 +1,96 @@
 resource "google_data_loss_prevention_discovery_config" "{{$.PrimaryResourceId}}" {
-	parent = "projects/{{index $.TestEnvVars "project"}}/locations/us"
-    location = "us"
-    status = "RUNNING"
+  parent   = "projects/{{index $.TestEnvVars "project"}}/locations/us"
+  location = "us"
+  status   = "RUNNING"
 
-    targets {
-        big_query_target {
-            filter {
-                other_tables {}
-            }
-        }
+  targets {
+    big_query_target {
+      filter {
+        other_tables {}
+      }
     }
-    actions {
-        export_data {
-            profile_table {
-                project_id = "project"
-                dataset_id = "dataset"
-                table_id = "table"
-            }
-        }
+  }
+  actions {
+    export_data {
+      profile_table {
+        project_id = "project"
+        dataset_id = "dataset"
+        table_id   = "table"
+      }
     }
-    actions { 
-        pub_sub_notification {
-            topic = "projects/%{project}/topics/${google_pubsub_topic.{{$.PrimaryResourceId}}.name}"
-            event = "NEW_PROFILE"
-            pubsub_condition {
-                expressions {
-                    logical_operator = "OR"
-                    conditions {
-                        minimum_sensitivity_score = "HIGH"
-                    }
-                }
-            }
-            detail_of_message = "TABLE_PROFILE"
+  }
+  actions {
+    pub_sub_notification {
+      topic = "projects/%{project}/topics/${google_pubsub_topic.{{$.PrimaryResourceId}}.name}"
+      event = "NEW_PROFILE"
+      pubsub_condition {
+        expressions {
+          logical_operator = "OR"
+          conditions {
+            minimum_sensitivity_score = "HIGH"
+          }
         }
+      }
+      detail_of_message = "TABLE_PROFILE"
     }
-    actions {
-        tag_resources {
-            tag_conditions {
-                tag {
-                    namespaced_value = "123456/environment/prod"
-                }
-                sensitivity_score {
-                    score = "SENSITIVITY_HIGH"
-                }
-            }
-            tag_conditions {
-                tag {
-                    namespaced_value = "123456/environment/test"
-                }
-                sensitivity_score {
-                    score = "SENSITIVITY_LOW"
-                }
-            }
-            profile_generations_to_tag = ["PROFILE_GENERATION_NEW", "PROFILE_GENERATION_UPDATE"]
-            lower_data_risk_to_low = true
+  }
+  actions {
+    tag_resources {
+      tag_conditions {
+        tag {
+          namespaced_value = "123456/environment/prod"
         }
+        sensitivity_score {
+          score = "SENSITIVITY_HIGH"
+        }
+      }
+      tag_conditions {
+        tag {
+          namespaced_value = "123456/environment/test"
+        }
+        sensitivity_score {
+          score = "SENSITIVITY_LOW"
+        }
+      }
+      profile_generations_to_tag = ["PROFILE_GENERATION_NEW", "PROFILE_GENERATION_UPDATE"]
+      lower_data_risk_to_low     = true
     }
-    inspect_templates = ["projects/%{project}/inspectTemplates/${google_data_loss_prevention_inspect_template.basic.name}"] 
+  }
+  inspect_templates = ["projects/%{project}/inspectTemplates/${google_data_loss_prevention_inspect_template.basic.name}"]
 }
 
 resource "google_pubsub_topic" "{{$.PrimaryResourceId}}" {
-    name = "fake-topic"
+  name = "fake-topic"
 }
 
 resource "google_data_loss_prevention_inspect_template" "basic" {
-	parent = "projects/{{index $.TestEnvVars "project"}}"
-	description = "My description"
-	display_name = "display_name"
+  parent      = "projects/{{index $.TestEnvVars "project"}}"
+  description = "My description"
+  display_name = "display_name"
 
-	inspect_config {
-		info_types {
-			name = "EMAIL_ADDRESS"
-		}
+  inspect_config {
+    info_types {
+      name = "EMAIL_ADDRESS"
     }
+  }
 }
 
 data "google_project" "project" {
-	project_id = "%{project}"
+  project_id = "%{project}"
 }
 
 resource "google_tags_tag_key" "tag_key" {
-	parent = "projects/${data.google_project.project.number}"
-	short_name = "environment"
+  parent     = "projects/${data.google_project.project.number}"
+  short_name = "environment"
 }
 
 resource "google_tags_tag_value" "tag_value" {
-	parent = "tagKeys/${google_tags_tag_key.tag_key.name}"
-	short_name = "prod"
+  parent     = google_tags_tag_key.tag_key.id
+  short_name = "prod"
 }
 
 resource "google_project_iam_member" "tag_role" {
-    project = "%{project}"
-    role    = "roles/resourcemanager.tagUser"
-    member = "serviceAccount:service-${data.google_project.project.number}@dlp-api.iam.gserviceaccount.com"
+  project = "%{project}"
+  role    = "roles/resourcemanager.tagUser"
+  member  = "serviceAccount:service-${data.google_project.project.number}@dlp-api.iam.gserviceaccount.com"
 }

--- a/mmv1/templates/terraform/examples/dlp_discovery_config_actions.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dlp_discovery_config_actions.tf.tmpl
@@ -80,7 +80,7 @@ data "google_project" "project" {
 }
 
 resource "google_tags_tag_key" "tag_key" {
-  parent     = "projects/${data.google_project.project.number}"
+  parent     = data.google_project.project.id
   short_name = "environment"
 }
 

--- a/mmv1/templates/terraform/examples/network_firewall_policy_rule.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_firewall_policy_rule.tf.tmpl
@@ -32,7 +32,7 @@ resource "google_compute_network_firewall_policy_rule" "{{$.PrimaryResourceId}}"
     src_threat_intelligences = ["iplist-known-malicious-ips"]
 
     src_secure_tags {
-      name = "tagValues/${google_tags_tag_value.basic_value.name}"
+      name = google_tags_tag_value.basic_value.id
     }
 
     layer4_configs {
@@ -59,6 +59,6 @@ resource "google_tags_tag_key" "basic_key" {
 
 resource "google_tags_tag_value" "basic_value" {
   description = "For valuename resources."
-  parent      = "tagKeys/${google_tags_tag_key.basic_key.name}"
+  parent      = google_tags_tag_key.basic_key.id
   short_name  = "tagvalue"
 }

--- a/mmv1/templates/terraform/examples/region_network_firewall_policy_rule.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_network_firewall_policy_rule.tf.tmpl
@@ -38,7 +38,7 @@ resource "google_compute_region_network_firewall_policy_rule" "{{$.PrimaryResour
     }
 
     src_secure_tags {
-      name = "tagValues/${google_tags_tag_value.basic_value.name}"
+      name = google_tags_tag_value.basic_value.id
     }
 
     src_address_groups = [google_network_security_address_group.basic_regional_networksecurity_address_group.id]
@@ -62,6 +62,6 @@ resource "google_tags_tag_key" "basic_key" {
 
 resource "google_tags_tag_value" "basic_value" {
   description = "For valuename resources."
-  parent      = "tagKeys/${google_tags_tag_key.basic_key.name}"
+  parent      = google_tags_tag_key.basic_key.id
   short_name  = "tagvalue"
 }

--- a/mmv1/templates/terraform/examples/tag_binding_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/tag_binding_basic.tf.tmpl
@@ -1,23 +1,24 @@
 resource "google_project" "project" {
-	project_id = "{{index $.Vars "project_id"}}"
-	name       = "{{index $.Vars "project_id"}}"
-	org_id     = "{{index $.TestEnvVars "org_id"}}"
-	deletion_policy = "DELETE"
+  project_id = "{{index $.Vars "project_id"}}"
+  name       = "{{index $.Vars "project_id"}}"
+  org_id     = "{{index $.TestEnvVars "org_id"}}"
+
+  deletion_policy = "DELETE"
 }
 
 resource "google_tags_tag_key" "key" {
-	parent = "organizations/{{index $.TestEnvVars "org_id"}}"
-	short_name = "{{index $.Vars "key_short_name"}}"
-	description = "For {{index $.Vars "key_short_name"}} resources."
+  parent      = "organizations/{{index $.TestEnvVars "org_id"}}"
+  short_name  = "{{index $.Vars "key_short_name"}}"
+  description = "For {{index $.Vars "key_short_name"}} resources."
 }
 
 resource "google_tags_tag_value" "value" {
-	parent = "tagKeys/${google_tags_tag_key.key.name}"
-	short_name = "{{index $.Vars "value_short_name"}}"
-	description = "For {{index $.Vars "value_short_name"}} resources."
+  parent      = google_tags_tag_key.key.id
+  short_name  = "{{index $.Vars "value_short_name"}}"
+  description = "For {{index $.Vars "value_short_name"}} resources."
 }
 
 resource "google_tags_tag_binding" "{{$.PrimaryResourceId}}" {
-	parent = "//cloudresourcemanager.googleapis.com/projects/${google_project.project.number}"
-	tag_value = "tagValues/${google_tags_tag_value.value.name}"
+  parent    = "//cloudresourcemanager.googleapis.com/projects/${google_project.project.number}"
+  tag_value = google_tags_tag_value.value.id
 }

--- a/mmv1/templates/terraform/examples/tag_value_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/tag_value_basic.tf.tmpl
@@ -1,11 +1,11 @@
 resource "google_tags_tag_key" "key" {
-	parent = "organizations/{{index $.TestEnvVars "org_id"}}"
-	short_name = "{{index $.Vars "key_short_name"}}"
+	parent      = "organizations/{{index $.TestEnvVars "org_id"}}"
+	short_name  = "{{index $.Vars "key_short_name"}}"
 	description = "For {{index $.Vars "key_short_name"}} resources."
 }
 
 resource "google_tags_tag_value" "{{$.PrimaryResourceId}}" {
-	parent = "tagKeys/${google_tags_tag_key.key.name}"
-	short_name = "{{index $.Vars "value_short_name"}}"
+	parent      = google_tags_tag_key.key.id
+	short_name  = "{{index $.Vars "value_short_name"}}"
 	description = "For {{index $.Vars "value_short_name"}} resources."
 }

--- a/mmv1/templates/terraform/examples/workstation_config_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/workstation_config_basic.tf.tmpl
@@ -6,7 +6,7 @@ resource "google_tags_tag_key" "tag_key1" {
 
 resource "google_tags_tag_value" "tag_value1" {
   provider   = google-beta
-  parent     = "tagKeys/${google_tags_tag_key.tag_key1.name}"
+  parent     = google_tags_tag_key.tag_key1.id
   short_name = "{{index $.Vars "value_short_name"}}"
 }
 
@@ -67,7 +67,7 @@ resource "google_workstations_workstation_config" "{{$.PrimaryResourceId}}" {
       disable_public_ip_addresses = true
       disable_ssh                 = false
       vm_tags = {
-        "tagKeys/${google_tags_tag_key.tag_key1.name}" = "tagValues/${google_tags_tag_value.tag_value1.name}"
+        (google_tags_tag_key.tag_key1.id) = google_tags_tag_value.tag_value1.id
       }
     }
   }

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_dataset_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_dataset_test.go.tmpl
@@ -827,8 +827,7 @@ resource "google_bigquery_dataset" "test" {
 
 func testAccBigQueryDataset_bigqueryDatasetResourceTags_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-data "google_project" "project" {
-}
+data "google_project" "project" {}
 
 resource "google_tags_tag_key" "tag_key1" {
   parent     = data.google_project.project.id

--- a/tpgtools/overrides/compute/samples/networkfirewallpolicyrule/global.tf.tmpl
+++ b/tpgtools/overrides/compute/samples/networkfirewallpolicyrule/global.tf.tmpl
@@ -32,7 +32,7 @@ resource "google_compute_network_firewall_policy_rule" "primary" {
     src_threat_intelligences = ["iplist-known-malicious-ips"]
 
     src_secure_tags {
-      name = "tagValues/${google_tags_tag_value.basic_value.name}"
+      name = google_tags_tag_value.basic_value.id
     }
 
     layer4_configs {
@@ -59,6 +59,6 @@ resource "google_tags_tag_key" "basic_key" {
 
 resource "google_tags_tag_value" "basic_value" {
   description = "For valuename resources."
-  parent      = "tagKeys/${google_tags_tag_key.basic_key.name}"
+  parent      = google_tags_tag_key.basic_key.id
   short_name  = "{{tagvalue}}"
 }

--- a/tpgtools/overrides/compute/samples/networkfirewallpolicyrule/global_update.tf.tmpl
+++ b/tpgtools/overrides/compute/samples/networkfirewallpolicyrule/global_update.tf.tmpl
@@ -40,7 +40,7 @@ resource "google_compute_network_firewall_policy_rule" "primary" {
   }
 
   target_secure_tags {
-    name = "tagValues/${google_tags_tag_value.basic_value.name}"
+    name = google_tags_tag_value.basic_value.id
   }
 }
 
@@ -62,6 +62,6 @@ resource "google_tags_tag_key" "basic_key" {
 
 resource "google_tags_tag_value" "basic_value" {
   description = "For valuename resources."
-  parent      = "tagKeys/${google_tags_tag_key.basic_key.name}"
+  parent      = google_tags_tag_key.basic_key.id
   short_name  = "{{tagvalue}}"
 }

--- a/tpgtools/overrides/compute/samples/networkfirewallpolicyrule/regional.tf.tmpl
+++ b/tpgtools/overrides/compute/samples/networkfirewallpolicyrule/regional.tf.tmpl
@@ -38,7 +38,7 @@ resource "google_compute_region_network_firewall_policy_rule" "primary" {
     }
 
     src_secure_tags {
-      name = "tagValues/${google_tags_tag_value.basic_value.name}"
+      name = google_tags_tag_value.basic_value.id
     }
     
     src_address_groups = [google_network_security_address_group.basic_regional_networksecurity_address_group.id]
@@ -62,6 +62,6 @@ resource "google_tags_tag_key" "basic_key" {
 
 resource "google_tags_tag_value" "basic_value" {
   description = "For valuename resources."
-  parent      = "tagKeys/${google_tags_tag_key.basic_key.name}"
+  parent      = google_tags_tag_key.basic_key.id
   short_name  = "{{tagvalue}}"
 }

--- a/tpgtools/overrides/compute/samples/networkfirewallpolicyrule/regional_update.tf.tmpl
+++ b/tpgtools/overrides/compute/samples/networkfirewallpolicyrule/regional_update.tf.tmpl
@@ -41,7 +41,7 @@ resource "google_compute_region_network_firewall_policy_rule" "primary" {
   }
 
   target_secure_tags {
-    name = "tagValues/${google_tags_tag_value.basic_value.name}"
+    name = google_tags_tag_value.basic_value.id
   }
 }
 
@@ -62,6 +62,6 @@ resource "google_tags_tag_key" "basic_key" {
 
 resource "google_tags_tag_value" "basic_value" {
   description = "For valuename resources."
-  parent      = "tagKeys/${google_tags_tag_key.basic_key.name}"
+  parent      = google_tags_tag_key.basic_key.id
   short_name  = "{{tagvalue}}"
 }


### PR DESCRIPTION
Part 2:

Update resource manager tag references in terraform code templates for generated tests (also some minor formatting changes)

- Update the code to use `foo.id` vs `"tagKeys/${foo.name}"` or `"tagValues/${foo.name}"`
- Update some project data source references to `project.id` vs `projects/.....number`
- Wrap map keys in parens where needed.

Followup to #12118

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```