### PR TITLE
Removing the version field from the ACM Fleet Default Member Config when MANAGEMENT_AUTOMATIC is used.

### DIFF
--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go.tmpl
@@ -602,7 +602,6 @@ resource "google_gke_hub_feature" "feature" {
   location = "global"
   fleet_default_member_config {
     configmanagement {
-      version = "1.19.2"
       management = "MANAGEMENT_AUTOMATIC"
       config_sync {
         prevent_drift = true


### PR DESCRIPTION
Otherwise, the Hub CLH throws a 400 error:
```
InvalidFieldError for field
fleet_default_member_config.configmanagement.version: the version field of fleet_default_member_config for feature configmanagement should not be set when Config Sync auto-upgrades are enabled.
```

This is to fix the broken test tracked in https://github.com/hashicorp/terraform-provider-google/issues/19080.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
