### PR TITLE
Simplify test for `CredentialsValidator` in plugin-framework code

### DIFF
--- a/mmv1/third_party/terraform/fwprovider/framework_validators_test.go
+++ b/mmv1/third_party/terraform/fwprovider/framework_validators_test.go
@@ -2,13 +2,13 @@ package fwprovider_test
 
 import (
 	"context"
-	"io/ioutil"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/fwprovider"
 
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
@@ -16,41 +16,26 @@ import (
 
 func TestFrameworkProvider_CredentialsValidator(t *testing.T) {
 	cases := map[string]struct {
-		ConfigValue          func(t *testing.T) types.String
+		ConfigValue          types.String
 		ExpectedWarningCount int
 		ExpectedErrorCount   int
 	}{
 		"configuring credentials as a path to a credentials JSON file is valid": {
-			ConfigValue: func(t *testing.T) types.String {
-				return types.StringValue(transport_tpg.TestFakeCredentialsPath) // Path to a test fixture
-			},
+			ConfigValue: types.StringValue(transport_tpg.TestFakeCredentialsPath), // Path to a test fixture
 		},
 		"configuring credentials as a path to a non-existant file is NOT valid": {
-			ConfigValue: func(t *testing.T) types.String {
-				return types.StringValue("./this/path/doesnt/exist.json") // Doesn't exist
-			},
+			ConfigValue:        types.StringValue("./this/path/doesnt/exist.json"), // Doesn't exist
 			ExpectedErrorCount: 1,
 		},
 		"configuring credentials as a credentials JSON string is valid": {
-			ConfigValue: func(t *testing.T) types.String {
-				contents, err := ioutil.ReadFile(transport_tpg.TestFakeCredentialsPath)
-				if err != nil {
-					t.Fatalf("Unexpected error: %s", err)
-				}
-				stringContents := string(contents)
-				return types.StringValue(stringContents)
-			},
+			ConfigValue: types.StringValue(acctest.GenerateFakeCredentialsJson("CredentialsValidator")),
 		},
 		"configuring credentials as an empty string is not valid": {
-			ConfigValue: func(t *testing.T) types.String {
-				return types.StringValue("")
-			},
+			ConfigValue:        types.StringValue(""),
 			ExpectedErrorCount: 1,
 		},
 		"leaving credentials unconfigured is valid": {
-			ConfigValue: func(t *testing.T) types.String {
-				return types.StringNull()
-			},
+			ConfigValue: types.StringNull(),
 		},
 	}
 
@@ -58,7 +43,7 @@ func TestFrameworkProvider_CredentialsValidator(t *testing.T) {
 		t.Run(tn, func(t *testing.T) {
 			// Arrange
 			req := validator.StringRequest{
-				ConfigValue: tc.ConfigValue(t),
+				ConfigValue: tc.ConfigValue,
 			}
 
 			resp := validator.StringResponse{


### PR DESCRIPTION
This PR removes use of a fake credentials file from the test, which allows code to be simplified

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
