### PR TITLE
Run changelog-checker on synchronize events

### DIFF
--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -4,7 +4,7 @@ permissions: read-all
 
 on:
   pull_request:
-    types: [opened, edited]
+    types: [opened, edited, synchronize]
 
 jobs:
   check:


### PR DESCRIPTION
This keeps a failed changelog-checker status from getting "lost" once the contributor adds a new commit.

For example, see https://github.com/GoogleCloudPlatform/magic-modules/actions/workflows/changelog-checker.yml?query=branch%3Achayanr-resize-request+ / https://github.com/GoogleCloudPlatform/magic-modules/pull/11968 - the checks all appeared to be passing before my edit even though the changelog was invalid.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
