### PR TITLE
Stop `TestAccDataSourceGoogleFirebaseWebAppConfig` failing when `database_url` isn't returned from the API

### DIFF
--- a/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_web_app_config_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_web_app_config_test.go.tmpl
@@ -26,9 +26,9 @@ func TestAccDataSourceGoogleFirebaseWebAppConfig(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 				Config:                   testAccDataSourceGoogleFirebaseWebAppConfig(context),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_firebase_web_app_config.my_app_config", "project", context["project"].(string)),
 					resource.TestCheckResourceAttrSet("data.google_firebase_web_app_config.my_app_config", "api_key"),
 					resource.TestCheckResourceAttrSet("data.google_firebase_web_app_config.my_app_config", "auth_domain"),
-					resource.TestCheckResourceAttrSet("data.google_firebase_web_app_config.my_app_config", "database_url"),
 					resource.TestCheckResourceAttrSet("data.google_firebase_web_app_config.my_app_config", "storage_bucket"),
 				),
 			},

--- a/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_web_app_config_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_web_app_config_test.go.tmpl
@@ -26,7 +26,7 @@ func TestAccDataSourceGoogleFirebaseWebAppConfig(t *testing.T) {
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 				Config:                   testAccDataSourceGoogleFirebaseWebAppConfig(context),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.google_firebase_web_app_config.my_app_config", "project", context["project"].(string)),
+					resource.TestCheckResourceAttr("data.google_firebase_web_app_config.my_app_config", "project", context["project_id"].(string)),
 					resource.TestCheckResourceAttrSet("data.google_firebase_web_app_config.my_app_config", "api_key"),
 					resource.TestCheckResourceAttrSet("data.google_firebase_web_app_config.my_app_config", "auth_domain"),
 					resource.TestCheckResourceAttrSet("data.google_firebase_web_app_config.my_app_config", "storage_bucket"),


### PR DESCRIPTION
This PR addresses [this test failure in the nightlies](https://hashicorp.teamcity.com/test/6629826488886142956?currentProjectId=TerraformProviders_GoogleCloud_GOOGLE_BETA_NIGHTLYTESTS&expandTestHistoryChartSection=true):

```
------- Stdout: -------
=== RUN   TestAccDataSourceGoogleFirebaseWebAppConfig
=== PAUSE TestAccDataSourceGoogleFirebaseWebAppConfig
=== CONT  TestAccDataSourceGoogleFirebaseWebAppConfig
    data_source_google_firebase_web_app_config_test.go:22: Step 1/1 error: Check failed: Check 3/4 error: data.google_firebase_web_app_config.my_app_config: Attribute 'database_url' expected to be set
--- FAIL: TestAccDataSourceGoogleFirebaseWebAppConfig (24.70s)
FAIL
```

The API isn't returning a value for this field. As the test only asserts that fields are set, not what their values are, I've stopped the test asserting that particular field is set. Instead I've made it assert the value of the project attribute.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
