### PR TITLE
Add `resp.EphemeralResourceData` in `framework_provider.Configure`

### DIFF
--- a/mmv1/third_party/terraform/fwprovider/framework_provider.go.tmpl
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider.go.tmpl
@@ -265,6 +265,7 @@ func (p *FrameworkProvider) Configure(ctx context.Context, req provider.Configur
 	// implemented using the plugin-framework. The resources' Configure functions receive this data in the ConfigureRequest argument. 
 	resp.DataSourceData = &p.FrameworkProviderConfig
 	resp.ResourceData = &p.FrameworkProviderConfig
+	resp.EphemeralResourceData = &p.FrameworkProviderConfig
 }
 
 


### PR DESCRIPTION

Fixes ProviderData being nil in ephemeralResources.


<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:REPLACEME

```
