### PR TITLE
`ephemeral`: add `ephemeral_google_service_account_key`

### DIFF
--- a/mmv1/third_party/terraform/fwprovider/framework_provider.go.tmpl
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider.go.tmpl
@@ -325,5 +325,6 @@ func (p *FrameworkProvider) EphemeralResources(_ context.Context) []func() ephem
         resourcemanager.GoogleEphemeralServiceAccountAccessToken,
         resourcemanager.GoogleEphemeralServiceAccountIdToken,
         resourcemanager.GoogleEphemeralServiceAccountJwt,
+        resourcemanager.GoogleEphemeralServiceAccountKey,
 	}
 }

--- a/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key.go
@@ -1,0 +1,117 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+package resourcemanager
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-google/google/fwtransport"
+	"github.com/hashicorp/terraform-provider-google/google/verify"
+)
+
+var _ ephemeral.EphemeralResource = &googleEphemeralServiceAccountKey{}
+
+func GoogleEphemeralServiceAccountKey() ephemeral.EphemeralResource {
+	return &googleEphemeralServiceAccountKey{}
+}
+
+type googleEphemeralServiceAccountKey struct {
+	providerConfig *fwtransport.FrameworkProviderConfig
+}
+
+func (p *googleEphemeralServiceAccountKey) Metadata(ctx context.Context, req ephemeral.MetadataRequest, resp *ephemeral.MetadataResponse) {
+	resp.TypeName = "google_service_account_key"
+}
+
+type ephemeralServiceAccountKeyModel struct {
+	Name          types.String `tfsdk:"name"`
+	PublicKeyType types.String `tfsdk:"public_key_type"`
+	Project       types.String `tfsdk:"project"`
+	KeyAlgorithm  types.String `tfsdk:"key_algorithm"`
+	PublicKey     types.String `tfsdk:"public_key"`
+}
+
+func (p *googleEphemeralServiceAccountKey) Schema(ctx context.Context, req ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				Required: true,
+				// TODO: Implement custom validation for ServiceAccountKeyNameRegex
+			},
+			"public_key_type": schema.StringAttribute{
+				Optional: true,
+				// TODO: Implement validation for allowed values
+			},
+			"project": schema.StringAttribute{
+				Optional: true,
+			},
+			"key_algorithm": schema.StringAttribute{
+				Computed: true,
+			},
+			"public_key": schema.StringAttribute{
+				Computed: true,
+			},
+		},
+	}
+}
+
+func (p *googleEphemeralServiceAccountKey) Configure(ctx context.Context, req ephemeral.ConfigureRequest, resp *ephemeral.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	pd, ok := req.ProviderData.(*fwtransport.FrameworkProviderConfig)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *fwtransport.FrameworkProviderConfig, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	p.providerConfig = pd
+}
+
+func (p *googleEphemeralServiceAccountKey) Open(ctx context.Context, req ephemeral.OpenRequest, resp *ephemeral.OpenResponse) {
+	var data ephemeralServiceAccountKeyModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+
+	keyName := data.Name.ValueString()
+
+	// Validate name
+	r := regexp.MustCompile(verify.ServiceAccountKeyNameRegex)
+	if !r.MatchString(keyName) {
+		resp.Diagnostics.AddError(
+			"Invalid key name",
+			fmt.Sprintf("Invalid key name %q does not match regexp %q", keyName, verify.ServiceAccountKeyNameRegex),
+		)
+		return
+	}
+
+	publicKeyType := data.PublicKeyType.ValueString()
+	if publicKeyType == "" {
+		publicKeyType = "TYPE_X509_PEM_FILE"
+	}
+
+	// Confirm the service account key exists
+	sak, err := p.providerConfig.NewIamClient(p.providerConfig.UserAgent).Projects.ServiceAccounts.Keys.Get(keyName).PublicKeyType(publicKeyType).Do()
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error retrieving Service Account Key",
+			fmt.Sprintf("Error retrieving Service Account Key %q: %s", keyName, err),
+		)
+		return
+	}
+
+	data.Name = types.StringValue(sak.Name)
+	data.KeyAlgorithm = types.StringValue(sak.KeyAlgorithm)
+	data.PublicKey = types.StringValue(sak.PublicKeyData)
+
+	resp.Diagnostics.Append(resp.Result.Set(ctx, &data)...)
+}

--- a/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key.go
@@ -38,9 +38,11 @@ type ephemeralServiceAccountKeyModel struct {
 
 func (p *googleEphemeralServiceAccountKey) Schema(ctx context.Context, req ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Description: "Get an ephemeral service account public key.",
 		Attributes: map[string]schema.Attribute{
 			"name": schema.StringAttribute{
-				Required: true,
+				Description: "The name of the service account key. This must have format `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{KEYID}`, where `{ACCOUNT}` is the email address or unique id of the service account.",
+				Required:    true,
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(
 						regexp.MustCompile(verify.ServiceAccountKeyNameRegex),
@@ -48,22 +50,27 @@ func (p *googleEphemeralServiceAccountKey) Schema(ctx context.Context, req ephem
 					),
 				}},
 			"public_key_type": schema.StringAttribute{
-				Optional: true,
+				Description: "The output format of the public key requested. TYPE_X509_PEM_FILE is the default output format.",
+				Optional:    true,
 				Validators: []validator.String{
 					stringvalidator.OneOf(
+						"TYPE_NONE",
 						"TYPE_X509_PEM_FILE",
-						"TYPE_RAW",
+						"TYPE_RAW_PUBLIC_KEY",
 					),
 				},
 			},
 			"project": schema.StringAttribute{
-				Optional: true,
+				Description: "The ID of the project that the service account will be created in. Defaults to the provider project configuration.",
+				Optional:    true,
 			},
 			"key_algorithm": schema.StringAttribute{
-				Computed: true,
+				Description: "The algorithm used to generate the key.",
+				Computed:    true,
 			},
 			"public_key": schema.StringAttribute{
-				Computed: true,
+				Description: "The public key, base64 encoded.",
+				Computed:    true,
 			},
 		},
 	}

--- a/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-provider-google/google/fwtransport"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	"github.com/hashicorp/terraform-provider-google/google/verify"
 )
 
@@ -21,7 +21,7 @@ func GoogleEphemeralServiceAccountKey() ephemeral.EphemeralResource {
 }
 
 type googleEphemeralServiceAccountKey struct {
-	providerConfig *fwtransport.FrameworkProviderConfig
+	providerConfig *transport_tpg.Config
 }
 
 func (p *googleEphemeralServiceAccountKey) Metadata(ctx context.Context, req ephemeral.MetadataRequest, resp *ephemeral.MetadataResponse) {
@@ -80,11 +80,11 @@ func (p *googleEphemeralServiceAccountKey) Configure(ctx context.Context, req ep
 		return
 	}
 
-	pd, ok := req.ProviderData.(*fwtransport.FrameworkProviderConfig)
+	pd, ok := req.ProviderData.(*transport_tpg.Config)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *fwtransport.FrameworkProviderConfig, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected *transport_tpg.Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 		return
 	}

--- a/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key.go
@@ -31,7 +31,6 @@ func (p *googleEphemeralServiceAccountKey) Metadata(ctx context.Context, req eph
 type ephemeralServiceAccountKeyModel struct {
 	Name          types.String `tfsdk:"name"`
 	PublicKeyType types.String `tfsdk:"public_key_type"`
-	Project       types.String `tfsdk:"project"`
 	KeyAlgorithm  types.String `tfsdk:"key_algorithm"`
 	PublicKey     types.String `tfsdk:"public_key"`
 }
@@ -58,10 +57,6 @@ func (p *googleEphemeralServiceAccountKey) Schema(ctx context.Context, req ephem
 						"TYPE_RAW_PUBLIC_KEY",
 					),
 				},
-			},
-			"project": schema.StringAttribute{
-				Description: "The ID of the project that the service account will be created in. Defaults to the provider project configuration.",
-				Optional:    true,
 			},
 			"key_algorithm": schema.StringAttribute{
 				Description: "The algorithm used to generate the key.",

--- a/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key.go
@@ -54,7 +54,6 @@ func (p *googleEphemeralServiceAccountKey) Schema(ctx context.Context, req ephem
 				Optional:    true,
 				Validators: []validator.String{
 					stringvalidator.OneOf(
-						"TYPE_NONE",
 						"TYPE_X509_PEM_FILE",
 						"TYPE_RAW_PUBLIC_KEY",
 					),

--- a/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key_test.go
@@ -13,16 +13,17 @@ func TestAccEphemeralServiceAccountKey_basic(t *testing.T) {
 	t.Parallel()
 
 	serviceAccount := envvar.GetTestServiceAccountFromEnv(t)
+	targetServiceAccountEmail := acctest.BootstrapServiceAccount(t, "key-basic", serviceAccount)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEphemeralServiceAccountKey_setup(serviceAccount),
+				Config: testAccEphemeralServiceAccountKey_setup(targetServiceAccountEmail),
 			},
 			{
-				Config: testAccEphemeralServiceAccountKey_basic(serviceAccount),
+				Config: testAccEphemeralServiceAccountKey_basic(targetServiceAccountEmail),
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key_test.go
@@ -1,0 +1,64 @@
+package resourcemanager_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccEphemeralServiceAccountKey_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"project":       envvar.GetTestProjectFromEnv(),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEphemeralServiceAccountKey_setup(context),
+			},
+			{
+				Config: testAccEphemeralServiceAccountKey_basic(context),
+			},
+		},
+	})
+}
+
+func testAccEphemeralServiceAccountKey_setup(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_service_account" "test_account" {
+  account_id   = "tf-test-%{random_suffix}"
+  display_name = "Test Service Account"
+}
+
+resource "google_service_account_key" "key" {
+  name = "${google_service_account.test_account.name}/keys/1234567890"
+  public_key_type = "TYPE_RAW"
+}
+`, context)
+}
+
+func testAccEphemeralServiceAccountKey_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_service_account" "test_account" {
+  account_id   = "tf-test-%{random_suffix}"
+  display_name = "Test Service Account"
+}
+
+resource "google_service_account_key" "key" {
+  name = "${google_service_account.test_account.name}/keys/1234567890"
+  public_key_type = "TYPE_RAW"
+}
+
+ephemeral "google_service_account_key" "key" {
+  name            = "${google_service_account.test_account.name}/keys/1234567890"
+  public_key_type = "TYPE_RAW"
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_key.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_key.html.markdown
@@ -33,8 +33,6 @@ The following arguments are supported:
   `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{KEYID}`, where `{ACCOUNT}`
   is the email address or unique id of the service account.
 
-* `project` - (Optional) The ID of the project that the service account is present in. Defaults to the provider project configuration.
-
 * `public_key_type` (Optional) The output format of the public key requested. TYPE_X509_PEM_FILE is the default output format.
 
 ## Attributes Reference

--- a/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_key.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_key.html.markdown
@@ -1,0 +1,45 @@
+---
+subcategory: "Cloud Platform"
+description: |-
+  Get a Google Cloud Platform service account Public Key
+---
+
+# google_service_account_key
+
+Get an ephemeral service account public key. For more information, see [the official documentation](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) and [API](https://cloud.google.com/iam/reference/rest/v1/projects.serviceAccounts.keys/get).
+
+## Example Usage
+
+```hcl
+resource "google_service_account" "myaccount" {
+  account_id = "dev-foo-account"
+}
+
+resource "google_service_account_key" "mykey" {
+  service_account_id = google_service_account.myaccount.name
+}
+
+ephemeral "google_service_account_key" "mykey" {
+  name            = google_service_account_key.mykey.name
+  public_key_type = "TYPE_X509_PEM_FILE"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the service account key. This must have format
+  `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{KEYID}`, where `{ACCOUNT}`
+  is the email address or unique id of the service account.
+
+* `project` - (Optional) The ID of the project that the service account will be created in.
+  Defaults to the provider project configuration.
+
+* `public_key_type` (Optional) The output format of the public key requested. TYPE_X509_PEM_FILE is the default output format.
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `public_key` - The public key, base64 encoded

--- a/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_key.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_key.html.markdown
@@ -33,8 +33,7 @@ The following arguments are supported:
   `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{KEYID}`, where `{ACCOUNT}`
   is the email address or unique id of the service account.
 
-* `project` - (Optional) The ID of the project that the service account will be created in.
-  Defaults to the provider project configuration.
+* `project` - (Optional) The ID of the project that the service account is present in. Defaults to the provider project configuration.
 
 * `public_key_type` (Optional) The output format of the public key requested. TYPE_X509_PEM_FILE is the default output format.
 


### PR DESCRIPTION
An ephemeral resource that mimics the [google_service_account_key](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/service_account_key) data source

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
