### PR TITLE
Unbreak TestAccBigQueryDataset_withProvider5

### DIFF
--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_dataset_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_dataset_test.go
@@ -166,7 +166,7 @@ func TestAccBigQueryDataset_withProvider5(t *testing.T) {
 		CheckDestroy: testAccCheckBigQueryDatasetDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config:            testAccBigQueryDataset_withoutLabels(datasetID),
+				Config:            testAccBigQueryDataset_withoutLabelsV4(datasetID),
 				ExternalProviders: oldVersion,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckNoResourceAttr("google_bigquery_dataset.test", "labels.%"),
@@ -498,6 +498,19 @@ provider "google" {
   add_terraform_attribution_label = false
 }
 
+resource "google_bigquery_dataset" "test" {
+  dataset_id                      = "%s"
+  friendly_name                   = "foo"
+  description                     = "This is a foo description"
+  location                        = "EU"
+  default_partition_expiration_ms = 3600000
+  default_table_expiration_ms     = 3600000
+}
+`, datasetID)
+}
+
+func testAccBigQueryDataset_withoutLabelsV4(datasetID string) string {
+	return fmt.Sprintf(`
 resource "google_bigquery_dataset" "test" {
   dataset_id                      = "%s"
   friendly_name                   = "foo"


### PR DESCRIPTION
The test was using a config shared with v6+ tests and was setting the attribution label, which doesn't work pre v6.

```release-note:none
```
