### PR TITLE
compute: added support for `advanced_machine_features.turbo_mode`

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -662,6 +662,7 @@ func expandAdvancedMachineFeatures(d tpgresource.TerraformResourceData) *compute
 	return &compute.AdvancedMachineFeatures{
 		EnableNestedVirtualization: d.Get(prefix + ".enable_nested_virtualization").(bool),
 		ThreadsPerCore:             int64(d.Get(prefix + ".threads_per_core").(int)),
+		TurboMode:                  d.Get(prefix + ".turbo_mode").(string),
 		VisibleCoreCount:           int64(d.Get(prefix + ".visible_core_count").(int)),
 	}
 }
@@ -673,6 +674,7 @@ func flattenAdvancedMachineFeatures(AdvancedMachineFeatures *compute.AdvancedMac
 	return []map[string]interface{}{{"{{"}}
 		"enable_nested_virtualization": AdvancedMachineFeatures.EnableNestedVirtualization,
 		"threads_per_core":             AdvancedMachineFeatures.ThreadsPerCore,
+		"turbo_mode":                   AdvancedMachineFeatures.TurboMode,
 		"visible_core_count":           AdvancedMachineFeatures.VisibleCoreCount,
 	{{"}}"}}
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -54,6 +54,13 @@ func IpCidrRangeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 }
 
 var (
+	advancedMachineFeaturesKeys = []string{
+		"advanced_machine_features.0.enable_nested_virtualization",
+		"advanced_machine_features.0.threads_per_core",
+		"advanced_machine_features.0.turbo_mode",
+		"advanced_machine_features.0.visible_core_count",
+	}
+
 	bootDiskKeys = []string{
 		"boot_disk.0.auto_delete",
 		"boot_disk.0.device_name",
@@ -1091,19 +1098,26 @@ be from 0 to 999,999,999 inclusive.`,
 						"enable_nested_virtualization": {
 							Type:        schema.TypeBool,
 							Optional:    true,
-							AtLeastOneOf: []string{"advanced_machine_features.0.enable_nested_virtualization","advanced_machine_features.0.threads_per_core"},
+							AtLeastOneOf: advancedMachineFeaturesKeys,
 							Description: `Whether to enable nested virtualization or not.`,
 						},
 						"threads_per_core": {
 							Type:        schema.TypeInt,
 							Optional:    true,
-							AtLeastOneOf: []string{"advanced_machine_features.0.enable_nested_virtualization","advanced_machine_features.0.threads_per_core"},
+							AtLeastOneOf: advancedMachineFeaturesKeys,
 							Description: `The number of threads per physical core. To disable simultaneous multithreading (SMT) set this to 1. If unset, the maximum number of threads supported per core by the underlying processor is assumed.`,
+						},
+						"turbo_mode": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							AtLeastOneOf: advancedMachineFeaturesKeys,
+							Description: `Turbo frequency mode to use for the instance. Currently supported modes is "ALL_CORE_MAX".`,
+							ValidateFunc: validation.StringInSlice([]string{"ALL_CORE_MAX"}, false),
 						},
 						"visible_core_count": {
 							Type:        schema.TypeInt,
 							Optional:    true,
-							AtLeastOneOf: []string{"advanced_machine_features.0.enable_nested_virtualization","advanced_machine_features.0.threads_per_core","advanced_machine_features.0.visible_core_count"},
+							AtLeastOneOf: advancedMachineFeaturesKeys,
 							Description: `The number of physical cores to expose to an instance. Multiply by the number of threads per core to compute the total number of virtual CPUs to expose to the instance. If unset, the number of cores is inferred from the instance\'s nominal CPU count and the underlying platform\'s SMT width.`,
 						},
 					},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
@@ -964,6 +964,12 @@ be from 0 to 999,999,999 inclusive.`,
 							ForceNew:    true,
 							Description: `The number of threads per physical core. To disable simultaneous multithreading (SMT) set this to 1. If unset, the maximum number of threads supported per core by the underlying processor is assumed.`,
 						},
+						"turbo_mode": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Turbo frequency mode to use for the instance. Currently supported modes is "ALL_CORE_MAX".`,
+							ValidateFunc: validation.StringInSlice([]string{"ALL_CORE_MAX"}, false),
+						},
 						"visible_core_count": {
 							Type:        schema.TypeInt,
 							Optional:    true,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.tmpl
@@ -3757,11 +3757,11 @@ data "google_compute_image" "my_image" {
 
 resource "google_compute_instance_template" "foobar" {
   name         = "tf-test-instance-template-%s"
-  machine_type = "n2-standard-2" // Nested Virt isn't supported on E2 and N2Ds https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#restrictions and https://cloud.google.com/compute/docs/instances/disabling-smt#limitations
+  machine_type = "c4-standard-2"
 
   disk {
     source_image = data.google_compute_image.my_image.self_link
-	auto_delete  = true
+    auto_delete  = true
     boot         = true
   }
 
@@ -3770,13 +3770,14 @@ resource "google_compute_instance_template" "foobar" {
   }
 
   advanced_machine_features {
-	threads_per_core = 1
-	enable_nested_virtualization = true
-	visible_core_count = 1
+    enable_nested_virtualization = true
+    threads_per_core             = 1
+    turbo_mode                   = "ALL_CORE_MAX"
+    visible_core_count           = 1
   }
 
   scheduling {
-	  on_host_maintenance = "TERMINATE"
+    on_host_maintenance = "TERMINATE"
   }
 
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -7158,7 +7158,7 @@ data "google_compute_image" "my_image" {
 
 resource "google_compute_instance" "foobar" {
   name         = "%s"
-  machine_type = "n1-standard-2" // Nested Virt isn't supported on E2 and N2Ds https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#restrictions and https://cloud.google.com/compute/docs/instances/disabling-smt#limitations
+  machine_type = "c4-standard-2"
   zone         = "us-central1-a"
 
   boot_disk {
@@ -7186,7 +7186,7 @@ data "google_compute_image" "my_image" {
 
 resource "google_compute_instance" "foobar" {
   name         = "%s"
-  machine_type = "n1-standard-2" // Nested Virt isn't supported on E2 and N2Ds https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#restrictions and https://cloud.google.com/compute/docs/instances/disabling-smt#limitations
+  machine_type = "c4-standard-2"
   zone         = "us-central1-a"
 
   boot_disk {
@@ -7199,9 +7199,10 @@ resource "google_compute_instance" "foobar" {
     network = "default"
   }
   advanced_machine_features {
-	threads_per_core = 1
-	enable_nested_virtualization = true
-	visible_core_count = 1
+    enable_nested_virtualization = true
+    threads_per_core             = 1
+    turbo_mode                   = "ALL_CORE_MAX"
+    visible_core_count           = 1
   }
   allow_stopping_for_update = true
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
@@ -916,6 +916,12 @@ be from 0 to 999,999,999 inclusive.`,
 							ForceNew:    true,
 							Description: `The number of threads per physical core. To disable simultaneous multithreading (SMT) set this to 1. If unset, the maximum number of threads supported per core by the underlying processor is assumed.`,
 						},
+						"turbo_mode": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Turbo frequency mode to use for the instance. Currently supported modes is "ALL_CORE_MAX".`,
+							ValidateFunc: validation.StringInSlice([]string{"ALL_CORE_MAX"}, false),
+						},
 						"visible_core_count": {
 							Type:        schema.TypeInt,
 							Optional:    true,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
@@ -3142,8 +3142,8 @@ data "google_compute_image" "my_image" {
 
 resource "google_compute_region_instance_template" "foobar" {
   name         = "tf-test-instance-template-%s"
-  region      = "us-central1"
-  machine_type = "n2-standard-2" // Nested Virt isn't supported on E2 and N2Ds https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#restrictions and https://cloud.google.com/compute/docs/instances/disabling-smt#limitations
+  region       = "us-central1"
+  machine_type = "c2-standard-2"
 
   disk {
     source_image = data.google_compute_image.my_image.self_link
@@ -3156,9 +3156,10 @@ resource "google_compute_region_instance_template" "foobar" {
   }
 
   advanced_machine_features {
-	threads_per_core = 1
 	enable_nested_virtualization = true
-	visible_core_count = 1
+	threads_per_core             = 1
+	turbo_mode                   = "ALL_CORE_MAX"
+	visible_core_count           = 1
   }
 
   scheduling {

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -566,11 +566,13 @@ specified, then this instance will have no external IPv6 Internet access. Struct
 
 <a name="nested_advanced_machine_features"></a>The `advanced_machine_features` block supports:
 
-* `enable_nested_virtualization` (Optional) Defines whether the instance should have [nested virtualization](#on_host_maintenance)  enabled. Defaults to false.
+* `enable_nested_virtualization` - (Optional) Defines whether the instance should have [nested virtualization](#on_host_maintenance)  enabled. Defaults to false.
 
-* `threads_per_core` (Optional) he number of threads per physical core. To disable [simultaneous multithreading (SMT)](https://cloud.google.com/compute/docs/instances/disabling-smt) set this to 1.
+* `threads_per_core` - (Optional) The number of threads per physical core. To disable [simultaneous multithreading (SMT)](https://cloud.google.com/compute/docs/instances/disabling-smt) set this to 1.
 
-* `visible_core_count` (Optional) The number of physical cores to expose to an instance. [visible cores info (VC)](https://cloud.google.com/compute/docs/instances/customize-visible-cores).
+* `turbo_mode` - (Optional) Turbo frequency mode to use for the instance. Supported modes are currently either `ALL_CORE_MAX` or unset (default).
+
+* `visible_core_count` - (Optional) The number of physical cores to expose to an instance. [visible cores info (VC)](https://cloud.google.com/compute/docs/instances/customize-visible-cores).
 
 <a name="nested_reservation_affinity"></a>The `reservation_affinity` block supports:
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -722,11 +722,13 @@ The `specific_reservation` block supports:
 
 <a name="nested_advanced_machine_features"></a>The `advanced_machine_features` block supports:
 
-* `enable_nested_virtualization` (Optional) Defines whether the instance should have [nested virtualization](#on_host_maintenance) enabled. Defaults to false.
+* `enable_nested_virtualization` - (Optional) Defines whether the instance should have [nested virtualization](#on_host_maintenance) enabled. Defaults to false.
 
-* `threads_per_core` (Optional) The number of threads per physical core. To disable [simultaneous multithreading (SMT)](https://cloud.google.com/compute/docs/instances/disabling-smt) set this to 1.
+* `threads_per_core` - (Optional) The number of threads per physical core. To disable [simultaneous multithreading (SMT)](https://cloud.google.com/compute/docs/instances/disabling-smt) set this to 1.
 
-* `visible_core_count` (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) The number of physical cores to expose to an instance. [visible cores info (VC)](https://cloud.google.com/compute/docs/instances/customize-visible-cores).
+* `turbo_mode` - (Optional) Turbo frequency mode to use for the instance. Supported modes are currently either `ALL_CORE_MAX` or unset (default).
+
+* `visible_core_count` - (Optional) The number of physical cores to expose to an instance. [visible cores info (VC)](https://cloud.google.com/compute/docs/instances/customize-visible-cores).
 
 ## Attributes Reference
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
@@ -682,11 +682,13 @@ The `specific_reservation` block supports:
 
 <a name="nested_advanced_machine_features"></a>The `advanced_machine_features` block supports:
 
-* `enable_nested_virtualization` (Optional) Defines whether the instance should have [nested virtualization](#on_host_maintenance) enabled. Defaults to false.
+* `enable_nested_virtualization` - (Optional) Defines whether the instance should have [nested virtualization](#on_host_maintenance) enabled. Defaults to false.
 
-* `threads_per_core` (Optional) The number of threads per physical core. To disable [simultaneous multithreading (SMT)](https://cloud.google.com/compute/docs/instances/disabling-smt) set this to 1.
+* `threads_per_core` - (Optional) The number of threads per physical core. To disable [simultaneous multithreading (SMT)](https://cloud.google.com/compute/docs/instances/disabling-smt) set this to 1.
 
-* `visible_core_count` (Optional, ) The number of physical cores to expose to an instance. [visible cores info (VC)](https://cloud.google.com/compute/docs/instances/customize-visible-cores).
+* `turbo_mode` - (Optional) Turbo frequency mode to use for the instance. Supported modes are currently either `ALL_CORE_MAX` or unset (default).
+
+* `visible_core_count` - (Optional) The number of physical cores to expose to an instance. [visible cores info (VC)](https://cloud.google.com/compute/docs/instances/customize-visible-cores).
 
 ## Attributes Reference
 


### PR DESCRIPTION
- Added support for `advanced_machine_features.turbo_mode` in `google_compute_instance`, `google_compute_instance_template`, and `google_compute_region_instance_template`
- Adjusted tests to use c4 instance types for `advanced_machine_features` tests
- Minor docs and formatting fixes

Fixes hashicorp/terraform-provider-google#20023

I'm guessing this may be missing something

I looked at adding it in `google_container_cluster` as well, but seems like it's not implemented yet in regular or beta container API.

Side note: `EnableUefiNetworking` and `PerformanceMonitoringUnit` also seem to be available [here](https://pkg.go.dev/google.golang.org/api@v0.203.0/compute/v1#AdvancedMachineFeatures) but not implemented in the provider yet.

Should I add anything in tgc as well (like #10848)?

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added support for `advanced_machine_features.turbo_mode` to `google_compute_instance`, `google_compute_instance_template`, and `google_compute_region_instance_template`
```