### PR TITLE
compute: update tdx tests to use standard images

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image_test.go.tmpl
@@ -599,7 +599,7 @@ resource "google_compute_instance" "vm5" {
 
   boot_disk {
     initialize_params {
-      image = "tdx-guest-images/ubuntu-2204-jammy-v20240701"
+      image = "ubuntu-os-cloud/ubuntu-2204-jammy-v20240927"
     }
   }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_test.go.tmpl
@@ -1714,7 +1714,7 @@ func testAccComputeInstanceFromTemplate_confidentialInstanceConfigNoConfigTdx(te
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image2" {
   family  = "ubuntu-2204-lts"
-  project = "tdx-guest-images"
+  project = "ubuntu-os-cloud"
 }
 
 resource "google_compute_disk" "foobar2" {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.tmpl
@@ -3719,7 +3719,7 @@ func testAccComputeInstanceTemplateConfidentialInstanceConfigEnableTdx(suffix st
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image3" {
   family  = "ubuntu-2204-lts"
-  project = "tdx-guest-images"
+  project = "ubuntu-os-cloud"
 }
 
 resource "google_compute_instance_template" "foobar5" {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -8689,7 +8689,7 @@ func testAccComputeInstanceConfidentialInstanceConfigEnableTdx(instance string, 
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image3" {
   family    = "ubuntu-2204-lts"
-  project   = "tdx-guest-images"
+  project   = "ubuntu-os-cloud"
 }
 
 resource "google_compute_instance" "foobar5" {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
@@ -3103,7 +3103,7 @@ func testAccComputeRegionInstanceTemplateConfidentialInstanceConfigEnableTdx(suf
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image3" {
   family  = "ubuntu-2204-lts"
-  project = "tdx-guest-images"
+  project = "ubuntu-os-cloud"
 }
 
 resource "google_compute_region_instance_template" "foobar5" {


### PR DESCRIPTION
It seems like the fix in #12062 may not have fixed the images relying on Ubuntu images in the `tdx-guest-images` project.

I'm not sure if this is the right fix, but running one of the affected tests _seemed_ to work for me (and the UI showed confidential mode enabled), so maybe this support is now available in the mainstream image?

Added a comment with more context here:
https://github.com/hashicorp/terraform-provider-google/issues/19885#issuecomment-2439622933
but seems like this may just be natively supported in the stock Ubuntu images now.

Part of hashicorp/terraform-provider-google#19885

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
