### PR TITLE
Update documentation of `hierarchical_namespace` in `google_storage_bucket` resource.

### DIFF
--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
@@ -555,14 +555,14 @@ func ResourceStorageBucket() *schema.Resource {
 				Optional:         true,
 				ForceNew:         true,
 				DiffSuppressFunc: hierachicalNamespaceDiffSuppress,
-				Description:      `The bucket's HNS support, which defines bucket can organize folders in logical file system structure`,
+				Description:      `The bucket's HNS configuration, which defines bucket can organize folders in logical file system structure.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
 							Type:        schema.TypeBool,
 							Required:    true,
 							ForceNew:    true,
-							Description: `Set this enabled flag to true when folders with logical files structure. Default value is false.`,
+							Description: `Set this field true to organize bucket with logical file system structure.`,
 						},
 					},
 				},
@@ -1328,7 +1328,7 @@ func flattenBucketHierarchicalNamespacePolicy(hierachicalNamespacePolicy *storag
 		defaultPolicy :=map[string]interface{}{
 			"enabled": false,
 		}
-		
+
 		policies = append(policies, defaultPolicy)
 		return policies
 	}
@@ -1970,6 +1970,6 @@ func hierachicalNamespaceDiffSuppress(k, old, new string, r *schema.ResourceData
 			return true
 		}
 	}
-	
+
 	return false
 }

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -171,7 +171,7 @@ The following arguments are supported:
 
 * `soft_delete_policy` -  (Optional, Computed) The bucket's soft delete policy, which defines the period of time that soft-deleted objects will be retained, and cannot be permanently deleted. If the block is not provided, Server side value will be kept which means removal of block won't generate any terraform change. Structure is [documented below](#nested_soft_delete_policy).
 
-* `hierarchical_namespace` -  (Optional, ForceNew) The bucket's hierarchical namespace policy, which defines the bucket capability to handle folders in logical structure. Structure is [documented below](#nested_hierarchical_namespace).
+* `hierarchical_namespace` -  (Optional, ForceNew) The bucket's hierarchical namespace policy, which defines the bucket capability to handle folders in logical structure. Structure is [documented below](#nested_hierarchical_namespace). To use this configuration, `uniform_bucket_level_access` must be enabled on bucket.
 
 <a name="nested_lifecycle_rule"></a>The `lifecycle_rule` block supports:
 
@@ -287,8 +287,7 @@ The following arguments are supported:
 
 <a name="nested_hierarchical_namespace"></a>The `hierarchical_namespace` block supports:
 
-* `enabled` - (Optional) Enable hierarchical namespace for the bucket. 
-To use this flag, you must also use --uniform-bucket-level-access
+* `enabled` - (Required) Enables hierarchical namespace for the bucket.
 
 
 ## Attributes Reference


### PR DESCRIPTION
The current documentation of `google_storage_bucket.hierarchichal_namespce` is misleading for users. This PR will make appropriate corrections and modifications to improve documentation of `google_storage_bucket` resource.

```release-note:none

```
