### PR TITLE
spanner: bootstrap permissions for `TestAccSpannerDatabase_cmek` and `TestAccSpannerDatabase_mrcmek`

### DIFF
--- a/mmv1/third_party/terraform/services/spanner/resource_spanner_database_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/spanner/resource_spanner_database_test.go.tmpl
@@ -517,19 +517,27 @@ resource "google_spanner_database" "database" {
 `, context)
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
-{{/* Field is not beta, but google_project_service_identity dependency is */ -}}
 func TestAccSpannerDatabase_cmek(t *testing.T) {
-	acctest.SkipIfVcr(t)
 	t.Parallel()
 
+	// Handle bootstrapping out of band so we don't need beta provider, and for consistency with mrcmek test
+	if acctest.BootstrapPSARole(t, "service-", "gcp-sa-spanner", "roles/cloudkms.cryptoKeyEncrypterDecrypter") {
+		t.Fatal("Stopping the test because a role was added to the policy.")
+	}
+
+	// Make the keys outside of Terraform so that a) the project isn't littered with a key from each run and b) so that VCR
+	// can work.
+	kmsKey := acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "europe-west1", "tf-test-cmek-test-key-europe-west1")
+
 	context := map[string]interface{}{
+		"key_name":      kmsKey.CryptoKey.Name,
+		"key_ring_name": kmsKey.KeyRing.Name,
 		"random_suffix": acctest.RandString(t, 10),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckSpannerDatabaseDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -548,14 +556,14 @@ func TestAccSpannerDatabase_cmek(t *testing.T) {
 func testAccSpannerDatabase_cmek(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_spanner_instance" "main" {
-  provider     = google-beta
-  config       = "regional-europe-west1"
+  name         = "tf-test-%{random_suffix}"
   display_name = "main-instance1"
-  num_nodes    = 1
+
+  config           = "regional-europe-west1"
+  processing_units = 200
 }
 
 resource "google_spanner_database" "database" {
-  provider = google-beta
   instance = google_spanner_instance.main.name
   name     = "tf-test-cmek-db%{random_suffix}"
   ddl = [
@@ -564,45 +572,11 @@ resource "google_spanner_database" "database" {
   ]
 
   encryption_config {
-  	kms_key_name = google_kms_crypto_key.example-key.id
+    kms_key_name = "%{key_name}"
   }
 
   deletion_protection = false
-
-  depends_on = [google_kms_crypto_key_iam_member.crypto-key-binding]
 }
-
-resource "google_kms_key_ring" "keyring" {
-  provider = google-beta
-  name     = "tf-test-ring%{random_suffix}"
-  location = "europe-west1"
-}
-
-resource "google_kms_crypto_key" "example-key" {
-  provider        = google-beta
-  name            = "tf-test-key%{random_suffix}"
-  key_ring        = google_kms_key_ring.keyring.id
-  rotation_period = "100000s"
-}
-
-resource "google_kms_crypto_key_iam_member" "crypto-key-binding" {
-  provider      = google-beta
-  crypto_key_id = google_kms_crypto_key.example-key.id
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-
-  member = google_project_service_identity.ck_sa.member
-}
-
-data "google_project" "project" {
-  provider = google-beta
-}
-
-resource "google_project_service_identity" "ck_sa" {
-  provider = google-beta
-  project  = data.google_project.project.project_id
-  service  = "spanner.googleapis.com"
-}
-
 `, context)
 }
 
@@ -612,24 +586,19 @@ func TestAccSpannerDatabase_mrcmek(t *testing.T) {
 	kms1 := acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-mr-cmek-test-key-us-central1")
 	kms2 := acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-east1", "tf-mr-cmek-test-key-us-east1")
 	kms3 := acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-east4", "tf-mr-cmek-test-key-us-east4")
-
-	if acctest.BootstrapPSARole(t, "service-", "gcp-sa-spanner", "roles/cloudkms.cryptoKeyEncrypterDecrypter") {
-		t.Fatal("Stopping the test because a role was added to the policy.")
-	}
-
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"key_ring1":      kms1.KeyRing.Name,
-		"key_name1":      kms1.CryptoKey.Name,
-		"key_ring2":      kms2.KeyRing.Name,
-		"key_name2":      kms2.CryptoKey.Name,
-		"key_ring3":      kms3.KeyRing.Name,
-		"key_name3":      kms3.CryptoKey.Name,
+		"key_ring1":     kms1.KeyRing.Name,
+		"key_name1":     kms1.CryptoKey.Name,
+		"key_ring2":     kms2.KeyRing.Name,
+		"key_name2":     kms2.CryptoKey.Name,
+		"key_ring3":     kms3.KeyRing.Name,
+		"key_name3":     kms3.CryptoKey.Name,
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckSpannerDatabaseDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -648,8 +617,6 @@ func TestAccSpannerDatabase_mrcmek(t *testing.T) {
 func testAccSpannerDatabase_mrcmek(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_spanner_instance" "main" {
-  provider = google-beta
-
   name         = "tf-test-%{random_suffix}"
   display_name = "Terraform test"
 
@@ -658,7 +625,6 @@ resource "google_spanner_instance" "main" {
 }
 
 resource "google_spanner_database" "database" {
-  provider = google-beta
   instance = google_spanner_instance.main.name
   name     = "tf-test-mrcmek-db%{random_suffix}"
   ddl = [
@@ -678,5 +644,3 @@ resource "google_spanner_database" "database" {
 }
 `, context)
 }
-
-{{- end }}

--- a/mmv1/third_party/terraform/services/spanner/resource_spanner_database_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/spanner/resource_spanner_database_test.go.tmpl
@@ -607,7 +607,6 @@ resource "google_project_service_identity" "ck_sa" {
 }
 
 func TestAccSpannerDatabase_mrcmek(t *testing.T) {
-	acctest.SkipIfVcr(t)
 	t.Parallel()
 
 	kms1 := acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-mr-cmek-test-key-us-central1")
@@ -649,10 +648,13 @@ func TestAccSpannerDatabase_mrcmek(t *testing.T) {
 func testAccSpannerDatabase_mrcmek(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_spanner_instance" "main" {
-  provider     = google-beta
-  config       = "nam3"
-  display_name = "main-instance1"
-  num_nodes    = 1
+  provider = google-beta
+
+  name         = "tf-test-%{random_suffix}"
+  display_name = "Terraform test"
+
+  config           = "nam3"
+  processing_units = 200
 }
 
 resource "google_spanner_database" "database" {

--- a/mmv1/third_party/terraform/services/spanner/resource_spanner_database_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/spanner/resource_spanner_database_test.go.tmpl
@@ -613,6 +613,11 @@ func TestAccSpannerDatabase_mrcmek(t *testing.T) {
 	kms1 := acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-mr-cmek-test-key-us-central1")
 	kms2 := acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-east1", "tf-mr-cmek-test-key-us-east1")
 	kms3 := acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-east4", "tf-mr-cmek-test-key-us-east4")
+
+	if acctest.BootstrapPSARole(t, "service-", "gcp-sa-spanner", "roles/cloudkms.cryptoKeyEncrypterDecrypter") {
+		t.Fatal("Stopping the test because a role was added to the policy.")
+	}
+
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
 		"key_ring1":      kms1.KeyRing.Name,
@@ -660,18 +665,15 @@ resource "google_spanner_database" "database" {
   ]
 
   encryption_config {
-  	kms_key_names = [
-	  "%{key_name1}",
-	  "%{key_name2}",
-	  "%{key_name3}",
-	]
+    kms_key_names = [
+      "%{key_name1}",
+      "%{key_name2}",
+      "%{key_name3}",
+    ]
   }
 
   deletion_protection = false
-
 }
-
-
 `, context)
 }
 


### PR DESCRIPTION
Fixes hashicorp/terraform-provider-google#20039

Aside from fixing a permissions issue that was breaking `TestAccSpannerDatabase_mrcmek`, by bootstrapping both the permissions and the keys, we can fix VCR not working, as well as not littering the test project with a keyring from each run, and make the mr (multi region) cmek and regular cmek tests more similar.

These should now both pass in recording and replaying modes.

The beta requirement was actually around `TestAccSpannerDatabase_cmek` using `google_project_service_identity`. Since we're bootstrapping outside of the test now, in 93bf49d6d8dac9301fb3b5288685366895208f55 I have updated `TestAccSpannerDatabase_cmek` to match the pattern used here, which will also solve the problem of making a ton of different kms keyrings, and handling the permissions outside of the Terraform code, just hard-coding the Spanner SA in the bootstrap code.

I will PR fixing most of the other skipped VCR tests in a separate PR if you all would like.

```
{
  "error": {
    "code": 400,
    "message": "KMS Key provided is not usable: ServiceAccount: service-350238341926@gcp-sa-spanner.iam.gserviceaccount.com KmsKeyName: projects/xxx/locations/us-central1/keyRings/tftest-shared-keyring-1/cryptoKeys/tf-mr-cmek-test-key-us-central1 Error: generic::permission_denied: Permission 'cloudkms.cryptoKeyVersions.useToEncrypt' denied on resource 'projects/xxx/locations/us-central1/keyRings/tftest-shared-keyring-1/cryptoKeys/tf-mr-cmek-test-key-us-central1' (or it may not exist). [google.rpc.error_details_ext] { message: \"Permission \\'cloudkms.cryptoKeyVersions.useToEncrypt\\' denied on resource \\'projects/xxx/locations/us-central1/keyRings/tftest-shared-keyring-1/cryptoKeys/tf-mr-cmek-test-key-us-central1\\' (or it may not exist).\" details { [type.googleapis.com/google.rpc.DebugInfo] { detail: \"cloud/security/kms/util/iam_authz.cc:244 - \" } } }.",
    "status": "FAILED_PRECONDITION"
  }
}
```

After bootstrapping permissions and running:

Recording:
```
--- PASS: TestAccSpannerDatabase_cmek (94.11s)
PASS
ok  	github.com/hashicorp/terraform-provider-google/google/services/spanner	95.264s
--- PASS: TestAccSpannerDatabase_mrcmek (102.63s)
PASS
ok  	github.com/hashicorp/terraform-provider-google/google/services/spanner	103.798s
```

Replaying:
```
--- PASS: TestAccSpannerDatabase_cmek (11.73s)
PASS
ok  	github.com/hashicorp/terraform-provider-google/google/services/spanner	12.882s
--- PASS: TestAccSpannerDatabase_mrcmek (11.90s)
PASS
ok  	github.com/hashicorp/terraform-provider-google/google/services/spanner	13.033s
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
