### PR TITLE
docs: remove colon from IAM binding docs

### DIFF
--- a/mmv1/templates/terraform/resource_iam.html.markdown.erb
+++ b/mmv1/templates/terraform/resource_iam.html.markdown.erb
@@ -314,7 +314,7 @@ IAM policy imports use the identifier of the resource in question, e.g.
 $ terraform import <%= resource_ns_iam -%>_policy.editor <%= all_formats.first.gsub('{{name}}', "{{#{object.name.underscore}}}") %>
 ```
 
--> **Custom Roles**: If you're importing a IAM resource with a custom role, make sure to use the
+-> **Custom Roles** If you're importing a IAM resource with a custom role, make sure to use the
  full name of the custom role, e.g. `[projects/my-project|organizations/my-org]/roles/my-custom-role`.
 
 <% if object.base_url.include?("{{project}}")-%>

--- a/mmv1/templates/terraform/resource_iam.html.markdown.tmpl
+++ b/mmv1/templates/terraform/resource_iam.html.markdown.tmpl
@@ -295,7 +295,7 @@ IAM policy imports use the identifier of the resource in question, e.g.
 $ terraform import {{ $.IamTerraformName }}_policy.editor {{ $.FirstIamImportIdFormat }}
 ```
 
--> **Custom Roles**: If you're importing a IAM resource with a custom role, make sure to use the
+-> **Custom Roles** If you're importing a IAM resource with a custom role, make sure to use the
  full name of the custom role, e.g. `[projects/my-project|organizations/my-org]/roles/my-custom-role`.
 {{- if contains $.BaseUrl "{{project}}" }}
 

--- a/mmv1/third_party/terraform/website/docs/r/bigtable_instance_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_instance_iam.html.markdown
@@ -104,7 +104,7 @@ exported:
 
 ## Import
 
--> **Custom Roles**: If you're importing a IAM resource with a custom role, make sure to use the
+-> **Custom Roles** If you're importing a IAM resource with a custom role, make sure to use the
  full name of the custom role, e.g. `[projects/my-project|organizations/my-org]/roles/my-custom-role`.
 
 ### Importing IAM members

--- a/mmv1/third_party/terraform/website/docs/r/bigtable_table_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_table_iam.html.markdown
@@ -101,7 +101,7 @@ exported:
 ## Import
 
 
--> **Custom Roles**: If you're importing a IAM resource with a custom role, make sure to use the
+-> **Custom Roles** If you're importing a IAM resource with a custom role, make sure to use the
  full name of the custom role, e.g. `[projects/my-project|organizations/my-org]/roles/my-custom-role`.
 
 ### Importing IAM members

--- a/mmv1/third_party/terraform/website/docs/r/billing_account_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/billing_account_iam.html.markdown
@@ -90,7 +90,7 @@ exported:
 ## Import
 
 
--> **Custom Roles**: If you're importing a IAM resource with a custom role, make sure to use the
+-> **Custom Roles** If you're importing a IAM resource with a custom role, make sure to use the
  full name of the custom role, e.g. `organizations/my-org-id/roles/my-custom-role`.
 
 ### Importing IAM members

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_cluster_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_cluster_iam.html.markdown
@@ -99,7 +99,7 @@ exported:
 
 ## Import
 
--> **Custom Roles**: If you're importing a IAM resource with a custom role, make sure to use the
+-> **Custom Roles** If you're importing a IAM resource with a custom role, make sure to use the
  full name of the custom role, e.g. `[projects/my-project|organizations/my-org]/roles/my-custom-role`.
 
 ### Importing IAM members

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_job_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_job_iam.html.markdown
@@ -99,7 +99,7 @@ exported:
 
 ## Import
 
--> **Custom Roles**: If you're importing a IAM resource with a custom role, make sure to use the
+-> **Custom Roles** If you're importing a IAM resource with a custom role, make sure to use the
  full name of the custom role, e.g. `[projects/my-project|organizations/my-org]/roles/my-custom-role`.
 
 ### Importing IAM members

--- a/mmv1/third_party/terraform/website/docs/r/google_folder_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_folder_iam.html.markdown
@@ -212,7 +212,7 @@ exported:
 
 ## Import
 
--> **Custom Roles**: If you're importing a IAM resource with a custom role, make sure to use the
+-> **Custom Roles** If you're importing a IAM resource with a custom role, make sure to use the
  full name of the custom role, e.g. `organizations/{{org_id}}/roles/{{role_id}}`.
  
 -> **Conditional IAM Bindings**: If you're importing a IAM binding with a condition block, make sure

--- a/mmv1/third_party/terraform/website/docs/r/google_organization_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_organization_iam.html.markdown
@@ -215,7 +215,7 @@ exported:
 
 ## Import
 
--> **Custom Roles**: If you're importing a IAM resource with a custom role, make sure to use the
+-> **Custom Roles** If you're importing a IAM resource with a custom role, make sure to use the
  full name of the custom role, e.g. `organizations/{{org_id}}/roles/{{role_id}}`.
 
 -> **Conditional IAM Bindings**: If you're importing a IAM binding with a condition block, make sure

--- a/mmv1/third_party/terraform/website/docs/r/google_project_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project_iam.html.markdown
@@ -212,7 +212,7 @@ exported:
 
 ## Import
 
--> **Custom Roles**: If you're importing a IAM resource with a custom role, make sure to use the
+-> **Custom Roles** If you're importing a IAM resource with a custom role, make sure to use the
  full name of the custom role, e.g. `[projects/my-project|organizations/my-org]/roles/my-custom-role`.
 
 -> **Conditional IAM Bindings**: If you're importing a IAM binding with a condition block, make sure

--- a/mmv1/third_party/terraform/website/docs/r/google_service_account_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_service_account_iam.html.markdown
@@ -176,7 +176,7 @@ exported:
 
 ## Import
 
--> **Custom Roles**: If you're importing a IAM resource with a custom role, make sure to use the
+-> **Custom Roles** If you're importing a IAM resource with a custom role, make sure to use the
 full name of the custom role, e.g. `[projects/my-project|organizations/my-org]/roles/my-custom-role`.
 
 ### Importing IAM members

--- a/mmv1/third_party/terraform/website/docs/r/healthcare_dataset_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/healthcare_dataset_iam.html.markdown
@@ -95,7 +95,7 @@ exported:
 
 ## Import
 
--> **Custom Roles**: If you're importing a IAM resource with a custom role, make sure to use the
+-> **Custom Roles** If you're importing a IAM resource with a custom role, make sure to use the
  full name of the custom role, e.g. `[projects/my-project|organizations/my-org]/roles/my-custom-role`.
 
 ### Importing IAM members

--- a/mmv1/third_party/terraform/website/docs/r/healthcare_dicom_store_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/healthcare_dicom_store_iam.html.markdown
@@ -95,7 +95,7 @@ exported:
 
 ## Import
 
--> **Custom Roles**: If you're importing a IAM resource with a custom role, make sure to use the
+-> **Custom Roles** If you're importing a IAM resource with a custom role, make sure to use the
  full name of the custom role, e.g. `[projects/my-project|organizations/my-org]/roles/my-custom-role`.
 
 ### Importing IAM members

--- a/mmv1/third_party/terraform/website/docs/r/healthcare_fhir_store_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/healthcare_fhir_store_iam.html.markdown
@@ -95,7 +95,7 @@ exported:
 
 ## Import
 
--> **Custom Roles**: If you're importing a IAM resource with a custom role, make sure to use the
+-> **Custom Roles** If you're importing a IAM resource with a custom role, make sure to use the
  full name of the custom role, e.g. `[projects/my-project|organizations/my-org]/roles/my-custom-role`.
 
 ### Importing IAM members

--- a/mmv1/third_party/terraform/website/docs/r/healthcare_hl7_v2_store_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/healthcare_hl7_v2_store_iam.html.markdown
@@ -96,7 +96,7 @@ exported:
 
 ## Import
 
--> **Custom Roles**: If you're importing a IAM resource with a custom role, make sure to use the
+-> **Custom Roles** If you're importing a IAM resource with a custom role, make sure to use the
  full name of the custom role, e.g. `[projects/my-project|organizations/my-org]/roles/my-custom-role`.
 
 ### Importing IAM members

--- a/mmv1/third_party/terraform/website/docs/r/pubsub_subscription_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/pubsub_subscription_iam.html.markdown
@@ -92,7 +92,7 @@ exported:
 
 ## Import
 
--> **Custom Roles**: If you're importing a IAM resource with a custom role, make sure to use the
+-> **Custom Roles** If you're importing a IAM resource with a custom role, make sure to use the
  full name of the custom role, e.g. `[projects/my-project|organizations/my-org]/roles/my-custom-role`.
 
 ### Importing IAM members

--- a/mmv1/third_party/terraform/website/docs/r/spanner_instance_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/spanner_instance_iam.html.markdown
@@ -95,7 +95,7 @@ exported:
 
 ## Import
 
--> **Custom Roles**: If you're importing a IAM resource with a custom role, make sure to use the
+-> **Custom Roles** If you're importing a IAM resource with a custom role, make sure to use the
  full name of the custom role, e.g. `[projects/my-project|organizations/my-org]/roles/my-custom-role`.
 
 ### Importing IAM members

--- a/mmv1/third_party/terraform/website/docs/r/storage_managed_folder_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_managed_folder_iam.html.markdown
@@ -199,5 +199,5 @@ IAM policy imports use the identifier of the resource in question, e.g.
 $ terraform import google_storage_managed_folder_iam_policy.editor b/{{bucket}}/managedFolders/{{managed_folder}}
 ```
 
--> **Custom Roles**: If you're importing a IAM resource with a custom role, make sure to use the
+-> **Custom Roles** If you're importing a IAM resource with a custom role, make sure to use the
  full name of the custom role, e.g. `[projects/my-project|organizations/my-org]/roles/my-custom-role`.


### PR DESCRIPTION
Remove trailing colons on some notes in IAM docs. Since the description of the note ends up in the header, the leading colon on some (but not all) of these looks weird.

I updated some .erb files and other templates that I'm not sure are in use anymore, just for consistency.

See example (from [here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam#google_project_iam_member)):
<img width="686" alt="image" src="https://github.com/user-attachments/assets/d0dda114-3967-48ac-88fb-8194cf4ee900">

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
