### PR TITLE
spanner: added `google_spanner_database` data source

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
@@ -205,6 +205,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_service_accounts":                          resourcemanager.DataSourceGoogleServiceAccounts(),
 	"google_site_verification_token":                   siteverification.DataSourceSiteVerificationToken(),
 	"google_sourcerepo_repository":                     sourcerepo.DataSourceGoogleSourceRepoRepository(),
+	"google_spanner_database":                          spanner.DataSourceSpannerDatabase(),
 	"google_spanner_instance":                          spanner.DataSourceSpannerInstance(),
 	"google_sql_ca_certs":                              sql.DataSourceGoogleSQLCaCerts(),
 	"google_sql_tiers":                                 sql.DataSourceGoogleSQLTiers(),

--- a/mmv1/third_party/terraform/services/spanner/data_source_spanner_database.go
+++ b/mmv1/third_party/terraform/services/spanner/data_source_spanner_database.go
@@ -1,0 +1,46 @@
+package spanner
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceSpannerDatabase() *schema.Resource {
+
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceSpannerDatabase().Schema)
+
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "name")
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "instance")
+
+	tpgresource.AddOptionalFieldsToSchema(dsSchema, "project")
+
+	return &schema.Resource{
+		Read:   dataSourceSpannerDatabaseRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceSpannerDatabaseRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+
+	id, err := tpgresource.ReplaceVars(d, config, "{{instance}}/{{name}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+
+	d.SetId(id)
+
+	err = resourceSpannerDatabaseRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
+}

--- a/mmv1/third_party/terraform/services/spanner/data_source_spanner_database_test.go
+++ b/mmv1/third_party/terraform/services/spanner/data_source_spanner_database_test.go
@@ -25,7 +25,11 @@ func TestAccDataSourceSpannerDatabase_basic(t *testing.T) {
 					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores(
 						"data.google_spanner_database.bar",
 						"google_spanner_database.foo",
-						map[string]struct{}{"deletion_protection": {}},
+						map[string]struct{}{
+							"ddl.#":               {},
+							"ddl.0":               {},
+							"deletion_protection": {},
+						},
 					),
 				),
 			},
@@ -48,7 +52,6 @@ resource "google_spanner_database" "foo" {
   instance = google_spanner_instance.instance.name
   ddl = [
     "CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)",
-    "CREATE TABLE t2 (t2 INT64 NOT NULL,) PRIMARY KEY(t2)",
   ]
 
   deletion_protection = false

--- a/mmv1/third_party/terraform/services/spanner/data_source_spanner_database_test.go
+++ b/mmv1/third_party/terraform/services/spanner/data_source_spanner_database_test.go
@@ -1,0 +1,62 @@
+package spanner_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccDataSourceSpannerDatabase_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSpannerDatabaseDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceSpannerDatabaseBasic(context),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores(
+						"data.google_spanner_database.bar",
+						"google_spanner_database.foo",
+						map[string]struct{}{"deletion_protection": {}},
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceSpannerDatabaseBasic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_spanner_instance" "instance" {
+  name         = "tf-test-instance-%{random_suffix}"
+  display_name = "Test spanner instance"
+
+  config           = "regional-us-central1"
+  processing_units = 200
+}
+
+resource "google_spanner_database" "foo" {
+  name     = "tf-test-db-%{random_suffix}"
+  instance = google_spanner_instance.instance.name
+  ddl = [
+    "CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)",
+    "CREATE TABLE t2 (t2 INT64 NOT NULL,) PRIMARY KEY(t2)",
+  ]
+
+  deletion_protection = false
+}
+
+data "google_spanner_database" "bar" {
+  name     = google_spanner_database.foo.name
+  instance = google_spanner_instance.instance.name
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/website/docs/d/spanner_database.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/spanner_database.html.markdown
@@ -33,4 +33,4 @@ The following arguments are supported:
 ## Attributes Reference
 See [google_spanner_database](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/spanner_database) resource for details of all the available attributes.
 
-**Note** `ddl` is a read only field, and thus will show up with a null value.
+**Note** `ddl` is a field where reads are ignored, and thus will show up with a null value.

--- a/mmv1/third_party/terraform/website/docs/d/spanner_database.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/spanner_database.html.markdown
@@ -32,3 +32,5 @@ The following arguments are supported:
 
 ## Attributes Reference
 See [google_spanner_database](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/spanner_database) resource for details of all the available attributes.
+
+**Note** `ddl` is a read only field, and thus will show up with a null value.

--- a/mmv1/third_party/terraform/website/docs/d/spanner_database.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/spanner_database.html.markdown
@@ -1,0 +1,38 @@
+---
+subcategory: "Cloud Spanner"
+description: |-
+  Get a spanner database from Google Cloud
+---
+
+# google_spanner_database
+
+Get a spanner database from Google Cloud by its name and instance name.
+
+## Example Usage
+
+```tf
+data "google_spanner_instance" "instance" {
+  name = "my-instance"
+}
+
+data "google_spanner_database" "foo" {
+  name     = "foo"
+  instance = data.google_spanner_instance.instance.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the spanner database.
+
+* `instance` - (Required) The name of the database's spanner instance.
+
+- - -
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+## Attributes Reference
+See [google_spanner_database](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/spanner_database) resource for details of all the available attributes.

--- a/mmv1/third_party/terraform/website/docs/d/spanner_database.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/spanner_database.html.markdown
@@ -11,13 +11,9 @@ Get a spanner database from Google Cloud by its name and instance name.
 ## Example Usage
 
 ```tf
-data "google_spanner_instance" "instance" {
-  name = "my-instance"
-}
-
 data "google_spanner_database" "foo" {
   name     = "foo"
-  instance = data.google_spanner_instance.instance.name
+  instance = google_spanner_instance.instance.name
 }
 ```
 


### PR DESCRIPTION
Add a `google_spanner_database` data source.

Fixes hashicorp/terraform-provider-google#13470

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
`google_spanner_database`
```
