### PR TITLE
container: remove ignores in `TestAccContainerClusterDatasource`

### DIFF
--- a/mmv1/third_party/terraform/services/container/data_source_google_container_cluster_test.go
+++ b/mmv1/third_party/terraform/services/container/data_source_google_container_cluster_test.go
@@ -24,13 +24,7 @@ func TestAccContainerClusterDatasource_zonal(t *testing.T) {
 					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores(
 						"data.google_container_cluster.kubes",
 						"google_container_cluster.kubes",
-						// Remove once https://github.com/hashicorp/terraform/issues/21347 is fixed.
-						map[string]struct{}{
-							"enable_autopilot":             {},
-							"enable_tpu":                   {},
-							"pod_security_policy_config.#": {},
-							"deletion_protection":          {},
-						},
+						map[string]struct{}{"deletion_protection": {}},
 					),
 				),
 			},
@@ -54,13 +48,9 @@ func TestAccContainerClusterDatasource_regional(t *testing.T) {
 					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores(
 						"data.google_container_cluster.kubes",
 						"google_container_cluster.kubes",
-						// Remove once https://github.com/hashicorp/terraform/issues/21347 is fixed.
 						map[string]struct{}{
-							"enable_autopilot":             {},
-							"enable_tpu":                   {},
-							"pod_security_policy_config.#": {},
-							"deletion_protection":          {},
-							"resource_labels.%":            {},
+							"deletion_protection": {},
+							"resource_labels.%":   {},
 						},
 					),
 				),
@@ -75,10 +65,11 @@ resource "google_container_cluster" "kubes" {
   name               = "tf-test-cluster-%s"
   location           = "us-central1-a"
   initial_node_count = 1
-  deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
 
+  network    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 
 data "google_container_cluster" "kubes" {
@@ -94,12 +85,13 @@ resource "google_container_cluster" "kubes" {
   name               = "tf-test-cluster-%s"
   location           = "us-central1"
   initial_node_count = 1
-  deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
   resource_labels = {
     created-by = "terraform"
   }
+  network    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 
 data "google_container_cluster" "kubes" {


### PR DESCRIPTION
Remove items commented out in `google_container_cluster` regional and zonal data source tests, since
https://github.com/hashicorp/terraform/issues/21347 is resolved

```
--- PASS: TestAccContainerClusterDatasource_zonal (549.39s)
PASS
ok  	github.com/hashicorp/terraform-provider-google/google/services/container	550.554s
--- PASS: TestAccContainerClusterDatasource_regional (616.24s)
PASS
ok  	github.com/hashicorp/terraform-provider-google/google/services/container	617.412s
```
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
