### PR TITLE
improve big query job error messages

### DIFF
--- a/mmv1/templates/terraform/custom_expand/bigquery_table_ref.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/bigquery_table_ref.go.tmpl
@@ -40,7 +40,7 @@ func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.T
 		transformed["tableId"] =  parts[3]
 	}
 
-	configError := "Invalid BigQuery job configuration. You must either:\n" +
+	configError := "Invalid BigQuery job destination_table configuration. You must either:\n" +
 	  "1. Set all of project_id, dataset_id, and table_id separately, or\n" +
 		"2. Provide table_id in the form '{{`projects/{{project}}/datasets/{{dataset_id}}/tables/{{table_id}}`}}'"
 

--- a/mmv1/templates/terraform/custom_expand/bigquery_table_ref.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/bigquery_table_ref.go.tmpl
@@ -55,4 +55,4 @@ func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.T
 	  return nil, fmt.Errorf("%s\nMissing or empty datasetId", configError)
 	}
 	return transformed, nil
- }
+}

--- a/mmv1/templates/terraform/custom_expand/bigquery_table_ref.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/bigquery_table_ref.go.tmpl
@@ -40,5 +40,19 @@ func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.T
 		transformed["tableId"] =  parts[3]
 	}
 
+	configError := "Invalid BigQuery job configuration. You must either:\n" +
+	  "1. Set all of project_id, dataset_id, and table_id separately, or\n" +
+		"2. Provide table_id in the form '{{`projects/{{project}}/datasets/{{dataset_id}}/tables/{{table_id}}`}}'"
+
+	// Validate required fields
+	if projectId, ok := transformed["projectId"]; !ok || projectId == nil || 
+	  reflect.ValueOf(projectId).IsZero() {
+		return nil, fmt.Errorf("%s\nMissing or empty projectId", configError)
+	}
+
+	if datasetId, ok := transformed["datasetId"]; !ok || datasetId == nil || 
+	  reflect.ValueOf(datasetId).IsZero() {
+	  return nil, fmt.Errorf("%s\nMissing or empty datasetId", configError)
+	}
 	return transformed, nil
-}
+ }

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_job_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_job_test.go
@@ -97,13 +97,13 @@ func TestAccBigQueryJob_validationErrors(t *testing.T) {
 			{
 				Config: testAccBigQueryJob_missingProjectId(context),
 				ExpectError: regexp.MustCompile(
-					`Invalid BigQuery job configuration\. You must either:.*Missing or empty projectId`,
+					`(?s)Invalid BigQuery job destination_table configuration\. You must either:.*Missing or empty projectId`,
 				),
 			},
 			{
 				Config: testAccBigQueryJob_missingDatasetId(context),
 				ExpectError: regexp.MustCompile(
-					`Invalid BigQuery job configuration\. You must either:.*Missing or empty datasetId`,
+					`(?s)Invalid BigQuery job destination_table configuration\. You must either:.*Missing or empty datasetId`,
 				),
 			},
 		},
@@ -112,18 +112,6 @@ func TestAccBigQueryJob_validationErrors(t *testing.T) {
 
 func testAccBigQueryJob_missingProjectId(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_bigquery_table" "foo" {
-  deletion_protection = false
-  dataset_id = google_bigquery_dataset.bar.dataset_id
-  table_id   = "tf_test_job_query%{random_suffix}_table"
-}
-
-resource "google_bigquery_dataset" "bar" {
-  dataset_id                  = "tf_test_job_query%{random_suffix}_dataset"
-  friendly_name               = "test"
-  description                 = "This is a test description"
-  location   = "US"
-}
 resource "google_bigquery_job" "job" {
   job_id     = "tf-test-job-%{random_suffix}"
 
@@ -141,18 +129,6 @@ resource "google_bigquery_job" "job" {
 
 func testAccBigQueryJob_missingDatasetId(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_bigquery_table" "foo" {
-  deletion_protection = false
-  dataset_id = google_bigquery_dataset.bar.dataset_id
-  table_id   = "tf_test_job_query%{random_suffix}_table"
-}
-
-resource "google_bigquery_dataset" "bar" {
-  dataset_id                  = "tf_test_job_query%{random_suffix}_dataset"
-  friendly_name               = "test"
-  description                 = "This is a test description"
-  location   = "US"
-}
 resource "google_bigquery_job" "job" {
   job_id     = "tf-test-job-%{random_suffix}"
 


### PR DESCRIPTION
- add validation to check if project_id and dataset_id are set,
- return descriptive error when the either variable is not set.

![image](https://github.com/user-attachments/assets/50d89f4e-6421-4f3d-b019-64123635478c)




Fixes https://github.com/hashicorp/terraform-provider-google/issues/19834

```release-note:enhancement
bigquery: added descriptive validation errors for missing required fields in `google_bigquery_job` destination table configuration
```
