### PR TITLE
Update TF version used to test FEATURE-BRANCH-ephemeral-resource

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/projects/feature_branches/FEATURE-BRANCH-ephemeral-resource.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/feature_branches/FEATURE-BRANCH-ephemeral-resource.kt
@@ -23,7 +23,7 @@ import vcs_roots.ModularMagicianVCSRootBeta
 import vcs_roots.ModularMagicianVCSRootGa
 
 const val featureBranchEphemeralResources = "FEATURE-BRANCH-ephemeral-resource"
-const val EphemeralResourcesTfCoreVersion = "1.10.0-alpha20240926" // TODO - update with correct release
+const val EphemeralResourcesTfCoreVersion = "1.10.0-alpha20241023"
 
 // featureBranchEphemeralResourcesSubProject creates a project just for testing ephemeral resources.
 // We know that all ephemeral resources we're adding are part of the Resource Manager service, so we only include those builds.


### PR DESCRIPTION
This PR updates the TF release used to test this feature branch

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
