### PR TITLE
Support sub-CA to be activated into staged state

### DIFF
--- a/mmv1/templates/terraform/constants/privateca_certificate_authority.go.tmpl
+++ b/mmv1/templates/terraform/constants/privateca_certificate_authority.go.tmpl
@@ -3,9 +3,6 @@ func resourcePrivateCaCACustomDiff(_ context.Context, diff *schema.ResourceDiff,
 		_, new := diff.GetChange("desired_state")
 
 		if tpgresource.IsNewResource(diff) {
-			if diff.Get("type").(string) == "SUBORDINATE" {
-				return fmt.Errorf("`desired_state` can not be specified when creating a SUBORDINATE CA")
-			}
 			if new.(string) != "STAGED" && new.(string) != "ENABLED" {
 				return fmt.Errorf("`desired_state` can only be set to `STAGED` or `ENABLED` when creating a new CA")
 			}

--- a/mmv1/templates/terraform/post_create/privateca_certificate_authority.go.tmpl
+++ b/mmv1/templates/terraform/post_create/privateca_certificate_authority.go.tmpl
@@ -15,7 +15,6 @@ if d.Get("type").(string) == "SUBORDINATE" {
 
 // Enable the CA if `desired_state` is unspecified or specified as `ENABLED`.
 if p, ok := d.GetOk("desired_state"); !ok || p.(string) == "ENABLED" {
-	// Skip enablement on SUBORDINATE CA for backward compatible.
 	if staged {
 		if err := enableCA(config, d, project, billingProject, userAgent); err != nil {
 			return fmt.Errorf("Error enabling CertificateAuthority: %v", err)

--- a/mmv1/third_party/terraform/services/privateca/resource_privateca_certificate_authority_test.go
+++ b/mmv1/third_party/terraform/services/privateca/resource_privateca_certificate_authority_test.go
@@ -147,6 +147,33 @@ func TestAccPrivatecaCertificateAuthority_subordinateCaActivatedByFirstPartyIssu
 	})
 }
 
+func TestAccPrivatecaCertificateAuthority_subordinateCaActivatedByFirstPartyIssuerOnCreationInStagedState(t *testing.T) {
+	t.Parallel()
+	acctest.SkipIfVcr(t)
+
+	random_suffix := acctest.RandString(t, 10)
+	context := map[string]interface{}{
+		"root_location": "us-central1",
+		"sub_location":  "australia-southeast1",
+		"random_suffix": random_suffix,
+	}
+
+	resourceName := "google_privateca_certificate_authority.sub-1"
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckPrivatecaCertificateAuthorityDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivatecaCertificateAuthority_privatecaCertificateAuthoritySubordinateStagedWithFirstPartyIssuer(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "state", "STAGED"),
+				),
+			},
+		},
+	})
+}
+
 func testAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityBasicRoot(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_privateca_certificate_authority" "default" {
@@ -396,6 +423,143 @@ resource "google_privateca_certificate_authority" "sub-1" {
 	pool = google_privateca_ca_pool.sub-pool.name 
 	certificate_authority_id = "tf-test-my-certificate-authority-sub-%{random_suffix}"
 	location = "%{sub_location}"
+	subordinate_config {
+		certificate_authority = google_privateca_certificate_authority.root-1.name
+	}
+	config {
+		subject_config {
+		subject {
+			organization = "HashiCorp"
+			common_name = "my-certificate-authority"
+		}
+		subject_alt_name {
+			dns_names = ["hashicorp.com"]
+		}
+		}
+		x509_config {
+		ca_options {
+			is_ca = true
+			max_issuer_path_length = 10
+		}
+		key_usage {
+			base_key_usage {
+			digital_signature = true
+			content_commitment = true
+			key_encipherment = false
+			data_encipherment = true
+			key_agreement = true
+			cert_sign = true
+			crl_sign = true
+			decipher_only = true
+			}
+			extended_key_usage {
+			server_auth = true
+			client_auth = false
+			email_protection = true
+			code_signing = true
+			time_stamping = true
+			}
+		}
+		}
+	}
+	lifetime = "86400s"
+	key_spec {
+		algorithm = "RSA_PKCS1_4096_SHA256"
+	}
+	type = "SUBORDINATE"
+
+	// Disable CA deletion related safe checks for easier cleanup.
+	deletion_protection                    = false
+	skip_grace_period                      = true
+	ignore_active_certificates_on_deletion = true
+}
+`, context)
+}
+
+// testAccPrivatecaCertificateAuthority_privatecaCertificateAuthoritySubordinateStagedWithFirstPartyIssuer provides a config
+// which contains
+// * A CaPool for root CA
+// * A root CA
+// * A CaPool for sub CA
+// * A subordinate CA which should be activated by the above root CA
+func testAccPrivatecaCertificateAuthority_privatecaCertificateAuthoritySubordinateStagedWithFirstPartyIssuer(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_privateca_ca_pool" "root-pool" {
+	name     = "root-pool-%{random_suffix}"
+	location = "%{root_location}"
+	tier     = "ENTERPRISE"
+	publishing_options {
+	  publish_ca_cert = true
+	  publish_crl     = true
+	}
+}
+
+resource "google_privateca_certificate_authority" "root-1" {
+	pool = google_privateca_ca_pool.root-pool.name 
+	certificate_authority_id = "tf-test-my-certificate-authority-root-%{random_suffix}"
+	location = "%{root_location}"
+	config {
+		subject_config {
+		subject {
+			organization = "HashiCorp"
+			common_name = "my-certificate-authority"
+		}
+		subject_alt_name {
+			dns_names = ["hashicorp.com"]
+		}
+		}
+		x509_config {
+		ca_options {
+			is_ca = true
+			max_issuer_path_length = 10
+		}
+		key_usage {
+			base_key_usage {
+			digital_signature = true
+			content_commitment = true
+			key_encipherment = false
+			data_encipherment = true
+			key_agreement = true
+			cert_sign = true
+			crl_sign = true
+			decipher_only = true
+			}
+			extended_key_usage {
+			server_auth = true
+			client_auth = false
+			email_protection = true
+			code_signing = true
+			time_stamping = true
+			}
+		}
+		}
+	}
+	lifetime = "86400s"
+	key_spec {
+		algorithm = "RSA_PKCS1_4096_SHA256"
+	}
+
+	// Disable CA deletion related safe checks for easier cleanup.
+	deletion_protection                    = false
+	skip_grace_period                      = true
+	ignore_active_certificates_on_deletion = true
+}
+
+resource "google_privateca_ca_pool" "sub-pool" {
+	name     = "sub-pool-%{random_suffix}"
+	location = "%{sub_location}"
+	tier     = "ENTERPRISE"
+	publishing_options {
+	  publish_ca_cert = true
+	  publish_crl     = true
+	}
+}
+
+resource "google_privateca_certificate_authority" "sub-1" {
+	pool = google_privateca_ca_pool.sub-pool.name 
+	certificate_authority_id = "tf-test-my-certificate-authority-sub-%{random_suffix}"
+	location = "%{sub_location}"
+	desired_state = "STAGED"
 	subordinate_config {
 		certificate_authority = google_privateca_certificate_authority.root-1.name
 	}


### PR DESCRIPTION
b/374108917

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: enhancement
privateca: added support for sub-CA to be activated into STAGED state
```
