### PR TITLE
Remove policycontroller block from ACM configmanagement in gkehub_feature_membership tests

### DIFF
--- a/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.tmpl
@@ -188,12 +188,6 @@ resource "google_gke_hub_feature_membership" "feature_member_2" {
         secret_type = "none"
       }
     }
-    policy_controller {
-      enabled = true
-      audit_interval_seconds = "10"
-      exemptable_namespaces = ["asdf", "1234"]
-      template_library_installed = true
-    }
   }
 }
 `, context)
@@ -227,12 +221,6 @@ resource "google_gke_hub_feature_membership" "feature_member_2" {
         secret_type = "none"
       }
     }
-    policy_controller {
-      enabled = true
-      audit_interval_seconds = "9"
-      exemptable_namespaces = ["different", "1234"]
-      template_library_installed = true
-    }
     hierarchy_controller {
       enable_hierarchical_resource_quota = true
       enable_pod_tree_labels = false
@@ -256,12 +244,6 @@ resource "google_gke_hub_feature_membership" "feature_member_3" {
         secret_type = "none"
       }
     }
-    policy_controller {
-      enabled = false
-      audit_interval_seconds = "100"
-      exemptable_namespaces = ["onetwothree", "fourfive"]
-      template_library_installed = true
-    }
     hierarchy_controller {
       enable_hierarchical_resource_quota = false
       enable_pod_tree_labels = true
@@ -277,15 +259,6 @@ resource "google_gke_hub_feature_membership" "feature_member_4" {
   membership = google_gke_hub_membership.membership_fourth.membership_id
   configmanagement {
     version = "1.18.2"
-    policy_controller {
-      enabled = true
-      audit_interval_seconds = "100"
-      template_library_installed = true
-      mutation_enabled = true
-      monitoring {
-        backends = ["CLOUD_MONITORING", "PROMETHEUS"]
-      }
-    }
   }
 }
 `, context)
@@ -311,12 +284,6 @@ resource "google_gke_hub_feature_membership" "feature_member_3" {
   membership = google_gke_hub_membership.membership_third.membership_id
   configmanagement {
     version = "1.18.2"
-    policy_controller {
-      enabled = true
-      audit_interval_seconds = "100"
-      exemptable_namespaces = ["onetwothree", "fourfive"]
-      template_library_installed = true
-    }
   }
 }
 `, context)
@@ -443,14 +410,6 @@ resource "google_gke_hub_feature_membership" "feature_member" {
         sync_wait_secs = "30"
       }
     }
-    policy_controller {
-      enabled = true
-      audit_interval_seconds = "100"
-      exemptable_namespaces = ["onetwothree", "fourfive"]
-      template_library_installed = true
-      referential_rules_enabled = true
-      log_denies_enabled = true
-    }
   }
 }
 `, context)
@@ -510,14 +469,6 @@ resource "google_gke_hub_feature_membership" "feature_member" {
         sync_wait_secs = "30"
       }
       prevent_drift = true
-    }
-    policy_controller {
-      enabled = true
-      audit_interval_seconds = "100"
-      exemptable_namespaces = ["onetwothree", "fourfive"]
-      template_library_installed = true
-      referential_rules_enabled = true
-      log_denies_enabled = true
     }
   }
 }
@@ -676,14 +627,6 @@ resource "google_gke_hub_feature_membership" "feature_member" {
       }
       prevent_drift = true
     }
-    policy_controller {
-      enabled = true
-      audit_interval_seconds = "100"
-      exemptable_namespaces = ["onetwothree", "fourfive"]
-      template_library_installed = true
-      referential_rules_enabled = true
-      log_denies_enabled = true
-    }
   }
 }
 `, context)
@@ -726,14 +669,6 @@ resource "google_gke_hub_feature_membership" "feature_member" {
       }
       prevent_drift = true
     }
-    policy_controller {
-      enabled = true
-      audit_interval_seconds = "100"
-      exemptable_namespaces = ["onetwothree", "fourfive"]
-      template_library_installed = true
-      referential_rules_enabled = true
-      log_denies_enabled = true
-    }
   }
 }
 `, context)
@@ -764,14 +699,6 @@ resource "google_gke_hub_feature_membership" "feature_member" {
   membership = google_gke_hub_membership.membership_acmoci.membership_id
   configmanagement {
     version = "1.18.2"
-    policy_controller {
-      enabled = true
-      audit_interval_seconds = "100"
-      exemptable_namespaces = ["onetwothree", "fourfive"]
-      template_library_installed = true
-      referential_rules_enabled = true
-      log_denies_enabled = true
-    }
   }
 }
 `, context)


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixing the permadiff in  `policy_controller` field inside `configmanagement` (https://github.com/hashicorp/terraform-provider-google/issues/14591#issuecomment-2327578415)


Copying data of `policycontroller` into ACM is async and the non-atomic operation caused the permadiff in `policy_controller` field inside `configmanagement`.
As `policycontroller` is deprecated inside ACM, it is going to be removed from `configmanagement` in the ACM tests.


 

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
