### PR TITLE
`GO 1.22`: update Dockerfile to reference go `v1.23`

### DIFF
--- a/.ci/containers/build-environment/Dockerfile
+++ b/.ci/containers/build-environment/Dockerfile
@@ -15,7 +15,7 @@ RUN go mod download
 FROM ruby:3.1-bullseye
 
 # golang
-COPY --from=golang:1.21-bullseye /usr/local/go /usr/local/go
+COPY --from=golang:1.23-bullseye /usr/local/go /usr/local/go
 ENV GOPATH /go
 ENV PATH /usr/local/go/bin:$PATH
 ENV PATH $GOPATH/bin:$PATH

--- a/.ci/containers/go-plus/Dockerfile
+++ b/.ci/containers/go-plus/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Download go module cache for builds
-FROM golang:1.21-bullseye AS builder
+FROM golang:1.23-bullseye AS builder
 ENV GOCACHE=/go/cache
 
 RUN apt-get update && apt-get install -y unzip
@@ -12,7 +12,7 @@ WORKDIR /app1/magic-modules-main/.ci/magician
 RUN go build -o /dev/null .
 
 # Stage 2: Creating the final image
-FROM golang:1.21-bullseye
+FROM golang:1.23-bullseye
 SHELL ["/bin/bash", "-c"]
 ENV GOCACHE=/go/cache
 


### PR DESCRIPTION
This is required to continue supporting versions of terraform plugin mux versions that utilize go 1.23 features.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
