### PR TITLE
Container dns endpoint

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -981,6 +981,13 @@ func ResourceContainerCluster() *schema.Resource {
 				// ConflictsWith: many fields, see https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview#comparison. The conflict is only set one-way, on other fields w/ this field.
 			},
 
+			"enable_dns_access": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: `Enable access to the cluster's control plane over DNS-based endpoint. DNS-based control plane access is recommended.`,
+			},
+
 			"allow_net_admin": {
 				Type: schema.TypeBool,
 				Optional: true,
@@ -2373,6 +2380,12 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 			EnableFqdnNetworkPolicy:              d.Get("enable_fqdn_network_policy").(bool),
 {{- end }}
 	    },
+		ControlPlaneEndpointsConfig: &container.ControlPlaneEndpointsConfig{
+			DnsEndpointConfig: &container.DNSEndpointConfig{
+				AllowExternalTraffic: d.Get("enable_dns_access").(bool),
+				ForceSendFields: 	  []string{"AllowExternalTraffic"},
+			},
+		},
 		MasterAuth:     expandMasterAuth(d.Get("master_auth")),
 		NotificationConfig: expandNotificationConfig(d.Get("notification_config")),
 		ConfidentialNodes: expandConfidentialNodes(d.Get("confidential_nodes")),
@@ -2893,6 +2906,9 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	if err := d.Set("enable_tpu", cluster.EnableTpu); err != nil {
 		return fmt.Errorf("Error setting enable_tpu: %s", err)
 	}
+	if err := d.Set("enable_dns_access", cluster.ControlPlaneEndpointsConfig.DnsEndpointConfig.AllowExternalTraffic); err != nil {
+		return fmt.Errorf("Error setting enable_dns_access: %s", err)
+	}
 	if err := d.Set("tpu_ipv4_cidr_block", cluster.TpuIpv4CidrBlock); err != nil {
 		return fmt.Errorf("Error setting tpu_ipv4_cidr_block: %s", err)
 	}
@@ -3184,6 +3200,28 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	    }
 
 		log.Printf("[INFO] GKE cluster %s's autopilot workload policy config allow_net_admin has been set to %v", d.Id(), allowed)
+	}
+
+	if d.HasChange("enable_dns_access") {
+		allowed := d.Get("enable_dns_access").(bool)
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				DesiredControlPlaneEndpointsConfig: &container.ControlPlaneEndpointsConfig{
+					DnsEndpointConfig: &container.DNSEndpointConfig{
+						AllowExternalTraffic: allowed,
+						ForceSendFields:      []string{"AllowExternalTraffic"},
+					},
+				},
+			},
+		}
+
+		updateF := updateFunc(req, "updating dns-endpoint control plane for GKE")
+		// Call update serially.
+		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] GKE cluster %s's dns-endpoint control plane config enable_dns_access has been set to %v", d.Id(), allowed)
 	}
 
 	if d.HasChange("private_cluster_config.0.enable_private_endpoint") {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -1318,6 +1318,33 @@ func TestAccContainerCluster_withTpu(t *testing.T) {
 }
 {{- end }}
 
+func TestAccContainerCluster_withDnsAccess(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	containerNetName := fmt.Sprintf("tf-test-container-net-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withDnsAccess(containerNetName, clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.with_dns_access", "enable_dns_access", "true"),
+				),
+			},
+			{
+				ResourceName:		 "google_container_cluster.with_dns_access",
+				ImportState:		 true,
+				ImportStateVerify:	 true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
 func TestAccContainerCluster_withPrivateClusterConfigBasic(t *testing.T) {
 	t.Parallel()
 
@@ -6787,6 +6814,62 @@ resource "google_container_cluster" "with_tpu" {
 }
 
 {{ end }}
+
+func testAccContainerCluster_withDnsAccess(containerNetName string, clusterName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "container_network" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "container_subnetwork" {
+  name    = google_compute_network.container_network.name
+  network = google_compute_network.container_network.name
+  region  = "us-central1"
+
+  ip_cidr_range            = "10.0.35.0/24"
+  private_ip_google_access = true
+
+  secondary_ip_range {
+    range_name    = "pod"
+    ip_cidr_range = "10.1.0.0/19"
+  }
+
+  secondary_ip_range {
+    range_name    = "svc"
+    ip_cidr_range = "10.2.0.0/22"
+  }
+}
+
+resource "google_container_cluster" "with_dns_access" {
+  name               = "%s"
+  location           = "us-central1-b"
+  initial_node_count = 1
+
+  enable_dns_access = true
+
+  network         = google_compute_network.container_network.name
+  subnetwork      = google_compute_subnetwork.container_subnetwork.name
+  networking_mode = "VPC_NATIVE"
+
+  private_cluster_config {
+    enable_private_endpoint = true
+    enable_private_nodes    = true
+    master_ipv4_cidr_block  = "10.42.0.0/28"
+  }
+
+  master_authorized_networks_config {
+  }
+
+  ip_allocation_policy {
+    cluster_secondary_range_name  = google_compute_subnetwork.container_subnetwork.secondary_ip_range[0].range_name
+    services_secondary_range_name = google_compute_subnetwork.container_subnetwork.secondary_ip_range[1].range_name
+  }
+  deletion_protection = false
+}
+`, containerNetName, clusterName)
+}
+
 func testAccContainerCluster_withIntraNodeVisibility(clusterName, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_intranode_visibility" {

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -171,6 +171,10 @@ for more information.
     Structure is [documented below](#nested_enable_k8s_beta_apis).
 
 * `enable_tpu` - (Optional) Whether to enable Cloud TPU resources in this cluster.
+    See the [official documentation](https://cloud.google.com/kubernetes-engine/docs/concepts/network-isolation#dns-based_endpoint).
+
+* `enable_dns_access` - (Optional) Enable access to the cluster's control plane over DNS-based  
+    endpoint. DNS-based control plane access is recommended.
     See the [official documentation](https://cloud.google.com/tpu/docs/kubernetes-engine-setup).
 
 * `enable_legacy_abac` - (Optional) Whether the ABAC authorizer is enabled for this cluster.


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

Added newly created [Control Plane Access DNS Endpoint](https://cloud.google.com/kubernetes-engine/docs/concepts/network-isolation#dns-based_endpoint)

```release-note:enhancement
container: added `enable_dns_access` field to `google_container_cluster` resource
```

tbh, not sure if this is the way to go.. feel free to guide me how the new feature should be implemented best :)
