### PR TITLE
Partly rollback changes from #11321 to fix an `alias_ip_range` bug

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -53,28 +53,17 @@ func expandAliasIpRanges(ranges []interface{}) []*compute.AliasIpRange {
 	return ipRanges
 }
 
-func flattenAliasIpRange(d *schema.ResourceData, ranges []*compute.AliasIpRange, i int) []map[string]interface{} {
-	prefix := fmt.Sprintf("network_interface.%d", i)
+func flattenAliasIpRange(ranges []*compute.AliasIpRange) []map[string]interface{} {
+	rangesSchema := make([]map[string]interface{}, 0, len(ranges))
 
-	configData := []map[string]interface{}{}
-	for _, item := range d.Get(prefix + ".alias_ip_range").([]interface{}) {
-		configData = append(configData, item.(map[string]interface{}))
-	}
-
-	apiData := make([]map[string]interface{}, 0, len(ranges))
 	for _, ipRange := range ranges {
-		apiData = append(apiData, map[string]interface{}{
+		rangesSchema = append(rangesSchema, map[string]interface{}{
 			"ip_cidr_range":         ipRange.IpCidrRange,
 			"subnetwork_range_name": ipRange.SubnetworkRangeName,
 		})
 	}
 
-	//permadiff fix
-	sorted, err := tpgresource.SortMapsByConfigOrder(configData, apiData, "ip_cidr_range")
-	if err != nil {
-		return apiData
-	}
-	return sorted
+	return rangesSchema
 }
 
 func expandScheduling(v interface{}) (*compute.Scheduling, error) {
@@ -414,7 +403,7 @@ func flattenNetworkInterfaces(d *schema.ResourceData, config *transport_tpg.Conf
 			"subnetwork":          tpgresource.ConvertSelfLinkToV1(iface.Subnetwork),
 			"subnetwork_project":  subnet.Project,
 			"access_config":       ac,
-			"alias_ip_range":      flattenAliasIpRange(d, iface.AliasIpRanges, i),
+			"alias_ip_range":      flattenAliasIpRange(iface.AliasIpRanges),
 			"nic_type":            iface.NicType,
 			"stack_type":          iface.StackType,
 			"ipv6_access_config": flattenIpv6AccessConfigs(iface.Ipv6AccessConfigs),

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -2270,9 +2270,6 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 					Fingerprint:     instNetworkInterface.Fingerprint,
 					ForceSendFields: []string{"AliasIpRanges"},
 				}
-				if commonAliasIpRanges := CheckForCommonAliasIp(instNetworkInterface, networkInterface); len(commonAliasIpRanges) > 0 {
-					ni.AliasIpRanges = commonAliasIpRanges
-				}
 				op, err := config.NewComputeClient(userAgent).Instances.UpdateNetworkInterface(project, zone, instance.Name, networkName, ni).Do()
 				if err != nil {
 					return errwrap.Wrapf("Error removing alias_ip_range: {{"{{"}}err{{"}}"}}", err)
@@ -3319,21 +3316,4 @@ func isEmptyServiceAccountBlock(d *schema.ResourceData) bool {
 		return true
 	}
 	return false
-}
-
-// Alias ip ranges cannot be removed and created at the same time. This checks if there are any unchanged alias ip ranges
-// to be kept in between the PATCH operations on Network Interface
-func CheckForCommonAliasIp(old, new *compute.NetworkInterface) []*compute.AliasIpRange {
-	newAliasIpMap := make(map[string]bool)
-	for _, ipRange := range new.AliasIpRanges {
-		newAliasIpMap[ipRange.IpCidrRange] = true
-	}
-
-	resultAliasIpRanges := make([]*compute.AliasIpRange, 0)
-	for _, val := range old.AliasIpRanges {
-		if newAliasIpMap[val.IpCidrRange] {
-			resultAliasIpRanges = append(resultAliasIpRanges, val)
-		}
-	}
-	return resultAliasIpRanges
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
@@ -97,60 +96,6 @@ func TestMinCpuPlatformDiffSuppress(t *testing.T) {
 		if tpgcompute.ComputeInstanceMinCpuPlatformEmptyOrAutomaticDiffSuppress("min_cpu_platform", tc.Old, tc.New, nil) != tc.ExpectDiffSuppress {
 			t.Errorf("bad: %s, %q => %q expect DiffSuppress to return %t", tn, tc.Old, tc.New, tc.ExpectDiffSuppress)
 		}
-	}
-}
-
-func TestCheckForCommonAliasIp(t *testing.T) {
-	type testCase struct {
-		old, new []*compute.AliasIpRange
-		expected []*compute.AliasIpRange
-	}
-
-	testCases := []testCase{
-		{
-			old: []*compute.AliasIpRange{
-				{IpCidrRange: "10.0.0.0/24"},
-				{IpCidrRange: "10.0.1.0/24"},
-			},
-			new: []*compute.AliasIpRange{
-				{IpCidrRange: "10.0.0.0/24"},
-				{IpCidrRange: "10.0.2.0/24"},
-			},
-			expected: []*compute.AliasIpRange{
-				{IpCidrRange: "10.0.0.0/24"},
-			},
-		},
-		{
-			old: []*compute.AliasIpRange{
-				{IpCidrRange: "172.16.0.0/24"},
-				{IpCidrRange: "10.0.1.0/24"},
-			},
-			new: []*compute.AliasIpRange{
-				{IpCidrRange: "172.16.0.0/24"},
-				{IpCidrRange: "10.0.2.0/24"},
-			},
-			expected: []*compute.AliasIpRange{
-				{IpCidrRange: "172.16.0.0/24"},
-			},
-		},
-		{
-			old: []*compute.AliasIpRange{
-				{IpCidrRange: "10.0.0.0/24"},
-				{IpCidrRange: "10.0.1.0/24"},
-			},
-			new: []*compute.AliasIpRange{
-				{IpCidrRange: "192.168.0.0/24"},
-				{IpCidrRange: "172.17.0.0/24"},
-			},
-			expected: []*compute.AliasIpRange{},
-		},
-	}
-
-	for _, tc := range testCases {
-		oldInterface := &compute.NetworkInterface{AliasIpRanges: tc.old}
-		newInterface := &compute.NetworkInterface{AliasIpRanges: tc.new}
-		result := tpgcompute.CheckForCommonAliasIp(oldInterface, newInterface)
-		assert.Equal(t, tc.expected, result)
 	}
 }
 
@@ -2038,7 +1983,7 @@ func TestAccComputeInstance_secondaryAliasIpRange(t *testing.T) {
 					testAccCheckComputeInstanceHasAliasIpRange(&instance, "inst-test-secondary", "172.16.0.0/24"),
 				),
 			},
-			computeInstanceImportStep("us-east1-d", instanceName, []string{"network_interface.0.alias_ip_range.0.ip_cidr_range", "network_interface.0.alias_ip_range.0.subnetwork_range_name", "network_interface.0.alias_ip_range.1.ip_cidr_range", "network_interface.0.alias_ip_range.1.subnetwork_range_name"}),
+			computeInstanceImportStep("us-east1-d", instanceName, []string{}),
 			{
 				Config: testAccComputeInstance_secondaryAliasIpRangeUpdate(networkName, subnetName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
@@ -2046,7 +1991,7 @@ func TestAccComputeInstance_secondaryAliasIpRange(t *testing.T) {
 					testAccCheckComputeInstanceHasAliasIpRange(&instance, "", "10.0.1.0/24"),
 				),
 			},
-			computeInstanceImportStep("us-east1-d", instanceName, []string{"network_interface.0.alias_ip_range.0.ip_cidr_range", "network_interface.0.alias_ip_range.0.subnetwork_range_name", "network_interface.0.alias_ip_range.1.ip_cidr_range", "network_interface.0.alias_ip_range.1.subnetwork_range_name"}),
+			computeInstanceImportStep("us-east1-d", instanceName, []string{}),
 		},
 	})
 }
@@ -2090,7 +2035,7 @@ func TestAccComputeInstance_aliasIpRangeCommonAddresses(t *testing.T) {
 					testAccCheckComputeInstanceHasAliasIpRange(&instance, "inst-test-tertiary", "10.1.3.0/24"),
 				),
 			},
-			computeInstanceImportStep("us-east1-d", instanceName, []string{"network_interface.0.alias_ip_range.0.ip_cidr_range", "network_interface.0.alias_ip_range.0.subnetwork_range_name", "network_interface.0.alias_ip_range.1.ip_cidr_range", "network_interface.0.alias_ip_range.1.subnetwork_range_name"}),
+			computeInstanceImportStep("us-east1-d", instanceName, []string{}),
 		},
 	})
 }
@@ -2933,15 +2878,15 @@ func TestAccComputeInstance_subnetworkUpdate(t *testing.T) {
 			{
 				Config: testAccComputeInstance_subnetworkUpdate(suffix, instanceName),
 			},
-			computeInstanceImportStep("us-east1-d", instanceName, []string{"allow_stopping_for_update", "network_interface.0.alias_ip_range.0.ip_cidr_range", "network_interface.0.alias_ip_range.0.subnetwork_range_name", "network_interface.0.alias_ip_range.1.ip_cidr_range", "network_interface.0.alias_ip_range.1.subnetwork_range_name"}),
+			computeInstanceImportStep("us-east1-d", instanceName, []string{}),
 			{
 				Config: testAccComputeInstance_subnetworkUpdateTwo(suffix, instanceName),
 			},
-			computeInstanceImportStep("us-east1-d", instanceName, []string{"allow_stopping_for_update", "network_interface.0.alias_ip_range.0.ip_cidr_range", "network_interface.0.alias_ip_range.0.subnetwork_range_name", "network_interface.0.alias_ip_range.1.ip_cidr_range", "network_interface.0.alias_ip_range.1.subnetwork_range_name"}),
+			computeInstanceImportStep("us-east1-d", instanceName, []string{}),
 			{
 				Config: testAccComputeInstance_subnetworkUpdate(suffix, instanceName),
 			},
-			computeInstanceImportStep("us-east1-d", instanceName, []string{"allow_stopping_for_update", "network_interface.0.alias_ip_range.0.ip_cidr_range", "network_interface.0.alias_ip_range.0.subnetwork_range_name", "network_interface.0.alias_ip_range.1.ip_cidr_range", "network_interface.0.alias_ip_range.1.subnetwork_range_name"}),
+			computeInstanceImportStep("us-east1-d", instanceName, []string{}),
 		},
 	})
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -2878,15 +2878,15 @@ func TestAccComputeInstance_subnetworkUpdate(t *testing.T) {
 			{
 				Config: testAccComputeInstance_subnetworkUpdate(suffix, instanceName),
 			},
-			computeInstanceImportStep("us-east1-d", instanceName, []string{}),
+			computeInstanceImportStep("us-east1-d", instanceName, []string{"allow_stopping_for_update"}),
 			{
 				Config: testAccComputeInstance_subnetworkUpdateTwo(suffix, instanceName),
 			},
-			computeInstanceImportStep("us-east1-d", instanceName, []string{}),
+			computeInstanceImportStep("us-east1-d", instanceName, []string{"allow_stopping_for_update"}),
 			{
 				Config: testAccComputeInstance_subnetworkUpdate(suffix, instanceName),
 			},
-			computeInstanceImportStep("us-east1-d", instanceName, []string{}),
+			computeInstanceImportStep("us-east1-d", instanceName, []string{"allow_stopping_for_update"}),
 		},
 	})
 }


### PR DESCRIPTION
rollback from https://github.com/GoogleCloudPlatform/magic-modules/pull/11321
closes https://github.com/hashicorp/terraform-provider-google/issues/19765 (more context in the comments of this issue)

This issue will get reintroduced https://github.com/hashicorp/terraform-provider-google/issues/12286

This cannot be easily fixed without introducing new edge cases or crazy overhead for this field hence the rollback. The problems are:
- alias_ip's cannot be simultaneously removed and added in the same request. THIS IS AN API LIMITATION
- alias_ip's are a list of blocks so it cannot be validated and checked against other values or have a customized diff because you cannot access data from another block in customdiff, diffsuppress or validate functions
- Because alias_ip's are a list of blocks their order in the code matters. So if a user changes the order of them without changing the IP's this is a diff that we have to account for
- This field is getting auto sorted on the API's side (causing diff in config) and also has computed values when given a syntax like "/32". This makes it very complicated to cover all of the different cases.

Overall, i'd say that we should accept the fact that the array of alias_ip ranges get's cleared in between requests and treat it as an API limitation until it gets fixed. I don't think we should build additional UX features on top of an API method that doesn't work according to Google's standards (it should support deletion and creation at the same time)

partly rollback because i'm leaving the tests introduced in the previous PR. They could be useful if this gets fixed in the future
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: `alias_ip_range` on `google_compute_instance` will no longer cause ordering issues when updating with "/xx" syntax
```
