### PR TITLE
Fix address group ordering for network firewall policy rule

### DIFF
--- a/mmv1/products/compute/NetworkFirewallPolicyRule.yaml
+++ b/mmv1/products/compute/NetworkFirewallPolicyRule.yaml
@@ -166,14 +166,16 @@ properties:
                 - 'INEFFECTIVE'
       - name: 'destAddressGroups'
         type: Array
-        send_empty_value: true
         description: |
           Address groups which should be matched against the traffic destination. Maximum number of destination address groups is 10.
         item_type:
           type: String
+        send_empty_value: true
+        custom_flatten: 'templates/terraform/custom_flatten/compute_network_firewall_policy_rule_dest_address_group_order.go.tmpl'
       - name: 'srcAddressGroups'
         type: Array
         send_empty_value: true
+        custom_flatten: 'templates/terraform/custom_flatten/compute_network_firewall_policy_rule_src_address_group_order.go.tmpl'
         description: |
           Address groups which should be matched against the traffic source. Maximum number of source address groups is 10.
         item_type:

--- a/mmv1/templates/terraform/custom_flatten/compute_network_firewall_policy_rule_dest_address_group_order.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/compute_network_firewall_policy_rule_dest_address_group_order.go.tmpl
@@ -1,0 +1,25 @@
+func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+    rawConfigValue := d.Get("match.0.dest_address_groups")
+
+    // Convert config value to []string
+    configValue, err := tpgresource.InterfaceSliceToStringSlice(rawConfigValue)
+    if err != nil {
+        log.Printf("[ERROR] Failed to convert config value: %s", err)
+        return v
+    }
+
+    // Convert v to []string
+    apiStringValue, err := tpgresource.InterfaceSliceToStringSlice(v)
+    if err != nil {
+        log.Printf("[ERROR] Failed to convert API value: %s", err)
+        return v
+    }
+
+    sortedStrings, err := tpgresource.SortStringsByConfigOrder(configValue, apiStringValue)
+    if err != nil {
+        log.Printf("[ERROR] Could not sort API response value: %s", err)
+        return v
+    }
+
+    return sortedStrings
+}

--- a/mmv1/templates/terraform/custom_flatten/compute_network_firewall_policy_rule_src_address_group_order.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/compute_network_firewall_policy_rule_src_address_group_order.go.tmpl
@@ -1,0 +1,25 @@
+func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+    rawConfigValue := d.Get("match.0.src_address_groups")
+
+    // Convert config value to []string
+    configValue, err := tpgresource.InterfaceSliceToStringSlice(rawConfigValue)
+    if err != nil {
+        log.Printf("[ERROR] Failed to convert config value: %s", err)
+        return v
+    }
+
+    // Convert v to []string
+    apiStringValue, err := tpgresource.InterfaceSliceToStringSlice(v)
+    if err != nil {
+        log.Printf("[ERROR] Failed to convert API value: %s", err)
+        return v
+    }
+
+    sortedStrings, err := tpgresource.SortStringsByConfigOrder(configValue, apiStringValue)
+    if err != nil {
+        log.Printf("[ERROR] Could not sort API response value: %s", err)
+        return v
+    }
+
+    return sortedStrings
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_firewall_policy_rule_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_firewall_policy_rule_test.go.tmpl
@@ -140,6 +140,41 @@ func TestAccComputeNetworkFirewallPolicyRule_multipleRules(t *testing.T) {
   })
 }
 
+func TestAccComputeNetworkFirewallPolicyRule_addressGroupOrder(t *testing.T) {
+  t.Parallel()
+
+  context := map[string]interface{}{
+    "random_suffix": acctest.RandString(t, 10),
+    "project":  envvar.GetTestProjectFromEnv(),
+  }
+
+  acctest.VcrTest(t, resource.TestCase{
+    PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+    Steps: []resource.TestStep{
+      {
+        Config: testAccComputeNetworkFirewallPolicyRule_addressGroupOrder(context),
+      },
+      {
+        ResourceName:      "google_compute_network_firewall_policy_rule.src_test",
+        ImportState:       true,
+        ImportStateVerify: true,
+        // Referencing using ID causes import to fail
+        // Client-side reordering doesn't work with no state, so ignore on import
+        ImportStateVerifyIgnore: []string{"firewall_policy", "match.0.src_address_groups"},
+      },
+      {
+        ResourceName:      "google_compute_network_firewall_policy_rule.dest_test",
+        ImportState:       true,
+        ImportStateVerify: true,
+        // Referencing using ID causes import to fail
+        // Client-side reordering doesn't work with no state, so ignore on import
+        ImportStateVerifyIgnore: []string{"firewall_policy", "match.0.dest_address_groups"},
+      },
+    },
+  })
+}
+
 func TestAccComputeNetworkFirewallPolicyRule_securityProfileGroup_update(t *testing.T) {
   t.Parallel()
 
@@ -894,5 +929,75 @@ resource "google_compute_network_firewall_policy_rule" "fw_policy_rule3" {
     src_threat_intelligences = ["iplist-known-malicious-ips"]
   }
 }
+`, context)
+}
+
+
+func testAccComputeNetworkFirewallPolicyRule_addressGroupOrder(context map[string]interface{}) string {
+  return acctest.Nprintf(`
+resource "google_compute_network_firewall_policy" "policy" {
+  name = "tf-test-policy-%{random_suffix}"
+  description = "Resource created for Terraform acceptance testing"
+}
+
+resource "google_network_security_address_group" "add-group1" {
+  name        = "tf-test-group-1-%{random_suffix}"
+  parent      = "projects/%{project}"
+  location    = "global"
+  type        = "IPV4"
+  capacity    = "10"
+  items       = ["10.0.1.1/32"]
+}
+resource "google_network_security_address_group" "add-group2" {
+  name        = "tf-test-group-2-%{random_suffix}"
+  parent      = "projects/%{project}"
+  location    = "global"
+  type        = "IPV4"
+  capacity    = "10"
+  items       = ["10.0.2.2/32"]
+}
+resource "google_network_security_address_group" "add-group3" {
+  name        = "tf-test-group-3-%{random_suffix}"
+  parent      = "projects/%{project}"
+  location    = "global"
+  type        = "IPV4"
+  capacity    = "10"
+  items       = ["10.0.3.3/32"]
+}
+
+resource "google_compute_network_firewall_policy_rule" "src_test" {
+  firewall_policy         = google_compute_network_firewall_policy.policy.id
+  action                  = "allow"
+  priority                = 1000
+  description             = "Testing address group order issue"
+  direction               = "INGRESS"
+  enable_logging          = true
+  match {
+    src_address_groups = [google_network_security_address_group.add-group2.id,
+                          google_network_security_address_group.add-group1.id]
+    dest_ip_ranges     = ["192.168.2.0/24", "10.0.3.4/32"]
+    layer4_configs {
+      ip_protocol = "all"
+    }
+  }
+}
+
+resource "google_compute_network_firewall_policy_rule" "dest_test" {
+  firewall_policy         = google_compute_network_firewall_policy.policy.id
+  action                  = "allow"
+  priority                = 1100
+  description             = "Testing address group order issue"
+  direction               = "EGRESS"
+  enable_logging          = true
+  match {
+    dest_address_groups = [google_network_security_address_group.add-group3.id,
+                           google_network_security_address_group.add-group2.id]
+    src_ip_ranges       = ["192.168.2.0/24", "10.0.3.4/32"]
+    layer4_configs {
+      ip_protocol = "all"
+    }
+  }
+}
+
 `, context)
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/18134

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fixed a diff based on server-side reordering of `match.src_address_groups` and `match.dest_address_groups` in `google_compute_network_firewall_policy_rule`
```
