### PR TITLE
Remove documentation of allow_resource_tags_on_deletion from google_bigquery_table

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -182,14 +182,6 @@ The following arguments are supported:
     parent organization or project resource for this tag key. Tag value is
     expected to be the short name, for example "Production".
 
-* `allow_resource_tags_on_deletion` - (Optional) If set to true, it allows table
-    deletion when there are still resource tags attached. The default value is
-    false.
-
-    ~>**Warning:** `allow_resource_tags_on_deletion` is deprecated and will be
-      removed in a future major release. The default behavior will be allowing
-      the presence of resource tags on deletion after the next major release.
-
 <a name="nested_external_data_configuration"></a>The `external_data_configuration` block supports:
 
 * `autodetect` - (Required) - Let BigQuery try to autodetect the schema


### PR DESCRIPTION


<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

A follow-up to https://github.com/GoogleCloudPlatform/magic-modules/pull/11393. The field itself was removed as part of v6.0.0.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
