### PR TITLE
feat: Add `disks` support to compute_node_template

### DIFF
--- a/mmv1/products/compute/NodeTemplate.yaml
+++ b/mmv1/products/compute/NodeTemplate.yaml
@@ -175,3 +175,23 @@ properties:
     enum_values:
       - 'ENABLED'
       - 'NONE'
+  - name: 'disks'
+    type: Array
+    description: |
+      List of the type, size and count of disks attached to the
+      node template
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'diskCount'
+          type: Integer
+          description: |
+            The number of disks exposed to this node template.
+        - name: 'diskType'
+          type: String
+          description: |
+            The type of disks exposed to this node template.
+        - name: 'diskSizeGb'
+          type: Integer
+          description: |
+            The disk pool size in GB.

--- a/mmv1/products/compute/NodeTemplate.yaml
+++ b/mmv1/products/compute/NodeTemplate.yaml
@@ -59,6 +59,10 @@ examples:
     primary_resource_id: 'template'
     vars:
       template_name: 'soletenant-with-accelerators'
+  - name: 'node_template_disks'
+    primary_resource_id: 'template'
+    vars:
+      template_name: 'soletenant-with-disks'
 parameters:
   - name: 'region'
     type: ResourceRef

--- a/mmv1/products/compute/NodeTemplate.yaml
+++ b/mmv1/products/compute/NodeTemplate.yaml
@@ -190,12 +190,12 @@ properties:
         - name: 'diskCount'
           type: Integer
           description: |
-            The number of disks exposed to this node template.
+            Specifies the number of such disks.
         - name: 'diskType'
           type: String
           description: |
-            The type of disks exposed to this node template.
+            Specifies the desired disk type on the node. This disk type must be a local storage type (e.g.: local-ssd). Note that for nodeTemplates, this should be the name of the disk type and not its URL.
         - name: 'diskSizeGb'
           type: Integer
           description: |
-            The disk pool size in GB.
+            Specifies the size of the disk in base-2 GB.

--- a/mmv1/templates/terraform/examples/node_template_disks.tf.tmpl
+++ b/mmv1/templates/terraform/examples/node_template_disks.tf.tmpl
@@ -1,0 +1,16 @@
+data "google_compute_node_types" "central1a" {
+  zone     = "us-central1-a"
+}
+
+resource "google_compute_node_template" "{{$.PrimaryResourceId}}" {
+  name      = "{{index $.Vars "template_name"}}"
+  region    = "us-central1"
+  node_type = "n2-node-80-640"
+
+  disks {
+    disk_count   = 16
+    disk_size_gb = 375
+    disk_type    = "local-ssd"
+  }
+}
+


### PR DESCRIPTION
This PR adds Local SSD disk settings support.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/20026

```release-note:enhancement
compute: added `disks` field to `google_compute_node_template` resource
```
