### PR TITLE
bigtable: fix failing test `TestAccBigtableTable_familyType

### DIFF
--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_table_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_table_test.go
@@ -141,7 +141,7 @@ func TestAccBigtableTable_familyType(t *testing.T) {
 			},
 			{
 				Config:      testAccBigtableTable_familyType(instanceName, tableName, family, "intmin"),
-				ExpectError: regexp.MustCompile(".*Immutable fields 'value_type' cannot be updated.*"),
+				ExpectError: regexp.MustCompile("Immutable fields 'value_type.aggregate_type' cannot be updated"),
 			},
 		},
 	})


### PR DESCRIPTION
Update regex to match the current error message

Fixes https://github.com/hashicorp/terraform-provider-google/issues/20001

I decided to lose the leading / trailing `.*`, which I think is redundant. Looks like since it's re2, the literal `.` doesn't need to be escaped.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
