### PR TITLE
Make review reminders only remind current reviewer

### DIFF
--- a/.ci/magician/cmd/scheduled_pr_reminders.go
+++ b/.ci/magician/cmd/scheduled_pr_reminders.go
@@ -66,11 +66,12 @@ var scheduledPrReminders = &cobra.Command{
 			return fmt.Errorf("did not provide GITHUB_TOKEN environment variable")
 		}
 		gh := github.NewClient(nil).WithAuthToken(githubToken)
-		return execScheduledPrReminders(gh)
+		mgh := membership.NewClient(githubToken)
+		return execScheduledPrReminders(gh, mgh)
 	},
 }
 
-func execScheduledPrReminders(gh *github.Client) error {
+func execScheduledPrReminders(gh *github.Client, mgh GithubClient) error {
 	ctx := context.Background()
 	opt := &github.PullRequestListOptions{
 		State:       "open",
@@ -165,7 +166,14 @@ func execScheduledPrReminders(gh *github.Client) error {
 		)
 		sinceDays := businessDaysDiff(since, time.Now())
 		if shouldNotify(pr, state, sinceDays) {
-			comment, err := formatReminderComment(pr, state, sinceDays)
+			// Determine the current primary reviewer.
+			comments, err := mgh.GetPullRequestComments(fmt.Sprintf("%d", *pr.Number))
+			if err != nil {
+				return err
+			}
+			_, currentReviewer := membership.FindReviewerComment(comments)
+
+			reminderComment, err := formatReminderComment(pr, state, sinceDays, currentReviewer)
 			if err != nil {
 				fmt.Printf(
 					"%d/%d: PR %d: error rendering comment: %s\n",
@@ -177,7 +185,7 @@ func execScheduledPrReminders(gh *github.Client) error {
 				continue
 			}
 			if dryRun {
-				fmt.Printf("DRY RUN: Would post comment: %s\n", comment)
+				fmt.Printf("DRY RUN: Would post comment: %s\n", reminderComment)
 			} else {
 				_, _, err := gh.Issues.CreateComment(
 					ctx,
@@ -185,7 +193,7 @@ func execScheduledPrReminders(gh *github.Client) error {
 					"magic-modules",
 					*pr.Number,
 					&github.IssueComment{
-						Body: github.String(comment),
+						Body: github.String(reminderComment),
 					},
 				)
 				if err != nil {
@@ -433,7 +441,7 @@ func shouldNotify(pr *github.PullRequest, state pullRequestReviewState, sinceDay
 	return false
 }
 
-func formatReminderComment(pullRequest *github.PullRequest, state pullRequestReviewState, sinceDays int) (string, error) {
+func formatReminderComment(pullRequest *github.PullRequest, state pullRequestReviewState, sinceDays int, currentReviewer string) (string, error) {
 	embeddedTemplate := ""
 	switch state {
 	case waitingForMerge:
@@ -454,11 +462,15 @@ func formatReminderComment(pullRequest *github.PullRequest, state pullRequestRev
 		panic(fmt.Sprintf("Unable to parse template for %s: %s", state.String(), err))
 	}
 
-	coreReviewers := []string{}
-	for _, reviewer := range pullRequest.RequestedReviewers {
-		if membership.IsCoreReviewer(*reviewer.Login) {
-			coreReviewers = append(coreReviewers, *reviewer.Login)
+	var coreReviewers []string
+	if currentReviewer == "" {
+		for _, reviewer := range pullRequest.RequestedReviewers {
+			if membership.IsCoreReviewer(*reviewer.Login) {
+				coreReviewers = append(coreReviewers, *reviewer.Login)
+			}
 		}
+	} else {
+		coreReviewers = append(coreReviewers, currentReviewer)
 	}
 
 	data := reminderCommentData{


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Part of https://github.com/hashicorp/terraform-provider-google/issues/19691

Once we are able to reassign reviewers, we will only want to remind the current reviewer.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
