### PR TITLE
Adds reservationSharingPolicy to compute/Reservation

### DIFF
--- a/mmv1/products/compute/Reservation.yaml
+++ b/mmv1/products/compute/Reservation.yaml
@@ -155,6 +155,21 @@ properties:
               type: String
               description: |
                 The project id/number, should be same as the key of this project config in the project map.
+  - name: 'reservationSharingPolicy'
+    type: NestedObject
+    description: |
+      Specify the reservation sharing policy. If unspecified, the reservation will not be shared with Google Cloud managed services.
+    min_version: 'beta'
+    default_from_api: true
+    properties:
+      - name: 'serviceShareType'
+        type: Enum
+        description: |
+          Sharing config for all Google Cloud services.
+        default_from_api: true
+        enum_values:
+          - 'ALLOW_ALL'
+          - 'DISALLOW_ALL'
   - name: 'specificReservation'
     type: NestedObject
     description: |

--- a/mmv1/third_party/terraform/services/compute/resource_compute_shared_reservation_update_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_shared_reservation_update_test.go
@@ -242,6 +242,9 @@ resource "google_compute_reservation" "gce_reservation" {
       project_id = google_project.guest_project_third.project_id
     }
   }
+  reservation_sharing_policy {
+    service_share_type = "ALLOW_ALL"
+  }
   depends_on = [google_organization_policy.shared_reservation_org_policy,google_project_service.compute,google_project_service.compute_second_project,google_project_service.compute_third_project]
 }
 `, context)


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `reservation_sharing_policy` field to `google_compute_reservation` resource
```
