### PR TITLE
Add Cloud Run v2 Service urls field

### DIFF
--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -1111,6 +1111,13 @@ properties:
     description: |
       The main URI in which this Service is serving traffic.
     output: true
+  - name: 'urls'
+    type: Array
+    item_type:
+      type: String
+    description: |-
+      All URLs serving traffic for this Service.
+    output: true
   - name: 'reconciling'
     type: Boolean
     description: |

--- a/mmv1/third_party/terraform/services/cloudrunv2/data_source_google_cloud_run_v2_service_test.go
+++ b/mmv1/third_party/terraform/services/cloudrunv2/data_source_google_cloud_run_v2_service_test.go
@@ -2,6 +2,7 @@ package cloudrunv2_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -17,6 +18,10 @@ func TestAccDataSourceGoogleCloudRunV2Service_basic(t *testing.T) {
 	name := fmt.Sprintf("tf-test-cloud-run-v2-service-%d", acctest.RandInt(t))
 	location := "us-central1"
 	id := fmt.Sprintf("projects/%s/locations/%s/services/%s", project, location, name)
+	deterministicURLRegex, err := regexp.Compile(fmt.Sprintf("https://%s-[0-9]+.%s.run.ap", name, location))
+	if err != nil {
+		t.Fatalf("Failed to compile deterministic URL regex: %v", err)
+	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -28,6 +33,8 @@ func TestAccDataSourceGoogleCloudRunV2Service_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.google_cloud_run_v2_service.hello", "id", id),
 					resource.TestCheckResourceAttr("data.google_cloud_run_v2_service.hello", "name", name),
 					resource.TestCheckResourceAttr("data.google_cloud_run_v2_service.hello", "location", location),
+					resource.TestCheckResourceAttr("data.google_cloud_run_v2_service.hello", "urls.#", "2"),
+					resource.TestMatchResourceAttr("data.google_cloud_run_v2_service.hello", "urls.0", deterministicURLRegex),
 				),
 			},
 		},


### PR DESCRIPTION
Adds the urls field for v2 Services which contains the recently launched deterministic Service URL in addition to the old style URL set in the singular uri field.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudrunv2: added `urls` output field to `google_cloud_run_v2_service` resource
```
