### PR TITLE
Add support for GKE DNS-based endpoints

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -2481,7 +2481,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 			DnsConfig:                            expandDnsConfig(d.Get("dns_config")),
 			GatewayApiConfig:                     expandGatewayApiConfig(d.Get("gateway_api_config")),
 			EnableMultiNetworking:                d.Get("enable_multi_networking").(bool),
-			DefaultEnablePrivateNodes:	          expandDefaultEnablePrivateNodes(d),
+			DefaultEnablePrivateNodes:            expandDefaultEnablePrivateNodes(d),
 {{- if ne $.TargetVersionName "ga" }}
 			EnableFqdnNetworkPolicy:              d.Get("enable_fqdn_network_policy").(bool),
 {{- end }}
@@ -5412,12 +5412,12 @@ func isEnablePDCSI(cluster *container.Cluster) bool {
 	return cluster.AddonsConfig.GcePersistentDiskCsiDriverConfig.Enabled
 }
 
-// Most of the contents of PrivateClusterConfig have been deprecated and replaced by ControlPlaneEndpointsConfig.
-// This function only handles the sole remaining undeprecated field, master_ipv4_cidr_block.
-// Unfortunately, since private_cluster_config.enable_private_nodes is not marked optional, we can't just leave it
-// unset, as that would implicitly use the value false, and it must match the value of
-// network_config.default_enable_private_nodes. This function is intended to be called only during cluster creation,
-// after the network_config field is been configured. This is possible because master_ipv4_cidr_block is immutable.
+// Most of the contents of PrivateClusterConfig have been deprecated in the underlying API and replaced by ControlPlaneEndpointsConfig.
+// This function primarily handles the sole remaining undeprecated field, master_ipv4_cidr_block.
+// Unfortunately, since the private_cluster_config.enable_private_nodes proto field is not marked optional, we can't just leave it
+// unset, as that would implicitly use the value false, and it must match the value of network_config.default_enable_private_nodes.
+// This function is intended to be called only during cluster creation, after the network_config field is been configured.
+// This is possible because master_ipv4_cidr_block is immutable.
 func expandPrivateClusterConfigMasterIpv4CidrBlock(configured interface{}, c *container.Cluster) *container.PrivateClusterConfig {
 	v := configured.(string)
 

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -59,6 +59,7 @@ var (
 			"private_endpoint_enforcement_enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
+				Computed: 	 true,
 				Description: `Whether authorized networks is enforced on the private endpoint or not. Defaults to false.`,
 			},
 		},
@@ -5330,28 +5331,31 @@ func expandMasterAuth(configured interface{}) *container.MasterAuth {
 }
 
 
-func expandMasterAuthorizedNetworksConfig(configured interface{}) *container.MasterAuthorizedNetworksConfig {
-	l := configured.([]interface{})
-	if len(l) == 0 {
+func expandMasterAuthorizedNetworksConfig(d *schema.ResourceData) *container.MasterAuthorizedNetworksConfig {
+	v := d.Get("master_authorized_networks_config")
+	if v == nil {
+		// TF doesn't have an explicit enabled field for authorized networks, it is assumed to be enabled based
+		// on whether the master_authorized_networks_conifg is present at all. The GKE API pays attention to the
+		// field presence of authorized_networks_config, so it's important to explicitly include enabled = false
+		// to allow disabling this during updates.
 		return &container.MasterAuthorizedNetworksConfig{
 			Enabled: false,
 		}
 	}
+
 	result := &container.MasterAuthorizedNetworksConfig{
 		Enabled: true,
 	}
-	if config, ok := l[0].(map[string]interface{}); ok {
-		if v, ok := config["cidr_blocks"]; ok {
-			result.CidrBlocks = expandManCidrBlocks(v)
-		}
-		if v, ok := config["gcp_public_cidrs_access_enabled"]; ok {
-			result.GcpPublicCidrsAccessEnabled = v.(bool)
-			result.ForceSendFields = append(result.ForceSendFields, "GcpPublicCidrsAccessEnabled")
-		}
-		if v, ok := config["private_endpoint_enforcement_enabled"]; ok {
-			result.PrivateEndpointEnforcementEnabled = v.(bool)
-			result.ForceSendFields = append(result.ForceSendFields, "PrivateEndpointEnforcementEnabled")
-		}
+	if v, ok := d.GetOk("master_authorized_networks_config.0.cidr_blocks"); ok {
+		result.CidrBlocks = expandManCidrBlocks(v)
+	}
+	if v, ok := d.GetOk("master_authorized_networks_config.0.gcp_public_cidrs_access_enabled"); ok {
+		result.GcpPublicCidrsAccessEnabled = v.(bool)
+		result.ForceSendFields = append(result.ForceSendFields, "GcpPublicCidrsAccessEnabled")
+	}
+	if v, ok := d.GetOk("master_authorized_networks_config.0.private_endpoint_enforcement_enabled"); ok {
+		result.PrivateEndpointEnforcementEnabled = v.(bool)
+		result.ForceSendFields = append(result.ForceSendFields, "PrivateEndpointEnforcementEnabled")
 	}
 	return result
 }
@@ -5461,17 +5465,7 @@ func expandControlPlaneEndpointsConfig(d *schema.ResourceData) *container.Contro
 		ip.GlobalAccess = v.(bool)
 		ip.ForceSendFields = append(ip.ForceSendFields, "GlobalAccess")
 	}
-	if v := d.Get("master_authorized_networks_config"); v != nil {
-		ip.AuthorizedNetworksConfig = expandMasterAuthorizedNetworksConfig(v)
-	} else {
-		// TF doesn't have an explicit enabled field for authorized networks, it is assumed to be enabled based
-		// on whether the master_authorized_networks_conifg is present at all. The GKE API pays attention to the
-		// field presence of authorized_networks_config, so it's important to explicitly include enabled = false
-		// to allow disabling this during updates.
-		ip.AuthorizedNetworksConfig = &container.MasterAuthorizedNetworksConfig{
-			Enabled: false,
-		}
-	}
+	ip.AuthorizedNetworksConfig = expandMasterAuthorizedNetworksConfig(d)
 
 	return &container.ControlPlaneEndpointsConfig{
 		DnsEndpointConfig: dns,

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -5332,8 +5332,8 @@ func expandMasterAuth(configured interface{}) *container.MasterAuth {
 
 
 func expandMasterAuthorizedNetworksConfig(d *schema.ResourceData) *container.MasterAuthorizedNetworksConfig {
-	v := d.Get("master_authorized_networks_config")
-	if v == nil {
+	v := d.Get("master_authorized_networks_config").([]interface{})
+	if len(v) == 0 {
 		// TF doesn't have an explicit enabled field for authorized networks, it is assumed to be enabled based
 		// on whether the master_authorized_networks_conifg is present at all. The GKE API pays attention to the
 		// field presence of authorized_networks_config, so it's important to explicitly include enabled = false

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -56,6 +56,11 @@ var (
 				Computed: true,
 				Description: `Whether Kubernetes master is accessible via Google Compute Engine Public IPs.`,
 			},
+			"private_endpoint_enforcement_enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether authorized networks is enforced on the private endpoint or not. Defaults to false.`,
+			},
 		},
 	}
 	cidrBlockConfig = &schema.Resource{
@@ -1720,6 +1725,40 @@ func ResourceContainerCluster() *schema.Resource {
 				ConflictsWith: []string{"enable_autopilot"},
 			},
 
+			"control_plane_endpoints_config": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Computed:    true,
+				Optional:    true,
+				Description: `Configuration for all of the cluster's control plane endpoints. Currently supports only DNS endpoint configuration, IP endpoint configuration is available in private_cluster_config.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"dns_endpoint_config": {
+							Type:        schema.TypeList,
+							MaxItems:    1,
+							Optional:    true,
+							Computed:    true,
+							Description: `DNS endpoint configuration.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"endpoint": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Computed:    true,
+										Description: `The cluster's DNS endpoint.`,
+									},
+									"allow_external_traffic": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Description: `Controls whether user traffic is allowed over this endpoint. Note that GCP-managed services may still use the endpoint even if this is false.`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
 			"private_cluster_config": {
 				Type:             schema.TypeList,
 				MaxItems:         1,
@@ -2402,7 +2441,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		Name:                           clusterName,
 		InitialNodeCount:               int64(d.Get("initial_node_count").(int)),
 		MaintenancePolicy:              expandMaintenancePolicy(d, meta),
-		MasterAuthorizedNetworksConfig: expandMasterAuthorizedNetworksConfig(d.Get("master_authorized_networks_config"), d),
+		ControlPlaneEndpointsConfig:    expandControlPlaneEndpointsConfig(d),
 		InitialClusterVersion:          d.Get("min_master_version").(string),
 		ClusterIpv4Cidr:                d.Get("cluster_ipv4_cidr").(string),
 		Description:                    d.Get("description").(string),
@@ -2442,6 +2481,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 			DnsConfig:                            expandDnsConfig(d.Get("dns_config")),
 			GatewayApiConfig:                     expandGatewayApiConfig(d.Get("gateway_api_config")),
 			EnableMultiNetworking:                d.Get("enable_multi_networking").(bool),
+			DefaultEnablePrivateNodes:	          expandDefaultEnablePrivateNodes(d),
 {{- if ne $.TargetVersionName "ga" }}
 			EnableFqdnNetworkPolicy:              d.Get("enable_fqdn_network_policy").(bool),
 {{- end }}
@@ -2540,8 +2580,8 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		cluster.AuthenticatorGroupsConfig = expandAuthenticatorGroupsConfig(v)
 	}
 
-	if v, ok := d.GetOk("private_cluster_config"); ok {
-		cluster.PrivateClusterConfig = expandPrivateClusterConfig(v)
+	if v, ok := d.GetOk("private_cluster_config.0.master_ipv4_cidr_block"); ok {
+		cluster.PrivateClusterConfig = expandPrivateClusterConfigMasterIpv4CidrBlock(v, cluster)
 	}
 
 	if v, ok := d.GetOk("vertical_pod_autoscaling"); ok {
@@ -2595,10 +2635,6 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if err := validateNodePoolAutoConfig(cluster); err != nil {
-		return err
-	}
-
-	if err := validatePrivateClusterConfig(cluster); err != nil {
 		return err
 	}
 
@@ -2892,8 +2928,11 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	if err := d.Set("master_auth", flattenMasterAuth(cluster.MasterAuth)); err != nil {
 		return err
 	}
-	if err := d.Set("master_authorized_networks_config", flattenMasterAuthorizedNetworksConfig(cluster.MasterAuthorizedNetworksConfig)); err != nil {
-		return err
+	if cluster.ControlPlaneEndpointsConfig != nil &&
+		cluster.ControlPlaneEndpointsConfig.IpEndpointsConfig != nil {
+		if err := d.Set("master_authorized_networks_config", flattenMasterAuthorizedNetworksConfig(cluster.ControlPlaneEndpointsConfig.IpEndpointsConfig.AuthorizedNetworksConfig)); err != nil {
+			return err
+		}
 	}
 	if err := d.Set("initial_node_count", cluster.InitialNodeCount); err != nil {
 		return fmt.Errorf("Error setting initial_node_count: %s", err)
@@ -3029,7 +3068,11 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	if err := d.Set("private_cluster_config", flattenPrivateClusterConfig(cluster.PrivateClusterConfig)); err != nil {
+	if err := d.Set("control_plane_endpoints_config", flattenControlPlaneEndpointsConfig(cluster.ControlPlaneEndpointsConfig)); err != nil {
+		return err
+	}
+
+	if err := d.Set("private_cluster_config", flattenPrivateClusterConfig(cluster.ControlPlaneEndpointsConfig, cluster.PrivateClusterConfig, cluster.NetworkConfig)); err != nil {
 		return err
 	}
 
@@ -3183,19 +3226,39 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	// The ClusterUpdate object that we use for most of these updates only allows updating one field at a time,
 	// so we have to make separate calls for each field that we want to update. The order here is fairly arbitrary-
 	// if the order of updating fields does matter, it is called out explicitly.
-	if d.HasChange("master_authorized_networks_config") {
-		c := d.Get("master_authorized_networks_config")
+	if d.HasChange("control_plane_endpoints_config") ||
+		d.HasChange("master_authorized_networks_config") ||
+		d.HasChange("private_cluster_config.0.enable_private_endpoint") ||
+		d.HasChange("private_cluster_config.0.master_global_access_config") {
 		req := &container.UpdateClusterRequest{
 			Update: &container.ClusterUpdate{
-				DesiredMasterAuthorizedNetworksConfig: expandMasterAuthorizedNetworksConfig(c, d),
+				DesiredControlPlaneEndpointsConfig: expandControlPlaneEndpointsConfig(d),
 			},
 		}
 
-		updateF := updateFunc(req, "updating GKE cluster master authorized networks")
+		updateF := updateFunc(req, "updating GKE control plane endpoints config")
 		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
 			return err
 		}
-		log.Printf("[INFO] GKE cluster %s master authorized networks config has been updated", d.Id())
+		log.Printf("[INFO] GKE cluster %s control plane endpoints config has been updated", d.Id())
+	}
+
+	if d.HasChange("network_config") || d.HasChange("private_cluster_config.0.enable_private_nodes"){
+		enabled := expandDefaultEnablePrivateNodes(d)
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				DesiredDefaultEnablePrivateNodes: enabled,
+				ForceSendFields:                  []string{"DesiredDefaultEnablePrivateNodes"},
+			},
+		}
+
+		updateF := updateFunc(req, "updating default enable private nodes")
+		// Call update serially.
+		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] GKE cluster %s's default enable private nodes has been updated to %v", d.Id(), enabled)
 	}
 
 	if d.HasChange("addons_config") {
@@ -3264,44 +3327,6 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	    }
 
 		log.Printf("[INFO] GKE cluster %s's autopilot workload policy config allow_net_admin has been set to %v", d.Id(), allowed)
-	}
-
-	if d.HasChange("private_cluster_config.0.enable_private_endpoint") {
-		enabled := d.Get("private_cluster_config.0.enable_private_endpoint").(bool)
-		req := &container.UpdateClusterRequest{
-			Update: &container.ClusterUpdate{
-				DesiredEnablePrivateEndpoint: enabled,
-				ForceSendFields:              []string{"DesiredEnablePrivateEndpoint"},
-			},
-		}
-
-		updateF := updateFunc(req, "updating enable private endpoint")
-		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
-			return err
-		}
-
-		log.Printf("[INFO] GKE cluster %s's enable private endpoint has been updated to %v", d.Id(), enabled)
-	}
-
-	if d.HasChange("private_cluster_config") && d.HasChange("private_cluster_config.0.master_global_access_config") {
-		config := d.Get("private_cluster_config.0.master_global_access_config")
-		req := &container.UpdateClusterRequest{
-			Update: &container.ClusterUpdate{
-				DesiredPrivateClusterConfig: &container.PrivateClusterConfig{
-					MasterGlobalAccessConfig: expandPrivateClusterConfigMasterGlobalAccessConfig(config),
-					ForceSendFields:          []string{"MasterGlobalAccessConfig"},
-				},
-			},
-		}
-
-		updateF := updateFunc(req, "updating master global access config")
-		// Call update serially.
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
-			return err
-		}
-
-		log.Printf("[INFO] GKE cluster %s's master global access config has been updated to %v", d.Id(), config)
 	}
 
 	if d.HasChange("binary_authorization") {
@@ -5304,7 +5329,8 @@ func expandMasterAuth(configured interface{}) *container.MasterAuth {
 	return result
 }
 
-func expandMasterAuthorizedNetworksConfig(configured interface{}, d *schema.ResourceData) *container.MasterAuthorizedNetworksConfig {
+
+func expandMasterAuthorizedNetworksConfig(configured interface{}) *container.MasterAuthorizedNetworksConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 {
 		return &container.MasterAuthorizedNetworksConfig{
@@ -5315,21 +5341,34 @@ func expandMasterAuthorizedNetworksConfig(configured interface{}, d *schema.Reso
 		Enabled: true,
 	}
 	if config, ok := l[0].(map[string]interface{}); ok {
-		if _, ok := config["cidr_blocks"]; ok {
-			cidrBlocks := config["cidr_blocks"].(*schema.Set).List()
-			result.CidrBlocks = make([]*container.CidrBlock, 0)
-			for _, v := range cidrBlocks {
-				cidrBlock := v.(map[string]interface{})
-				result.CidrBlocks = append(result.CidrBlocks, &container.CidrBlock{
-					CidrBlock:   cidrBlock["cidr_block"].(string),
-					DisplayName: cidrBlock["display_name"].(string),
-				})
-			}
+		if v, ok := config["cidr_blocks"]; ok {
+			result.CidrBlocks = expandManCidrBlocks(v)
 		}
-		if v, ok := d.GetOkExists("master_authorized_networks_config.0.gcp_public_cidrs_access_enabled"); ok {
+		if v, ok := config["gcp_public_cidrs_access_enabled"]; ok {
 			result.GcpPublicCidrsAccessEnabled = v.(bool)
-			result.ForceSendFields = []string{"GcpPublicCidrsAccessEnabled"}
+			result.ForceSendFields = append(result.ForceSendFields, "GcpPublicCidrsAccessEnabled")
 		}
+		if v, ok := config["private_endpoint_enforcement_enabled"]; ok {
+			result.PrivateEndpointEnforcementEnabled = v.(bool)
+			result.ForceSendFields = append(result.ForceSendFields, "PrivateEndpointEnforcementEnabled")
+		}
+	}
+	return result
+}
+
+func expandManCidrBlocks(configured interface{}) []*container.CidrBlock {
+	config, ok := configured.(*schema.Set)
+	if !ok {
+		return nil
+	}
+	cidrBlocks := config.List()
+	result := make([]*container.CidrBlock, 0)
+	for _, v := range cidrBlocks {
+		cidrBlock := v.(map[string]interface{})
+		result = append(result, &container.CidrBlock{
+			CidrBlock:   cidrBlock["cidr_block"].(string),
+			DisplayName: cidrBlock["display_name"].(string),
+		})
 	}
 	return result
 }
@@ -5373,31 +5412,70 @@ func isEnablePDCSI(cluster *container.Cluster) bool {
 	return cluster.AddonsConfig.GcePersistentDiskCsiDriverConfig.Enabled
 }
 
-func expandPrivateClusterConfig(configured interface{}) *container.PrivateClusterConfig {
-	l := configured.([]interface{})
-	if len(l) == 0 {
-		return nil
-	}
-	config := l[0].(map[string]interface{})
+// Most of the contents of PrivateClusterConfig have been deprecated and replaced by ControlPlaneEndpointsConfig.
+// This function only handles the sole remaining undeprecated field, master_ipv4_cidr_block.
+// Unfortunately, since private_cluster_config.enable_private_nodes is not marked optional, we can't just leave it
+// unset, as that would implicitly use the value false, and it must match the value of
+// network_config.default_enable_private_nodes. This function is intended to be called only during cluster creation,
+// after the network_config field is been configured. This is possible because master_ipv4_cidr_block is immutable.
+func expandPrivateClusterConfigMasterIpv4CidrBlock(configured interface{}, c *container.Cluster) *container.PrivateClusterConfig {
+	v := configured.(string)
+
 	return &container.PrivateClusterConfig{
-		EnablePrivateEndpoint:      config["enable_private_endpoint"].(bool),
-		EnablePrivateNodes:         config["enable_private_nodes"].(bool),
-		MasterIpv4CidrBlock:        config["master_ipv4_cidr_block"].(string),
-		MasterGlobalAccessConfig:   expandPrivateClusterConfigMasterGlobalAccessConfig(config["master_global_access_config"]),
-		PrivateEndpointSubnetwork:  config["private_endpoint_subnetwork"].(string),
-		ForceSendFields:            []string{"EnablePrivateEndpoint", "EnablePrivateNodes", "MasterIpv4CidrBlock", "MasterGlobalAccessConfig"},
+		MasterIpv4CidrBlock: v,
+		EnablePrivateNodes:  c.NetworkConfig.DefaultEnablePrivateNodes,
+		ForceSendFields:     []string{"MasterIpv4CidrBlock"},
 	}
 }
 
-func expandPrivateClusterConfigMasterGlobalAccessConfig(configured interface{}) *container.PrivateClusterMasterGlobalAccessConfig {
-	l := configured.([]interface{})
-	if len(l) == 0 {
-		return nil
+func expandDefaultEnablePrivateNodes(d *schema.ResourceData) bool {
+	b, ok := d.GetOk("private_cluster_config.0.enable_private_nodes")
+	if ok {
+		v, _ := b.(bool)
+		return v
 	}
-	config := l[0].(map[string]interface{})
-	return &container.PrivateClusterMasterGlobalAccessConfig{
-		Enabled: config["enabled"].(bool),
-		ForceSendFields:       []string{"Enabled"},
+	return false
+}
+
+func expandControlPlaneEndpointsConfig(d *schema.ResourceData) *container.ControlPlaneEndpointsConfig {
+	dns := &container.DNSEndpointConfig{}
+	if v := d.Get("control_plane_endpoints_config.0.dns_endpoint_config.0.allow_external_traffic"); v != nil {
+		dns.AllowExternalTraffic = v.(bool)
+		dns.ForceSendFields = []string{"AllowExternalTraffic"}
+	}
+
+	ip := &container.IPEndpointsConfig{
+		// There isn't yet a config field to disable IP endpoints, so this is hardcoded to be enabled for the time being.
+		Enabled:         true,
+		ForceSendFields: []string{"Enabled"},
+	}
+	if v := d.Get("private_cluster_config.0.enable_private_endpoint"); v != nil {
+		ip.EnablePublicEndpoint = !v.(bool)
+		ip.ForceSendFields = append(ip.ForceSendFields, "EnablePublicEndpoint")
+	}
+	if v := d.Get("private_cluster_config.0.private_endpoint_subnetwork"); v != nil {
+		ip.PrivateEndpointSubnetwork = v.(string)
+		ip.ForceSendFields = append(ip.ForceSendFields, "PrivateEndpointSubnetwork")
+	}
+	if v := d.Get("private_cluster_config.0.master_global_access_config.0.enabled"); v != nil {
+		ip.GlobalAccess = v.(bool)
+		ip.ForceSendFields = append(ip.ForceSendFields, "GlobalAccess")
+	}
+	if v := d.Get("master_authorized_networks_config"); v != nil {
+		ip.AuthorizedNetworksConfig = expandMasterAuthorizedNetworksConfig(v)
+	} else {
+		// TF doesn't have an explicit enabled field for authorized networks, it is assumed to be enabled based
+		// on whether the master_authorized_networks_conifg is present at all. The GKE API pays attention to the
+		// field presence of authorized_networks_config, so it's important to explicitly include enabled = false
+		// to allow disabling this during updates.
+		ip.AuthorizedNetworksConfig = &container.MasterAuthorizedNetworksConfig{
+			Enabled: false,
+		}
+	}
+
+	return &container.ControlPlaneEndpointsConfig{
+		DnsEndpointConfig: dns,
+		IpEndpointsConfig: ip,
 	}
 }
 
@@ -6073,33 +6151,58 @@ func flattenAuthenticatorGroupsConfig(c *container.AuthenticatorGroupsConfig) []
 	}
 }
 
-func flattenPrivateClusterConfig(c *container.PrivateClusterConfig) []map[string]interface{} {
+func flattenControlPlaneEndpointsConfig(c *container.ControlPlaneEndpointsConfig) []map[string]interface{} {
 	if c == nil {
 		return nil
 	}
 	return []map[string]interface{}{
 		{
-			"enable_private_endpoint":     c.EnablePrivateEndpoint,
-			"enable_private_nodes":        c.EnablePrivateNodes,
-			"master_ipv4_cidr_block":      c.MasterIpv4CidrBlock,
-			"master_global_access_config": flattenPrivateClusterConfigMasterGlobalAccessConfig(c.MasterGlobalAccessConfig),
-			"peering_name":                c.PeeringName,
-			"private_endpoint":            c.PrivateEndpoint,
-			"private_endpoint_subnetwork": c.PrivateEndpointSubnetwork,
-			"public_endpoint":             c.PublicEndpoint,
+			"dns_endpoint_config": flattenDnsEndpointConfig(c.DnsEndpointConfig),
 		},
 	}
 }
 
-// Like most GKE blocks, this is not returned from the API at all when false. This causes trouble
-// for users who've set enabled = false in config as they will get a permadiff. Always setting the
-// field resolves that. We can assume if it was not returned, it's false.
-func flattenPrivateClusterConfigMasterGlobalAccessConfig(c *container.PrivateClusterMasterGlobalAccessConfig) []map[string]interface{} {
+func flattenDnsEndpointConfig(dns *container.DNSEndpointConfig) []map[string]interface{} {
+	if dns == nil {
+		return nil
+	}
 	return []map[string]interface{}{
 		{
-			"enabled": c != nil && c.Enabled,
+			"endpoint":               dns.Endpoint,
+			"allow_external_traffic": dns.AllowExternalTraffic,
 		},
 	}
+}
+
+// Most of PrivateClusterConfig has moved to ControlPlaneEndpointsConfig.
+func flattenPrivateClusterConfig(cpec *container.ControlPlaneEndpointsConfig, pcc *container.PrivateClusterConfig, nc *container.NetworkConfig) []map[string]interface{} {
+	if cpec == nil && pcc == nil && nc == nil {
+		return nil
+	}
+
+	r := map[string]interface{}{}
+	if cpec != nil {
+		// Note the change in semantics from private to public endpoint.
+		r["enable_private_endpoint"] =     !cpec.IpEndpointsConfig.EnablePublicEndpoint
+		r["private_endpoint"] =            cpec.IpEndpointsConfig.PrivateEndpoint
+		r["private_endpoint_subnetwork"] = cpec.IpEndpointsConfig.PrivateEndpointSubnetwork
+		r["public_endpoint"] =             cpec.IpEndpointsConfig.PublicEndpoint
+		r["master_global_access_config"] = []map[string]interface{}{
+			{
+				"enabled": cpec.IpEndpointsConfig.GlobalAccess,
+			},
+		}
+	}
+	// This is the only field that is canonically still in the PrivateClusterConfig message.
+	if pcc != nil {
+		r["peering_name"] = pcc.PeeringName
+		r["master_ipv4_cidr_block"] = pcc.MasterIpv4CidrBlock
+	}
+	if nc != nil {
+		r["enable_private_nodes"] = nc.DefaultEnablePrivateNodes
+	}
+
+	return []map[string]interface{}{r}
 }
 
 func flattenVerticalPodAutoscaling(c *container.VerticalPodAutoscaling) []map[string]interface{} {
@@ -6429,6 +6532,7 @@ func flattenMasterAuthorizedNetworksConfig(c *container.MasterAuthorizedNetworks
 	}
 	result["cidr_blocks"] = schema.NewSet(schema.HashResource(cidrBlockConfig), cidrBlocks)
 	result["gcp_public_cidrs_access_enabled"] = c.GcpPublicCidrsAccessEnabled
+	result["private_endpoint_enforcement_enabled"] = c.PrivateEndpointEnforcementEnabled
 	return []map[string]interface{}{result}
 }
 
@@ -6843,24 +6947,6 @@ func containerClusterPrivateClusterConfigSuppress(k, old, new string, d *schema.
 		return (hasMasterCidr && new == "" && old != "") || tpgresource.CompareSelfLinkOrResourceName(k, old, new, d)
 	}
 	return false
-}
-
-func validatePrivateClusterConfig(cluster *container.Cluster) error {
-	if cluster == nil || cluster.PrivateClusterConfig == nil {
-		return nil
-	}
-	if !cluster.PrivateClusterConfig.EnablePrivateNodes && len(cluster.PrivateClusterConfig.MasterIpv4CidrBlock) > 0 {
-		return fmt.Errorf("master_ipv4_cidr_block can only be set if enable_private_nodes is true")
-	}
-	if cluster.PrivateClusterConfig.EnablePrivateNodes && len(cluster.PrivateClusterConfig.MasterIpv4CidrBlock) == 0 {
-		if len(cluster.PrivateClusterConfig.PrivateEndpointSubnetwork) > 0 {
-			return nil
-		}
-		if cluster.Autopilot == nil || !cluster.Autopilot.Enabled {
-			return fmt.Errorf("master_ipv4_cidr_block must be set if enable_private_nodes is true")
-		}
-	}
-	return nil
 }
 
 // Autopilot clusters have preconfigured defaults: https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview#comparison.

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -5349,11 +5349,11 @@ func expandMasterAuthorizedNetworksConfig(d *schema.ResourceData) *container.Mas
 	if v, ok := d.GetOk("master_authorized_networks_config.0.cidr_blocks"); ok {
 		result.CidrBlocks = expandManCidrBlocks(v)
 	}
-	if v, ok := d.GetOk("master_authorized_networks_config.0.gcp_public_cidrs_access_enabled"); ok {
+	if v, ok := d.GetOkExists("master_authorized_networks_config.0.gcp_public_cidrs_access_enabled"); ok {
 		result.GcpPublicCidrsAccessEnabled = v.(bool)
 		result.ForceSendFields = append(result.ForceSendFields, "GcpPublicCidrsAccessEnabled")
 	}
-	if v, ok := d.GetOk("master_authorized_networks_config.0.private_endpoint_enforcement_enabled"); ok {
+	if v, ok := d.GetOkExists("master_authorized_networks_config.0.private_endpoint_enforcement_enabled"); ok {
 		result.PrivateEndpointEnforcementEnabled = v.(bool)
 		result.ForceSendFields = append(result.ForceSendFields, "PrivateEndpointEnforcementEnabled")
 	}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -1410,49 +1410,6 @@ func TestAccContainerCluster_withPrivateClusterConfigBasic(t *testing.T) {
 	})
 }
 
-func TestAccContainerCluster_withPrivateClusterConfigMissingCidrBlock(t *testing.T) {
-	t.Parallel()
-
-	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
-	containerNetName := fmt.Sprintf("tf-test-container-net-%s", acctest.RandString(t, 10))
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config:	testAccContainerCluster_withPrivateClusterConfigMissingCidrBlock(containerNetName, clusterName, "us-central1-a", false),
-				ExpectError: regexp.MustCompile("master_ipv4_cidr_block must be set if enable_private_nodes is true"),
-			},
-		},
-	})
-}
-
-func TestAccContainerCluster_withPrivateClusterConfigMissingCidrBlock_withAutopilot(t *testing.T) {
-	t.Parallel()
-
-	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
-	containerNetName := fmt.Sprintf("tf-test-container-net-%s", acctest.RandString(t, 10))
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config:	testAccContainerCluster_withPrivateClusterConfigMissingCidrBlock(containerNetName, clusterName, "us-central1", true),
-			},
-			{
-				ResourceName:      "google_container_cluster.with_private_cluster",
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{"deletion_protection"},
-			},
-		},
-	})
-}
-
 func TestAccContainerCluster_withPrivateClusterConfigGlobalAccessEnabledOnly(t *testing.T) {
 	t.Parallel()
 
@@ -5069,23 +5026,6 @@ func TestAccContainerCluster_withIncompatibleMasterVersionNodeVersion(t *testing
 	})
 }
 
-func TestAccContainerCluster_withIPv4Error(t *testing.T) {
-	t.Parallel()
-
-	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccContainerCluster_withIPv4Error(clusterName),
-				ExpectError: regexp.MustCompile("master_ipv4_cidr_block can only be set if"),
-			},
-		},
-	})
-}
-
 func TestAccContainerCluster_withDNSConfig(t *testing.T) {
 	t.Parallel()
 
@@ -6779,6 +6719,7 @@ resource "google_container_cluster" "with_master_authorized_networks" {
 
   master_authorized_networks_config {
     %s
+	private_endpoint_enforcement_enabled = true
   }
   deletion_protection = false
 }
@@ -10410,22 +10351,6 @@ resource "google_container_cluster" "primary" {
   deletion_protection = false
 }
 `, cluster, networkName, subnetworkName)
-}
-
-func testAccContainerCluster_withIPv4Error(name string) string {
-	return fmt.Sprintf(`
-resource "google_container_cluster" "primary" {
-  name               = "%s"
-  location           = "us-central1-a"
-  initial_node_count = 1
-  private_cluster_config {
-    enable_private_endpoint = true
-    enable_private_nodes    = false
-    master_ipv4_cidr_block  = "10.42.0.0/28"
-  }
-  deletion_protection = false
-}
-`, name)
 }
 
 func testAccContainerCluster_withAutopilot(projectID string, containerNetName string, clusterName string, location string, enabled bool, withNetworkTag bool, serviceAccount string) string {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -1208,6 +1208,61 @@ resource "google_container_cluster" "with_gcp_public_cidrs_access_enabled" {
 `, clusterName, networkName, subnetworkName)
 }
 
+func TestAccContainerCluster_withAuthorizedNetworkPrivateEnforcementToggle(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withAuthorizedNetworkPrivateEnforcementToggle(clusterName, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary",
+						"master_authorized_networks_config.0.private_endpoint_enforcement_enabled", "false"),
+				),
+			},
+			{
+				ResourceName:				"google_container_cluster.primary",
+				ImportState:				true,
+				ImportStateVerify:			true,
+				ImportStateVerifyIgnore:	[]string{"min_master_version", "deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_withAuthorizedNetworkPrivateEnforcementToggle(clusterName, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary",
+						"master_authorized_networks_config.0.private_endpoint_enforcement_enabled", "true"),
+				),
+			},
+			{
+				ResourceName:				"google_container_cluster.primary",
+				ImportState:				true,
+				ImportStateVerify:			true,
+				ImportStateVerifyIgnore:	[]string{"min_master_version", "deletion_protection"},
+			},
+		},
+	})
+}
+
+func testAccContainerCluster_withAuthorizedNetworkPrivateEnforcementToggle(clusterName string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  deletion_protection = false
+
+  master_authorized_networks_config {
+    private_endpoint_enforcement_enabled = %t
+  }
+}
+`, clusterName, enabled)
+}
+
 func TestAccContainerCluster_regional(t *testing.T) {
 	t.Parallel()
 

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -12615,3 +12615,58 @@ resource "google_container_cluster" "with_autopilot_gcp_filestore" {
 }
 `, name)
 }
+
+func TestAccContainerCluster_withDnsEndpoint(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withDnsEndpoint(clusterName, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// The DNS endpoint should always be set, even if allow_external_traffic is false.
+					resource.TestCheckResourceAttrSet("google_container_cluster.primary", "control_plane_endpoints_config.0.dns_endpoint_config.0.endpoint"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.dns_endpoint_config.0.allow_external_traffic", "false"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_withDnsEndpoint(clusterName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_container_cluster.primary", "control_plane_endpoints_config.0.dns_endpoint_config.0.endpoint"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.dns_endpoint_config.0.allow_external_traffic", "true"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+func testAccContainerCluster_withDnsEndpoint(name string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 1
+  deletion_protection = false
+  control_plane_endpoints_config {
+    dns_endpoint_config {
+      allow_external_traffic = %t
+    }
+  }
+}`, name, enabled)
+}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -6719,7 +6719,6 @@ resource "google_container_cluster" "with_master_authorized_networks" {
 
   master_authorized_networks_config {
     %s
-	private_endpoint_enforcement_enabled = true
   }
   deletion_protection = false
 }

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -300,6 +300,9 @@ region are guaranteed to support the same version.
     [Google Groups for GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#groups-setup-gsuite) feature.
     Structure is [documented below](#nested_authenticator_groups_config).
 
+* `control_plane_endpoints_config` - (Optional) Configuration for all of the cluster's control plane endpoints.
+    Structure is [documented below](#nested_control_plane_endpoints_config).
+
 * `private_cluster_config` - (Optional) Configuration for [private clusters](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters),
 clusters with private nodes. Structure is [documented below](#nested_private_cluster_config).
 
@@ -817,6 +820,8 @@ The `master_authorized_networks_config.cidr_blocks` block supports:
 
 * `display_name` - (Optional) Field for users to identify CIDR blocks.
 
+* `private_endpoint_enforcement_enabled` - (Optional) Whether authorized networks is enforced on the private endpoint or not.
+
 <a name="nested_network_policy"></a>The `network_policy` block supports:
 
 * `provider` - (Optional) The selected network policy provider. Defaults to PROVIDER_UNSPECIFIED.
@@ -1165,6 +1170,16 @@ notification_config {
 <a name="nested_secret_manager_config"></a>The `secret_manager_config` block supports:
 
 * `enabled` (Required) - Enable the Secret Manager add-on for this cluster.
+
+<a name="nested_control_plane_endpoints_config"></a>The `control_plane_endpoints_config` block supports:
+
+* `dns_endpoint_config` - (Optional) DNS endpoint configuration.
+
+The `control_plane_endpoints_config.dns_endpoint_config` block supports:
+
+* `endpoint` - (Output) The cluster's DNS endpoint.
+
+* `allow_external_traffic` - (Optional) Controls whether user traffic is allowed over this endpoint. Note that GCP-managed services may still use the endpoint even if this is false.
 
 <a name="nested_private_cluster_config"></a>The `private_cluster_config` block supports:
 


### PR DESCRIPTION
Add support for GKE DNS-based endpoints

Uses the newly introduced ControlPlaneEndpointsConfig message in the underlying GKE API calls, avoiding using deprecated fields. Support for the IPEndpointsConfig subfield, along with migration of related PrivateClusterConfig fields, will follow.

```release-note:enhancement
container: added `control_plane_endpoints_config` field to `cluster` resource.
```
