### PR TITLE
Added missing period for nested objects with no description

### DIFF
--- a/mmv1/api/type.go
+++ b/mmv1/api/type.go
@@ -320,7 +320,7 @@ func (t *Type) SetDefault(r *Resource) {
 		}
 
 		if t.Description == "" {
-			t.Description = "A nested object resource"
+			t.Description = "A nested object resource."
 		}
 
 		for _, p := range t.Properties {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Fixes issue where nested objects with no explicit documentation end up generating a string that is missing a period.

<img width="692" alt="Screenshot 2024-10-30 at 3 49 40 PM" src="https://github.com/user-attachments/assets/c812bd3e-3134-4a9b-8998-ba53d6d3a91f">


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
