### PR TITLE
updating go template test to support backticks

### DIFF
--- a/tools/template-check/gotemplate/gotemplate.go
+++ b/tools/template-check/gotemplate/gotemplate.go
@@ -21,9 +21,9 @@ var allowedGuards = []string{
 	`{{ if eq $.TargetVersionName "ga" }}`,
 	`{{ if eq $.TargetVersionName "ga" -}}`,
 	`{{- if eq $.TargetVersionName "ga" -}}`,
-	`{{ if eq $.TargetVersionName `ga` }}`,
-	`{{ if eq $.TargetVersionName `ga` -}}`,
-	`{{- if eq $.TargetVersionName `ga` -}}`,
+	"{{- if ne $.TargetVersionName `ga` }}",
+	"{{ if ne $.TargetVersionName `ga` }}",
+	"{{- if ne $.TargetVersionName `ga` -}}",
 }
 
 // Note: this does not account for _every_ possible use of a version guard (for example, those

--- a/tools/template-check/gotemplate/gotemplate.go
+++ b/tools/template-check/gotemplate/gotemplate.go
@@ -21,6 +21,9 @@ var allowedGuards = []string{
 	`{{ if eq $.TargetVersionName "ga" }}`,
 	`{{ if eq $.TargetVersionName "ga" -}}`,
 	`{{- if eq $.TargetVersionName "ga" -}}`,
+	`{{ if eq $.TargetVersionName `ga` }}`,
+	`{{ if eq $.TargetVersionName `ga` -}}`,
+	`{{- if eq $.TargetVersionName `ga` -}}`,
 }
 
 // Note: this does not account for _every_ possible use of a version guard (for example, those


### PR DESCRIPTION
currently tests are [failing out](https://github.com/GoogleCloudPlatform/magic-modules/actions/runs/11603177670/job/32309652121?pr=12195) if a PR modifies a template with pre-existing version guards that use string literal backtick wrapped "ga"s.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
