### PR TITLE
Adds reservationSharingPolicy to compute/Reservation

### DIFF
--- a/mmv1/products/compute/Reservation.yaml
+++ b/mmv1/products/compute/Reservation.yaml
@@ -155,6 +155,23 @@ properties:
               type: String
               description: |
                 The project id/number, should be same as the key of this project config in the project map.
+  - name: 'reservationSharingPolicy'
+    type: NestedObject
+    description: |
+      Specify the reservation sharing policy. If unspecified, the reservation will not be shared with Google Cloud managed services.
+    default_from_api: true
+    min_version: 'beta'
+    update_url: 'projects/{{project}}/zones/{{zone}}/reservations/{{name}}?paths=reservationSharingPolicy.serviceShareType'
+    update_verb: 'PATCH'
+    properties:
+      - name: 'serviceShareType'
+        type: Enum
+        description: |
+          Sharing config for all Google Cloud services.
+        default_from_api: true
+        enum_values:
+          - 'ALLOW_ALL'
+          - 'DISALLOW_ALL'
   - name: 'specificReservation'
     type: NestedObject
     description: |
@@ -201,6 +218,7 @@ properties:
             type: Array
             description: |
               Guest accelerator type and count.
+            default_from_api: true
             immutable: true
             item_type:
               type: NestedObject
@@ -213,6 +231,7 @@ properties:
                     `projects/my-project/zones/us-central1-c/acceleratorTypes/nvidia-tesla-p100`
 
                     If you are creating an instance template, specify only the accelerator name.
+                  default_from_api: true
                   required: true
                   immutable: true
                 - name: 'acceleratorCount'
@@ -220,6 +239,7 @@ properties:
                   description: |
                     The number of the guest accelerator cards exposed to
                     this instance.
+                  default_from_api: true
                   required: true
                   immutable: true
           - name: 'localSsds'

--- a/mmv1/templates/terraform/update_encoder/reservation.go.tmpl
+++ b/mmv1/templates/terraform/update_encoder/reservation.go.tmpl
@@ -123,4 +123,21 @@
 		}
 	}
 
+	if d.HasChange("reservation_sharing_policy") {
+		// Get name.
+		nameProp, err := expandComputeReservationName(d.Get("name"), d, config)
+		if err != nil {
+			return nil, fmt.Errorf("Invalid value for name: %s", err)
+		} else if v, ok := d.GetOkExists("name"); !tpgresource.IsEmptyValue(reflect.ValueOf(nameProp)) && (ok || !reflect.DeepEqual(v, nameProp)) {
+			newObj["name"] = nameProp
+		}
+
+		policyProp, err := expandComputeReservationReservationSharingPolicy(d.Get("reservation_sharing_policy"), d, config)
+		if err != nil {
+			return nil, fmt.Errorf("Invalid value for reservationSharingPolicy: %s", err)
+		} else if v, ok := d.GetOkExists("reservation_sharing_policy"); !tpgresource.IsEmptyValue(reflect.ValueOf(policyProp)) && (ok || !reflect.DeepEqual(v, policyProp)) {
+			newObj["reservationSharingPolicy"] = policyProp
+		}
+	}
+
 	return newObj, nil

--- a/mmv1/third_party/terraform/services/compute/resource_compute_reservation_sharing_policy_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_reservation_sharing_policy_test.go
@@ -1,0 +1,86 @@
+package compute_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccComputeReservationSharingPolicy(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project":         envvar.GetTestProjectFromEnv(),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
+		"random_suffix":   acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeReservationDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeReservationWithDefaultReservationSharingPolicy(context),
+			},
+			{
+				Config: testAccComputeReservationWithReservationSharingPolicyAllowAll(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+					},
+				},
+			},
+			{
+				Config: testAccComputeReservationWithDefaultReservationSharingPolicy(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccComputeReservationWithDefaultReservationSharingPolicy(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_reservation" "gce_reservation" {
+  project = "%{project}"
+  name = "tf-test-%{random_suffix}"
+  zone = "us-central1-a"
+
+  specific_reservation {
+    count = 1
+    instance_properties {
+      machine_type     = "a2-highgpu-1g"
+    }
+  }
+}
+`, context)
+}
+
+func testAccComputeReservationWithReservationSharingPolicyAllowAll(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_reservation" "gce_reservation" {
+  project = "%{project}"
+  name = "tf-test-%{random_suffix}"
+  zone = "us-central1-a"
+
+  specific_reservation {
+    count = 1
+    instance_properties {
+      machine_type     = "a2-highgpu-1g"
+    }
+  }
+
+  reservation_sharing_policy {
+    service_share_type = "ALLOW_ALL"
+  }
+}
+`, context)
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `reservation_sharing_policy` field to `google_compute_reservation` resource
```
