### PR TITLE
Add missing documentation for custom learned routes

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.tmpl
@@ -152,7 +152,7 @@ IP address is provided without a subnet mask, it is interpreted as, for IPv4, a 
 						"range": {
 							Type:     schema.TypeString,
 							Required: true,
-							Description: `The IP range to advertise. The value must be a
+							Description: `The IP range to learn. The value must be a
 CIDR-formatted string.`,
 						},
 					},
@@ -440,7 +440,7 @@ func resourceComputeRouterBgpPeerCreate(d *schema.ResourceData, meta interface{}
 	} else if v, ok := d.GetOkExists("advertised_ip_ranges"); ok || !reflect.DeepEqual(v, advertisedIpRangesProp) {
 		obj["advertisedIpRanges"] = advertisedIpRangesProp
 	}
-        customLearnedIpRangesProp, err := expandNestedComputeRouterBgpPeerCustomLearnedIpRanges(d.Get("custom_learned_ip_ranges"), d, config)
+    customLearnedIpRangesProp, err := expandNestedComputeRouterBgpPeerCustomLearnedIpRanges(d.Get("custom_learned_ip_ranges"), d, config)
 	if err != nil {
 		return err
 	} else if v, ok := d.GetOkExists("custom_learned_ip_ranges"); ok || !reflect.DeepEqual(v, customLearnedIpRangesProp) {
@@ -684,8 +684,8 @@ func resourceComputeRouterBgpPeerRead(d *schema.ResourceData, meta interface{}) 
 	if err := d.Set("advertised_ip_ranges", flattenNestedComputeRouterBgpPeerAdvertisedIpRanges(res["advertisedIpRanges"], d, config)); err != nil {
 		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
 	}
-        if err := d.Set("custom_learned_ip_ranges", flattenNestedComputeRouterBgpPeerCustomLearnedIpRanges(res["customLearnedIpRanges"], d, config)); err != nil {
-		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
+	if err := d.Set("custom_learned_ip_ranges", flattenNestedComputeRouterBgpPeerCustomLearnedIpRanges(res["customLearnedIpRanges"], d, config)); err != nil {
+	return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
 	}
 	if err := d.Set("custom_learned_route_priority", flattenNestedComputeRouterBgpPeerCustomLearnedRoutePriority(res["customLearnedRoutePriority"], d, config)); err != nil {
 		return fmt.Errorf("Error reading RouterBgpPeer: %s", err)
@@ -793,7 +793,7 @@ func resourceComputeRouterBgpPeerUpdate(d *schema.ResourceData, meta interface{}
 	} else if v, ok := d.GetOkExists("advertised_ip_ranges"); ok || !reflect.DeepEqual(v, advertisedIpRangesProp) {
 		obj["advertisedIpRanges"] = advertisedIpRangesProp
 	}
-        customLearnedIpRangesProp, err := expandNestedComputeRouterBgpPeerCustomLearnedIpRanges(d.Get("custom_learned_ip_ranges"), d, config)
+    customLearnedIpRangesProp, err := expandNestedComputeRouterBgpPeerCustomLearnedIpRanges(d.Get("custom_learned_ip_ranges"), d, config)
 	if err != nil {
 		return err
 	} else if v, ok := d.GetOkExists("custom_learned_ip_ranges"); ok || !reflect.DeepEqual(v, customLearnedIpRangesProp) {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.tmpl
@@ -1285,7 +1285,7 @@ func flattenNestedComputeRouterBgpPeerPeerIpv4NexthopAddress(v interface{}, d *s
 	return v
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{- if ne $.TargetVersionName `ga` }}
 func flattenNestedComputeRouterBgpPeerExportPolicies(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	return v
 }
@@ -1524,7 +1524,7 @@ func expandNestedComputeRouterBgpPeerPeerIpv4NexthopAddress(v interface{}, d tpg
 	return v, nil
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{- if ne $.TargetVersionName `ga` }}
 func expandNestedComputeRouterBgpPeerExportPolicies(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
 	return v, nil
 }

--- a/mmv1/third_party/terraform/website/docs/r/compute_router_peer.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_router_peer.html.markdown
@@ -413,6 +413,20 @@ The following arguments are supported:
   Leave this field blank to advertise no custom IP ranges.
   Structure is [documented below](#nested_advertised_ip_ranges).
 
+* `custom_learned_route_priority` -
+  (Optional)
+  The user-defined custom learned route priority for a BGP session.
+  This value is applied to all custom learned route ranges for the session.
+  You can choose a value from 0 to 65335. If you don't provide a value,
+  Google Cloud assigns a priority of 100 to the ranges.
+
+* `custom_learned_ip_ranges` -
+  (Optional)
+  The custom learned route IP address range. Must be a valid CIDR-formatted prefix.
+  If an IP address is provided without a subnet mask, it is interpreted as, for IPv4,
+  a /32 singular IP address range, and, for IPv6, /128.
+  Structure is [documented below](#nested_custom_learned_ip_ranges).
+
 * `bfd` -
   (Optional)
   BFD configuration for the BGP peering.
@@ -493,6 +507,13 @@ The following arguments are supported:
 * `description` -
   (Optional)
   User-specified description for the IP range.
+
+<a name="nested_custom_learned_ip_ranges"></a>The `custom_learned_ip_ranges` block supports:
+
+* `range` -
+  (Required)
+  The IP range to learn. The value must be a
+  CIDR-formatted string.
 
 <a name="nested_bfd"></a>The `bfd` block supports:
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Add missing documentation for fields related to custom learned routes added in #11118.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
docs: added documentation for `custom_learned_ip_ranges` and `custom_learned_route_priority` fields in `google_compute_router_peer` resource
```
