### PR TITLE
looker: required `oauth_config` in `google_looker_instance`

### DIFF
--- a/mmv1/products/looker/Instance.yaml
+++ b/mmv1/products/looker/Instance.yaml
@@ -390,6 +390,7 @@ properties:
     description: |
       Looker Instance OAuth login settings.
     ignore_read: true
+    required: true
     properties:
       - name: 'clientId'
         type: String


### PR DESCRIPTION
Make `oauth_config` required in `google_looker_instance`

Fixes https://github.com/hashicorp/terraform-provider-google/issues/20140

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
looker: made `oauth_config` a required field in `google_looker_instance`, as creating this resource without that field always triggers an API error
```
