### PR TITLE
Hard-configuring machine type of dataproc cluster in nodeaffinity test

### DIFF
--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
@@ -1655,9 +1655,12 @@ resource "google_dataproc_cluster" "basic" {
   region = "us-central1"
 
   cluster_config {
-  	master_config {
-  		machine_type = "n1-standard-2"
-  	}
+    master_config {
+      machine_type = "n1-standard-2"
+    }
+    worker_config {
+      machine_type = "n1-standard-2"
+    }
     software_config {
       image_version = "2.0.35-debian10"
     }

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
@@ -1655,6 +1655,9 @@ resource "google_dataproc_cluster" "basic" {
   region = "us-central1"
 
   cluster_config {
+  	master_config {
+  		machine_type = "n1-standard-2"
+  	}
     software_config {
       image_version = "2.0.35-debian10"
     }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/13634

When dataproc cluster is created without a specified machine type, it defaults to `n1-standard-4` as we can see in the first test run of this PR where only `master_config` was updated

```
   "masterConfig": {
    "numInstances": 1,
    "imageUri": "https://www.googleapis.com/compute/v1/projects/cloud-dataproc/global/images/dataproc-2-0-deb10-20220324-060200-rc01",
    "machineTypeUri": "https://www.googleapis.com/compute/v1/projects/***/zones/us-central1-f/machineTypes/n1-standard-2",
    "diskConfig": {
     "bootDiskSizeGb": 1000,
     "bootDiskType": "pd-standard"
    },
    "minCpuPlatform": "AUTOMATIC",
    "preemptibility": "NON_PREEMPTIBLE"
   },
   "workerConfig": {
    "numInstances": 2,
    "imageUri": "https://www.googleapis.com/compute/v1/projects/cloud-dataproc/global/images/dataproc-2-0-deb10-20220324-060200-rc01",
    "machineTypeUri": "https://www.googleapis.com/compute/v1/projects/***/zones/us-central1-f/machineTypes/n1-standard-4",
    "diskConfig": {
     "bootDiskSizeGb": 1000,
     "bootDiskType": "pd-standard"
    },
```

Generally the `dataproc_cluster` attempts to create with a `n1-standard-4` machine_type when unspecified, however this value could shift based on [available zonal reservations](https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/auto-zone) that it attempts to prioritize even without declaring a reservation affinity, which may be affected by our other in-flight tests that create `compute_reservations` and adjust other regional/zonal policies in the process of update tests. My assumption right now is the flakey test is the result of default provisioning changing due to flux in our project state mid-testing. By hard declaring a machine for the cluster in this test, we should be able to force it to provision a compatible machine type. 

NOTE:
the attached issue's included error message is not the main one being experienced, but rather the following
```
        Error: Error waiting for creating Dataproc cluster: Error code 9, message: Instance could not be scheduled due to no matching node with property compatibility.
        
        Explanation:
        The matching node group(s) <test-nodegroup-randomsuffix> do not match the intance's machine family type.
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
