### PR TITLE
refactor: terraform code updates and formatting for `google_container_cluster` tests

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -12473,7 +12473,8 @@ resource "google_container_cluster" "storage_pools_with_node_pool" {
   location = "%s"
 
   node_pool {
-    name               = "%s"
+    name = "%s"
+
     initial_node_count = 1
     node_config {
       machine_type  = "c3-standard-4"
@@ -12487,7 +12488,7 @@ resource "google_container_cluster" "storage_pools_with_node_pool" {
 
   deletion_protection = false
 }
-`, cluster, location, networkName, subnetworkName, np, storagePoolResourceName)
+`, cluster, location, np, storagePoolResourceName, networkName, subnetworkName)
 }
 
 func TestAccContainerCluster_storagePoolsWithNodeConfig(t *testing.T) {
@@ -12540,7 +12541,7 @@ resource "google_container_cluster" "storage_pools_with_node_config" {
 
   deletion_protection = false
 }
-`, cluster, location, networkName, subnetworkName, storagePoolResourceName)
+`, cluster, location, storagePoolResourceName, networkName, subnetworkName)
 }
 
 func TestAccContainerCluster_withAutopilotGcpFilestoreCsiDriver(t *testing.T) {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -210,9 +210,9 @@ func TestAccContainerCluster_withAddons(t *testing.T) {
 				Config: testAccContainerCluster_withAddons(pid, clusterName, networkName, subnetworkName),
 			},
 			{
-				ResourceName:            "google_container_cluster.primary",
-				ImportState:             true,
-				ImportStateVerify:       true,
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
 			},
 			{
@@ -5334,12 +5334,12 @@ resource "google_container_cluster" "primary" {
   initial_node_count = 1
 
   fleet {
-	project = "%s"
+    project = "%s"
   }
 
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, name, projectID, networkName, subnetworkName)
 }
@@ -5347,27 +5347,26 @@ resource "google_container_cluster" "primary" {
 func testAccContainerCluster_DisableFleet(resource_name, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
-  name               = "%s"
-  location           = "us-central1-a"
-  initial_node_count = 1
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 1
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, resource_name, networkName, subnetworkName)
 }
 
 func testAccContainerCluster_withIncompatibleMasterVersionNodeVersion(name string) string {
 	return fmt.Sprintf(`
-	resource "google_container_cluster" "gke_cluster" {
-		name = "%s"
-		location = "us-central1"
+resource "google_container_cluster" "gke_cluster" {
+  name     = "%s"
+  location = "us-central1"
 
-		min_master_version = "1.10.9-gke.5"
-		node_version = "1.10.6-gke.11"
-		initial_node_count = 1
-
-	}
+  min_master_version = "1.10.9-gke.5"
+  node_version       = "1.10.6-gke.11"
+  initial_node_count = 1
+}
 	`, name)
 }
 
@@ -5378,11 +5377,11 @@ resource "google_container_cluster" "with_security_posture_config" {
   location           = "us-central1-a"
   initial_node_count = 1
   security_posture_config {
-	mode = "BASIC"
+    mode = "BASIC"
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, resource_name, networkName, subnetworkName)
 }
@@ -5394,11 +5393,11 @@ resource "google_container_cluster" "with_security_posture_config" {
   location           = "us-central1-a"
   initial_node_count = 1
   security_posture_config {
-	mode = "ENTERPRISE"
+    mode = "ENTERPRISE"
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, resource_name, networkName, subnetworkName)
 }
@@ -5410,11 +5409,11 @@ resource "google_container_cluster" "with_security_posture_config" {
   location           = "us-central1-a"
   initial_node_count = 1
   security_posture_config {
-	vulnerability_mode = "VULNERABILITY_BASIC"
+    vulnerability_mode = "VULNERABILITY_BASIC"
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, resource_name, networkName, subnetworkName)
 }
@@ -5426,11 +5425,11 @@ resource "google_container_cluster" "with_security_posture_config" {
   location           = "us-central1-a"
   initial_node_count = 1
   security_posture_config {
-	vulnerability_mode = "VULNERABILITY_ENTERPRISE"
+    vulnerability_mode = "VULNERABILITY_ENTERPRISE"
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, resource_name, networkName, subnetworkName)
 }
@@ -5442,12 +5441,12 @@ resource "google_container_cluster" "with_security_posture_config" {
   location           = "us-central1-a"
   initial_node_count = 1
   security_posture_config {
-	mode = "DISABLED"
-	vulnerability_mode = "VULNERABILITY_DISABLED"
+    mode               = "DISABLED"
+    vulnerability_mode = "VULNERABILITY_DISABLED"
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, resource_name, networkName, subnetworkName)
 }
@@ -5949,12 +5948,12 @@ func testAccCheckContainerClusterDestroyProducer(t *testing.T) func(s *terraform
 func testAccContainerCluster_basic(name, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
-  name               = "%s"
-  location           = "us-central1-a"
-  initial_node_count = 1
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 1
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, name, networkName, subnetworkName)
 }
@@ -5962,20 +5961,20 @@ resource "google_container_cluster" "primary" {
 func testAccContainerCluster_networkingModeRoutes(firstName, secondName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
-  name               = "%s"
-  location           = "us-central1-a"
-  initial_node_count = 1
-  networking_mode    = "ROUTES"
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 1
+  networking_mode     = "ROUTES"
   deletion_protection = false
 }
 
 resource "google_container_cluster" "secondary" {
-	name               = "%s"
-	location           = "us-central1-a"
-	initial_node_count = 1
-	cluster_ipv4_cidr  = "10.96.0.0/14"
-	deletion_protection = false
-  }
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 1
+  cluster_ipv4_cidr   = "10.96.0.0/14"
+  deletion_protection = false
+}
 `, firstName, secondName)
 }
 
@@ -6007,11 +6006,13 @@ resource "google_container_cluster" "primary" {
     evaluation_mode = "PROJECT_SINGLETON_POLICY_ENFORCE"
   }
 {{- if ne $.TargetVersionName "ga" }}
+
   enable_intranode_visibility = true
+
 {{- end }}
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, name, networkName, subnetworkName)
 }
@@ -6045,11 +6046,13 @@ resource "google_container_cluster" "primary" {
     evaluation_mode = "PROJECT_SINGLETON_POLICY_ENFORCE"
   }
 {{- if ne $.TargetVersionName "ga" }}
+
   enable_intranode_visibility = true
+
 {{- end }}
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, name, networkName, subnetworkName)
 }
@@ -6160,9 +6163,7 @@ resource "google_container_cluster" "primary" {
       enabled = true
     }
     cloudrun_config {
-    # https://github.com/hashicorp/terraform-provider-google/issues/11943
-      # disabled = false
-      disabled = true
+      disabled = false
     }
     dns_cache_config {
       enabled = true
@@ -6210,7 +6211,7 @@ resource "google_container_cluster" "primary" {
 }
 
 func testAccContainerCluster_withInternalLoadBalancer(projectID string, clusterName, networkName, subnetworkName string) string {
- 	return fmt.Sprintf(`
+	return fmt.Sprintf(`
 data "google_project" "project" {
   project_id = "%s"
 }
@@ -6237,14 +6238,13 @@ resource "google_container_cluster" "primary" {
       disabled = false
     }
     cloudrun_config {
-      disabled = false
+      disabled           = false
       load_balancer_type = "LOAD_BALANCER_TYPE_INTERNAL"
     }
   }
-  network    = "%s"
-  subnetwork = "%s"
-
   deletion_protection = false
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, projectID, clusterName, networkName, subnetworkName)
 }
@@ -6350,7 +6350,6 @@ resource "google_container_cluster" "filtered_notification_config" {
 func testAccContainerCluster_disableFilteredNotificationConfig(clusterName, topic, networkName, subnetworkName string) string {
 
 	return fmt.Sprintf(`
-
 resource "google_pubsub_topic" "%s" {
   name = "%s"
 }
@@ -6360,14 +6359,14 @@ resource "google_container_cluster" "filtered_notification_config" {
   location           = "us-central1-a"
   initial_node_count = 3
   notification_config {
-	pubsub {
-	  enabled = true
-	  topic   = google_pubsub_topic.%s.id
-	}
+    pubsub {
+      enabled = true
+      topic   = google_pubsub_topic.%s.id
+    }
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, topic, topic, clusterName, topic, networkName, subnetworkName)
 }
@@ -7099,9 +7098,9 @@ resource "google_container_cluster" "with_intranode_visibility" {
   location                    = "us-central1-a"
   initial_node_count          = 1
   enable_intranode_visibility = true
-  deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  deletion_protection         = false
+  network                     = "%s"
+  subnetwork                  = "%s"
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -7114,9 +7113,9 @@ resource "google_container_cluster" "with_intranode_visibility" {
   initial_node_count          = 1
   enable_intranode_visibility = false
   private_ipv6_google_access  = "PRIVATE_IPV6_GOOGLE_ACCESS_BIDIRECTIONAL"
-  deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  deletion_protection         = false
+  network                     = "%s"
+  subnetwork                  = "%s"
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -7128,13 +7127,13 @@ data "google_container_engine_versions" "central1a" {
 }
 
 resource "google_container_cluster" "with_version" {
-  name               = "%s"
-  location           = "us-central1-a"
-  min_master_version = data.google_container_engine_versions.central1a.latest_master_version
-  initial_node_count = 1
+  name                = "%s"
+  location            = "us-central1-a"
+  min_master_version  = data.google_container_engine_versions.central1a.latest_master_version
+  initial_node_count  = 1
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -7146,14 +7145,14 @@ data "google_container_engine_versions" "central1a" {
 }
 
 resource "google_container_cluster" "with_version" {
-  name               = "%s"
-  location           = "us-central1-a"
-  min_master_version = data.google_container_engine_versions.central1a.release_channel_default_version["STABLE"]
-  node_version       = data.google_container_engine_versions.central1a.release_channel_default_version["STABLE"]
-  initial_node_count = 1
+  name                = "%s"
+  location            = "us-central1-a"
+  min_master_version  = data.google_container_engine_versions.central1a.release_channel_default_version["STABLE"]
+  node_version        = data.google_container_engine_versions.central1a.release_channel_default_version["STABLE"]
+  initial_node_count  = 1
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -7170,8 +7169,8 @@ resource "google_container_cluster" "with_master_auth_no_cert" {
     }
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -7183,14 +7182,14 @@ data "google_container_engine_versions" "central1a" {
 }
 
 resource "google_container_cluster" "with_version" {
-  name               = "%s"
-  location           = "us-central1-a"
-  min_master_version = data.google_container_engine_versions.central1a.release_channel_latest_version["STABLE"]
-  node_version       = data.google_container_engine_versions.central1a.release_channel_latest_version["STABLE"]
-  initial_node_count = 1
+  name                = "%s"
+  location            = "us-central1-a"
+  min_master_version  = data.google_container_engine_versions.central1a.release_channel_latest_version["STABLE"]
+  node_version        = data.google_container_engine_versions.central1a.release_channel_latest_version["STABLE"]
+  initial_node_count  = 1
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -7938,26 +7937,26 @@ resource "google_container_cluster" "with_autoprovisioning_management" {
   cluster_autoscaling {
     enabled = true
 
-	resource_limits {
-	  resource_type = "cpu"
-	  maximum       = 2
-	}
+    resource_limits {
+      resource_type = "cpu"
+      maximum       = 2
+    }
 
-	resource_limits {
-	  resource_type = "memory"
-	  maximum       = 2048
-	}
+    resource_limits {
+      resource_type = "memory"
+      maximum       = 2048
+    }
 
     auto_provisioning_defaults {
       management {
-        auto_upgrade    = %t
-        auto_repair     = %t
+        auto_upgrade = %t
+        auto_repair  = %t
       }
     }
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, clusterName, autoUpgrade, autoRepair, networkName, subnetworkName)
 }
@@ -7983,15 +7982,15 @@ resource "google_container_cluster" "with_autoprovisioning_locations" {
   cluster_autoscaling {
     enabled = true
 
-	resource_limits {
-	  resource_type = "cpu"
-	  maximum       = 2
-	}
+    resource_limits {
+      resource_type = "cpu"
+      maximum       = 2
+    }
 
-	resource_limits {
-	  resource_type = "memory"
-	  maximum       = 2048
-	}
+    resource_limits {
+      resource_type = "memory"
+      maximum       = 2048
+    }
 
     %s
   }
@@ -8108,8 +8107,8 @@ resource "google_container_cluster" "with_node_pool" {
     version            = data.google_container_engine_versions.central1a.valid_node_versions[1]
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, cluster, nodePool, networkName, subnetworkName)
 }
@@ -8130,8 +8129,8 @@ resource "google_container_cluster" "with_node_pool" {
     node_count = 2
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, cluster, nodePool, networkName, subnetworkName)
 }
@@ -8152,8 +8151,8 @@ resource "google_container_cluster" "with_node_pool" {
     node_count = 3
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, cluster, nodePool, networkName, subnetworkName)
 }
@@ -8170,8 +8169,8 @@ resource "google_container_cluster" "autoscaling_with_profile" {
     autoscaling_profile = "%s"
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, cluster, autoscalingProfile, networkName, subnetworkName)
 	return config
@@ -8184,13 +8183,13 @@ data "google_container_engine_versions" "central1a" {
 }
 
 resource "google_container_cluster" "with_autoprovisioning" {
-  name               = "%s"
-  location           = "us-central1-a"
-  min_master_version = data.google_container_engine_versions.central1a.latest_master_version
-  initial_node_count = 1
+  name                = "%s"
+  location            = "us-central1-a"
+  min_master_version  = data.google_container_engine_versions.central1a.latest_master_version
+  initial_node_count  = 1
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 `, cluster, networkName, subnetworkName)
 	if autoprovisioning {
 		config += `
@@ -8531,12 +8530,12 @@ resource "google_container_cluster" "nap_boot_disk_kms_key" {
       maximum       = 2048
     }
     auto_provisioning_defaults {
-	  boot_disk_kms_key = "%s"
+      boot_disk_kms_key = "%s"
     }
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, clusterName, kmsKeyName, networkName, subnetworkName)
 }
@@ -9135,36 +9134,36 @@ resource "google_container_cluster" "with_ip_allocation_policy" {
 func testAccContainerCluster_stackType_withDualStack(containerNetName string, clusterName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "container_network" {
-    name                    = "%s"
-    auto_create_subnetworks = false
+  name                    = "%s"
+  auto_create_subnetworks = false
 }
 
-    resource "google_compute_subnetwork" "container_subnetwork" {
-    name    = google_compute_network.container_network.name
-    network = google_compute_network.container_network.name
-    region  = "us-central1"
+resource "google_compute_subnetwork" "container_subnetwork" {
+  name    = google_compute_network.container_network.name
+  network = google_compute_network.container_network.name
+  region  = "us-central1"
 
-    ip_cidr_range = "10.2.0.0/16"
-    stack_type = "IPV4_IPV6"
-    ipv6_access_type = "EXTERNAL"
+  ip_cidr_range    = "10.2.0.0/16"
+  stack_type       = "IPV4_IPV6"
+  ipv6_access_type = "EXTERNAL"
 }
 
 resource "google_container_cluster" "with_stack_type" {
-    name       = "%s"
-    location   = "us-central1-a"
-    network    = google_compute_network.container_network.name
-    subnetwork = google_compute_subnetwork.container_subnetwork.name
+  name       = "%s"
+  location   = "us-central1-a"
+  network    = google_compute_network.container_network.name
+  subnetwork = google_compute_subnetwork.container_subnetwork.name
 
-    initial_node_count = 1
-    datapath_provider = "ADVANCED_DATAPATH"
-    enable_l4_ilb_subsetting = true
+  initial_node_count       = 1
+  datapath_provider        = "ADVANCED_DATAPATH"
+  enable_l4_ilb_subsetting = true
 
-    ip_allocation_policy {
-        cluster_ipv4_cidr_block  = "10.0.0.0/16"
-        services_ipv4_cidr_block = "10.1.0.0/16"
-        stack_type = "IPV4_IPV6"
-    }
-	deletion_protection = false
+  ip_allocation_policy {
+    cluster_ipv4_cidr_block  = "10.0.0.0/16"
+    services_ipv4_cidr_block = "10.1.0.0/16"
+    stack_type               = "IPV4_IPV6"
+  }
+  deletion_protection = false
 }
 `, containerNetName, clusterName)
 }
@@ -9172,33 +9171,33 @@ resource "google_container_cluster" "with_stack_type" {
 func testAccContainerCluster_stackType_withSingleStack(containerNetName string, clusterName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "container_network" {
-    name                    = "%s"
-    auto_create_subnetworks = false
+  name                    = "%s"
+  auto_create_subnetworks = false
 }
 
-    resource "google_compute_subnetwork" "container_subnetwork" {
-    name    = google_compute_network.container_network.name
-    network = google_compute_network.container_network.name
-    region  = "us-central1"
+resource "google_compute_subnetwork" "container_subnetwork" {
+  name    = google_compute_network.container_network.name
+  network = google_compute_network.container_network.name
+  region  = "us-central1"
 
-    ip_cidr_range = "10.2.0.0/16"
+  ip_cidr_range = "10.2.0.0/16"
 }
 
 resource "google_container_cluster" "with_stack_type" {
-    name       = "%s"
-    location   = "us-central1-a"
-    network    = google_compute_network.container_network.name
-    subnetwork = google_compute_subnetwork.container_subnetwork.name
+  name       = "%s"
+  location   = "us-central1-a"
+  network    = google_compute_network.container_network.name
+  subnetwork = google_compute_subnetwork.container_subnetwork.name
 
-    initial_node_count = 1
-    enable_l4_ilb_subsetting = true
+  initial_node_count       = 1
+  enable_l4_ilb_subsetting = true
 
-    ip_allocation_policy {
-        cluster_ipv4_cidr_block  = "10.0.0.0/16"
-        services_ipv4_cidr_block = "10.1.0.0/16"
-        stack_type = "IPV4"
-    }
-	deletion_protection = false
+  ip_allocation_policy {
+    cluster_ipv4_cidr_block  = "10.0.0.0/16"
+    services_ipv4_cidr_block = "10.1.0.0/16"
+    stack_type               = "IPV4"
+  }
+  deletion_protection = false
 }
 `, containerNetName, clusterName)
 }
@@ -9206,35 +9205,35 @@ resource "google_container_cluster" "with_stack_type" {
 func testAccContainerCluster_with_PodCIDROverprovisionDisabled(containerNetName string, clusterName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "container_network" {
-    name                    = "%s"
-    auto_create_subnetworks = false
+  name                    = "%s"
+  auto_create_subnetworks = false
 }
 
-    resource "google_compute_subnetwork" "container_subnetwork" {
-    name    = google_compute_network.container_network.name
-    network = google_compute_network.container_network.name
-    region  = "us-central1"
+resource "google_compute_subnetwork" "container_subnetwork" {
+  name    = google_compute_network.container_network.name
+  network = google_compute_network.container_network.name
+  region  = "us-central1"
 
-    ip_cidr_range = "10.0.0.0/16"
+  ip_cidr_range = "10.0.0.0/16"
 }
 
 resource "google_container_cluster" "with_pco_disabled" {
-    name       = "%s"
-    location   = "us-central1-a"
-    network    = google_compute_network.container_network.name
-    subnetwork = google_compute_subnetwork.container_subnetwork.name
+  name       = "%s"
+  location   = "us-central1-a"
+  network    = google_compute_network.container_network.name
+  subnetwork = google_compute_subnetwork.container_subnetwork.name
 
-    initial_node_count = 1
-    datapath_provider = "ADVANCED_DATAPATH"
+  initial_node_count = 1
+  datapath_provider  = "ADVANCED_DATAPATH"
 
-    ip_allocation_policy {
-        cluster_ipv4_cidr_block  = "10.1.0.0/16"
-        services_ipv4_cidr_block = "10.2.0.0/16"
-		pod_cidr_overprovision_config {
-			disabled = true
-		}
+  ip_allocation_policy {
+    cluster_ipv4_cidr_block  = "10.1.0.0/16"
+    services_ipv4_cidr_block = "10.2.0.0/16"
+    pod_cidr_overprovision_config {
+      disabled = true
     }
-	deletion_protection = false
+  }
+  deletion_protection = false
 }
 `, containerNetName, clusterName)
 }
@@ -9384,7 +9383,7 @@ resource "google_container_cluster" "with_private_cluster" {
     master_ipv4_cidr_block  = "10.42.0.0/28"
     master_global_access_config {
       enabled = %t
-	}
+    }
   }
   master_authorized_networks_config {
   }
@@ -9407,11 +9406,11 @@ resource "google_container_cluster" "with_private_cluster" {
     enable_private_endpoint = false
     master_global_access_config {
       enabled = %t
-	}
+    }
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, clusterName, masterGlobalAccessEnabled, networkName, subnetworkName)
 }
@@ -9424,9 +9423,9 @@ resource "google_container_cluster" "with_shielded_nodes" {
   initial_node_count = 1
 
   enable_shielded_nodes = %v
-  deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  deletion_protection   = false
+  network               = "%s"
+  subnetwork            = "%s"
 }
 `, clusterName, enabled, networkName, subnetworkName)
 }
@@ -9446,9 +9445,9 @@ resource "google_container_cluster" "with_workload_identity_config" {
     workload_pool = "${data.google_project.project.project_id}.svc.id.goog"
   }
   remove_default_node_pool = true
-  deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  deletion_protection      = false
+  network                  = "%s"
+  subnetwork               = "%s"
 }
 `, projectID, clusterName, networkName, subnetworkName)
 }
@@ -9467,7 +9466,7 @@ resource "google_container_cluster" "with_workload_identity_config" {
   workload_identity_config {
     workload_pool = "${data.google_project.project.project_id}.svc.id.goog"
   }
-  enable_autopilot = true
+  enable_autopilot    = true
   deletion_protection = false
 }
 `, projectID, clusterName)
@@ -9493,14 +9492,14 @@ data "google_project" "project" {
 }
 
 resource "google_container_cluster" "with_workload_identity_config" {
-  name               = "%s"
-  location           = "us-central1-a"
-  initial_node_count = 1
+  name                     = "%s"
+  location                 = "us-central1-a"
+  initial_node_count       = 1
   remove_default_node_pool = true
   %s
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, projectID, clusterName, workloadIdentityConfig, networkName, subnetworkName)
 }
@@ -10141,21 +10140,21 @@ resource "google_container_cluster" "with_private_cluster" {
 func testAccContainerCluster_withEnableKubernetesAlpha(cluster, np, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
-  name               = "%s"
-  location           = "us-central1-a"
+  name                    = "%s"
+  location                = "us-central1-a"
   enable_kubernetes_alpha = true
 
   node_pool {
-    name = "%s"
-	initial_node_count = 1
-	management {
-		auto_repair = false
-		auto_upgrade = false
-	}
+    name               = "%s"
+    initial_node_count = 1
+    management {
+      auto_repair  = false
+      auto_upgrade = false
+    }
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, cluster, np, networkName, subnetworkName)
 }
@@ -10167,13 +10166,13 @@ data "google_container_engine_versions" "central1a" {
 }
 
 resource "google_container_cluster" "primary" {
-  name               = "%s"
-  location           = "us-central1-a"
-  min_master_version = data.google_container_engine_versions.central1a.release_channel_latest_version["STABLE"]
-  initial_node_count = 1
+  name                = "%s"
+  location            = "us-central1-a"
+  min_master_version  = data.google_container_engine_versions.central1a.release_channel_latest_version["STABLE"]
+  initial_node_count  = 1
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -10185,10 +10184,10 @@ data "google_container_engine_versions" "uscentral1a" {
 }
 
 resource "google_container_cluster" "primary" {
-  name               = "%s"
-  location           = "us-central1-a"
-  min_master_version = data.google_container_engine_versions.uscentral1a.release_channel_latest_version["STABLE"]
-  initial_node_count = 1
+  name                = "%s"
+  location            = "us-central1-a"
+  min_master_version  = data.google_container_engine_versions.uscentral1a.release_channel_latest_version["STABLE"]
+  initial_node_count  = 1
   deletion_protection = false
 
   # This feature has been available since GKE 1.27, and currently the only
@@ -10215,7 +10214,7 @@ resource "google_container_cluster" "primary" {
     enabled_apis = ["authentication.k8s.io/v1beta1/selfsubjectreviews"]
   }
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
 }
 `, cluster, networkName, subnetworkName)
 }
@@ -10225,8 +10224,8 @@ func testAccContainerCluster_withIPv4Error(name string) string {
 resource "google_container_cluster" "primary" {
   name               = "%s"
   location           = "us-central1-a"
-	initial_node_count = 1
-	private_cluster_config {
+  initial_node_count = 1
+  private_cluster_config {
     enable_private_endpoint = true
     enable_private_nodes    = false
     master_ipv4_cidr_block  = "10.42.0.0/28"
@@ -10242,86 +10241,86 @@ func testAccContainerCluster_withAutopilot(projectID string, containerNetName st
 	if serviceAccount != "" {
 		config += fmt.Sprintf(`
 resource "google_service_account" "service_account" {
-	account_id   = "%[1]s"
-	project      = "%[2]s"
-	display_name = "Service Account"
+  account_id   = "%[1]s"
+  project      = "%[2]s"
+  display_name = "Service Account"
 }
 
 resource "google_project_iam_member" "project" {
-	project = "%[2]s"
-	role    = "roles/container.nodeServiceAccount"
-	member = "serviceAccount:%[1]s@%[2]s.iam.gserviceaccount.com"
+  project = "%[2]s"
+  role    = "roles/container.nodeServiceAccount"
+  member = "serviceAccount:%[1]s@%[2]s.iam.gserviceaccount.com"
 }`, serviceAccount, projectID)
 
 		clusterAutoscaling = fmt.Sprintf(`
-	cluster_autoscaling {
-		auto_provisioning_defaults {
-			service_account = "%s@%s.iam.gserviceaccount.com"
-			oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
-		}
-	}`, serviceAccount, projectID)
+  cluster_autoscaling {
+    auto_provisioning_defaults {
+      service_account = "%s@%s.iam.gserviceaccount.com"
+      oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+    }
+  }`, serviceAccount, projectID)
 	}
 
 	config += fmt.Sprintf(`
 
 resource "google_compute_network" "container_network" {
-	name                    = "%s"
-	auto_create_subnetworks = false
+  name                    = "%s"
+  auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "container_subnetwork" {
-	name                     = google_compute_network.container_network.name
-	network                  = google_compute_network.container_network.name
-	ip_cidr_range            = "10.0.36.0/24"
-	region                   = "us-central1"
-	private_ip_google_access = true
+  name                     = google_compute_network.container_network.name
+  network                  = google_compute_network.container_network.name
+  ip_cidr_range            = "10.0.36.0/24"
+  region                   = "us-central1"
+  private_ip_google_access = true
 
-	secondary_ip_range {
-	  range_name    = "pod"
-	  ip_cidr_range = "10.0.0.0/19"
-	}
+  secondary_ip_range {
+    range_name    = "pod"
+    ip_cidr_range = "10.0.0.0/19"
+  }
 
-	secondary_ip_range {
-	  range_name    = "svc"
-	  ip_cidr_range = "10.0.32.0/22"
-	}
+  secondary_ip_range {
+    range_name    = "svc"
+    ip_cidr_range = "10.0.32.0/22"
+  }
 }
 
 data "google_container_engine_versions" "central1a" {
-	location = "us-central1-a"
+  location = "us-central1-a"
 }
 
 resource "google_container_cluster" "with_autopilot" {
-	name               = "%s"
-	location           = "%s"
-	enable_autopilot   = %v
-	deletion_protection = false
-	min_master_version = "latest"
-	release_channel {
-		channel = "RAPID"
-	}
-	network       = google_compute_network.container_network.name
-	subnetwork    = google_compute_subnetwork.container_subnetwork.name
-	ip_allocation_policy {
-		cluster_secondary_range_name  = google_compute_subnetwork.container_subnetwork.secondary_ip_range[0].range_name
-		services_secondary_range_name = google_compute_subnetwork.container_subnetwork.secondary_ip_range[1].range_name
-	}
-	addons_config {
-		horizontal_pod_autoscaling {
-			disabled = false
-		}
-	}
-	%s
-	vertical_pod_autoscaling {
-		enabled = true
-	}`, containerNetName, clusterName, location, enabled, clusterAutoscaling)
+  name                = "%s"
+  location            = "%s"
+  enable_autopilot    = %v
+  deletion_protection = false
+  min_master_version  = "latest"
+  release_channel {
+    channel = "RAPID"
+  }
+  network    = google_compute_network.container_network.name
+  subnetwork = google_compute_subnetwork.container_subnetwork.name
+  ip_allocation_policy {
+    cluster_secondary_range_name  = google_compute_subnetwork.container_subnetwork.secondary_ip_range[0].range_name
+    services_secondary_range_name = google_compute_subnetwork.container_subnetwork.secondary_ip_range[1].range_name
+  }
+  addons_config {
+    horizontal_pod_autoscaling {
+      disabled = false
+    }
+  }
+  %s
+  vertical_pod_autoscaling {
+    enabled = true
+  }`, containerNetName, clusterName, location, enabled, clusterAutoscaling)
 	if withNetworkTag {
 		config += `
-	node_pool_auto_config {
-		network_tags {
-			tags = ["test-network-tag"]
-		}
-	}`
+  node_pool_auto_config {
+    network_tags {
+      tags = ["test-network-tag"]
+    }
+  }`
 	}
 	config += `
 }`
@@ -10331,17 +10330,17 @@ resource "google_container_cluster" "with_autopilot" {
 func testAccContainerCluster_withDNSConfig(clusterName, clusterDns, clusterDnsDomain, clusterDnsScope, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
-	name               = "%s"
-	location           = "us-central1-a"
+  name               = "%s"
+  location           = "us-central1-a"
   initial_node_count = 1
   dns_config {
-    cluster_dns 	   = "%s"
+    cluster_dns        = "%s"
     cluster_dns_domain = "%s"
     cluster_dns_scope  = "%s"
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, clusterName, clusterDns, clusterDnsDomain, clusterDnsScope, networkName, subnetworkName)
 }
@@ -10513,11 +10512,11 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   monitoring_config {
-      enable_components = []
+    enable_components = []
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, name, networkName, subnetworkName)
 }
@@ -10529,11 +10528,11 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   monitoring_config {
-         enable_components = [ "SYSTEM_COMPONENTS", "APISERVER", "CONTROLLER_MANAGER" ]
+    enable_components = ["SYSTEM_COMPONENTS", "APISERVER", "CONTROLLER_MANAGER"]
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, name, networkName, subnetworkName)
 }
@@ -10545,14 +10544,14 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   monitoring_config {
-         enable_components = [ "SYSTEM_COMPONENTS", "APISERVER", "CONTROLLER_MANAGER", "SCHEDULER" ]
-         managed_prometheus {
-                 enabled = true
-         }
+    enable_components = ["SYSTEM_COMPONENTS", "APISERVER", "CONTROLLER_MANAGER", "SCHEDULER"]
+    managed_prometheus {
+      enabled = true
+    }
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, name, networkName, subnetworkName)
 }
@@ -10564,14 +10563,14 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   monitoring_config {
-	     enable_components = []
-         managed_prometheus {
-                enabled = true
-         }
+    enable_components = []
+    managed_prometheus {
+      enabled = true
+    }
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, name, networkName, subnetworkName)
 }
@@ -10583,13 +10582,13 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
   monitoring_config {
-         managed_prometheus {
-                enabled = true
-         }
+    managed_prometheus {
+      enabled = true
+    }
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, name, networkName, subnetworkName)
 }
@@ -10623,7 +10622,7 @@ resource "google_container_cluster" "primary" {
   name               = "%s"
   location           = "us-central1-a"
   initial_node_count = 1
-  datapath_provider = "ADVANCED_DATAPATH"
+  datapath_provider  = "ADVANCED_DATAPATH"
 
   network    = google_compute_network.container_network.name
   subnetwork = google_compute_subnetwork.container_subnetwork.name
@@ -10732,56 +10731,56 @@ resource "google_container_cluster" "primary" {
 func testAccContainerCluster_withTPUConfig(network, cluster string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "container_network" {
-	name                    = "%s"
-	auto_create_subnetworks = false
+  name                    = "%s"
+  auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "container_subnetwork" {
-	name                     = google_compute_network.container_network.name
-	network                  = google_compute_network.container_network.name
-	ip_cidr_range            = "10.0.36.0/24"
-	region                   = "us-central1"
-	private_ip_google_access = true
+  name                     = google_compute_network.container_network.name
+  network                  = google_compute_network.container_network.name
+  ip_cidr_range            = "10.0.36.0/24"
+  region                   = "us-central1"
+  private_ip_google_access = true
 
-	secondary_ip_range {
-		range_name    = "pod"
-		ip_cidr_range = "10.0.0.0/19"
-	}
+  secondary_ip_range {
+    range_name    = "pod"
+    ip_cidr_range = "10.0.0.0/19"
+  }
 
-	secondary_ip_range {
-		range_name    = "svc"
-		ip_cidr_range = "10.0.32.0/22"
-	}
+  secondary_ip_range {
+    range_name    = "svc"
+    ip_cidr_range = "10.0.32.0/22"
+  }
 }
 
 resource "google_container_cluster" "with_tpu_config" {
-	name               = "%s"
-	location           = "us-central1-a"
-	initial_node_count = 1
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
 
 
-	tpu_config {
-		enabled                = true
-		use_service_networking = true
-	}
+  tpu_config {
+    enabled                = true
+    use_service_networking = true
+  }
 
-	network         = google_compute_network.container_network.name
-	subnetwork      = google_compute_subnetwork.container_subnetwork.name
-	networking_mode = "VPC_NATIVE"
+  network         = google_compute_network.container_network.name
+  subnetwork      = google_compute_subnetwork.container_subnetwork.name
+  networking_mode = "VPC_NATIVE"
 
-	private_cluster_config {
-		enable_private_endpoint = true
-		enable_private_nodes    = true
-		master_ipv4_cidr_block  = "10.42.0.0/28"
-	}
-	master_authorized_networks_config {
-	}
+  private_cluster_config {
+    enable_private_endpoint = true
+    enable_private_nodes    = true
+    master_ipv4_cidr_block  = "10.42.0.0/28"
+  }
+  master_authorized_networks_config {
+  }
 
-	ip_allocation_policy {
-		cluster_secondary_range_name  = google_compute_subnetwork.container_subnetwork.secondary_ip_range[0].range_name
-		services_secondary_range_name = google_compute_subnetwork.container_subnetwork.secondary_ip_range[1].range_name
-	}
-	deletion_protection = false
+  ip_allocation_policy {
+    cluster_secondary_range_name  = google_compute_subnetwork.container_subnetwork.secondary_ip_range[0].range_name
+    services_secondary_range_name = google_compute_subnetwork.container_subnetwork.secondary_ip_range[1].range_name
+  }
+  deletion_protection = false
 }
 `, network, cluster)
 }
@@ -10796,14 +10795,14 @@ resource "google_container_cluster" "primary" {
   initial_node_count = 1
 
   protect_config {
-	workload_config {
-		audit_mode = "BASIC"
-	}
-	workload_vulnerability_mode = "BASIC"
+    workload_config {
+      audit_mode = "BASIC"
+    }
+    workload_vulnerability_mode = "BASIC"
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, name, networkName, subnetworkName)
 }
@@ -10816,14 +10815,14 @@ resource "google_container_cluster" "primary" {
   initial_node_count = 1
 
   protect_config {
-	workload_config {
-		audit_mode = "DISABLED"
-	}
-	workload_vulnerability_mode = "DISABLED"
+    workload_config {
+      audit_mode = "DISABLED"
+    }
+    workload_vulnerability_mode = "DISABLED"
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, name, networkName, subnetworkName)
 }
@@ -10833,9 +10832,9 @@ resource "google_container_cluster" "primary" {
 func testAccContainerCluster_autopilot_minimal(name string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
-  name             = "%s"
-  location         = "us-central1"
-  enable_autopilot = true
+  name                = "%s"
+  location            = "us-central1"
+  enable_autopilot    = true
   deletion_protection = false
 }`, name)
 }
@@ -10892,9 +10891,8 @@ func TestAccContainerCluster_customPlacementPolicy(t *testing.T) {
 
 func testAccContainerCluster_customPlacementPolicy(cluster, np, policyName, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
-
 resource "google_compute_resource_policy" "policy" {
-  name = "%s"
+  name   = "%s"
   region = "us-central1"
   group_placement_policy {
     collocation = "COLLOCATED"
@@ -10902,8 +10900,8 @@ resource "google_compute_resource_policy" "policy" {
 }
 
 resource "google_container_cluster" "cluster" {
-  name               = "%s"
-  location           = "us-central1-a"
+  name     = "%s"
+  location = "us-central1-a"
 
   node_pool {
     name               = "%s"
@@ -10914,13 +10912,13 @@ resource "google_container_cluster" "cluster" {
     }
 
     placement_policy {
-      type = "COMPACT"
+      type        = "COMPACT"
       policy_name = google_compute_resource_policy.policy.name
     }
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, policyName, cluster, np, networkName, subnetworkName)
 }
@@ -10942,66 +10940,66 @@ func testAccContainerCluster_additional_pod_ranges_config(name string, nameCount
 
 	return fmt.Sprintf(`
 	resource "google_compute_network" "main" {
-		name                    = "%s"
-		auto_create_subnetworks = false
+	  name                    = "%s"
+	  auto_create_subnetworks = false
 	}
 	resource "google_compute_subnetwork" "main" {
-		ip_cidr_range = "10.10.0.0/16"
-		name          = "%s"
-		network       = google_compute_network.main.self_link
-		region        = "us-central1"
+	  ip_cidr_range = "10.10.0.0/16"
+	  name          = "%s"
+	  network       = google_compute_network.main.self_link
+	  region        = "us-central1"
 
-		secondary_ip_range {
-			range_name    = "gke-autopilot-services"
-			ip_cidr_range = "10.11.0.0/20"
-		}
+	  secondary_ip_range {
+	    range_name    = "gke-autopilot-services"
+	    ip_cidr_range = "10.11.0.0/20"
+	  }
 
-		secondary_ip_range {
-			range_name    = "gke-autopilot-pods"
-			ip_cidr_range = "10.12.0.0/16"
-		}
+	  secondary_ip_range {
+	    range_name    = "gke-autopilot-pods"
+	    ip_cidr_range = "10.12.0.0/16"
+	  }
 
-		secondary_ip_range {
-			range_name    = "gke-autopilot-pods-add"
-			ip_cidr_range = "10.100.0.0/16"
-		}
-		secondary_ip_range {
-			range_name    = "gke-autopilot-pods-add-2"
-			ip_cidr_range = "100.0.0.0/16"
-		}
+	  secondary_ip_range {
+	    range_name    = "gke-autopilot-pods-add"
+	    ip_cidr_range = "10.100.0.0/16"
+	  }
+	  secondary_ip_range {
+	    range_name    = "gke-autopilot-pods-add-2"
+	    ip_cidr_range = "100.0.0.0/16"
+	  }
 	}
 	resource "google_container_cluster" "primary" {
-		name     = "%s"
-		location = "us-central1"
+	  name     = "%s"
+	  location = "us-central1"
 
-		enable_autopilot = true
+	  enable_autopilot = true
 
-		release_channel {
-			channel = "REGULAR"
-		}
+	  release_channel {
+	    channel = "REGULAR"
+	  }
 
-		network    = google_compute_network.main.name
-		subnetwork = google_compute_subnetwork.main.name
+	  network    = google_compute_network.main.name
+	  subnetwork = google_compute_subnetwork.main.name
 
-		private_cluster_config {
-			enable_private_endpoint = false
-			enable_private_nodes    = true
-			master_ipv4_cidr_block  = "172.16.0.0/28"
-		}
+	  private_cluster_config {
+	    enable_private_endpoint = false
+	    enable_private_nodes    = true
+	    master_ipv4_cidr_block  = "172.16.0.0/28"
+	  }
 
-		# supresses permadiff
-		dns_config {
-			cluster_dns = "CLOUD_DNS"
-			cluster_dns_domain = "cluster.local"
-			cluster_dns_scope = "CLUSTER_SCOPE"
-		}
+	  # supresses permadiff
+	  dns_config {
+	    cluster_dns        = "CLOUD_DNS"
+	    cluster_dns_domain = "cluster.local"
+	    cluster_dns_scope  = "CLUSTER_SCOPE"
+	  }
 
-		ip_allocation_policy {
-			cluster_secondary_range_name  = "gke-autopilot-pods"
-			services_secondary_range_name = "gke-autopilot-services"
-			%s
-		}
-		deletion_protection = false
+	  ip_allocation_policy {
+	    cluster_secondary_range_name  = "gke-autopilot-pods"
+	    services_secondary_range_name = "gke-autopilot-services"
+	    %s
+	  }
+	  deletion_protection = false
 	}
 	`, name, name, name, aprc)
 }
@@ -11040,31 +11038,31 @@ func TestAccContainerCluster_withConfidentialBootDisk(t *testing.T) {
 func testAccContainerCluster_withConfidentialBootDisk(clusterName, npName, kmsKeyName, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_confidential_boot_disk" {
-  name               = "%s"
-  location           = "us-central1-a"
+  name     = "%s"
+  location = "us-central1-a"
   confidential_nodes {
-  	enabled = true
+    enabled = true
   }
   release_channel {
     channel = "RAPID"
   }
   node_pool {
-    name = "%s"
+    name               = "%s"
     initial_node_count = 1
     node_config {
       oauth_scopes = [
         "https://www.googleapis.com/auth/cloud-platform",
       ]
-      image_type = "COS_CONTAINERD"
-      boot_disk_kms_key = "%s"
-      machine_type = "n2d-standard-2"
+      image_type                  = "COS_CONTAINERD"
+      boot_disk_kms_key           = "%s"
+      machine_type                = "n2d-standard-2"
       enable_confidential_storage = true
-      disk_type = "hyperdisk-balanced"
+      disk_type                   = "hyperdisk-balanced"
     }
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, clusterName, npName, kmsKeyName, networkName, subnetworkName)
 }
@@ -11102,10 +11100,10 @@ func TestAccContainerCluster_withConfidentialBootDiskNodeConfig(t *testing.T) {
 func testAccContainerCluster_withConfidentialBootDiskNodeConfig(clusterName, kmsKeyName, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_confidential_boot_disk_node_config" {
-  name               = "%s"
-  location           = "us-central1-a"
+  name     = "%s"
+  location = "us-central1-a"
   confidential_nodes {
-  	enabled = true
+    enabled = true
   }
   initial_node_count = 1
   release_channel {
@@ -11115,15 +11113,15 @@ resource "google_container_cluster" "with_confidential_boot_disk_node_config" {
     oauth_scopes = [
       "https://www.googleapis.com/auth/cloud-platform",
     ]
-    image_type = "COS_CONTAINERD"
-    boot_disk_kms_key = "%s"
-    machine_type = "n2d-standard-2"
+    image_type                  = "COS_CONTAINERD"
+    boot_disk_kms_key           = "%s"
+    machine_type                = "n2d-standard-2"
     enable_confidential_storage = true
-    disk_type = "hyperdisk-balanced"
+    disk_type                   = "hyperdisk-balanced"
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, clusterName, kmsKeyName, networkName, subnetworkName)
 }
@@ -11156,27 +11154,27 @@ func TestAccContainerCluster_withoutConfidentialBootDisk(t *testing.T) {
 func testAccContainerCluster_withoutConfidentialBootDisk(clusterName, npName, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "without_confidential_boot_disk" {
-  name               = "%s"
-  location           = "us-central1-a"
+  name     = "%s"
+  location = "us-central1-a"
   release_channel {
     channel = "RAPID"
   }
   node_pool {
-    name = "%s"
+    name               = "%s"
     initial_node_count = 1
     node_config {
       oauth_scopes = [
-       "https://www.googleapis.com/auth/cloud-platform",
+        "https://www.googleapis.com/auth/cloud-platform",
       ]
-      image_type = "COS_CONTAINERD"
-      machine_type = "n2-standard-2"
+      image_type                  = "COS_CONTAINERD"
+      machine_type                = "n2-standard-2"
       enable_confidential_storage = false
-      disk_type = "pd-balanced"
+      disk_type                   = "pd-balanced"
     }
   }
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, clusterName, npName, networkName, subnetworkName)
 }
@@ -11184,38 +11182,38 @@ resource "google_container_cluster" "without_confidential_boot_disk" {
 {{ if ne $.TargetVersionName `ga` -}}
 func testAccContainerCluster_withWorkloadALTSConfig(projectID, name, networkName, subnetworkName string, enable bool) string {
   return fmt.Sprintf(`
-  data "google_project" "project" {
-    provider = google-beta
-    project_id = "%s"
+data "google_project" "project" {
+  provider   = google-beta
+  project_id = "%s"
+}
+resource "google_compute_network" "network" {
+  provider                 = google-beta
+  name                     = "%s"
+  auto_create_subnetworks  = false
+  enable_ula_internal_ipv6 = true
+}
+resource "google_compute_subnetwork" "subnet" {
+  provider      = google-beta
+  name          = "%s"
+  network       = google_compute_network.network.id
+  ip_cidr_range = "9.12.22.0/24"
+  region        = "us-central1"
+}
+resource "google_container_cluster" "with_workload_alts_config" {
+  provider           = google-beta
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  network            = google_compute_network.network.name
+  subnetwork         = google_compute_subnetwork.subnet.name
+  workload_alts_config {
+    enable_alts = %v
   }
-  resource "google_compute_network" "network" {
-    provider                 = google-beta
-    name                     = "%s"
-    auto_create_subnetworks  = false
-    enable_ula_internal_ipv6 = true
+  workload_identity_config {
+    workload_pool = "${data.google_project.project.project_id}.svc.id.goog"
   }
-  resource "google_compute_subnetwork" "subnet" {
-    provider         = google-beta
-    name             = "%s"
-    network          = google_compute_network.network.id
-    ip_cidr_range    = "9.12.22.0/24"
-    region           = "us-central1"
-  }
-  resource "google_container_cluster" "with_workload_alts_config" {
-    provider = google-beta
-    name               = "%s"
-    location           = "us-central1-a"
-    initial_node_count = 1
-    network         = google_compute_network.network.name
-    subnetwork      = google_compute_subnetwork.subnet.name
-    workload_alts_config {
-      enable_alts = %v
-    }
-    workload_identity_config {
-      workload_pool = "${data.google_project.project.project_id}.svc.id.goog"
-    }
-    deletion_protection = false
-  }
+  deletion_protection = false
+}
 `, projectID, networkName, subnetworkName, name, enable)
 }
 
@@ -11246,41 +11244,41 @@ func testAccContainerCluster_withWorkloadALTSConfigAutopilot(projectID, name str
 
 func testAccContainerCluster_withAutopilotKubeletConfigBaseline(name string) string {
   return fmt.Sprintf(`
-  resource "google_container_cluster" "with_autopilot_kubelet_config" {
-    name                = "%s"
-    location            = "us-central1"
-    initial_node_count  = 1
-    enable_autopilot    = true
-    deletion_protection = false
-  }
+resource "google_container_cluster" "with_autopilot_kubelet_config" {
+  name                = "%s"
+  location            = "us-central1"
+  initial_node_count  = 1
+  enable_autopilot    = true
+  deletion_protection = false
+}
 `, name)
 }
 
 func testAccContainerCluster_withAutopilotKubeletConfigUpdates(name, insecureKubeletReadonlyPortEnabled string) string {
   return fmt.Sprintf(`
-  resource "google_container_cluster" "with_autopilot_kubelet_config" {
-    name               = "%s"
-    location           = "us-central1"
-    initial_node_count = 1
+resource "google_container_cluster" "with_autopilot_kubelet_config" {
+  name               = "%s"
+  location           = "us-central1"
+  initial_node_count = 1
 
-    node_pool_auto_config {
-      node_kubelet_config {
-        insecure_kubelet_readonly_port_enabled = "%s"
-      }
+  node_pool_auto_config {
+    node_kubelet_config {
+      insecure_kubelet_readonly_port_enabled = "%s"
     }
-
-    enable_autopilot    = true
-    deletion_protection = false
   }
+
+  enable_autopilot    = true
+  deletion_protection = false
+}
 `, name, insecureKubeletReadonlyPortEnabled)
 }
 
 func testAccContainerCluster_withAutopilot_withNodePoolDefaults(name, networkName, subnetworkName string) string {
   return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
-  name                = "%s"
-  location            = "us-central1"
-  enable_autopilot    = true
+  name             = "%s"
+  location         = "us-central1"
+  enable_autopilot = true
 
   node_pool_defaults {
     node_config_defaults {
@@ -11288,9 +11286,9 @@ resource "google_container_cluster" "primary" {
   }
 
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
- }
+  network             = "%s"
+  subnetwork          = "%s"
+}
 `, name, networkName, subnetworkName)
 }
 
@@ -11401,13 +11399,13 @@ data "google_project" "project" {
 resource "google_project_iam_member" "tagHoldAdmin" {
   project = "%[1]s"
   role    = "roles/resourcemanager.tagHoldAdmin"
-  member = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
+  member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
 }
 
 resource "google_project_iam_member" "tagUser1" {
   project = "%[1]s"
   role    = "roles/resourcemanager.tagUser"
-  member = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
+  member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
 
   depends_on = [google_project_iam_member.tagHoldAdmin]
 }
@@ -11415,7 +11413,7 @@ resource "google_project_iam_member" "tagUser1" {
 resource "google_project_iam_member" "tagUser2" {
   project = "%[1]s"
   role    = "roles/resourcemanager.tagUser"
-  member = "serviceAccount:${data.google_project.project.number}@cloudservices.gserviceaccount.com"
+  member  = "serviceAccount:${data.google_project.project.number}@cloudservices.gserviceaccount.com"
 
   depends_on = [google_project_iam_member.tagHoldAdmin]
 }
@@ -11431,10 +11429,10 @@ resource "time_sleep" "wait_120_seconds" {
 }
 
 resource "google_tags_tag_key" "key1" {
-  parent = "projects/%[1]s"
-  short_name = "foobarbaz1-%[2]s"
+  parent      = "projects/%[1]s"
+  short_name  = "foobarbaz1-%[2]s"
   description = "For foo/bar1 resources"
-  purpose = "GCE_FIREWALL"
+  purpose     = "GCE_FIREWALL"
   purpose_data = {
     network = "%[1]s/%[4]s"
   }
@@ -11443,16 +11441,16 @@ resource "google_tags_tag_key" "key1" {
 }
 
 resource "google_tags_tag_value" "value1" {
-  parent = "tagKeys/${google_tags_tag_key.key1.name}"
-  short_name = "foo1-%[2]s"
+  parent      = google_tags_tag_key.key1.id
+  short_name  = "foo1-%[2]s"
   description = "For foo1 resources"
 }
 
 resource "google_tags_tag_key" "key2" {
-  parent = "projects/%[1]s"
-  short_name = "foobarbaz2-%[2]s"
+  parent      = "projects/%[1]s"
+  short_name  = "foobarbaz2-%[2]s"
   description = "For foo/bar2 resources"
-  purpose = "GCE_FIREWALL"
+  purpose     = "GCE_FIREWALL"
   purpose_data = {
     network = "%[1]s/%[4]s"
   }
@@ -11464,8 +11462,8 @@ resource "google_tags_tag_key" "key2" {
 }
 
 resource "google_tags_tag_value" "value2" {
-  parent = "tagKeys/${google_tags_tag_key.key2.name}"
-  short_name = "foo2-%[2]s"
+  parent      = google_tags_tag_key.key2.id
+  short_name  = "foo2-%[2]s"
   description = "For foo2 resources"
 }
 
@@ -11497,14 +11495,14 @@ data "google_container_engine_versions" "uscentral1a" {
 }
 
 resource "google_container_cluster" "with_autopilot" {
-  name = "%[3]s"
-  location = "us-central1"
+  name               = "%[3]s"
+  location           = "us-central1"
   min_master_version = data.google_container_engine_versions.uscentral1a.release_channel_latest_version["REGULAR"]
-  enable_autopilot = true
+  enable_autopilot   = true
 
   deletion_protection = false
-  network       = google_compute_network.container_network.name
-  subnetwork    = google_compute_subnetwork.container_subnetwork.name
+  network             = google_compute_network.container_network.name
+  subnetwork          = google_compute_subnetwork.container_subnetwork.name
   ip_allocation_policy {
     cluster_secondary_range_name  = google_compute_subnetwork.container_subnetwork.secondary_ip_range[0].range_name
     services_secondary_range_name = google_compute_subnetwork.container_subnetwork.secondary_ip_range[1].range_name
@@ -11512,8 +11510,8 @@ resource "google_container_cluster" "with_autopilot" {
 
   node_pool_auto_config {
     resource_manager_tags = {
-      "tagKeys/${google_tags_tag_key.key1.name}" = "tagValues/${google_tags_tag_value.value1.name}"
-	}
+      (google_tags_tag_key.key1.id) = google_tags_tag_value.value1.id
+    }
   }
 
   addons_config {
@@ -11539,13 +11537,13 @@ data "google_project" "project" {
 resource "google_project_iam_member" "tagHoldAdmin" {
   project = "%[1]s"
   role    = "roles/resourcemanager.tagHoldAdmin"
-  member = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
+  member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
 }
 
 resource "google_project_iam_member" "tagUser1" {
   project = "%[1]s"
   role    = "roles/resourcemanager.tagUser"
-  member = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
+  member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
 
   depends_on = [google_project_iam_member.tagHoldAdmin]
 }
@@ -11553,7 +11551,7 @@ resource "google_project_iam_member" "tagUser1" {
 resource "google_project_iam_member" "tagUser2" {
   project = "%[1]s"
   role    = "roles/resourcemanager.tagUser"
-  member = "serviceAccount:${data.google_project.project.number}@cloudservices.gserviceaccount.com"
+  member  = "serviceAccount:${data.google_project.project.number}@cloudservices.gserviceaccount.com"
 
   depends_on = [google_project_iam_member.tagHoldAdmin]
 }
@@ -11569,10 +11567,10 @@ resource "time_sleep" "wait_120_seconds" {
 }
 
 resource "google_tags_tag_key" "key1" {
-  parent = "projects/%[1]s"
-  short_name = "foobarbaz1-%[2]s"
+  parent      = "projects/%[1]s"
+  short_name  = "foobarbaz1-%[2]s"
   description = "For foo/bar1 resources"
-  purpose = "GCE_FIREWALL"
+  purpose     = "GCE_FIREWALL"
   purpose_data = {
     network = "%[1]s/%[4]s"
   }
@@ -11581,16 +11579,16 @@ resource "google_tags_tag_key" "key1" {
 }
 
 resource "google_tags_tag_value" "value1" {
-  parent = "tagKeys/${google_tags_tag_key.key1.name}"
-  short_name = "foo1-%[2]s"
+  parent      = google_tags_tag_key.key1.id
+  short_name  = "foo1-%[2]s"
   description = "For foo1 resources"
 }
 
 resource "google_tags_tag_key" "key2" {
-  parent = "projects/%[1]s"
-  short_name = "foobarbaz2-%[2]s"
+  parent      = "projects/%[1]s"
+  short_name  = "foobarbaz2-%[2]s"
   description = "For foo/bar2 resources"
-  purpose = "GCE_FIREWALL"
+  purpose     = "GCE_FIREWALL"
   purpose_data = {
     network = "%[1]s/%[4]s"
   }
@@ -11602,8 +11600,8 @@ resource "google_tags_tag_key" "key2" {
 }
 
 resource "google_tags_tag_value" "value2" {
-  parent = "tagKeys/${google_tags_tag_key.key2.name}"
-  short_name = "foo2-%[2]s"
+  parent      = google_tags_tag_key.key2.id
+  short_name  = "foo2-%[2]s"
   description = "For foo2 resources"
 }
 
@@ -11635,14 +11633,14 @@ data "google_container_engine_versions" "uscentral1a" {
 }
 
 resource "google_container_cluster" "with_autopilot" {
-  name = "%[3]s"
-  location = "us-central1"
+  name               = "%[3]s"
+  location           = "us-central1"
   min_master_version = data.google_container_engine_versions.uscentral1a.release_channel_latest_version["REGULAR"]
-  enable_autopilot = true
+  enable_autopilot   = true
 
   deletion_protection = false
-  network       = google_compute_network.container_network.name
-  subnetwork    = google_compute_subnetwork.container_subnetwork.name
+  network             = google_compute_network.container_network.name
+  subnetwork          = google_compute_subnetwork.container_subnetwork.name
   ip_allocation_policy {
     cluster_secondary_range_name  = google_compute_subnetwork.container_subnetwork.secondary_ip_range[0].range_name
     services_secondary_range_name = google_compute_subnetwork.container_subnetwork.secondary_ip_range[1].range_name
@@ -11650,9 +11648,9 @@ resource "google_container_cluster" "with_autopilot" {
 
   node_pool_auto_config {
     resource_manager_tags = {
-      "tagKeys/${google_tags_tag_key.key1.name}" = "tagValues/${google_tags_tag_value.value1.name}"
-      "tagKeys/${google_tags_tag_key.key2.name}" = "tagValues/${google_tags_tag_value.value2.name}"
-	}
+      (google_tags_tag_key.key1.id) = google_tags_tag_value.value1.id
+      (google_tags_tag_key.key2.id) = google_tags_tag_value.value2.id
+    }
   }
 
   addons_config {
@@ -11678,13 +11676,13 @@ data "google_project" "project" {
 resource "google_project_iam_member" "tagHoldAdmin" {
   project = "%[1]s"
   role    = "roles/resourcemanager.tagHoldAdmin"
-  member = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
+  member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
 }
 
 resource "google_project_iam_member" "tagUser1" {
   project = "%[1]s"
   role    = "roles/resourcemanager.tagUser"
-  member = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
+  member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
 
   depends_on = [google_project_iam_member.tagHoldAdmin]
 }
@@ -11692,7 +11690,7 @@ resource "google_project_iam_member" "tagUser1" {
 resource "google_project_iam_member" "tagUser2" {
   project = "%[1]s"
   role    = "roles/resourcemanager.tagUser"
-  member = "serviceAccount:${data.google_project.project.number}@cloudservices.gserviceaccount.com"
+  member  = "serviceAccount:${data.google_project.project.number}@cloudservices.gserviceaccount.com"
 
   depends_on = [google_project_iam_member.tagHoldAdmin]
 }
@@ -11708,10 +11706,10 @@ resource "time_sleep" "wait_120_seconds" {
 }
 
 resource "google_tags_tag_key" "key1" {
-  parent = "projects/%[1]s"
-  short_name = "foobarbaz1-%[2]s"
+  parent      = "projects/%[1]s"
+  short_name  = "foobarbaz1-%[2]s"
   description = "For foo/bar1 resources"
-  purpose = "GCE_FIREWALL"
+  purpose     = "GCE_FIREWALL"
   purpose_data = {
     network = "%[1]s/%[4]s"
   }
@@ -11720,16 +11718,16 @@ resource "google_tags_tag_key" "key1" {
 }
 
 resource "google_tags_tag_value" "value1" {
-  parent = "tagKeys/${google_tags_tag_key.key1.name}"
-  short_name = "foo1-%[2]s"
+  parent      = google_tags_tag_key.key1.id
+  short_name  = "foo1-%[2]s"
   description = "For foo1 resources"
 }
 
 resource "google_tags_tag_key" "key2" {
-  parent = "projects/%[1]s"
-  short_name = "foobarbaz2-%[2]s"
+  parent      = "projects/%[1]s"
+  short_name  = "foobarbaz2-%[2]s"
   description = "For foo/bar2 resources"
-  purpose = "GCE_FIREWALL"
+  purpose     = "GCE_FIREWALL"
   purpose_data = {
     network = "%[1]s/%[4]s"
   }
@@ -11741,8 +11739,8 @@ resource "google_tags_tag_key" "key2" {
 }
 
 resource "google_tags_tag_value" "value2" {
-  parent = "tagKeys/${google_tags_tag_key.key2.name}"
-  short_name = "foo2-%[2]s"
+  parent      = google_tags_tag_key.key2.id
+  short_name  = "foo2-%[2]s"
   description = "For foo2 resources"
 }
 
@@ -11774,14 +11772,14 @@ data "google_container_engine_versions" "uscentral1a" {
 }
 
 resource "google_container_cluster" "with_autopilot" {
-  name = "%[3]s"
-  location = "us-central1"
+  name               = "%[3]s"
+  location           = "us-central1"
   min_master_version = data.google_container_engine_versions.uscentral1a.release_channel_latest_version["REGULAR"]
-  enable_autopilot = true
+  enable_autopilot   = true
 
   deletion_protection = false
-  network       = google_compute_network.container_network.name
-  subnetwork    = google_compute_subnetwork.container_subnetwork.name
+  network             = google_compute_network.container_network.name
+  subnetwork          = google_compute_subnetwork.container_subnetwork.name
   ip_allocation_policy {
     cluster_secondary_range_name  = google_compute_subnetwork.container_subnetwork.secondary_ip_range[0].range_name
     services_secondary_range_name = google_compute_subnetwork.container_subnetwork.secondary_ip_range[1].range_name
@@ -12251,15 +12249,15 @@ provider "google" {
 }
 
 resource "google_container_cluster" "primary" {
-  name               = "%s"
-  location           = "us-central1-a"
-  initial_node_count = 1
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 1
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
   resource_labels = {
-    created-by = "terraform"
-	default_key1 = "value1"
+    created-by   = "terraform"
+    default_key1 = "value1"
   }
 }
 `, name, networkName, subnetworkName)
@@ -12270,17 +12268,17 @@ func testAccContainerCluster_moveResourceLabelToProviderDefaultLabels(name, netw
 provider "google" {
   default_labels = {
     default_key1 = "default_value1"
-	created-by   = "terraform"
+    created-by   = "terraform"
   }
 }
 
 resource "google_container_cluster" "primary" {
-  name               = "%s"
-  location           = "us-central1-a"
-  initial_node_count = 1
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 1
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
 }
 `, name, networkName, subnetworkName)
 }
@@ -12320,19 +12318,19 @@ func TestAccContainerCluster_storagePoolsWithNodePool(t *testing.T) {
 func testAccContainerCluster_storagePoolsWithNodePool(cluster, location, networkName, subnetworkName, np, storagePoolResourceName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "storage_pools_with_node_pool" {
-  name               = "%s"
-  location           = "%s"
+  name                = "%s"
+  location            = "%s"
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
   node_pool {
-    name = "%s"
+    name               = "%s"
     initial_node_count = 1
     node_config {
-      machine_type = "c3-standard-4"
-      image_type = "COS_CONTAINERD"
+      machine_type  = "c3-standard-4"
+      image_type    = "COS_CONTAINERD"
       storage_pools = ["%s"]
-	  disk_type = "hyperdisk-balanced"
+      disk_type     = "hyperdisk-balanced"
     }
   }
 }
@@ -12373,17 +12371,17 @@ func TestAccContainerCluster_storagePoolsWithNodeConfig(t *testing.T) {
 func testAccContainerCluster_storagePoolsWithNodeConfig(cluster, location, networkName, subnetworkName, storagePoolResourceName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "storage_pools_with_node_config" {
-  name               = "%s"
-  location           = "%s"
-  initial_node_count = 1
+  name                = "%s"
+  location            = "%s"
+  initial_node_count  = 1
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
   node_config {
-    machine_type = "c3-standard-4"
-    image_type = "COS_CONTAINERD"
+    machine_type  = "c3-standard-4"
+    image_type    = "COS_CONTAINERD"
     storage_pools = ["%s"]
-	disk_type = "hyperdisk-balanced"
+    disk_type     = "hyperdisk-balanced"
   }
 }
 `, cluster, location, networkName, subnetworkName, storagePoolResourceName)

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -1179,9 +1179,10 @@ resource "google_container_cluster" "with_gcp_public_cidrs_access_enabled" {
   master_authorized_networks_config {
     gcp_public_cidrs_access_enabled = %s
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, flag, networkName, subnetworkName)
 }
@@ -1198,9 +1199,11 @@ resource "google_container_cluster" "with_gcp_public_cidrs_access_enabled" {
   location           = "us-central1-a"
   min_master_version = data.google_container_engine_versions.uscentral1a.release_channel_latest_version["STABLE"]
   initial_node_count = 1
-  deletion_protection = false
+
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -5337,9 +5340,10 @@ resource "google_container_cluster" "primary" {
     project = "%s"
   }
 
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, name, projectID, networkName, subnetworkName)
 }
@@ -5347,12 +5351,14 @@ resource "google_container_cluster" "primary" {
 func testAccContainerCluster_DisableFleet(resource_name, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
-  name                = "%s"
-  location            = "us-central1-a"
-  initial_node_count  = 1
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, resource_name, networkName, subnetworkName)
 }
@@ -5379,9 +5385,10 @@ resource "google_container_cluster" "with_security_posture_config" {
   security_posture_config {
     mode = "BASIC"
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, resource_name, networkName, subnetworkName)
 }
@@ -5395,9 +5402,10 @@ resource "google_container_cluster" "with_security_posture_config" {
   security_posture_config {
     mode = "ENTERPRISE"
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, resource_name, networkName, subnetworkName)
 }
@@ -5411,9 +5419,10 @@ resource "google_container_cluster" "with_security_posture_config" {
   security_posture_config {
     vulnerability_mode = "VULNERABILITY_BASIC"
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, resource_name, networkName, subnetworkName)
 }
@@ -5427,9 +5436,10 @@ resource "google_container_cluster" "with_security_posture_config" {
   security_posture_config {
     vulnerability_mode = "VULNERABILITY_ENTERPRISE"
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, resource_name, networkName, subnetworkName)
 }
@@ -5444,9 +5454,10 @@ resource "google_container_cluster" "with_security_posture_config" {
     mode               = "DISABLED"
     vulnerability_mode = "VULNERABILITY_DISABLED"
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, resource_name, networkName, subnetworkName)
 }
@@ -5948,12 +5959,13 @@ func testAccCheckContainerClusterDestroyProducer(t *testing.T) func(s *terraform
 func testAccContainerCluster_basic(name, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
-  name                = "%s"
-  location            = "us-central1-a"
-  initial_node_count  = 1
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  network            = "%s"
+  subnetwork         = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, name, networkName, subnetworkName)
 }
@@ -6010,9 +6022,10 @@ resource "google_container_cluster" "primary" {
   enable_intranode_visibility = true
 
 {{- end }}
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, name, networkName, subnetworkName)
 }
@@ -6050,9 +6063,10 @@ resource "google_container_cluster" "primary" {
   enable_intranode_visibility = true
 
 {{- end }}
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, name, networkName, subnetworkName)
 }
@@ -6242,9 +6256,10 @@ resource "google_container_cluster" "primary" {
       load_balancer_type = "LOAD_BALANCER_TYPE_INTERNAL"
     }
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, projectID, clusterName, networkName, subnetworkName)
 }
@@ -6266,9 +6281,10 @@ resource "google_container_cluster" "notification_config" {
       topic   = google_pubsub_topic.%s.id
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, topic, topic, clusterName, topic, networkName, subnetworkName)
 }
@@ -6284,9 +6300,10 @@ resource "google_container_cluster" "notification_config" {
       enabled = false
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -6312,9 +6329,10 @@ resource "google_container_cluster" "filtered_notification_config" {
       }
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, topic, topic, clusterName, topic, networkName, subnetworkName)
 }
@@ -6340,9 +6358,10 @@ resource "google_container_cluster" "filtered_notification_config" {
 	  }
 	}
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, topic, topic, clusterName, topic, networkName, subnetworkName)
 }
@@ -6364,9 +6383,10 @@ resource "google_container_cluster" "filtered_notification_config" {
       topic   = google_pubsub_topic.%s.id
     }
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, topic, topic, clusterName, topic, networkName, subnetworkName)
 }
@@ -6391,9 +6411,10 @@ resource "google_container_cluster" "confidential_nodes" {
   confidential_nodes {
     enabled = true
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, npName, networkName, subnetworkName)
 }
@@ -6418,9 +6439,10 @@ resource "google_container_cluster" "confidential_nodes" {
   confidential_nodes {
     enabled = false
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, npName, networkName, subnetworkName)
 }
@@ -6428,14 +6450,14 @@ resource "google_container_cluster" "confidential_nodes" {
 func testAccContainerCluster_withILBSubSetting(clusterName, npName, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "confidential_nodes" {
-  name               = "%s"
-  location           = "us-central1-a"
+  name     = "%s"
+  location = "us-central1-a"
   release_channel {
     channel = "RAPID"
   }
 
   node_pool {
-    name = "%s"
+    name               = "%s"
     initial_node_count = 1
     node_config {
       machine_type = "e2-medium"
@@ -6443,9 +6465,11 @@ resource "google_container_cluster" "confidential_nodes" {
   }
 
   enable_l4_ilb_subsetting = true
-  deletion_protection = false
+
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, npName, networkName, subnetworkName)
 }
@@ -6468,9 +6492,10 @@ resource "google_container_cluster" "confidential_nodes" {
   }
 
   enable_l4_ilb_subsetting = false
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, npName, networkName, subnetworkName)
 }
@@ -6493,9 +6518,10 @@ resource "google_container_cluster" "with_network_policy_enabled" {
       disabled = false
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -6524,9 +6550,10 @@ resource "google_container_cluster" "with_release_channel" {
   release_channel {
     channel = "%s"
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, channel, networkName, subnetworkName)
 }
@@ -6543,9 +6570,10 @@ resource "google_container_cluster" "with_release_channel" {
   location           = "us-central1-a"
   initial_node_count = 1
   min_master_version = data.google_container_engine_versions.central1a.release_channel_default_version["%s"]
+  network            = "%s"
+  subnetwork         = "%s"
+
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
 }
 `, clusterName, channel, networkName, subnetworkName)
 }
@@ -6561,9 +6589,10 @@ resource "google_container_cluster" "with_cluster_telemetry" {
   cluster_telemetry {
     type = "%s"
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, telemetryType, networkName, subnetworkName)
 }
@@ -6576,9 +6605,11 @@ resource "google_container_cluster" "with_network_policy_enabled" {
   location                 = "us-central1-a"
   initial_node_count       = 1
   remove_default_node_pool = true
-  deletion_protection = false
+
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -6594,9 +6625,10 @@ resource "google_container_cluster" "with_network_policy_enabled" {
   network_policy {
     enabled = false
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -6618,9 +6650,10 @@ resource "google_container_cluster" "with_network_policy_enabled" {
       disabled = true
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -6635,9 +6668,10 @@ resource "google_container_cluster" "primary" {
   authenticator_groups_config {
     security_group = "gke-security-groups@%s"
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, name, orgDomain, networkName, subnetworkName)
 }
@@ -6652,9 +6686,10 @@ resource "google_container_cluster" "primary" {
   authenticator_groups_config {
     security_group = ""
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, name, networkName, subnetworkName)
 }
@@ -6706,9 +6741,11 @@ resource "google_container_cluster" "regional" {
   name               = "%s"
   location           = "us-central1"
   initial_node_count = 1
-  deletion_protection = false
+
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -6975,9 +7012,10 @@ resource "google_container_cluster" "with_enable_private_endpoint" {
   private_cluster_config {
     enable_private_endpoint = %s
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, flag, networkName, subnetworkName)
 }
@@ -6991,9 +7029,10 @@ resource "google_container_cluster" "regional" {
   node_pool {
     name = "%s"
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, cluster, nodePool, networkName, subnetworkName)
 }
@@ -7009,9 +7048,10 @@ resource "google_container_cluster" "with_node_locations" {
     "us-central1-f",
     "us-central1-c",
   ]
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -7027,9 +7067,10 @@ resource "google_container_cluster" "with_node_locations" {
     "us-central1-f",
     "us-central1-b",
   ]
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -7098,9 +7139,11 @@ resource "google_container_cluster" "with_intranode_visibility" {
   location                    = "us-central1-a"
   initial_node_count          = 1
   enable_intranode_visibility = true
-  deletion_protection         = false
-  network                     = "%s"
-  subnetwork                  = "%s"
+
+  network    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -7113,9 +7156,11 @@ resource "google_container_cluster" "with_intranode_visibility" {
   initial_node_count          = 1
   enable_intranode_visibility = false
   private_ipv6_google_access  = "PRIVATE_IPV6_GOOGLE_ACCESS_BIDIRECTIONAL"
-  deletion_protection         = false
-  network                     = "%s"
-  subnetwork                  = "%s"
+
+  network    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -7127,13 +7172,15 @@ data "google_container_engine_versions" "central1a" {
 }
 
 resource "google_container_cluster" "with_version" {
-  name                = "%s"
-  location            = "us-central1-a"
-  min_master_version  = data.google_container_engine_versions.central1a.latest_master_version
-  initial_node_count  = 1
+  name               = "%s"
+  location           = "us-central1-a"
+  min_master_version = data.google_container_engine_versions.central1a.latest_master_version
+  initial_node_count = 1
+
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -7145,14 +7192,16 @@ data "google_container_engine_versions" "central1a" {
 }
 
 resource "google_container_cluster" "with_version" {
-  name                = "%s"
-  location            = "us-central1-a"
-  min_master_version  = data.google_container_engine_versions.central1a.release_channel_default_version["STABLE"]
-  node_version        = data.google_container_engine_versions.central1a.release_channel_default_version["STABLE"]
-  initial_node_count  = 1
+  name               = "%s"
+  location           = "us-central1-a"
+  min_master_version = data.google_container_engine_versions.central1a.release_channel_default_version["STABLE"]
+  node_version       = data.google_container_engine_versions.central1a.release_channel_default_version["STABLE"]
+  initial_node_count = 1
+
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -7168,9 +7217,10 @@ resource "google_container_cluster" "with_master_auth_no_cert" {
       issue_client_certificate = false
     }
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -7182,14 +7232,16 @@ data "google_container_engine_versions" "central1a" {
 }
 
 resource "google_container_cluster" "with_version" {
-  name                = "%s"
-  location            = "us-central1-a"
-  min_master_version  = data.google_container_engine_versions.central1a.release_channel_latest_version["STABLE"]
-  node_version        = data.google_container_engine_versions.central1a.release_channel_latest_version["STABLE"]
-  initial_node_count  = 1
+  name               = "%s"
+  location           = "us-central1-a"
+  min_master_version = data.google_container_engine_versions.central1a.release_channel_latest_version["STABLE"]
+  node_version       = data.google_container_engine_versions.central1a.release_channel_latest_version["STABLE"]
+  initial_node_count = 1
+
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -7239,9 +7291,10 @@ resource "google_container_cluster" "with_node_config" {
     // Updatable fields
     image_type = "COS_CONTAINERD"
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -7281,10 +7334,10 @@ resource "google_container_cluster" "with_node_config_gcfs_config" {
       enabled = %t
     }
   }
+  network    = "%s"
+  subnetwork = "%s"
 
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, clusterName, enabled, networkName, subnetworkName)
 }
@@ -7301,9 +7354,10 @@ resource "google_container_cluster" "with_node_config_kubelet_config_settings" {
       pod_pids_limit = 1024
     }
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -7324,9 +7378,10 @@ resource "google_container_cluster" "with_node_config_kubelet_config_settings" {
       pod_pids_limit                         = %v
     }
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, clusterName, cpuManagerPolicy, cpuCfsQuota, cpuCfsQuotaPeriod, insecureKubeletReadonlyPortEnabled, podPidsLimit, networkName, subnetworkName)
 }
@@ -7334,8 +7389,8 @@ resource "google_container_cluster" "with_node_config_kubelet_config_settings" {
 func testAccContainerCluster_withInsecureKubeletReadonlyPortEnabledInNodePool(clusterName, nodePoolName, networkName, subnetworkName, insecureKubeletReadonlyPortEnabled string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_insecure_kubelet_readonly_port_enabled_in_node_pool" {
-  name               = "%s"
-  location           = "us-central1-f"
+  name     = "%s"
+  location = "us-central1-f"
 
   node_pool {
     name               = "%s"
@@ -7347,9 +7402,10 @@ resource "google_container_cluster" "with_insecure_kubelet_readonly_port_enabled
       }
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, nodePoolName, insecureKubeletReadonlyPortEnabled, networkName, subnetworkName)
 }
@@ -7361,9 +7417,10 @@ resource "google_container_cluster" "with_insecure_kubelet_readonly_port_enabled
   location           = "us-central1-f"
   initial_node_count = 1
 
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -7380,9 +7437,10 @@ resource "google_container_cluster" "with_insecure_kubelet_readonly_port_enabled
       insecure_kubelet_readonly_port_enabled = "%s"
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, insecureKubeletReadonlyPortEnabled, networkName, subnetworkName)
 }
@@ -7397,9 +7455,10 @@ resource "google_container_cluster" "with_logging_variant_in_node_config" {
   node_config {
     logging_variant = "%s"
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, loggingVariant, networkName, subnetworkName)
 }
@@ -7407,8 +7466,8 @@ resource "google_container_cluster" "with_logging_variant_in_node_config" {
 func testAccContainerCluster_withLoggingVariantInNodePool(clusterName, nodePoolName, loggingVariant, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_logging_variant_in_node_pool" {
-  name               = "%s"
-  location           = "us-central1-f"
+  name     = "%s"
+  location = "us-central1-f"
 
   node_pool {
     name               = "%s"
@@ -7417,9 +7476,10 @@ resource "google_container_cluster" "with_logging_variant_in_node_pool" {
       logging_variant = "%s"
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, nodePoolName, loggingVariant, networkName, subnetworkName)
 }
@@ -7436,9 +7496,10 @@ resource "google_container_cluster" "with_logging_variant_node_pool_default" {
       logging_variant = "%s"
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, loggingVariant, networkName, subnetworkName)
 }
@@ -7446,8 +7507,8 @@ resource "google_container_cluster" "with_logging_variant_node_pool_default" {
 func testAccContainerCluster_withAdvancedMachineFeaturesInNodePool(clusterName, nodePoolName, networkName, subnetworkName string, nvEnabled bool) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_advanced_machine_features_in_node_pool" {
-  name               = "%s"
-  location           = "us-central1-f"
+  name     = "%s"
+  location = "us-central1-f"
 
   node_pool {
     name               = "%s"
@@ -7455,14 +7516,15 @@ resource "google_container_cluster" "with_advanced_machine_features_in_node_pool
     node_config {
       machine_type = "c2-standard-4"
       advanced_machine_features {
-        threads_per_core = 1
+        threads_per_core             = 1
         enable_nested_virtualization = "%t"
-	    }
+      }
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, nodePoolName, nvEnabled, networkName, subnetworkName)
 }
@@ -7481,9 +7543,10 @@ resource "google_container_cluster" "with_node_pool_defaults" {
       }
     }
   }
-  deletion_protection = false
   network    = "%s"
   subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, enabled, networkName, subnetworkName)
 }
@@ -7536,9 +7599,10 @@ resource "google_container_cluster" "with_node_config" {
 
     image_type = "UBUNTU_CONTAINERD"
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -7587,9 +7651,10 @@ resource "google_container_cluster" "with_node_config_scope_alias" {
     disk_size_gb = 15
     oauth_scopes = ["compute-rw", "storage-ro", "logging-write", "monitoring"]
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -7602,9 +7667,9 @@ resource "google_container_cluster" "with_node_config" {
   initial_node_count = 1
 
   node_config {
-    machine_type    = "e2-medium"
-    disk_size_gb    = 15
-    disk_type       = "pd-ssd"
+    machine_type = "e2-medium"
+    disk_size_gb = 15
+    disk_type    = "pd-ssd"
     oauth_scopes = [
       "https://www.googleapis.com/auth/monitoring",
       "https://www.googleapis.com/auth/compute",
@@ -7619,8 +7684,8 @@ resource "google_container_cluster" "with_node_config" {
     labels = {
       foo = "bar"
     }
-    tags             = ["foo", "bar"]
-    preemptible      = true
+    tags        = ["foo", "bar"]
+    preemptible = true
 
     // Updatable fields
     image_type = "COS_CONTAINERD"
@@ -7630,9 +7695,10 @@ resource "google_container_cluster" "with_node_config" {
       enable_integrity_monitoring = true
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -7645,9 +7711,9 @@ resource "google_container_cluster" "with_node_config" {
   initial_node_count = 1
 
   node_config {
-    machine_type    = "e2-medium"
-    disk_size_gb    = 15
-    disk_type       = "pd-ssd"
+    machine_type = "e2-medium"
+    disk_size_gb = 15
+    disk_type    = "pd-ssd"
     oauth_scopes = [
       "https://www.googleapis.com/auth/monitoring",
       "https://www.googleapis.com/auth/compute",
@@ -7662,8 +7728,8 @@ resource "google_container_cluster" "with_node_config" {
     labels = {
       foo = "bar"
     }
-    tags             = ["foo", "bar"]
-    preemptible      = true
+    tags        = ["foo", "bar"]
+    preemptible = true
 
     // Updatable fields
     image_type = "COS_CONTAINERD"
@@ -7672,9 +7738,10 @@ resource "google_container_cluster" "with_node_config" {
       consume_reservation_type = "ANY_RESERVATION"
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -7715,9 +7782,9 @@ resource "google_container_cluster" "with_node_config" {
   initial_node_count = 1
 
   node_config {
-    machine_type    = "n1-standard-1"
-    disk_size_gb    = 15
-    disk_type       = "pd-ssd"
+    machine_type = "n1-standard-1"
+    disk_size_gb = 15
+    disk_type    = "pd-ssd"
     oauth_scopes = [
       "https://www.googleapis.com/auth/monitoring",
       "https://www.googleapis.com/auth/compute",
@@ -7732,23 +7799,24 @@ resource "google_container_cluster" "with_node_config" {
     labels = {
       foo = "bar"
     }
-    tags             = ["foo", "bar"]
+    tags = ["foo", "bar"]
 
     // Updatable fields
     image_type = "COS_CONTAINERD"
 
     reservation_affinity {
       consume_reservation_type = "SPECIFIC_RESERVATION"
-      key = "compute.googleapis.com/reservation-name"
+      key                      = "compute.googleapis.com/reservation-name"
       values = [
         google_compute_reservation.gce_reservation.name
       ]
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
-  depends_on = [google_project_service.container]
+  subnetwork = "%s"
+
+  deletion_protection = false
+  depends_on          = [google_project_service.container]
 }
 `, reservation, clusterName, networkName, subnetworkName)
 }
@@ -7781,9 +7849,10 @@ resource "google_container_cluster" "with_workload_metadata_config" {
       mode = "%s"
     }
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, clusterName, workloadMetadataConfigMode, networkName, subnetworkName)
 }
@@ -7802,7 +7871,7 @@ resource "google_container_cluster" "with_sandbox_config" {
   min_master_version = data.google_container_engine_versions.central1a.latest_master_version
 
   node_config {
-    machine_type = "n1-standard-1"  // can't be e2 because of gvisor
+    machine_type = "n1-standard-1" // can't be e2 because of gvisor
     oauth_scopes = [
       "https://www.googleapis.com/auth/logging.write",
       "https://www.googleapis.com/auth/monitoring",
@@ -7824,9 +7893,10 @@ resource "google_container_cluster" "with_sandbox_config" {
       effect = "NO_SCHEDULE"
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -7844,7 +7914,7 @@ resource "google_container_cluster" "with_sandbox_config" {
   min_master_version = data.google_container_engine_versions.central1a.latest_master_version
 
   node_config {
-    machine_type = "n1-standard-1"  // can't be e2 because of gvisor
+    machine_type = "n1-standard-1" // can't be e2 because of gvisor
     oauth_scopes = [
       "https://www.googleapis.com/auth/logging.write",
       "https://www.googleapis.com/auth/monitoring",
@@ -7857,7 +7927,7 @@ resource "google_container_cluster" "with_sandbox_config" {
     }
 
     labels = {
-      "test.terraform.io/gke-sandbox" = "true"
+      "test.terraform.io/gke-sandbox"         = "true"
       "test.terraform.io/gke-sandbox-amended" = "also-true"
     }
 
@@ -7867,9 +7937,10 @@ resource "google_container_cluster" "with_sandbox_config" {
       effect = "NO_SCHEDULE"
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -7893,9 +7964,10 @@ resource "google_container_cluster" "with_boot_disk_kms_key" {
 
     boot_disk_kms_key = "%s"
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, kmsKeyName, networkName, subnetworkName)
 }
@@ -7913,6 +7985,7 @@ resource "google_container_cluster" "with_net_ref_by_url" {
   initial_node_count = 1
 
   network = google_compute_network.container_network.self_link
+
   deletion_protection = false
 }
 
@@ -7922,6 +7995,7 @@ resource "google_container_cluster" "with_net_ref_by_name" {
   initial_node_count = 1
 
   network = google_compute_network.container_network.name
+
   deletion_protection = false
 }
 `, network, cluster, cluster)
@@ -7954,9 +8028,10 @@ resource "google_container_cluster" "with_autoprovisioning_management" {
       }
     }
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, clusterName, autoUpgrade, autoRepair, networkName, subnetworkName)
 }
@@ -7994,9 +8069,10 @@ resource "google_container_cluster" "with_autoprovisioning_locations" {
 
     %s
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, apl, networkName, subnetworkName)
 }
@@ -8040,9 +8116,10 @@ resource "google_container_cluster" "primary" {
       "https://www.googleapis.com/auth/monitoring",
     ]
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, cluster, cluster, cluster, networkName, subnetworkName)
 }
@@ -8052,7 +8129,6 @@ func testAccContainerCluster_withNodePoolBasic(cluster, nodePool, networkName, s
 resource "google_container_cluster" "with_node_pool" {
   name     = "%s"
   location = "us-central1-a"
-  deletion_protection = false
 
   node_pool {
     name               = "%s"
@@ -8060,7 +8136,9 @@ resource "google_container_cluster" "with_node_pool" {
   }
 
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, cluster, nodePool, networkName, subnetworkName)
 }
@@ -8082,9 +8160,10 @@ resource "google_container_cluster" "with_node_pool" {
     initial_node_count = 2
     version            = data.google_container_engine_versions.central1a.valid_node_versions[2]
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, cluster, nodePool, networkName, subnetworkName)
 }
@@ -8106,9 +8185,10 @@ resource "google_container_cluster" "with_node_pool" {
     initial_node_count = 2
     version            = data.google_container_engine_versions.central1a.valid_node_versions[1]
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, cluster, nodePool, networkName, subnetworkName)
 }
@@ -8128,9 +8208,10 @@ resource "google_container_cluster" "with_node_pool" {
     name       = "%s"
     node_count = 2
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, cluster, nodePool, networkName, subnetworkName)
 }
@@ -8150,9 +8231,10 @@ resource "google_container_cluster" "with_node_pool" {
     name       = "%s"
     node_count = 3
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, cluster, nodePool, networkName, subnetworkName)
 }
@@ -8168,9 +8250,10 @@ resource "google_container_cluster" "autoscaling_with_profile" {
     enabled             = false
     autoscaling_profile = "%s"
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, cluster, autoscalingProfile, networkName, subnetworkName)
 	return config
@@ -8187,9 +8270,11 @@ resource "google_container_cluster" "with_autoprovisioning" {
   location            = "us-central1-a"
   min_master_version  = data.google_container_engine_versions.central1a.latest_master_version
   initial_node_count  = 1
+
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 `, cluster, networkName, subnetworkName)
 	if autoprovisioning {
 		config += `
@@ -8234,10 +8319,9 @@ resource "google_container_cluster" "with_autoprovisioning" {
   location           = "us-central1-a"
   min_master_version = data.google_container_engine_versions.central1a.latest_master_version
   initial_node_count = 1
-  deletion_protection = false
 
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
 
   logging_service    = "none"
   monitoring_service = "none"
@@ -8268,6 +8352,7 @@ if monitoringWrite {
       ]
     }
   }
+  deletion_protection = false
 }`
 	return config
 }
@@ -8355,9 +8440,10 @@ func testAccContainerCluster_autoprovisioningDefaultsUpgradeSettings(clusterName
           }
         }
       }
-      deletion_protection = false
       network    = "%s"
-      subnetwork    = "%s"
+      subnetwork = "%s"
+
+      deletion_protection = false
     }
   `, clusterName, maxSurge, maxUnavailable, strategy, blueGreenSettings, networkName, subnetworkName)
 }
@@ -8395,9 +8481,10 @@ func testAccContainerCluster_autoprovisioningDefaultsUpgradeSettingsWithBlueGree
             }
           }
         }
-        deletion_protection = false
         network    = "%s"
-        subnetwork    = "%s"
+        subnetwork = "%s"
+
+        deletion_protection = false
       }
     `, clusterName, strategy, duration, duration, networkName, subnetworkName)
 }
@@ -8431,9 +8518,10 @@ resource "google_container_cluster" "with_autoprovisioning" {
       %s
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, cluster, DiskSizeGbCfg, networkName, subnetworkName)
 }
@@ -8467,9 +8555,10 @@ resource "google_container_cluster" "with_autoprovisioning" {
       %s
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, cluster, DiskTypeCfg, networkName, subnetworkName)
 }
@@ -8503,9 +8592,10 @@ resource "google_container_cluster" "with_autoprovisioning" {
       %s
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, cluster, imageTypeCfg, networkName, subnetworkName)
 }
@@ -8533,9 +8623,10 @@ resource "google_container_cluster" "nap_boot_disk_kms_key" {
       boot_disk_kms_key = "%s"
     }
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, clusterName, kmsKeyName, networkName, subnetworkName)
 }
@@ -8567,9 +8658,10 @@ resource "google_container_cluster" "nap_shielded_instance" {
       }
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, cluster, networkName, subnetworkName)
 }
@@ -8588,9 +8680,10 @@ resource "google_container_cluster" "with_node_pool" {
       max_node_count = 3
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, cluster, np, networkName, subnetworkName)
 }
@@ -8609,9 +8702,10 @@ resource "google_container_cluster" "with_node_pool" {
       max_node_count = 5
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, cluster, np, networkName, subnetworkName)
 }
@@ -8623,8 +8717,8 @@ data "google_container_engine_versions" "uscentral1a" {
 }
 
 resource "google_container_cluster" "with_node_pool" {
-  name     = "%s"
-  location = "us-central1"
+  name               = "%s"
+  location           = "us-central1"
   min_master_version = data.google_container_engine_versions.uscentral1a.release_channel_latest_version["STABLE"]
 
   node_pool {
@@ -8633,12 +8727,13 @@ resource "google_container_cluster" "with_node_pool" {
     autoscaling {
       total_min_node_count = 3
       total_max_node_count = 21
-      location_policy = "BALANCED"
+      location_policy      = "BALANCED"
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, cluster, np, networkName, subnetworkName)
 }
@@ -8650,8 +8745,8 @@ data "google_container_engine_versions" "uscentral1a" {
 }
 
 resource "google_container_cluster" "with_node_pool" {
-  name     = "%s"
-  location = "us-central1"
+  name               = "%s"
+  location           = "us-central1"
   min_master_version = data.google_container_engine_versions.uscentral1a.release_channel_latest_version["STABLE"]
 
   node_pool {
@@ -8660,12 +8755,13 @@ resource "google_container_cluster" "with_node_pool" {
     autoscaling {
       total_min_node_count = 4
       total_max_node_count = 32
-      location_policy = "ANY"
+      location_policy      = "ANY"
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, cluster, np, networkName, subnetworkName)
 }
@@ -8677,17 +8773,18 @@ data "google_container_engine_versions" "uscentral1a" {
 }
 
 resource "google_container_cluster" "with_node_pool" {
-  name     = "%s"
-  location = "us-central1"
+  name               = "%s"
+  location           = "us-central1"
   min_master_version = data.google_container_engine_versions.uscentral1a.release_channel_latest_version["STABLE"]
 
   node_pool {
     name               = "%s"
     initial_node_count = 2
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, cluster, nodePool, networkName, subnetworkName)
 }
@@ -8702,9 +8799,10 @@ resource "google_container_cluster" "with_node_pool_name_prefix" {
     name_prefix = "%s"
     node_count  = 2
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, cluster, npPrefix, networkName, subnetworkName)
 }
@@ -8724,9 +8822,10 @@ resource "google_container_cluster" "with_node_pool_multiple" {
     name       = "%s-two"
     node_count = 3
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, cluster, npPrefix, npPrefix, networkName, subnetworkName)
 }
@@ -8757,7 +8856,7 @@ resource "google_container_cluster" "with_node_pool_node_config" {
     name       = "%s"
     node_count = 2
     node_config {
-      machine_type    = "n1-standard-1"  // can't be e2 because of local-ssd
+      machine_type    = "n1-standard-1" // can't be e2 because of local-ssd
       disk_size_gb    = 15
       local_ssd_count = 1
       oauth_scopes = [
@@ -8778,9 +8877,10 @@ resource "google_container_cluster" "with_node_pool_node_config" {
       tags = ["foo", "bar"]
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, cluster, np, networkName, subnetworkName)
 }
@@ -8802,9 +8902,11 @@ resource "google_container_cluster" "with_maintenance_window" {
   location           = "us-central1-a"
   initial_node_count = 1
   %s
-  deletion_protection = false
+
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, maintenancePolicy, networkName, subnetworkName)
 }
@@ -8828,9 +8930,11 @@ resource "google_container_cluster" "with_recurring_maintenance_window" {
   location           = "us-central1-a"
   initial_node_count = 1
   %s
-  deletion_protection = false
+
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, maintenancePolicy, networkName, subnetworkName)
 
@@ -8847,23 +8951,24 @@ resource "google_container_cluster" "with_maintenance_exclusion_window" {
   maintenance_policy {
     recurring_window {
       start_time = "%s"
-      end_time = "%s"
+      end_time   = "%s"
       recurrence = "FREQ=DAILY"
     }
     maintenance_exclusion {
       exclusion_name = "batch job"
-      start_time = "%s"
-      end_time = "%s"
+      start_time     = "%s"
+      end_time       = "%s"
     }
     maintenance_exclusion {
       exclusion_name = "holiday data load"
-      start_time = "%s"
-      end_time = "%s"
+      start_time     = "%s"
+      end_time       = "%s"
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, w1startTime, w1endTime, w1startTime, w1endTime, w2startTime, w2endTime, networkName, subnetworkName)
 }
@@ -8879,29 +8984,30 @@ resource "google_container_cluster" "with_maintenance_exclusion_options" {
   maintenance_policy {
     recurring_window {
       start_time = "%s"
-      end_time = "%s"
+      end_time   = "%s"
       recurrence = "FREQ=DAILY"
     }
     maintenance_exclusion {
       exclusion_name = "batch job"
-      start_time = "%s"
-      end_time = "%s"
+      start_time     = "%s"
+      end_time       = "%s"
       exclusion_options {
         scope = "%s"
       }
     }
     maintenance_exclusion {
       exclusion_name = "holiday data load"
-      start_time = "%s"
-      end_time = "%s"
+      start_time     = "%s"
+      end_time       = "%s"
       exclusion_options {
         scope = "%s"
       }
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, cclusterName, w1startTime, w1endTime, w1startTime, w1endTime, scope1, w2startTime, w2endTime, scope2, networkName, subnetworkName)
 }
@@ -8917,23 +9023,24 @@ resource "google_container_cluster" "with_maintenance_exclusion_options" {
   maintenance_policy {
     recurring_window {
       start_time = "%s"
-      end_time = "%s"
+      end_time   = "%s"
       recurrence = "FREQ=DAILY"
     }
     maintenance_exclusion {
       exclusion_name = "batch job"
-      start_time = "%s"
-      end_time = "%s"
+      start_time     = "%s"
+      end_time       = "%s"
     }
     maintenance_exclusion {
       exclusion_name = "holiday data load"
-      start_time = "%s"
-      end_time = "%s"
+      start_time     = "%s"
+      end_time       = "%s"
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, cclusterName, w1startTime, w1endTime, w1startTime, w1endTime, w2startTime, w2endTime, networkName, subnetworkName)
 }
@@ -8945,33 +9052,34 @@ resource "google_container_cluster" "with_maintenance_exclusion_options" {
   name               = "%s"
   location           = "us-central1-a"
   initial_node_count = 1
-  deletion_protection = false
 
   maintenance_policy {
     recurring_window {
       start_time = "%s"
-      end_time = "%s"
+      end_time   = "%s"
       recurrence = "FREQ=DAILY"
     }
     maintenance_exclusion {
       exclusion_name = "batch job"
-      start_time = "%s"
-      end_time = "%s"
+      start_time     = "%s"
+      end_time       = "%s"
       exclusion_options {
         scope = "%s"
       }
     }
     maintenance_exclusion {
       exclusion_name = "holiday data load"
-      start_time = "%s"
-      end_time = "%s"
+      start_time     = "%s"
+      end_time       = "%s"
       exclusion_options {
         scope = "%s"
       }
     }
   }
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, cclusterName, w1startTime, w1endTime, w1startTime, w1endTime, scope1, w2startTime, w2endTime, scope2, networkName, subnetworkName)
 }
@@ -8987,13 +9095,14 @@ resource "google_container_cluster" "with_maintenance_exclusion_window" {
   maintenance_policy {
     recurring_window {
       start_time = "%s"
-      end_time = "%s"
+      end_time   = "%s"
       recurrence = "FREQ=DAILY"
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, w1startTime, w1endTime, networkName, subnetworkName)
 }
@@ -9012,13 +9121,14 @@ resource "google_container_cluster" "with_maintenance_exclusion_window" {
     }
     maintenance_exclusion {
       exclusion_name = "batch job"
-      start_time = "%s"
-      end_time = "%s"
+      start_time     = "%s"
+      end_time       = "%s"
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, w1startTime, w1endTime, networkName, subnetworkName)
 }
@@ -9262,9 +9372,10 @@ resource "google_container_cluster" "with_resource_usage_export_config" {
       dataset_id = google_bigquery_dataset.default.dataset_id
     }
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, datasetId, clusterName, enableMetering, networkName, subnetworkName)
 }
@@ -9281,9 +9392,11 @@ resource "google_container_cluster" "with_resource_usage_export_config" {
   name               = "%s"
   location           = "us-central1-a"
   initial_node_count = 1
-  deletion_protection = false
+
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, datasetId, clusterName, networkName, subnetworkName)
 }
@@ -9408,9 +9521,10 @@ resource "google_container_cluster" "with_private_cluster" {
       enabled = %t
     }
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, clusterName, masterGlobalAccessEnabled, networkName, subnetworkName)
 }
@@ -9423,9 +9537,11 @@ resource "google_container_cluster" "with_shielded_nodes" {
   initial_node_count = 1
 
   enable_shielded_nodes = %v
+
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection   = false
-  network               = "%s"
-  subnetwork            = "%s"
 }
 `, clusterName, enabled, networkName, subnetworkName)
 }
@@ -9445,9 +9561,11 @@ resource "google_container_cluster" "with_workload_identity_config" {
     workload_pool = "${data.google_project.project.project_id}.svc.id.goog"
   }
   remove_default_node_pool = true
-  deletion_protection      = false
-  network                  = "%s"
-  subnetwork               = "%s"
+
+  network    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, projectID, clusterName, networkName, subnetworkName)
 }
@@ -9497,9 +9615,11 @@ resource "google_container_cluster" "with_workload_identity_config" {
   initial_node_count       = 1
   remove_default_node_pool = true
   %s
+
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, projectID, clusterName, workloadIdentityConfig, networkName, subnetworkName)
 }
@@ -9625,9 +9745,10 @@ resource "google_container_cluster" "with_binary_authorization_enabled_bool" {
   binary_authorization {
     enabled = %v
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, enabled, networkName, subnetworkName)
 }
@@ -9645,9 +9766,10 @@ resource "google_container_cluster" "with_binary_authorization_evaluation_mode" 
   binary_authorization {
     evaluation_mode = "%s"
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, autopilot_enabled, evaluation_mode, networkName, subnetworkName)
 }
@@ -9813,9 +9935,10 @@ resource "google_container_cluster" "with_external_ips_config" {
   service_external_ips_config {
     enabled = %v
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, projectID, clusterName, enabled, networkName, subnetworkName)
 }
@@ -9827,9 +9950,9 @@ data "google_project" "project" {
 }
 
 resource "google_container_cluster" "with_mesh_certificates_config" {
-  name               = "%s"
-  location           = "us-central1-a"
-  initial_node_count = 1
+  name                     = "%s"
+  location                 = "us-central1-a"
+  initial_node_count       = 1
   remove_default_node_pool = true
   workload_identity_config {
     workload_pool = "${data.google_project.project.project_id}.svc.id.goog"
@@ -9837,9 +9960,10 @@ resource "google_container_cluster" "with_mesh_certificates_config" {
   mesh_certificates {
     enable_certificates = true
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, projectID, clusterName, networkName, subnetworkName)
 }
@@ -9861,9 +9985,10 @@ resource "google_container_cluster" "with_mesh_certificates_config" {
   mesh_certificates {
     enable_certificates = %v
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, projectID, clusterName, enabled, networkName, subnetworkName)
 }
@@ -9881,9 +10006,10 @@ resource "google_container_cluster" "with_cost_management_config" {
   cost_management_config {
     enabled = %v
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, projectID, clusterName, enabled, networkName, subnetworkName)
 }
@@ -9912,9 +10038,10 @@ resource "google_container_cluster" "primary" {
     state    = "ENCRYPTED"
     key_name = "%[2]s"
   }
-  deletion_protection = false
   network    = "%[4]s"
   subnetwork = "%[5]s"
+
+  deletion_protection = false
 }
 `, kmsData.KeyRing.Name, kmsData.CryptoKey.Name, clusterName, networkName, subnetworkName)
 }
@@ -9933,9 +10060,10 @@ resource "google_container_cluster" "primary" {
   release_channel {
     channel = "RAPID"
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, datapathProvider, networkName, subnetworkName)
 }
@@ -10152,9 +10280,10 @@ resource "google_container_cluster" "primary" {
       auto_upgrade = false
     }
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, cluster, np, networkName, subnetworkName)
 }
@@ -10166,13 +10295,15 @@ data "google_container_engine_versions" "central1a" {
 }
 
 resource "google_container_cluster" "primary" {
-  name                = "%s"
-  location            = "us-central1-a"
-  min_master_version  = data.google_container_engine_versions.central1a.release_channel_latest_version["STABLE"]
-  initial_node_count  = 1
+  name               = "%s"
+  location           = "us-central1-a"
+  min_master_version = data.google_container_engine_versions.central1a.release_channel_latest_version["STABLE"]
+  initial_node_count = 1
+
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, clusterName, networkName, subnetworkName)
 }
@@ -10184,11 +10315,10 @@ data "google_container_engine_versions" "uscentral1a" {
 }
 
 resource "google_container_cluster" "primary" {
-  name                = "%s"
-  location            = "us-central1-a"
-  min_master_version  = data.google_container_engine_versions.uscentral1a.release_channel_latest_version["STABLE"]
-  initial_node_count  = 1
-  deletion_protection = false
+  name               = "%s"
+  location           = "us-central1-a"
+  min_master_version = data.google_container_engine_versions.uscentral1a.release_channel_latest_version["STABLE"]
+  initial_node_count = 1
 
   # This feature has been available since GKE 1.27, and currently the only
   # supported Beta API is authentication.k8s.io/v1beta1/selfsubjectreviews.
@@ -10215,6 +10345,8 @@ resource "google_container_cluster" "primary" {
   }
   network    = "%s"
   subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, cluster, networkName, subnetworkName)
 }
@@ -10294,13 +10426,15 @@ resource "google_container_cluster" "with_autopilot" {
   name                = "%s"
   location            = "%s"
   enable_autopilot    = %v
-  deletion_protection = false
   min_master_version  = "latest"
   release_channel {
     channel = "RAPID"
   }
   network    = google_compute_network.container_network.name
   subnetwork = google_compute_subnetwork.container_subnetwork.name
+
+  deletion_protection = false
+
   ip_allocation_policy {
     cluster_secondary_range_name  = google_compute_subnetwork.container_subnetwork.secondary_ip_range[0].range_name
     services_secondary_range_name = google_compute_subnetwork.container_subnetwork.secondary_ip_range[1].range_name
@@ -10338,9 +10472,10 @@ resource "google_container_cluster" "primary" {
     cluster_dns_domain = "%s"
     cluster_dns_scope  = "%s"
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, clusterName, clusterDns, clusterDnsDomain, clusterDnsScope, networkName, subnetworkName)
 }
@@ -10715,14 +10850,15 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-f"
   initial_node_count = 1
   node_config {
-    machine_type    = "n1-standard-1"  // can't be e2 because of local-ssd
-    disk_size_gb    = 15
-    disk_type       = "pd-ssd"
-    node_group = google_compute_node_group.group.name
+    machine_type = "n1-standard-1" // can't be e2 because of local-ssd
+    disk_size_gb = 15
+    disk_type    = "pd-ssd"
+    node_group   = google_compute_node_group.group.name
   }
-  deletion_protection = false
   network    = "%s"
-  subnetwork    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, name, name, name, networkName, subnetworkName)
 }
@@ -10800,9 +10936,10 @@ resource "google_container_cluster" "primary" {
     }
     workload_vulnerability_mode = "BASIC"
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, name, networkName, subnetworkName)
 }
@@ -10820,9 +10957,10 @@ resource "google_container_cluster" "primary" {
     }
     workload_vulnerability_mode = "DISABLED"
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, name, networkName, subnetworkName)
 }
@@ -10916,9 +11054,10 @@ resource "google_container_cluster" "cluster" {
       policy_name = google_compute_resource_policy.policy.name
     }
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, policyName, cluster, np, networkName, subnetworkName)
 }
@@ -11060,9 +11199,10 @@ resource "google_container_cluster" "with_confidential_boot_disk" {
       disk_type                   = "hyperdisk-balanced"
     }
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, clusterName, npName, kmsKeyName, networkName, subnetworkName)
 }
@@ -11119,9 +11259,10 @@ resource "google_container_cluster" "with_confidential_boot_disk_node_config" {
     enable_confidential_storage = true
     disk_type                   = "hyperdisk-balanced"
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, clusterName, kmsKeyName, networkName, subnetworkName)
 }
@@ -11172,9 +11313,10 @@ resource "google_container_cluster" "without_confidential_boot_disk" {
       disk_type                   = "pd-balanced"
     }
   }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, clusterName, npName, networkName, subnetworkName)
 }
@@ -11992,9 +12134,6 @@ resource "google_container_cluster" "primary" {
   name               = "%s"
   location           = "us-central1-a"
   initial_node_count = 1
-  deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
 
   node_config {
     oauth_scopes = [
@@ -12010,6 +12149,11 @@ resource "google_container_cluster" "primary" {
       }
     }
   }
+
+  network    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, clusterName, networkName, subnetworkName)
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -12371,15 +12371,17 @@ provider "google" {
 }
 
 resource "google_container_cluster" "primary" {
-  name               = "%s"
-  location           = "us-central1-a"
+  name     = "%s"
+  location = "us-central1-a"
+
   initial_node_count = 1
-  deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
   resource_labels = {
     created-by = "terraform"
   }
+  network    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, name, networkName, subnetworkName)
 }
@@ -12393,16 +12395,18 @@ provider "google" {
 }
 
 resource "google_container_cluster" "primary" {
-  name                = "%s"
-  location            = "us-central1-a"
-  initial_node_count  = 1
-  deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
+  name     = "%s"
+  location = "us-central1-a"
+
+  initial_node_count = 1
   resource_labels = {
     created-by   = "terraform"
     default_key1 = "value1"
   }
+  network    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, name, networkName, subnetworkName)
 }
@@ -12417,12 +12421,15 @@ provider "google" {
 }
 
 resource "google_container_cluster" "primary" {
-  name                = "%s"
-  location            = "us-central1-a"
-  initial_node_count  = 1
+  name     = "%s"
+  location = "us-central1-a"
+
+  initial_node_count = 1
+
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
 }
 `, name, networkName, subnetworkName)
 }
@@ -12462,11 +12469,9 @@ func TestAccContainerCluster_storagePoolsWithNodePool(t *testing.T) {
 func testAccContainerCluster_storagePoolsWithNodePool(cluster, location, networkName, subnetworkName, np, storagePoolResourceName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "storage_pools_with_node_pool" {
-  name                = "%s"
-  location            = "%s"
-  deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
+  name     = "%s"
+  location = "%s"
+
   node_pool {
     name               = "%s"
     initial_node_count = 1
@@ -12477,6 +12482,10 @@ resource "google_container_cluster" "storage_pools_with_node_pool" {
       disk_type     = "hyperdisk-balanced"
     }
   }
+  network    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, cluster, location, networkName, subnetworkName, np, storagePoolResourceName)
 }
@@ -12515,18 +12524,21 @@ func TestAccContainerCluster_storagePoolsWithNodeConfig(t *testing.T) {
 func testAccContainerCluster_storagePoolsWithNodeConfig(cluster, location, networkName, subnetworkName, storagePoolResourceName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "storage_pools_with_node_config" {
-  name                = "%s"
-  location            = "%s"
-  initial_node_count  = 1
-  deletion_protection = false
-  network             = "%s"
-  subnetwork          = "%s"
+  name     = "%s"
+  location = "%s"
+
+  initial_node_count = 1
   node_config {
     machine_type  = "c3-standard-4"
     image_type    = "COS_CONTAINERD"
     storage_pools = ["%s"]
     disk_type     = "hyperdisk-balanced"
   }
+
+  network    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
 }
 `, cluster, location, networkName, subnetworkName, storagePoolResourceName)
 }


### PR DESCRIPTION
- Use direct references where possible for resource manager tags (similar to #12118 and #12132)
- Reformatting for much of the terraform code in `google_container_cluster` tests (similar to #12084 but for `google_container_cluster`
- Fix version guards to preferred style (resolves CI failure)
 
If you do a `git diff -w upstream/main  mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl` or similar, it makes it easier to see the changes other than whitespace.

I think the preference is to have `deletion_protection` by itself as it is here?

Feel free to close if it's a nuisance or too big.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
