### PR TITLE
container: unskipped VCR for `TestAccContainerCluster_privateRegistry`

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -11803,7 +11803,6 @@ resource "google_container_cluster" "with_autopilot" {
 
 func TestAccContainerCluster_privateRegistry(t *testing.T) {
 	// This test also checks containerd_config and its updates
-	acctest.SkipIfVcr(t)
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))


### PR DESCRIPTION
While working on #12216 (and #12135), I noticed that `TestAccContainerCluster_privateRegistry` appears to work in replaying mode:

```
--- PASS: TestAccContainerCluster_privateRegistry (34.42s)
PASS
ok  	github.com/hashicorp/terraform-provider-google/google/services/container	35.703s
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
