### PR TITLE
refactor: updated container version guard formatting

### DIFF
--- a/mmv1/third_party/terraform/services/container/container_operation.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/container_operation.go.tmpl
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
-{{ if eq $.TargetVersionName `ga` }}
+{{ if eq $.TargetVersionName "ga" }}
 	"google.golang.org/api/container/v1"
 {{- else }}
 	container "google.golang.org/api/container/v1beta1"

--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
-{{ if eq $.TargetVersionName `ga` }}
+{{ if eq $.TargetVersionName "ga" }}
 	"google.golang.org/api/container/v1"
 {{- else }}
 	container "google.golang.org/api/container/v1beta1"
@@ -258,7 +258,7 @@ func schemaNodeConfig() *schema.Schema {
 
 				"logging_variant": schemaLoggingVariant(),
 
-	{{ if ne $.TargetVersionName `ga` -}}
+	{{ if ne $.TargetVersionName "ga" }}
 				"ephemeral_storage_config": {
 					Type:     schema.TypeList,
 					Optional: true,
@@ -568,7 +568,7 @@ func schemaNodeConfig() *schema.Schema {
 					},
 				},
 
-	{{ if ne $.TargetVersionName `ga` -}}
+	{{ if ne $.TargetVersionName "ga" }}
 				"sandbox_config": {
 					Type:       schema.TypeList,
 					Optional:   true,
@@ -934,7 +934,7 @@ func expandNodeConfig(v interface{}) *container.NodeConfig {
 		}
 	}
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" }}
 	if v, ok := nodeConfig["ephemeral_storage_config"]; ok && len(v.([]interface{})) > 0 {
 		conf := v.([]interface{})[0].(map[string]interface{})
 		nc.EphemeralStorageConfig = &container.EphemeralStorageConfig{
@@ -1120,7 +1120,7 @@ func expandNodeConfig(v interface{}) *container.NodeConfig {
 		nc.WorkloadMetadataConfig = expandWorkloadMetadataConfig(v)
 	}
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" }}
 	if v, ok := nodeConfig["sandbox_config"]; ok && len(v.([]interface{})) > 0 {
 		conf := v.([]interface{})[0].(map[string]interface{})
 		nc.SandboxConfig = &container.SandboxConfig{
@@ -1160,7 +1160,7 @@ func expandNodeConfig(v interface{}) *container.NodeConfig {
 		nc.EnableConfidentialStorage = v.(bool)
 	}
 
-	{{ if ne $.TargetVersionName `ga` -}}
+	{{ if ne $.TargetVersionName "ga" }}
 	if v, ok := nodeConfig["host_maintenance_policy"]; ok {
 		nc.HostMaintenancePolicy = expandHostMaintenancePolicy(v)
 	}
@@ -1437,7 +1437,7 @@ func expandSoleTenantConfig(v interface{}) *container.SoleTenantConfig {
 	}
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" }}
 func expandHostMaintenancePolicy(v interface{}) *container.HostMaintenancePolicy {
 	if v == nil {
 		return nil
@@ -1625,7 +1625,7 @@ func flattenShieldedInstanceConfig(c *container.ShieldedInstanceConfig) []map[st
 	return result
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" }}
 func flattenEphemeralStorageConfig(c *container.EphemeralStorageConfig) []map[string]interface{} {
 	result := []map[string]interface{}{}
 	if c != nil {
@@ -1977,7 +1977,7 @@ func flattenFastSocket(c *container.FastSocket) []map[string]interface{} {
 	return result
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" }}
 func flattenHostMaintenancePolicy(c *container.HostMaintenancePolicy) []map[string]interface{} {
 	result := []map[string]interface{}{}
 	if c != nil {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -20,7 +20,7 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	"github.com/hashicorp/terraform-provider-google/google/verify"
 
-{{ if eq $.TargetVersionName `ga` }}
+{{ if eq $.TargetVersionName "ga" }}
 	"google.golang.org/api/container/v1"
 {{- else }}
 	container "google.golang.org/api/container/v1beta1"
@@ -927,7 +927,7 @@ func ResourceContainerCluster() *schema.Resource {
 {{- end }}
 			},
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 			"tpu_config": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -1147,7 +1147,7 @@ func ResourceContainerCluster() *schema.Resource {
 				},
 			},
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 			"protect_config": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -1515,7 +1515,7 @@ func ResourceContainerCluster() *schema.Resource {
 				Description: `The Kubernetes version on the nodes. Must either be unset or set to the same value as min_master_version on create. Defaults to the default version set by GKE which is not necessarily the latest version. This only affects nodes in the default node pool. While a fuzzy version can be specified, it's recommended that you specify explicit versions as Terraform will see spurious diffs when fuzzy versions are used. See the google_container_engine_versions data source's version_prefix field to approximate fuzzy versions in a Terraform-compatible way. To update nodes in other node pools, use the version attribute on the node pool.`,
 			},
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 			"pod_security_policy_config": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -1961,7 +1961,7 @@ func ResourceContainerCluster() *schema.Resource {
 				Description: `The IP address range of the Cloud TPUs in this cluster, in CIDR notation (e.g. 1.2.3.4/29).`,
 			},
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 			"cluster_telemetry": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -2551,7 +2551,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		cluster.IdentityServiceConfig = expandIdentityServiceConfig(v)
 	}
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 	if v, ok := d.GetOk("tpu_config"); ok {
 		cluster.TpuConfig = expandContainerClusterTpuConfig(v)
 	}
@@ -2613,7 +2613,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		cluster.AddonsConfig.GcePersistentDiskCsiDriverConfig.Enabled = true
 	}
 
-	{{ if ne $.TargetVersionName `ga` -}}
+	{{ if ne $.TargetVersionName "ga" -}}
 	if v, ok := d.GetOk("workload_alts_config"); ok {
 		cluster.WorkloadAltsConfig = expandWorkloadAltsConfig(v)
 	}
@@ -3040,7 +3040,7 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 	if err := d.Set("pod_security_policy_config", flattenPodSecurityPolicyConfig(cluster.PodSecurityPolicyConfig)); err != nil {
 		return err
 	}
@@ -3105,13 +3105,13 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 	if err := d.Set("protect_config", flattenProtectConfig(cluster.ProtectConfig)); err != nil {
 		return err
 	}
 {{- end }}
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 	if err := d.Set("workload_alts_config", flattenWorkloadAltsConfig(cluster.WorkloadAltsConfig)); err != nil {
 		return err
 	}
@@ -3460,7 +3460,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		log.Printf("[INFO] GKE cluster %s L4 ILB Subsetting has been updated to %v", d.Id(), enabled)
 	}
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 	if d.HasChange("enable_fqdn_network_policy") {
 		enabled := d.Get("enable_fqdn_network_policy").(bool)
 		req := &container.UpdateClusterRequest{
@@ -3998,7 +3998,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		log.Printf("[INFO] GKE cluster %s database encryption config has been updated", d.Id())
 	}
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 	if d.HasChange("pod_security_policy_config") {
 		c := d.Get("pod_security_policy_config")
 		req := &container.UpdateClusterRequest{
@@ -4457,7 +4457,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 	d.Partial(false)
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 	if d.HasChange("cluster_telemetry") {
 		req := &container.UpdateClusterRequest{
 			Update: &container.ClusterUpdate{
@@ -4495,7 +4495,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 	if d.HasChange("protect_config") {
 		req := &container.UpdateClusterRequest{
 			Update: &container.ClusterUpdate{
@@ -4758,7 +4758,7 @@ func expandClusterAddonsConfig(configured interface{}) *container.AddonsConfig {
 		}
 	}
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 	if v, ok := config["istio_config"]; ok && len(v.([]interface{})) > 0 {
 		addon := v.([]interface{})[0].(map[string]interface{})
 		ac.IstioConfig = &container.IstioConfig{
@@ -5100,7 +5100,7 @@ func expandAuthenticatorGroupsConfig(configured interface{}) *container.Authenti
 	return result
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 func expandProtectConfig(configured interface{}) *container.ProtectConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
@@ -5434,7 +5434,7 @@ func expandReleaseChannel(configured interface{}) *container.ReleaseChannel {
 	}
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 func expandClusterTelemetry(configured interface{}) *container.ClusterTelemetry {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
@@ -5487,7 +5487,7 @@ func expandIdentityServiceConfig(configured interface{}) *container.IdentityServ
 	return v
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 func expandPodSecurityPolicyConfig(configured interface{}) *container.PodSecurityPolicyConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
@@ -5707,7 +5707,7 @@ func expandMonitoringConfig(configured interface{}) *container.MonitoringConfig 
 	return mc
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 func expandContainerClusterTpuConfig(configured interface{}) *container.TpuConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
@@ -5805,7 +5805,7 @@ func expandNodePoolAutoConfigNetworkTags(configured interface{}) *container.Netw
 	return nt
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 func expandWorkloadAltsConfig(configured interface{}) *container.WorkloadALTSConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
@@ -5994,7 +5994,7 @@ func flattenClusterAddonsConfig(c *container.AddonsConfig) []map[string]interfac
 		}
 	}
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 	if c.IstioConfig != nil {
 		result["istio_config"] = []map[string]interface{}{
 			{
@@ -6096,7 +6096,7 @@ func flattenReleaseChannel(c *container.ReleaseChannel) []map[string]interface{}
 	return result
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 
 func flattenClusterTelemetry(c *container.ClusterTelemetry) []map[string]interface{} {
 	result := []map[string]interface{}{}
@@ -6400,7 +6400,7 @@ func flattenMasterAuthorizedNetworksConfig(c *container.MasterAuthorizedNetworks
 	return []map[string]interface{}{result}
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 func flattenPodSecurityPolicyConfig(c *container.PodSecurityPolicyConfig) []map[string]interface{} {
 	if c == nil {
 		return []map[string]interface{}{
@@ -6664,7 +6664,7 @@ func flattenNodePoolAutoConfigNetworkTags(c *container.NetworkTags) []map[string
 	return []map[string]interface{}{result}
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 func flattenWorkloadAltsConfig(c *container.WorkloadALTSConfig) []map[string]interface{} {
 	if c == nil {
 		return nil
@@ -6870,7 +6870,7 @@ func containerClusterNetworkPolicyEmptyCustomizeDiff(_ context.Context, d *schem
 	return nil
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 func podSecurityPolicyCfgSuppress(k, old, new string, r *schema.ResourceData) bool {
 	if k == "pod_security_policy_config.#" && old == "1" && new == "0" {
 		if v, ok := r.GetOk("pod_security_policy_config"); ok {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_internal_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_internal_test.go.tmpl
@@ -10,7 +10,7 @@ import (
 {{- end }}
 )
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{- if ne $.TargetVersionName "ga" }}
 func TestValidateNodePoolAutoConfig(t *testing.T) {
 	withTags := &container.NodePoolAutoConfig{
 		NetworkTags: &container.NetworkTags{

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_migratev1.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_migratev1.go.tmpl
@@ -660,7 +660,7 @@ func resourceContainerClusterResourceV1() *schema.Resource {
 {{- end }}
 			},
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" }}
 			"tpu_config": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -880,7 +880,7 @@ func resourceContainerClusterResourceV1() *schema.Resource {
 				},
 			},
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 			"protect_config": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -1249,7 +1249,7 @@ func resourceContainerClusterResourceV1() *schema.Resource {
 				Description: `The Kubernetes version on the nodes. Must either be unset or set to the same value as min_master_version on create. Defaults to the default version set by GKE which is not necessarily the latest version. This only affects nodes in the default node pool. While a fuzzy version can be specified, it's recommended that you specify explicit versions as Terraform will see spurious diffs when fuzzy versions are used. See the google_container_engine_versions data source's version_prefix field to approximate fuzzy versions in a Terraform-compatible way. To update nodes in other node pools, use the version attribute on the node pool.`,
 			},
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 			"pod_security_policy_config": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -1663,7 +1663,7 @@ func resourceContainerClusterResourceV1() *schema.Resource {
 				Description: `The IP address range of the Cloud TPUs in this cluster, in CIDR notation (e.g. 1.2.3.4/29).`,
 			},
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 			"cluster_telemetry": {
 				Type:     schema.TypeList,
 				Optional: true,

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -482,7 +482,7 @@ func TestAccContainerCluster_withMultiNetworking(t *testing.T) {
 	})
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 func TestAccContainerCluster_withFQDNNetworkPolicy(t *testing.T) {
 	t.Parallel()
 
@@ -742,7 +742,7 @@ resource "google_container_cluster" "cluster" {
 `, clusterName)
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 func testAccContainerCluster_withFQDNNetworkPolicy(clusterName string, enabled bool) string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "uscentral1a" {
@@ -1000,7 +1000,7 @@ func TestAccContainerCluster_withInvalidReleaseChannel(t *testing.T) {
 	})
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 func TestAccContainerCluster_withTelemetryEnabled(t *testing.T) {
 	t.Parallel()
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
@@ -1290,7 +1290,7 @@ func TestAccContainerCluster_regionalWithNodeLocations(t *testing.T) {
 	})
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 func TestAccContainerCluster_withTpu(t *testing.T) {
 	t.Parallel()
 
@@ -4058,8 +4058,7 @@ func TestAccContainerCluster_withInvalidAutoscalingProfile(t *testing.T) {
 	})
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
-
+{{ if ne $.TargetVersionName "ga" -}}
 func TestAccContainerCluster_sharedVpc(t *testing.T) {
 	// Multiple fine-grained resources
 	acctest.SkipIfVcr(t)
@@ -5098,7 +5097,7 @@ func TestAccContainerCluster_withGatewayApiConfig(t *testing.T) {
 	})
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 func TestAccContainerCluster_withTPUConfig(t *testing.T) {
 	t.Parallel()
 
@@ -5258,7 +5257,7 @@ func TestAccContainerCluster_withFleetConfig(t *testing.T) {
 	})
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 func TestAccContainerCluster_withWorkloadALTSConfig(t *testing.T) {
 	t.Parallel()
 
@@ -6551,7 +6550,7 @@ resource "google_container_cluster" "with_release_channel" {
 `, clusterName, channel, networkName, subnetworkName)
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 func testAccContainerCluster_withTelemetryEnabled(clusterName, telemetryType, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_cluster_telemetry" {
@@ -7035,7 +7034,7 @@ resource "google_container_cluster" "with_node_locations" {
 `, clusterName, networkName, subnetworkName)
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 func testAccContainerCluster_withTpu(containerNetName string, clusterName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "container_network" {
@@ -7090,8 +7089,8 @@ resource "google_container_cluster" "with_tpu" {
 }
 `, containerNetName, clusterName)
 }
+{{- end }}
 
-{{ end }}
 func testAccContainerCluster_withIntraNodeVisibility(clusterName, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_intranode_visibility" {
@@ -10728,7 +10727,7 @@ resource "google_container_cluster" "primary" {
 `, name, name, name, networkName, subnetworkName)
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 func testAccContainerCluster_withTPUConfig(network, cluster string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "container_network" {
@@ -10785,9 +10784,9 @@ resource "google_container_cluster" "with_tpu_config" {
 }
 `, network, cluster)
 }
-{{- end }}
+{{ end }}
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{- if ne $.TargetVersionName "ga" }}
 func testAccContainerCluster_withProtectConfig(name, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
@@ -11181,7 +11180,7 @@ resource "google_container_cluster" "without_confidential_boot_disk" {
 `, clusterName, npName, networkName, subnetworkName)
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 func testAccContainerCluster_withWorkloadALTSConfig(projectID, name, networkName, subnetworkName string, enable bool) string {
   return fmt.Sprintf(`
   data "google_project" "project" {
@@ -11241,8 +11240,7 @@ func testAccContainerCluster_withWorkloadALTSConfigAutopilot(projectID, name str
   }
 `, projectID, name, enable)
 }
-
-{{ end }}
+{{- end }}
 
 func testAccContainerCluster_withAutopilotKubeletConfigBaseline(name string) string {
   return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
@@ -17,7 +17,7 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	"github.com/hashicorp/terraform-provider-google/google/verify"
 
-{{ if eq $.TargetVersionName `ga` }}
+{{ if eq $.TargetVersionName "ga" }}
 	"google.golang.org/api/container/v1"
 {{- else }}
 	container "google.golang.org/api/container/v1beta1"

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -1482,9 +1482,7 @@ func TestAccContainerNodePool_withSoleTenantConfig(t *testing.T) {
 	})
 }
 
-
-
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 func TestAccContainerNodePool_ephemeralStorageConfig(t *testing.T) {
 	t.Parallel()
 
@@ -4230,7 +4228,7 @@ resource "google_container_node_pool" "with_tpu_topology" {
 `, cluster, networkName, subnetworkName, np1, np2, tpuTopology)
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
+{{ if ne $.TargetVersionName "ga" -}}
 func TestAccContainerNodePool_withHostMaintenancePolicy(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Cherry-picking out separately the version guard formatting changes CI seems to want.

Note: there may still be some lines or files that use a slightly different style; does result in a few whitespace changes downstream - let me know if some of these should not have the `-` on the left to trim space.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
