### PR TITLE
transcoder: ignored `start_time` in `JobManifestsExample` test

### DIFF
--- a/mmv1/products/transcoder/Job.yaml
+++ b/mmv1/products/transcoder/Job.yaml
@@ -76,6 +76,7 @@ examples:
     ignore_read_extra:
       - 'state'
       - 'end_time'
+      - 'start_time'
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/transcoder/Job.yaml
+++ b/mmv1/products/transcoder/Job.yaml
@@ -75,8 +75,8 @@ examples:
       bucket_name: 'transcoder-job'
     ignore_read_extra:
       - 'state'
-      - 'end_time'
       - 'start_time'
+      - 'end_time'
 parameters:
   - name: 'location'
     type: String


### PR DESCRIPTION
Ignored `start_time` for `TestAccTranscoderJob_transcoderJobManifestsExample` (assume the other tests aren't failing as often, but could ignore this in some / all of the other ones where `end_time` is already ignored if desired.

Fixes hashicorp/terraform-provider-google#20004

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```