### PR TITLE
alloydb: re-enabled VCR for `TestAccAlloydb*` tests

### DIFF
--- a/mmv1/products/alloydb/Backup.yaml
+++ b/mmv1/products/alloydb/Backup.yaml
@@ -75,7 +75,6 @@ examples:
     ignore_read_extra:
       - 'reconciling'
       - 'update_time'
-    exclude_test: true
   - name: 'alloydb_backup_full_test'
     primary_resource_id: 'default'
     vars:

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_secondary_cluster_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_secondary_cluster_test.go
@@ -11,8 +11,6 @@ import (
 // The cluster creation should succeed with minimal number of arguments
 func TestAccAlloydbCluster_secondaryClusterMandatoryFields(t *testing.T) {
 	t.Parallel()
-	// https://github.com/hashicorp/terraform-provider-google/issues/16231
-	acctest.SkipIfVcr(t)
 	context := map[string]interface{}{
 		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydbinstance-network-config-1"),
 		"random_suffix": acctest.RandString(t, 10),
@@ -151,9 +149,6 @@ data "google_compute_network" "default" {
 // Validation test to ensure proper error is raised if secondary_config field is provided but no cluster_type is specified.
 func TestAccAlloydbCluster_secondaryClusterDefinedSecondaryConfigButMissingClusterTypeSecondary(t *testing.T) {
 	t.Parallel()
-
-	// Unskip in https://github.com/hashicorp/terraform-provider-google/issues/16231
-	acctest.SkipIfVcr(t)
 
 	context := map[string]interface{}{
 		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydbinstance-network-config-1"),


### PR DESCRIPTION
Fixes hashicorp/terraform-provider-google#16231

From [this comment](https://github.com/hashicorp/terraform-provider-google/issues/16231#issuecomment-1986290508), I think these 3 tests can just be re-enabled, unless there's something else specific the owning team has to do?

All 3 of these pass in both recording and replaying mode in my test project, though IIRC, I got a segfault vs. just an error before enabling `servicenetworking` (is there a utility to ensure a specific service is enabled in the default test project). I think you have a way to run this in Teamcity too, which would probably confirm if the test will work there?

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
