### PR TITLE
Add support for Dataproc on GDC ApplicationEnvironment

### DIFF
--- a/mmv1/products/dataprocgdc/ApplicationEnvironment.yaml
+++ b/mmv1/products/dataprocgdc/ApplicationEnvironment.yaml
@@ -1,0 +1,107 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: ApplicationEnvironment
+references:
+  guides:
+    'Dataproc Intro': 'https://cloud.google.com/dataproc/'
+  api: 'https://cloud.google.com/dataproc-gdc/docs/reference/rest/v1/projects.locations.applicationEnvironments'
+description: An ApplicationEnvironment contains shared configuration that may be referenced by multiple SparkApplications.
+base_url: projects/{{project}}/locations/{{location}}/serviceInstances/{{serviceinstance}}/applicationEnvironments
+create_url: projects/{{project}}/locations/{{location}}/serviceInstances/{{serviceinstance}}/applicationEnvironments?applicationEnvironmentId={{application_environment_id}}
+self_link: projects/{{project}}/locations/{{location}}/serviceInstances/{{serviceinstance}}/applicationEnvironments/{{application_environment_id}}
+id_format: projects/{{project}}/locations/{{location}}/serviceInstances/{{serviceinstance}}/applicationEnvironments/{{application_environment_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/serviceInstances/{{serviceinstance}}/applicationEnvironments/{{application_environment_id}}
+parameters:
+  - name: location
+    type: String
+    description: 'The location of the application environment'
+    url_param_only: true
+    required: true
+    immutable: true
+  - name: serviceinstance
+    type: String
+    description: 'The id of the service instance to which this application environment belongs.'
+    url_param_only: true
+    required: true
+    immutable: true
+  - name: applicationEnvironmentId
+    type: String
+    description: 'The id of the application environment '
+    url_param_only: true
+    immutable: true
+examples:
+  - name: "dataprocgdc_applicationenvironment_basic"
+    primary_resource_id: "application-environment"
+    vars:
+      application_environment_id: "dp-tf-e2e-application-environment-basic"
+      project: "my-project"
+    test_vars_overrides:
+      'project': '"gdce-cluster-monitoring"'
+  - name: "dataprocgdc_applicationenvironment"
+    primary_resource_id: "application-environment"
+    vars:
+      application_environment_id: "dp-tf-e2e-application-environment"
+      project: "my-project"
+    test_vars_overrides:
+      'project': '"gdce-cluster-monitoring"'
+update_verb: PATCH
+update_mask: true
+autogen_async: false
+properties:
+  - name: name
+    type: String
+    description: "Identifier. The name of the application environment. Format: projects/{project}/locations/{location}/serviceInstances/{service_instance}/applicationEnvironments/{application_environment_id} "
+    output: true
+  - name: uid
+    type: String
+    description: "System generated unique identifier for this application environment, formatted as UUID4. "
+    output: true
+  - name: displayName
+    type: String
+    description: 'User-provided human-readable name to be used in user interfaces. '
+  - name: createTime
+    type: String
+    description: 'The timestamp when the resource was created. '
+    output: true
+  - name: updateTime
+    type: String
+    description: 'The timestamp when the resource was most recently updated. '
+    output: true
+  - name: labels
+    type: KeyValueLabels
+    description: "The labels to associate with this application environment.
+      Labels may be used for filtering and billing tracking. "
+  - name: annotations
+    type: KeyValueAnnotations
+    description: "The annotations to associate with this application environment.
+      Annotations may be used to store client information, but are not used by the
+      server."
+  - name: sparkApplicationEnvironmentConfig
+    type: NestedObject
+    properties:
+      - name: defaultProperties
+        type: KeyValuePairs
+        description: "A map of default Spark properties to apply to workloads
+          in this application environment. These defaults may be overridden by per-application properties. "
+      - name: defaultVersion
+        type: String
+        description: "The default Dataproc version to use for applications submitted
+          to this application environment "
+    description: 'Represents the SparkApplicationEnvironmentConfig. '
+  - name: namespace
+    type: String
+    description: "The name of the namespace in which to create this ApplicationEnvironment. This
+      namespace must already exist in the cluster "

--- a/mmv1/templates/terraform/examples/dataprocgdc_applicationenvironment.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataprocgdc_applicationenvironment.tf.tmpl
@@ -1,0 +1,20 @@
+resource "google_dataproc_gdc_application_environment" "{{$.PrimaryResourceId}}" {
+  application_environment_id = "{{index $.Vars "application_environment_id"}}"
+  serviceinstance = "do-not-delete-dataproc-gdc-instance"
+  project         = "{{index $.Vars "project"}}"
+  location        = "us-west2"
+  namespace = "default"
+  display_name = "An application environment"
+  labels = {
+    "test-label": "label-value"
+  }
+  annotations = {
+    "an_annotation": "annotation_value"
+  }
+  spark_application_environment_config {
+    default_properties = {
+      "spark.executor.memory": "4g"
+    }
+    default_version = "1.2"
+  }
+}

--- a/mmv1/templates/terraform/examples/dataprocgdc_applicationenvironment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataprocgdc_applicationenvironment_basic.tf.tmpl
@@ -1,0 +1,7 @@
+resource "google_dataproc_gdc_application_environment" "{{$.PrimaryResourceId}}" {
+  application_environment_id = "{{index $.Vars "application_environment_id"}}"
+  serviceinstance = "do-not-delete-dataproc-gdc-instance"
+  project         = "{{index $.Vars "project"}}"
+  location        = "us-west2"
+  namespace = "default"
+}

--- a/mmv1/third_party/terraform/services/dataprocgdc/resource_dataproc_gdc_application_environment_test.go
+++ b/mmv1/third_party/terraform/services/dataprocgdc/resource_dataproc_gdc_application_environment_test.go
@@ -1,0 +1,93 @@
+package dataprocgdc_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccDataprocGdcApplicationEnvironment_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataprocGdcApplicationEnvironment_full(context),
+			},
+			{
+				ResourceName:            "google_dataproc_gdc_application_environment.application-environment",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "application_environment_id", "labels", "location", "serviceinstance", "terraform_labels"},
+			},
+			{
+				Config: testAccDataprocGdcApplicationEnvironment_update(context),
+			},
+			{
+				ResourceName:            "google_dataproc_gdc_application_environment.application-environment",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "application_environment_id", "labels", "location", "serviceinstance", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccDataprocGdcApplicationEnvironment_full(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_dataproc_gdc_application_environment" "application-environment" {
+  application_environment_id = "tf-test-dp-tf-e2e-application-environment%{random_suffix}"
+  serviceinstance = "do-not-delete-dataproc-gdc-instance"
+  project         = "gdce-cluster-monitoring"
+  location        = "us-west2"
+  namespace = "default"
+  display_name = "An application environment"
+  labels = {
+    "test-label": "label-value"
+  }
+  annotations = {
+    "an_annotation": "annotation_value"
+  }
+  spark_application_environment_config {
+    default_properties = {
+      "spark.executor.memory": "4g"
+    }
+    default_version = "1.2"
+  }
+}
+`, context)
+}
+
+func testAccDataprocGdcApplicationEnvironment_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_dataproc_gdc_application_environment" "application-environment" {
+  application_environment_id = "tf-test-dp-tf-e2e-application-environment%{random_suffix}"
+  serviceinstance = "do-not-delete-dataproc-gdc-instance"
+  project         = "gdce-cluster-monitoring"
+  location        = "us-west2"
+  namespace = "default"
+  display_name = "An application environment"
+  labels = {
+    "test-label": "new-label-value"
+  }
+  annotations = {
+    "an_annotation": "new_annotation_value"
+    "another_annotation": "ok"
+  }
+  spark_application_environment_config {
+    default_properties = {
+      "spark.executor.memory": "2g"
+    }
+    default_version = "1.1"
+  }
+}
+`, context)
+}


### PR DESCRIPTION
This PR adds support for the Dataproc on GDC ApplicationEnvironment resource to the provider.

```release-note:new-resource
`google_dataproc_gdc_application_environment`
```
