### PR TITLE
ci: updated match group in reassign-reviewer

### DIFF
--- a/.github/workflows/reassign-reviewer.yml
+++ b/.github/workflows/reassign-reviewer.yml
@@ -42,4 +42,4 @@ jobs:
           go build .
       - name: Run command
         if: steps.read-comment.outputs.match != ''
-        run: .ci/magician/magician reassign-reviewer ${{ github.event.issue.number }} ${{ steps.read-comment.outputs.match.groups.1 }}
+        run: .ci/magician/magician reassign-reviewer ${{ github.event.issue.number }} ${{ steps.read-comment.outputs.match.group1 }}


### PR DESCRIPTION
Related to hashicorp/terraform-provider-google#19691 and #12193

Seeing if this resolves failures like [this one](https://github.com/GoogleCloudPlatform/magic-modules/actions/runs/11635154095)

Based on the docs for the third party action this is using, seems like it should be `group1` vs `group.1`: https://github.com/actions-ecosystem/action-regex-match

Actionlint seems to complain unless I take the `${{ }}` out entirely, which from reading the docs _might_ be valid?

```
% actionlint .github/workflows/reassign-reviewer.yml
.github/workflows/reassign-reviewer.yml:45:91: receiver of object dereference "group1" must be type of object but got "string" [expression]
   |
45 |         run: .ci/magician/magician reassign-reviewer ${{ github.event.issue.number }} ${{ steps.read-comment.outputs.match.group1 }}
   |                                                                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
