### PR TITLE
tgc fix: Check that storageClient is not nil before fetching GCS bucket

### DIFF
--- a/mmv1/third_party/tgc/ancestrymanager/ancestrymanager.go
+++ b/mmv1/third_party/tgc/ancestrymanager/ancestrymanager.go
@@ -364,7 +364,7 @@ func (m *manager) getProjectFromResource(d tpgresource.TerraformResourceData, co
 		m.errorLogger.Warn(fmt.Sprintf("Failed to retrieve project_id for %s from cai resource", cai.Name))
 
 		bucketField, ok := d.GetOk("bucket")
-		if ok {
+		if ok && m.storageClient != nil {
 			bucket := bucketField.(string)
 			resp, err := m.storageClient.Buckets.Get(bucket).Do()
 			if err == nil {


### PR DESCRIPTION
When running the conversion in offline mode, this client is nil which causes the converter to panic.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
tgc: fixed a panic in storageClient when running tfplan2cai converter in offline mode
```
