### PR TITLE
compute: forced recreation of `google_compute_security_policy` on `type` updates

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
@@ -71,6 +71,7 @@ func ResourceComputeSecurityPolicy() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
+				ForceNew:    true,
 				Description: `The type indicates the intended use of the security policy. CLOUD_ARMOR - Cloud Armor backend security policies can be configured to filter incoming HTTP requests targeting backend services. They filter requests before they hit the origin servers. CLOUD_ARMOR_EDGE - Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache.`,
 				ValidateFunc: validation.StringInSlice([]string{"CLOUD_ARMOR", "CLOUD_ARMOR_EDGE", "CLOUD_ARMOR_INTERNAL_SERVICE"}, false),
 			},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.tmpl
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
@@ -22,7 +23,48 @@ func TestAccComputeSecurityPolicy_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckComputeSecurityPolicyDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeSecurityPolicy_basic(spName),
+				Config: testAccComputeSecurityPolicy_basic(spName, "CLOUD_ARMOR"),
+			},
+			{
+				ResourceName:      "google_compute_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeSecurityPolicy_basicUpdate(t *testing.T) {
+	t.Parallel()
+
+	spName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeSecurityPolicyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSecurityPolicy_basic(spName, "CLOUD_ARMOR"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_compute_security_policy.policy", "type", "CLOUD_ARMOR"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeSecurityPolicy_basic(spName, "CLOUD_ARMOR_EDGE"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_compute_security_policy.policy", plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_compute_security_policy.policy", "type", "CLOUD_ARMOR_EDGE"),
+				),
 			},
 			{
 				ResourceName:      "google_compute_security_policy.policy",
@@ -205,7 +247,7 @@ func TestAccComputeSecurityPolicy_withAdvancedOptionsConfig(t *testing.T) {
 		CheckDestroy:             testAccCheckComputeSecurityPolicyDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeSecurityPolicy_basic(spName),
+				Config: testAccComputeSecurityPolicy_basic(spName, "CLOUD_ARMOR"),
 			},
 			{
 				ResourceName:      "google_compute_security_policy.policy",
@@ -247,7 +289,7 @@ func TestAccComputeSecurityPolicy_withAdvancedOptionsConfig(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeSecurityPolicy_basic(spName),
+				Config: testAccComputeSecurityPolicy_basic(spName, "CLOUD_ARMOR"),
 			},
 			{
 				ResourceName:      "google_compute_security_policy.policy",
@@ -527,7 +569,7 @@ func TestAccComputeSecurityPolicy_withRecaptchaOptionsConfig(t *testing.T) {
 		CheckDestroy:             testAccCheckComputeSecurityPolicyDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeSecurityPolicy_basic(spName),
+				Config: testAccComputeSecurityPolicy_basic(spName, "CLOUD_ARMOR"),
 			},
 			{
 				ResourceName:      "google_compute_security_policy.policy",
@@ -775,14 +817,14 @@ func testAccCheckComputeSecurityPolicyDestroyProducer(t *testing.T) func(s *terr
 	}
 }
 
-func testAccComputeSecurityPolicy_basic(spName string) string {
+func testAccComputeSecurityPolicy_basic(spName, policyType string) string {
 	return fmt.Sprintf(`
 resource "google_compute_security_policy" "policy" {
   name        = "%s"
   description = "basic security policy"
-  type        = "CLOUD_ARMOR"
+  type        = "%s"
 }
-`, spName)
+`, spName, policyType)
 }
 
 func testAccComputeSecurityPolicy_withRule(spName string) string {


### PR DESCRIPTION
Updating the `type` of `google_compute_security_policy` (e.g., from `CLOUD_ARMOR` to `CLOUD_ARMOR_EDGE`) requires the resource to be recreated.

Fixes hashicorp/terraform-provider-google#20071

Without the change (and without the plancheck), verified that this test fails.
```
    resource_compute_security_policy_test.go:43: Step 3/4 error: Check failed: Check 1/1 error: google_compute_security_policy.policy: Attribute 'type' expected "CLOUD_ARMOR_EDGE", got "CLOUD_ARMOR"
--- FAIL: TestAccComputeSecurityPolicy_basicUpdate (41.37s)
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fixed permadiff on attempted `type` field updates in `google_computer_security_policy`, updating this field will now force recreation of the resource
```
