### PR TITLE
Support SQL Server Switchover (after resolving email rebase conflicts)

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -185,6 +185,7 @@ func ResourceSqlDatabaseInstance() *schema.Resource {
 						"edition": {
 							Type:         schema.TypeString,
 							Optional:     true,
+							Computed:     true,
 							Default:      "ENTERPRISE",
 							ValidateFunc: validation.StringInSlice([]string{"ENTERPRISE", "ENTERPRISE_PLUS"}, false),
 							Description:  `The edition of the instance, can be ENTERPRISE or ENTERPRISE_PLUS.`,
@@ -206,6 +207,7 @@ func ResourceSqlDatabaseInstance() *schema.Resource {
 						"data_cache_config": {
 							Type:        schema.TypeList,
 							Optional:    true,
+							Computed:    true,
 							MaxItems:    1,
 							Description: `Data cache configurations.`,
 							Elem: &schema.Resource{

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -89,6 +90,7 @@ var (
 	}
 
 	replicaConfigurationKeys = []string{
+		"replica_configuration.0.cascadable_replica",
 		"replica_configuration.0.ca_certificate",
 		"replica_configuration.0.client_certificate",
 		"replica_configuration.0.client_key",
@@ -136,7 +138,13 @@ func ResourceSqlDatabaseInstance() *schema.Resource {
 		CustomizeDiff: customdiff.All(
 			tpgresource.DefaultProviderProject,
 			customdiff.ForceNewIfChange("settings.0.disk_size", compute.IsDiskShrinkage),
-			customdiff.ForceNewIfChange("master_instance_name", isMasterInstanceNameSet),
+			customdiff.ForceNewIf("master_instance_name", func(_ context.Context, d *schema.ResourceDiff, meta interface{}) bool {
+				// If we set master but this is not the new master of a switchover, require replacement and warn user.
+				return !isSwitchoverFromOldPrimarySide(d)
+			}),
+			customdiff.ForceNewIf("replica_configuration.0.cascadable_replica", func(_ context.Context, d *schema.ResourceDiff, meta interface{}) bool {
+				return !isSwitchoverFromOldPrimarySide(d)
+			}),
 			customdiff.IfValueChange("instance_type", isReplicaPromoteRequested, checkPromoteConfigurationsAndUpdateDiff),
 			privateNetworkCustomizeDiff,
 			pitrSupportDbCustomizeDiff,
@@ -177,7 +185,7 @@ func ResourceSqlDatabaseInstance() *schema.Resource {
 						"edition": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							Computed:     true,
+							Default:      "ENTERPRISE",
 							ValidateFunc: validation.StringInSlice([]string{"ENTERPRISE", "ENTERPRISE_PLUS"}, false),
 							Description:  `The edition of the instance, can be ENTERPRISE or ENTERPRISE_PLUS.`,
 						},
@@ -198,7 +206,6 @@ func ResourceSqlDatabaseInstance() *schema.Resource {
 						"data_cache_config": {
 							Type:        schema.TypeList,
 							Optional:    true,
-							Computed:    true,
 							MaxItems:    1,
 							Description: `Data cache configurations.`,
 							Elem: &schema.Resource{
@@ -801,6 +808,12 @@ is set to true. Defaults to ZONAL.`,
 							AtLeastOneOf: replicaConfigurationKeys,
 							Description:  `PEM representation of the trusted CA's x509 certificate.`,
 						},
+						"cascadable_replica": {
+							Type: schema.TypeBool,
+							Optional: true,
+							AtLeastOneOf: replicaConfigurationKeys, 
+							Description: `Specifies if a SQL Server replica is a cascadable replica. A cascadable replica is a SQL Server cross region replica that supports replica(s) under it.`,
+						},
 						"client_certificate": {
 							Type:         schema.TypeString,
 							Optional:     true,
@@ -875,6 +888,15 @@ is set to true. Defaults to ZONAL.`,
 					},
 				},
 				Description: `The configuration for replication.`,
+			},
+			"replica_names": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: `The replicas of the instance.`,
 			},
 			"server_ca_cert": {
 				Type:      schema.TypeList,
@@ -1318,6 +1340,7 @@ func expandReplicaConfiguration(configured []interface{}) *sqladmin.ReplicaConfi
 
 	_replicaConfiguration := configured[0].(map[string]interface{})
 	return &sqladmin.ReplicaConfiguration{
+		CascadableReplica: _replicaConfiguration["cascadable_replica"].(bool),
 		FailoverTarget: _replicaConfiguration["failover_target"].(bool),
 
 		// MysqlReplicaConfiguration has been flattened in the TF schema, so
@@ -1646,6 +1669,10 @@ func resourceSqlDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) e
 	if err := d.Set("replica_configuration", flattenReplicaConfiguration(instance.ReplicaConfiguration, d)); err != nil {
 		log.Printf("[WARN] Failed to set SQL Database Instance Replica Configuration")
 	}
+	
+	if err := d.Set("replica_names", instance.ReplicaNames); err != nil {
+		return fmt.Errorf("Error setting replica_names: %w", err)
+	}
 	ipAddresses := flattenIpAddresses(instance.IpAddresses)
 	if err := d.Set("ip_address", ipAddresses); err != nil {
 		log.Printf("[WARN] Failed to set SQL Database Instance IP Addresses")
@@ -1700,6 +1727,14 @@ func resourceSqlDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) e
 	return nil
 }
 
+type replicaDRKind int
+
+const (
+	replicaDRNone replicaDRKind = iota
+	replicaDRByPromote
+	replicaDRBySwitchover
+)
+
 func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
 	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
@@ -1716,17 +1751,20 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 		maintenance_version = v.(string)
 	}
 
-	promoteReadReplicaRequired := false
+	replicaDRKind := replicaDRNone
 	if d.HasChange("instance_type") {
 		oldInstanceType, newInstanceType := d.GetChange("instance_type")
 
 		if isReplicaPromoteRequested(nil, oldInstanceType, newInstanceType, nil) {
-			err = checkPromoteConfigurations(d)
-			if err != nil {
-				return err
+			if isSwitchoverRequested(d) {
+				replicaDRKind = replicaDRBySwitchover
+			} else {
+				err = checkPromoteConfigurations(d)
+				if err != nil {
+					return err
+				}
+				replicaDRKind = replicaDRByPromote
 			}
-
-			promoteReadReplicaRequired = true
 		}
 	}
 
@@ -1874,12 +1912,25 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 		}
 	}
 
-	if promoteReadReplicaRequired {
-		err = transport_tpg.Retry(transport_tpg.RetryOptions{
-			RetryFunc: func() (rerr error) {
+	if replicaDRKind != replicaDRNone {
+		var retryFunc func() (rerr error)
+		switch replicaDRKind {
+		case replicaDRByPromote:
+			retryFunc = func() (rerr error) {
 				op, rerr = config.NewSqlAdminClient(userAgent).Instances.PromoteReplica(project, d.Get("name").(string)).Do()
 				return rerr
-			},
+			}
+		case replicaDRBySwitchover:
+			retryFunc = func() (rerr error) {
+				op, rerr = config.NewSqlAdminClient(userAgent).Instances.Switchover(project, d.Get("name").(string)).Do()
+				return rerr
+			}
+		default:
+			return fmt.Errorf("unknown replica DR scenario: %v", replicaDRKind)
+		}
+
+		err = transport_tpg.Retry(transport_tpg.RetryOptions{
+			RetryFunc:            retryFunc,
 			Timeout:              d.Timeout(schema.TimeoutUpdate),
 			ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{transport_tpg.IsSqlOperationInProgressError},
 		})
@@ -2340,6 +2391,7 @@ func flattenReplicaConfiguration(replicaConfiguration *sqladmin.ReplicaConfigura
 
 	if replicaConfiguration != nil {
 		data := map[string]interface{}{
+			"cascadable_replica": replicaConfiguration.CascadableReplica,
 			"failover_target": replicaConfiguration.FailoverTarget,
 
 			// Don't attempt to assign anything from replicaConfiguration.MysqlReplicaConfiguration,
@@ -2527,6 +2579,20 @@ func isMasterInstanceNameSet(_ context.Context, oldMasterInstanceName interface{
 	return true
 }
 
+func isSwitchoverRequested(d *schema.ResourceData) bool {
+	originalPrimaryName, _ := d.GetChange("master_instance_name")
+	_, newReplicaNames := d.GetChange("replica_names")
+	if !slices.Contains(newReplicaNames.([]interface{}), originalPrimaryName) {
+		return false
+	}
+	dbVersion := d.Get("database_version")
+	if !strings.HasPrefix(dbVersion.(string), "SQLSERVER") {
+		log.Printf("[WARN] Switchover is only supported for SQL Server %q", dbVersion)
+		return false
+	}
+	return true
+}
+
 func isReplicaPromoteRequested(_ context.Context, oldInstanceType interface{}, newInstanceType interface{}, _ interface{}) bool {
 	oldInstanceType = oldInstanceType.(string)
 	newInstanceType = newInstanceType.(string)
@@ -2536,6 +2602,34 @@ func isReplicaPromoteRequested(_ context.Context, oldInstanceType interface{}, n
 	}
 
 	return false
+}
+
+// Check if this resource change is the manual update done on old primary after a switchover. If true, no replacement is needed.
+func isSwitchoverFromOldPrimarySide(d *schema.ResourceDiff) bool {
+	dbVersion := d.Get("database_version")
+	if !strings.HasPrefix(dbVersion.(string), "SQLSERVER") {
+		log.Printf("[WARN] Switchover is only supported for SQL Server %q", dbVersion)
+		return false
+	}
+	oldInstanceType, newInstanceType := d.GetChange("instance_type")
+	oldReplicaNames, newReplicaNames := d.GetChange("replica_names")
+    _, newMasterInstanceName := d.GetChange("master_instance_name")
+	_, newReplicaConfiguration := d.GetChange("replica_configuration")
+	if len(newReplicaConfiguration.([]interface{})) != 1 || newReplicaConfiguration.([]interface{})[0] == nil{
+		return false;
+	}
+	replicaConfiguration := newReplicaConfiguration.([]interface{})[0].(map[string]interface{})
+	cascadableReplica, cascadableReplicaFieldExists := replicaConfiguration["cascadable_replica"]
+
+	instanceTypeChangedFromPrimaryToReplica := 	oldInstanceType.(string) == "CLOUD_SQL_INSTANCE" && newInstanceType.(string) == "READ_REPLICA_INSTANCE"
+	newMasterInOldReplicaNames := slices.Contains(oldReplicaNames.([]interface{}), newMasterInstanceName)
+	newMasterNotInNewReplicaNames := !slices.Contains(newReplicaNames.([]interface{}), newMasterInstanceName)
+	isCascadableReplica := cascadableReplicaFieldExists && cascadableReplica.(bool) 
+
+	return newMasterInstanceName != nil &&
+	instanceTypeChangedFromPrimaryToReplica &&
+	newMasterInOldReplicaNames && newMasterNotInNewReplicaNames &&
+	isCascadableReplica
 }
 
 func checkPromoteConfigurations(d *schema.ResourceData) error {

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -186,7 +186,6 @@ func ResourceSqlDatabaseInstance() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Computed:     true,
-							Default:      "ENTERPRISE",
 							ValidateFunc: validation.StringInSlice([]string{"ENTERPRISE", "ENTERPRISE_PLUS"}, false),
 							Description:  `The edition of the instance, can be ENTERPRISE or ENTERPRISE_PLUS.`,
 						},

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -2811,7 +2811,7 @@ resource "google_sql_database_instance" "instance" {
   settings {
     tier = "%s"
     edition = "%s"
-	 backup_configuration {
+	backup_configuration {
 	  transaction_log_retention_days = 7
     }
   }

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -1598,6 +1598,32 @@ func TestAccSQLDatabaseInstance_DenyMaintenancePeriod(t *testing.T) {
 	})
 }
 
+func TestAccSQLDatabaseInstance_DefaultEdition(t *testing.T) {
+	t.Parallel()
+	databaseName := "tf-test-" + acctest.RandString(t, 10)
+	databaseVersion := "POSTGRES_16"
+	enterprisePlusTier := "db-perf-optimized-N-2"
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleSqlDatabaseInstance_DefaultEdition(databaseName, databaseVersion, enterprisePlusTier),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("google_sql_database_instance.instance", "settings.0.edition", "ENTERPRISE_PLUS"),
+				),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
 func TestAccSqlDatabaseInstance_Edition(t *testing.T) {
 	t.Parallel()
 	enterprisePlusName := "tf-test-enterprise-plus" + acctest.RandString(t, 10)
@@ -1757,7 +1783,7 @@ func TestAccSqlDatabaseInstance_Postgres_Edition_Upgrade(t *testing.T) {
 		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testGoogleSqlDatabaseInstance_EditionConfig_noEdition(editionUpgrade, enterpriseTier),
+				Config: testGoogleSqlDatabaseInstance_EditionConfig(editionUpgrade, enterpriseTier, "ENTERPRISE"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("google_sql_database_instance.instance", "settings.0.edition", "ENTERPRISE"),
 				),
@@ -1785,6 +1811,7 @@ func TestAccSqlDatabaseInstance_Postgres_Edition_Upgrade(t *testing.T) {
 }
 
 func TestAccSqlDatabaseInstance_Edition_Downgrade(t *testing.T) {
+	t.Skip("https://github.com/hashicorp/terraform-provider-google/issues/20010")
 	t.Parallel()
 	enterprisePlusTier := "db-perf-optimized-N-2"
 	enterpriseTier := "db-custom-2-13312"
@@ -1807,7 +1834,7 @@ func TestAccSqlDatabaseInstance_Edition_Downgrade(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testGoogleSqlDatabaseInstance_EditionConfig_noEdition(editionDowngrade, enterpriseTier),
+				Config: testGoogleSqlDatabaseInstance_EditionConfig(editionDowngrade, enterpriseTier, "ENTERPRISE"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("google_sql_database_instance.instance", "settings.0.edition", "ENTERPRISE"),
 				),
@@ -2553,6 +2580,50 @@ func TestAccSqlDatabaseInstance_useInternalCaByDefault(t *testing.T) {
 	})
 }
 
+func TestAccSqlDatabaseInstance_useCasBasedServerCa(t *testing.T) {
+	t.Parallel()
+
+	databaseName := "tf-test-" + acctest.RandString(t, 10)
+	resourceName := "google_sql_database_instance.instance"
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
+
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleSqlDatabaseInstance_setCasServerCa(databaseName, "GOOGLE_MANAGED_CAS_CA"),
+				Check:  resource.ComposeTestCheckFunc(resource.TestCheckResourceAttr(resourceName, "settings.0.ip_configuration.0.server_ca_mode", "GOOGLE_MANAGED_CAS_CA")),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+func testGoogleSqlDatabaseInstance_setCasServerCa(databaseName, serverCaMode string) string {
+	return fmt.Sprintf(`
+resource "google_sql_database_instance" "instance" {
+  name                = "%s"
+  region              = "us-central1"
+  database_version    = "POSTGRES_15"
+  deletion_protection = false
+  settings {
+    tier = "db-f1-micro"
+    ip_configuration {
+      ipv4_enabled    = "true"
+      server_ca_mode  = "%s"
+    }
+  }
+}
+`, databaseName, serverCaMode)
+}
+
 func testGoogleSqlDatabaseInstance_setSslOptionsForPostgreSQL(databaseName string, databaseVersion string, sslMode string) string {
 	return fmt.Sprintf(`
 resource "google_sql_database_instance" "instance" {
@@ -2702,6 +2773,19 @@ resource "google_sql_database_instance" "instance" {
 }`, databaseName, endDate, startDate, time)
 }
 
+func testGoogleSqlDatabaseInstance_DefaultEdition(databaseName, databaseVersion, tier string) string {
+	return fmt.Sprintf(`
+resource "google_sql_database_instance" "instance" {
+  name             = "%s"
+  region           = "us-east1"
+  database_version    = "%s"
+  deletion_protection = false
+  settings {
+    tier = "%s"
+  }
+}`, databaseName, databaseVersion, tier)
+}
+
 func testGoogleSqlDatabaseInstance_EditionConfig_noEdition(databaseName, tier string) string {
 	return fmt.Sprintf(`
 
@@ -2712,9 +2796,6 @@ resource "google_sql_database_instance" "instance" {
   deletion_protection = false
   settings {
     tier = "%s"
-     backup_configuration {
-      transaction_log_retention_days = 7
-     }    
   }
 }`, databaseName, tier)
 }
@@ -2730,6 +2811,9 @@ resource "google_sql_database_instance" "instance" {
   settings {
     tier = "%s"
     edition = "%s"
+	 backup_configuration {
+	  transaction_log_retention_days = 7
+    }
   }
 }`, databaseName, tier, edition)
 }

--- a/mmv1/third_party/terraform/website/docs/guides/sql_instance_switchover.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/sql_instance_switchover.html.markdown
@@ -1,0 +1,86 @@
+---
+page_title: "Performing a SQL Instance Switchover"
+description: |-
+  A walkthrough for performing a SQL instance switchover through terraform
+---
+
+# Performing a SQL Instance Switchover
+This page is a brief walkthrough of performing a switchover through terraform. 
+
+  ~> **NOTE:** Only supported for SQL Server.
+
+1. Create a **cross-region** primary and cascadable replica. It is recommended to use deletion_protection to prevent accidental deletions.
+```
+resource "google_sql_database_instance" "original-primary" {
+name = "p1"
+region = "us-central1"
+deletion_protection = true
+instance_type = "CLOUD_SQL_INSTANCE"
+replica_names = ["p1-r1"] 
+    ...
+}
+resource "google_sql_database_instance" "original-replica" {
+name = "p1-r1"
+region = "us-east1"
+deletion_protection = true
+instance_type = "READ_REPLICA_INSTANCE"
+master_instance_name = "p1"
+replica_configuration {
+    cascadable_replica = true
+}
+...
+}
+```
+
+2. Invoke switchover on the replica \
+a. Change `instance_type` from `READ_REPLICA_INSTANCE` to `CLOUD_SQL_INSTANCE` \
+b. Remove `master_instance_name` \
+c. Remove `replica_configuration` \
+d. Add current primary's name to the replica's `replica_names` list
+
+```diff 
+resource "google_sql_database_instance" "original-replica" {
+  name = "p1-r1"
+  region = "us-east1"
+- instance_type = "READ_REPLICA_INSTANCE"
++ instance_type = "CLOUD_SQL_INSTANCE"
+
+- master_instance_name = "p1"
+- replica_configuration {
+- cascadable_replica = true
+- }
++ replica_names = ["p1"]
+  ...  
+}
+```
+
+3. Update the old primary and run `terraform plan` \
+a. Change `instance_type` from `CLOUD_SQL_INSTANCE` to `READ_REPLICA_INSTANCE` \
+b. Set `master_instance_name` to the new primary (original replica) \
+c. Set `replica_configuration` and indicate this is a `cascadable-replica` \
+d. Remove old replica from `replica_names` \
+    ~> **NOTE**: Do **not** delete the replica_names field, even if it has no replicas remaining. Set replica_names = [ ] to indicate it having no replicas. \
+e. Run `terraform plan` and verify that everything is done in-place (or data will be lost)
+
+```diff
+resource "google_sql_database_instance" "original-primary" {
+  name = "p1"
+  region="us-central1"
+- instance_type = "CLOUD_SQL_INSTANCE"
++ instance_type = "READ_REPLICA_INSTANCE"
++ master_instance_name = "p1-r1"
++ replica_configuration 
++   cascadable_replica = true
++ }
+- replica_names = ["p1-r1"] 
++ replica_names = [] 
+  ...
+}
+```
+
+#### Plan and verify that:
+- `terraform plan` outputs **"0 to add, 0 to destroy"**
+- `terraform plan` does not say **"must be replaced"** for any resource
+- Every resource **"will be updated in-place"**
+- Only the 2 instances involved in switchover have planned changes
+- (Recommended) Use `deletion_protection` on instances as a safety measure

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -379,9 +379,9 @@ Specifying a network enables private IP.
 At least `ipv4_enabled` must be enabled or a `private_network` must be configured.
 This setting can be updated, but it cannot be removed after it is set.
 
-* `ssl_mode` - (Optional) Specify how SSL connection should be enforced in DB connections.
+* `ssl_mode` - (Optional) Specify how SSL connection should be enforced in DB connections. Supported values are `ALLOW_UNENCRYPTED_AND_ENCRYPTED`, `ENCRYPTED_ONLY`, and `TRUSTED_CLIENT_CERTIFICATE_REQUIRED` (not supported for SQL Server). See [API reference doc](https://cloud.google.com/sql/docs/postgres/admin-api/rest/v1/instances#ipconfiguration) for details.
 
-* `server_ca_mode` - (Optional) Specify how the server certificate's Certificate Authority is hosted. Supported value is `GOOGLE_MANAGED_INTERNAL_CA`.
+* `server_ca_mode` - (Optional) Specify how the server certificate's Certificate Authority is hosted. Supported values are `GOOGLE_MANAGED_INTERNAL_CA` and `GOOGLE_MANAGED_CAS_CA`.
 
 * `allocated_ip_range` - (Optional) The name of the allocated ip range for the private ip CloudSQL instance. For example: "google-managed-services-default". If set, the instance ip will be created in the allocated range. The range name must comply with [RFC 1035](https://datatracker.ietf.org/doc/html/rfc1035). Specifically, the name must be 1-63 characters long and match the regular expression [a-z]([-a-z0-9]*[a-z0-9])?.
 
@@ -451,11 +451,14 @@ The optional `settings.password_validation_policy` subblock for instances declar
 * `enable_password_policy` - Enables or disable the password validation policy.
 
 The optional `replica_configuration` block must have `master_instance_name` set
-to work, cannot be updated, and supports:
+to work, cannot be updated and supports:
 
 * `cascadable_replica` - (Optional) Specifies if the replica is a cascadable replica. If true, instance must be in different region from primary.
-
-  ~> **NOTE:** Only supported for SQL Server database.
+-> **Note:** `replica_configuration` field is not meant to be used if the master
+instance is a source representation instance. The configuration provided by this
+field can be set on the source representation instance directly. If this field
+is present when the master instance is a source representation instance, `dump_file_path` must be provided.
+-> **NOTE:** Only supported for SQL Server database.
 
 * `ca_certificate` - (Optional) PEM representation of the trusted CA's x509
     certificate.
@@ -470,14 +473,15 @@ to work, cannot be updated, and supports:
     between connect retries. MySQL's default is 60 seconds.
 
 * `dump_file_path` - (Optional) Path to a SQL file in GCS from which replica
-    instances are created. Format is `gs://bucket/filename`.
+    instances are created. Format is `gs://bucket/filename`. Note, if the master
+    instance is a source representation instance this field must be present.
 
 * `failover_target` - (Optional) Specifies if the replica is the failover target.
     If the field is set to true the replica will be designated as a failover replica.
     If the master instance fails, the replica instance will be promoted as
     the new master instance.
 
-  ~> **NOTE:** Only supported for MySQL.
+  ~> **NOTE:** Not supported for Postgres database.
 
 * `master_heartbeat_period` - (Optional) Time in ms between replication
     heartbeats.

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -453,12 +453,14 @@ The optional `settings.password_validation_policy` subblock for instances declar
 The optional `replica_configuration` block must have `master_instance_name` set
 to work, cannot be updated and supports:
 
-* `cascadable_replica` - (Optional) Specifies if the replica is a cascadable replica. If true, instance must be in different region from primary.
--> **Note:** `replica_configuration` field is not meant to be used if the master
+~> **Note:** `replica_configuration` field is not meant to be used if the master
 instance is a source representation instance. The configuration provided by this
 field can be set on the source representation instance directly. If this field
 is present when the master instance is a source representation instance, `dump_file_path` must be provided.
--> **NOTE:** Only supported for SQL Server database.
+
+* `cascadable_replica` - (Optional) Specifies if the replica is a cascadable replica. If true, instance must be in different region from primary.
+
+  ~> **NOTE:** Only supported for SQL Server database.
 
 * `ca_certificate` - (Optional) PEM representation of the trusted CA's x509
     certificate.
@@ -480,7 +482,6 @@ is present when the master instance is a source representation instance, `dump_f
     If the field is set to true the replica will be designated as a failover replica.
     If the master instance fails, the replica instance will be promoted as
     the new master instance.
-
   ~> **NOTE:** Not supported for Postgres database.
 
 * `master_heartbeat_period` - (Optional) Time in ms between replication


### PR DESCRIPTION
Support SQL Server Switchover through terraform
The full design doc can be found in go/sqlserver-switchover-terraform-proposal (Googler-only)

The API changes are rolled out, and my manual testing passes without causing a permadiff

```release-note:enhancement
compute: added `replica_names` field to `sql_database_instance` resource
```
