### PR TITLE
Add performance config field to Filestore instance

### DIFF
--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -292,3 +292,39 @@ properties:
     type: String
     description: |
       The reason for enabling deletion protection.
+  - name: 'performanceConfig'
+    type: NestedObject
+    description: |
+      Performance configuration for the instance. If not provided,
+      the default performance settings will be used.
+    properties:
+      - name: 'iopsPerTb'
+        type: NestedObject
+        description: |
+          The instance provisioned IOPS will change dynamically
+          based on the capacity of the instance.
+        conflicts:
+          - fixed_iops
+        properties:
+          - name: 'maxIopsPerTb'
+            type: Integer
+            description: |
+              The instance max IOPS will be calculated by multiplying
+              the capacity of the instance (TB) by max_iops_per_tb,
+              and rounding to the nearest 1000. The instance max IOPS
+              will be changed dynamically based on the instance
+              capacity.
+      - name: 'fixedIops'
+        type: NestedObject
+        description: |
+          The instance will have a fixed provisioned IOPS value,
+          which will remain constant regardless of instance
+          capacity.
+        conflicts:
+          - iops_per_tb
+        properties:
+          - name: 'maxIops'
+            type: Integer
+            description: |
+              The number of IOPS to provision for the instance.
+              max_iops must be in multiple of 1000.

--- a/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
+++ b/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
@@ -285,3 +285,127 @@ resource "google_filestore_instance" "instance" {
 }
 `, name, location, tier, deletionProtection, deletionProtectionReason)
 }
+
+func TestAccFilestoreInstance_performanceConfig(t *testing.T) {
+	t.Parallel()
+
+	name := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+	location := "us-central1"
+	tier := "REGIONAL"
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckFilestoreInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFilestoreInstance_fixedIopsPerformanceConfig(name, location, tier),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_filestore_instance.instance", "performance_config.0.fixed_iops.0.max_iops", "17000"),
+				),
+			},
+			{
+				ResourceName:            "google_filestore_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"zone"},
+			},
+			{
+				Config: testAccFilestoreInstance_iopsPerTbPerformanceConfig(name, location, tier),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_filestore_instance.instance", "performance_config.0.iops_per_tb.0.max_iops_per_tb", "17000"),
+				),
+			},
+			{
+				ResourceName:            "google_filestore_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"zone"},
+			},
+			{
+				Config: testAccFilestoreInstance_defaultConfig(name, location, tier),
+			},
+			{
+				ResourceName:            "google_filestore_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"zone"},
+			},
+		},
+	})
+}
+
+func testAccFilestoreInstance_fixedIopsPerformanceConfig(name, location, tier string) string {
+	return fmt.Sprintf(`
+resource "google_filestore_instance" "instance" {
+  name        = "%s"
+  location    = "%s"
+  tier        = "%s"
+  description = "An instance created during testing."
+
+  file_shares {
+    capacity_gb = 1024
+    name        = "share"
+  }
+
+  networks {
+    network = "default"
+		modes   = ["MODE_IPV4"]
+  }
+
+  performance_config {
+    fixed_iops {
+      max_iops = 17000
+    }
+  }
+}
+`, name, location, tier)
+}
+
+func testAccFilestoreInstance_iopsPerTbPerformanceConfig(name, location, tier string) string {
+	return fmt.Sprintf(`
+resource "google_filestore_instance" "instance" {
+  name        = "%s"
+  zone        = "%s"
+  tier        = "%s"
+  description = "An instance created during testing."
+
+  file_shares {
+    capacity_gb = 1024
+    name        = "share"
+  }
+
+  networks {
+    network = "default"
+		modes   = ["MODE_IPV4"]
+  }
+
+  performance_config {
+    iops_per_tb {
+      max_iops_per_tb = 17000
+    }
+  }
+}
+`, name, location, tier)
+}
+
+func testAccFilestoreInstance_defaultConfig(name, location, tier string) string {
+	return fmt.Sprintf(`
+resource "google_filestore_instance" "instance" {
+  name        = "%s"
+  zone        = "%s"
+  tier        = "%s"
+  description = "An instance created during testing."
+
+  file_shares {
+    capacity_gb = 1024
+    name        = "share"
+  }
+
+  networks {
+    network = "default"
+		modes   = ["MODE_IPV4"]
+  }
+}
+`, name, location, tier)
+}


### PR DESCRIPTION
Performance configuration support for Filestore.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
filestore: added `performance_config` field to `google_filestore_instance`
```
