### PR TITLE
spanner: updated docs for database name regex

### DIFF
--- a/mmv1/products/spanner/Database.yaml
+++ b/mmv1/products/spanner/Database.yaml
@@ -103,8 +103,8 @@ properties:
   - name: 'name'
     type: String
     description: |
-      A unique identifier for the database, which cannot be changed after
-      the instance is created. Values are of the form [a-z][-_a-z0-9]*[a-z0-9].
+      A unique identifier for the database, which cannot be changed after the
+      instance is created. Values are of the form `[a-z][-_a-z0-9]*[a-z0-9]`.
     required: true
     immutable: true
     custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'

--- a/mmv1/products/spanner/Database.yaml
+++ b/mmv1/products/spanner/Database.yaml
@@ -104,7 +104,7 @@ properties:
     type: String
     description: |
       A unique identifier for the database, which cannot be changed after
-      the instance is created. Values are of the form [a-z][-a-z0-9]*[a-z0-9].
+      the instance is created. Values are of the form [a-z][-_a-z0-9]*[a-z0-9].
     required: true
     immutable: true
     custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'


### PR DESCRIPTION
Fixes hashicorp/terraform-provider-google#17608

This basically just unifies the regex in the doc with the regex that's actually applied.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
