### PR TITLE
feat(spanner): add support for defaultBackupScheduleType in spanner instance

### DIFF
--- a/mmv1/products/spanner/Instance.yaml
+++ b/mmv1/products/spanner/Instance.yaml
@@ -280,6 +280,5 @@ properties:
       if unset or NONE, no default backup schedule will be created for new databases within the instance.
     default_from_api: true
     enum_values:
-      - 'UNSPECIFIED'
       - 'NONE'
       - 'AUTOMATIC'

--- a/mmv1/products/spanner/Instance.yaml
+++ b/mmv1/products/spanner/Instance.yaml
@@ -272,3 +272,14 @@ properties:
       - 'STANDARD'
       - 'ENTERPRISE'
       - 'ENTERPRISE_PLUS'
+  - name: 'defaultBackupScheduleType'
+    type: Enum
+    description: |
+      Controls the default backup behavior for new databases within the instance.
+      Note that `AUTOMATIC` is not permitted for free instances, as backups and backup schedules are not allowed for free instances.
+      if unset or NONE, no default backup schedule will be created for new databases within the instance.
+    default_from_api: true
+    enum_values:
+      - 'UNSPECIFIED'
+      - 'NONE'
+      - 'AUTOMATIC'

--- a/mmv1/templates/terraform/encoders/spanner_instance_update.go.tmpl
+++ b/mmv1/templates/terraform/encoders/spanner_instance_update.go.tmpl
@@ -9,6 +9,9 @@ updateMask := make([]string, 0)
 if d.HasChange("edition") {
   updateMask = append(updateMask, "edition")
 }
+if d.HasChange("default_backup_schedule_type") {
+  updateMask = append(updateMask, "defaultBackupScheduleType")
+}
 if d.HasChange("num_nodes") {
 	updateMask = append(updateMask, "nodeCount")
 }

--- a/mmv1/templates/terraform/examples/spanner_instance_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/spanner_instance_basic.tf.tmpl
@@ -3,6 +3,7 @@ resource "google_spanner_instance" "example" {
   display_name = "Test Spanner Instance"
   num_nodes    = 2
   edition      = "STANDARD"
+  default_backup_schedule_type = "AUTOMATIC"
   labels = {
     "foo" = "bar"
   }

--- a/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
+++ b/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
@@ -367,6 +367,7 @@ resource "google_spanner_instance" "basic" {
   display_name = "%s-dname"
   num_nodes    = 1
   edition      = "ENTERPRISE"
+  default_backup_schedule_type = "NONE"
 }
 `, name, name)
 }
@@ -460,6 +461,7 @@ resource "google_spanner_instance" "basic" {
     }
   }
   edition      = "ENTERPRISE"
+  default_backup_schedule_type = "AUTOMATIC"
 }
 `, name, name, maxProcessingUnits, minProcessingUnits, cupUtilizationPercent, storageUtilizationPercent)
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
spanner: added `default_backup_schedule_type` field to  `google_spanner_instance`
```
