### PR TITLE
privateca: update certificate authority samples with more realistic values

### DIFF
--- a/mmv1/templates/terraform/examples/privateca_certificate_authority_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/privateca_certificate_authority_basic.tf.tmpl
@@ -8,40 +8,28 @@ resource "google_privateca_certificate_authority" "{{$.PrimaryResourceId}}" {
   config {
     subject_config {
       subject {
-        organization = "HashiCorp"
+        organization = "ACME"
         common_name = "my-certificate-authority"
-      }
-      subject_alt_name {
-        dns_names = ["hashicorp.com"]
       }
     }
     x509_config {
       ca_options {
+        # is_ca *MUST* be true for certificate authorities
         is_ca = true
-        max_issuer_path_length = 10
       }
       key_usage {
         base_key_usage {
-          digital_signature = true
-          content_commitment = true
-          key_encipherment = false
-          data_encipherment = true
-          key_agreement = true
+          # cert_sign and crl_sign *MUST* be true for certificate authorities
           cert_sign = true
           crl_sign = true
-          decipher_only = true
         }
         extended_key_usage {
-          server_auth = true
-          client_auth = false
-          email_protection = true
-          code_signing = true
-          time_stamping = true
         }
       }
     }
   }
-  lifetime = "86400s"
+  # valid for 10 years
+  lifetime = "${10 * 365 * 24 * 3600}s"
   key_spec {
     algorithm = "RSA_PKCS1_4096_SHA256"
   }

--- a/mmv1/templates/terraform/examples/privateca_certificate_authority_byo_key.tf.tmpl
+++ b/mmv1/templates/terraform/examples/privateca_certificate_authority_byo_key.tf.tmpl
@@ -37,7 +37,6 @@ resource "google_privateca_certificate_authority" "{{$.PrimaryResourceId}}" {
       ca_options {
         # is_ca *MUST* be true for certificate authorities
         is_ca = true
-        max_issuer_path_length = 10
       }
       key_usage {
         base_key_usage {
@@ -46,7 +45,6 @@ resource "google_privateca_certificate_authority" "{{$.PrimaryResourceId}}" {
           crl_sign = true
         }
         extended_key_usage {
-          server_auth = false
         }
       }
       name_constraints {

--- a/mmv1/templates/terraform/examples/privateca_certificate_authority_custom_ski.tf.tmpl
+++ b/mmv1/templates/terraform/examples/privateca_certificate_authority_custom_ski.tf.tmpl
@@ -8,11 +8,8 @@ resource "google_privateca_certificate_authority" "{{$.PrimaryResourceId}}" {
   config {
     subject_config {
       subject {
-        organization = "HashiCorp"
+        organization = "ACME"
         common_name = "my-certificate-authority"
-      }
-      subject_alt_name {
-        dns_names = ["hashicorp.com"]
       }
     }
     subject_key_id {
@@ -21,30 +18,19 @@ resource "google_privateca_certificate_authority" "{{$.PrimaryResourceId}}" {
     x509_config {
       ca_options {
         is_ca = true
-        max_issuer_path_length = 10
       }
       key_usage {
         base_key_usage {
-          digital_signature = true
-          content_commitment = true
-          key_encipherment = false
-          data_encipherment = true
-          key_agreement = true
           cert_sign = true
           crl_sign = true
-          decipher_only = true
         }
         extended_key_usage {
-          server_auth = true
-          client_auth = false
-          email_protection = true
-          code_signing = true
-          time_stamping = true
         }
       }
     }
   }
-  lifetime = "86400s"
+  # valid for 10 years
+  lifetime = "${10 * 365 * 24 * 3600}s"
   key_spec {
     cloud_kms_key_version = "{{index $.Vars "kms_key_name"}}/cryptoKeyVersions/1"
   }

--- a/mmv1/templates/terraform/examples/privateca_certificate_authority_subordinate.tf.tmpl
+++ b/mmv1/templates/terraform/examples/privateca_certificate_authority_subordinate.tf.tmpl
@@ -5,11 +5,8 @@ resource "google_privateca_certificate_authority" "root-ca" {
   config {
     subject_config {
       subject {
-        organization = "HashiCorp"
+        organization = "ACME"
         common_name = "my-certificate-authority"
-      }
-      subject_alt_name {
-        dns_names = ["hashicorp.com"]
       }
     }
     x509_config {
@@ -24,7 +21,6 @@ resource "google_privateca_certificate_authority" "root-ca" {
           crl_sign = true
         }
         extended_key_usage {
-          server_auth = false
         }
       }
     }
@@ -52,43 +48,33 @@ resource "google_privateca_certificate_authority" "{{$.PrimaryResourceId}}" {
   config {
     subject_config {
       subject {
-        organization = "HashiCorp"
+        organization = "ACME"
         common_name = "my-subordinate-authority"
-      }
-      subject_alt_name {
-        dns_names = ["hashicorp.com"]
       }
     }
     x509_config {
       ca_options {
         is_ca = true
-        # Force the sub CA to only issue leaf certs
-        max_issuer_path_length = 0
+        # Force the sub CA to only issue leaf certs.
+        # Use e.g.
+        #    max_issuer_path_length = 1
+        # if you need to chain more subordinates.
+        zero_max_issuer_path_length = true
       }
       key_usage {
         base_key_usage {
-          digital_signature = true
-          content_commitment = true
-          key_encipherment = false
-          data_encipherment = true
-          key_agreement = true
           cert_sign = true
           crl_sign = true
-          decipher_only = true
         }
         extended_key_usage {
-          server_auth = true
-          client_auth = false
-          email_protection = true
-          code_signing = true
-          time_stamping = true
         }
       }
     }
   }
-  lifetime = "86400s"
+  # valid for 5 years
+  lifetime = "${5 * 365 * 24 * 3600}s"
   key_spec {
-    algorithm = "RSA_PKCS1_4096_SHA256"
+    algorithm = "RSA_PKCS1_2048_SHA256"
   }
   type = "SUBORDINATE"
 }


### PR DESCRIPTION
Some of the properties configured here are either wrong or at least not very sensible on root certificates / subordinates.
A similar set of fixes got applied to terraform documentation samples in https://github.com/terraform-google-modules/terraform-docs-samples/pull/631

What is left out here is placing the subordinate CA in it's own pool. I could not figure out what is required here to prepare the test infrastructure to provision another pool dedicated to the sub-ca. Technically those two certificates should not reside in the same pool.


```release-note:none
```