### PR TITLE
networkservices: increased `path_matcher` and `host_rule` limits

### DIFF
--- a/mmv1/products/networkservices/EdgeCacheService.yaml
+++ b/mmv1/products/networkservices/EdgeCacheService.yaml
@@ -191,7 +191,7 @@ properties:
                 The name of the pathMatcher associated with this hostRule.
               required: true
         min_size: 1
-        max_size: 10
+        max_size: 50
       - name: 'path_matcher'
         type: Array
         description: |
@@ -891,7 +891,7 @@ properties:
               min_size: 1
               max_size: 200
         min_size: 1
-        max_size: 10
+        max_size: 50
   - name: 'logConfig'
     type: NestedObject
     description: |

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_edge_cache_service_test.go
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_edge_cache_service_test.go
@@ -37,107 +37,109 @@ func TestAccNetworkServicesEdgeCacheService_updateAndImport(t *testing.T) {
 		},
 	})
 }
+
 func testAccNetworkServicesEdgeCacheService_update_0(bktName, originName, serviceName string) string {
 	return fmt.Sprintf(`
-	resource "google_storage_bucket" "dest" {
-		name          = "%s"
-		location      = "US"
-		force_destroy = true
-	}
-	resource "google_network_services_edge_cache_origin" "instance" {
-		name                 = "%s"
-		origin_address       = google_storage_bucket.dest.url
-		description          = "The default bucket for media edge test"
-		max_attempts         = 2
-		timeout {
-			connect_timeout = "10s"
-		}
-	}
-	resource "google_network_services_edge_cache_service" "served" {
-		name                 = "%s"
-		description          = "some description"
-		routing {
-			host_rule {
-				description = "host rule description"
-				hosts = ["sslcert.tf-test.club"]
-				path_matcher = "routes"
-			}
-			path_matcher {
-				name = "routes"
-				route_rule {
-					description = "a route rule to match against"
-					priority = 1
-					match_rule {
-						prefix_match = "/"
-					}
-					origin = google_network_services_edge_cache_origin.instance.name
-					route_action {
-						cdn_policy {
-								cache_mode = "CACHE_ALL_STATIC"
-								default_ttl = "3600s"
-						}
-					}
-					header_action {
-						response_header_to_add {
-							header_name = "x-cache-status"
-							header_value = "{cdn_cache_status}"
-						}
-					}
-				}
-			}
-		}
-	}
+resource "google_storage_bucket" "dest" {
+  name          = "%s"
+  location      = "US"
+  force_destroy = true
+}
+resource "google_network_services_edge_cache_origin" "instance" {
+  name           = "%s"
+  origin_address = google_storage_bucket.dest.url
+  description    = "The default bucket for media edge test"
+  max_attempts   = 2
+  timeout {
+    connect_timeout = "10s"
+  }
+}
+resource "google_network_services_edge_cache_service" "served" {
+  name        = "%s"
+  description = "some description"
+  routing {
+    host_rule {
+      description  = "host rule description"
+      hosts        = ["sslcert.tf-test.club"]
+      path_matcher = "routes"
+    }
+    path_matcher {
+      name = "routes"
+      route_rule {
+        description = "a route rule to match against"
+        priority    = 1
+        match_rule {
+          prefix_match = "/"
+        }
+        origin = google_network_services_edge_cache_origin.instance.name
+        route_action {
+          cdn_policy {
+            cache_mode  = "CACHE_ALL_STATIC"
+            default_ttl = "3600s"
+          }
+        }
+        header_action {
+          response_header_to_add {
+            header_name  = "x-cache-status"
+            header_value = "{cdn_cache_status}"
+          }
+        }
+      }
+    }
+  }
+}
 `, bktName, originName, serviceName)
 }
+
 func testAccNetworkServicesEdgeCacheService_update_1(bktName, originName, serviceName string) string {
 	return fmt.Sprintf(`
-	resource "google_storage_bucket" "dest" {
-		name          = "%s"
-		location      = "US"
-		force_destroy = true
-	}
-	resource "google_network_services_edge_cache_origin" "instance" {
-		name                 = "%s"
-		origin_address       = google_storage_bucket.dest.url
-		description          = "The default bucket for media edge test"
-		max_attempts         = 2
-		timeout {
-			connect_timeout = "10s"
-		}
-	}
-	resource "google_network_services_edge_cache_service" "served" {
-		name                 = "%s"
-		description          = "some description"
-		routing {
-			host_rule {
-				description = "host rule description"
-				hosts = ["sslcert.tf-test.club"]
-				path_matcher = "routes"
-			}
-			path_matcher {
-				name = "routes"
-				route_rule {
-					description = "a route rule to match against"
-					priority = 1
-					match_rule {
-						prefix_match = "/"
-					}
-					origin = google_network_services_edge_cache_origin.instance.name
-					route_action {
-						cdn_policy {
-								cache_mode = "CACHE_ALL_STATIC"
-								default_ttl = "3600s"
-						}
-					}
-					header_action {
-						response_header_to_add {
-							header_name = "x-cache-status"
-							header_value = "{cdn_cache_status}"
-						}
-					}
-				}
-			}
-		}
-	}
+resource "google_storage_bucket" "dest" {
+  name          = "%s"
+  location      = "US"
+  force_destroy = true
+}
+resource "google_network_services_edge_cache_origin" "instance" {
+  name           = "%s"
+  origin_address = google_storage_bucket.dest.url
+  description    = "The default bucket for media edge test"
+  max_attempts   = 2
+  timeout {
+    connect_timeout = "10s"
+  }
+}
+resource "google_network_services_edge_cache_service" "served" {
+  name        = "%s"
+  description = "some description"
+  routing {
+    host_rule {
+      description  = "host rule description"
+      hosts        = ["sslcert.tf-test.club"]
+      path_matcher = "routes"
+    }
+    path_matcher {
+      name = "routes"
+      route_rule {
+        description = "a route rule to match against"
+        priority    = 1
+        match_rule {
+          prefix_match = "/"
+        }
+        origin = google_network_services_edge_cache_origin.instance.name
+        route_action {
+          cdn_policy {
+            cache_mode  = "CACHE_ALL_STATIC"
+            default_ttl = "3600s"
+          }
+        }
+        header_action {
+          response_header_to_add {
+            header_name  = "x-cache-status"
+            header_value = "{cdn_cache_status}"
+          }
+        }
+      }
+    }
+  }
+}
 `, bktName, originName, serviceName)
 }


### PR DESCRIPTION
Increased `path_matcher` and `host_rule limits` from 10 to 50 within `google_network_services_edge_cache_service`

Fixes hashicorp/terraform-provider-google#19780
Fixes hashicorp/terraform-provider-google#20197

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
networkservices: increased `path_matcher` and `host_rule limits` from 10 to 50 within `google_network_services_edge_cache_service`
```
