### PR TITLE
container: removed `master_ipv4_cidr_block` requirement for private clusters

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -106,7 +106,6 @@ var (
 	privateClusterConfigKeys = []string{
 		"private_cluster_config.0.enable_private_endpoint",
 		"private_cluster_config.0.enable_private_nodes",
-		"private_cluster_config.0.master_ipv4_cidr_block",
 		"private_cluster_config.0.private_endpoint_subnetwork",
 		"private_cluster_config.0.master_global_access_config",
 	}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -1410,6 +1410,30 @@ func TestAccContainerCluster_withPrivateClusterConfigBasic(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_withPrivateClusterConfigNoCidrBlock(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	containerNetName := fmt.Sprintf("tf-test-container-net-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withPrivateClusterConfigNoCidrBlock(containerNetName, clusterName, false),
+			},
+			{
+				ResourceName:		 "google_container_cluster.with_private_cluster",
+				ImportState:		 true,
+				ImportStateVerify:	 true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
 func TestAccContainerCluster_withPrivateClusterConfigGlobalAccessEnabledOnly(t *testing.T) {
 	t.Parallel()
 
@@ -6952,8 +6976,8 @@ resource "google_container_cluster" "with_private_flexible_cluster" {
   subnetwork = google_compute_subnetwork.container_subnetwork.name
 
   private_cluster_config {
-    enable_private_nodes    = true
-	master_ipv4_cidr_block  = "10.42.0.0/28"
+    enable_private_nodes   = true
+    master_ipv4_cidr_block = "10.42.0.0/28"
   }
   deletion_protection = false
 }
@@ -9402,7 +9426,7 @@ resource "google_container_cluster" "with_resource_usage_export_config" {
 `, datasetId, clusterName, networkName, subnetworkName)
 }
 
-func testAccContainerCluster_withPrivateClusterConfigMissingCidrBlock(containerNetName, clusterName, location string, autopilotEnabled bool) string {
+func testAccContainerCluster_withPrivateClusterConfigNoCidrBlock(containerNetName, clusterName string, autopilotEnabled bool) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "container_network" {
   name                    = "%s"
@@ -9429,21 +9453,18 @@ resource "google_compute_subnetwork" "container_subnetwork" {
 
 resource "google_container_cluster" "with_private_cluster" {
   name               = "%s"
-  location           = "%s"
+  location           = "us-central1"
   initial_node_count = 1
 
   networking_mode = "VPC_NATIVE"
-  network    = google_compute_network.container_network.name
-  subnetwork = google_compute_subnetwork.container_subnetwork.name
+  network         = google_compute_network.container_network.name
+  subnetwork      = google_compute_subnetwork.container_subnetwork.name
 
   private_cluster_config {
-    enable_private_endpoint = true
-    enable_private_nodes    = true
+    enable_private_nodes = true
   }
 
   enable_autopilot = %t
-
-  master_authorized_networks_config {}
 
   ip_allocation_policy {
     cluster_secondary_range_name  = google_compute_subnetwork.container_subnetwork.secondary_ip_range[0].range_name
@@ -9451,7 +9472,7 @@ resource "google_container_cluster" "with_private_cluster" {
   }
   deletion_protection = false
 }
-`, containerNetName, clusterName, location, autopilotEnabled)
+`, containerNetName, clusterName, autopilotEnabled)
 }
 
 func testAccContainerCluster_withPrivateClusterConfig(containerNetName string, clusterName string, masterGlobalAccessEnabled bool) string {


### PR DESCRIPTION
Remove `master_ipv4_cidr_block` from `privateClusterConfigKeys`. It seems safe to assume that on older cluster versions which don't support this, there will be an API level error anyway.

Not sure if this should be a bug or an enhancement; put it as a bug for now.

Tested locally with built provider. I also repurposed an existing test that seems to be completely unused, which tested a different, but similar, configuration.

Fixes hashicorp/terraform-provider-google#20191

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
container: removed `private_cluster_config.master_ipv4_cidr_block` requirement for private clusters (no longer required since v1.29.x)
```
