### PR TITLE
Make another example for Rules release to a non-default Firestore db

### DIFF
--- a/tpgtools/overrides/firebaserules/samples/release/firestore_release.tf.tmpl
+++ b/tpgtools/overrides/firebaserules/samples/release/firestore_release.tf.tmpl
@@ -1,9 +1,3 @@
-# In case there are existing rules in the default db
-import {
-  id = "projects/{{project}}/releases/cloud.firestore"
-  to = google_firebaserules_release.primary
-}
-
 resource "google_firebaserules_release" "primary" {
   name         = "cloud.firestore"
   project      = "{{project}}"

--- a/tpgtools/overrides/firebaserules/samples/release/firestore_release.tf.tmpl
+++ b/tpgtools/overrides/firebaserules/samples/release/firestore_release.tf.tmpl
@@ -1,3 +1,9 @@
+# In case there are existing rules in the default db
+import {
+  id = "projects/{{project}}/releases/cloud.firestore"
+  to = google_firebaserules_release.primary
+}
+
 resource "google_firebaserules_release" "primary" {
   name         = "cloud.firestore"
   project      = "{{project}}"

--- a/tpgtools/overrides/firebaserules/samples/release/firestore_release_additional.tf.tmpl
+++ b/tpgtools/overrides/firebaserules/samples/release/firestore_release_additional.tf.tmpl
@@ -1,5 +1,5 @@
 resource "google_firebaserules_release" "primary" {
-  name         = "cloud.firestore"
+  name         = "cloud.firestore/{{database}}"
   project      = "{{project}}"
   ruleset_name = "projects/{{project}}/rulesets/${google_firebaserules_ruleset.firestore.name}"
 }

--- a/tpgtools/overrides/firebaserules/samples/release/firestore_release_additional.yaml
+++ b/tpgtools/overrides/firebaserules/samples/release/firestore_release_additional.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC. All Rights Reserved.
+# Copyright 2024 Google LLC. All Rights Reserved.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,13 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: firestore_release
-description: Creates a Firebase Rules Release to the default Cloud Firestore instance
+name: firestore_release_additional
+description: Creates a Firebase Rules Release to an additional Cloud Firestore instance
 type: release
 versions:
 - ga
 - beta
-resource: ./firestore_release.tf.tmpl
+resource: ./firestore_release_additional.tf.tmpl
 variables:
 - name: project
   type: project
+- name: database
+  type: resource_name

--- a/tpgtools/overrides/firebaserules/samples/release/meta.yaml
+++ b/tpgtools/overrides/firebaserules/samples/release/meta.yaml
@@ -1,0 +1,2 @@
+test_hide:
+  - firestore_release.yaml

--- a/tpgtools/overrides/firebaserules/samples/release/meta.yaml
+++ b/tpgtools/overrides/firebaserules/samples/release/meta.yaml
@@ -1,2 +1,7 @@
+# meta.yaml
+# this is a shared config file that all the tests merge with
+#
+# The firestore_release test uses the default Firestore instance, which can have an existing Rules deployment for whatever reason.
+# However, the firestore_release_additional test was sufficient because Rules deployment doesn't care about whether it's the default Firestore instance
 test_hide:
-  - firestore_release.yaml
+  - firestore_release.tf.tmpl


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/16324
Fixes https://github.com/hashicorp/terraform-provider-google/issues/15838

Deploying rules to non-default Firestore instances already works. Adding examples to guide users better.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
