### PR TITLE
Promoting Managed Kafka Cluster and Topic resources to GA

### DIFF
--- a/mmv1/products/managedkafka/Cluster.yaml
+++ b/mmv1/products/managedkafka/Cluster.yaml
@@ -51,6 +51,7 @@ examples:
       keyring_name: 'example-keyring'
   - name: 'managedkafka_cluster_cmek'
     primary_resource_id: 'example'
+    min_version: 'beta'
     vars:
       cluster_id: 'my-cluster'
       key_name: 'example-key'

--- a/mmv1/products/managedkafka/Cluster.yaml
+++ b/mmv1/products/managedkafka/Cluster.yaml
@@ -14,7 +14,6 @@
 ---
 name: 'Cluster'
 description: A Managed Service for Apache Kafka cluster. Apache Kafka is a trademark owned by the Apache Software Foundation.
-min_version: 'beta'
 docs:
 id_format: 'projects/{{project}}/locations/{{location}}/clusters/{{cluster_id}}'
 base_url: 'projects/{{project}}/locations/{{location}}/clusters'
@@ -46,14 +45,12 @@ custom_code:
 examples:
   - name: 'managedkafka_cluster_basic'
     primary_resource_id: 'example'
-    min_version: 'beta'
     vars:
       cluster_id: 'my-cluster'
       key_name: 'example-key'
       keyring_name: 'example-keyring'
   - name: 'managedkafka_cluster_cmek'
     primary_resource_id: 'example'
-    min_version: 'beta'
     vars:
       cluster_id: 'my-cluster'
       key_name: 'example-key'
@@ -65,7 +62,6 @@ parameters:
     description: "ID of the location of the Kafka resource. See
       https://cloud.google.com/managed-kafka/docs/locations for a list of
       supported locations."
-    min_version: 'beta'
     url_param_only: true
     required: true
     immutable: true
@@ -75,7 +71,6 @@ parameters:
       component of the cluster's name. The ID must be 1-63 characters long, and match
       the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` to comply with RFC 1035. This
       value is structured like: `my-cluster-id`."
-    min_version: 'beta'
     url_param_only: true
     required: true
     immutable: true
@@ -83,13 +78,11 @@ properties:
   - name: 'gcpConfig'
     type: NestedObject
     description: "Configuration properties for a Kafka cluster deployed to Google Cloud Platform."
-    min_version: 'beta'
     required: true
     properties:
       - name: 'accessConfig'
         type: NestedObject
         description: "The configuration of access to the Kafka cluster."
-        min_version: 'beta'
         required: true
         properties:
           - name: 'networkConfigs'
@@ -98,7 +91,6 @@ properties:
               cluster are allocated. To make the cluster available in a VPC, you must specify at least
               one subnet per network. You must specify between 1 and 10 subnets.
               Additional subnets may be specified with additional `network_configs` blocks."
-            min_version: 'beta'
             required: true
             item_type:
               type: NestedObject
@@ -110,7 +102,6 @@ properties:
                     in the subnet. The subnet must be located in the same region as the
                     cluster. The project may differ. The name of the subnet must be
                     in the format `projects/PROJECT_ID/regions/REGION/subnetworks/SUBNET`."
-                  min_version: 'beta'
                   required: true
                   diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
       - name: 'kmsKey'
@@ -118,23 +109,19 @@ properties:
         description: "The Cloud KMS Key name to use for encryption.
           The key must be located in the same region as the cluster and cannot be changed.
           Must be in the format `projects/PROJECT_ID/locations/LOCATION/keyRings/KEY_RING/cryptoKeys/KEY`."
-        min_version: 'beta'
         immutable: true
         diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
   - name: 'name'
     type: String
     description: "The name of the cluster. Structured like: `projects/PROJECT_ID/locations/LOCATION/clusters/CLUSTER_ID`."
-    min_version: 'beta'
     output: true
   - name: 'createTime'
     type: String
     description: "The time when the cluster was created."
-    min_version: 'beta'
     output: true
   - name: 'updateTime'
     type: String
     description: "The time when the cluster was last updated."
-    min_version: 'beta'
     output: true
   - name: 'labels'
     type: KeyValueLabels
@@ -142,36 +129,29 @@ properties:
         character and contain only hyphens (-), underscores (\_), lowercase
         characters, and numbers. Values must contain only hyphens (-),
         underscores (\_), lowercase characters, and numbers."
-    min_version: 'beta'
   - name: 'capacityConfig'
     type: NestedObject
     description: "A capacity configuration of a Kafka cluster."
-    min_version: 'beta'
     required: true
     properties:
       - name: 'vcpuCount'
         type: String
         description: "The number of vCPUs to provision for the cluster. The minimum is 3."
-        min_version: 'beta'
         required: true
       - name: 'memoryBytes'
         type: String
         description: "The memory to provision for the cluster in bytes. The value must be
           between 1 GiB and 8 GiB per vCPU. Ex. 1024Mi, 4Gi."
-        min_version: 'beta'
         required: true
   - name: 'rebalanceConfig'
     type: NestedObject
     description: "Defines rebalancing behavior of a Kafka cluster."
-    min_version: 'beta'
     properties:
       - name: 'mode'
         type: String
         description: "The rebalance behavior for the cluster. When not specified,
           defaults to `NO_REBALANCE`. Possible values: `MODE_UNSPECIFIED`, `NO_REBALANCE`, `AUTO_REBALANCE_ON_SCALE_UP`."
-        min_version: 'beta'
   - name: 'state'
     type: String
     description: "The current state of the cluster. Possible values: `STATE_UNSPECIFIED`, `CREATING`, `ACTIVE`, `DELETING`."
-    min_version: 'beta'
     output: true

--- a/mmv1/products/managedkafka/Topic.yaml
+++ b/mmv1/products/managedkafka/Topic.yaml
@@ -14,7 +14,6 @@
 ---
 name: 'Topic'
 description: A Managed Service for Apache Kafka topic. Apache Kafka is a trademark owned by the Apache Software Foundation.
-min_version: 'beta'
 docs:
 id_format: 'projects/{{project}}/locations/{{location}}/clusters/{{cluster}}/topics/{{topic_id}}'
 base_url: 'projects/{{project}}/locations/{{location}}/clusters/{{cluster}}/topics'
@@ -33,7 +32,6 @@ custom_code:
 examples:
   - name: 'managedkafka_topic_basic'
     primary_resource_id: 'example'
-    min_version: 'beta'
     vars:
       cluster_id: 'my-cluster'
       topic_id: 'my-topic'
@@ -43,14 +41,12 @@ parameters:
     description: "ID of the location of the Kafka resource. See
       https://cloud.google.com/managed-kafka/docs/locations for a list of
       supported locations."
-    min_version: 'beta'
     url_param_only: true
     required: true
     immutable: true
   - name: 'cluster'
     type: String
     description: "The cluster name."
-    min_version: 'beta'
     url_param_only: true
     required: true
     immutable: true
@@ -58,7 +54,6 @@ parameters:
     type: String
     description: "The ID to use for the topic, which will become the final
       component of the topic's name. This value is structured like: `my-topic-name`."
-    min_version: 'beta'
     url_param_only: true
     required: true
     immutable: true
@@ -67,19 +62,16 @@ properties:
     type: String
     description: "The name of the topic. The `topic` segment is used when
       connecting directly to the cluster. Must be in the format `projects/PROJECT_ID/locations/LOCATION/clusters/CLUSTER_ID/topics/TOPIC_ID`."
-    min_version: 'beta'
     output: true
   - name: 'partitionCount'
     type: Integer
     description: "The number of partitions in a topic. You can increase the partition
       count for a topic, but you cannot decrease it. Increasing partitions
       for a topic that uses a key might change how messages are distributed."
-    min_version: 'beta'
   - name: 'replicationFactor'
     type: Integer
     description: "The number of replicas of each partition. A replication factor of 3 is
       recommended for high availability."
-    min_version: 'beta'
     required: true
     immutable: true
   - name: 'configs'
@@ -87,4 +79,3 @@ properties:
     description: "Configuration for the topic that are overridden from the cluster
       defaults. The key of the map is a Kafka topic property name,
       for example: `cleanup.policy=compact`, `compression.type=producer`."
-    min_version: 'beta'

--- a/mmv1/products/managedkafka/product.yaml
+++ b/mmv1/products/managedkafka/product.yaml
@@ -15,6 +15,8 @@
 name: 'ManagedKafka'
 display_name: 'Managed Kafka'
 versions:
+  - name: 'ga'
+    base_url: 'https://managedkafka.googleapis.com/v1/'
   - name: 'beta'
     base_url: 'https://managedkafka.googleapis.com/v1/'
 scopes:

--- a/mmv1/templates/terraform/examples/managedkafka_cluster_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/managedkafka_cluster_basic.tf.tmpl
@@ -18,10 +18,7 @@ resource "google_managed_kafka_cluster" "{{$.PrimaryResourceId}}" {
   labels = {
     key = "value"
   }
-
-  provider = google-beta
 }
 
 data "google_project" "project" {
-  provider = google-beta
 }

--- a/mmv1/templates/terraform/examples/managedkafka_cluster_cmek.tf.tmpl
+++ b/mmv1/templates/terraform/examples/managedkafka_cluster_cmek.tf.tmpl
@@ -13,21 +13,29 @@ resource "google_managed_kafka_cluster" "{{$.PrimaryResourceId}}" {
     }
     kms_key = google_kms_crypto_key.key.id
   }
+
+  provider = google-beta
 }
 
 resource "google_project_service_identity" "kafka_service_identity" {
   project  = data.google_project.project.project_id
   service  = "managedkafka.googleapis.com"
+
+  provider = google-beta
 }
 
 resource "google_kms_crypto_key" "key" {
   name     = "{{index $.Vars "key_name"}}"
   key_ring = google_kms_key_ring.key_ring.id
+
+  provider = google-beta
 }
 
 resource "google_kms_key_ring" "key_ring" {
   name     = "{{index $.Vars "key_ring_name"}}"
   location = "us-central1"
+
+  provider = google-beta
 }
 
 resource "google_kms_crypto_key_iam_binding" "crypto_key_binding" {
@@ -37,7 +45,10 @@ resource "google_kms_crypto_key_iam_binding" "crypto_key_binding" {
   members = [
     "serviceAccount:service-${data.google_project.project.number}@gcp-sa-managedkafka.iam.gserviceaccount.com",
   ]
+
+  provider = google-beta
 }
 
 data "google_project" "project" {
+  provider = google-beta
 }

--- a/mmv1/templates/terraform/examples/managedkafka_cluster_cmek.tf.tmpl
+++ b/mmv1/templates/terraform/examples/managedkafka_cluster_cmek.tf.tmpl
@@ -13,29 +13,21 @@ resource "google_managed_kafka_cluster" "{{$.PrimaryResourceId}}" {
     }
     kms_key = google_kms_crypto_key.key.id
   }
-
-  provider = google-beta
 }
 
 resource "google_project_service_identity" "kafka_service_identity" {
   project  = data.google_project.project.project_id
   service  = "managedkafka.googleapis.com"
-
-  provider = google-beta
 }
 
 resource "google_kms_crypto_key" "key" {
   name     = "{{index $.Vars "key_name"}}"
   key_ring = google_kms_key_ring.key_ring.id
-
-  provider = google-beta
 }
 
 resource "google_kms_key_ring" "key_ring" {
   name     = "{{index $.Vars "key_ring_name"}}"
   location = "us-central1"
-
-  provider = google-beta
 }
 
 resource "google_kms_crypto_key_iam_binding" "crypto_key_binding" {
@@ -45,10 +37,7 @@ resource "google_kms_crypto_key_iam_binding" "crypto_key_binding" {
   members = [
     "serviceAccount:service-${data.google_project.project.number}@gcp-sa-managedkafka.iam.gserviceaccount.com",
   ]
-
-  provider = google-beta
 }
 
 data "google_project" "project" {
-  provider = google-beta
 }

--- a/mmv1/templates/terraform/examples/managedkafka_topic_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/managedkafka_topic_basic.tf.tmpl
@@ -12,8 +12,6 @@ resource "google_managed_kafka_cluster" "cluster" {
       }
     }
   }
-
-  provider = google-beta
 }
 
 resource "google_managed_kafka_topic" "{{$.PrimaryResourceId}}" {
@@ -25,10 +23,7 @@ resource "google_managed_kafka_topic" "{{$.PrimaryResourceId}}" {
   configs = {
     "cleanup.policy" = "compact"
   }
-
-  provider = google-beta
 }
 
 data "google_project" "project" {
-  provider = google-beta
 }

--- a/mmv1/third_party/terraform/services/managedkafka/resource_managed_kafka_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/managedkafka/resource_managed_kafka_cluster_test.go.tmpl
@@ -1,5 +1,4 @@
 package managedkafka_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"testing"
@@ -17,7 +16,7 @@ func TestAccManagedKafkaCluster_update(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckManagedKafkaClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -64,12 +63,9 @@ resource "google_managed_kafka_cluster" "example" {
   labels = {
     key = "value"
   }
-
-  provider = google-beta
 }
 
 data "google_project" "project" {
-  provider = google-beta
 }
 `, context)
 }
@@ -96,15 +92,9 @@ resource "google_managed_kafka_cluster" "example" {
   labels = {
     key = "new-value"
   }
-
-  provider = google-beta
 }
 
 data "google_project" "project" {
-  provider = google-beta
 }
 `, context)
 }
-{{- else }}
-// Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
-{{- end }}

--- a/mmv1/third_party/terraform/services/managedkafka/resource_managed_kafka_topic_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/managedkafka/resource_managed_kafka_topic_test.go.tmpl
@@ -1,5 +1,4 @@
 package managedkafka_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"testing"
@@ -17,7 +16,7 @@ func TestAccManagedKafkaTopic_update(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckManagedKafkaTopicDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -58,8 +57,6 @@ resource "google_managed_kafka_cluster" "example" {
       }
     }
   }
-
-  provider = google-beta
 }
 
 resource "google_managed_kafka_topic" "example" {
@@ -71,12 +68,9 @@ resource "google_managed_kafka_topic" "example" {
   configs = {
     "cleanup.policy" = "compact"
   }
-
-  provider = google-beta
 }
 
 data "google_project" "project" {
-  provider = google-beta
 }
 `, context)
 }
@@ -97,8 +91,6 @@ resource "google_managed_kafka_cluster" "example" {
       }
     }
   }
-
-  provider = google-beta
 }
 
 resource "google_managed_kafka_topic" "example" {
@@ -110,15 +102,9 @@ resource "google_managed_kafka_topic" "example" {
   configs = {
     "cleanup.policy" = "compact"
   }
-
-  provider = google-beta
 }
 
 data "google_project" "project" {
-  provider = google-beta
 }
 `, context)
 }
-{{- else }}
-// Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
-{{- end }}


### PR DESCRIPTION
https://b.corp.google.com/issues/371049718

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-resource
`google_managed_kafka_cluster` and `google_managed_kafka_topic` (ga)
```
