### PR TITLE
`ephemeral`: add `IAMBasePath` support

### DIFF
--- a/mmv1/third_party/terraform/fwtransport/framework_config.go.tmpl
+++ b/mmv1/third_party/terraform/fwtransport/framework_config.go.tmpl
@@ -63,6 +63,7 @@ type FrameworkProviderConfig struct {
 
 	// paths for client setup
 	IAMCredentialsBasePath           string // TODO: This will be removed once we resove the muxing issues
+	IAMBasePath                    string // TODO: This will be removed once we resove the muxing issues
 	{{- range $product := $.Products }}
 	{{ $product.Name }}BasePath string
 	{{- end }}
@@ -106,6 +107,7 @@ func (p *FrameworkProviderConfig) LoadAndValidateFramework(ctx context.Context, 
 	// Setup Base Paths for clients
 	// Generated products
 	p.IAMCredentialsBasePath = data.IamCredentialsCustomEndpoint.ValueString() // TODO: This will be removed once we resove the muxing issues
+	p.IAMBasePath = data.IAMCustomEndpoint.ValueString() // TODO: This will be removed once we resove the muxing issues
 	{{- range $product := $.Products }}
 	p.{{ $product.Name }}BasePath = data.{{ $product.Name }}CustomEndpoint.ValueString()
 	{{- end }}

--- a/mmv1/third_party/terraform/fwtransport/framework_provider_clients.go.tmpl
+++ b/mmv1/third_party/terraform/fwtransport/framework_provider_clients.go.tmpl
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"google.golang.org/api/dns/v1"
+	"google.golang.org/api/iam/v1"
 {{- if ne $.TargetVersionName "ga" }}
 	firebase "google.golang.org/api/firebase/v1beta1"
 {{- end }}
@@ -51,6 +52,20 @@ func (p *FrameworkProviderConfig) NewIamCredentialsClient(userAgent string) *iam
 	clientIamCredentials.BasePath = iamCredentialsClientBasePath
 
 	return clientIamCredentials
+}
+
+func (p *FrameworkProviderConfig) NewIamClient(userAgent string) *iam.Service {
+	iamClientBasePath := transport_tpg.RemoveBasePathVersion(p.IAMBasePath)
+	log.Printf("[INFO] Instantiating Google Cloud IAM client for path %s", iamClientBasePath)
+	clientIAM, err := iam.NewService(p.Context, option.WithHTTPClient(p.Client))
+	if err != nil {
+		log.Printf("[WARN] Error creating client iam: %s", err)
+		return nil
+	}
+	clientIAM.UserAgent = userAgent
+	clientIAM.BasePath = iamClientBasePath
+
+	return clientIAM
 }
 
 {{ if ne $.TargetVersionName `ga` -}}


### PR DESCRIPTION
During the work for supporting `service_account_key` ephemeral I found issues using IAM2. It turns out that the endpoint meant for support this will need to be `iam/v1` and not `iam/v2` seeing that we haven't supported this yet. This PR would add it in order to support `service_account_key` ephemeral.

This PR will need to be merged in order to support merging https://github.com/GoogleCloudPlatform/magic-modules/pull/12143

To confirm that this works you can run checkout this branch and run the ephemeral locally: I've built and ran an example configuration using the provider that includes the `service_account_key` ephemeral code as well as the code found here that allows it to work properly: https://github.com/hashicorp/terraform-provider-google/commit/45943f8fea966bc9e7413666b80c223d5a1d0cfc

It is based on  https://github.com/GoogleCloudPlatform/magic-modules/pull/12143 and can be ran with the following config:

```hcl
resource "google_service_account_key" "acceptance" {
  service_account_id = "projects/-/serviceAccounts/<SERVICE-ACCOUNT>"
  public_key_type    = "TYPE_X509_PEM_FILE"
}

# have this commented out first, uncomment on second terraform apply
# ephemeral "google_service_account_key" "test_key" {
#   name = "projects/-/serviceAccounts/<SERVICE-ACCOUNT>/keys/<KEY-CREATED-FROM-RESOURCE>"
#   public_key_type = "TYPE_X509_PEM_FILE"
# }

```

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
