### PR TITLE
Update `clean-provider` target in GNUmakefile to not remove TPG/TPGB CODEOWNERS files

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -75,7 +75,7 @@ tpgtools:
 clean-provider:
 	cd $(OUTPUT_PATH);\
 		go mod download;\
-		find . -type f -not -wholename "./.git*" -not -wholename "./.changelog*" -not -name ".travis.yml" -not -name ".golangci.yml" -not -name "CHANGELOG.md" -not -name "CHANGELOG_v*.md" -not -name "GNUmakefile" -not -name "docscheck.sh" -not -name "LICENSE" -not -name "README.md" -not -wholename "./examples*" -not -name ".go-version" -not -name ".hashibot.hcl" -print0 | xargs -0 git rm > /dev/null
+		find . -type f -not -wholename "./.git*" -not -wholename "./.changelog*" -not -name ".travis.yml" -not -name ".golangci.yml" -not -name "CHANGELOG.md" -not -name "CHANGELOG_v*.md" -not -name "GNUmakefile" -not -name "docscheck.sh" -not -name "LICENSE" -not -name "CODEOWNERS" -not -name "README.md" -not -wholename "./examples*" -not -name ".go-version" -not -name ".hashibot.hcl" -print0 | xargs -0 git rm > /dev/null
 
 clean-tgc:
 	cd $(OUTPUT_PATH);\


### PR DESCRIPTION
Unblocks https://github.com/hashicorp/terraform-provider-google/pull/20227
Unblocks https://github.com/hashicorp/terraform-provider-google-beta/pull/8650

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
