### PR TITLE
Updated remaining tag key / value examples

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
@@ -3860,12 +3860,12 @@ resource "google_compute_region_instance_template" "foobar" {
     boot         = true
 
     resource_manager_tags = {
-      "tagKeys/${google_tags_tag_key.key.name}" = "tagValues/${google_tags_tag_value.value.name}"
+      (google_tags_tag_key.key.id) = google_tags_tag_value.value.id
     }
   }
 
   resource_manager_tags = {
-    "tagKeys/${google_tags_tag_key.key.name}" = "tagValues/${google_tags_tag_value.value.name}"
+    (google_tags_tag_key.key.id) = google_tags_tag_value.value.id
   }
 
   network_interface {

--- a/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_discovery_config_test.go
+++ b/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_discovery_config_test.go
@@ -521,7 +521,7 @@ resource "google_tags_tag_key" "tag_key" {
 }
 
 resource "google_tags_tag_value" "tag_value" {
-	parent = "tagKeys/${google_tags_tag_key.tag_key.name}"
+	parent = google_tags_tag_key.tag_key.id
 	short_name = "prod"
 }
 

--- a/mmv1/third_party/terraform/website/docs/r/google_tags_location_tag_binding.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_tags_location_tag_binding.html.markdown
@@ -20,27 +20,27 @@ To bind a tag to a Cloud Run service:
 
 ```hcl
 resource "google_project" "project" {
-	project_id = "project_id"
-	name       = "project_id"
-	org_id     = "123456789"
+  project_id = "project_id"
+  name       = "project_id"
+  org_id     = "123456789"
 }
 
 resource "google_tags_tag_key" "key" {
-	parent      = "organizations/123456789"
-	short_name  = "keyname"
-	description = "For keyname resources."
+  parent      = "organizations/123456789"
+  short_name  = "keyname"
+  description = "For keyname resources."
 }
 
 resource "google_tags_tag_value" "value" {
-	parent      = "tagKeys/${google_tags_tag_key.key.name}"
-	short_name  = "valuename"
-	description = "For valuename resources."
+  parent      = google_tags_tag_key.key.id
+  short_name  = "valuename"
+  description = "For valuename resources."
 }
 
 resource "google_tags_location_tag_binding" "binding" {
-	parent    = "//run.googleapis.com/projects/${data.google_project.project.number}/locations/${google_cloud_run_service.default.location}/services/${google_cloud_run_service.default.name}"
-	tag_value = "tagValues/${google_tags_tag_value.value.name}"
-	location  = "us-central1"
+  parent    = "//run.googleapis.com/projects/${data.google_project.project.number}/locations/${google_cloud_run_service.default.location}/services/${google_cloud_run_service.default.name}"
+  tag_value = google_tags_tag_value.value.id
+  location  = "us-central1"
 }
 ```
 
@@ -48,27 +48,27 @@ resource "google_tags_location_tag_binding" "binding" {
 
 ```hcl
 resource "google_project" "project" {
-	project_id = "project_id"
-	name       = "project_id"
-	org_id     = "123456789"
+  project_id = "project_id"
+  name       = "project_id"
+  org_id     = "123456789"
 }
 
 resource "google_tags_tag_key" "key" {
-	parent      = "organizations/123456789"
-	short_name  = "keyname"
-	description = "For keyname resources."
+  parent      = "organizations/123456789"
+  short_name  = "keyname"
+  description = "For keyname resources."
 }
 
 resource "google_tags_tag_value" "value" {
-	parent      = "tagKeys/${google_tags_tag_key.key.name}"
-	short_name  = "valuename"
-	description = "For valuename resources."
+  parent      = google_tags_tag_key.key.id
+  short_name  = "valuename"
+  description = "For valuename resources."
 }
 
 resource "google_tags_location_tag_binding" "binding" {
-	parent    = "//compute.googleapis.com/projects/${google_project.project.number}/zones/us-central1-a/instances/${google_compute_instance.instance.instance_id}"
-	tag_value = "tagValues/${google_tags_tag_value.value.name}"
-	location  = "us-central1-a"
+  parent    = "//compute.googleapis.com/projects/${google_project.project.number}/zones/us-central1-a/instances/${google_compute_instance.instance.instance_id}"
+  tag_value = google_tags_tag_value.value.id
+  location  = "us-central1-a"
 }
 ```
 


### PR DESCRIPTION
- Used id of key / value vs. string interpolation in `mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl` and `mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_discovery_config_test.go` (maybe weren't present when I did the earlier passes)
- Updated example doc for `google_tags_location_tag_binding` as well

See #12118, #12132 etc

Note: the docs examples seem to have the google project data resource defined, but then use the organization vs. the project as the parent. I'm not sure if that is intentional or if there should be an example using the project vs. the org as the parent (or whether the unused project data resources should be removed entirely), but I left them as-is.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
