### PR TITLE
Add new TPUv2 QueuedResource resource in beta

### DIFF
--- a/mmv1/products/tpuv2/QueuedResource.yaml
+++ b/mmv1/products/tpuv2/QueuedResource.yaml
@@ -1,0 +1,111 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'QueuedResource'
+description: |
+  A Cloud TPU Queued Resource.
+min_version: 'beta'
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/tpu/docs/'
+  api: 'https://cloud.google.com/tpu/docs/reference/rest/v2/projects.locations.queuedResources'
+base_url: 'projects/{{project}}/locations/{{zone}}/queuedResources'
+self_link: 'projects/{{project}}/locations/{{zone}}/queuedResources/{{name}}'
+create_url: 'projects/{{project}}/locations/{{zone}}/queuedResources?queuedResourceId={{name}}'
+update_url: 'projects/{{project}}/locations/{{zone}}/queuedResources/{{name}}'
+update_verb: 'PATCH'
+update_mask: true
+autogen_async: true
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+    path: 'name'
+    wait_ms: 1000
+  result:
+    path: 'response'
+    resource_inside_response: true
+  status:
+    path: 'done'
+    complete: true
+    allowed:
+      - true
+      - false
+  error:
+    path: 'error'
+    message: 'message'
+examples:
+  - name: 'tpu_v2_queued_resource_basic'
+    primary_resource_id: 'qr'
+    min_version: 'beta'
+    vars:
+      qr_name: 'test-qr'
+      tpu_name: 'test-tpu'
+    test_env_vars:
+      project: 'PROJECT_NAME'
+    skip_vcr: true
+parameters:
+  - name: 'zone'
+    type: String
+    description: |
+      The GCP location for the Queued Resource. If it is not provided, the provider zone is used.
+    url_param_only: true
+    immutable: true
+    default_from_api: true
+properties:
+  - name: 'name'
+    type: String
+    description: |
+      The immutable name of the Queued Resource.
+    required: true
+    immutable: true
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'
+  - name: 'tpu'
+    type: NestedObject
+    description: |
+      Defines a TPU resource.
+    properties:
+      - name: 'nodeSpec'
+        type: Array
+        description: |
+          The TPU node(s) being requested.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'parent'
+              description: |
+                The parent resource name.
+            - name: 'nodeId'
+              immutable: true
+              description: |
+                Unqualified node identifier used to identify the node in the project once provisioned.
+            - name: 'node'
+              type: NestedObject
+              description: |
+                The node.
+              properties:
+                - name: 'runtimeVersion'
+                  required: true
+                  immutable: true
+                  description: |
+                    Runtime version for the TPU.
+                - name: 'acceleratorType'
+                  immutable: true
+                  default_value: 'v2-8'
+                  description: |
+                    TPU accelerator type for the TPU. If not specified, this defaults to 'v2-8'.
+                - name: 'description'
+                  description: |
+                    Text description of the TPU.

--- a/mmv1/products/tpuv2/QueuedResource.yaml
+++ b/mmv1/products/tpuv2/QueuedResource.yaml
@@ -87,23 +87,22 @@ properties:
             - name: 'parent'
               description: |
                 The parent resource name.
+              required: true
             - name: 'nodeId'
-              immutable: true
               description: |
                 Unqualified node identifier used to identify the node in the project once provisioned.
             - name: 'node'
               type: NestedObject
               description: |
                 The node.
+              required: true
               properties:
                 - name: 'runtimeVersion'
                   required: true
-                  immutable: true
                   description: |
                     Runtime version for the TPU.
                 - name: 'acceleratorType'
-                  immutable: true
-                  default_value: 'v2-8'
+                  default_from_api: true
                   description: |
                     TPU accelerator type for the TPU. If not specified, this defaults to 'v2-8'.
                 - name: 'description'

--- a/mmv1/products/tpuv2/QueuedResource.yaml
+++ b/mmv1/products/tpuv2/QueuedResource.yaml
@@ -28,7 +28,7 @@ update_verb: 'PATCH'
 update_mask: true
 autogen_async: true
 async:
-  actions: ['create', 'delete', 'update']
+  actions: ['create', 'delete']
   type: 'OpAsync'
   operation:
     base_url: '{{op_id}}'

--- a/mmv1/products/tpuv2/QueuedResource.yaml
+++ b/mmv1/products/tpuv2/QueuedResource.yaml
@@ -23,9 +23,7 @@ references:
 base_url: 'projects/{{project}}/locations/{{zone}}/queuedResources'
 self_link: 'projects/{{project}}/locations/{{zone}}/queuedResources/{{name}}'
 create_url: 'projects/{{project}}/locations/{{zone}}/queuedResources?queuedResourceId={{name}}'
-update_url: 'projects/{{project}}/locations/{{zone}}/queuedResources/{{name}}'
-update_verb: 'PATCH'
-update_mask: true
+immutable: true
 autogen_async: true
 async:
   actions: ['create', 'delete']
@@ -88,6 +86,7 @@ properties:
               description: |
                 The parent resource name.
               required: true
+              diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
             - name: 'nodeId'
               description: |
                 Unqualified node identifier used to identify the node in the project once provisioned.

--- a/mmv1/templates/terraform/examples/tpu_v2_queued_resource_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/tpu_v2_queued_resource_basic.tf.tmpl
@@ -1,8 +1,9 @@
 resource "google_tpu_v2_queued_resource" "{{$.PrimaryResourceId}}" {
   provider = google-beta
 
-  name = "{{index $.Vars "qr_name"}}"
-  zone = "us-central1-c"
+  name    = "{{index $.Vars "qr_name"}}"
+  zone    = "us-central1-c"
+  project = "{{index $.TestEnvVars "project_id"}}"
 
   tpu {
     node_spec {

--- a/mmv1/templates/terraform/examples/tpu_v2_queued_resource_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/tpu_v2_queued_resource_basic.tf.tmpl
@@ -3,7 +3,7 @@ resource "google_tpu_v2_queued_resource" "{{$.PrimaryResourceId}}" {
 
   name    = "{{index $.Vars "qr_name"}}"
   zone    = "us-central1-c"
-  project = "{{index $.TestEnvVars "project_id"}}"
+  project = "{{index $.TestEnvVars "project"}}"
 
   tpu {
     node_spec {

--- a/mmv1/templates/terraform/examples/tpu_v2_queued_resource_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/tpu_v2_queued_resource_basic.tf.tmpl
@@ -6,10 +6,12 @@ resource "google_tpu_v2_queued_resource" "{{$.PrimaryResourceId}}" {
 
   tpu {
     node_spec {
-      parent = "projects/{{index $.TestEnvVars "project"}}/locations/us-central1-c"
+      parent  = "projects/{{index $.TestEnvVars "project"}}/locations/us-central1-c"
       node_id = "{{index $.Vars "tpu_name"}}"
       node {
-        runtime_version = "tpu-vm-tf-2.13.0"
+        runtime_version  = "tpu-vm-tf-2.13.0"
+        accelerator_type = "v2-8"
+        description      = "Text description of the TPU."
       }
     }
   }

--- a/mmv1/templates/terraform/examples/tpu_v2_queued_resource_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/tpu_v2_queued_resource_basic.tf.tmpl
@@ -1,0 +1,16 @@
+resource "google_tpu_v2_queued_resource" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+
+  name = "{{index $.Vars "qr_name"}}"
+  zone = "us-central1-c"
+
+  tpu {
+    node_spec {
+      parent = "projects/{{index $.TestEnvVars "project"}}/locations/us-central1-c"
+      node_id = "{{index $.Vars "tpu_name"}}"
+      node {
+        runtime_version = "tpu-vm-tf-2.13.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Add new TPUv2 QueuedResource resource with minimum required fields to google-beta provider.

```release-note:new-resource
`google_tpu_v2_queued_resource` (beta)
```
