### PR TITLE
compute: use `net.IP.Equal` vs `bytes.Equal` for IP comparison

### DIFF
--- a/mmv1/templates/terraform/constants/compute_forwarding_rule.go.tmpl
+++ b/mmv1/templates/terraform/constants/compute_forwarding_rule.go.tmpl
@@ -51,7 +51,7 @@ func InternalIpDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
 			addr_equality = true
 		} else {
 			// old and new are IP addresses
-			addr_equality = bytes.Equal(addr_old, addr_new)
+			addr_equality = net.IP.Equal(addr_old, addr_new)
 		}
 	}
 


### PR DESCRIPTION
Resolves a lint warning and removes an extra import:
SA1021: use net.IP.Equal to compare net.IPs, not bytes.Equal

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
