### PR TITLE
doc: fix wrong iam auth flag for sql_user

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/sql_user.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_user.html.markdown
@@ -53,7 +53,7 @@ resource "google_sql_database_instance" "main" {
     tier = "db-f1-micro"
 
     database_flags {
-      name  = "cloudsql_iam_authentication"
+      name  = "cloudsql.iam_authentication"
       value = "on"
     }
   }


### PR DESCRIPTION
This PR was incorrect https://github.com/GoogleCloudPlatform/magic-modules/pull/10728

Flags are slightly inconsistent between MySQL and Postgres.

This fixes the flag for the Postgres example.

![image](https://github.com/user-attachments/assets/cf1b9b2b-c725-42c4-98bd-7087a4f7ec86)


<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
cloudsql: fixed example in doc using wrong iam auth flag for PostgresQL in `google_sql_user`
```

