### PR TITLE
compute: added `numeric_id` to `google_compute_subnetwork`

### DIFF
--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -73,6 +73,9 @@ iam_policy:
 custom_code:
   extra_schema_entry: 'templates/terraform/extra_schema_entry/subnetwork.tmpl'
   constants: 'templates/terraform/constants/subnetwork.tmpl'
+  decoder: 'templates/terraform/decoders/compute_subnetwork.go.tmpl'
+  encoder: 'templates/terraform/encoders/compute_subnetwork.go.tmpl'
+  update_encoder: 'templates/terraform/update_encoder/compute_subnetwork.go.tmpl'
   post_update: 'templates/terraform/post_update/compute_subnetwork.go.tmpl'
 custom_diff:
   - 'customdiff.ForceNewIfChange("ip_cidr_range", IsShrinkageIpCidr)'
@@ -203,6 +206,10 @@ properties:
     custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
     resource: 'Network'
     imports: 'selfLink'
+  - name: 'numericId'
+    type: String
+    description: The numeric ID of the resource as a string.
+    output: true
   - name: 'purpose'
     type: String
     description: |

--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -207,8 +207,8 @@ properties:
     resource: 'Network'
     imports: 'selfLink'
   - name: 'numericId'
-    type: String
-    description: The numeric ID of the resource as a string.
+    type: Integer
+    description: The numeric ID of the resource.
     output: true
   - name: 'purpose'
     type: String

--- a/mmv1/templates/terraform/decoders/compute_subnetwork.go.tmpl
+++ b/mmv1/templates/terraform/decoders/compute_subnetwork.go.tmpl
@@ -1,0 +1,2 @@
+res["numericId"] = res["id"] // stores unique id into numericId attribute before it's changed to path format
+return res, nil

--- a/mmv1/templates/terraform/encoders/compute_subnetwork.go.tmpl
+++ b/mmv1/templates/terraform/encoders/compute_subnetwork.go.tmpl
@@ -1,0 +1,2 @@
+delete(obj, "numeric_id") // Field doesn't exist in the API
+return obj, nil

--- a/mmv1/templates/terraform/update_encoder/compute_subnetwork.go.tmpl
+++ b/mmv1/templates/terraform/update_encoder/compute_subnetwork.go.tmpl
@@ -1,0 +1,2 @@
+delete(obj, "numeric_id") // Field doesn't exist in the API
+return obj, nil

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_subnetwork.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_subnetwork.go.tmpl
@@ -2,6 +2,7 @@ package compute
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
@@ -28,6 +29,10 @@ func DataSourceGoogleComputeSubnetwork() *schema.Resource {
 				Computed: true,
 			},
 			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"numeric_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -98,6 +103,10 @@ func dataSourceGoogleComputeSubnetworkRead(d *schema.ResourceData, meta interfac
 	subnetwork, err := config.NewComputeClient(userAgent).Subnetworks.Get(project, region, name).Do()
 	if err != nil {
 		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Subnetwork Not Found : %s", name), id)
+	}
+
+	if err := d.Set("numeric_id", strconv.Itoa(int(subnetwork.Id))); err != nil {
+		return fmt.Errorf("Error setting numeric_id: %s", err)
 	}
 
 	if err := d.Set("ip_cidr_range", subnetwork.IpCidrRange); err != nil {

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_subnetwork.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_subnetwork.go.tmpl
@@ -2,7 +2,6 @@ package compute
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
@@ -33,7 +32,7 @@ func DataSourceGoogleComputeSubnetwork() *schema.Resource {
 				Computed: true,
 			},
 			"numeric_id": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeInt,
 				Computed: true,
 			},
 			"ip_cidr_range": {
@@ -105,7 +104,7 @@ func dataSourceGoogleComputeSubnetworkRead(d *schema.ResourceData, meta interfac
 		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Subnetwork Not Found : %s", name), id)
 	}
 
-	if err := d.Set("numeric_id", strconv.Itoa(int(subnetwork.Id))); err != nil {
+	if err := d.Set("numeric_id", subnetwork.Id); err != nil {
 		return fmt.Errorf("Error setting numeric_id: %s", err)
 	}
 

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_subnetwork_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_subnetwork_test.go
@@ -47,6 +47,7 @@ func testAccDataSourceGoogleSubnetworkCheck(data_source_name string, resource_na
 			"id",
 			"name",
 			"description",
+			"numeric_id",
 			"ip_cidr_range",
 			"private_ip_google_access",
 			"internal_ipv6_prefix",

--- a/mmv1/third_party/terraform/services/compute/resource_compute_subnetwork_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_subnetwork_test.go.tmpl
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
 
 {{ if eq $.TargetVersionName `ga` }}
@@ -93,6 +95,36 @@ func TestAccComputeSubnetwork_basic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccComputeSubnetwork_numericId(t *testing.T) {
+	t.Parallel()
+
+	cnName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	subnetworkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	projectId := envvar.GetTestProjectFromEnv()
+	subnetworkId := fmt.Sprintf("projects/%s/regions/us-central1/subnetworks/%s", projectId, subnetworkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeSubnetworkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSubnetwork_numericId(cnName, subnetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("google_compute_subnetwork.numeric_id_test", "numeric_id", regexp.MustCompile("^\\d{16,48}$")),
+					resource.TestCheckResourceAttr("google_compute_subnetwork.numeric_id_test", "id", subnetworkId),
+				),
+			},
+			{
+				ResourceName:      "google_compute_subnetwork.numeric_id_test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 
 func TestAccComputeSubnetwork_update(t *testing.T) {
 	t.Parallel()
@@ -544,6 +576,23 @@ resource "google_compute_subnetwork" "network-with-private-google-access" {
   private_ip_google_access = true
 }
 `, cnName, subnetwork1Name, subnetwork2Name, subnetwork3Name)
+}
+
+func testAccComputeSubnetwork_numericId(cnName, subnetworkName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "test" {
+  name                     = "%s"
+  auto_create_subnetworks  = false
+  enable_ula_internal_ipv6 = true
+}
+
+resource "google_compute_subnetwork" "numeric_id_test" {
+  name          = "%s"
+  ip_cidr_range = "10.2.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.test.self_link
+}
+`, cnName, subnetworkName)
 }
 
 func testAccComputeSubnetwork_update1(cnName, cidrRange, subnetworkName string) string {

--- a/mmv1/third_party/terraform/website/docs/d/compute_subnetwork.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_subnetwork.html.markdown
@@ -40,7 +40,7 @@ In addition to the arguments listed above, the following attributes are exported
 * `network` - The network name or resource link to the parent
     network of this subnetwork.
 
-* `numeric_id` - The numeric ID of the resource as a string.
+* `numeric_id` - The numeric ID of the resource.
 
 * `description` - Description of this subnetwork.
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_subnetwork.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_subnetwork.html.markdown
@@ -40,6 +40,8 @@ In addition to the arguments listed above, the following attributes are exported
 * `network` - The network name or resource link to the parent
     network of this subnetwork.
 
+* `numeric_id` - The numeric ID of the resource as a string.
+
 * `description` - Description of this subnetwork.
 
 * `ip_cidr_range` - The IP address range that machines in this


### PR DESCRIPTION
Added `numeric_id` to `google_compute_subnetwork` resource and data source.

Since Terraform uses `id` internally, follow the example of `google_compute_network`, and make `numeric_id` contain the `id` field from the API.

As mentioned in the issue below, it would be very nice if there were a simpler way to just say "map `id` in the API to `numericId` here", but guessing that's not possible?

Part of hashicorp/terraform-provider-google#20223

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `numeric_id` to `google_compute_subnetwork` resource and data source
```
