### PR TITLE
Use regular string sorting for custom access context manager ingress and egress flatteners

### DIFF
--- a/mmv1/templates/terraform/custom_flatten/accesscontextmanager_egress_policy_resources_custom_flatten.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/accesscontextmanager_egress_policy_resources_custom_flatten.go.tmpl
@@ -1,25 +1,26 @@
 func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
     rawConfigValue := d.Get("egress_to.0.resources")
-
     // Convert config value to []string
     configValue, err := tpgresource.InterfaceSliceToStringSlice(rawConfigValue)
     if err != nil {
         log.Printf("[ERROR] Failed to convert config value: %s", err)
         return v
     }
+    sortedConfigValue := append([]string{}, configValue...)
+    sort.Strings(sortedConfigValue)
 
     // Convert v to []string
-    apiStringValue, err := tpgresource.InterfaceSliceToStringSlice(v)
+    apiValue, err := tpgresource.InterfaceSliceToStringSlice(v)
     if err != nil {
         log.Printf("[ERROR] Failed to convert API value: %s", err)
         return v
     }
+    sortedApiValue := append([]string{}, apiValue...)
+    sort.Strings(sortedApiValue)
 
-    sortedStrings, err := tpgresource.SortStringsByConfigOrder(configValue, apiStringValue)
-    if err != nil {
-        log.Printf("[ERROR] Could not sort API response value: %s", err)
-        return v
+    if (slices.Equal(sortedApiValue, sortedConfigValue)) {
+        return configValue
     }
 
-    return sortedStrings
+    return apiValue
 }

--- a/mmv1/templates/terraform/custom_flatten/accesscontextmanager_ingress_policy_resources_custom_flatten.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/accesscontextmanager_ingress_policy_resources_custom_flatten.go.tmpl
@@ -1,25 +1,26 @@
 func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
     rawConfigValue := d.Get("ingress_to.0.resources")
-
     // Convert config value to []string
     configValue, err := tpgresource.InterfaceSliceToStringSlice(rawConfigValue)
     if err != nil {
         log.Printf("[ERROR] Failed to convert config value: %s", err)
         return v
     }
+    sortedConfigValue := append([]string{}, configValue...)
+    sort.Strings(sortedConfigValue)
 
     // Convert v to []string
-    apiStringValue, err := tpgresource.InterfaceSliceToStringSlice(v)
+    apiValue, err := tpgresource.InterfaceSliceToStringSlice(v)
     if err != nil {
         log.Printf("[ERROR] Failed to convert API value: %s", err)
         return v
     }
+    sortedApiValue := append([]string{}, apiValue...)
+    sort.Strings(sortedApiValue)
 
-    sortedStrings, err := tpgresource.SortStringsByConfigOrder(configValue, apiStringValue)
-    if err != nil {
-        log.Printf("[ERROR] Could not sort API response value: %s", err)
-        return v
+    if (slices.Equal(sortedApiValue, sortedConfigValue)) {
+        return configValue
     }
 
-    return sortedStrings
+    return apiValue
 }


### PR DESCRIPTION
The SortStringsByConfigOrder function fails when there are duplicate items in the array which is a problem since duplicates are allowed by the API. Instead, we are using a regular string sort on both arrays and comparing them, if they are equal, we return the config value so that Terraform sees the state as being unchanged. If the arrays aren't equal, return the API response.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
accesscontextmanager: Fix permadiff in perimeter ingress / egress rules when there are duplicate resources in the rules
```
