### PR TITLE
Fix edition downgrade failure for an ENTERPRISE_PLUS instance with da…

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -1987,6 +1987,7 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 	instance.Settings.SettingsVersion = int64(_settings["version"].(int))
 	// Collation cannot be included in the update request
 	instance.Settings.Collation = ""
+	instance.Settings.DataCacheConfig = expandDataCacheConfig(_settings["data_cache_config"].([]interface{}))
 
 	// Lock on the master_instance_name just in case updating any replica
 	// settings causes operations on the master.

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -1811,7 +1811,6 @@ func TestAccSqlDatabaseInstance_Postgres_Edition_Upgrade(t *testing.T) {
 }
 
 func TestAccSqlDatabaseInstance_Edition_Downgrade(t *testing.T) {
-	t.Skip("https://github.com/hashicorp/terraform-provider-google/issues/20010")
 	t.Parallel()
 	enterprisePlusTier := "db-perf-optimized-N-2"
 	enterpriseTier := "db-custom-2-13312"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Recently there was an API change to enable data cache by default for `ENTERPRISE_PLUS` edition (both MySQL and Postgres) instances. When `data_cache_config` was not a `computed` attribute this resulted in acceptance test failures that were fixed in https://github.com/GoogleCloudPlatform/magic-modules/pull/12096. 

Now that `data_cache_config` is computed, it stays in the resource state after a downgrade even though `data_cache_config` is cleared from the instance metadata. This is a consequence of performing a [PATCH](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl#L1960) (for edition upgrade / downgrade) followed by an [UPDATE](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl#L2009) while ignoring the change in CloudSQL instance settings from the PATCH operation. The downgrade implicitly unsets the data cache config in the API as it is not allowed to be used with `ENTERPRISE` edition.

This PR fixes this issue (edition downgrade failure for an `ENTERPRISE_PLUS` instance with data cache enabled) by persisting the `data_cache_config` received after the PATCH operation for edition upgrade / downgrade. Also fixes https://github.com/hashicorp/terraform-provider-google/issues/20010 as `TestAccSqlDatabaseInstance_Edition_Downgrade` can now run.

b/375381759

I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
sql: fixed edition downgrade failure for an `ENTERPRISE_PLUS` instance with data cache enabled.
```
