### PR TITLE
Support `common_repository` for `google_artifact_registry_repository`

### DIFF
--- a/mmv1/products/artifactregistry/Repository.yaml
+++ b/mmv1/products/artifactregistry/Repository.yaml
@@ -173,6 +173,17 @@ examples:
       # Ignore this field as it is INPUT_ONLY. AR will not return this in the
       # response.
       - 'remote_repository_config.0.disable_upstream_validation'
+  - name: 'artifact_registry_repository_remote_common_repository_with_docker'
+    primary_resource_id: 'my-repo'
+    vars:
+      repository_id: 'example-common-remote'
+      desc: 'example remote common repository with docker upstream'
+      upstream_repository_id: 'example-upstream-repo'
+      upstream_repository_desc: 'example upstream repository'
+    ignore_read_extra:
+      # Ignore this field as it is INPUT_ONLY. AR will not return this in the
+      # response.
+      - 'remote_repository_config.0.disable_upstream_validation'
 parameters:
 properties:
   - name: 'name'
@@ -419,6 +430,7 @@ properties:
           - 'remoteRepositoryConfig.0.npm_repository'
           - 'remoteRepositoryConfig.0.python_repository'
           - 'remoteRepositoryConfig.0.yum_repository'
+          - 'remoteRepositoryConfig.0.common_repository'
         properties:
           - name: 'publicRepository'
             type: NestedObject
@@ -453,6 +465,7 @@ properties:
           - 'remoteRepositoryConfig.0.npm_repository'
           - 'remoteRepositoryConfig.0.python_repository'
           - 'remoteRepositoryConfig.0.yum_repository'
+          - 'remoteRepositoryConfig.0.common_repository'
         properties:
           - name: 'publicRepository'
             type: Enum
@@ -491,6 +504,7 @@ properties:
           - 'remoteRepositoryConfig.0.npm_repository'
           - 'remoteRepositoryConfig.0.python_repository'
           - 'remoteRepositoryConfig.0.yum_repository'
+          - 'remoteRepositoryConfig.0.common_repository'
         properties:
           - name: 'publicRepository'
             type: Enum
@@ -529,6 +543,7 @@ properties:
           - 'remoteRepositoryConfig.0.npm_repository'
           - 'remoteRepositoryConfig.0.python_repository'
           - 'remoteRepositoryConfig.0.yum_repository'
+          - 'remoteRepositoryConfig.0.common_repository'
         properties:
           - name: 'publicRepository'
             type: Enum
@@ -567,6 +582,7 @@ properties:
           - 'remoteRepositoryConfig.0.npm_repository'
           - 'remoteRepositoryConfig.0.python_repository'
           - 'remoteRepositoryConfig.0.yum_repository'
+          - 'remoteRepositoryConfig.0.common_repository'
         properties:
           - name: 'publicRepository'
             type: Enum
@@ -605,6 +621,7 @@ properties:
           - 'remoteRepositoryConfig.0.npm_repository'
           - 'remoteRepositoryConfig.0.python_repository'
           - 'remoteRepositoryConfig.0.yum_repository'
+          - 'remoteRepositoryConfig.0.common_repository'
         properties:
           - name: 'publicRepository'
             type: NestedObject
@@ -631,6 +648,26 @@ properties:
                   Specific repository from the base, e.g. `"pub/rocky/9/BaseOS/x86_64/os"`
                 required: true
                 immutable: true
+      - name: 'commonRepository'
+        type: NestedObject
+        description: |-
+          Specific settings for an Artifact Registory remote repository.
+        immutable: true
+        exactly_one_of:
+          - 'remoteRepositoryConfig.0.apt_repository'
+          - 'remoteRepositoryConfig.0.docker_repository'
+          - 'remoteRepositoryConfig.0.maven_repository'
+          - 'remoteRepositoryConfig.0.npm_repository'
+          - 'remoteRepositoryConfig.0.python_repository'
+          - 'remoteRepositoryConfig.0.yum_repository'
+          - 'remoteRepositoryConfig.0.common_repository'
+        properties:
+          - name: 'uri'
+            type: String
+            description: |-
+              Specific uri to the Artifact Registory repository, e.g. `projects/UPSTREAM_PROJECT_ID/locations/REGION/repositories/UPSTREAM_REPOSITORY`
+            immutable: true
+            required: true
       - name: 'upstreamCredentials'
         type: NestedObject
         description: |-

--- a/mmv1/templates/terraform/examples/artifact_registry_repository_remote_common_repository_with_docker.tf.tmpl
+++ b/mmv1/templates/terraform/examples/artifact_registry_repository_remote_common_repository_with_docker.tf.tmpl
@@ -1,0 +1,20 @@
+resource "google_artifact_registry_repository" "upstream_repo" {
+  location      = "us-central1"
+  repository_id = "{{index $.Vars "upstream_repository_id"}}"
+  description   = "{{index $.Vars "upstream_repository_desc"}}"
+  format        = "DOCKER"
+}
+
+resource "google_artifact_registry_repository" "{{$.PrimaryResourceId}}" {
+  location      = "us-central1"
+  repository_id = "{{index $.Vars "repository_id"}}"
+  description   = "{{index $.Vars "desc"}}"
+  format        = "DOCKER"
+  mode          = "REMOTE_REPOSITORY"
+  remote_repository_config {
+    description = "pull-through cache of another Artifact Registry repository"
+    common_repository {
+      uri         = google_artifact_registry_repository.upstream_repo.id
+    }
+  }
+}


### PR DESCRIPTION
Adds support for `common_repository` in remote
`google_artifact_registry_repository` repositories.

This is useful for creating pull-through caches in front of other Artifact Registry repos.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/20278



<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
artifactregistry: added `common_repository` field to `google_artifact_registry_repository` resource
```
