### PR TITLE
Add Mirroring and Intercept resources to Network Security.

### DIFF
--- a/mmv1/products/networksecurity/InterceptDeployment.yaml
+++ b/mmv1/products/networksecurity/InterceptDeployment.yaml
@@ -48,13 +48,13 @@ examples:
     config_path: 'templates/terraform/examples/network_security_intercept_deployment_basic.tf.tmpl'
     primary_resource_id: 'default'
     vars:
-      subnetwork_name: 'example-subnet'
       network_name: 'example-network'
-      deployment_group_id: 'example-mdg'
-      deployment_id: 'example-deployment'
+      subnetwork_name: 'example-subnet'
+      health_check_name: 'example-hc'
+      backend_service_name: 'example-bs'
       forwarding_rule_name: 'example-fwr'
-      target_pool_name: 'example-pool'
-      backend_name: 'example-be'
+      deployment_group_id: 'example-dg'
+      deployment_id: 'example-deployment'
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/networksecurity/InterceptDeployment.yaml
+++ b/mmv1/products/networksecurity/InterceptDeployment.yaml
@@ -1,0 +1,121 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'InterceptDeployment'
+description: InterceptDeployment represents the collectors within a Zone and is associated with a deployment group.
+min_version: 'beta'
+docs:
+id_format: 'projects/{{project}}/locations/{{location}}/interceptDeployments/{{intercept_deployment_id}}'
+base_url: 'projects/{{project}}/locations/{{location}}/interceptDeployments'
+self_link: 'projects/{{project}}/locations/{{location}}/interceptDeployments/{{intercept_deployment_id}}'
+create_url: 'projects/{{project}}/locations/{{location}}/interceptDeployments?interceptDeploymentId={{intercept_deployment_id}}'
+update_verb: 'PATCH'
+update_mask: true
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/interceptDeployments/{{intercept_deployment_id}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+autogen_async: true
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+    path: 'name'
+    wait_ms: 1000
+  result:
+    path: 'response'
+    resource_inside_response: true
+  error:
+    path: 'error'
+    message: 'message'
+custom_code:
+examples:
+  - name: 'network_security_intercept_deployment_basic'
+    config_path: 'templates/terraform/examples/network_security_intercept_deployment_basic.tf.tmpl'
+    primary_resource_id: 'default'
+    vars:
+      subnetwork_name: 'example-subnet'
+      network_name: 'example-network'
+      deployment_group_id: 'example-mdg'
+      deployment_id: 'example-deployment'
+      forwarding_rule_name: 'example-fwr'
+      target_pool_name: 'example-pool'
+      backend_name: 'example-be'
+parameters:
+  - name: 'location'
+    type: String
+    description: 'Resource ID segment making up resource `name`. It identifies the resource
+    within its parent collection as described in https://google.aip.dev/122. See documentation
+    for resource type `networksecurity.googleapis.com/InterceptDeployment`. '
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+  - name: 'interceptDeploymentId'
+    type: String
+    description: "Required. Id of the requesting object\nIf auto-generating Id server-side,
+    remove this field and\nintercept_deployment_id from the method_signature of Create
+    RPC "
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+properties:
+  - name: 'name'
+    type: String
+    description: 'Output only. Identifier. The name of the InterceptDeployment. '
+    min_version: 'beta'
+    output: true
+  - name: 'createTime'
+    type: String
+    description: 'Output only. [Output only] Create time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'updateTime'
+    type: String
+    description: 'Output only. [Output only] Update time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'labels'
+    type: KeyValueLabels
+    description: 'Optional. Labels as key value pairs '
+    min_version: 'beta'
+  - name: 'forwardingRule'
+    type: String
+    description: "Required. Immutable. The regional load balancer which the intercepted
+    traffic should be forwarded\nto. Format is:\nprojects/{project}/regions/{region}/forwardingRules/{forwardingRule} "
+    min_version: 'beta'
+    required: true
+    immutable: true
+  - name: 'interceptDeploymentGroup'
+    type: String
+    description: "Required. Immutable. The Intercept Deployment Group that this resource
+    is part of. Format is:\n`projects/{project}/locations/global/interceptDeploymentGroups/{interceptDeploymentGroup}` "
+    min_version: 'beta'
+    required: true
+    immutable: true
+  - name: 'state'
+    type: String
+    description: "Output only. Current state of the deployment. \n Possible values:\n
+    STATE_UNSPECIFIED\nACTIVE\nCREATING\nDELETING\nOUT_OF_SYNC\nDELETE_FAILED"
+    min_version: 'beta'
+    output: true
+  - name: 'reconciling'
+    type: Boolean
+    description: "Output only. Whether reconciling is in progress, recommended per\nhttps://google.aip.dev/128. "
+    min_version: 'beta'
+    output: true

--- a/mmv1/products/networksecurity/InterceptDeploymentGroup.yaml
+++ b/mmv1/products/networksecurity/InterceptDeploymentGroup.yaml
@@ -1,0 +1,124 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'InterceptDeploymentGroup'
+description: A Deployment Group represents the collector deployments across different zones within an organization.
+min_version: 'beta'
+docs:
+id_format: 'projects/{{project}}/locations/{{location}}/interceptDeploymentGroups/{{intercept_deployment_group_id}}'
+base_url: 'projects/{{project}}/locations/{{location}}/interceptDeploymentGroups'
+self_link: 'projects/{{project}}/locations/{{location}}/interceptDeploymentGroups/{{intercept_deployment_group_id}}'
+create_url: 'projects/{{project}}/locations/{{location}}/interceptDeploymentGroups?interceptDeploymentGroupId={{intercept_deployment_group_id}}'
+update_verb: 'PATCH'
+update_mask: true
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/interceptDeploymentGroups/{{intercept_deployment_group_id}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+autogen_async: true
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+    path: 'name'
+    wait_ms: 1000
+  result:
+    path: 'response'
+    resource_inside_response: true
+  error:
+    path: 'error'
+    message: 'message'
+custom_code:
+examples:
+  - name: 'network_security_intercept_deployment_group_basic'
+    config_path: 'templates/terraform/examples/network_security_intercept_deployment_group_basic.tf.tmpl'
+    primary_resource_id: 'default'
+    vars:
+      subnetwork_name: 'example-subnet'
+      network_name: 'example-network'
+      deployment_group_id: 'example-mdg'
+parameters:
+  - name: 'location'
+    type: String
+    description: 'Resource ID segment making up resource `name`. It identifies the resource
+    within its parent collection as described in https://google.aip.dev/122. See documentation
+    for resource type `networksecurity.googleapis.com/InterceptDeploymentGroup`. '
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+  - name: 'interceptDeploymentGroupId'
+    type: String
+    description: "Required. Id of the requesting object\nIf auto-generating Id server-side,
+    remove this field and\nintercept_deployment_group_id from the method_signature
+    of Create RPC "
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+properties:
+  - name: 'name'
+    type: String
+    description: 'Output only. Identifier. Then name of the InterceptDeploymentGroup. '
+    min_version: 'beta'
+    output: true
+  - name: 'createTime'
+    type: String
+    description: 'Output only. [Output only] Create time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'updateTime'
+    type: String
+    description: 'Output only. [Output only] Update time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'labels'
+    type: KeyValueLabels
+    description: 'Optional. Labels as key value pairs '
+    min_version: 'beta'
+  - name: 'network'
+    type: String
+    description: "Required. Immutable. The network that is being used for the deployment.
+    Format is:\nprojects/{project}/global/networks/{network}. "
+    min_version: 'beta'
+    required: true
+    immutable: true
+  - name: 'connectedEndpointGroups'
+    type: Array
+    min_version: 'beta'
+    description: 'Output only. The list of Intercept Endpoint Groups that are connected
+      to this resource. '
+    output: true
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'name'
+          type: String
+          description: 'Output only. A connected intercept endpoint group. '
+          min_version: 'beta'
+          output: true
+  - name: 'state'
+    type: String
+    description: "Output only. Current state of the deployment group. \n Possible values:\n
+    STATE_UNSPECIFIED\nACTIVE\nCREATING\nDELETING"
+    min_version: 'beta'
+    output: true
+  - name: 'reconciling'
+    type: Boolean
+    description: "Output only. Whether reconciling is in progress, recommended per\nhttps://google.aip.dev/128. "
+    min_version: 'beta'
+    output: true

--- a/mmv1/products/networksecurity/InterceptDeploymentGroup.yaml
+++ b/mmv1/products/networksecurity/InterceptDeploymentGroup.yaml
@@ -48,9 +48,9 @@ examples:
     config_path: 'templates/terraform/examples/network_security_intercept_deployment_group_basic.tf.tmpl'
     primary_resource_id: 'default'
     vars:
-      subnetwork_name: 'example-subnet'
       network_name: 'example-network'
-      deployment_group_id: 'example-mdg'
+      subnetwork_name: 'example-subnet'
+      deployment_group_id: 'example-dg'
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/networksecurity/InterceptEndpointGroup.yaml
+++ b/mmv1/products/networksecurity/InterceptEndpointGroup.yaml
@@ -1,0 +1,115 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'InterceptEndpointGroup'
+description: An intercept endpoint group is a global resource in the consumer account representing the producer’s deployment group.
+min_version: 'beta'
+docs:
+id_format: 'projects/{{project}}/locations/{{location}}/interceptEndpointGroups/{{intercept_endpoint_group_id}}'
+base_url: 'projects/{{project}}/locations/{{location}}/interceptEndpointGroups'
+self_link: 'projects/{{project}}/locations/{{location}}/interceptEndpointGroups/{{intercept_endpoint_group_id}}'
+create_url: 'projects/{{project}}/locations/{{location}}/interceptEndpointGroups?interceptEndpointGroupId={{intercept_endpoint_group_id}}'
+update_verb: 'PATCH'
+update_mask: true
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/interceptEndpointGroups/{{intercept_endpoint_group_id}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+autogen_async: true
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+    path: 'name'
+    wait_ms: 1000
+  result:
+    path: 'response'
+    resource_inside_response: true
+  error:
+    path: 'error'
+    message: 'message'
+custom_code:
+examples:
+  - name: 'network_security_intercept_endpoint_group_basic'
+    config_path: 'templates/terraform/examples/network_security_intercept_endpoint_group_basic.tf.tmpl'
+    primary_resource_id: 'default'
+    vars:
+      subnetwork_name: 'example-subnet'
+      network_name: 'example-network'
+      deployment_group_id: 'example-mdg'
+      deployment_id: 'example-deployment'
+      forwarding_rule_name: 'example-fwr'
+      target_pool_name: 'example-pool'
+      backend_name: 'example-be'
+      intercept_endpoint_group_id: 'meg-id'
+parameters:
+  - name: 'location'
+    type: String
+    description: 'Resource ID segment making up resource `name`. It identifies the resource
+    within its parent collection as described in https://google.aip.dev/122. See documentation
+    for resource type `networksecurity.googleapis.com/InterceptEndpointGroup`. '
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+  - name: 'interceptEndpointGroupId'
+    type: String
+    description: "Required. Id of the requesting object\nIf auto-generating Id server-side,
+    remove this field and\nintercept_endpoint_group_id from the method_signature of
+    Create RPC "
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+properties:
+  - name: 'name'
+    type: String
+    description: 'Output only. Identifier. The name of the InterceptEndpointGroup. '
+    min_version: 'beta'
+    output: true
+  - name: 'createTime'
+    type: String
+    description: 'Output only. [Output only] Create time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'updateTime'
+    type: String
+    description: 'Output only. [Output only] Update time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'labels'
+    type: KeyValueLabels
+    description: 'Optional. Labels as key value pairs '
+    min_version: 'beta'
+  - name: 'interceptDeploymentGroup'
+    type: String
+    description: "Required. Immutable. The Intercept Deployment Group that this resource
+    is connected to. Format\nis:\n`projects/{project}/locations/global/interceptDeploymentGroups/{interceptDeploymentGroup}` "
+    min_version: 'beta'
+    required: true
+    immutable: true
+  - name: 'state'
+    type: String
+    description: "Output only. Current state of the endpoint group. \n Possible values:\n
+    STATE_UNSPECIFIED\nACTIVE\nCLOSED\nCREATING\nDELETING\nOUT_OF_SYNC"
+    min_version: 'beta'
+    output: true
+  - name: 'reconciling'
+    type: Boolean
+    description: "Output only. Whether reconciling is in progress, recommended per\nhttps://google.aip.dev/128. "
+    min_version: 'beta'
+    output: true

--- a/mmv1/products/networksecurity/InterceptEndpointGroup.yaml
+++ b/mmv1/products/networksecurity/InterceptEndpointGroup.yaml
@@ -48,14 +48,9 @@ examples:
     config_path: 'templates/terraform/examples/network_security_intercept_endpoint_group_basic.tf.tmpl'
     primary_resource_id: 'default'
     vars:
-      subnetwork_name: 'example-subnet'
       network_name: 'example-network'
-      deployment_group_id: 'example-mdg'
-      deployment_id: 'example-deployment'
-      forwarding_rule_name: 'example-fwr'
-      target_pool_name: 'example-pool'
-      backend_name: 'example-be'
-      intercept_endpoint_group_id: 'meg-id'
+      deployment_group_id: 'example-dg'
+      endpoint_group_id: 'example-eg'
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/networksecurity/InterceptEndpointGroupAssociation.yaml
+++ b/mmv1/products/networksecurity/InterceptEndpointGroupAssociation.yaml
@@ -48,16 +48,11 @@ examples:
     config_path: 'templates/terraform/examples/network_security_intercept_endpoint_group_association_basic.tf.tmpl'
     primary_resource_id: 'default'
     vars:
-      subnetwork_name: 'example-subnet'
-      producer_network_name: 'producer-network'
-      consumer_network_name: 'consumer-network'
-      deployment_group_id: 'example-mdg'
-      deployment_id: 'example-deployment'
-      forwarding_rule_name: 'example-fwr'
-      target_pool_name: 'example-pool'
-      backend_name: 'example-be'
-      intercept_endpoint_group_id: 'meg-id'
-      intercept_endpoint_group_association_id: 'meg-association-id'
+      producer_network_name: 'example-prod-network'
+      consumer_network_name: 'example-cons-network'
+      deployment_group_id: 'example-dg'
+      endpoint_group_id: 'example-eg'
+      endpoint_group_association_id: 'example-ega'
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/networksecurity/InterceptEndpointGroupAssociation.yaml
+++ b/mmv1/products/networksecurity/InterceptEndpointGroupAssociation.yaml
@@ -1,0 +1,142 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'InterceptEndpointGroupAssociation'
+description: Creates an association between a VPC and an intercept endpoint group in order to intercept traffic in that VPC.
+min_version: 'beta'
+docs:
+id_format: 'projects/{{project}}/locations/{{location}}/interceptEndpointGroupAssociations/{{intercept_endpoint_group_association_id}}'
+base_url: 'projects/{{project}}/locations/{{location}}/interceptEndpointGroupAssociations'
+self_link: 'projects/{{project}}/locations/{{location}}/interceptEndpointGroupAssociations/{{intercept_endpoint_group_association_id}}'
+create_url: 'projects/{{project}}/locations/{{location}}/interceptEndpointGroupAssociations?interceptEndpointGroupAssociationId={{intercept_endpoint_group_association_id}}'
+update_verb: 'PATCH'
+update_mask: true
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/interceptEndpointGroupAssociations/{{intercept_endpoint_group_association_id}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+autogen_async: true
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+    path: 'name'
+    wait_ms: 1000
+  result:
+    path: 'response'
+    resource_inside_response: true
+  error:
+    path: 'error'
+    message: 'message'
+custom_code:
+examples:
+  - name: 'network_security_intercept_endpoint_group_association_basic'
+    config_path: 'templates/terraform/examples/network_security_intercept_endpoint_group_association_basic.tf.tmpl'
+    primary_resource_id: 'default'
+    vars:
+      subnetwork_name: 'example-subnet'
+      producer_network_name: 'producer-network'
+      consumer_network_name: 'consumer-network'
+      deployment_group_id: 'example-mdg'
+      deployment_id: 'example-deployment'
+      forwarding_rule_name: 'example-fwr'
+      target_pool_name: 'example-pool'
+      backend_name: 'example-be'
+      intercept_endpoint_group_id: 'meg-id'
+      intercept_endpoint_group_association_id: 'meg-association-id'
+parameters:
+  - name: 'location'
+    type: String
+    description: 'Resource ID segment making up resource `name`. It identifies the resource
+    within its parent collection as described in https://google.aip.dev/122. See documentation
+    for resource type `networksecurity.googleapis.com/InterceptEndpointGroupAssociation`. '
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+  - name: 'interceptEndpointGroupAssociationId'
+    type: String
+    description: "Optional. Id of the requesting object\nIf auto-generating Id server-side,
+    remove this field and\nintercept_endpoint_group_association_id from the method_signature
+    of Create\nRPC "
+    min_version: 'beta'
+    url_param_only: true
+    immutable: true
+properties:
+  - name: 'name'
+    type: String
+    description: 'Output only. Identifier. The name of the InterceptEndpointGroupAssociation. '
+    min_version: 'beta'
+    output: true
+  - name: 'createTime'
+    type: String
+    description: 'Output only. [Output only] Create time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'updateTime'
+    type: String
+    description: 'Output only. [Output only] Update time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'labels'
+    type: KeyValueLabels
+    description: 'Optional. Labels as key value pairs '
+    min_version: 'beta'
+  - name: 'interceptEndpointGroup'
+    type: String
+    description: "Required. Immutable. The Intercept Endpoint Group that this resource
+    is connected to. Format\nis:\n`projects/{project}/locations/global/interceptEndpointGroups/{interceptEndpointGroup}` "
+    min_version: 'beta'
+    required: true
+    immutable: true
+  - name: 'network'
+    type: String
+    description: "Required. Immutable. The VPC network associated. Format:\nprojects/{project}/global/networks/{network}. "
+    min_version: 'beta'
+    required: true
+    immutable: true
+  - name: 'locationsDetails'
+    type: Array
+    description: 'Output only. The list of locations that this association is in and
+      its details. '
+    min_version: 'beta'
+    output: true
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'location'
+          type: String
+          min_version: 'beta'
+          description: 'Output only. The cloud location. '
+          output: true
+        - name: 'state'
+          type: String
+          description: "Output only. The association state in this location. \n Possible
+            values:\n STATE_UNSPECIFIED\nACTIVE\nOUT_OF_SYNC"
+          min_version: 'beta'
+          output: true
+  - name: 'state'
+    type: String
+    description: "Output only. Current state of the endpoint group association. \n Possible
+      values:\n STATE_UNSPECIFIED\nACTIVE\nCREATING\nDELETING\nCLOSED\nOUT_OF_SYNC\nDELETE_FAILED"
+    min_version: 'beta'
+    output: true
+  - name: 'reconciling'
+    type: Boolean
+    description: "Output only. Whether reconciling is in progress, recommended per\nhttps://google.aip.dev/128. "
+    min_version: 'beta'
+    output: true

--- a/mmv1/products/networksecurity/MirroringDeployment.yaml
+++ b/mmv1/products/networksecurity/MirroringDeployment.yaml
@@ -44,13 +44,13 @@ examples:
     config_path: 'templates/terraform/examples/network_security_mirroring_deployment_basic.tf.tmpl'
     primary_resource_id: 'default'
     vars:
-      subnetwork_name: 'example-subnet'
       network_name: 'example-network'
-      deployment_group_id: 'example-mdg'
-      deployment_id: 'example-deployment'
+      subnetwork_name: 'example-subnet'
+      health_check_name: 'example-hc'
+      backend_service_name: 'example-bs'
       forwarding_rule_name: 'example-fwr'
-      target_pool_name: 'example-pool'
-      backend_name: 'example-be'
+      deployment_group_id: 'example-dg'
+      deployment_id: 'example-deployment'
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/networksecurity/MirroringDeployment.yaml
+++ b/mmv1/products/networksecurity/MirroringDeployment.yaml
@@ -1,0 +1,118 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'MirroringDeployment'
+description: MirroringDeployment represents the collectors within a Zone and is associated with a deployment group.
+min_version: 'beta'
+docs:
+id_format: 'projects/{{project}}/locations/{{location}}/mirroringDeployments/{{mirroring_deployment_id}}'
+base_url: 'projects/{{project}}/locations/{{location}}/mirroringDeployments'
+self_link: 'projects/{{project}}/locations/{{location}}/mirroringDeployments/{{mirroring_deployment_id}}'
+create_url: 'projects/{{project}}/locations/{{location}}/mirroringDeployments?mirroringDeploymentId={{mirroring_deployment_id}}'
+update_verb: 'PATCH'
+update_mask: true
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/mirroringDeployments/{{mirroring_deployment_id}}'
+autogen_async: true
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+    path: 'name'
+    wait_ms: 1000
+  result:
+    path: 'response'
+    resource_inside_response: true
+  error:
+    path: 'error'
+    message: 'message'
+custom_code:
+examples:
+  - name: 'network_security_mirroring_deployment_basic'
+    config_path: 'templates/terraform/examples/network_security_mirroring_deployment_basic.tf.tmpl'
+    primary_resource_id: 'default'
+    vars:
+      subnetwork_name: 'example-subnet'
+      network_name: 'example-network'
+      deployment_group_id: 'example-mdg'
+      deployment_id: 'example-deployment'
+      forwarding_rule_name: 'example-fwr'
+      target_pool_name: 'example-pool'
+      backend_name: 'example-be'
+parameters:
+  - name: 'location'
+    type: String
+    description: 'Resource ID segment making up resource `name`. It identifies the resource
+    within its parent collection as described in https://google.aip.dev/122. See documentation
+    for resource type `networksecurity.googleapis.com/MirroringDeployment`. '
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+  - name: 'mirroringDeploymentId'
+    type: String
+    description: "Required. Id of the requesting object\nIf auto-generating Id server-side,
+    remove this field and\nmirroring_deployment_id from the method_signature of Create
+    RPC "
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+properties:
+  - name: 'name'
+    type: String
+    description: 'Immutable. Identifier. The name of the MirroringDeployment. '
+    min_version: 'beta'
+    immutable: true
+    output: true
+  - name: 'createTime'
+    type: String
+    description: 'Output only. [Output only] Create time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'updateTime'
+    type: String
+    description: 'Output only. [Output only] Update time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'labels'
+    type: KeyValueLabels
+    description: 'Optional. Labels as key value pairs '
+    min_version: 'beta'
+  - name: 'forwardingRule'
+    type: String
+    description: "Required. Immutable. The regional load balancer which the mirrored
+    traffic should be forwarded\nto. Format is:\nprojects/{project}/regions/{region}/forwardingRules/{forwardingRule} "
+    min_version: 'beta'
+    required: true
+    immutable: true
+  - name: 'mirroringDeploymentGroup'
+    type: String
+    description: "Required. Immutable. The Mirroring Deployment Group that this resource
+    is part of. Format is:\n`projects/{project}/locations/global/mirroringDeploymentGroups/{mirroringDeploymentGroup}` "
+    min_version: 'beta'
+    required: true
+    immutable: true
+  - name: 'state'
+    type: String
+    description: "Output only. Current state of the deployment. \n Possible values:\n
+    STATE_UNSPECIFIED\nACTIVE\nCREATING\nDELETING\nOUT_OF_SYNC\nDELETE_FAILED"
+    min_version: 'beta'
+    output: true
+  - name: 'reconciling'
+    type: Boolean
+    description: "Output only. Whether reconciling is in progress, recommended per\nhttps://google.aip.dev/128. "
+    min_version: 'beta'
+    output: true

--- a/mmv1/products/networksecurity/MirroringDeploymentGroup.yaml
+++ b/mmv1/products/networksecurity/MirroringDeploymentGroup.yaml
@@ -1,0 +1,121 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'MirroringDeploymentGroup'
+description: A Deployment Group represents the collector deployments across different zones within an organization.
+min_version: 'beta'
+docs:
+id_format: 'projects/{{project}}/locations/{{location}}/mirroringDeploymentGroups/{{mirroring_deployment_group_id}}'
+base_url: 'projects/{{project}}/locations/{{location}}/mirroringDeploymentGroups'
+self_link: 'projects/{{project}}/locations/{{location}}/mirroringDeploymentGroups/{{mirroring_deployment_group_id}}'
+create_url: 'projects/{{project}}/locations/{{location}}/mirroringDeploymentGroups?mirroringDeploymentGroupId={{mirroring_deployment_group_id}}'
+update_verb: 'PATCH'
+update_mask: true
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/mirroringDeploymentGroups/{{mirroring_deployment_group_id}}'
+autogen_async: true
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+    path: 'name'
+    wait_ms: 1000
+  result:
+    path: 'response'
+    resource_inside_response: true
+  error:
+    path: 'error'
+    message: 'message'
+custom_code:
+examples:
+  - name: 'network_security_mirroring_deployment_group_basic'
+    config_path: 'templates/terraform/examples/network_security_mirroring_deployment_group_basic.tf.tmpl'
+    primary_resource_id: 'default'
+    vars:
+      subnetwork_name: 'example-subnet'
+      network_name: 'example-network'
+      deployment_group_id: 'example-mdg'
+parameters:
+  - name: 'location'
+    type: String
+    description: 'Resource ID segment making up resource `name`. It identifies the resource
+    within its parent collection as described in https://google.aip.dev/122. See documentation
+    for resource type `networksecurity.googleapis.com/MirroringDeploymentGroup`. '
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+  - name: 'mirroringDeploymentGroupId'
+    type: String
+    description: "Required. Id of the requesting object\nIf auto-generating Id server-side,
+    remove this field and\nmirroring_deployment_group_id from the method_signature
+    of Create RPC "
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+properties:
+  - name: 'name'
+    type: String
+    description: 'Immutable. Identifier. Then name of the MirroringDeploymentGroup. '
+    min_version: 'beta'
+    immutable: true
+    output: true
+  - name: 'createTime'
+    type: String
+    description: 'Output only. [Output only] Create time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'updateTime'
+    type: String
+    description: 'Output only. [Output only] Update time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'labels'
+    type: KeyValueLabels
+    description: 'Optional. Labels as key value pairs '
+    min_version: 'beta'
+  - name: 'network'
+    type: String
+    description: "Required. Immutable. The network that is being used for the deployment.
+    Format is:\nprojects/{project}/global/networks/{network}. "
+    min_version: 'beta'
+    required: true
+    immutable: true
+  - name: 'connectedEndpointGroups'
+    type: Array
+    description: 'Output only. The list of Mirroring Endpoint Groups that are connected
+      to this resource. '
+    min_version: 'beta'
+    output: true
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'name'
+          type: String
+          description: 'Output only. A connected mirroring endpoint group. '
+          min_version: 'beta'
+          output: true
+  - name: 'state'
+    type: String
+    description: "Output only. Current state of the deployment group. \n Possible values:\n
+    STATE_UNSPECIFIED\nACTIVE\nCREATING\nDELETING"
+    min_version: 'beta'
+    output: true
+  - name: 'reconciling'
+    type: Boolean
+    description: "Output only. Whether reconciling is in progress, recommended per\nhttps://google.aip.dev/128. "
+    min_version: 'beta'
+    output: true

--- a/mmv1/products/networksecurity/MirroringDeploymentGroup.yaml
+++ b/mmv1/products/networksecurity/MirroringDeploymentGroup.yaml
@@ -44,9 +44,9 @@ examples:
     config_path: 'templates/terraform/examples/network_security_mirroring_deployment_group_basic.tf.tmpl'
     primary_resource_id: 'default'
     vars:
-      subnetwork_name: 'example-subnet'
       network_name: 'example-network'
-      deployment_group_id: 'example-mdg'
+      subnetwork_name: 'example-subnet'
+      deployment_group_id: 'example-dg'
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/networksecurity/MirroringEndpointGroup.yaml
+++ b/mmv1/products/networksecurity/MirroringEndpointGroup.yaml
@@ -1,0 +1,112 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'MirroringEndpointGroup'
+description: A mirroring endpoint group is a global resource in the consumer account representing the producer’s deployment group.
+min_version: 'beta'
+docs:
+id_format: 'projects/{{project}}/locations/{{location}}/mirroringEndpointGroups/{{mirroring_endpoint_group_id}}'
+base_url: 'projects/{{project}}/locations/{{location}}/mirroringEndpointGroups'
+self_link: 'projects/{{project}}/locations/{{location}}/mirroringEndpointGroups/{{mirroring_endpoint_group_id}}'
+create_url: 'projects/{{project}}/locations/{{location}}/mirroringEndpointGroups?mirroringEndpointGroupId={{mirroring_endpoint_group_id}}'
+update_verb: 'PATCH'
+update_mask: true
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/mirroringEndpointGroups/{{mirroring_endpoint_group_id}}'
+autogen_async: true
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+    path: 'name'
+    wait_ms: 1000
+  result:
+    path: 'response'
+    resource_inside_response: true
+  error:
+    path: 'error'
+    message: 'message'
+custom_code:
+examples:
+  - name: 'network_security_mirroring_endpoint_group_basic'
+    config_path: 'templates/terraform/examples/network_security_mirroring_endpoint_group_basic.tf.tmpl'
+    primary_resource_id: 'default'
+    vars:
+      subnetwork_name: 'example-subnet'
+      network_name: 'example-network'
+      deployment_group_id: 'example-mdg'
+      deployment_id: 'example-deployment'
+      forwarding_rule_name: 'example-fwr'
+      target_pool_name: 'example-pool'
+      backend_name: 'example-be'
+      mirroring_endpoint_group_id: 'meg-id'
+parameters:
+  - name: 'location'
+    type: String
+    description: 'Resource ID segment making up resource `name`. It identifies the resource
+    within its parent collection as described in https://google.aip.dev/122. See documentation
+    for resource type `networksecurity.googleapis.com/MirroringEndpointGroup`. '
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+  - name: 'mirroringEndpointGroupId'
+    type: String
+    description: "Required. Id of the requesting object\nIf auto-generating Id server-side,
+    remove this field and\nmirroring_endpoint_group_id from the method_signature of
+    Create RPC "
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+properties:
+  - name: 'name'
+    type: String
+    description: 'Immutable. Identifier. The name of the MirroringEndpointGroup. '
+    min_version: 'beta'
+    immutable: true
+    output: true
+  - name: 'createTime'
+    type: String
+    description: 'Output only. [Output only] Create time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'updateTime'
+    type: String
+    description: 'Output only. [Output only] Update time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'labels'
+    type: KeyValueLabels
+    description: 'Optional. Labels as key value pairs '
+    min_version: 'beta'
+  - name: 'mirroringDeploymentGroup'
+    type: String
+    description: "Required. Immutable. The Mirroring Deployment Group that this resource
+    is connected to. Format\nis:\n`projects/{project}/locations/global/mirroringDeploymentGroups/{mirroringDeploymentGroup}` "
+    min_version: 'beta'
+    required: true
+    immutable: true
+  - name: 'state'
+    type: String
+    description: "Output only. Current state of the endpoint group. \n Possible values:\n
+    STATE_UNSPECIFIED\nACTIVE\nCLOSED\nCREATING\nDELETING\nOUT_OF_SYNC"
+    min_version: 'beta'
+    output: true
+  - name: 'reconciling'
+    type: Boolean
+    description: "Output only. Whether reconciling is in progress, recommended per\nhttps://google.aip.dev/128. "
+    min_version: 'beta'
+    output: true

--- a/mmv1/products/networksecurity/MirroringEndpointGroup.yaml
+++ b/mmv1/products/networksecurity/MirroringEndpointGroup.yaml
@@ -44,14 +44,9 @@ examples:
     config_path: 'templates/terraform/examples/network_security_mirroring_endpoint_group_basic.tf.tmpl'
     primary_resource_id: 'default'
     vars:
-      subnetwork_name: 'example-subnet'
       network_name: 'example-network'
-      deployment_group_id: 'example-mdg'
-      deployment_id: 'example-deployment'
-      forwarding_rule_name: 'example-fwr'
-      target_pool_name: 'example-pool'
-      backend_name: 'example-be'
-      mirroring_endpoint_group_id: 'meg-id'
+      deployment_group_id: 'example-dg'
+      endpoint_group_id: 'example-eg'
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/networksecurity/MirroringEndpointGroupAssociation.yaml
+++ b/mmv1/products/networksecurity/MirroringEndpointGroupAssociation.yaml
@@ -1,0 +1,139 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'MirroringEndpointGroupAssociation'
+description: Creates an association between a VPC and a mirroring endpoint group in order to mirror traffic in that VPC.
+min_version: 'beta'
+docs:
+id_format: 'projects/{{project}}/locations/{{location}}/mirroringEndpointGroupAssociations/{{mirroring_endpoint_group_association_id}}'
+base_url: 'projects/{{project}}/locations/{{location}}/mirroringEndpointGroupAssociations'
+self_link: 'projects/{{project}}/locations/{{location}}/mirroringEndpointGroupAssociations/{{mirroring_endpoint_group_association_id}}'
+create_url: 'projects/{{project}}/locations/{{location}}/mirroringEndpointGroupAssociations?mirroringEndpointGroupAssociationId={{mirroring_endpoint_group_association_id}}'
+update_verb: 'PATCH'
+update_mask: true
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/mirroringEndpointGroupAssociations/{{mirroring_endpoint_group_association_id}}'
+autogen_async: true
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+    path: 'name'
+    wait_ms: 1000
+  result:
+    path: 'response'
+    resource_inside_response: true
+  error:
+    path: 'error'
+    message: 'message'
+custom_code:
+examples:
+  - name: 'network_security_mirroring_endpoint_group_association_basic'
+    config_path: 'templates/terraform/examples/network_security_mirroring_endpoint_group_association_basic.tf.tmpl'
+    primary_resource_id: 'default'
+    vars:
+      subnetwork_name: 'example-subnet'
+      producer_network_name: 'producer-network'
+      consumer_network_name: 'consumer-network'
+      deployment_group_id: 'example-mdg'
+      deployment_id: 'example-deployment'
+      forwarding_rule_name: 'example-fwr'
+      target_pool_name: 'example-pool'
+      backend_name: 'example-be'
+      mirroring_endpoint_group_id: 'meg-id'
+      mirroring_endpoint_group_association_id: 'meg-association-id'
+parameters:
+  - name: 'location'
+    type: String
+    description: 'Resource ID segment making up resource `name`. It identifies the resource
+    within its parent collection as described in https://google.aip.dev/122. See documentation
+    for resource type `networksecurity.googleapis.com/MirroringEndpointGroupAssociation`. '
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+  - name: 'mirroringEndpointGroupAssociationId'
+    type: String
+    description: "Optional. Id of the requesting object\nIf auto-generating Id server-side,
+    remove this field and\nmirroring_endpoint_group_association_id from the method_signature
+    of Create\nRPC "
+    min_version: 'beta'
+    url_param_only: true
+    immutable: true
+properties:
+  - name: 'name'
+    type: String
+    description: 'Immutable. Identifier. The name of the MirroringEndpointGroupAssociation. '
+    min_version: 'beta'
+    immutable: true
+    output: true
+  - name: 'createTime'
+    type: String
+    description: 'Output only. [Output only] Create time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'updateTime'
+    type: String
+    description: 'Output only. [Output only] Update time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'labels'
+    type: KeyValueLabels
+    description: 'Optional. Labels as key value pairs '
+    min_version: 'beta'
+  - name: 'mirroringEndpointGroup'
+    type: String
+    description: "Required. Immutable. The Mirroring Endpoint Group that this resource
+    is connected to. Format\nis:\n`projects/{project}/locations/global/mirroringEndpointGroups/{mirroringEndpointGroup}` "
+    min_version: 'beta'
+    required: true
+    immutable: true
+  - name: 'network'
+    type: String
+    description: "Required. Immutable. The VPC network associated. Format:\nprojects/{project}/global/networks/{network}. "
+    min_version: 'beta'
+    required: true
+    immutable: true
+  - name: 'locationsDetails'
+    type: Array
+    description: 'Output only. The list of locations that this association is in and
+    its details. '
+    min_version: 'beta'
+    output: true
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'location'
+          type: String
+          description: 'Output only. The cloud location. '
+          min_version: 'beta'
+          output: true
+        - name: 'state'
+          type: String
+          description: "Output only. The association state in this location. \n
+        Possible values:\n STATE_UNSPECIFIED\nACTIVE\nOUT_OF_SYNC"
+          min_version: 'beta'
+          output: true
+  - name: 'state'
+    type: String
+    description: "Output only. Current state of the endpoint group association. \n
+    Possible values:\n STATE_UNSPECIFIED\nACTIVE\nCREATING\nDELETING\nCLOSED\nOUT_OF_SYNC\nDELETE_FAILED"
+    min_version: 'beta'
+    output: true
+  - name: 'reconciling'
+    type: Boolean
+    description: "Output only. Whether reconciling is in progress, recommended per\nhttps://google.aip.dev/128. "
+    min_version: 'beta'
+    output: true

--- a/mmv1/products/networksecurity/MirroringEndpointGroupAssociation.yaml
+++ b/mmv1/products/networksecurity/MirroringEndpointGroupAssociation.yaml
@@ -44,16 +44,11 @@ examples:
     config_path: 'templates/terraform/examples/network_security_mirroring_endpoint_group_association_basic.tf.tmpl'
     primary_resource_id: 'default'
     vars:
-      subnetwork_name: 'example-subnet'
-      producer_network_name: 'producer-network'
-      consumer_network_name: 'consumer-network'
-      deployment_group_id: 'example-mdg'
-      deployment_id: 'example-deployment'
-      forwarding_rule_name: 'example-fwr'
-      target_pool_name: 'example-pool'
-      backend_name: 'example-be'
-      mirroring_endpoint_group_id: 'meg-id'
-      mirroring_endpoint_group_association_id: 'meg-association-id'
+      producer_network_name: 'example-prod-network'
+      consumer_network_name: 'example-cons-network'
+      deployment_group_id: 'example-dg'
+      endpoint_group_id: 'example-eg'
+      endpoint_group_association_id: 'example-ega'
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/templates/terraform/examples/network_security_intercept_deployment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_deployment_basic.tf.tmpl
@@ -7,7 +7,7 @@ resource "google_compute_network" "network" {
 resource "google_compute_subnetwork" "subnetwork" {
   provider      = google-beta
   name          = "{{index $.Vars "subnetwork_name"}}"
-  region        = "us-central1"
+  region        = "asia-east1"
   ip_cidr_range = "10.1.0.0/16"
   network       = google_compute_network.network.name
 }
@@ -15,7 +15,7 @@ resource "google_compute_subnetwork" "subnetwork" {
 resource "google_compute_region_health_check" "health_check" {
   provider = google-beta
   name     = "{{index $.Vars "health_check_name"}}"
-  region   = "us-central1"
+  region   = "asia-east1"
   http_health_check {
     port = 80
   }
@@ -24,7 +24,7 @@ resource "google_compute_region_health_check" "health_check" {
 resource "google_compute_region_backend_service" "backend_service" {
   provider              = google-beta
   name                  = "{{index $.Vars "backend_service_name"}}"
-  region                = "us-central1"
+  region                = "asia-east1"
   health_checks         = [google_compute_region_health_check.health_check.id]
   protocol              = "UDP"
   load_balancing_scheme = "INTERNAL"
@@ -33,7 +33,7 @@ resource "google_compute_region_backend_service" "backend_service" {
 resource "google_compute_forwarding_rule" "forwarding_rule" {
   provider               = google-beta
   name                   = "{{index $.Vars "forwarding_rule_name"}}"
-  region                 = "us-central1"
+  region                 = "asia-east1"
   network                = google_compute_network.network.name
   subnetwork             = google_compute_subnetwork.subnetwork.name
   backend_service        = google_compute_region_backend_service.backend_service.id
@@ -52,7 +52,10 @@ resource "google_network_security_intercept_deployment_group" "deployment_group"
 resource "google_network_security_intercept_deployment" "{{$.PrimaryResourceId}}" {
   provider                   = google-beta
   intercept_deployment_id    = "{{index $.Vars "deployment_id"}}"
-  location                   = "us-central1-a"
+  location                   = "asia-east1-a"
   forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id
   intercept_deployment_group = google_network_security_intercept_deployment_group.deployment_group.id
+  labels = {
+    foo = "bar"
+  }
 }

--- a/mmv1/templates/terraform/examples/network_security_intercept_deployment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_deployment_basic.tf.tmpl
@@ -1,48 +1,57 @@
 resource "google_compute_network" "network" {
+  provider                = google-beta
   name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "subnetwork" {
+  provider      = google-beta
   name          = "{{index $.Vars "subnetwork_name"}}"
+  region        = "us-central1"
   ip_cidr_range = "10.1.0.0/16"
   network       = google_compute_network.network.name
 }
 
 resource "google_compute_region_health_check" "health_check" {
-  name = "{{index $.Vars "health_check_name"}}"
+  provider = google-beta
+  name     = "{{index $.Vars "health_check_name"}}"
+  region   = "us-central1"
   http_health_check {
     port = 80
   }
 }
 
 resource "google_compute_region_backend_service" "backend_service" {
+  provider              = google-beta
   name                  = "{{index $.Vars "backend_service_name"}}"
+  region                = "us-central1"
   health_checks         = [google_compute_region_health_check.health_check.id]
   protocol              = "UDP"
   load_balancing_scheme = "INTERNAL"
 }
 
 resource "google_compute_forwarding_rule" "forwarding_rule" {
-  name                  = "{{index $.Vars "forwarding_rule_name"}}"
-  backend_service       = google_compute_region_backend_service.backend_service.id
-  network               = google_compute_network.network.name
-  subnetwork            = google_compute_subnetwork.subnetwork.name
-  load_balancing_scheme = "INTERNAL"
-  ports                 = [6081]
-  ip_protocol           = "UDP"
+  provider               = google-beta
+  name                   = "{{index $.Vars "forwarding_rule_name"}}"
+  region                 = "us-central1"
+  network                = google_compute_network.network.name
+  subnetwork             = google_compute_subnetwork.subnetwork.name
+  backend_service        = google_compute_region_backend_service.backend_service.id
+  load_balancing_scheme  = "INTERNAL"
+  ports                  = [6081]
+  ip_protocol            = "UDP"
 }
 
 resource "google_network_security_intercept_deployment_group" "deployment_group" {
   provider                      = google-beta
-  intercept_deployment_group_id = "{{index $.Vars "deployment_group_name"}}"
+  intercept_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
   location                      = "global"
   network                       = google_compute_network.network.id
 }
 
 resource "google_network_security_intercept_deployment" "{{$.PrimaryResourceId}}" {
   provider                   = google-beta
-  intercept_deployment_id    = "{{index $.Vars "resource_name"}}"
+  intercept_deployment_id    = "{{index $.Vars "deployment_id"}}"
   location                   = "us-central1-a"
   forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id
   intercept_deployment_group = google_network_security_intercept_deployment_group.deployment_group.id

--- a/mmv1/templates/terraform/examples/network_security_intercept_deployment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_deployment_basic.tf.tmpl
@@ -1,0 +1,49 @@
+resource "google_compute_network" "network" {
+  name                    = "{{index $.Vars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  name          = "{{index $.Vars "subnetwork_name"}}"
+  ip_cidr_range = "10.1.0.0/16"
+  network       = google_compute_network.network.name
+}
+
+resource "google_compute_region_health_check" "health_check" {
+  name = "{{index $.Vars "health_check_name"}}"
+  http_health_check {
+    port = 80
+  }
+}
+
+resource "google_compute_region_backend_service" "backend_service" {
+  name                  = "{{index $.Vars "backend_service_name"}}"
+  health_checks         = [google_compute_region_health_check.health_check.id]
+  protocol              = "UDP"
+  load_balancing_scheme = "INTERNAL"
+}
+
+resource "google_compute_forwarding_rule" "forwarding_rule" {
+  name                  = "{{index $.Vars "forwarding_rule_name"}}"
+  backend_service       = google_compute_region_backend_service.backend_service.id
+  network               = google_compute_network.network.name
+  subnetwork            = google_compute_subnetwork.subnetwork.name
+  load_balancing_scheme = "INTERNAL"
+  ports                 = [6081]
+  ip_protocol           = "UDP"
+}
+
+resource "google_network_security_intercept_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "{{index $.Vars "deployment_group_name"}}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+}
+
+resource "google_network_security_intercept_deployment" "{{$.PrimaryResourceId}}" {
+  provider                   = google-beta
+  intercept_deployment_id    = "{{index $.Vars "resource_name"}}"
+  location                   = "us-central1-a"
+  forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id
+  intercept_deployment_group = google_network_security_intercept_deployment_group.deployment_group.id
+}

--- a/mmv1/templates/terraform/examples/network_security_intercept_deployment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_deployment_basic.tf.tmpl
@@ -7,7 +7,7 @@ resource "google_compute_network" "network" {
 resource "google_compute_subnetwork" "subnetwork" {
   provider      = google-beta
   name          = "{{index $.Vars "subnetwork_name"}}"
-  region        = "asia-east1"
+  region        = "us-central1"
   ip_cidr_range = "10.1.0.0/16"
   network       = google_compute_network.network.name
 }
@@ -15,7 +15,7 @@ resource "google_compute_subnetwork" "subnetwork" {
 resource "google_compute_region_health_check" "health_check" {
   provider = google-beta
   name     = "{{index $.Vars "health_check_name"}}"
-  region   = "asia-east1"
+  region   = "us-central1"
   http_health_check {
     port = 80
   }
@@ -24,7 +24,7 @@ resource "google_compute_region_health_check" "health_check" {
 resource "google_compute_region_backend_service" "backend_service" {
   provider              = google-beta
   name                  = "{{index $.Vars "backend_service_name"}}"
-  region                = "asia-east1"
+  region                = "us-central1"
   health_checks         = [google_compute_region_health_check.health_check.id]
   protocol              = "UDP"
   load_balancing_scheme = "INTERNAL"
@@ -33,7 +33,7 @@ resource "google_compute_region_backend_service" "backend_service" {
 resource "google_compute_forwarding_rule" "forwarding_rule" {
   provider               = google-beta
   name                   = "{{index $.Vars "forwarding_rule_name"}}"
-  region                 = "asia-east1"
+  region                 = "us-central1"
   network                = google_compute_network.network.name
   subnetwork             = google_compute_subnetwork.subnetwork.name
   backend_service        = google_compute_region_backend_service.backend_service.id
@@ -52,7 +52,7 @@ resource "google_network_security_intercept_deployment_group" "deployment_group"
 resource "google_network_security_intercept_deployment" "{{$.PrimaryResourceId}}" {
   provider                   = google-beta
   intercept_deployment_id    = "{{index $.Vars "deployment_id"}}"
-  location                   = "asia-east1-a"
+  location                   = "us-central1-a"
   forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id
   intercept_deployment_group = google_network_security_intercept_deployment_group.deployment_group.id
   labels = {

--- a/mmv1/templates/terraform/examples/network_security_intercept_deployment_group_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_deployment_group_basic.tf.tmpl
@@ -1,11 +1,12 @@
 resource "google_compute_network" "network" {
+  provider                = google-beta
   name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_intercept_deployment_group" "{{$.PrimaryResourceId}}" {
   provider                      = google-beta
-  intercept_deployment_group_id = "{{index $.Vars "resource_name"}}"
+  intercept_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
   location                      = "global"
   network                       = google_compute_network.network.id
 }

--- a/mmv1/templates/terraform/examples/network_security_intercept_deployment_group_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_deployment_group_basic.tf.tmpl
@@ -1,0 +1,11 @@
+resource "google_compute_network" "network" {
+  name                    = "{{index $.Vars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "{{$.PrimaryResourceId}}" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "{{index $.Vars "resource_name"}}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+}

--- a/mmv1/templates/terraform/examples/network_security_intercept_deployment_group_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_deployment_group_basic.tf.tmpl
@@ -9,4 +9,7 @@ resource "google_network_security_intercept_deployment_group" "{{$.PrimaryResour
   intercept_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
   location                      = "global"
   network                       = google_compute_network.network.id
+  labels = {
+    foo = "bar"
+  }
 }

--- a/mmv1/templates/terraform/examples/network_security_intercept_endpoint_group_association_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_endpoint_group_association_basic.tf.tmpl
@@ -30,4 +30,7 @@ resource "google_network_security_intercept_endpoint_group_association" "{{$.Pri
   location                                = "global"
   network                                 = google_compute_network.consumer_network.id
   intercept_endpoint_group                = google_network_security_intercept_endpoint_group.endpoint_group.id
+  labels = {
+    foo = "bar"
+  }
 }

--- a/mmv1/templates/terraform/examples/network_security_intercept_endpoint_group_association_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_endpoint_group_association_basic.tf.tmpl
@@ -1,0 +1,31 @@
+resource "google_compute_network" "producer_network" {
+  name                    = "{{index $.Vars "producer_network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_network" "consumer_network" {
+  name                    = "{{index $.Vars "consumer_network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "{{index $.Vars "deployment_group_name"}}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+}
+
+resource "google_network_security_intercept_endpoint_group" "endpoint_group" {
+  provider                      = google-beta
+  intercept_endpoint_group_id   = "{{index $.Vars "endpoint_group_name"}}"
+  location                      = "global"
+  intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
+}
+
+resource "google_network_security_intercept_endpoint_group_association" "{{$.PrimaryResourceId}}" {
+  provider                                = google-beta
+  intercept_endpoint_group_association_id = "{{index $.Vars "resource_name"}}"
+  location                                = "global"
+  network                                 = google_compute_network.consumer_network.id
+  intercept_endpoint_group                = google_network_security_intercept_endpoint_group.endpoint_group.id
+}

--- a/mmv1/templates/terraform/examples/network_security_intercept_endpoint_group_association_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_endpoint_group_association_basic.tf.tmpl
@@ -1,30 +1,32 @@
 resource "google_compute_network" "producer_network" {
+  provider                = google-beta
   name                    = "{{index $.Vars "producer_network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_network" "consumer_network" {
+  provider                = google-beta
   name                    = "{{index $.Vars "consumer_network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_intercept_deployment_group" "deployment_group" {
   provider                      = google-beta
-  intercept_deployment_group_id = "{{index $.Vars "deployment_group_name"}}"
+  intercept_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
   location                      = "global"
-  network                       = google_compute_network.network.id
+  network                       = google_compute_network.producer_network.id
 }
 
 resource "google_network_security_intercept_endpoint_group" "endpoint_group" {
   provider                      = google-beta
-  intercept_endpoint_group_id   = "{{index $.Vars "endpoint_group_name"}}"
+  intercept_endpoint_group_id   = "{{index $.Vars "endpoint_group_id"}}"
   location                      = "global"
   intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
 }
 
 resource "google_network_security_intercept_endpoint_group_association" "{{$.PrimaryResourceId}}" {
   provider                                = google-beta
-  intercept_endpoint_group_association_id = "{{index $.Vars "resource_name"}}"
+  intercept_endpoint_group_association_id = "{{index $.Vars "endpoint_group_association_id"}}"
   location                                = "global"
   network                                 = google_compute_network.consumer_network.id
   intercept_endpoint_group                = google_network_security_intercept_endpoint_group.endpoint_group.id

--- a/mmv1/templates/terraform/examples/network_security_intercept_endpoint_group_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_endpoint_group_basic.tf.tmpl
@@ -16,4 +16,7 @@ resource "google_network_security_intercept_endpoint_group" "{{$.PrimaryResource
   intercept_endpoint_group_id   = "{{index $.Vars "endpoint_group_id"}}"
   location                      = "global"
   intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
+  labels = {
+    foo = "bar"
+  }
 }

--- a/mmv1/templates/terraform/examples/network_security_intercept_endpoint_group_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_endpoint_group_basic.tf.tmpl
@@ -1,18 +1,19 @@
 resource "google_compute_network" "network" {
+  provider                = google-beta
   name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_intercept_deployment_group" "deployment_group" {
   provider                      = google-beta
-  intercept_deployment_group_id = "{{index $.Vars "deployment_group_name"}}"
+  intercept_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
   location                      = "global"
   network                       = google_compute_network.network.id
 }
 
 resource "google_network_security_intercept_endpoint_group" "{{$.PrimaryResourceId}}" {
   provider                      = google-beta
-  intercept_endpoint_group_id   = "{{index $.Vars "resource_name"}}"
+  intercept_endpoint_group_id   = "{{index $.Vars "endpoint_group_id"}}"
   location                      = "global"
   intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
 }

--- a/mmv1/templates/terraform/examples/network_security_intercept_endpoint_group_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_endpoint_group_basic.tf.tmpl
@@ -1,0 +1,18 @@
+resource "google_compute_network" "network" {
+  name                    = "{{index $.Vars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "{{index $.Vars "deployment_group_name"}}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+}
+
+resource "google_network_security_intercept_endpoint_group" "{{$.PrimaryResourceId}}" {
+  provider                      = google-beta
+  intercept_endpoint_group_id   = "{{index $.Vars "resource_name"}}"
+  location                      = "global"
+  intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
+}

--- a/mmv1/templates/terraform/examples/network_security_mirroring_deployment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_mirroring_deployment_basic.tf.tmpl
@@ -1,0 +1,50 @@
+resource "google_compute_network" "network" {
+  name                    = "{{index $.Vars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  name          = "{{index $.Vars "subnetwork_name"}}"
+  ip_cidr_range = "10.1.0.0/16"
+  network       = google_compute_network.network.name
+}
+
+resource "google_compute_region_health_check" "health_check" {
+  name = "{{index $.Vars "health_check_name"}}"
+  http_health_check {
+    port = 80
+  }
+}
+
+resource "google_compute_region_backend_service" "backend_service" {
+  name                  = "{{index $.Vars "backend_service_name"}}"
+  health_checks         = [google_compute_region_health_check.health_check.id]
+  protocol              = "UDP"
+  load_balancing_scheme = "INTERNAL"
+}
+
+resource "google_compute_forwarding_rule" "forwarding_rule" {
+  name                   = "{{index $.Vars "forwarding_rule_name"}}"
+  backend_service        = google_compute_region_backend_service.backend_service.id
+  network                = google_compute_network.network.name
+  subnetwork             = google_compute_subnetwork.subnetwork.name
+  load_balancing_scheme  = "INTERNAL"
+  ports                  = [6081]
+  ip_protocol            = "UDP"
+  is_mirroring_collector = true
+}
+
+resource "google_network_security_mirroring_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  mirroring_deployment_group_id = "{{index $.Vars "deployment_group_name"}}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+}
+
+resource "google_network_security_mirroring_deployment" "{{$.PrimaryResourceId}}" {
+  provider                   = google-beta
+  mirroring_deployment_id    = "{{index $.Vars "resource_name"}}"
+  location                   = "us-central1-a"
+  forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id
+  mirroring_deployment_group = google_network_security_mirroring_deployment_group.deployment_group.id
+}

--- a/mmv1/templates/terraform/examples/network_security_mirroring_deployment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_mirroring_deployment_basic.tf.tmpl
@@ -7,7 +7,7 @@ resource "google_compute_network" "network" {
 resource "google_compute_subnetwork" "subnetwork" {
   provider      = google-beta
   name          = "{{index $.Vars "subnetwork_name"}}"
-  region        = "us-central1"
+  region        = "asia-east1"
   ip_cidr_range = "10.1.0.0/16"
   network       = google_compute_network.network.name
 }
@@ -15,7 +15,7 @@ resource "google_compute_subnetwork" "subnetwork" {
 resource "google_compute_region_health_check" "health_check" {
   provider = google-beta
   name     = "{{index $.Vars "health_check_name"}}"
-  region   = "us-central1"
+  region   = "asia-east1"
   http_health_check {
     port = 80
   }
@@ -24,7 +24,7 @@ resource "google_compute_region_health_check" "health_check" {
 resource "google_compute_region_backend_service" "backend_service" {
   provider              = google-beta
   name                  = "{{index $.Vars "backend_service_name"}}"
-  region                = "us-central1"
+  region                = "asia-east1"
   health_checks         = [google_compute_region_health_check.health_check.id]
   protocol              = "UDP"
   load_balancing_scheme = "INTERNAL"
@@ -33,7 +33,7 @@ resource "google_compute_region_backend_service" "backend_service" {
 resource "google_compute_forwarding_rule" "forwarding_rule" {
   provider               = google-beta
   name                   = "{{index $.Vars "forwarding_rule_name"}}"
-  region                 = "us-central1"
+  region                 = "asia-east1"
   network                = google_compute_network.network.name
   subnetwork             = google_compute_subnetwork.subnetwork.name
   backend_service        = google_compute_region_backend_service.backend_service.id
@@ -53,7 +53,10 @@ resource "google_network_security_mirroring_deployment_group" "deployment_group"
 resource "google_network_security_mirroring_deployment" "{{$.PrimaryResourceId}}" {
   provider                   = google-beta
   mirroring_deployment_id    = "{{index $.Vars "deployment_id"}}"
-  location                   = "us-central1-a"
+  location                   = "asia-east1-a"
   forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id
   mirroring_deployment_group = google_network_security_mirroring_deployment_group.deployment_group.id
+  labels = {
+    foo = "bar"
+  }
 }

--- a/mmv1/templates/terraform/examples/network_security_mirroring_deployment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_mirroring_deployment_basic.tf.tmpl
@@ -7,7 +7,7 @@ resource "google_compute_network" "network" {
 resource "google_compute_subnetwork" "subnetwork" {
   provider      = google-beta
   name          = "{{index $.Vars "subnetwork_name"}}"
-  region        = "asia-east1"
+  region        = "us-central1"
   ip_cidr_range = "10.1.0.0/16"
   network       = google_compute_network.network.name
 }
@@ -15,7 +15,7 @@ resource "google_compute_subnetwork" "subnetwork" {
 resource "google_compute_region_health_check" "health_check" {
   provider = google-beta
   name     = "{{index $.Vars "health_check_name"}}"
-  region   = "asia-east1"
+  region   = "us-central1"
   http_health_check {
     port = 80
   }
@@ -24,7 +24,7 @@ resource "google_compute_region_health_check" "health_check" {
 resource "google_compute_region_backend_service" "backend_service" {
   provider              = google-beta
   name                  = "{{index $.Vars "backend_service_name"}}"
-  region                = "asia-east1"
+  region                = "us-central1"
   health_checks         = [google_compute_region_health_check.health_check.id]
   protocol              = "UDP"
   load_balancing_scheme = "INTERNAL"
@@ -33,7 +33,7 @@ resource "google_compute_region_backend_service" "backend_service" {
 resource "google_compute_forwarding_rule" "forwarding_rule" {
   provider               = google-beta
   name                   = "{{index $.Vars "forwarding_rule_name"}}"
-  region                 = "asia-east1"
+  region                 = "us-central1"
   network                = google_compute_network.network.name
   subnetwork             = google_compute_subnetwork.subnetwork.name
   backend_service        = google_compute_region_backend_service.backend_service.id
@@ -53,7 +53,7 @@ resource "google_network_security_mirroring_deployment_group" "deployment_group"
 resource "google_network_security_mirroring_deployment" "{{$.PrimaryResourceId}}" {
   provider                   = google-beta
   mirroring_deployment_id    = "{{index $.Vars "deployment_id"}}"
-  location                   = "asia-east1-a"
+  location                   = "us-central1-a"
   forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id
   mirroring_deployment_group = google_network_security_mirroring_deployment_group.deployment_group.id
   labels = {

--- a/mmv1/templates/terraform/examples/network_security_mirroring_deployment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_mirroring_deployment_basic.tf.tmpl
@@ -1,33 +1,42 @@
 resource "google_compute_network" "network" {
+  provider                = google-beta
   name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "subnetwork" {
+  provider      = google-beta
   name          = "{{index $.Vars "subnetwork_name"}}"
+  region        = "us-central1"
   ip_cidr_range = "10.1.0.0/16"
   network       = google_compute_network.network.name
 }
 
 resource "google_compute_region_health_check" "health_check" {
-  name = "{{index $.Vars "health_check_name"}}"
+  provider = google-beta
+  name     = "{{index $.Vars "health_check_name"}}"
+  region   = "us-central1"
   http_health_check {
     port = 80
   }
 }
 
 resource "google_compute_region_backend_service" "backend_service" {
+  provider              = google-beta
   name                  = "{{index $.Vars "backend_service_name"}}"
+  region                = "us-central1"
   health_checks         = [google_compute_region_health_check.health_check.id]
   protocol              = "UDP"
   load_balancing_scheme = "INTERNAL"
 }
 
 resource "google_compute_forwarding_rule" "forwarding_rule" {
+  provider               = google-beta
   name                   = "{{index $.Vars "forwarding_rule_name"}}"
-  backend_service        = google_compute_region_backend_service.backend_service.id
+  region                 = "us-central1"
   network                = google_compute_network.network.name
   subnetwork             = google_compute_subnetwork.subnetwork.name
+  backend_service        = google_compute_region_backend_service.backend_service.id
   load_balancing_scheme  = "INTERNAL"
   ports                  = [6081]
   ip_protocol            = "UDP"
@@ -36,14 +45,14 @@ resource "google_compute_forwarding_rule" "forwarding_rule" {
 
 resource "google_network_security_mirroring_deployment_group" "deployment_group" {
   provider                      = google-beta
-  mirroring_deployment_group_id = "{{index $.Vars "deployment_group_name"}}"
+  mirroring_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
   location                      = "global"
   network                       = google_compute_network.network.id
 }
 
 resource "google_network_security_mirroring_deployment" "{{$.PrimaryResourceId}}" {
   provider                   = google-beta
-  mirroring_deployment_id    = "{{index $.Vars "resource_name"}}"
+  mirroring_deployment_id    = "{{index $.Vars "deployment_id"}}"
   location                   = "us-central1-a"
   forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id
   mirroring_deployment_group = google_network_security_mirroring_deployment_group.deployment_group.id

--- a/mmv1/templates/terraform/examples/network_security_mirroring_deployment_group_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_mirroring_deployment_group_basic.tf.tmpl
@@ -9,4 +9,7 @@ resource "google_network_security_mirroring_deployment_group" "{{$.PrimaryResour
   mirroring_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
   location                      = "global"
   network                       = google_compute_network.network.id
+  labels = {
+    foo = "bar"
+  }
 }

--- a/mmv1/templates/terraform/examples/network_security_mirroring_deployment_group_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_mirroring_deployment_group_basic.tf.tmpl
@@ -1,11 +1,12 @@
 resource "google_compute_network" "network" {
+  provider                = google-beta
   name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_mirroring_deployment_group" "{{$.PrimaryResourceId}}" {
   provider                      = google-beta
-  mirroring_deployment_group_id = "{{index $.Vars "resource_name"}}"
+  mirroring_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
   location                      = "global"
   network                       = google_compute_network.network.id
 }

--- a/mmv1/templates/terraform/examples/network_security_mirroring_deployment_group_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_mirroring_deployment_group_basic.tf.tmpl
@@ -1,0 +1,11 @@
+resource "google_compute_network" "network" {
+  name                    = "{{index $.Vars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_mirroring_deployment_group" "{{$.PrimaryResourceId}}" {
+  provider                      = google-beta
+  mirroring_deployment_group_id = "{{index $.Vars "resource_name"}}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+}

--- a/mmv1/templates/terraform/examples/network_security_mirroring_endpoint_group_association_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_mirroring_endpoint_group_association_basic.tf.tmpl
@@ -1,30 +1,32 @@
 resource "google_compute_network" "producer_network" {
+  provider                = google-beta
   name                    = "{{index $.Vars "producer_network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_network" "consumer_network" {
+  provider                = google-beta
   name                    = "{{index $.Vars "consumer_network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_mirroring_deployment_group" "deployment_group" {
   provider                      = google-beta
-  mirroring_deployment_group_id = "{{index $.Vars "deployment_group_name"}}"
+  mirroring_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
   location                      = "global"
-  network                       = google_compute_network.network.id
+  network                       = google_compute_network.producer_network.id
 }
 
 resource "google_network_security_mirroring_endpoint_group" "endpoint_group" {
   provider                      = google-beta
-  mirroring_endpoint_group_id   = "{{index $.Vars "endpoint_group_name"}}"
+  mirroring_endpoint_group_id   = "{{index $.Vars "endpoint_group_id"}}"
   location                      = "global"
   mirroring_deployment_group    = google_network_security_mirroring_deployment_group.deployment_group.id
 }
 
 resource "google_network_security_mirroring_endpoint_group_association" "{{$.PrimaryResourceId}}" {
   provider                                = google-beta
-  mirroring_endpoint_group_association_id = "{{index $.Vars "resource_name"}}"
+  mirroring_endpoint_group_association_id = "{{index $.Vars "endpoint_group_association_id"}}"
   location                                = "global"
   network                                 = google_compute_network.consumer_network.id
   mirroring_endpoint_group                = google_network_security_mirroring_endpoint_group.endpoint_group.id

--- a/mmv1/templates/terraform/examples/network_security_mirroring_endpoint_group_association_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_mirroring_endpoint_group_association_basic.tf.tmpl
@@ -1,0 +1,31 @@
+resource "google_compute_network" "producer_network" {
+  name                    = "{{index $.Vars "producer_network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_network" "consumer_network" {
+  name                    = "{{index $.Vars "consumer_network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_mirroring_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  mirroring_deployment_group_id = "{{index $.Vars "deployment_group_name"}}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+}
+
+resource "google_network_security_mirroring_endpoint_group" "endpoint_group" {
+  provider                      = google-beta
+  mirroring_endpoint_group_id   = "{{index $.Vars "endpoint_group_name"}}"
+  location                      = "global"
+  mirroring_deployment_group    = google_network_security_mirroring_deployment_group.deployment_group.id
+}
+
+resource "google_network_security_mirroring_endpoint_group_association" "{{$.PrimaryResourceId}}" {
+  provider                                = google-beta
+  mirroring_endpoint_group_association_id = "{{index $.Vars "resource_name"}}"
+  location                                = "global"
+  network                                 = google_compute_network.consumer_network.id
+  mirroring_endpoint_group                = google_network_security_mirroring_endpoint_group.endpoint_group.id
+}

--- a/mmv1/templates/terraform/examples/network_security_mirroring_endpoint_group_association_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_mirroring_endpoint_group_association_basic.tf.tmpl
@@ -30,4 +30,7 @@ resource "google_network_security_mirroring_endpoint_group_association" "{{$.Pri
   location                                = "global"
   network                                 = google_compute_network.consumer_network.id
   mirroring_endpoint_group                = google_network_security_mirroring_endpoint_group.endpoint_group.id
+  labels = {
+    foo = "bar"
+  }
 }

--- a/mmv1/templates/terraform/examples/network_security_mirroring_endpoint_group_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_mirroring_endpoint_group_basic.tf.tmpl
@@ -16,4 +16,7 @@ resource "google_network_security_mirroring_endpoint_group" "{{$.PrimaryResource
   mirroring_endpoint_group_id   = "{{index $.Vars "endpoint_group_id"}}"
   location                      = "global"
   mirroring_deployment_group    = google_network_security_mirroring_deployment_group.deployment_group.id
+  labels = {
+    foo = "bar"
+  }
 }

--- a/mmv1/templates/terraform/examples/network_security_mirroring_endpoint_group_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_mirroring_endpoint_group_basic.tf.tmpl
@@ -1,18 +1,19 @@
 resource "google_compute_network" "network" {
+  provider                = google-beta
   name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_mirroring_deployment_group" "deployment_group" {
   provider                      = google-beta
-  mirroring_deployment_group_id = "{{index $.Vars "deployment_group_name"}}"
+  mirroring_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
   location                      = "global"
   network                       = google_compute_network.network.id
 }
 
 resource "google_network_security_mirroring_endpoint_group" "{{$.PrimaryResourceId}}" {
   provider                      = google-beta
-  mirroring_endpoint_group_id   = "{{index $.Vars "resource_name"}}"
+  mirroring_endpoint_group_id   = "{{index $.Vars "endpoint_group_id"}}"
   location                      = "global"
   mirroring_deployment_group    = google_network_security_mirroring_deployment_group.deployment_group.id
 }

--- a/mmv1/templates/terraform/examples/network_security_mirroring_endpoint_group_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_mirroring_endpoint_group_basic.tf.tmpl
@@ -1,0 +1,18 @@
+resource "google_compute_network" "network" {
+  name                    = "{{index $.Vars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_mirroring_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  mirroring_deployment_group_id = "{{index $.Vars "deployment_group_name"}}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+}
+
+resource "google_network_security_mirroring_endpoint_group" "{{$.PrimaryResourceId}}" {
+  provider                      = google-beta
+  mirroring_endpoint_group_id   = "{{index $.Vars "resource_name"}}"
+  location                      = "global"
+  mirroring_deployment_group    = google_network_security_mirroring_deployment_group.deployment_group.id
+}

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_deployment_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_deployment_generated_test.go.tmpl
@@ -1,0 +1,183 @@
+package networksecurity_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccNetworkSecurityInterceptDeployment_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkSecurityInterceptDeployment_basic(context),
+			},
+			{
+				ResourceName:            "google_network_security_intercept_deployment.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccNetworkSecurityInterceptDeployment_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_network_security_intercept_deployment.default", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_network_security_intercept_deployment.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccNetworkSecurityInterceptDeployment_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "tf-test-example-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  provider      = google-beta
+  name          = "tf-test-example-subnet%{random_suffix}"
+  region        = "us-central1"
+  ip_cidr_range = "10.1.0.0/16"
+  network       = google_compute_network.network.name
+}
+
+resource "google_compute_region_health_check" "health_check" {
+  provider = google-beta
+  name     = "tf-test-example-hc%{random_suffix}"
+  region   = "us-central1"
+  http_health_check {
+    port = 80
+  }
+}
+
+resource "google_compute_region_backend_service" "backend_service" {
+  provider              = google-beta
+  name                  = "tf-test-example-bs%{random_suffix}"
+  region                = "us-central1"
+  health_checks         = [google_compute_region_health_check.health_check.id]
+  protocol              = "UDP"
+  load_balancing_scheme = "INTERNAL"
+}
+
+resource "google_compute_forwarding_rule" "forwarding_rule" {
+  provider               = google-beta
+  name                   = "tf-test-example-fwr%{random_suffix}"
+  region                 = "us-central1"
+  network                = google_compute_network.network.name
+  subnetwork             = google_compute_subnetwork.subnetwork.name
+  backend_service        = google_compute_region_backend_service.backend_service.id
+  load_balancing_scheme  = "INTERNAL"
+  ports                  = [6081]
+  ip_protocol            = "UDP"
+}
+
+resource "google_network_security_intercept_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+}
+
+resource "google_network_security_intercept_deployment" "default" {
+  provider                   = google-beta
+  intercept_deployment_id    = "tf-test-example-deployment%{random_suffix}"
+  location                   = "us-central1-a"
+  forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id
+  intercept_deployment_group = google_network_security_intercept_deployment_group.deployment_group.id
+  labels = {
+    foo = "bar"
+  }
+}
+`, context)
+}
+
+func testAccNetworkSecurityInterceptDeployment_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "tf-test-example-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  provider      = google-beta
+  name          = "tf-test-example-subnet%{random_suffix}"
+  region        = "us-central1"
+  ip_cidr_range = "10.1.0.0/16"
+  network       = google_compute_network.network.name
+}
+
+resource "google_compute_region_health_check" "health_check" {
+  provider = google-beta
+  name     = "tf-test-example-hc%{random_suffix}"
+  region   = "us-central1"
+  http_health_check {
+    port = 80
+  }
+}
+
+resource "google_compute_region_backend_service" "backend_service" {
+  provider              = google-beta
+  name                  = "tf-test-example-bs%{random_suffix}"
+  region                = "us-central1"
+  health_checks         = [google_compute_region_health_check.health_check.id]
+  protocol              = "UDP"
+  load_balancing_scheme = "INTERNAL"
+}
+
+resource "google_compute_forwarding_rule" "forwarding_rule" {
+  provider               = google-beta
+  name                   = "tf-test-example-fwr%{random_suffix}"
+  region                 = "us-central1"
+  network                = google_compute_network.network.name
+  subnetwork             = google_compute_subnetwork.subnetwork.name
+  backend_service        = google_compute_region_backend_service.backend_service.id
+  load_balancing_scheme  = "INTERNAL"
+  ports                  = [6081]
+  ip_protocol            = "UDP"
+}
+
+resource "google_network_security_intercept_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+}
+
+resource "google_network_security_intercept_deployment" "default" {
+  provider                   = google-beta
+  intercept_deployment_id    = "tf-test-example-deployment%{random_suffix}"
+  location                   = "us-central1-a"
+  forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id
+  intercept_deployment_group = google_network_security_intercept_deployment_group.deployment_group.id
+  labels = {
+    foo = "goo"
+  }
+}
+`, context)
+}
+
+{{ end }}

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_deployment_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_deployment_generated_test.go.tmpl
@@ -42,7 +42,7 @@ func TestAccNetworkSecurityInterceptDeployment_update(t *testing.T) {
 				ResourceName:            "google_network_security_intercept_deployment.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"update_time", "labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_deployment_group_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_deployment_group_generated_test.go.tmpl
@@ -42,7 +42,7 @@ func TestAccNetworkSecurityInterceptDeploymentGroup_update(t *testing.T) {
 				ResourceName:            "google_network_security_intercept_deployment_group.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"update_time", "labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_deployment_group_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_deployment_group_generated_test.go.tmpl
@@ -1,0 +1,91 @@
+package networksecurity_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccNetworkSecurityInterceptDeploymentGroup_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkSecurityInterceptDeploymentGroup_basic(context),
+			},
+			{
+				ResourceName:            "google_network_security_intercept_deployment_group.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccNetworkSecurityInterceptDeploymentGroup_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_network_security_intercept_deployment_group.default", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_network_security_intercept_deployment_group.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccNetworkSecurityInterceptDeploymentGroup_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "tf-test-example-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "default" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+  labels = {
+    foo = "bar"
+  }
+}
+`, context)
+}
+
+func testAccNetworkSecurityInterceptDeploymentGroup_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "tf-test-example-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "default" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+  labels = {
+    foo = "goo"
+  }
+}
+`, context)
+}
+
+{{ end }}

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_endpoint_group_association_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_endpoint_group_association_generated_test.go.tmpl
@@ -20,7 +20,6 @@ func TestAccNetworkSecurityInterceptEndpointGroupAssociation_update(t *testing.T
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
-		CheckDestroy:             testAccCheckNetworkSecurityInterceptEndpointGroupAssociationDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNetworkSecurityInterceptEndpointGroupAssociation_basic(context),

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_endpoint_group_association_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_endpoint_group_association_generated_test.go.tmpl
@@ -1,0 +1,134 @@
+package networksecurity_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccNetworkSecurityInterceptEndpointGroupAssociation_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckNetworkSecurityInterceptEndpointGroupAssociationDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkSecurityInterceptEndpointGroupAssociation_basic(context),
+			},
+			{
+				ResourceName:            "google_network_security_intercept_endpoint_group_association.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccNetworkSecurityInterceptEndpointGroupAssociation_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_network_security_intercept_endpoint_group_association.default", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_network_security_intercept_endpoint_group_association.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccNetworkSecurityInterceptEndpointGroupAssociation_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "producer_network" {
+  provider                = google-beta
+  name                    = "tf-test-example-prod-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_network" "consumer_network" {
+  provider                = google-beta
+  name                    = "tf-test-example-cons-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.producer_network.id
+}
+
+resource "google_network_security_intercept_endpoint_group" "endpoint_group" {
+  provider                      = google-beta
+  intercept_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
+  location                      = "global"
+  intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
+}
+
+resource "google_network_security_intercept_endpoint_group_association" "default" {
+  provider                                = google-beta
+  intercept_endpoint_group_association_id = "tf-test-example-ega%{random_suffix}"
+  location                                = "global"
+  network                                 = google_compute_network.consumer_network.id
+  intercept_endpoint_group                = google_network_security_intercept_endpoint_group.endpoint_group.id
+  labels = {
+    foo = "bar"
+  }
+}
+`, context)
+}
+
+func testAccNetworkSecurityInterceptEndpointGroupAssociation_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "producer_network" {
+  provider                = google-beta
+  name                    = "tf-test-example-prod-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_network" "consumer_network" {
+  provider                = google-beta
+  name                    = "tf-test-example-cons-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.producer_network.id
+}
+
+resource "google_network_security_intercept_endpoint_group" "endpoint_group" {
+  provider                      = google-beta
+  intercept_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
+  location                      = "global"
+  intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
+}
+
+resource "google_network_security_intercept_endpoint_group_association" "default" {
+  provider                                = google-beta
+  intercept_endpoint_group_association_id = "tf-test-example-ega%{random_suffix}"
+  location                                = "global"
+  network                                 = google_compute_network.consumer_network.id
+  intercept_endpoint_group                = google_network_security_intercept_endpoint_group.endpoint_group.id
+  labels = {
+    foo = "goo"
+  }
+}
+`, context)
+}
+
+{{ end }}

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_endpoint_group_association_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_endpoint_group_association_generated_test.go.tmpl
@@ -42,7 +42,7 @@ func TestAccNetworkSecurityInterceptEndpointGroupAssociation_update(t *testing.T
 				ResourceName:            "google_network_security_intercept_endpoint_group_association.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"update_time", "labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_endpoint_group_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_endpoint_group_generated_test.go.tmpl
@@ -42,7 +42,7 @@ func TestAccNetworkSecurityInterceptEndpointGroup_update(t *testing.T) {
 				ResourceName:            "google_network_security_intercept_endpoint_group.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"update_time", "labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_endpoint_group_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_endpoint_group_generated_test.go.tmpl
@@ -1,0 +1,105 @@
+package networksecurity_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccNetworkSecurityInterceptEndpointGroup_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkSecurityInterceptEndpointGroup_basic(context),
+			},
+			{
+				ResourceName:            "google_network_security_intercept_endpoint_group.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccNetworkSecurityInterceptEndpointGroup_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_network_security_intercept_endpoint_group.default", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_network_security_intercept_endpoint_group.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccNetworkSecurityInterceptEndpointGroup_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "tf-test-example-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+}
+
+resource "google_network_security_intercept_endpoint_group" "default" {
+  provider                      = google-beta
+  intercept_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
+  location                      = "global"
+  intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
+  labels = {
+    foo = "bar"
+  }
+}
+`, context)
+}
+
+func testAccNetworkSecurityInterceptEndpointGroup_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "tf-test-example-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+}
+
+resource "google_network_security_intercept_endpoint_group" "default" {
+  provider                      = google-beta
+  intercept_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
+  location                      = "global"
+  intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
+  labels = {
+    foo = "goo"
+  }
+}
+`, context)
+}
+
+{{ end }}

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_deployment_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_deployment_generated_test.go.tmpl
@@ -1,0 +1,185 @@
+package networksecurity_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccNetworkSecurityMirroringDeployment_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkSecurityMirroringDeployment_basic(context),
+			},
+			{
+				ResourceName:            "google_network_security_mirroring_deployment.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccNetworkSecurityMirroringDeployment_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_network_security_mirroring_deployment.default", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_network_security_mirroring_deployment.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccNetworkSecurityMirroringDeployment_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "tf-test-example-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  provider      = google-beta
+  name          = "tf-test-example-subnet%{random_suffix}"
+  region        = "us-central1"
+  ip_cidr_range = "10.1.0.0/16"
+  network       = google_compute_network.network.name
+}
+
+resource "google_compute_region_health_check" "health_check" {
+  provider = google-beta
+  name     = "tf-test-example-hc%{random_suffix}"
+  region   = "us-central1"
+  http_health_check {
+    port = 80
+  }
+}
+
+resource "google_compute_region_backend_service" "backend_service" {
+  provider              = google-beta
+  name                  = "tf-test-example-bs%{random_suffix}"
+  region                = "us-central1"
+  health_checks         = [google_compute_region_health_check.health_check.id]
+  protocol              = "UDP"
+  load_balancing_scheme = "INTERNAL"
+}
+
+resource "google_compute_forwarding_rule" "forwarding_rule" {
+  provider               = google-beta
+  name                   = "tf-test-example-fwr%{random_suffix}"
+  region                 = "us-central1"
+  network                = google_compute_network.network.name
+  subnetwork             = google_compute_subnetwork.subnetwork.name
+  backend_service        = google_compute_region_backend_service.backend_service.id
+  load_balancing_scheme  = "INTERNAL"
+  ports                  = [6081]
+  ip_protocol            = "UDP"
+  is_mirroring_collector = true
+}
+
+resource "google_network_security_mirroring_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  mirroring_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+}
+
+resource "google_network_security_mirroring_deployment" "default" {
+  provider                   = google-beta
+  mirroring_deployment_id    = "tf-test-example-deployment%{random_suffix}"
+  location                   = "us-central1-a"
+  forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id
+  mirroring_deployment_group = google_network_security_mirroring_deployment_group.deployment_group.id
+  labels = {
+    foo = "bar"
+  }
+}
+`, context)
+}
+
+func testAccNetworkSecurityMirroringDeployment_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "tf-test-example-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  provider      = google-beta
+  name          = "tf-test-example-subnet%{random_suffix}"
+  region        = "us-central1"
+  ip_cidr_range = "10.1.0.0/16"
+  network       = google_compute_network.network.name
+}
+
+resource "google_compute_region_health_check" "health_check" {
+  provider = google-beta
+  name     = "tf-test-example-hc%{random_suffix}"
+  region   = "us-central1"
+  http_health_check {
+    port = 80
+  }
+}
+
+resource "google_compute_region_backend_service" "backend_service" {
+  provider              = google-beta
+  name                  = "tf-test-example-bs%{random_suffix}"
+  region                = "us-central1"
+  health_checks         = [google_compute_region_health_check.health_check.id]
+  protocol              = "UDP"
+  load_balancing_scheme = "INTERNAL"
+}
+
+resource "google_compute_forwarding_rule" "forwarding_rule" {
+  provider               = google-beta
+  name                   = "tf-test-example-fwr%{random_suffix}"
+  region                 = "us-central1"
+  network                = google_compute_network.network.name
+  subnetwork             = google_compute_subnetwork.subnetwork.name
+  backend_service        = google_compute_region_backend_service.backend_service.id
+  load_balancing_scheme  = "INTERNAL"
+  ports                  = [6081]
+  ip_protocol            = "UDP"
+  is_mirroring_collector = true
+}
+
+resource "google_network_security_mirroring_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  mirroring_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+}
+
+resource "google_network_security_mirroring_deployment" "default" {
+  provider                   = google-beta
+  mirroring_deployment_id    = "tf-test-example-deployment%{random_suffix}"
+  location                   = "us-central1-a"
+  forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id
+  mirroring_deployment_group = google_network_security_mirroring_deployment_group.deployment_group.id
+  labels = {
+    foo = "goo"
+  }
+}
+`, context)
+}
+
+{{ end }}

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_deployment_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_deployment_generated_test.go.tmpl
@@ -42,7 +42,7 @@ func TestAccNetworkSecurityMirroringDeployment_update(t *testing.T) {
 				ResourceName:            "google_network_security_mirroring_deployment.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"update_time", "labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_deployment_group_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_deployment_group_generated_test.go.tmpl
@@ -42,7 +42,7 @@ func TestAccNetworkSecurityMirroringDeploymentGroup_update(t *testing.T) {
 				ResourceName:            "google_network_security_mirroring_deployment_group.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"update_time", "labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_deployment_group_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_deployment_group_generated_test.go.tmpl
@@ -1,0 +1,91 @@
+package networksecurity_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccNetworkSecurityMirroringDeploymentGroup_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkSecurityMirroringDeploymentGroup_basic(context),
+			},
+			{
+				ResourceName:            "google_network_security_mirroring_deployment_group.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccNetworkSecurityMirroringDeploymentGroup_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_network_security_mirroring_deployment_group.default", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_network_security_mirroring_deployment_group.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccNetworkSecurityMirroringDeploymentGroup_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "tf-test-example-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_mirroring_deployment_group" "default" {
+  provider                      = google-beta
+  mirroring_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+  labels = {
+    foo = "bar"
+  }
+}
+`, context)
+}
+
+func testAccNetworkSecurityMirroringDeploymentGroup_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "tf-test-example-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_mirroring_deployment_group" "default" {
+  provider                      = google-beta
+  mirroring_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+  labels = {
+    foo = "goo"
+  }
+}
+`, context)
+}
+
+{{ end }}

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_endpoint_group_association_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_endpoint_group_association_generated_test.go.tmpl
@@ -42,7 +42,7 @@ func TestAccNetworkSecurityMirroringEndpointGroupAssociation_update(t *testing.T
 				ResourceName:            "google_network_security_mirroring_endpoint_group_association.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"update_time", "labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_endpoint_group_association_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_endpoint_group_association_generated_test.go.tmpl
@@ -1,0 +1,133 @@
+package networksecurity_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccNetworkSecurityMirroringEndpointGroupAssociation_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkSecurityMirroringEndpointGroupAssociation_basic(context),
+			},
+			{
+				ResourceName:            "google_network_security_mirroring_endpoint_group_association.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccNetworkSecurityMirroringEndpointGroupAssociation_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_network_security_mirroring_endpoint_group_association.default", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_network_security_mirroring_endpoint_group_association.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccNetworkSecurityMirroringEndpointGroupAssociation_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "producer_network" {
+  provider                = google-beta
+  name                    = "tf-test-example-prod-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_network" "consumer_network" {
+  provider                = google-beta
+  name                    = "tf-test-example-cons-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_mirroring_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  mirroring_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.producer_network.id
+}
+
+resource "google_network_security_mirroring_endpoint_group" "endpoint_group" {
+  provider                      = google-beta
+  mirroring_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
+  location                      = "global"
+  mirroring_deployment_group    = google_network_security_mirroring_deployment_group.deployment_group.id
+}
+
+resource "google_network_security_mirroring_endpoint_group_association" "default" {
+  provider                                = google-beta
+  mirroring_endpoint_group_association_id = "tf-test-example-ega%{random_suffix}"
+  location                                = "global"
+  network                                 = google_compute_network.consumer_network.id
+  mirroring_endpoint_group                = google_network_security_mirroring_endpoint_group.endpoint_group.id
+  labels = {
+    foo = "bar"
+  }
+}
+`, context)
+}
+
+func testAccNetworkSecurityMirroringEndpointGroupAssociation_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "producer_network" {
+  provider                = google-beta
+  name                    = "tf-test-example-prod-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_network" "consumer_network" {
+  provider                = google-beta
+  name                    = "tf-test-example-cons-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_mirroring_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  mirroring_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.producer_network.id
+}
+
+resource "google_network_security_mirroring_endpoint_group" "endpoint_group" {
+  provider                      = google-beta
+  mirroring_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
+  location                      = "global"
+  mirroring_deployment_group    = google_network_security_mirroring_deployment_group.deployment_group.id
+}
+
+resource "google_network_security_mirroring_endpoint_group_association" "default" {
+  provider                                = google-beta
+  mirroring_endpoint_group_association_id = "tf-test-example-ega%{random_suffix}"
+  location                                = "global"
+  network                                 = google_compute_network.consumer_network.id
+  mirroring_endpoint_group                = google_network_security_mirroring_endpoint_group.endpoint_group.id
+  labels = {
+    foo = "goo"
+  }
+}
+`, context)
+}
+
+{{ end }}

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_endpoint_group_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_endpoint_group_generated_test.go.tmpl
@@ -42,7 +42,7 @@ func TestAccNetworkSecurityMirroringEndpointGroup_update(t *testing.T) {
 				ResourceName:            "google_network_security_mirroring_endpoint_group.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"update_time", "labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_endpoint_group_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_endpoint_group_generated_test.go.tmpl
@@ -1,0 +1,105 @@
+package networksecurity_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccNetworkSecurityMirroringEndpointGroup_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkSecurityMirroringEndpointGroup_basic(context),
+			},
+			{
+				ResourceName:            "google_network_security_mirroring_endpoint_group.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccNetworkSecurityMirroringEndpointGroup_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_network_security_mirroring_endpoint_group.default", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_network_security_mirroring_endpoint_group.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccNetworkSecurityMirroringEndpointGroup_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "tf-test-example-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_mirroring_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  mirroring_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+}
+
+resource "google_network_security_mirroring_endpoint_group" "default" {
+  provider                      = google-beta
+  mirroring_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
+  location                      = "global"
+  mirroring_deployment_group    = google_network_security_mirroring_deployment_group.deployment_group.id
+  labels = {
+    foo = "bar"
+  }
+}
+`, context)
+}
+
+func testAccNetworkSecurityMirroringEndpointGroup_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "tf-test-example-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_mirroring_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  mirroring_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+}
+
+resource "google_network_security_mirroring_endpoint_group" "default" {
+  provider                      = google-beta
+  mirroring_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
+  location                      = "global"
+  mirroring_deployment_group    = google_network_security_mirroring_deployment_group.deployment_group.id
+  labels = {
+    foo = "goo"
+  }
+}
+`, context)
+}
+
+{{ end }}


### PR DESCRIPTION
Removal from google-private: https://cloud-internal-review.git.corp.google.com/c/cloud-graphite-eng/magic-modules-private-overrides/+/49230

```release-note:new-resource
`google_network_security_intercept_deployment`, `google_network_security_intercept_deployment_group`, `google_network_security_intercept_endpoint_group_association`, `google_network_security_intercept_endpoint_group`, `google_network_security_mirroring_deployment`, `google_network_security_mirroring_deployment_group`, `google_network_security_mirroring_endpoint_group_association`, `google_network_security_mirroring_endpoint_group`
```