### PR TITLE
container: fix `TestAccContainerCluster_withFleetConfig` failure

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -5232,7 +5232,7 @@ func TestAccContainerCluster_withFleetConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
 			},
 			{
-				Config:		testAccContainerCluster_withFleetConfig(clusterName, "random-project", networkName, subnetworkName),
+				Config:		testAccContainerCluster_withFleetConfig(clusterName, "tdx-guest-images", networkName, subnetworkName),
 				ExpectError: regexp.MustCompile(`changing existing fleet host project is not supported`),
 			},
 			{

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -5232,6 +5232,7 @@ func TestAccContainerCluster_withFleetConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
 			},
 			{
+				// This project must exist, though no permissions are needed on it.
 				Config:		testAccContainerCluster_withFleetConfig(clusterName, "tdx-guest-images", networkName, subnetworkName),
 				ExpectError: regexp.MustCompile(`changing existing fleet host project is not supported`),
 			},


### PR DESCRIPTION
Use a valid (but different) project for the test that migrating the fleet or cluster to a different project fails

Fixes hashicorp/terraform-provider-google/issues/20253

See comments in linked issue

Basically, it just needs some valid project ID... not sure if the right fix here is to use `BootstrapProject` (which exists, but seems to be unused?) to create a project for this purpose, tied to the test project ID, or just hardcode a different project that we know is valid.

I'm not sure if there used to be a project called `random-project` and it got deleted, or if the API behavior just changed. For now, I used `tdx-guest-images`, which I know from other tests is a valid project, and which these accounts wouldn't have permissions on. But let me know if there's a specific project name that would be better to use for this purpose that we know will reliably exist.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
