### PR TITLE
Made google_container_cluster.user_managed_keys_config not settable and fixed diff due to server-set values

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -6691,11 +6691,22 @@ func flattenUserManagedKeysConfig(c *container.UserManagedKeysConfig) []map[stri
 		"control_plane_disk_encryption_key": c.ControlPlaneDiskEncryptionKey,
 		"gkeops_etcd_backup_encryption_key": c.GkeopsEtcdBackupEncryptionKey,
 	}
+	allEmpty := true
+	for _, v := range f {
+		if v.(string) != "" {
+			allEmpty = false
+		}
+	}
 	if len(c.ServiceAccountSigningKeys) != 0 {
 		f["service_account_signing_keys"] = schema.NewSet(schema.HashString, tpgresource.ConvertStringArrToInterface(c.ServiceAccountSigningKeys))
+		allEmpty = false
 	}
 	if len(c.ServiceAccountVerificationKeys) != 0 {
 		f["service_account_verification_keys"] = schema.NewSet(schema.HashString, tpgresource.ConvertStringArrToInterface(c.ServiceAccountVerificationKeys))
+		allEmpty = false
+	}
+	if allEmpty {
+		return nil
 	}
 	return []map[string]interface{}{f}
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -2250,6 +2250,7 @@ func ResourceContainerCluster() *schema.Resource {
 			"user_managed_keys_config": {
 				Type:        schema.TypeList,
 				Optional:    true,
+				ForceNew:    true,
 				MaxItems:    1,
 				Description: `The custom keys configuration of the cluster.`,
 				Elem: &schema.Resource{
@@ -4292,20 +4293,6 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			return err
 		}
 		log.Printf("[INFO] GKE cluster %s fleet config has been updated", d.Id())
-	}
-
-	if d.HasChange("user_managed_keys_config") {
-		req := &container.UpdateClusterRequest{
-			Update: &container.ClusterUpdate{
-				UserManagedKeysConfig: expandUserManagedKeysConfig(d.Get("user_managed_keys_config")),
-			},
-		}
-		updateF := updateFunc(req, "updating GKE cluster user managed keys config.")
-		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
-			return err
-		}
-
-		log.Printf("[INFO] GKE cluster %s user managed key config has been updated to %#v", d.Id(), req.Update.UserManagedKeysConfig)
 	}
 
 	if d.HasChange("enable_k8s_beta_apis") {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_internal_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_internal_test.go.tmpl
@@ -3,9 +3,13 @@ package container
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
-{{- if ne $.TargetVersionName "ga" }}
+
+{{ if eq $.TargetVersionName `ga` }}
+	"google.golang.org/api/container/v1"
+{{- else }}
 	container "google.golang.org/api/container/v1beta1"
 {{- end }}
 )
@@ -293,5 +297,163 @@ func TestContainerCluster_NodeVersionCustomizeDiff(t* testing.T) {
 		if !tc.ExpectError && err != nil {
 			t.Errorf("%s failed, found unexpected error: %s", tn, err)
 		}
+	}
+}
+
+func TestContainerCluster_flattenUserManagedKeysConfig(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		config *container.UserManagedKeysConfig
+		want   []map[string]interface{}
+	}{
+		{
+			name: "nil",
+		},
+		{
+			name:   "empty",
+			config: &container.UserManagedKeysConfig{},
+		},
+		{
+			name: "cluster_ca",
+			config: &container.UserManagedKeysConfig{
+				ClusterCa: "value",
+			},
+			want: []map[string]interface{}{
+				{
+					"cluster_ca":                        "value",
+					"etcd_api_ca":                       "",
+					"etcd_peer_ca":                      "",
+					"aggregation_ca":                    "",
+					"control_plane_disk_encryption_key": "",
+					"gkeops_etcd_backup_encryption_key": "",
+				},
+			},
+		},
+		{
+			name: "etcd_api_ca",
+			config: &container.UserManagedKeysConfig{
+				EtcdApiCa: "value",
+			},
+			want: []map[string]interface{}{
+				{
+					"cluster_ca":                        "",
+					"etcd_api_ca":                       "value",
+					"etcd_peer_ca":                      "",
+					"aggregation_ca":                    "",
+					"control_plane_disk_encryption_key": "",
+					"gkeops_etcd_backup_encryption_key": "",
+				},
+			},
+		},
+		{
+			name: "etcd_peer_ca",
+			config: &container.UserManagedKeysConfig{
+				EtcdPeerCa: "value",
+			},
+			want: []map[string]interface{}{
+				{
+					"cluster_ca":                        "",
+					"etcd_api_ca":                       "",
+					"etcd_peer_ca":                      "value",
+					"aggregation_ca":                    "",
+					"control_plane_disk_encryption_key": "",
+					"gkeops_etcd_backup_encryption_key": "",
+				},
+			},
+		},
+		{
+			name: "aggregation_ca",
+			config: &container.UserManagedKeysConfig{
+				AggregationCa: "value",
+			},
+			want: []map[string]interface{}{
+				{
+					"cluster_ca":                        "",
+					"etcd_api_ca":                       "",
+					"etcd_peer_ca":                      "",
+					"aggregation_ca":                    "value",
+					"control_plane_disk_encryption_key": "",
+					"gkeops_etcd_backup_encryption_key": "",
+				},
+			},
+		},
+		{
+			name: "control_plane_disk_encryption_key",
+			config: &container.UserManagedKeysConfig{
+				ControlPlaneDiskEncryptionKey: "value",
+			},
+			want: []map[string]interface{}{
+				{
+					"cluster_ca":                        "",
+					"etcd_api_ca":                       "",
+					"etcd_peer_ca":                      "",
+					"aggregation_ca":                    "",
+					"control_plane_disk_encryption_key": "value",
+					"gkeops_etcd_backup_encryption_key": "",
+				},
+			},
+		},
+		{
+			name: "gkeops_etcd_backup_encryption_key",
+			config: &container.UserManagedKeysConfig{
+				GkeopsEtcdBackupEncryptionKey: "value",
+			},
+			want: []map[string]interface{}{
+				{
+					"cluster_ca":                        "",
+					"etcd_api_ca":                       "",
+					"etcd_peer_ca":                      "",
+					"aggregation_ca":                    "",
+					"control_plane_disk_encryption_key": "",
+					"gkeops_etcd_backup_encryption_key": "value",
+				},
+			},
+		},
+		{
+			name: "service_account_signing_keys",
+			config: &container.UserManagedKeysConfig{
+				ServiceAccountSigningKeys: []string{"value"},
+			},
+			want: []map[string]interface{}{
+				{
+					"cluster_ca":                        "",
+					"etcd_api_ca":                       "",
+					"etcd_peer_ca":                      "",
+					"aggregation_ca":                    "",
+					"control_plane_disk_encryption_key": "",
+					"gkeops_etcd_backup_encryption_key": "",
+					"service_account_signing_keys":      schema.NewSet(schema.HashString, []interface{}{"value"}),
+				},
+			},
+		},
+		{
+			name: "service_account_verification_keys",
+			config: &container.UserManagedKeysConfig{
+				ServiceAccountVerificationKeys: []string{"value"},
+			},
+			want: []map[string]interface{}{
+				{
+					"cluster_ca":                        "",
+					"etcd_api_ca":                       "",
+					"etcd_peer_ca":                      "",
+					"aggregation_ca":                    "",
+					"control_plane_disk_encryption_key": "",
+					"gkeops_etcd_backup_encryption_key": "",
+					"service_account_verification_keys": schema.NewSet(schema.HashString, []interface{}{"value"}),
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := flattenUserManagedKeysConfig(tc.config)
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Errorf("flattenUserManagedKeysConfig(%s) returned unexpected diff. +got, -want:\n%s", tc.name, diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/20301

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
container: fixed diff on `google_container_cluster.user_managed_keys_config` field for resources that had not set it. (patch release)
```

```release-note:bug
container: marked `google_container_cluster.user_managed_keys_config` as immutable because it can't be updated in place. (patch release)
```