### PR TITLE
pubsub: additional test permissions fixes

### DIFF
--- a/mmv1/templates/terraform/examples/pubsub_subscription_push_bq_service_account.tf.tmpl
+++ b/mmv1/templates/terraform/examples/pubsub_subscription_push_bq_service_account.tf.tmpl
@@ -11,24 +11,27 @@ resource "google_pubsub_subscription" "{{$.PrimaryResourceId}}" {
     service_account_email = google_service_account.bq_write_service_account.email
   }
 
-  depends_on = [google_service_account.bq_write_service_account, google_project_iam_member.viewer, google_project_iam_member.editor]
+  depends_on = [
+    google_service_account.bq_write_service_account,
+    google_project_iam_member.bigquery_metadata_viewer,
+    google_project_iam_member.bigquery_data_editor
+  ]
 }
 
-data "google_project" "project" {
-}
+data "google_project" "project" {}
 
 resource "google_service_account" "bq_write_service_account" {
   account_id = "{{index $.Vars "service_account_id"}}"
   display_name = "BQ Write Service Account"
 }
 
-resource "google_project_iam_member" "viewer" {
+resource "google_project_iam_member" "bigquery_metadata_viewer" {
   project = data.google_project.project.project_id
   role   = "roles/bigquery.metadataViewer"
   member = "serviceAccount:${google_service_account.bq_write_service_account.email}"
 }
 
-resource "google_project_iam_member" "editor" {
+resource "google_project_iam_member" "bigquery_data_editor" {
   project = data.google_project.project.project_id
   role   = "roles/bigquery.dataEditor"
   member = "serviceAccount:${google_service_account.bq_write_service_account.email}"

--- a/mmv1/third_party/terraform/services/pubsub/resource_pubsub_subscription_test.go
+++ b/mmv1/third_party/terraform/services/pubsub/resource_pubsub_subscription_test.go
@@ -683,6 +683,7 @@ resource "google_pubsub_subscription" "foo" {
 func testAccPubsubSubscriptionBigQuery_basic(dataset, table, topic, subscription string, useTableSchema bool, serviceAccountId string) string {
 	serviceAccountEmailField := ""
 	serviceAccountResource := ""
+	tfDependencies := ""
 	if serviceAccountId != "" {
 		serviceAccountResource = fmt.Sprintf(`
 resource "google_service_account" "bq_write_service_account" {
@@ -690,34 +691,24 @@ resource "google_service_account" "bq_write_service_account" {
   display_name = "BQ Write Service Account"
 }
 
-resource "google_project_iam_member" "viewer" {
+resource "google_project_iam_member" "bigquery_metadata_viewer" {
   project = data.google_project.project.project_id
   role    = "roles/bigquery.metadataViewer"
   member  = "serviceAccount:${google_service_account.bq_write_service_account.email}"
 }
 
-resource "google_project_iam_member" "editor" {
+resource "google_project_iam_member" "bigquery_data_editor" {
   project = data.google_project.project.project_id
   role    = "roles/bigquery.dataEditor"
   member  = "serviceAccount:${google_service_account.bq_write_service_account.email}"
 }`, serviceAccountId)
 		serviceAccountEmailField = "service_account_email = google_service_account.bq_write_service_account.email"
+		tfDependencies = `    google_project_iam_member.bigquery_metadata_viewer,
+    google_project_iam_member.bigquery_data_editor,
+    time_sleep.wait_30_seconds,`
 	} else {
-		serviceAccountResource = fmt.Sprintf(`
-resource "google_project_iam_member" "viewer" {
-  project = data.google_project.project.project_id
-  role    = "roles/bigquery.metadataViewer"
-  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
-}
-
-resource "google_project_iam_member" "editor" {
-  project = data.google_project.project.project_id
-  role    = "roles/bigquery.dataEditor"
-  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
-}
-	`)
+		tfDependencies = "    time_sleep.wait_30_seconds,"
 	}
-
 	return fmt.Sprintf(`
 data "google_project" "project" {}
 
@@ -763,12 +754,10 @@ resource "google_pubsub_subscription" "foo" {
   }
 
   depends_on = [
-    google_project_iam_member.viewer,
-    google_project_iam_member.editor,
-    time_sleep.wait_30_seconds,
+    %s
   ]
 }
-	`, serviceAccountResource, dataset, table, topic, subscription, useTableSchema, serviceAccountEmailField)
+	`, serviceAccountResource, dataset, table, topic, subscription, useTableSchema, serviceAccountEmailField, tfDependencies)
 }
 
 func testAccPubsubSubscriptionCloudStorage_basic(bucket, topic, subscription, filenamePrefix, filenameSuffix, filenameDatetimeFormat string, maxBytes int, maxDuration string, maxMessages int, serviceAccountId, outputFormat string) string {


### PR DESCRIPTION
Remove duplicated permissions, and work around terraform `depends_on` with some additional logic.

Rename terraform resources `bigquery_foo_xxx` instead of just `editor` / `viewer`, to avoid confusion with project viewer / editor roles.

Followup to #12095

I am pretty sure this will fix the last item; left the other two marked as "part of" in case this doesn't resolve those, but since those the two generated tests have `test_vars_overrides` for bootstrapping that this would have interfered with, hopefully this helps with any such issues.

Part of hashicorp/terraform-provider-google#20274
Part of hashicorp/terraform-provider-google#20262
Fixes hashicorp/terraform-provider-google#20261

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
