### PR TITLE
chore: updated Makefile and mmv builder

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,3 +1,5 @@
+SHELL=/bin/bash -eo pipefail
+
 # See https://googlecloudplatform.github.io/magic-modules/docs/getting-started/generate-providers/
 # for a guide on provider generation.
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -59,11 +59,10 @@ terraform build provider:
 	make tpgtools
 
 mmv1:
+	# Chaining these with "&&" is critical so this will exit non-0 if the first
+	# command fails, since we're not forcing bash and errexit / pipefail here.
 	cd mmv1;\
 		if [ "$(VERSION)" = "ga" ]; then \
-			# Chaining these with "&&" is critical here to prevent this
-			# from exiting 0 on failure of the first command, since we're
-			# not forcing bash and errexit / pipefail here. 
 			go run . --output $(OUTPUT_PATH) --version ga --no-docs $(mmv1_compile) \
 			&& go run . --output $(OUTPUT_PATH) --version beta --no-code $(mmv1_compile); \
 		else \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,3 @@
-SHELL=/usr/bin/env bash -eo pipefail
-
 # See https://googlecloudplatform.github.io/magic-modules/docs/getting-started/generate-providers/
 # for a guide on provider generation.
 
@@ -63,8 +61,7 @@ terraform build provider:
 mmv1:
 	cd mmv1;\
 		if [ "$(VERSION)" = "ga" ]; then \
-			go run . --output $(OUTPUT_PATH) --version ga --no-docs $(mmv1_compile); \
-			go run . --output $(OUTPUT_PATH) --version beta --no-code $(mmv1_compile); \
+			go run . --output $(OUTPUT_PATH) --version ga --no-docs $(mmv1_compile) && go run . --output $(OUTPUT_PATH) --version beta --no-code $(mmv1_compile); \
 		else \
 			go run . --output $(OUTPUT_PATH) --version $(VERSION) $(mmv1_compile); \
 		fi

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -61,7 +61,11 @@ terraform build provider:
 mmv1:
 	cd mmv1;\
 		if [ "$(VERSION)" = "ga" ]; then \
-			go run . --output $(OUTPUT_PATH) --version ga --no-docs $(mmv1_compile) && go run . --output $(OUTPUT_PATH) --version beta --no-code $(mmv1_compile); \
+			# Chaining these with "&&" is critical here to prevent this
+			# from exiting 0 on failure of the first command, since we're
+			# not forcing bash and errexit / pipefail here. 
+			go run . --output $(OUTPUT_PATH) --version ga --no-docs $(mmv1_compile) \
+			&& go run . --output $(OUTPUT_PATH) --version beta --no-code $(mmv1_compile); \
 		else \
 			go run . --output $(OUTPUT_PATH) --version $(VERSION) $(mmv1_compile); \
 		fi

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-SHELL=/bin/bash -eo pipefail
+SHELL=/usr/bin/env bash -eo pipefail
 
 # See https://googlecloudplatform.github.io/magic-modules/docs/getting-started/generate-providers/
 # for a guide on provider generation.

--- a/mmv1/main.go
+++ b/mmv1/main.go
@@ -132,9 +132,13 @@ func main() {
 	}
 
 	startTime := time.Now()
+	providerName := "default (terraform)"
+	if *forceProvider != "" {
+		providerName = *forceProvider
+	}
 	log.Printf("Generating MM output to '%s'", *outputPath)
-	log.Printf("Using %s version", *version)
-	log.Printf("Using %s provider", *forceProvider)
+	log.Printf("Building %s version", *version)
+	log.Printf("Building %s provider", providerName)
 
 	// Building compute takes a long time and can't be parallelized within the product
 	// so lets build it first

--- a/mmv1/provider/terraform.go
+++ b/mmv1/provider/terraform.go
@@ -499,7 +499,7 @@ func (t Terraform) CompileFileList(outputFolder string, files map[string]string,
 
 func (t Terraform) addHashicorpCopyRightHeader(outputFolder, target string) {
 	if !expectedOutputFolder(outputFolder) {
-		log.Printf("Unexpected output folder (%s) detected"+
+		log.Printf("Unexpected output folder (%s) detected "+
 			"when deciding to add HashiCorp copyright headers.\n"+
 			"Watch out for unexpected changes to copied files", outputFolder)
 	}


### PR DESCRIPTION
* Chain the two `go run` commands in the `mmv1` make target with `&&` (**edit:** did a narrower fix here than in the initial PR)
With this, the error in the linked ticket will now exit on provider build failure instead of continuing to the next step and exiting 0:
```
F1112 22:07:54.227629   53015 examples.go:300] template: artifact_registry_repository.go.tmpl:12: function "project" not defined
2024/11/12 22:07:54 products/dialogflowcx not specified, skipping generation
2024/11/12 22:07:54 products/iambeta not specified, skipping generation
2024/11/12 22:07:54 products/securitycenter not specified, skipping generation
2024/11/12 22:07:54 products/privateca not specified, skipping generation
exit status 1
make[1]: *** [mmv1] Error 1
make: *** [provider] Error 2
% echo $?
2
```
* Added the product being built in the case where `forceProvider` is set to an empty string, and changed prefix to "Building" vs "Using"

This avoids the extra space and missing provider type that show up when building the default (Terraform) provider:
```
2024/11/12 20:14:47 Using ga version
2024/11/12 20:14:47 Using  provider
```
in favor of:
```
2024/11/12 22:23:30 Building ga version
2024/11/12 22:23:30 Building default (terraform) provider
```
* Also fixed missing space here:
```
2024/11/12 22:40:26 Unexpected output folder (--version) detectedwhen deciding to add HashiCorp copyright headers.
```

Fixes hashicorp/terraform-provider-google#20317

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
