### PR TITLE
tpgresource: added support for default location in `tpgresource.ReplaceVars`

### DIFF
--- a/mmv1/third_party/terraform/tpgresource/utils_test.go
+++ b/mmv1/third_party/terraform/tpgresource/utils_test.go
@@ -1079,6 +1079,32 @@ func TestReplaceVars(t *testing.T) {
 			},
 			Expected: "projects/default-project/zones/default-zone/instances",
 		},
+		"location with provider level region": {
+			Template: "projects/{{project}}/locations/{{location}}/repositories",
+			Config: &transport_tpg.Config{
+				Project: "default-project",
+				Region:  "default-region",
+			},
+			Expected: "projects/default-project/locations/default-region/repositories",
+		},
+		"location with provider level region and zone": {
+			Template: "projects/{{project}}/locations/{{location}}/repositories",
+			Config: &transport_tpg.Config{
+				Project: "default-project",
+				Region:  "default-region",
+				Zone:    "default-region-a",
+			},
+			Expected: "projects/default-project/locations/default-region/repositories",
+		},
+		"location with provider level zone": {
+			// May not actually be useful / valid for all use cases.
+			Template: "projects/{{project}}/locations/{{location}}/repositories",
+			Config: &transport_tpg.Config{
+				Project: "default-project",
+				Zone:    "default-region-a",
+			},
+			Expected: "projects/default-project/locations/default-region-a/repositories",
+		},
 		"regional schema values": {
 			Template: "projects/{{project}}/regions/{{region}}/subnetworks/{{name}}",
 			SchemaValues: map[string]interface{}{
@@ -1124,6 +1150,19 @@ func TestReplaceVars(t *testing.T) {
 				"innerzone": "inner",
 			},
 			Expected: "projects/project1/zones/wrapperinnerwrapper/instances/instance1",
+		},
+		"location with schema values": {
+			Template: "projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}",
+			Config: &transport_tpg.Config{
+				Project: "default-project",
+				Region:  "default-region",
+			},
+			SchemaValues: map[string]interface{}{
+				"location":      "other-location",
+				"project":       "project1",
+				"repository_id": "foo",
+			},
+			Expected: "projects/project1/locations/other-location/repositories/foo",
 		},
 		"base path recursive replacement": {
 			Template: "{{CloudRunBasePath}}namespaces/{{project}}/services",


### PR DESCRIPTION
This supports inferring `{{location}}` from the provider (similar to what is done with `{{region}}` and `{{zone}}` in
`tpgresource.ReplaceVars()`, vs. just taking a value if it's explicitly set.

Even if all tests pass, it's probably necessary for someone who understands how this is used to weigh in and make sure this isn't likely to have any unintended consequences / side effects.

While `ReplaceVars()` is used all over the place, like the replacements for `{{region}}` and `{{zone}}`, `BuildReplacementFunc()` is using a method (`GetLocation()`, in this case) that was seemingly originally intended for use with GKE clusters, but probably generically will work in some situations.

In this case, for an artifact registry repository resource with a location set at provider level, this fixes some issues with import _if_ the resource is in the same region that's configured at provider level.

Part of hashicorp/terraform-provider-google#19266

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
