### PR TITLE
Made traffic_split field use default_from_api

### DIFF
--- a/mmv1/products/vertexai/Endpoint.yaml
+++ b/mmv1/products/vertexai/Endpoint.yaml
@@ -375,7 +375,7 @@ properties:
       the `deployModel` [example](https://cloud.google.com/vertex-ai/docs/general/deployment#deploy_a_model_to_an_endpoint) and
       [documentation](https://cloud.google.com/vertex-ai/docs/reference/rest/v1beta1/projects.locations.endpoints/deployModel) for more information.
 
-      ~> **Note:** To set the map to empty, use `"{}"`. Leaving unset or setting to `""` will persist the last value returned from the API.
+      ~> **Note:** To set the map to empty, set `"{}"`, apply, and then remove the field from your config.
     state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
     custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
     custom_expand: 'templates/terraform/custom_expand/json_schema.tmpl'

--- a/mmv1/products/vertexai/Endpoint.yaml
+++ b/mmv1/products/vertexai/Endpoint.yaml
@@ -367,15 +367,15 @@ properties:
           output: true
   - name: 'trafficSplit'
     type: String
+    default_from_api: true
     description: |
       A map from a DeployedModel's id to the percentage of this Endpoint's traffic that should be forwarded to that DeployedModel.
       If a DeployedModel's id is not listed in this map, then it receives no traffic.
-      The traffic percentage values must add up to 100, or map must be empty if the Endpoint is to not accept any traffic at a moment.
-
-      ~> **Note:** The `traffic_split` setting only applies after a model has been deployed to the endpoint. Re-applying a `google_vertex_ai_endpoint`
-      resource without updating the `traffic_split` post-deployment may lead to your deployed `traffic_split` being lost; see
+      The traffic percentage values must add up to 100, or map must be empty if the Endpoint is to not accept any traffic at a moment. See
       the `deployModel` [example](https://cloud.google.com/vertex-ai/docs/general/deployment#deploy_a_model_to_an_endpoint) and
-      [documentation](https://cloud.google.com/vertex-ai/docs/reference/rest/v1beta1/projects.locations.endpoints/deployModel) for details.
+      [documentation](https://cloud.google.com/vertex-ai/docs/reference/rest/v1beta1/projects.locations.endpoints/deployModel) for more information.
+
+      ~> **Note:** To set the map to empty, use `"{}"`. Leaving unset or setting to `""` will persist the last value returned from the API.
     state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
     custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
     custom_expand: 'templates/terraform/custom_expand/json_schema.tmpl'


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Testing behavior of `"{}"`: gpaste/6027469969948672
Testing behavior of `"{}"` if there's already a value set remotely: gpaste/4841573379735552

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
vertexai: fixed issue with google_vertex_ai_endpoint where upgrading to 6.11.0 would delete all traffic splits that were set outside Terraform (which was previously a required step for all meaningful use of this resource).
```
