### PR TITLE
Clarify `responseHeader` in `Bucket.yaml`

### DIFF
--- a/mmv1/products/storage/Bucket.yaml
+++ b/mmv1/products/storage/Bucket.yaml
@@ -189,8 +189,9 @@ properties:
         - name: 'responseHeader'
           type: Array
           description: |
-            The list of HTTP headers other than the simple response headers
-            to give permission for the user-agent to share across domains.
+            The list of HTTP headers to give permission for the user-agent
+            to share across domains. A typical example would e.g. be to
+            allow the `Content-Type` header.
           item_type:
             type: String
   - name: 'defaultEventBasedHold'


### PR DESCRIPTION
Analogous to https://github.com/hashicorp/terraform-provider-google/pull/20330, so that that PR won't be automatically overridden.

The description of `responseHeader` prior to this change claimed that simple response headers were always implicitly included in  the `responseHeader` list. [According to MDN](https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_response_header), the `Content-Type` would be considered such a simple response header. However on my bucket, preflight requests on a bucket failed until the `response_header` argument in Terraform was set to `["Content-Type"]`, countering the docs. The wrong docs cost me hours, until I finally decided to go try adding going with code analogous to the [basic CORS example configuration](https://cloud.google.com/storage/docs/cors-configurations). Now my assumption is that at least `Content-Type` is not automatically returned in responses to cross origin preflight requests.

```release-note:none
storage: improved outdated/misleading description of the `responseHeader` field
```