### PR TITLE
Make top-level immutable field more visible in the contribution guide

### DIFF
--- a/docs/content/develop/resource.md
+++ b/docs/content/develop/resource.md
@@ -92,7 +92,7 @@ For more information about types of resources and the generation process overall
    # If true, the resource and all its fields are considered immutable - that is,
    # only creatable, not updatable. Individual fields can override this if they
    # have a custom update method in the API.
-   # immutable: true
+   immutable: true
 
    # URL for the resource's standard Create method, including query parameters.
    # https://google.aip.dev/133


### PR DESCRIPTION
When referring to the contribution site I realised this field is commented out, which makes it hard to notice in the yaml code block:

![Screenshot 2024-11-14 at 11 38 04](https://github.com/user-attachments/assets/e3a7ce16-bd6b-41ce-a51a-25da76cb2c41)

This PR uncomments it, which I assume was in error

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
