### PR TITLE
Add support for diffing field sets

### DIFF
--- a/tools/diff-processor/diff/diff.go
+++ b/tools/diff-processor/diff/diff.go
@@ -2,11 +2,10 @@ package diff
 
 import (
 	"reflect"
+	"strings"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"golang.org/x/exp/maps"
 )
 
 // SchemaDiff is a nested map with resource names as top-level keys.
@@ -15,7 +14,22 @@ type SchemaDiff map[string]ResourceDiff
 type ResourceDiff struct {
 	ResourceConfig ResourceConfigDiff
 	Fields         map[string]FieldDiff
+	FieldSets      ResourceFieldSetsDiff
 }
+
+type ResourceFieldSetsDiff struct {
+	Old ResourceFieldSets
+	New ResourceFieldSets
+}
+
+type ResourceFieldSets struct {
+	ConflictsWith []FieldSet
+	ExactlyOneOf  []FieldSet
+	AtLeastOneOf  []FieldSet
+	RequiredWith  []FieldSet
+}
+
+type FieldSet map[string]struct{}
 
 type ResourceConfigDiff struct {
 	Old *schema.Resource
@@ -29,7 +43,7 @@ type FieldDiff struct {
 
 func ComputeSchemaDiff(oldResourceMap, newResourceMap map[string]*schema.Resource) SchemaDiff {
 	schemaDiff := make(SchemaDiff)
-	for resource, _ := range union(maps.Keys(oldResourceMap), maps.Keys(newResourceMap)) {
+	for resource := range union(oldResourceMap, newResourceMap) {
 		// Compute diff between old and new resources and fields.
 		// TODO: add support for computing diff between resource configs, not just whether the
 		// resource was added/removed. b/300114839
@@ -47,14 +61,12 @@ func ComputeSchemaDiff(oldResourceMap, newResourceMap map[string]*schema.Resourc
 		}
 
 		resourceDiff.Fields = make(map[string]FieldDiff)
-		for key, _ := range union(maps.Keys(flattenedOldSchema), maps.Keys(flattenedNewSchema)) {
+		for key := range union(flattenedOldSchema, flattenedNewSchema) {
 			oldField := flattenedOldSchema[key]
 			newField := flattenedNewSchema[key]
-			if fieldChanged(oldField, newField) {
-				resourceDiff.Fields[key] = FieldDiff{
-					Old: oldField,
-					New: newField,
-				}
+			if fieldDiff, fieldSetsDiff, changed := diffFields(oldField, newField, key); changed {
+				resourceDiff.Fields[key] = fieldDiff
+				resourceDiff.FieldSets = mergeFieldSetsDiff(fieldSetsDiff, resourceDiff.FieldSets)
 			}
 		}
 		if len(resourceDiff.Fields) > 0 || !cmp.Equal(resourceDiff.ResourceConfig.Old, resourceDiff.ResourceConfig.New) {
@@ -62,17 +74,6 @@ func ComputeSchemaDiff(oldResourceMap, newResourceMap map[string]*schema.Resourc
 		}
 	}
 	return schemaDiff
-}
-
-func union(keys1, keys2 []string) map[string]struct{} {
-	allKeys := make(map[string]struct{})
-	for _, key := range keys1 {
-		allKeys[key] = struct{}{}
-	}
-	for _, key := range keys2 {
-		allKeys[key] = struct{}{}
-	}
-	return allKeys
 }
 
 func flattenSchema(parentKey string, schemaObj map[string]*schema.Schema) map[string]*schema.Schema {
@@ -96,16 +97,48 @@ func flattenSchema(parentKey string, schemaObj map[string]*schema.Schema) map[st
 	return flattened
 }
 
-func fieldChanged(oldField, newField *schema.Schema) bool {
+func diffFields(oldField, newField *schema.Schema, fieldName string) (FieldDiff, ResourceFieldSetsDiff, bool) {
 	// If either field is nil, it is changed; if both are nil (which should never happen) it's not
 	if oldField == nil && newField == nil {
-		return false
+		return FieldDiff{}, ResourceFieldSetsDiff{}, false
+	}
+
+	oldFieldSets := fieldSets(oldField, fieldName)
+	newFieldSets := fieldSets(newField, fieldName)
+
+	fieldDiff := FieldDiff{
+		Old: oldField,
+		New: newField,
+	}
+	fieldSetsDiff := ResourceFieldSetsDiff{
+		Old: oldFieldSets,
+		New: newFieldSets,
 	}
 	if oldField == nil || newField == nil {
-		return true
+		return fieldDiff, fieldSetsDiff, true
 	}
 	// Check if any basic Schema struct fields have changed.
 	// https://github.com/hashicorp/terraform-plugin-sdk/blob/v2.24.0/helper/schema/schema.go#L44
+	if basicSchemaChanged(oldField, newField) {
+		return fieldDiff, fieldSetsDiff, true
+	}
+
+	if !cmp.Equal(oldFieldSets, newFieldSets) {
+		return fieldDiff, fieldSetsDiff, true
+	}
+
+	if elemChanged(oldField, newField) {
+		return fieldDiff, fieldSetsDiff, true
+	}
+
+	if funcsChanged(oldField, newField) {
+		return fieldDiff, fieldSetsDiff, true
+	}
+
+	return FieldDiff{}, ResourceFieldSetsDiff{}, false
+}
+
+func basicSchemaChanged(oldField, newField *schema.Schema) bool {
 	if oldField.Type != newField.Type {
 		return true
 	}
@@ -148,26 +181,35 @@ func fieldChanged(oldField, newField *schema.Schema) bool {
 	if oldField.Sensitive != newField.Sensitive {
 		return true
 	}
+	return false
+}
 
-	// Compare slices
-	less := func(a, b string) bool { return a < b }
-
-	if (len(oldField.ConflictsWith) > 0 || len(newField.ConflictsWith) > 0) && !cmp.Equal(oldField.ConflictsWith, newField.ConflictsWith, cmpopts.SortSlices(less)) {
-		return true
+func fieldSets(field *schema.Schema, fieldName string) ResourceFieldSets {
+	if field == nil {
+		return ResourceFieldSets{}
 	}
-
-	if (len(oldField.ExactlyOneOf) > 0 || len(newField.ExactlyOneOf) > 0) && !cmp.Equal(oldField.ExactlyOneOf, newField.ExactlyOneOf, cmpopts.SortSlices(less)) {
-		return true
+	var conflictsWith, exactlyOneOf, atLeastOneOf, requiredWith []FieldSet
+	if len(field.ConflictsWith) > 0 {
+		conflictsWith = []FieldSet{sliceToSetRemoveZeroPadding(append(field.ConflictsWith, fieldName))}
 	}
-
-	if (len(oldField.AtLeastOneOf) > 0 || len(newField.AtLeastOneOf) > 0) && !cmp.Equal(oldField.AtLeastOneOf, newField.AtLeastOneOf, cmpopts.SortSlices(less)) {
-		return true
+	if len(field.ExactlyOneOf) > 0 {
+		exactlyOneOf = []FieldSet{sliceToSetRemoveZeroPadding(append(field.ExactlyOneOf, fieldName))}
 	}
-
-	if (len(oldField.RequiredWith) > 0 || len(newField.RequiredWith) > 0) && !cmp.Equal(oldField.RequiredWith, newField.RequiredWith, cmpopts.SortSlices(less)) {
-		return true
+	if len(field.AtLeastOneOf) > 0 {
+		atLeastOneOf = []FieldSet{sliceToSetRemoveZeroPadding(append(field.AtLeastOneOf, fieldName))}
 	}
+	if len(field.RequiredWith) > 0 {
+		requiredWith = []FieldSet{sliceToSetRemoveZeroPadding(append(field.RequiredWith, fieldName))}
+	}
+	return ResourceFieldSets{
+		ConflictsWith: conflictsWith,
+		ExactlyOneOf:  exactlyOneOf,
+		AtLeastOneOf:  atLeastOneOf,
+		RequiredWith:  requiredWith,
+	}
+}
 
+func elemChanged(oldField, newField *schema.Schema) bool {
 	// Check if Elem changed (unless old and new both represent nested fields)
 	if (oldField.Elem == nil && newField.Elem != nil) || (oldField.Elem != nil && newField.Elem == nil) {
 		return true
@@ -183,12 +225,15 @@ func fieldChanged(oldField, newField *schema.Schema) bool {
 			return true
 		}
 		if !oldIsResource && !newIsResource {
-			if fieldChanged(oldField.Elem.(*schema.Schema), newField.Elem.(*schema.Schema)) {
+			if _, _, changed := diffFields(oldField.Elem.(*schema.Schema), newField.Elem.(*schema.Schema), ""); changed {
 				return true
 			}
 		}
 	}
+	return false
+}
 
+func funcsChanged(oldField, newField *schema.Schema) bool {
 	// Check if any Schema struct fields that are functions have changed
 	if funcChanged(oldField.DiffSuppressFunc, newField.DiffSuppressFunc) {
 		return true
@@ -208,7 +253,6 @@ func fieldChanged(oldField, newField *schema.Schema) bool {
 	if funcChanged(oldField.ValidateDiagFunc, newField.ValidateDiagFunc) {
 		return true
 	}
-
 	return false
 }
 
@@ -224,4 +268,37 @@ func funcChanged(oldFunc, newFunc interface{}) bool {
 	// determine whether the function changed, so we assume that it has not changed.
 	// b/300157205
 	return false
+}
+
+func mergeFieldSetsDiff(a, b ResourceFieldSetsDiff) ResourceFieldSetsDiff {
+	a.Old = mergeResourceFieldSets(a.Old, b.Old)
+	a.New = mergeResourceFieldSets(a.New, b.New)
+	return a
+}
+
+func mergeResourceFieldSets(a, b ResourceFieldSets) ResourceFieldSets {
+	a.ConflictsWith = mergeFieldSets(a.ConflictsWith, b.ConflictsWith)
+	a.ExactlyOneOf = mergeFieldSets(a.ExactlyOneOf, b.ExactlyOneOf)
+	a.AtLeastOneOf = mergeFieldSets(a.AtLeastOneOf, b.AtLeastOneOf)
+	a.RequiredWith = mergeFieldSets(a.RequiredWith, b.RequiredWith)
+	return a
+}
+
+func mergeFieldSets(a, b []FieldSet) []FieldSet {
+	keys := make(map[string]struct{})
+	for _, set := range a {
+		slice := setToSortedSlice(set)
+		key := strings.Join(slice, ",")
+		keys[key] = struct{}{}
+	}
+	for _, set := range b {
+		slice := setToSortedSlice(set)
+		key := strings.Join(slice, ",")
+		if _, ok := keys[key]; ok {
+			continue
+		}
+		keys[key] = struct{}{}
+		a = append(a, set)
+	}
+	return a
 }

--- a/tools/diff-processor/diff/diff.go
+++ b/tools/diff-processor/diff/diff.go
@@ -301,6 +301,9 @@ func mergeResourceFieldSets(allFields ResourceFieldSetsWithKeys, currentField Re
 }
 
 func mergeFieldSets(allFields map[string]FieldSet, currentField []FieldSet) map[string]FieldSet {
+	if allFields == nil {
+		allFields = make(map[string]FieldSet)
+	}
 	for _, fieldSet := range currentField {
 		allFields[setKey(fieldSet)] = fieldSet
 	}

--- a/tools/diff-processor/diff/diff_test.go
+++ b/tools/diff-processor/diff/diff_test.go
@@ -984,7 +984,7 @@ func TestFieldChanged(t *testing.T) {
 		tc := tc
 		t.Run(tn, func(t *testing.T) {
 			t.Parallel()
-			changed := fieldChanged(tc.oldField, tc.newField)
+			_, _, changed := diffFields(tc.oldField, tc.newField, "")
 			if changed != tc.expectChanged {
 				if diff := cmp.Diff(tc.oldField, tc.newField); diff != "" {
 					t.Errorf("want %t; got %t.\nField diff (-old, +new):\n%s",
@@ -1074,9 +1074,15 @@ func TestComputeSchemaDiff(t *testing.T) {
 					Schema: map[string]*schema.Schema{
 						"field_one": {
 							Type: schema.TypeString,
+							ConflictsWith: []string{
+								"field_two",
+							},
 						},
 						"field_two": {
 							Type: schema.TypeList,
+							ConflictsWith: []string{
+								"field_one",
+							},
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"field_three": {
@@ -1110,9 +1116,15 @@ func TestComputeSchemaDiff(t *testing.T) {
 					Schema: map[string]*schema.Schema{
 						"field_one": {
 							Type: schema.TypeString,
+							ConflictsWith: []string{
+								"field_two",
+							},
 						},
 						"field_two": {
 							Type: schema.TypeList,
+							ConflictsWith: []string{
+								"field_one",
+							},
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"field_three": {
@@ -1134,9 +1146,15 @@ func TestComputeSchemaDiff(t *testing.T) {
 								Schema: map[string]*schema.Schema{
 									"field_three": {
 										Type: schema.TypeString,
+										ConflictsWith: []string{
+											"field_two.0.field_four",
+										},
 									},
 									"field_four": {
 										Type: schema.TypeInt,
+										ConflictsWith: []string{
+											"field_two.0.field_three",
+										},
 									},
 								},
 							},
@@ -1151,10 +1169,35 @@ func TestComputeSchemaDiff(t *testing.T) {
 						New: &schema.Resource{},
 					},
 					Fields: map[string]FieldDiff{
+						"field_two.field_three": FieldDiff{
+							Old: &schema.Schema{
+								Type: schema.TypeString,
+							},
+							New: &schema.Schema{
+								Type: schema.TypeString,
+								ConflictsWith: []string{
+									"field_two.0.field_four",
+								},
+							},
+						},
 						"field_two.field_four": FieldDiff{
 							Old: nil,
 							New: &schema.Schema{
 								Type: schema.TypeInt,
+								ConflictsWith: []string{
+									"field_two.0.field_three",
+								},
+							},
+						},
+					},
+					FieldSets: ResourceFieldSetsDiff{
+						Old: ResourceFieldSets{},
+						New: ResourceFieldSets{
+							ConflictsWith: []FieldSet{
+								{
+									"field_two.field_three": {},
+									"field_two.field_four":  {},
+								},
 							},
 						},
 					},

--- a/tools/diff-processor/diff/sets.go
+++ b/tools/diff-processor/diff/sets.go
@@ -1,0 +1,55 @@
+package diff
+
+import (
+	"sort"
+	"strings"
+)
+
+// Return the union of two maps, overwriting any shared keys with the second map's values
+func union[K comparable, V any](map1, map2 map[K]V) map[K]V {
+	if len(map1) == 0 {
+		return map2
+	}
+	if len(map2) == 0 {
+		return map1
+	}
+	merged := make(map[K]V, len(map1)+len(map2))
+	for k, v := range map1 {
+		merged[k] = v
+	}
+	for k, v := range map2 {
+		merged[k] = v
+	}
+	return merged
+}
+
+func sliceToSetRemoveZeroPadding(slice []string) map[string]struct{} {
+	set := make(map[string]struct{})
+	for _, item := range slice {
+		set[removeZeroPadding(item)] = struct{}{}
+	}
+	return set
+}
+
+// field1.0.field2 -> field1.field2
+func removeZeroPadding(zeroPadded string) string {
+	var trimmed string
+	for _, part := range strings.Split(zeroPadded, ".") {
+		if part != "0" {
+			trimmed += part + "."
+		}
+	}
+	if trimmed == "" {
+		return ""
+	}
+	return trimmed[:len(trimmed)-1]
+}
+
+func setToSortedSlice(set map[string]struct{}) []string {
+	slice := make([]string, 0, len(set))
+	for item := range set {
+		slice = append(slice, item)
+	}
+	sort.Strings(slice)
+	return slice
+}

--- a/tools/diff-processor/diff/sets_test.go
+++ b/tools/diff-processor/diff/sets_test.go
@@ -1,0 +1,33 @@
+package diff
+
+import (
+	"testing"
+)
+
+func TestRemoveZeroPadding(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		zeroPadded string
+		expected   string
+	}{
+		{
+			name:       "no zeroes",
+			zeroPadded: "a.b.c",
+			expected:   "a.b.c",
+		},
+		{
+			name:       "one zero",
+			zeroPadded: "a.0.b.c",
+			expected:   "a.b.c",
+		},
+		{
+			name:       "two zeroes",
+			zeroPadded: "a.0.b.0.c",
+			expected:   "a.b.c",
+		},
+	} {
+		if got := removeZeroPadding(tc.zeroPadded); got != tc.expected {
+			t.Errorf("unexpected result for test case %s: %s (expected %s)", tc.name, got, tc.expected)
+		}
+	}
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This is a less complicated approach to diffing conflict sets, which can be used to detect breaking changes in `ExactlyOneOf` or `AtLeastOneOf`.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
