### PR TITLE
Fixes documentation of vpc_ip_subnetworks in google_access_context_ma…

### DIFF
--- a/mmv1/products/accesscontextmanager/AccessLevel.yaml
+++ b/mmv1/products/accesscontextmanager/AccessLevel.yaml
@@ -281,7 +281,7 @@ properties:
                         required: true
                       - name: 'vpcIpSubnetworks'
                         type: Array
-                        description: 'CIDR block IP subnetwork specification. Must be IPv4.'
+                        description: 'A list of CIDR block IP subnetwork specification. Must be IPv4.'
                         item_type:
                           type: String
         min_size: 1


### PR DESCRIPTION
Fixes documentation of vpc_ip_subnetworks in google_access_context_manager_access_level.

Fixes hashicorp/terraform-provider-google/issues/19539.

```release-note:none
```
