### PR TITLE
Fix TestAccDataprocCluster_withNetworkRefs

### DIFF
--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
@@ -2578,3 +2578,4 @@ resource "google_dataproc_metastore_service" "ms" {
 }
 `, clusterName, serviceId)
 }
+

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
@@ -909,14 +909,13 @@ func TestAccDataprocCluster_withNetworkRefs(t *testing.T) {
 
 	var c1, c2 dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
-	netName := fmt.Sprintf(`dproc-cluster-test-%s-net`, rnd)
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withNetworkRefs(rnd, netName),
+				Config: testAccDataprocCluster_withNetworkRefs(rnd),
 				Check: resource.ComposeTestCheckFunc(
 					// successful creation of the clusters is good enough to assess it worked
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_net_ref_by_url", &c1),
@@ -2301,13 +2300,26 @@ resource "google_dataproc_cluster" "with_service_account" {
 `, sa, rnd, subnetworkName)
 }
 
-func testAccDataprocCluster_withNetworkRefs(rnd, netName string) string {
+func testAccDataprocCluster_withNetworkRefs(rnd string) string {
 	return fmt.Sprintf(`
-resource "google_compute_network" "dataproc_network" {
-  name                    = "%s"
-  auto_create_subnetworks = true
+variable "subnetwork_cidr" {
+  default = "10.0.0.0/16"
 }
-
+resource "google_compute_network" "dataproc_network" {
+  name                    = "tf-test-dproc-net-%s"
+  auto_create_subnetworks = false
+}
+#
+# Create a subnet with Private IP Access enabled to test
+# deploying a Dataproc cluster with Internal IP Only enabled.
+#
+resource "google_compute_subnetwork" "dataproc_subnetwork" {
+  name                     = "tf-test-dproc-subnet-%s"
+  ip_cidr_range            = var.subnetwork_cidr
+  network                  = google_compute_network.dataproc_network.self_link
+  region                   = "us-central1"
+  private_ip_google_access = true
+}
 #
 # The default network within GCP already comes pre configured with
 # certain firewall rules open to allow internal communication. As we
@@ -2316,24 +2328,21 @@ resource "google_compute_network" "dataproc_network" {
 # internally as part of their configuration or this will just hang.
 #
 resource "google_compute_firewall" "dataproc_network_firewall" {
-  name          = "tf-test-dproc-%s"
-  description   = "Firewall rules for dataproc Terraform acceptance testing"
-  network       = google_compute_network.dataproc_network.name
-  source_ranges = ["192.168.0.0/16"]
-
+  name        = "tf-test-dproc-firewall-%s"
+  description = "Firewall rules for dataproc Terraform acceptance testing"
+  network     = google_compute_network.dataproc_network.name
   allow {
     protocol = "icmp"
   }
-
   allow {
     protocol = "tcp"
     ports    = ["0-65535"]
   }
-
   allow {
     protocol = "udp"
     ports    = ["0-65535"]
   }
+  source_ranges = [var.subnetwork_cidr]
 }
 
 resource "google_dataproc_cluster" "with_net_ref_by_name" {
@@ -2358,7 +2367,8 @@ resource "google_dataproc_cluster" "with_net_ref_by_name" {
     }
 
     gce_cluster_config {
-      network = google_compute_network.dataproc_network.name
+      subnetwork       = google_compute_subnetwork.dataproc_subnetwork.name
+      internal_ip_only = true
     }
   }
 }
@@ -2385,12 +2395,12 @@ resource "google_dataproc_cluster" "with_net_ref_by_url" {
     }
 
     gce_cluster_config {
-      network = google_compute_network.dataproc_network.self_link
-      internal_ip_only = false
+      subnetwork       = google_compute_subnetwork.dataproc_subnetwork.name
+      internal_ip_only = true
     }
   }
 }
-`, netName, rnd, rnd, rnd)
+`, rnd, rnd, rnd, rnd, rnd)
 }
 
 func testAccDataprocCluster_KMS(rnd, kmsKey, subnetworkName string) string {

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
@@ -909,13 +909,14 @@ func TestAccDataprocCluster_withNetworkRefs(t *testing.T) {
 
 	var c1, c2 dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
+	netName := fmt.Sprintf(`dproc-cluster-test-%s-net`, rnd)
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withNetworkRefs(rnd),
+				Config: testAccDataprocCluster_withNetworkRefs(rnd, netName),
 				Check: resource.ComposeTestCheckFunc(
 					// successful creation of the clusters is good enough to assess it worked
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_net_ref_by_url", &c1),
@@ -2300,26 +2301,13 @@ resource "google_dataproc_cluster" "with_service_account" {
 `, sa, rnd, subnetworkName)
 }
 
-func testAccDataprocCluster_withNetworkRefs(rnd string) string {
+func testAccDataprocCluster_withNetworkRefs(rnd, netName string) string {
 	return fmt.Sprintf(`
-variable "subnetwork_cidr" {
-  default = "10.0.0.0/16"
-}
 resource "google_compute_network" "dataproc_network" {
-  name                    = "tf-test-dproc-net-%s"
-  auto_create_subnetworks = false
+  name                    = "%s"
+  auto_create_subnetworks = true
 }
-#
-# Create a subnet with Private IP Access enabled to test
-# deploying a Dataproc cluster with Internal IP Only enabled.
-#
-resource "google_compute_subnetwork" "dataproc_subnetwork" {
-  name                     = "tf-test-dproc-subnet-%s"
-  ip_cidr_range            = var.subnetwork_cidr
-  network                  = google_compute_network.dataproc_network.self_link
-  region                   = "us-central1"
-  private_ip_google_access = true
-}
+
 #
 # The default network within GCP already comes pre configured with
 # certain firewall rules open to allow internal communication. As we
@@ -2328,21 +2316,24 @@ resource "google_compute_subnetwork" "dataproc_subnetwork" {
 # internally as part of their configuration or this will just hang.
 #
 resource "google_compute_firewall" "dataproc_network_firewall" {
-  name        = "tf-test-dproc-firewall-%s"
-  description = "Firewall rules for dataproc Terraform acceptance testing"
-  network     = google_compute_network.dataproc_network.name
+  name          = "tf-test-dproc-%s"
+  description   = "Firewall rules for dataproc Terraform acceptance testing"
+  network       = google_compute_network.dataproc_network.name
+  source_ranges = ["192.168.0.0/16"]
+
   allow {
     protocol = "icmp"
   }
+
   allow {
     protocol = "tcp"
     ports    = ["0-65535"]
   }
+
   allow {
     protocol = "udp"
     ports    = ["0-65535"]
   }
-  source_ranges = [var.subnetwork_cidr]
 }
 
 resource "google_dataproc_cluster" "with_net_ref_by_name" {
@@ -2360,15 +2351,15 @@ resource "google_dataproc_cluster" "with_net_ref_by_name" {
     }
 
     master_config {
-      machine_type = "e2-medium"
+      machine_type = "e2-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
     }
 
     gce_cluster_config {
-      subnetwork       = google_compute_subnetwork.dataproc_subnetwork.name
-      internal_ip_only = true
+      network          = google_compute_network.dataproc_network.name
+      internal_ip_only = false
     }
   }
 }
@@ -2388,19 +2379,19 @@ resource "google_dataproc_cluster" "with_net_ref_by_url" {
     }
 
     master_config {
-      machine_type = "e2-medium"
+      machine_type = "e2-standard-2"
       disk_config {
         boot_disk_size_gb = 35
       }
     }
 
     gce_cluster_config {
-      subnetwork       = google_compute_subnetwork.dataproc_subnetwork.name
-      internal_ip_only = true
+      network          = google_compute_network.dataproc_network.self_link
+      internal_ip_only = false
     }
   }
 }
-`, rnd, rnd, rnd, rnd, rnd)
+`, netName, rnd, rnd, rnd)
 }
 
 func testAccDataprocCluster_KMS(rnd, kmsKey, subnetworkName string) string {
@@ -2587,4 +2578,3 @@ resource "google_dataproc_metastore_service" "ms" {
 }
 `, clusterName, serviceId)
 }
-

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
@@ -2386,6 +2386,7 @@ resource "google_dataproc_cluster" "with_net_ref_by_url" {
 
     gce_cluster_config {
       network = google_compute_network.dataproc_network.self_link
+      internal_ip_only = false
     }
   }
 }


### PR DESCRIPTION
Dataproc doesn't allow cluster creation when `internal_ip_only` is set to `true` and Private Google Access is not enabled on the subnet. Since the subnetwork in this test is auto created, it does not have Private google access. Setting `internal_ip_only` to false

Fixes: https://github.com/hashicorp/hashicorp/terraform-provider-google/issues/20254
Fixes: hashicorp/terraform-provider-google#20254

```release-note:none
```
