### PR TITLE
Document `auth_string` output parameter for google_redis_instance

### DIFF
--- a/mmv1/products/redis/Instance.yaml
+++ b/mmv1/products/redis/Instance.yaml
@@ -20,6 +20,8 @@ references:
     'Official Documentation': 'https://cloud.google.com/memorystore/docs/redis/'
   api: 'https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances'
 docs:
+  attributes: |
+    * `auth_string` - AUTH String set on the instance. This field will only be populated if auth_enabled is true.
 base_url: 'projects/{{project}}/locations/{{region}}/instances'
 create_url: 'projects/{{project}}/locations/{{region}}/instances?instanceId={{name}}'
 update_verb: 'PATCH'

--- a/mmv1/templates/terraform/resource.html.markdown.tmpl
+++ b/mmv1/templates/terraform/resource.html.markdown.tmpl
@@ -148,6 +148,9 @@ In addition to the arguments listed above, the following computed attributes are
 * `self_link` - The URI of the created resource.
 {{ "" }}
 {{- end }}
+{{- if $.Docs.Attributes }}
+{{ $.Docs.Attributes }}
+{{- end }}
 {{ range $p := $.AllUserProperties }}
 	{{- if $p.Output }}
 {{- trimTemplate "nested_property_documentation.html.markdown.tmpl" $p }}


### PR DESCRIPTION
Add missing documentation for `auth_string` for google_redis_instance.

**Release Note Template for Downstream PRs (will be copied)**



```release-note:none

```
