### PR TITLE
artifactregistry: updated repository docs and import format

### DIFF
--- a/mmv1/products/artifactregistry/Repository.yaml
+++ b/mmv1/products/artifactregistry/Repository.yaml
@@ -27,7 +27,6 @@ update_verb: 'PATCH'
 update_mask: true
 import_format:
   - 'projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}'
-  - '{{location}}/{{repository_id}}'
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/artifactregistry/Repository.yaml
+++ b/mmv1/products/artifactregistry/Repository.yaml
@@ -27,7 +27,7 @@ update_verb: 'PATCH'
 update_mask: true
 import_format:
   - 'projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}'
-  - '{{repository_id}}'
+  - '{{location}}/{{repository_id}}'
 timeouts:
   insert_minutes: 20
   update_minutes: 20
@@ -63,6 +63,12 @@ custom_code:
   pre_create: 'templates/terraform/pre_create/artifact_registry_remote_repository.go.tmpl'
 examples:
   - name: 'artifact_registry_repository_basic'
+    primary_resource_id: 'my-repo'
+    primary_resource_name: 'fmt.Sprintf("tf-test-my-repository%s", context["random_suffix"])'
+    vars:
+      repository_id: 'my-repository'
+      desc: 'example docker repository'
+  - name: 'artifact_registry_repository_multi_region'
     primary_resource_id: 'my-repo'
     primary_resource_name: 'fmt.Sprintf("tf-test-my-repository%s", context["random_suffix"])'
     vars:
@@ -209,15 +215,6 @@ examples:
       # response.
       - 'remote_repository_config.0.disable_upstream_validation'
 parameters:
-properties:
-  - name: 'name'
-    type: String
-    description: |-
-      The name of the repository, for example:
-      "repo1"
-    output: true
-    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'
-    custom_expand: 'templates/terraform/custom_expand/shortname_to_url.go.tmpl'
   - name: 'repository_id'
     type: String
     description: |-
@@ -229,12 +226,26 @@ properties:
     custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'
   - name: 'location'
     type: String
-    description: |
-      The name of the location this repository is located in.
+    description: |-
+      The name of the repository's location. In addition to specific regions,
+      special values for multi-region locations are `asia`, `europe`, and `us`.
+      See [here](https://cloud.google.com/artifact-registry/docs/repositories/repo-locations),
+      or use the
+      [google_artifact_registry_locations](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/artifact_registry_locations)
+      data source for possible values.
     url_param_only: true
     required: false
     immutable: true
     default_from_api: true
+properties:
+  - name: 'name'
+    type: String
+    description: |-
+      The name of the repository, for example:
+      "repo1"
+    output: true
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'
+    custom_expand: 'templates/terraform/custom_expand/shortname_to_url.go.tmpl'
   - name: 'format'
     type: String
     description: |-

--- a/mmv1/templates/terraform/examples/artifact_registry_repository_multi_region.tf.tmpl
+++ b/mmv1/templates/terraform/examples/artifact_registry_repository_multi_region.tf.tmpl
@@ -1,0 +1,6 @@
+resource "google_artifact_registry_repository" "{{$.PrimaryResourceId}}" {
+  repository_id = "{{index $.Vars "repository_id"}}"
+  description   = "{{index $.Vars "desc"}}"
+  location      = "us"
+  format        = "DOCKER"
+}


### PR DESCRIPTION
It turns out that fixing importing regional or multi-region artifact repository resources is challenging. Regional ones could eventually be inferred based on the provider location, if ReplaceVars were updated and / or custom code were used, but multi-region ones will likely not be possible, because (in my understanding), we can't look at the actual resource's defined location when importing, and while we could _maybe_ infer regional location from provider region, the multi-regional path has multiple options, so I don't think there's a way to guess the multi-region location -- for some resources, they'll fall back to global (or a service default, like `US` for Bigquery) if `location` isn't already present or inferrable from the provider, but in this case, doesn't seem safe.

So, this is basically just docs fixes and one other tweak (see my comment about properties vs. parameters).

See description and discussion in #12320, as well as the linked issue, for more on this.

* Update import format to `{{location}}/{{repository_id}}` or the longer version of the same; ~standardize to `repository_id` for the IAM resource~, and add more documentation about locations and what locations are valid.

* Also add a multi-region example test case.

Part of hashicorp/terraform-provider-google#19266

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
