### PR TITLE
add server-side id for a few resources

### DIFF
--- a/mmv1/products/compute/GlobalForwardingRule.yaml
+++ b/mmv1/products/compute/GlobalForwardingRule.yaml
@@ -215,6 +215,12 @@ properties:
     description: |
       An optional description of this resource. Provide this property when
       you create the resource.
+  - name: 'forwardingRuleId'
+    type: Integer
+    description: |
+      The unique identifier number for the resource. This identifier is defined by the server.
+    api_name: id
+    output: true
   # This is a multi-resource resource reference (Address, GlobalAddress)
   - name: 'IPAddress'
     type: String

--- a/mmv1/products/compute/InstanceGroupManager.yaml
+++ b/mmv1/products/compute/InstanceGroupManager.yaml
@@ -65,6 +65,12 @@ properties:
       hyphen and a random four-character string to the base instance name.
       The base instance name must comply with RFC1035.
     required: true
+  - name: 'instanceGroupManagerId'
+    type: Integer
+    description: |
+      The unique identifier number for the resource. This identifier is defined by the server.
+    api_name: id
+    output: true
   - name: 'creationTimestamp'
     type: Time
     description: |

--- a/mmv1/products/compute/RegionHealthCheck.yaml
+++ b/mmv1/products/compute/RegionHealthCheck.yaml
@@ -141,6 +141,12 @@ properties:
       An optional description of this resource. Provide this property when
       you create the resource.
     send_empty_value: true
+  - name: 'healthCheckId'
+    type: Integer
+    description: |
+      The unique identifier number for the resource. This identifier is defined by the server.
+    api_name: id
+    output: true
   - name: 'healthyThreshold'
     type: Integer
     description: |

--- a/mmv1/products/compute/RegionInstanceGroupManager.yaml
+++ b/mmv1/products/compute/RegionInstanceGroupManager.yaml
@@ -64,6 +64,12 @@ properties:
       hyphen and a random four-character string to the base instance name.
       The base instance name must comply with RFC1035.
     required: true
+  - name: 'instanceGroupManagerId'
+    type: Integer
+    description: |
+      The unique identifier number for the resource. This identifier is defined by the server.
+    api_name: id
+    output: true
   - name: 'creationTimestamp'
     type: Time
     description: |

--- a/mmv1/products/compute/RegionNetworkEndpoint.yaml
+++ b/mmv1/products/compute/RegionNetworkEndpoint.yaml
@@ -128,6 +128,12 @@ properties:
       IPv4 address external endpoint.
 
       This can only be specified when network_endpoint_type of the NEG is INTERNET_IP_PORT.
+  - name: 'networkEndpointId'
+    type: Integer
+    description: |
+      The unique identifier number for the resource. This identifier is defined by the server.
+    api_name: id
+    output: true
   - name: 'fqdn'
     type: String
     description: |

--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -153,6 +153,12 @@ properties:
       An optional description of this resource. Provide this property when
       you create the resource. This field can be set only at resource
       creation time.
+  - name: 'subnetworkId'
+    type: Integer
+    description: |
+      The unique identifier number for the resource. This identifier is defined by the server.
+    api_name: id
+    output: true
   - name: 'gatewayAddress'
     type: String
     description: |

--- a/mmv1/third_party/terraform/services/compute/resource_compute_global_forwarding_rule_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_global_forwarding_rule_test.go.tmpl
@@ -32,7 +32,6 @@ func TestAccComputeGlobalForwardingRule_updateTarget(t *testing.T) {
 						"google_compute_global_forwarding_rule.forwarding_rule", "target", regexp.MustCompile(proxy + "$")),
           resource.TestCheckResourceAttrSet(
             "google_compute_global_forwarding_rule.forwarding_rule", "forwarding_rule_id")),
-        ),
 			},
 			{
 				ResourceName:      "google_compute_global_forwarding_rule.forwarding_rule",

--- a/mmv1/third_party/terraform/services/compute/resource_compute_global_forwarding_rule_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_global_forwarding_rule_test.go.tmpl
@@ -30,7 +30,9 @@ func TestAccComputeGlobalForwardingRule_updateTarget(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(
 						"google_compute_global_forwarding_rule.forwarding_rule", "target", regexp.MustCompile(proxy + "$")),
-				),
+          resource.TestCheckResourceAttrSet(
+            "google_compute_global_forwarding_rule.forwarding_rule", "forwarding_rule_id")),
+        ),
 			},
 			{
 				ResourceName:      "google_compute_global_forwarding_rule.forwarding_rule",

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.tmpl
@@ -119,6 +119,12 @@ func ResourceComputeInstanceGroupManager() *schema.Resource {
 				Description: `An optional textual description of the instance group manager.`,
 			},
 
+			"instance_group_manager_id": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The unique identifier number for the resource. This identifier is defined by the server.`,
+			},
+
 			"fingerprint": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -839,6 +845,11 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 	if err := d.Set("description", manager.Description); err != nil {
 		return fmt.Errorf("Error setting description: %s", err)
 	}
+
+	if err := d.Set("instance_group_manager_id", manager.Id); err != nil {
+		return fmt.Errorf("Error setting description: %s", err)
+	}
+	
 	if err := d.Set("project", project); err != nil {
 		return fmt.Errorf("Error setting project: %s", err)
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_test.go.tmpl
@@ -27,6 +27,9 @@ func TestAccInstanceGroupManager_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceGroupManager_basic(template, target, igm1, igm2),
+        Check: resource.ComposeTestCheckFunc(
+          resource.TestCheckResourceAttrSet(
+            "google_compute_instance_group_manager.igm-no-tp", "instance_group_manager_id")),
 			},
 			{
 				ResourceName:            "google_compute_instance_group_manager.igm-basic",

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_health_check_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_health_check_test.go.tmpl
@@ -21,6 +21,10 @@ func TestAccComputeRegionHealthCheck_tcp_update(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccComputeRegionHealthCheck_tcp(hckName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"google_compute_region_health_check.foobar", "health_check_id"),
+				),
 			},
 			{
 				ResourceName:      "google_compute_region_health_check.foobar",

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.tmpl
@@ -164,6 +164,12 @@ func ResourceComputeRegionInstanceGroupManager() *schema.Resource {
 				Description: `An optional textual description of the instance group manager.`,
 			},
 
+			"instance_group_manager_id": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The unique identifier number for the resource. This identifier is defined by the server.`,
+			},
+
 			"fingerprint": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -828,6 +834,9 @@ func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta 
 		return fmt.Errorf("Error reading creation_timestamp: %s", err)
 	}
 	if err := d.Set("description", manager.Description); err != nil {
+		return fmt.Errorf("Error setting description: %s", err)
+	}
+	if err := d.Set("instance_group_manager_id", manager.Id); err != nil {
 		return fmt.Errorf("Error setting description: %s", err)
 	}
 	if err := d.Set("project", project); err != nil {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.tmpl
@@ -28,6 +28,9 @@ func TestAccRegionInstanceGroupManager_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRegionInstanceGroupManager_basic(template, target, igm1, igm2),
+        Check: resource.ComposeTestCheckFunc(
+          resource.TestCheckResourceAttrSet(
+            "google_compute_region_instance_group_manager.igm-basic", "instance_group_manager_id")),
 			},
 			{
 				ResourceName:            "google_compute_region_instance_group_manager.igm-basic",

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_network_endpoint_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_network_endpoint_test.go.tmpl
@@ -31,6 +31,10 @@ func TestAccComputeRegionNetworkEndpoint_regionNetworkEndpointBasic(t *testing.T
 			{
 				// Create one endpoint
 				Config: testAccComputeRegionNetworkEndpoint_regionNetworkEndpointBasic(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"google_compute_region_network_endpoint.default", "network_endpoint_id"),
+				),
 			},
 			{
 				ResourceName:      "google_compute_region_network_endpoint.default",

--- a/mmv1/third_party/terraform/services/compute/resource_compute_subnetwork_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_subnetwork_test.go.tmpl
@@ -78,7 +78,8 @@ func TestAccComputeSubnetwork_basic(t *testing.T) {
 						t, "google_compute_subnetwork.network-ref-by-url", &subnetwork1),
 					testAccCheckComputeSubnetworkExists(
 						t, "google_compute_subnetwork.network-ref-by-name", &subnetwork2),
-				),
+					resource.TestCheckResourceAttrSet(
+						"google_compute_subnetwork.network-ref-by-name", "subnetwork_id"),				),
 			},
 			{
 				ResourceName:      "google_compute_subnetwork.network-ref-by-url",


### PR DESCRIPTION
closes https://github.com/hashicorp/terraform-provider-google/issues/20223


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: enhancement
compute: added server generated id as `forwarding_rule_id` to `google_compute_global_forwarding_rule`
```

```release-note: enhancement
compute: added server generated id as `health_check_id` to `google_region_health_check`
```


```release-note: enhancement
compute: added server generated id as `instance_group_manager_id` to `google_region_instance_group_manager`
```

```release-note: enhancement
compute: added server generated id as `instance_group_manager_id` to `google_instance_group_manager`
```

```release-note: enhancement
compute: added server generated id as `network_endpoint_id` to `google_region_network_endpoint`
```

```release-note: enhancement
compute: added server generated id as `subnetwork_id` to `google_subnetwork`
```
