### PR TITLE
Added CA_ENTERPRISE_ANNUAL option for ProjectCloudArmorTier;

### DIFF
--- a/mmv1/products/compute/ProjectCloudArmorTier.yaml
+++ b/mmv1/products/compute/ProjectCloudArmorTier.yaml
@@ -53,7 +53,7 @@ custom_code:
 examples:
   - name: 'compute_project_cloud_armor_tier_basic'
     primary_resource_id: 'cloud_armor_tier_config'
-    exclude_test: true
+    skip_vcr: true
   - name: 'compute_project_cloud_armor_tier_project_set'
     primary_resource_id: 'cloud_armor_tier_config'
     vars:
@@ -61,7 +61,7 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    exclude_test: true
+    skip_vcr: true
 parameters:
 properties:
   - name: 'cloudArmorTier'
@@ -72,3 +72,4 @@ properties:
     enum_values:
       - 'CA_STANDARD'
       - 'CA_ENTERPRISE_PAYGO'
+      - 'CA_ENTERPRISE_ANNUAL'

--- a/mmv1/products/compute/ProjectCloudArmorTier.yaml
+++ b/mmv1/products/compute/ProjectCloudArmorTier.yaml
@@ -53,7 +53,7 @@ custom_code:
 examples:
   - name: 'compute_project_cloud_armor_tier_basic'
     primary_resource_id: 'cloud_armor_tier_config'
-    skip_vcr: true
+    exclude_test: true
   - name: 'compute_project_cloud_armor_tier_project_set'
     primary_resource_id: 'cloud_armor_tier_config'
     vars:
@@ -61,7 +61,7 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
-    skip_vcr: true
+    exclude_test: true
 parameters:
 properties:
   - name: 'cloudArmorTier'


### PR DESCRIPTION
Adds the capability to enroll a project to `CA_ENTERPRISE_ANNUAL` when using the `ProjectCloudArmorTier` resource.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/19703

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `CA_ENTERPRISE_ANNUAL` option for field `cloud_armor_tier` in `google_compute_project_cloud_armor_tier` resource
```
