### PR TITLE
Support V6E for type of accelerator_config in google_tpu_v2_vm

### DIFF
--- a/mmv1/products/tpuv2/Vm.yaml
+++ b/mmv1/products/tpuv2/Vm.yaml
@@ -264,18 +264,12 @@ properties:
       - accelerator_type
     properties:
       - name: 'type'
-        type: Enum
+        type: String
         description: |
-          Type of TPU.
+          Type of TPU. Please select one of the allowed types: https://cloud.google.com/tpu/docs/reference/rest/v2/AcceleratorConfig#Type
         min_version: 'beta'
         required: true
         immutable: true
-        enum_values:
-          - 'V2'
-          - 'V3'
-          - 'V4'
-          - 'V5P'
-          - 'V6E'
       - name: 'topology'
         type: String
         description: |

--- a/mmv1/products/tpuv2/Vm.yaml
+++ b/mmv1/products/tpuv2/Vm.yaml
@@ -275,6 +275,7 @@ properties:
           - 'V3'
           - 'V4'
           - 'V5P'
+          - 'V6E'
       - name: 'topology'
         type: String
         description: |


### PR DESCRIPTION

```release-note:none
tpuv2: changed `accelerator_config.tpye` field from enum to string in `google_tpu_v2_vm` resource (beta)
```
