### PR TITLE
Add `autotuning_config` and `cohort` fields for Dataproc batch

### DIFF
--- a/mmv1/products/dataproc/Batch.yaml
+++ b/mmv1/products/dataproc/Batch.yaml
@@ -113,6 +113,19 @@ examples:
       'prevent_destroy': 'false'
     ignore_read_extra:
       - 'runtime_config.0.properties'
+  - name: 'dataproc_batch_autotuning'
+    primary_resource_id: 'example_batch_autotuning'
+    primary_resource_name: 'fmt.Sprintf("tf-test-batch-autotuning%s", context["random_suffix"])'
+    vars:
+      subnetwork_name: 'default'
+      prevent_destroy: 'true'
+    test_env_vars:
+      project_name: 'PROJECT_NAME'
+    test_vars_overrides:
+      'subnetwork_name': 'acctest.BootstrapSubnetWithFirewallForDataprocBatches(t, "dataproc-autotuning-test-network", "dataproc-autotuning-test-subnetwork")'
+      'prevent_destroy': 'false'
+    ignore_read_extra:
+      - 'runtime_config.0.properties'
 parameters:
   - name: 'location'
     type: String
@@ -278,6 +291,33 @@ properties:
         description: |
           A mapping of property names to values, which are used to configure workload execution.
         output: true
+      - name: 'autotuningConfig'
+        type: NestedObject
+        immutable: true
+        description: |
+          Optional. Autotuning configuration of the workload.
+        properties:
+          - name: 'scenarios'
+            type: Array
+            required_with:
+              - 'runtimeConfig.0.cohort'
+            description: |
+              Optional. Scenarios for which tunings are applied.
+            item_type:
+              type: Enum
+              description: |
+                Scenario represents a specific goal that autotuning will attempt to achieve by modifying workloads.
+              required: true
+              enum_values:
+                - 'SCALING'
+                - 'BROADCAST_HASH_JOIN'
+                - 'MEMORY'
+      - name: 'cohort'
+        type: String
+        description: |
+          Optional. Cohort identifier. Identifies families of the workloads having the same shape, e.g. daily ETL jobs.
+        immutable: true
+        required: false
   - name: 'environmentConfig'
     type: NestedObject
     description: |

--- a/mmv1/templates/terraform/examples/dataproc_batch_autotuning.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataproc_batch_autotuning.tf.tmpl
@@ -1,0 +1,29 @@
+resource "google_dataproc_batch" "{{$.PrimaryResourceId}}" {
+
+    batch_id      = "tf-test-batch%{random_suffix}"
+    location      = "us-central1"
+    labels        = {"batch_test": "terraform"}
+
+    runtime_config {
+      version       = "2.2"
+      properties    = { "spark.dynamicAllocation.enabled": "false", "spark.executor.instances": "2" }
+      cohort        = "tf-dataproc-batch-example"
+      autotuning_config {
+        scenarios = ["SCALING", "MEMORY"]
+      }
+    }
+
+    environment_config {
+      execution_config {
+        subnetwork_uri = "{{index $.Vars "subnetwork_name"}}"
+        ttl            = "3600s"
+      }
+    }
+
+    spark_batch {
+      main_class    = "org.apache.spark.examples.SparkPi"
+      args          = ["10"]
+      jar_file_uris = ["file:///usr/lib/spark/examples/jars/spark-examples.jar"]
+    }
+}
+


### PR DESCRIPTION
Add `autotuning_config` and `cohort` fields for Dataproc batch

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
dataproc: added `autotuning_config` and `cohort` fields to `google_dataproc_batch`
```
