### PR TITLE
compute: Implement graceful switch for metadata_startup_script

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -815,7 +815,6 @@ func ResourceComputeInstance() *schema.Resource {
 			"metadata_startup_script": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
 				Description: `Metadata startup scripts made available within the instance.`,
 			},
 
@@ -1315,6 +1314,9 @@ be from 0 to 999,999,999 inclusive.`,
 				},
 				suppressEmptyGuestAcceleratorDiff,
 			),
+			customdiff.ForceNewIf("metadata_startup_script", func(_ context.Context, d *schema.ResourceDiff, meta interface{}) bool {
+				return isGracefulMetadataStartupSwitch(d)
+			}),
 			validateSubnetworkProject,
 			forceNewIfNetworkIPNotUpdatable,
 			tpgresource.SetLabelsDiff,
@@ -2975,6 +2977,52 @@ func suppressEmptyGuestAcceleratorDiff(_ context.Context, d *schema.ResourceDiff
 	}
 
 	return nil
+}
+
+// Function checks whether a graceful switch (without ForceNew) is available
+// between `metadata_startup_script` and `metadata.startup-script`.
+// Graceful switch can be executed in two situations:
+// 1. When `metadata_startup_script` is created with the old value of
+// `metadata.startup-script`.
+// 2. When `metadata_startup_script` is deleted and the old value remains in
+// `metadata.startup-script`
+// For all other changes in `metadata_startup_script`, function sets ForceNew.
+func isGracefulMetadataStartupSwitch(d *schema.ResourceDiff) bool {
+	oldMd, newMd := d.GetChange("metadata")
+	oldMdMap := oldMd.(map[string]interface{})
+	newMdMap := newMd.(map[string]interface{})
+
+	//No new and old metadata
+	if len(oldMdMap) == 0 && len(newMdMap) == 0 {
+		return true
+	}
+
+	oldMds, newMds := d.GetChange("metadata_startup_script")
+	vMdOld, okOld := oldMdMap["startup-script"]
+	vMdNew, okNew := newMdMap["startup-script"]
+
+	// metadata_startup_script is created
+	if oldMds == "" {
+		if !okOld {
+			return true
+		} else if newMds == vMdOld {
+			return false
+		} else {
+			return true
+		}
+	}
+	// metadata_startup_script is deleted
+	if newMds == "" {
+		if !okNew {
+			return true
+		} else if oldMds == vMdNew {
+			return false
+		} else {
+			return true
+		}
+	}
+
+	return true
 }
 
 func resourceComputeInstanceDelete(d *schema.ResourceData, meta interface{}) error {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -3508,6 +3508,43 @@ func TestAccComputeInstance_metadataStartupScript_update(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstance_metadataStartupScript_gracefulSwitch(t *testing.T) {
+	t.Parallel()
+
+	var instance compute.Instance
+	var instanceName = fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_metadataStartupScript(instanceName, "e2-medium", "abc"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceMetadata(
+						&instance, "foo", "abc"),
+					testAccCheckComputeInstanceMetadata(
+						&instance, "startup-script", "echo hi > /test.txt"),
+				),
+			},
+			{
+				Config: testAccComputeInstance_metadataStartupScript_gracefulSwitch(instanceName, "e2-medium", "abc"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceMetadata(
+						&instance, "foo", "abc"),
+					testAccCheckComputeInstanceMetadata(
+						&instance, "startup-script", "echo hi > /test.txt"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccComputeInstance_regionBootDisk(t *testing.T) {
 	t.Parallel()
 
@@ -9877,6 +9914,39 @@ resource "google_compute_instance" "foobar" {
 `, instance, machineType, metadata)
 }
 
+func testAccComputeInstance_metadataStartupScript_gracefulSwitch(instance, machineType, metadata string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name           = "%s"
+  machine_type   = "%s"
+  zone           = "us-central1-a"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  metadata = {
+    foo = "%s"
+	startup-script = "echo hi > /test.txt"
+  }
+
+  allow_stopping_for_update = true
+}
+`, instance, machineType, metadata)
+}
 
 func testAccComputeInstance_regionBootDisk(instance, diskName, suffix string) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
This patch checks whether a graceful switch (without ForceNew) is available between `metadata_startup_script` and `metadata.startup-script`. Graceful switch can be executed in two situations:
1. When `metadata_startup_script` is created with the old value of `metadata.startup-script`.
2. When `metadata_startup_script` is deleted and the old value remains in `metadata.startup-script`.

For all other changes in `metadata_startup_script`, `isGracefulMetadataStartupSwitch` sets ForceNew. 

The change is covered by:
`TestAccComputeInstance_metadataStartupScript_update` and `TestAccComputeInstance_metadataStartupScript_gracefulSwitch`

closes: https://github.com/hashicorp/terraform-provider-google/issues/9459

```release-note:enhancement
compute: made `metadata_startup_script` able to be updated via graceful switch in `google_compute_instance`
```