### PR TITLE
adding deployment type to beta provider

### DIFF
--- a/mmv1/products/parallelstore/Instance.yaml
+++ b/mmv1/products/parallelstore/Instance.yaml
@@ -194,8 +194,8 @@ properties:
     type: String
     min_version: 'beta'
     description: |
-    Parallelstore Instance deployment type.
-      Possible values:
-      DEPLOYMENT_TYPE_UNSPECIFIED
-      SCRATCH
-      PERSISTENT
+      Parallelstore Instance deployment type.
+        Possible values:
+        DEPLOYMENT_TYPE_UNSPECIFIED
+        SCRATCH
+        PERSISTENT

--- a/mmv1/products/parallelstore/Instance.yaml
+++ b/mmv1/products/parallelstore/Instance.yaml
@@ -190,3 +190,12 @@ properties:
         DIRECTORY_STRIPE_LEVEL_MIN
         DIRECTORY_STRIPE_LEVEL_BALANCED
         DIRECTORY_STRIPE_LEVEL_MAX
+  - name: deploymentType
+    type: String
+    min_version: 'beta'
+    description: |
+    Parallelstore Instance deployment type.
+      Possible values:
+      DEPLOYMENT_TYPE_UNSPECIFIED
+      SCRATCH
+      PERSISTENT

--- a/mmv1/products/parallelstore/Instance.yaml
+++ b/mmv1/products/parallelstore/Instance.yaml
@@ -45,6 +45,7 @@ custom_code:
 examples:
   - name: 'parallelstore_instance_basic'
     primary_resource_id: 'instance'
+    min_version: 'beta'
     vars:
       name: 'instance'
       network_name: 'network'

--- a/mmv1/templates/terraform/examples/parallelstore_instance_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/parallelstore_instance_basic.tf.tmpl
@@ -6,9 +6,11 @@ resource "google_parallelstore_instance" "{{$.PrimaryResourceId}}" {
   network = google_compute_network.network.name
   file_stripe_level = "FILE_STRIPE_LEVEL_MIN"
   directory_stripe_level = "DIRECTORY_STRIPE_LEVEL_MIN"
+  deployment_type = "SCRATCH"
   labels = {
     test = "value"
   }
+  provider = google-beta
   depends_on = [google_service_networking_connection.default]
 }
 
@@ -16,6 +18,7 @@ resource "google_compute_network" "network" {
   name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = true
   mtu = 8896
+  provider = google-beta
 }
 
 # Create an IP address
@@ -24,6 +27,7 @@ resource "google_compute_global_address" "private_ip_alloc" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 24
+  provider = google-beta
   network       = google_compute_network.network.id
 }
 
@@ -31,5 +35,6 @@ resource "google_compute_global_address" "private_ip_alloc" {
 resource "google_service_networking_connection" "default" {
   network                 = google_compute_network.network.id
   service                 = "servicenetworking.googleapis.com"
+  provider = google-beta
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }


### PR DESCRIPTION
Adding deployment type field to beta provider

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
parallelstore: added `deployment_type` to `google_parallelstore_instance`
```
