### PR TITLE
Etag support for ACM service perimeters

### DIFF
--- a/mmv1/products/accesscontextmanager/ServicePerimeter.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeter.yaml
@@ -71,6 +71,7 @@ async:
 custom_code:
   constants: 'templates/terraform/constants/access_context_manager.go.tmpl'
   encoder: 'templates/terraform/encoders/access_level_never_send_parent.go.tmpl'
+  pre_update: 'templates/terraform/pre_update/access_context_manager_service_perimeter.go.tmpl'
   custom_import: 'templates/terraform/custom_import/set_access_policy_parent_from_self_link.go.tmpl'
 # Skipping the sweeper due to the non-standard base_url
 exclude_sweeper: true
@@ -788,3 +789,10 @@ properties:
       actually enforcing them. This testing is done through analyzing the differences
       between currently enforced and suggested restrictions. useExplicitDryRunSpec must
       bet set to True if any of the fields in the spec are set to non-default values.
+  - name: 'etag'
+    type: Fingerprint
+    description: |
+      An opaque identifier for the current version of the ServicePerimeter. This
+      identifier does not follow any specific format. If an etag is not provided, the
+      operation will be performed as if a valid etag is provided.
+    output: true

--- a/mmv1/products/accesscontextmanager/ServicePerimeters.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeters.yaml
@@ -100,6 +100,13 @@ properties:
           description: |
             Description of the ServicePerimeter and its use. Does not affect
             behavior.
+        - name: 'etag'
+          type: Fingerprint
+          description: |
+            An opaque identifier for the current version of the ServicePerimeter. This
+            identifier does not follow any specific format. If an etag is not provided, the
+            operation will be performed as if a valid etag is provided.
+          output: true
         - name: 'createTime'
           type: Time
           description: |

--- a/mmv1/templates/terraform/custom_flatten/accesscontextmanager_serviceperimeters_custom_flatten.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/accesscontextmanager_serviceperimeters_custom_flatten.go.tmpl
@@ -18,6 +18,7 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 			"perimeter_type":            flattenAccessContextManagerServicePerimetersServicePerimetersPerimeterType(original["perimeterType"], d, config),
 			"status":                    flattenAccessContextManagerServicePerimetersServicePerimetersStatus(original["status"], d, config),
 			"spec":                      flattenAccessContextManagerServicePerimetersServicePerimetersSpec(original["spec"], d, config),
+			"etag":                      flattenAccessContextManagerServicePerimetersServicePerimetersEtag(original["etag"], d, config),
 			"use_explicit_dry_run_spec": flattenAccessContextManagerServicePerimetersServicePerimetersUseExplicitDryRunSpec(original["useExplicitDryRunSpec"], d, config),
 		})
 	}
@@ -35,6 +36,10 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 }
 
 func flattenAccessContextManagerServicePerimetersServicePerimetersName(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenAccessContextManagerServicePerimetersServicePerimetersEtag(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	return v
 }
 

--- a/mmv1/templates/terraform/pre_update/access_context_manager_service_perimeter.go.tmpl
+++ b/mmv1/templates/terraform/pre_update/access_context_manager_service_perimeter.go.tmpl
@@ -1,0 +1,5 @@
+if _, ok := d.GetOkExists("etag"); ok {
+	updateMask = append(updateMask, "etag")
+
+	url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
+}

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_test.go.tmpl
@@ -26,6 +26,7 @@ func testAccAccessContextManagerServicePerimeter_basicTest(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccessContextManagerServicePerimeter_basic(org, "my policy", "level", "perimeter"),
+				Check: resource.TestCheckResourceAttrSet("google_access_context_manager_service_perimeter.test-access", "etag"),
 			},
 			{
 				ResourceName:      "google_access_context_manager_service_perimeter.test-access",


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
accesscontextmanager: added `etag` to `google_access_context_manager_service_perimeter` and `google_access_context_manager_service_perimeters`
```
