### PR TITLE
Add threshold_configs in Cloud Armor Adaptive Protection security policy

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
@@ -547,6 +547,80 @@ func ResourceComputeSecurityPolicy() *schema.Resource {
 										ValidateFunc: validation.StringInSlice([]string{"STANDARD", "PREMIUM"}, false),
 										Description: `Rule visibility. Supported values include: "STANDARD", "PREMIUM".`,
 									},
+									"threshold_configs": {
+										Type: schema.TypeList,
+										Description: `Configuration options for layer7 adaptive protection for various customizable thresholds.`,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"name": {
+													Type: schema.TypeString,
+													Required: true,
+													Description: `The name must be 1-63 characters long, and comply with RFC1035. The name must be unique within the security policy.`,
+													ValidateFunc: validation.StringLenBetween(1, 63),
+												},
+												"auto_deploy_load_threshold": {
+													Type: schema.TypeFloat,
+													Optional: true,
+													ValidateFunc: validation.FloatAtLeast(0.0),
+												},
+												"auto_deploy_confidence_threshold": {
+													Type: schema.TypeFloat,
+													Optional: true,
+													ValidateFunc: validation.FloatBetween(0.0, 1.0),
+												},
+												"auto_deploy_impacted_baseline_threshold": {
+													Type: schema.TypeFloat,
+													Optional: true,
+													ValidateFunc: validation.FloatBetween(0.0, 1.0),
+												},
+												"auto_deploy_expiration_sec": {
+													Type: schema.TypeInt,
+													Optional: true,
+													ValidateFunc: validation.IntBetween(1, 7776000),
+												},
+												"detection_load_threshold": {
+													Type: schema.TypeFloat,
+													Optional: true,
+													ValidateFunc: validation.FloatAtLeast(0.0),
+												},
+												"detection_absolute_qps": {
+													Type: schema.TypeFloat,
+													Optional: true,
+													ValidateFunc: validation.FloatAtLeast(0.0),
+												},
+												"detection_relative_to_baseline_qps": {
+													Type: schema.TypeFloat,
+													Optional: true,
+													ValidateFunc: validation.FloatAtLeast(1.0),
+												},
+												"traffic_granularity_configs": {
+													Type: schema.TypeList,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"type": {
+																Type: schema.TypeString,
+																Required: true,
+																Description: `Type of this configuration.`,
+																ValidateFunc: validation.StringInSlice([]string{"HTTP_HEADER_HOST", "HTTP_PATH"}, false),
+															},
+															"value": {
+																Type: schema.TypeString,
+																Optional: true,
+																Description: `Requests that match this value constitute a granular traffic unit.`,
+															},
+															"enable_each_unique_value": {
+																Type: schema.TypeBool,
+																Optional: true,
+																Description: `If enabled, traffic matching each unique value for the specified type constitutes a separate traffic unit. It can only be set to true if value is empty.`,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
 								},
 							},
 						},
@@ -1403,8 +1477,45 @@ func expandLayer7DdosDefenseConfig(configured []interface{}) *compute.SecurityPo
 	return &compute.SecurityPolicyAdaptiveProtectionConfigLayer7DdosDefenseConfig{
 		Enable: data["enable"].(bool),
 		RuleVisibility: data["rule_visibility"].(string),
+		ThresholdConfigs: expandThresholdConfigs(data["threshold_configs"].([]interface{})),
 		ForceSendFields: []string{"Enable"},
 	}
+}
+
+func expandThresholdConfigs(configured []interface{}) []*compute.SecurityPolicyAdaptiveProtectionConfigLayer7DdosDefenseConfigThresholdConfig{
+	params := make([]*compute.SecurityPolicyAdaptiveProtectionConfigLayer7DdosDefenseConfigThresholdConfig, 0, len(configured))
+	for _, raw := range configured {
+		params = append(params, expandThresholdConfig(raw))
+	}
+	return params
+}
+
+func expandThresholdConfig(configured interface{}) *compute.SecurityPolicyAdaptiveProtectionConfigLayer7DdosDefenseConfigThresholdConfig{
+	data := configured.(map[string]interface{})
+	return &compute.SecurityPolicyAdaptiveProtectionConfigLayer7DdosDefenseConfigThresholdConfig{
+		AutoDeployConfidenceThreshold:       data["auto_deploy_confidence_threshold"].(float64),
+		AutoDeployExpirationSec:             int64(data["auto_deploy_expiration_sec"].(int)),
+		AutoDeployImpactedBaselineThreshold: data["auto_deploy_impacted_baseline_threshold"].(float64),
+		AutoDeployLoadThreshold:             data["auto_deploy_load_threshold"].(float64),
+		DetectionAbsoluteQps:                data["detection_absolute_qps"].(float64),
+		DetectionLoadThreshold:              data["detection_load_threshold"].(float64),
+		DetectionRelativeToBaselineQps:      data["detection_relative_to_baseline_qps"].(float64),
+		Name:                                data["name"].(string),
+		TrafficGranularityConfigs:           expandTrafficGranularityConfig(data["traffic_granularity_configs"].([]interface{})),
+	}
+}
+
+func expandTrafficGranularityConfig(configured []interface{}) []*compute.SecurityPolicyAdaptiveProtectionConfigLayer7DdosDefenseConfigThresholdConfigTrafficGranularityConfig{
+	params := make([]*compute.SecurityPolicyAdaptiveProtectionConfigLayer7DdosDefenseConfigThresholdConfigTrafficGranularityConfig, 0, len(configured))
+	for _, raw := range configured {
+		data := raw.(map[string]interface{})
+		params = append(params, &compute.SecurityPolicyAdaptiveProtectionConfigLayer7DdosDefenseConfigThresholdConfigTrafficGranularityConfig{
+			EnableEachUniqueValue: data["enable_each_unique_value"].(bool),
+			Type:                  data["type"].(string),
+			Value:                 data["value"].(string),
+		})
+	}
+	return params
 }
 
 {{ if ne $.TargetVersionName `ga` -}}
@@ -1446,9 +1557,42 @@ func flattenLayer7DdosDefenseConfig(conf *compute.SecurityPolicyAdaptiveProtecti
 	data := map[string]interface{}{
 		"enable": conf.Enable,
 		"rule_visibility": conf.RuleVisibility,
+		"threshold_configs": flattenThresholdConfigs(conf.ThresholdConfigs),
 	}
 
 	return []map[string]interface{}{data}
+}
+
+func flattenThresholdConfigs(conf []*compute.SecurityPolicyAdaptiveProtectionConfigLayer7DdosDefenseConfigThresholdConfig)[]map[string]interface{} {
+	configs := make([]map[string]interface{}, 0, len(conf))
+	for _, field := range conf {
+		data := map[string]interface{}{
+			"name": field.Name,
+			"auto_deploy_load_threshold": field.AutoDeployLoadThreshold,
+			"auto_deploy_confidence_threshold": field.AutoDeployConfidenceThreshold,
+			"auto_deploy_impacted_baseline_threshold": field.AutoDeployImpactedBaselineThreshold,
+			"auto_deploy_expiration_sec": field.AutoDeployExpirationSec,
+			"detection_load_threshold": field.DetectionLoadThreshold,
+			"detection_absolute_qps": field.DetectionAbsoluteQps,
+			"detection_relative_to_baseline_qps": field.DetectionRelativeToBaselineQps,
+			"traffic_granularity_configs": flattenTrafficGranularityConfigs(field.TrafficGranularityConfigs),
+		}
+		configs = append(configs, data)
+	}
+	return configs
+}
+
+func flattenTrafficGranularityConfigs(conf []*compute.SecurityPolicyAdaptiveProtectionConfigLayer7DdosDefenseConfigThresholdConfigTrafficGranularityConfig)[]map[string]interface{} {
+	configs := make([]map[string]interface{}, 0, len(conf))
+	for _, field := range conf {
+		data := map[string]interface{}{
+			"type": field.Type,
+			"value": field.Value,
+			"enable_each_unique_value": field.EnableEachUniqueValue,
+		}
+		configs = append(configs, data)
+	}
+	return configs
 }
 
 {{ if ne $.TargetVersionName `ga` -}}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.tmpl
@@ -369,6 +369,36 @@ func TestAccComputeSecurityPolicy_withoutAdaptiveProtection(t *testing.T) {
 	})
 }
 
+func TestAccComputeSecurityPolicy_withAdaptiveProtection_withThresholdConfigs(t *testing.T) {
+	t.Parallel()
+
+	spName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeSecurityPolicyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSecurityPolicy_withAdaptiveProtection_enabled_withThresholdConfigs(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeSecurityPolicy_withAdaptiveProtection_update_ThresholdConfigs(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 {{ if ne $.TargetVersionName `ga` -}}
 func TestAccComputeSecurityPolicy_withAdaptiveProtectionAutoDeployConfig(t *testing.T) {
 	t.Parallel()
@@ -1474,6 +1504,62 @@ resource "google_compute_security_policy" "policy" {
     layer_7_ddos_defense_config {
       enable = true
       rule_visibility = "STANDARD"
+	}
+  }
+}
+`, spName)
+}
+
+func testAccComputeSecurityPolicy_withAdaptiveProtection_enabled_withThresholdConfigs(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+  name        = "%s"
+  description = "updated description"
+
+  adaptive_protection_config {
+    layer_7_ddos_defense_config {
+      enable = true
+      rule_visibility = "STANDARD"
+			threshold_configs {
+				name                                    = "threshold-name"
+				auto_deploy_load_threshold              = 0.1
+				auto_deploy_confidence_threshold        = 0.5
+				auto_deploy_impacted_baseline_threshold = 0.02
+				auto_deploy_expiration_sec              = 3600
+				detection_load_threshold                = 0.7
+				detection_absolute_qps                  = 1.0
+				detection_relative_to_baseline_qps      = 1.1
+				traffic_granularity_configs {
+					type                     = "HTTP_HEADER_HOST"
+					enable_each_unique_value = true
+				}
+			}
+	}
+  }
+}
+`, spName)
+}
+
+func testAccComputeSecurityPolicy_withAdaptiveProtection_update_ThresholdConfigs(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+  name        = "%s"
+  description = "updated description"
+
+  adaptive_protection_config {
+    layer_7_ddos_defense_config {
+      enable = true
+      rule_visibility = "STANDARD"
+			threshold_configs {
+				name                                    = "threshold-name-updated"
+				auto_deploy_load_threshold              = 0.2
+				auto_deploy_confidence_threshold        = 0.6
+				auto_deploy_impacted_baseline_threshold = 0.03
+				auto_deploy_expiration_sec              = 7200
+				detection_load_threshold                = 0.8
+				detection_absolute_qps                  = 1.1
+				detection_relative_to_baseline_qps      = 1.2
+			}
 	}
   }
 }

--- a/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
@@ -454,7 +454,7 @@ The following arguments are supported:
 
 <a name="nested_traffic_granularity_configs"></a>The `traffic_granularity_configs` block supports:
 
-* `type` - a granular traffic unit can be one of the following:
+* `type` - The type of this configuration, a granular traffic unit can be one of the following:
   * `HTTP_HEADER_HOST`
   * `HTTP_PATH`
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
@@ -430,6 +430,39 @@ The following arguments are supported:
   * `STANDARD` - opaque rules. (default)
   * `PREMIUM` - transparent rules.
 
+* `threshold_configs` - (Optional) Configuration options for layer7 adaptive protection for various customizable thresholds. Structure is [documented below](#nested_threshold_configs).
+
+<a name="nested_threshold_configs"></a>The `threshold_configs` block supports:
+
+* `name` - The name of config. The name must be 1-63 characters long, and comply with RFC1035. The name must be unique within the security policy.
+
+* `auto_deploy_load_threshold` - (Optional) Load threshold above which Adaptive Protection automatically deploy threshold based on the backend load threshold and detect a new rule during an alerted attack.
+
+* `auto_deploy_confidence_threshold` - (Optional) Confidence threshold above which Adaptive Protection's auto-deploy takes actions.
+
+* `auto_deploy_impacted_baseline_threshold` - (Optional) Impacted baseline threshold below which Adaptive Protection's auto-deploy takes actions.
+
+* `auto_deploy_expiration_sec` - (Optional) Duration over which Adaptive Protection's auto-deployed actions last.
+
+* `detection_load_threshold` - (Optional) Detection threshold based on the backend service's load.
+
+* `detection_absolute_qps` - (Optional) Detection threshold based on absolute QPS.
+
+* `detection_relative_to_baseline_qps` - (Optional) Detection threshold based on QPS relative to the average of baseline traffic.
+
+* `traffic_granularity_configs` - (Optional) Configuration options for enabling Adaptive Protection to work on the specified service granularity. Structure is [documented below](#nested_traffic_granularity_configs).
+
+<a name="nested_traffic_granularity_configs"></a>The `traffic_granularity_configs` block supports:
+
+* `type` - a granular traffic unit can be one of the following:
+  * `HTTP_HEADER_HOST`
+  * `HTTP_PATH`
+
+* `value` - (Optional) Requests that match this value constitute a granular traffic unit.
+
+* `enable_each_unique_value` - (Optional) If enabled, traffic matching each unique value for the specified type constitutes a separate traffic unit. It can only be set to true if value is empty.
+
+
 <a name="nested_auto_deploy_config"></a>The `auto_deploy_config` block supports:
 
 * `load_threshold` - (Optional) Identifies new attackers only when the load to the backend service that is under attack exceeds this threshold.


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/18788

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: enhancement
compute: added `threshold_configs` field to `google_compute_security_policy` resource
```
