### PR TITLE
Replace use of GetRegionFromSchema and standard field names with use of GetRegion

### DIFF
--- a/mmv1/templates/terraform/encoders/location_from_region.go.tmpl
+++ b/mmv1/templates/terraform/encoders/location_from_region.go.tmpl
@@ -12,7 +12,7 @@
 */ -}}
 config := meta.(*transport_tpg.Config)
 if _, ok := d.GetOk("location"); !ok {
-	location, err := tpgresource.GetRegionFromSchema("region", "zone", d, config)
+	location, err := tpgresource.GetRegion(d, config)
 	if err != nil {
 		return nil, fmt.Errorf("Cannot determine location: set in this resource, or set provider-level 'region' or 'zone'.")
 	}


### PR DESCRIPTION
GetRegionFromSchema("region", "zone", d, config) is equivalent to GetRegion(d, config).

In this PR I'm trying to reduce direct usage of GetRegionFromSchema in resources so it's only used by resources who have non-standard location-type fields (for example google_redis_instance's use of [location_id](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/redis_instance#location_id-1)). 

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
