### PR TITLE
 Use TF v1.10.0-rc2 in FEATURE-BRANCH-ephemeral-resource

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/projects/feature_branches/FEATURE-BRANCH-ephemeral-resource.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/feature_branches/FEATURE-BRANCH-ephemeral-resource.kt
@@ -23,7 +23,7 @@ import vcs_roots.ModularMagicianVCSRootBeta
 import vcs_roots.ModularMagicianVCSRootGa
 
 const val featureBranchEphemeralResources = "FEATURE-BRANCH-ephemeral-resource"
-const val EphemeralResourcesTfCoreVersion = "1.10.0-beta1"
+const val EphemeralResourcesTfCoreVersion = "1.10.0-rc2"
 
 // featureBranchEphemeralResourcesSubProject creates a project just for testing ephemeral resources.
 // We know that all ephemeral resources we're adding are part of the Resource Manager service, so we only include those builds.


### PR DESCRIPTION
release candidate 2 was released 30 minutes ago, addressing some bugs before GA. Let's run tests to ensure the changes made in that release don't affect our ephemeral resource work.

[`v1.10.0-rc2`](https://github.com/hashicorp/terraform/releases/tag/v1.10.0-rc2)

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
