### PR TITLE
Remove the tagHoldAdmin for TestAccContainerCluster_resourceManagerTags since we already have bootstrap it

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -69,7 +69,8 @@ func TestAccContainerCluster_resourceManagerTags(t *testing.T) {
 	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
 	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
-	if acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagHoldAdmin") {
+	if acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagHoldAdmin") 
+		|| acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagAdmin") {
 		t.Fatal("Stopping the test because a role was added to the policy.")
 	}
 
@@ -11448,12 +11449,6 @@ func testAccContainerCluster_resourceManagerTags(projectID, clusterName, network
 	return fmt.Sprintf(`
 data "google_project" "project" {
   project_id = "%[1]s"
-}
-
-resource "google_project_iam_member" "tagHoldAdmin" {
-  project = "%[1]s"
-  role    = "roles/resourcemanager.tagHoldAdmin"
-  member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
 }
 
 resource "google_project_iam_member" "tagUser1" {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -69,8 +69,8 @@ func TestAccContainerCluster_resourceManagerTags(t *testing.T) {
 	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
 	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
-	if acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagHoldAdmin") 
-		|| acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagAdmin") {
+	if acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagHoldAdmin") ||
+		acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagAdmin") {
 		t.Fatal("Stopping the test because a role was added to the policy.")
 	}
 


### PR DESCRIPTION
Removed the tagHoldAdmin for TestAccContainerCluster_resourceManagerTags since we already have bootstrap it. Also added the tagAdmin IAM permission in order to update the tag.

Fix for https://github.com/hashicorp/terraform-provider-google/issues/20252.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
container: Removed the tagHoldAdmin for TestAccContainerCluster_resourceManagerTags since we already have bootstrap it. Also added the tagAdmin IAM permission in order to update the tag.
```
