### PR TITLE
google_compute_subnetwork resource and data output externalIpv6Prefix

### DIFF
--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -438,6 +438,7 @@ properties:
     description: |
       The range of external IPv6 addresses that are owned by this subnetwork.
     default_from_api: true
+    output: true
   - name: 'allowSubnetCidrRoutesOverlap'
     type: Boolean
     description: |

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_subnetwork.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_subnetwork.go.tmpl
@@ -39,6 +39,10 @@ func DataSourceGoogleComputeSubnetwork() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"external_ipv6_prefix": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"private_ip_google_access": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -105,6 +109,9 @@ func dataSourceGoogleComputeSubnetworkRead(d *schema.ResourceData, meta interfac
 	}
 	if err := d.Set("internal_ipv6_prefix", subnetwork.InternalIpv6Prefix); err != nil {
 		return fmt.Errorf("Error setting internal_ipv6_prefix: %s", err)
+	}
+	if err := d.Set("external_ipv6_prefix", subnetwork.ExternalIpv6Prefix); err != nil {
+		return fmt.Errorf("Error setting external_ipv6_prefix: %s", err)
 	}
 	if err := d.Set("private_ip_google_access", subnetwork.PrivateIpGoogleAccess); err != nil {
 		return fmt.Errorf("Error setting private_ip_google_access: %s", err)


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/20424
(just uses `external_ipv6_prefix` vs `ipv6_cidr_range` attribute)

**Release Note Template for Downstream PRs (will be copied)**

```release-note: enhancement
compute: data source `google_compute_subnetwork` now fetches `externalIpv6Prefix`
```

```release-note: enhancement
compute: resource `google_compute_subnetwork` now outputs `externalIpv6Prefix`
```

