### PR TITLE
Revert "wait for SA to propagate on beyondcord app"

### DIFF
--- a/mmv1/products/beyondcorp/AppConnection.yaml
+++ b/mmv1/products/beyondcorp/AppConnection.yaml
@@ -59,7 +59,6 @@ examples:
       account_id: 'my-account'
       app_connector_name: 'my-app-connector'
       app_connection_name: 'my-app-connection'
-    external_providers: ["time"]
   - name: 'beyondcorp_app_connection_full'
     primary_resource_id: 'app_connection'
     primary_resource_name: 'fmt.Sprintf("tf_test_my_app_connection%s", context["random_suffix"])'
@@ -69,7 +68,6 @@ examples:
       app_connector_name: 'my-app-connector'
       app_connection_name: 'my-app-connection'
       display_name: 'some display name'
-    external_providers: ["time"]
 parameters:
 properties:
   - name: 'name'

--- a/mmv1/templates/terraform/examples/beyondcorp_app_connection_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/beyondcorp_app_connection_basic.tf.tmpl
@@ -3,18 +3,7 @@ resource "google_service_account" "service_account" {
   display_name = "Test Service Account"
 }
 
-# wait for service account to propagate -- can be needed due to 
-# SA eventual consistency issue
-resource "time_sleep" "wait_120_seconds" {
-  depends_on = [google_service_account.service_account]
-
-  create_duration = "120s"
-}
-
-
 resource "google_beyondcorp_app_connector" "app_connector" {
-  depends_on = [time_sleep.wait_120_seconds]
-
   name = "{{index $.Vars "app_connector_name"}}"
   principal_info {
     service_account {

--- a/mmv1/templates/terraform/examples/beyondcorp_app_connection_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/beyondcorp_app_connection_full.tf.tmpl
@@ -3,14 +3,6 @@ resource "google_service_account" "service_account" {
   display_name = "Test Service Account"
 }
 
-# wait for service account to propagate -- can be needed due to 
-# SA eventual consistency issue
-resource "time_sleep" "wait_120_seconds" {
-  depends_on = [google_service_account.service_account]
-
-  create_duration = "120s"
-}
-
 resource "google_beyondcorp_app_gateway" "app_gateway" {
   name = "{{index $.Vars "app_gateway_name"}}"
   type = "TCP_PROXY"
@@ -18,8 +10,6 @@ resource "google_beyondcorp_app_gateway" "app_gateway" {
 }
 
 resource "google_beyondcorp_app_connector" "app_connector" {
-  depends_on = [time_sleep.wait_120_seconds]
-
   name = "{{index $.Vars "app_connector_name"}}"
   principal_info {
     service_account {

--- a/mmv1/third_party/terraform/services/beyondcorp/data_source_google_beyondcorp_app_connection_test.go
+++ b/mmv1/third_party/terraform/services/beyondcorp/data_source_google_beyondcorp_app_connection_test.go
@@ -18,10 +18,7 @@ func TestAccDataSourceGoogleBeyondcorpAppConnection_basic(t *testing.T) {
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"time": {},
-		},
-		CheckDestroy: testAccCheckBeyondcorpAppConnectionDestroyProducer(t),
+		CheckDestroy:             testAccCheckBeyondcorpAppConnectionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceGoogleBeyondcorpAppConnection_basic(context),
@@ -43,10 +40,7 @@ func TestAccDataSourceGoogleBeyondcorpAppConnection_full(t *testing.T) {
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"time": {},
-		},
-		CheckDestroy: testAccCheckBeyondcorpAppConnectionDestroyProducer(t),
+		CheckDestroy:             testAccCheckBeyondcorpAppConnectionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceGoogleBeyondcorpAppConnection_full(context),
@@ -61,43 +55,34 @@ func TestAccDataSourceGoogleBeyondcorpAppConnection_full(t *testing.T) {
 func testAccDataSourceGoogleBeyondcorpAppConnection_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_service_account" "service_account" {
-  account_id   = "tf-test-my-account%{random_suffix}"
-  display_name = "Test Service Account"
+	account_id   = "tf-test-my-account%{random_suffix}"
+	display_name = "Test Service Account"
 }
-
-resource "time_sleep" "wait_120_seconds" {
-  depends_on = [google_service_account.service_account]
-
-  create_duration = "120s"
-}
-
 
 resource "google_beyondcorp_app_connector" "app_connector" {
-  depends_on = [time_sleep.wait_120_seconds]
-
-  name = "tf-test-appconnector-%{random_suffix}"
-  principal_info {
-    service_account {
-      email = google_service_account.service_account.email
-    }
-  }
+	name = "tf-test-appconnector-%{random_suffix}"
+	principal_info {
+		service_account {
+			email = google_service_account.service_account.email
+		}
+	}
 }
 
 resource "google_beyondcorp_app_connection" "foo" {
-  name = "tf-test-my-app-connection-%{random_suffix}"
-  type = "TCP_PROXY"
-  application_endpoint {
-    host = "foo-host"
-    port = 8080
-  }
-  connectors = [google_beyondcorp_app_connector.app_connector.id]
-  labels = {
-    my-label = "my-label-value"
-  }
+	name = "tf-test-my-app-connection-%{random_suffix}"
+	type = "TCP_PROXY"
+	application_endpoint {
+		host = "foo-host"
+		port = 8080
+	}
+	connectors = [google_beyondcorp_app_connector.app_connector.id]
+	labels = {
+		my-label = "my-label-value"
+	}
 }
 
 data "google_beyondcorp_app_connection" "foo" {
-  name = google_beyondcorp_app_connection.foo.name
+	name = google_beyondcorp_app_connection.foo.name
 }
 `, context)
 }
@@ -105,41 +90,33 @@ data "google_beyondcorp_app_connection" "foo" {
 func testAccDataSourceGoogleBeyondcorpAppConnection_full(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_service_account" "service_account" {
-  account_id   = "tf-test-my-account%{random_suffix}"
-  display_name = "Test Service Account"
-}
-
-resource "time_sleep" "wait_120_seconds" {
-  depends_on = [google_service_account.service_account]
-
-  create_duration = "120s"
+	account_id   = "tf-test-my-account%{random_suffix}"
+	display_name = "Test Service Account"
 }
 
 resource "google_beyondcorp_app_connector" "app_connector" {
-  depends_on = [time_sleep.wait_120_seconds]
-
-  name = "tf-test-appconnector-%{random_suffix}"
-  principal_info {
-    service_account {
-      email = google_service_account.service_account.email
-    }
-  }
+	name = "tf-test-appconnector-%{random_suffix}"
+	principal_info {
+		service_account {
+			email = google_service_account.service_account.email
+		}
+	}
 }
 
 resource "google_beyondcorp_app_connection" "foo" {
-  name = "tf-test-my-app-connection-%{random_suffix}"
-  type = "TCP_PROXY"
-  application_endpoint {
-    host = "foo-host"
-    port = 8080
-  }
-  connectors = [google_beyondcorp_app_connector.app_connector.id]
+	name = "tf-test-my-app-connection-%{random_suffix}"
+	type = "TCP_PROXY"
+	application_endpoint {
+		host = "foo-host"
+		port = 8080
+	}
+	connectors = [google_beyondcorp_app_connector.app_connector.id]
 }
 
 data "google_beyondcorp_app_connection" "foo" {
-  name    = google_beyondcorp_app_connection.foo.name
-  project = google_beyondcorp_app_connection.foo.project
-  region  = google_beyondcorp_app_connection.foo.region
+	name    = google_beyondcorp_app_connection.foo.name
+	project = google_beyondcorp_app_connection.foo.project
+	region  = google_beyondcorp_app_connection.foo.region
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/beyondcorp/resource_beyondcorp_app_connection_test.go
+++ b/mmv1/third_party/terraform/services/beyondcorp/resource_beyondcorp_app_connection_test.go
@@ -17,10 +17,7 @@ func TestAccBeyondcorpAppConnection_beyondcorpAppConnectionUpdateExample(t *test
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"time": {},
-		},
-		CheckDestroy: testAccCheckBeyondcorpAppConnectionDestroyProducer(t),
+		CheckDestroy:             testAccCheckBeyondcorpAppConnectionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBeyondcorpAppConnection_beyondcorpAppConnectionBasicExample(context),
@@ -54,16 +51,7 @@ resource "google_service_account" "service_account" {
   display_name = "Test Service Account"
 }
 
-resource "time_sleep" "wait_120_seconds" {
-  depends_on = [google_service_account.service_account]
-
-  create_duration = "120s"
-}
-
-
 resource "google_beyondcorp_app_connector" "app_connector" {
-  depends_on = [time_sleep.wait_120_seconds]  
-
   name = "tf-test-my-app-connector%{random_suffix}"
   principal_info {
     service_account {


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#12365

This did not fix the tests as intended
https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_GoogleCloud_GOOGLE_NIGHTLYTESTS_GOOGLE_PACKAGE_BEYONDCORP/269754?hideTestsFromDependencies=false&hideProblemsFromDependencies=false

https://github.com/hashicorp/terraform-provider-google/commits/main/

55301f5 still failed which is ahead of this commit

```release-note:none
````