### PR TITLE
Add confidential compute support to google_dataproc_cluster

### DIFF
--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
@@ -62,6 +62,7 @@ var (
 		"cluster_config.0.gce_cluster_config.0.metadata",
 		"cluster_config.0.gce_cluster_config.0.reservation_affinity",
 		"cluster_config.0.gce_cluster_config.0.node_group_affinity",
+		"cluster_config.0.gce_cluster_config.0.confidential_instance_config",
 	}
 
 	schieldedInstanceConfigKeys = []string{
@@ -74,6 +75,10 @@ var (
 		"cluster_config.0.gce_cluster_config.0.reservation_affinity.0.consume_reservation_type",
 		"cluster_config.0.gce_cluster_config.0.reservation_affinity.0.key",
 		"cluster_config.0.gce_cluster_config.0.reservation_affinity.0.values",
+	}
+
+	confidentialInstanceConfigKeys = []string{
+		"cluster_config.0.gce_cluster_config.0.confidential_instance_config.0.enable_confidential_compute",
 	}
 
 	masterDiskConfigKeys            = diskConfigKeys("master_config")
@@ -753,6 +758,26 @@ func ResourceDataprocCluster() *schema.Resource {
 													Required:         true,
 													Description:      `The URI of a sole-tenant that the cluster will be created on.`,
 													DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName,
+												},
+											},
+										},
+									},
+									"confidential_instance_config": {
+										Type:         schema.TypeList,
+										Optional:     true,
+										AtLeastOneOf: gceClusterConfigKeys,
+										Computed:     true,
+										MaxItems:     1,
+										Description:  `Confidential Instance Config for clusters using Compute Engine Confidential VMs.`,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"enable_confidential_compute": {
+													Type:         schema.TypeBool,
+													Optional:     true,
+													Default:      false,
+													AtLeastOneOf: confidentialInstanceConfigKeys,
+													ForceNew:     true,
+													Description:  `Defines whether the instance should have confidential compute enabled.`,
 												},
 											},
 										},
@@ -2246,6 +2271,13 @@ func expandGceClusterConfig(d *schema.ResourceData, config *transport_tpg.Config
 			conf.NodeGroupAffinity.NodeGroupUri = v.(string)
 		}
 	}
+	if v, ok := d.GetOk("cluster_config.0.gce_cluster_config.0.confidential_instance_config"); ok {
+		cfgCic := v.([]interface{})[0].(map[string]interface{})
+		conf.ConfidentialInstanceConfig = &dataproc.ConfidentialInstanceConfig{}
+		if v, ok := cfgCic["enable_confidential_compute"]; ok {
+			conf.ConfidentialInstanceConfig.EnableConfidentialCompute = v.(bool)
+		}
+	}
 	return conf, nil
 }
 
@@ -3191,6 +3223,13 @@ func flattenGceClusterConfig(d *schema.ResourceData, gcc *dataproc.GceClusterCon
 		gceConfig["node_group_affinity"] = []map[string]interface{}{
 			{
 				"node_group_uri": gcc.NodeGroupAffinity.NodeGroupUri,
+			},
+		}
+	}
+	if gcc.ConfidentialInstanceConfig != nil {
+		gceConfig["confidential_instance_config"] = []map[string]interface{}{
+			{
+				"enable_confidential_compute": gcc.ConfidentialInstanceConfig.EnableConfidentialCompute,
 			},
 		}
 	}

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
@@ -264,7 +264,7 @@ func TestAccDataprocCluster_withConfidentialCompute(t *testing.T) {
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
 	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
-	imageUri := "projects/cloud-dataproc/global/images/dataproc-2-1-ubu20-20241026-165100-rc01"
+	imageUri := "https://www.googleapis.com/compute/v1/projects/cloud-dataproc/global/images/dataproc-2-1-ubu20-20241026-165100-rc01"
 
     acctest.VcrTest(t, resource.TestCase{
         PreCheck:                 func() { acctest.AccTestPreCheck(t) },

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
@@ -256,6 +256,51 @@ func TestAccDataprocCluster_withInternalIpOnlyTrueAndShieldedConfig(t *testing.T
 	})
 }
 
+func TestAccDataprocCluster_withConfidentialCompute(t *testing.T) {
+    t.Parallel()
+
+    var cluster dataproc.Cluster
+    rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+	imageUri := "projects/cloud-dataproc/global/images/dataproc-2-1-ubu20-20241026-165100-rc01"
+
+    acctest.VcrTest(t, resource.TestCase{
+        PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+        ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+        CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
+        Steps: []resource.TestStep{
+            {
+                Config: testAccDataprocCluster_withConfidentialCompute(rnd, subnetworkName, imageUri),
+                Check: resource.ComposeTestCheckFunc(
+                    testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.confidential", &cluster),
+
+                    // Check confidential compute
+                    resource.TestCheckResourceAttr("google_dataproc_cluster.confidential",
+                        "cluster_config.0.gce_cluster_config.0.confidential_instance_config.0.enable_confidential_compute", "true"),
+
+                    // Check master
+                    resource.TestCheckResourceAttr("google_dataproc_cluster.confidential",
+                        "cluster_config.0.master_config.0.machine_type", "n2d-standard-2"),
+                    resource.TestCheckResourceAttr("google_dataproc_cluster.confidential",
+                        "cluster_config.0.master_config.0.image_uri", imageUri),
+                    resource.TestCheckResourceAttr("google_dataproc_cluster.confidential",
+                        "cluster_config.0.master_config.0.min_cpu_platform", "AMD Rome"),
+
+                    // Check worker
+                    resource.TestCheckResourceAttr("google_dataproc_cluster.confidential",
+                        "cluster_config.0.worker_config.0.machine_type", "n2d-standard-2"),
+                    resource.TestCheckResourceAttr("google_dataproc_cluster.confidential",
+                        "cluster_config.0.worker_config.0.image_uri", imageUri),
+                    resource.TestCheckResourceAttr("google_dataproc_cluster.confidential",
+                        "cluster_config.0.worker_config.0.min_cpu_platform", "AMD Rome"),
+                ),
+            },
+        },
+    })
+}
+
 func TestAccDataprocCluster_withMetadataAndTags(t *testing.T) {
 	t.Parallel()
 
@@ -1536,6 +1581,36 @@ resource "google_dataproc_cluster" "basic" {
   }
 }
 `, rnd, rnd, rnd, rnd)
+}
+
+func testAccDataprocCluster_withConfidentialCompute(rnd, subnetworkName string, imageUri string) string {
+    return fmt.Sprintf(`
+resource "google_dataproc_cluster" "confidential" {
+    name   = "tf-test-dproc-%s"
+    region = "us-central1"
+
+    cluster_config {
+        gce_cluster_config {
+			subnetwork = "%s"
+            confidential_instance_config {
+                enable_confidential_compute = true
+            }
+        }
+
+        master_config {
+            machine_type     = "n2d-standard-2"
+            image_uri        = "%s"
+            min_cpu_platform = "AMD Rome"
+        }
+
+        worker_config {
+            machine_type     = "n2d-standard-2"
+            image_uri        = "%s"
+            min_cpu_platform = "AMD Rome"
+        }
+    }
+}
+`, rnd, subnetworkName, imageUri, imageUri)
 }
 
 func testAccDataprocCluster_withMetadataAndTags(rnd, subnetworkName string) string {

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -448,6 +448,9 @@ resource "google_dataproc_cluster" "accelerated_cluster" {
 * `node_group_affinity` - (Optional) Node Group Affinity for sole-tenant clusters.
     * `node_group_uri` - (Required) The URI of a sole-tenant node group resource that the cluster will be created on.
 
+* `confidential_instance_config` - (Optional) Confidential Instance Config for clusters using [Confidential VMs](https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/confidential-compute)
+    * `enable_confidential_compute` - (Optional) Defines whether the instance should have confidential compute enabled.
+
 * `shielded_instance_config` (Optional) Shielded Instance Config for clusters using [Compute Engine Shielded VMs](https://cloud.google.com/security/shielded-cloud/shielded-vm).
 
 - - -


### PR DESCRIPTION
This PR adds support for [confidential compute](https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/confidential-compute) in `google_dataproc_cluster`.

Addresses: https://github.com/hashicorp/terraform-provider-google/issues/12656

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
dataproc: added `confidential_instance_config` field to `google_dataproc_cluster` resource
```
