### PR TITLE
Add diff suppress for computed scratch disks on Z3 instances

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -1007,7 +1007,7 @@ be from 0 to 999,999,999 inclusive.`,
 				Type:        	  schema.TypeList,
 				Optional:    	  true,
 				ForceNew:    	  true,
-				DiffSuppressFunc: scratchDiskDiffSuppress
+				DiffSuppressFunc: scratchDiskDiffSuppress,
 				Description: 	  `The scratch disks attached to the instance.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -29,6 +29,13 @@ import (
 {{- end }}
 )
 
+func scratchDiskDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	// Z3 instances have 12 disks that are added without user input by the API
+	// These disks cannot be edited or deleted when using type Z3
+	// No additional local-ssd disk can be added on top of these 12 so we can just suppress this diff
+	return regexp.MustCompile("z3").MatchString(d.Get("machine_type").(string))
+}
+
 func IpCidrRangeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	// The range may be a:
 	// A) single IP address (e.g. 10.2.3.4)
@@ -997,10 +1004,11 @@ be from 0 to 999,999,999 inclusive.`,
 			},
 
 			"scratch_disk": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				ForceNew:    true,
-				Description: `The scratch disks attached to the instance.`,
+				Type:        	  schema.TypeList,
+				Optional:    	  true,
+				ForceNew:    	  true,
+				DiffSuppressFunc: scratchDiskDiffSuppress
+				Description: 	  `The scratch disks attached to the instance.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"device_name": {

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -130,6 +130,8 @@ The following arguments are supported:
 
     There is a limit of 6.5 GB per CPU unless you add [extended memory](https://cloud.google.com/compute/docs/instances/creating-instance-with-custom-machine-type#extendedmemory). You must do this explicitly by adding the suffix `-ext`, e.g. `custom-2-15360-ext` for 2 vCPU and 15 GB of memory.
 
+    More advanced machine types like [Z3](https://cloud.google.com/compute/docs/storage-optimized-machines) have a fixed storage requirement that's added without it being set by the user.
+
 * `name` - (Required) A unique name for the resource, required by GCE.
     Changing this forces a new resource to be created.
 


### PR DESCRIPTION
closes https://github.com/hashicorp/terraform-provider-google/issues/19648

may be a breaking change, would love opinions here but CI tests should show if it's breaking.

Z3 instance type creates 12 scratch disks as a base for the instance. They cannot be edited, or deleted and this instance type cannot have more than 12 of these autogenerated local-ssd's so no new can be added. Hence the diff suppression

Not really sure if we want this kind of logic in terraform. The other solution would be to inform the user via docs that he has to add these disks to the configuration to get rid of this diff or use `lifecycle_rule.ignore_changes`. As these disks cannot be changed in any way but will show up as diff regardless

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: `google_compute_instance` will no longer show unexpected difference in plan for z3 machine types
```
