### PR TITLE
Composer 3 GA: Reintroduce changes

### DIFF
--- a/mmv1/products/composer/UserWorkloadsConfigMap.yaml
+++ b/mmv1/products/composer/UserWorkloadsConfigMap.yaml
@@ -19,7 +19,6 @@ description: |
 min_version: 'ga'
 references:
   guides:
-  api: 'https://cloud.google.com/composer/docs/reference/rest/v1beta1/projects.locations.environments.userWorkloadsConfigMaps'
   api: 'https://cloud.google.com/composer/docs/reference/rest/v1/projects.locations.environments.userWorkloadsConfigMaps'
 docs:
 base_url: 'projects/{{project}}/locations/{{region}}/environments/{{environment}}/userWorkloadsConfigMaps'

--- a/mmv1/products/composer/UserWorkloadsConfigMap.yaml
+++ b/mmv1/products/composer/UserWorkloadsConfigMap.yaml
@@ -16,11 +16,11 @@ name: 'UserWorkloadsConfigMap'
 description: |
   User workloads ConfigMap used by Airflow tasks that run with Kubernetes Executor or KubernetesPodOperator.
   Intended for Composer 3 Environments.
-min_version: 'beta'
+min_version: 'ga'
 references:
   guides:
-  # TODO: add v1 reference when this is moved to ga
   api: 'https://cloud.google.com/composer/docs/reference/rest/v1beta1/projects.locations.environments.userWorkloadsConfigMaps'
+  api: 'https://cloud.google.com/composer/docs/reference/rest/v1/projects.locations.environments.userWorkloadsConfigMaps'
 docs:
 base_url: 'projects/{{project}}/locations/{{region}}/environments/{{environment}}/userWorkloadsConfigMaps'
 self_link: 'projects/{{project}}/locations/{{region}}/environments/{{environment}}/userWorkloadsConfigMaps/{{name}}'
@@ -41,7 +41,7 @@ parameters:
     type: String
     description: |
       The location or Compute Engine region for the environment.
-    min_version: 'beta'
+    min_version: 'ga'
     url_param_only: true
     immutable: true
     default_from_api: true
@@ -49,7 +49,7 @@ parameters:
     type: String
     description: |
       Environment where the Kubernetes ConfigMap will be stored and used.
-    min_version: 'beta'
+    min_version: 'ga'
     url_param_only: true
     required: true
     immutable: true
@@ -60,7 +60,7 @@ properties:
     type: String
     description: |
       Name of the Kubernetes ConfigMap.
-    min_version: 'beta'
+    min_version: 'ga'
     required: true
     immutable: true
     custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'
@@ -72,5 +72,5 @@ properties:
     description: |
       The "data" field of Kubernetes ConfigMap, organized in key-value pairs.
       For details see: https://kubernetes.io/docs/concepts/configuration/configmap/
-    min_version: 'beta'
+    min_version: 'ga'
     immutable: false

--- a/mmv1/products/composer/UserWorkloadsConfigMap.yaml
+++ b/mmv1/products/composer/UserWorkloadsConfigMap.yaml
@@ -16,7 +16,6 @@ name: 'UserWorkloadsConfigMap'
 description: |
   User workloads ConfigMap used by Airflow tasks that run with Kubernetes Executor or KubernetesPodOperator.
   Intended for Composer 3 Environments.
-min_version: 'ga'
 references:
   guides:
   api: 'https://cloud.google.com/composer/docs/reference/rest/v1/projects.locations.environments.userWorkloadsConfigMaps'
@@ -40,7 +39,6 @@ parameters:
     type: String
     description: |
       The location or Compute Engine region for the environment.
-    min_version: 'ga'
     url_param_only: true
     immutable: true
     default_from_api: true
@@ -48,7 +46,6 @@ parameters:
     type: String
     description: |
       Environment where the Kubernetes ConfigMap will be stored and used.
-    min_version: 'ga'
     url_param_only: true
     required: true
     immutable: true
@@ -59,7 +56,6 @@ properties:
     type: String
     description: |
       Name of the Kubernetes ConfigMap.
-    min_version: 'ga'
     required: true
     immutable: true
     custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'
@@ -71,5 +67,4 @@ properties:
     description: |
       The "data" field of Kubernetes ConfigMap, organized in key-value pairs.
       For details see: https://kubernetes.io/docs/concepts/configuration/configmap/
-    min_version: 'ga'
     immutable: false

--- a/mmv1/templates/terraform/examples/composer_user_workloads_config_map_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/composer_user_workloads_config_map_basic.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_composer_environment" "environment" {
-  provider = google-beta
   name   = "{{index $.Vars "environment_name"}}"
   region = "us-central1"
   config {
@@ -10,7 +9,6 @@ resource "google_composer_environment" "environment" {
 }
 
 resource "google_composer_user_workloads_config_map" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   name = "{{index $.Vars "config_map_name"}}"
   region = "us-central1"
   environment = google_composer_environment.environment.name

--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
@@ -7,7 +7,6 @@ import (
 	  "github.com/hashicorp/terraform-provider-google/google/services/{{ $service }}"
 	{{- end }}
 
-	"github.com/hashicorp/terraform-provider-google/google/services/composer"
 	"github.com/hashicorp/terraform-provider-google/google/services/container"
 	"github.com/hashicorp/terraform-provider-google/google/services/containeraws"
 	"github.com/hashicorp/terraform-provider-google/google/services/containerazure"

--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
@@ -7,9 +7,7 @@ import (
 	  "github.com/hashicorp/terraform-provider-google/google/services/{{ $service }}"
 	{{- end }}
 
-	{{ if eq $.TargetVersionName `ga` }}
 	"github.com/hashicorp/terraform-provider-google/google/services/composer"
-	{{- end }}
 	"github.com/hashicorp/terraform-provider-google/google/services/container"
 	"github.com/hashicorp/terraform-provider-google/google/services/containeraws"
 	"github.com/hashicorp/terraform-provider-google/google/services/containerazure"
@@ -67,10 +65,8 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_cloud_run_v2_job":                          cloudrunv2.DataSourceGoogleCloudRunV2Job(),
 	"google_cloud_run_v2_service":                      cloudrunv2.DataSourceGoogleCloudRunV2Service(),
 	"google_composer_environment":                      composer.DataSourceGoogleComposerEnvironment(),
-	{{- if ne $.TargetVersionName "ga" }}
 	"google_composer_user_workloads_config_map":        composer.DataSourceGoogleComposerUserWorkloadsConfigMap(),
 	"google_composer_user_workloads_secret":            composer.DataSourceGoogleComposerUserWorkloadsSecret(),
-	{{- end }}
 	"google_composer_image_versions":                   composer.DataSourceGoogleComposerImageVersions(),
 	"google_compute_address":                           compute.DataSourceGoogleComputeAddress(),
 	"google_compute_addresses":                         compute.DataSourceGoogleComputeAddresses(),
@@ -323,9 +319,7 @@ var handwrittenResources = map[string]*schema.Resource{
 	"google_billing_subaccount":                    resourcemanager.ResourceBillingSubaccount(),
 	"google_cloudfunctions_function":               cloudfunctions.ResourceCloudFunctionsFunction(),
 	"google_composer_environment":                  composer.ResourceComposerEnvironment(),
-	{{- if ne $.TargetVersionName "ga" }}
 	"google_composer_user_workloads_secret":        composer.ResourceComposerUserWorkloadsSecret(),
-	{{- end }}
 	"google_compute_attached_disk":                 compute.ResourceComputeAttachedDisk(),
 	"google_compute_instance":                      compute.ResourceComputeInstance(),
 	"google_compute_disk_async_replication":        compute.ResourceComputeDiskAsyncReplication(),

--- a/mmv1/third_party/terraform/services/composer/data_source_google_composer_user_workloads_config_map.go.tmpl
+++ b/mmv1/third_party/terraform/services/composer/data_source_google_composer_user_workloads_config_map.go.tmpl
@@ -1,6 +1,5 @@
 package composer
 
-{{ if ne $.TargetVersionName `ga` -}}
 import (
 	"fmt"
 
@@ -48,4 +47,3 @@ func dataSourceGoogleComposerUserWorkloadsConfigMapRead(d *schema.ResourceData, 
 
 	return nil
 }
-{{- end }}

--- a/mmv1/third_party/terraform/services/composer/data_source_google_composer_user_workloads_config_map_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/composer/data_source_google_composer_user_workloads_config_map_test.go.tmpl
@@ -1,6 +1,5 @@
 package composer_test
 
-{{ if ne $.TargetVersionName `ga` -}}
 import (
 	"fmt"
 	"testing"
@@ -56,4 +55,3 @@ data "google_composer_user_workloads_config_map" "test" {
 }
 `, context)
 }
-{{- end }}

--- a/mmv1/third_party/terraform/services/composer/data_source_google_composer_user_workloads_secret.go.tmpl
+++ b/mmv1/third_party/terraform/services/composer/data_source_google_composer_user_workloads_secret.go.tmpl
@@ -1,6 +1,5 @@
 package composer
 
-{{ if ne $.TargetVersionName `ga` -}}
 import (
 	"fmt"
 
@@ -60,4 +59,3 @@ func dataSourceGoogleComposerUserWorkloadsSecretRead(d *schema.ResourceData, met
 
 	return nil
 }
-{{- end }}

--- a/mmv1/third_party/terraform/services/composer/data_source_google_composer_user_workloads_secret_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/composer/data_source_google_composer_user_workloads_secret_test.go.tmpl
@@ -1,6 +1,5 @@
 package composer_test
 
-{{ if ne $.TargetVersionName `ga` -}}
 import (
 	"errors"
 	"fmt"
@@ -99,4 +98,3 @@ data "google_composer_user_workloads_secret" "test" {
 }
 `, context)
 }
-{{- end }}

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.tmpl
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.tmpl
@@ -56,9 +56,7 @@ var (
 		"config.0.software_config.0.python_version",
 		"config.0.software_config.0.scheduler_count",
 		"config.0.software_config.0.cloud_data_lineage_integration",
-{{- if ne $.TargetVersionName "ga" }}
 		"config.0.software_config.0.web_server_plugins_mode",
-{{- end }}
 	}
 
 	composerConfigKeys = []string{
@@ -76,10 +74,8 @@ var (
 		"config.0.environment_size",
 		"config.0.master_authorized_networks_config",
 		"config.0.resilience_mode",
-{{- if ne $.TargetVersionName "ga" }}
 		"config.0.enable_private_environment",
 		"config.0.enable_private_builds_only",
-{{- end }}
 		"config.0.data_retention_config",
 	}
 
@@ -92,9 +88,7 @@ var (
 		"config.0.workloads_config.0.triggerer",
 		"config.0.workloads_config.0.web_server",
 		"config.0.workloads_config.0.worker",
-{{- if ne $.TargetVersionName "ga" }}
 		"config.0.workloads_config.0.dag_processor",
-{{- end }}
 	}
 
 	composerPrivateEnvironmentConfig = []string{
@@ -173,10 +167,8 @@ func ResourceComposerEnvironment() *schema.Resource {
 				customdiff.ValidateChange("config.0.software_config.0.image_version", imageVersionChangeValidationFunc),
 				versionValidationCustomizeDiffFunc,
 			),
-{{- if ne $.TargetVersionName "ga" }}
 			customdiff.ForceNewIf("config.0.node_config.0.network", forceNewCustomDiff("config.0.node_config.0.network")),
 			customdiff.ForceNewIf("config.0.node_config.0.subnetwork", forceNewCustomDiff("config.0.node_config.0.subnetwork")),
-{{- end }}
 		),
 
 		Schema: map[string]*schema.Schema{
@@ -246,29 +238,18 @@ func ResourceComposerEnvironment() *schema.Resource {
 										Type:             schema.TypeString,
 										Computed:         true,
 										Optional:         true,
-{{- if eq $.TargetVersionName "ga" }}
-										ForceNew:         true,
-{{- else }}
-										ForceNew:         false,
 										ConflictsWith:    []string{"config.0.node_config.0.composer_network_attachment"},
-{{- end }}
 										DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName,
 										Description:      `The Compute Engine machine type used for cluster instances, specified as a name or relative resource name. For example: "projects/{project}/zones/{zone}/machineTypes/{machineType}". Must belong to the enclosing environment's project and region/zone. The network must belong to the environment's project. If unspecified, the "default" network ID in the environment's project is used. If a Custom Subnet Network is provided, subnetwork must also be provided.`,
 									},
 									"subnetwork": {
 										Type:             schema.TypeString,
 										Optional:         true,
-{{- if eq $.TargetVersionName "ga" }}
-										ForceNew:         true,
-{{- else }}
-										ForceNew:         false,
 										Computed:         true,
 										ConflictsWith:    []string{"config.0.node_config.0.composer_network_attachment"},
-{{- end }}
 										DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName,
 										Description:      `The Compute Engine subnetwork to be used for machine communications, specified as a self-link, relative resource name (e.g. "projects/{project}/regions/{region}/subnetworks/{subnetwork}"), or by name. If subnetwork is provided, network must also be provided and the subnetwork must belong to the enclosing environment's project and region.`,
 									},
-{{- if ne $.TargetVersionName "ga" }}
 									"composer_network_attachment": {
 										Type:             schema.TypeString,
 										Computed:         true,
@@ -276,7 +257,6 @@ func ResourceComposerEnvironment() *schema.Resource {
 										ForceNew:         false,
 										Description:      `PSC (Private Service Connect) Network entry point. Customers can pre-create the Network Attachment and point Cloud Composer environment to use. It is possible to share network attachment among many environments, provided enough IP addresses are available.`,
 									},
-{{- end }}
 									"disk_size_gb": {
 										Type:        schema.TypeInt,
 										Computed:    true,
@@ -385,7 +365,6 @@ func ResourceComposerEnvironment() *schema.Resource {
 											},
 										},
 									},
-{{- if ne $.TargetVersionName "ga" }}
 									"composer_internal_ipv4_cidr_block": {
 										Type:             schema.TypeString,
 										Computed:         true,
@@ -394,7 +373,6 @@ func ResourceComposerEnvironment() *schema.Resource {
 										ValidateFunc:     validateComposerInternalIpv4CidrBlock,
 										Description:      `IPv4 cidr range that will be used by Composer internal components.`,
 									},
-{{- end }}
 								},
 							},
 						},
@@ -513,7 +491,6 @@ func ResourceComposerEnvironment() *schema.Resource {
 											},
 										},
 									},
-{{- if ne $.TargetVersionName "ga" }}
 									"web_server_plugins_mode": {
 										Type:         schema.TypeString,
 										Optional:     true,
@@ -523,7 +500,6 @@ func ResourceComposerEnvironment() *schema.Resource {
 										ValidateFunc: validation.StringInSlice([]string{"ENABLED", "DISABLED"}, false),
 										Description:  `Should be either 'ENABLED' or 'DISABLED'. Defaults to 'ENABLED'. Used in Composer 3.`,
 									},
-{{- end }}
 								},
 							},
 						},
@@ -606,7 +582,6 @@ func ResourceComposerEnvironment() *schema.Resource {
 								},
 							},
 						},
-{{- if ne $.TargetVersionName "ga" }}
 						"enable_private_environment": {
 							Type:         schema.TypeBool,
 							Computed:     true,
@@ -623,7 +598,6 @@ func ResourceComposerEnvironment() *schema.Resource {
 							AtLeastOneOf: composerConfigKeys,
 							Description:  `Optional. If true, builds performed during operations that install Python packages have only private connectivity to Google services. If false, the builds also have access to the internet.`,
 						},
-{{- end }}
 						"web_server_network_access_control": {
 							Type:        schema.TypeList,
 							Optional:    true,
@@ -933,7 +907,6 @@ func ResourceComposerEnvironment() *schema.Resource {
 											},
 										},
 									},
-{{- if ne $.TargetVersionName "ga" }}
 									"dag_processor": {
 										Type:         schema.TypeList,
 										Optional:     true,
@@ -979,7 +952,6 @@ func ResourceComposerEnvironment() *schema.Resource {
 											},
 										},
 									},
-{{- end }}
 								},
 							},
 						},
@@ -1225,7 +1197,6 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 			return err
 		}
 
-{{ if ne $.TargetVersionName `ga` -}}
 		noChangeErrorMessage := "Update request does not result in any change to the environment's configuration"
 		if d.HasChange("config.0.node_config.0.network") || d.HasChange("config.0.node_config.0.subnetwork"){
 			// step 1: update with empty network and subnetwork
@@ -1285,7 +1256,6 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 				}
 			}
 		}
-{{- end }}
 
 		if d.HasChange("config.0.software_config.0.image_version") {
 			patchObj := &composer.Environment{
@@ -1387,7 +1357,6 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 			}
 		}
 
-{{ if ne $.TargetVersionName `ga` -}}
 		if d.HasChange("config.0.enable_private_environment") {
 			patchObj := &composer.Environment{
 				Config: &composer.EnvironmentConfig{
@@ -1429,7 +1398,6 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 				return err
 			}
 		}
-{{- end }}
 
 		if d.HasChange("config.0.node_count") {
 			patchObj := &composer.Environment{Config: &composer.EnvironmentConfig{}}
@@ -1689,12 +1657,10 @@ func flattenComposerEnvironmentConfig(envCfg *composer.EnvironmentConfig) interf
 	if !isComposer3(imageVersion){
 		transformed["private_environment_config"] = flattenComposerEnvironmentConfigPrivateEnvironmentConfig(envCfg.PrivateEnvironmentConfig)
 	}
-{{- if ne $.TargetVersionName "ga" }}
 	if isComposer3(imageVersion) && envCfg.PrivateEnvironmentConfig != nil {
 		transformed["enable_private_environment"] = envCfg.PrivateEnvironmentConfig.EnablePrivateEnvironment
 		transformed["enable_private_builds_only"] = envCfg.PrivateEnvironmentConfig.EnablePrivateBuildsOnly
 	}
-{{- end }}
 	transformed["web_server_network_access_control"] = flattenComposerEnvironmentConfigWebServerNetworkAccessControl(envCfg.WebServerNetworkAccessControl)
 	transformed["database_config"] = flattenComposerEnvironmentConfigDatabaseConfig(envCfg.DatabaseConfig)
 	transformed["web_server_config"] = flattenComposerEnvironmentConfigWebServerConfig(envCfg.WebServerConfig)
@@ -1837,17 +1803,13 @@ func flattenComposerEnvironmentConfigWorkloadsConfig(workloadsConfig *composer.W
 	transformedTriggerer := make(map[string]interface{})
 	transformedWebServer := make(map[string]interface{})
 	transformedWorker := make(map[string]interface{})
-{{- if ne $.TargetVersionName "ga" }}
 	transformedDagProcessor := make(map[string]interface{})
-{{- end }}
 
 	wlCfgScheduler := workloadsConfig.Scheduler
 	wlCfgTriggerer := workloadsConfig.Triggerer
 	wlCfgWebServer := workloadsConfig.WebServer
 	wlCfgWorker := workloadsConfig.Worker
-{{- if ne $.TargetVersionName "ga" }}
 	wlCfgDagProcessor := workloadsConfig.DagProcessor
-{{- end }}
 
 	if wlCfgScheduler == nil {
 		transformedScheduler = nil
@@ -1884,7 +1846,6 @@ func flattenComposerEnvironmentConfigWorkloadsConfig(workloadsConfig *composer.W
 		transformedWorker["max_count"] = wlCfgWorker.MaxCount
 	}
 
-{{ if ne $.TargetVersionName `ga` -}}
 	if wlCfgDagProcessor == nil {
 			transformedDagProcessor = nil
 	} else {
@@ -1893,7 +1854,6 @@ func flattenComposerEnvironmentConfigWorkloadsConfig(workloadsConfig *composer.W
 		transformedDagProcessor["storage_gb"] = wlCfgDagProcessor.StorageGb
 		transformedDagProcessor["count"] = wlCfgDagProcessor.Count
 	}
-{{- end }}
 
 	transformed["scheduler"] = []interface{}{transformedScheduler}
 	if transformedTriggerer != nil {
@@ -1901,12 +1861,9 @@ func flattenComposerEnvironmentConfigWorkloadsConfig(workloadsConfig *composer.W
 	}
 	transformed["web_server"] = []interface{}{transformedWebServer}
 	transformed["worker"] = []interface{}{transformedWorker}
-{{- if ne $.TargetVersionName "ga" }}
 	if transformedDagProcessor != nil {
 		transformed["dag_processor"] = []interface{}{transformedDagProcessor}
 	}
-{{- end }}
-
 
 	return []interface{}{transformed}
 }
@@ -1942,9 +1899,7 @@ func flattenComposerEnvironmentConfigNodeConfig(nodeCfg *composer.NodeConfig) in
 	transformed["machine_type"] = nodeCfg.MachineType
 	transformed["network"] = nodeCfg.Network
 	transformed["subnetwork"] = nodeCfg.Subnetwork
-{{- if ne $.TargetVersionName "ga" }}
 	transformed["composer_network_attachment"] = nodeCfg.ComposerNetworkAttachment
-{{- end }}
 	transformed["disk_size_gb"] = nodeCfg.DiskSizeGb
 	transformed["service_account"] = nodeCfg.ServiceAccount
 	transformed["oauth_scopes"] = flattenComposerEnvironmentConfigNodeConfigOauthScopes(nodeCfg.OauthScopes)
@@ -1954,9 +1909,7 @@ func flattenComposerEnvironmentConfigNodeConfig(nodeCfg *composer.NodeConfig) in
 	transformed["enable_ip_masq_agent"] = nodeCfg.EnableIpMasqAgent
 	transformed["tags"] = flattenComposerEnvironmentConfigNodeConfigTags(nodeCfg.Tags)
 	transformed["ip_allocation_policy"] = flattenComposerEnvironmentConfigNodeConfigIPAllocationPolicy(nodeCfg.IpAllocationPolicy)
-{{- if ne $.TargetVersionName "ga" }}
 	transformed["composer_internal_ipv4_cidr_block"] = nodeCfg.ComposerInternalIpv4CidrBlock
-{{- end }}
 	return []interface{}{transformed}
 }
 
@@ -2000,7 +1953,6 @@ func flattenComposerEnvironmentConfigSoftwareConfig(softwareCfg *composer.Softwa
 	transformed["env_variables"] = softwareCfg.EnvVariables
 	transformed["scheduler_count"] = softwareCfg.SchedulerCount
 	transformed["cloud_data_lineage_integration"] = flattenComposerEnvironmentConfigSoftwareConfigCloudDataLineageIntegration(softwareCfg.CloudDataLineageIntegration)
-{{- if ne $.TargetVersionName "ga" }}
 	if softwareCfg.WebServerPluginsMode == "PLUGINS_DISABLED"{
 		transformed["web_server_plugins_mode"] = "DISABLED"
 	} else if softwareCfg.WebServerPluginsMode == "PLUGINS_ENABLED"{
@@ -2008,7 +1960,6 @@ func flattenComposerEnvironmentConfigSoftwareConfig(softwareCfg *composer.Softwa
 	} else {
 		transformed["web_server_plugins_mode"] = softwareCfg.WebServerPluginsMode
 	}
-{{- end }}
 	return []interface{}{transformed}
 }
 
@@ -2078,7 +2029,6 @@ func expandComposerEnvironmentConfig(v interface{}, d *schema.ResourceData, conf
 	}
 	transformed.PrivateEnvironmentConfig = transformedPrivateEnvironmentConfig
 
-{{ if ne $.TargetVersionName `ga` -}}
 	/*
 		config.enable_private_environment in terraform maps to
 		composer.PrivateEnvironmentConfig.EnablePrivateEnvironment in API.
@@ -2094,7 +2044,6 @@ func expandComposerEnvironmentConfig(v interface{}, d *schema.ResourceData, conf
 			transformed.PrivateEnvironmentConfig.EnablePrivateBuildsOnly = enablePrivateBuildsOnlyRaw.(bool)
 		}
 	}
-{{- end }}
 
 	transformedWebServerNetworkAccessControl, err := expandComposerEnvironmentConfigWebServerNetworkAccessControl(original["web_server_network_access_control"], d, config)
 	if err != nil {
@@ -2393,7 +2342,6 @@ func expandComposerEnvironmentConfigWorkloadsConfig(v interface{}, d *schema.Res
 		}
 	}
 
-{{ if ne $.TargetVersionName `ga` -}}
 	if v, ok := original["dag_processor"]; ok {
 		if len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
 			transformedDagProcessor := &composer.DagProcessorResource{}
@@ -2405,7 +2353,6 @@ func expandComposerEnvironmentConfigWorkloadsConfig(v interface{}, d *schema.Res
 			transformed.DagProcessor = transformedDagProcessor
 		}
 	}
-{{- end }}
 
 	return transformed, nil
 }
@@ -2562,11 +2509,9 @@ func expandComposerEnvironmentConfigNodeConfig(v interface{}, d *schema.Resource
 		transformed.Subnetwork = transformedSubnetwork
 	}
 
-{{ if ne $.TargetVersionName `ga` -}}
 	if v, ok := original["composer_network_attachment"]; ok {
 		transformed.ComposerNetworkAttachment = v.(string)
 	}
-{{- end }}
 
 	transformedIPAllocationPolicy, err := expandComposerEnvironmentIPAllocationPolicy(original["ip_allocation_policy"], d, config)
 	if err != nil {
@@ -2586,11 +2531,9 @@ func expandComposerEnvironmentConfigNodeConfig(v interface{}, d *schema.Resource
 	}
 	transformed.Tags = transformedTags
 
-{{ if ne $.TargetVersionName `ga` -}}
 	if transformedComposerInternalIpv4CidrBlock, ok := original["composer_internal_ipv4_cidr_block"]; ok {
 		transformed.ComposerInternalIpv4CidrBlock = transformedComposerInternalIpv4CidrBlock.(string)
 	}
-{{- end }}
 
 	return transformed, nil
 }
@@ -2741,7 +2684,6 @@ func expandComposerEnvironmentConfigSoftwareConfig(v interface{}, d *schema.Reso
 	}
 	transformed.CloudDataLineageIntegration = transformedCloudDataLineageIntegration
 
-{{ if ne $.TargetVersionName `ga` -}}
 	if original["web_server_plugins_mode"].(string) == "DISABLED"{
 		transformed.WebServerPluginsMode = "PLUGINS_DISABLED"
 	} else if original["web_server_plugins_mode"].(string) == "ENABLED"{
@@ -2749,7 +2691,6 @@ func expandComposerEnvironmentConfigSoftwareConfig(v interface{}, d *schema.Reso
 	} else {
 		transformed.WebServerPluginsMode = original["web_server_plugins_mode"].(string)
 	}
-{{- end }}
 
 	return transformed, nil
 }

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.tmpl
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.tmpl
@@ -167,8 +167,8 @@ func ResourceComposerEnvironment() *schema.Resource {
 				customdiff.ValidateChange("config.0.software_config.0.image_version", imageVersionChangeValidationFunc),
 				versionValidationCustomizeDiffFunc,
 			),
-			customdiff.ForceNewIf("config.0.node_config.0.network", forceNewCustomDiff("config.0.node_config.0.network")),
-			customdiff.ForceNewIf("config.0.node_config.0.subnetwork", forceNewCustomDiff("config.0.node_config.0.subnetwork")),
+			customdiff.ForceNewIf("config.0.node_config.0.network", forceNewIfNotComposer3CustomDiff("config.0.node_config.0.network")),
+			customdiff.ForceNewIf("config.0.node_config.0.subnetwork", forceNewIfNotComposer3CustomDiff("config.0.node_config.0.subnetwork")),
 		),
 
 		Schema: map[string]*schema.Schema{
@@ -2988,7 +2988,7 @@ func isComposer3(imageVersion string)	bool {
 	return strings.Contains(imageVersion, "composer-3")
 }
 
-func forceNewCustomDiff(key string) customdiff.ResourceConditionFunc {
+func forceNewIfNotComposer3CustomDiff(key string) customdiff.ResourceConditionFunc {
 	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
 		old, new := d.GetChange(key)
 		imageVersion := d.Get("config.0.software_config.0.image_version").(string)

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go.tmpl
@@ -1191,7 +1191,6 @@ func TestAccComposerEnvironment_customBucketWithUrl(t *testing.T) {
 	})
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 // Checks Composer 3 environment creation with new fields.
 func TestAccComposerEnvironmentComposer3_basic(t *testing.T) {
 	t.Parallel()
@@ -1548,7 +1547,6 @@ func TestAccComposerEnvironmentComposer3_usesUnsupportedField_expectError(t *tes
 		},
 	})
 }
-{{- end }}
 
 func testAccComposerEnvironment_customBucket(bucketName, envName, network, subnetwork string) string {
 	return fmt.Sprintf(`
@@ -2747,9 +2745,7 @@ resource "google_composer_environment" "test" {
       zone       = "us-central1-a"
 
       service_account = google_service_account.test.name
-{{- if ne $.TargetVersionName "ga" }}
       max_pods_per_node = 33
-{{- end }}
       ip_allocation_policy {
         use_ip_aliases          = true
         cluster_ipv4_cidr_block = "10.0.0.0/16"
@@ -3233,7 +3229,6 @@ resource "google_project_iam_member" "composer-worker" {
 `, environment, network, subnetwork, serviceAccount)
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func testAccComposerEnvironmentComposer2_empty(name, network, subnetwork string) string {
 	return fmt.Sprintf(`
 resource "google_composer_environment" "test" {
@@ -3573,7 +3568,6 @@ resource "google_compute_subnetwork" "test" {
 }
 `, name, networkAttachment, network, subnetwork)
 }
-{{- end }}
 
 // WARNING: This is not actually a check and is a terrible clean-up step because Composer Environments
 // have a bug that hasn't been fixed. Composer will add firewalls to non-default networks for environments

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go.tmpl
@@ -3297,7 +3297,7 @@ resource "google_composer_environment" "test" {
   config {
     software_config {
       image_version = "composer-2-airflow-2"
-			web_server_plugins_mode = "ENABLED"
+	  web_server_plugins_mode = "ENABLED"
     }
   }
 }

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go.tmpl
@@ -2745,7 +2745,9 @@ resource "google_composer_environment" "test" {
       zone       = "us-central1-a"
 
       service_account = google_service_account.test.name
+{{- if ne $.TargetVersionName "ga" }}
       max_pods_per_node = 33
+{{- end }}
       ip_allocation_policy {
         use_ip_aliases          = true
         cluster_ipv4_cidr_block = "10.0.0.0/16"

--- a/mmv1/third_party/terraform/services/composer/resource_composer_user_workloads_config_map_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_user_workloads_config_map_test.go.tmpl
@@ -80,7 +80,6 @@ func TestAccComposerUserWorkloadsConfigMap_composerUserWorkloadsConfigMapBasicEx
 func testAccComposerUserWorkloadsConfigMap_composerUserWorkloadsConfigMapBasicExample_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_composer_environment" "environment" {
-  provider = google-beta
   name   = "tf-test-test-environment%{random_suffix}"
   region = "us-central1"
   config {
@@ -91,7 +90,6 @@ resource "google_composer_environment" "environment" {
 }
 
 resource "google_composer_user_workloads_config_map" "config_map" {
-  provider = google-beta
   name = "tf-test-test-config-map%{random_suffix}"
   region = "us-central1"
   environment = google_composer_environment.environment.name
@@ -105,7 +103,6 @@ resource "google_composer_user_workloads_config_map" "config_map" {
 func testAccComposerUserWorkloadsConfigMap_composerUserWorkloadsConfigMapBasicExample_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_composer_environment" "environment" {
-  provider = google-beta
   name   = "tf-test-test-environment%{random_suffix}"
   region = "us-central1"
   config {
@@ -116,7 +113,6 @@ resource "google_composer_environment" "environment" {
 }
 
 resource "google_composer_user_workloads_config_map" "config_map" {
-  provider = google-beta
   name = "tf-test-test-config-map%{random_suffix}"
   region = "us-central1"
   environment = google_composer_environment.environment.name
@@ -130,7 +126,6 @@ resource "google_composer_user_workloads_config_map" "config_map" {
 func testAccComposerUserWorkloadsConfigMap_composerUserWorkloadsConfigMapBasicExample_delete(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_composer_environment" "environment" {
-  provider = google-beta
   name   = "tf-test-test-environment%{random_suffix}"
   region = "us-central1"
   config {

--- a/mmv1/third_party/terraform/services/composer/resource_composer_user_workloads_config_map_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_user_workloads_config_map_test.go.tmpl
@@ -1,7 +1,5 @@
 package composer_test
 
-{{ if ne $.TargetVersionName `ga` -}}
-
 import (
 	"fmt"
 	"strings"
@@ -166,5 +164,3 @@ func testAccComposerUserWorkloadsConfigMapDestroyed(t *testing.T) func(s *terraf
 		return nil
 	}
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/composer/resource_composer_user_workloads_config_map_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_user_workloads_config_map_test.go.tmpl
@@ -20,7 +20,7 @@ func TestAccComposerUserWorkloadsConfigMap_composerUserWorkloadsConfigMapBasicEx
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComposerUserWorkloadsConfigMapDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -56,7 +56,7 @@ func TestAccComposerUserWorkloadsConfigMap_composerUserWorkloadsConfigMapBasicEx
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComposerUserWorkloadsConfigMapDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{

--- a/mmv1/third_party/terraform/services/composer/resource_composer_user_workloads_secret.go.tmpl
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_user_workloads_secret.go.tmpl
@@ -1,7 +1,5 @@
 package composer
 
-{{ if ne $.TargetVersionName `ga` -}}
-
 import (
 	"fmt"
 	"log"
@@ -267,5 +265,3 @@ func (n *UserWorkloadsSecretName) ResourceName() string {
 func (n *UserWorkloadsSecretName) ParentName() string {
 	return fmt.Sprintf("projects/%s/locations/%s/environments/%s", n.Project, n.Region, n.Environment)
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/composer/resource_composer_user_workloads_secret_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_user_workloads_secret_test.go.tmpl
@@ -1,7 +1,5 @@
 package composer_test
 
-{{ if ne $.TargetVersionName `ga` -}}
-
 import (
 	"fmt"
 	"testing"
@@ -179,5 +177,3 @@ func testAccComposerUserWorkloadsSecretDestroyed(t *testing.T) func(s *terraform
 		return nil
 	}
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/website/docs/d/composer_user_workloads_config_map.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/composer_user_workloads_config_map.html.markdown
@@ -8,9 +8,6 @@ description: |-
 
 Provides access to Kubernetes ConfigMap configuration for a given project, region and Composer Environment.
 
-> **Warning:** This data source is in beta, and should be used with the terraform-provider-google-beta provider.
-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
-
 ## Example Usage
 
 ```hcl

--- a/mmv1/third_party/terraform/website/docs/d/composer_user_workloads_secret.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/composer_user_workloads_secret.html.markdown
@@ -8,9 +8,6 @@ description: |-
 
 Provides access to Kubernetes Secret configuration for a given project, region and Composer Environment.
 
-~> **Warning:** This data source is in beta, and should be used with the terraform-provider-google-beta provider.
-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
-
 ## Example Usage
 
 ```hcl

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -363,6 +363,32 @@ resource "google_composer_environment" "example" {
 }
 ```
 
+When using an existing network attachment that is also managed in Terraform, ensure Terraform ignores changes to producer_accept_lists as follows:
+
+```hcl
+resource "google_compute_network_attachment" "example" {
+  lifecycle {
+    ignore_changes = [producer_accept_lists]
+  }
+
+  # ... other configuration parameters
+}
+
+resource "google_composer_environment" "example" {
+  name = "example-environment"
+  region = "us-central1"
+
+  config {
+
+    node_config {
+      composer_network_attachment = google_compute_network_attachment.example.id
+    }
+
+    # ... other configuration parameters
+  }
+}
+```
+
 ### With Software (Airflow) Config
 
 ```hcl

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -1303,11 +1303,11 @@ The following arguments are supported:
   The configuration settings for software (Airflow) inside the environment. Structure is [documented below](#nested_software_config_c3).
 
 * `enable_private_environment` -
-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html), Cloud Composer 3 only)
+  (Optional, Cloud Composer 3 only)
   If true, a private Composer environment will be created.
 
 * `enable_private_builds_only` -
-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html), Cloud Composer 3 only)
+  (Optional, Cloud Composer 3 only)
   If true, builds performed during operations that install Python packages have only private connectivity to Google services.
   If false, the builds also have access to the internet.
 
@@ -1377,7 +1377,7 @@ The following arguments are supported:
   network must also be provided and the subnetwork must belong to the enclosing environment's project and region.
 
 * `composer_network_attachment` -
-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html), Cloud Composer 3 only)
+  (Optional, Cloud Composer 3 only)
   PSC (Private Service Connect) Network entry point. Customers can pre-create the Network Attachment 
   and point Cloud Composer environment to use. It is possible to share network attachment among many environments, 
   provided enough IP addresses are available.
@@ -1398,7 +1398,7 @@ The following arguments are supported:
   Cannot be updated.
 
 * `composer_internal_ipv4_cidr_block` -
-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html), Cloud Composer 3 only)
+  (Optional, Cloud Composer 3 only)
   /20 IPv4 cidr range that will be used by Composer internal components.
   Cannot be updated.
 
@@ -1471,7 +1471,7 @@ The following arguments are supported:
   [documented below](#nested_cloud_data_lineage_integration_c3).
 
 * `web_server_plugins_mode` -
-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html), Cloud Composer 3 only)
+  (Optional, Cloud Composer 3 only)
   Web server plugins configuration. Can be either 'ENABLED' or 'DISABLED'. Defaults to 'ENABLED'.
 
 <a name="nested_cloud_data_lineage_integration_c3"></a>The `cloud_data_lineage_integration` block supports:
@@ -1523,7 +1523,7 @@ The `workloads_config` block supports:
   Configuration for resources used by Airflow workers.
 
 * `dag_processor` -
-  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html), Cloud Composer 3 only)
+  (Optional, Cloud Composer 3 only)
   Configuration for resources used by DAG processor.
 
 The `scheduler` block supports:

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -363,7 +363,10 @@ resource "google_composer_environment" "example" {
 }
 ```
 
-When using an existing network attachment that is also managed in Terraform, ensure Terraform ignores changes to producer_accept_lists as follows:
+If you specify an existing network attachment that you also manage in Terraform, then Terraform will revert changes
+to the attachment done by Cloud Composer when you apply configuration changes. As a result, the environment will no
+longer use the attachment. To address this problem, make sure that Terraform ignores changes to the
+`producer_accept_lists` parameter of the attachment, as follows:
 
 ```hcl
 resource "google_compute_network_attachment" "example" {

--- a/mmv1/third_party/terraform/website/docs/r/composer_user_workloads_secret.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_user_workloads_secret.html.markdown
@@ -6,9 +6,6 @@ description: |-
 
 # google_composer_user_workloads_secret
 
-~> **Warning:** These resources are in beta, and should be used with the terraform-provider-google-beta provider.
-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.
-
 User workloads Secret used by Airflow tasks that run with Kubernetes Executor or KubernetesPodOperator. 
 Intended for Composer 3 Environments.
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-datasource
`google_composer_user_workloads_config_map` (GA)
```
```release-note:new-datasource
`google_composer_user_workloads_secret` (GA)
```
```release-note:new-resource
`google_composer_user_workloads_config_map` (GA)
```
```release-note:new-resource
`google_composer_user_workloads_secret` (GA)
```
```release-note:enhancement
composer: added multiple composer 3 related fields to `google_composer_environment` (GA)
```

This PR reintroduces changes that were previously approved, but merged too early and subsequently reverted: https://github.com/GoogleCloudPlatform/magic-modules/pull/12234.

***Please do not merge yet.*** We'd like to have it approved and ready but align the release of this with composer 3 GA rollout scheduled for first half of December.
