### PR TITLE
Remove unused LocationDescriber interface from google_provider_config_plugin_framework

### DIFF
--- a/mmv1/third_party/terraform/fwprovider/data_source_provider_config_plugin_framework.go
+++ b/mmv1/third_party/terraform/fwprovider/data_source_provider_config_plugin_framework.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-google/google/fwmodels"
-	"github.com/hashicorp/terraform-provider-google/google/fwresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
@@ -18,7 +17,6 @@ import (
 var (
 	_ datasource.DataSource              = &GoogleProviderConfigPluginFrameworkDataSource{}
 	_ datasource.DataSourceWithConfigure = &GoogleProviderConfigPluginFrameworkDataSource{}
-	_ fwresource.LocationDescriber       = &GoogleProviderConfigPluginFrameworkModel{}
 )
 
 func NewGoogleProviderConfigPluginFrameworkDataSource() datasource.DataSource {
@@ -54,15 +52,6 @@ type GoogleProviderConfigPluginFrameworkModel struct {
 	DefaultLabels                             types.Map    `tfsdk:"default_labels"`
 	AddTerraformAttributionLabel              types.Bool   `tfsdk:"add_terraform_attribution_label"`
 	TerraformAttributionLabelAdditionStrategy types.String `tfsdk:"terraform_attribution_label_addition_strategy"`
-}
-
-func (m *GoogleProviderConfigPluginFrameworkModel) GetLocationDescription(providerConfig *transport_tpg.Config) fwresource.LocationDescription {
-	return fwresource.LocationDescription{
-		RegionSchemaField: types.StringValue("region"),
-		ZoneSchemaField:   types.StringValue("zone"),
-		ProviderRegion:    types.StringValue(providerConfig.Region),
-		ProviderZone:      types.StringValue(providerConfig.Zone),
-	}
 }
 
 func (d *GoogleProviderConfigPluginFrameworkDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {


### PR DESCRIPTION
Context: I've shared a document with the Google Terraform team about why LocationDescriber was made and why I think it should be replaced.

google_provider_config_plugin_framework includes the LocationDescriber interface but the GetLocationDescription method is never used; we should remove it


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
