### PR TITLE
Remove LocationDescriber interface from google_client_config as it's unneeded

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_client_config.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_client_config.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-google/google/fwmodels"
-	"github.com/hashicorp/terraform-provider-google/google/fwresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
@@ -16,7 +15,6 @@ import (
 var (
 	_ datasource.DataSource              = &GoogleClientConfigDataSource{}
 	_ datasource.DataSourceWithConfigure = &GoogleClientConfigDataSource{}
-	_ fwresource.LocationDescriber       = &GoogleClientConfigModel{}
 )
 
 func NewGoogleClientConfigDataSource() datasource.DataSource {
@@ -36,17 +34,6 @@ type GoogleClientConfigModel struct {
 	Zone          types.String `tfsdk:"zone"`
 	AccessToken   types.String `tfsdk:"access_token"`
 	DefaultLabels types.Map    `tfsdk:"default_labels"`
-}
-
-func (m *GoogleClientConfigModel) GetLocationDescription(providerConfig *transport_tpg.Config) fwresource.LocationDescription {
-	return fwresource.LocationDescription{
-		RegionSchemaField: types.StringValue("region"),
-		ZoneSchemaField:   types.StringValue("zone"),
-		ResourceRegion:    m.Region,
-		ResourceZone:      m.Zone,
-		ProviderRegion:    types.StringValue(providerConfig.Region),
-		ProviderZone:      types.StringValue(providerConfig.Zone),
-	}
 }
 
 func (d *GoogleClientConfigDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -131,14 +118,10 @@ func (d *GoogleClientConfigDataSource) Read(ctx context.Context, req datasource.
 		return
 	}
 
-	locationInfo := data.GetLocationDescription(d.providerConfig)
-	region, _ := locationInfo.GetRegion()
-	zone, _ := locationInfo.GetZone()
-
-	data.Id = types.StringValue(fmt.Sprintf("projects/%s/regions/%s/zones/%s", d.providerConfig.Project, region.String(), zone.String()))
+	data.Id = types.StringValue(fmt.Sprintf("projects/%s/regions/%s/zones/%s", d.providerConfig.Project, d.providerConfig.Region, d.providerConfig.Zone))
 	data.Project = types.StringValue(d.providerConfig.Project)
-	data.Region = region
-	data.Zone = zone
+	data.Region = types.StringValue(d.providerConfig.Region)
+	data.Zone = types.StringValue(d.providerConfig.Zone)
 
 	// Convert default labels from SDK type system to plugin-framework data type
 	m := map[string]*string{}


### PR DESCRIPTION
Context: I've shared a document with the Google Terraform team about why LocationDescriber was made and why I think it should be replaced.

Here in google_client_config it is unnecessary; there is no region or zone value provided via config to compare to provider-defaults as this resource is only for exposing provider default values. This PR removes use of the LocationDescriber interface and instead passes the values directly into the data source.

Post-muxing fixes the values coming from the provider when there isn't a provider-default will be `""`.
So, when no region or zone values are present:
* the `id` of the data source would be `projects/my-project/regions//zones/` (matching the data source when it was in SDK)
* the `region` will be `""`, not null (matching SDK)
* the `zone` will be `""`, not null (matching SDK)

The data source could be updated to make region and zone null if no provider-default value is present, but that's an explicit change in behaviour and is not in scope for this PR.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
