### PR TITLE
Make allowedPersistenceRegions optional in messageStoragePolicy for google_pubsub_topic.

### DIFF
--- a/mmv1/products/pubsub/Topic.yaml
+++ b/mmv1/products/pubsub/Topic.yaml
@@ -126,7 +126,7 @@ properties:
           of GCP altogether) will be routed for storage in one of the
           allowed regions. An empty list means that no regions are allowed,
           and is not a valid configuration.
-        required: true
+        required: false
         item_type:
           type: String
   - name: 'schemaSettings'

--- a/mmv1/third_party/terraform/services/pubsub/resource_pubsub_topic_test.go
+++ b/mmv1/third_party/terraform/services/pubsub/resource_pubsub_topic_test.go
@@ -207,6 +207,44 @@ func TestAccPubsubTopic_cloudStorageIngestionUpdate(t *testing.T) {
 	})
 }
 
+func TestAccPubsubTopic_messageStoragePolicyRemove(t *testing.T) {
+	resourceName := "google_pubsub_topic.usage-metrics"
+
+	initialConfig := `
+resource "google_pubsub_topic" "usage-metrics" {
+  name = "topic-name"
+
+  message_storage_policy {
+    allowed_persistence_regions = ["us-central1"]
+  }
+}
+`
+
+	updatedConfig := `
+resource "google_pubsub_topic" "usage-metrics" {
+  name = "topic-name"
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {},
+		Steps: []resource.TestStep{
+			{
+				Config: initialConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "message_storage_policy.0.allowed_persistence_regions.#", "1"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "message_storage_policy.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func testAccPubsubTopic_update(topic, key, value string) string {
 	return fmt.Sprintf(`
 resource "google_pubsub_topic" "foo" {


### PR DESCRIPTION
closes https://github.com/hashicorp/terraform-provider-google/issues/20431

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
pubsub: fixed perma-diff in `google_pubsub_topic`
```
