### PR TITLE
Update link about VCR tests on automated PR comments

### DIFF
--- a/.ci/magician/cmd/templates/vcr/with_replay_failed_tests.tmpl
+++ b/.ci/magician/cmd/templates/vcr/with_replay_failed_tests.tmpl
@@ -9,4 +9,4 @@
 </blockquote>
 </details>
 
-[Get to know how VCR tests work](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/contributing/#general-contributing-steps)
+[Get to know how VCR tests work](https://googlecloudplatform.github.io/magic-modules/develop/test/test/)

--- a/.ci/magician/cmd/test_terraform_vcr_test.go
+++ b/.ci/magician/cmd/test_terraform_vcr_test.go
@@ -447,7 +447,7 @@ func TestWithReplayFailedTests(t *testing.T) {
 					"</blockquote>",
 					"</details>",
 					"",
-					"[Get to know how VCR tests work](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/contributing/#general-contributing-steps)",
+					"[Get to know how VCR tests work](https://googlecloudplatform.github.io/magic-modules/develop/test/test/)",
 				},
 				"\n",
 			),


### PR DESCRIPTION
Addresses feedback in https://github.com/hashicorp/terraform-provider-google/issues/20059

The previous link no longer exists, so this replacement value is the current page that has the most information about VCR tests currently.

Note: the develop/test/test/ page in the contribution website is hopefully going to get some extra VCR information added to it via https://github.com/GoogleCloudPlatform/magic-modules/pull/12407


```release-note:none

```
