### PR TITLE
Fix ApigeeOrganization update response type.

### DIFF
--- a/mmv1/products/apigee/Organization.yaml
+++ b/mmv1/products/apigee/Organization.yaml
@@ -30,7 +30,7 @@ timeouts:
   delete_minutes: 45
 autogen_async: true
 async:
-  actions: ['create', 'delete', 'update']
+  actions: ['create', 'delete']
   type: 'OpAsync'
   operation:
     base_url: '{{op_id}}'

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_organization_update_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_organization_update_test.go
@@ -1,0 +1,313 @@
+package apigee_test
+
+import (
+	"maps"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccApigeeOrganization_update(t *testing.T) {
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+
+	default_context := map[string]interface{}{
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"random_suffix":   acctest.RandString(t, 10),
+	}
+	update_context := maps.Clone(default_context)
+	update_context["org_description"] = "Updated Apigee Org description."
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigeeOrganization_full(default_context),
+			},
+			{
+				ResourceName:            "google_apigee_organization.org",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"project_id", "properties", "retention"},
+			},
+			{
+				Config: testAccApigeeOrganization_update(update_context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_apigee_organization.org", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_apigee_organization.org",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"project_id", "properties", "retention"},
+			},
+		},
+	})
+}
+
+func testAccApigeeOrganization_full(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_project" "project" {
+  provider = google
+
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
+  deletion_policy = "DELETE"
+}
+
+resource "google_project_service" "apigee" {
+  provider = google
+
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+}
+
+resource "google_project_service" "compute" {
+  provider = google
+
+  project = google_project.project.project_id
+  service = "compute.googleapis.com"
+}
+
+resource "google_project_service" "servicenetworking" {
+  provider = google
+
+  project = google_project.project.project_id
+  service = "servicenetworking.googleapis.com"
+}
+
+resource "google_project_service" "kms" {
+  provider = google
+
+  project = google_project.project.project_id
+  service = "cloudkms.googleapis.com"
+}
+
+resource "google_compute_network" "apigee_network" {
+  provider = google
+
+  name       = "apigee-network"
+  project    = google_project.project.project_id
+  depends_on = [google_project_service.compute]
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  provider = google
+
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+  project       = google_project.project.project_id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  provider = google
+
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+  depends_on              = [google_project_service.servicenetworking]
+}
+
+resource "google_kms_key_ring" "apigee_keyring" {
+  provider = google
+
+  name       = "apigee-keyring"
+  location   = "us-central1"
+  project    = google_project.project.project_id
+  depends_on = [google_project_service.kms]
+}
+
+resource "google_kms_crypto_key" "apigee_key" {
+  provider = google
+
+  name            = "apigee-key"
+  key_ring        = google_kms_key_ring.apigee_keyring.id
+}
+
+resource "google_project_service_identity" "apigee_sa" {
+  provider = google
+
+  project = google_project.project.project_id
+  service = google_project_service.apigee.service
+}
+
+resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
+  provider = google
+
+  crypto_key_id = google_kms_crypto_key.apigee_key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+  member = google_project_service_identity.apigee_sa.member
+}
+
+resource "google_apigee_organization" "org" {
+  provider = google
+
+  display_name                         = "apigee-org"
+  description                          = "%{org_description}"
+  analytics_region                     = "us-central1"
+  project_id                           = google_project.project.project_id
+  authorized_network                   = google_compute_network.apigee_network.id
+  billing_type                         = "EVALUATION"
+  runtime_database_encryption_key_name = google_kms_crypto_key.apigee_key.id
+  properties {
+    property {
+      name = "features.hybrid.enabled"
+      value = "true"
+    }
+    property {
+      name = "features.mart.connect.enabled"
+      value = "true"
+    }
+  }
+
+  depends_on = [
+    google_service_networking_connection.apigee_vpc_connection,
+    google_kms_crypto_key_iam_member.apigee_sa_keyuser,
+  ]
+}
+`, context)
+}
+
+func testAccApigeeOrganization_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_project" "project" {
+  provider = google
+
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
+  deletion_policy = "DELETE"
+}
+
+resource "google_project_service" "apigee" {
+  provider = google
+
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+}
+
+resource "google_project_service" "compute" {
+  provider = google
+
+  project = google_project.project.project_id
+  service = "compute.googleapis.com"
+}
+
+resource "google_project_service" "servicenetworking" {
+  provider = google
+
+  project = google_project.project.project_id
+  service = "servicenetworking.googleapis.com"
+}
+
+resource "google_project_service" "kms" {
+  provider = google
+
+  project = google_project.project.project_id
+  service = "cloudkms.googleapis.com"
+}
+
+resource "google_compute_network" "apigee_network" {
+  provider = google
+
+  name       = "apigee-network"
+  project    = google_project.project.project_id
+  depends_on = [google_project_service.compute]
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  provider = google
+
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+  project       = google_project.project.project_id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  provider = google
+
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+  depends_on              = [google_project_service.servicenetworking]
+}
+
+resource "google_kms_key_ring" "apigee_keyring" {
+  provider = google
+
+  name       = "apigee-keyring"
+  location   = "us-central1"
+  project    = google_project.project.project_id
+  depends_on = [google_project_service.kms]
+}
+
+resource "google_kms_crypto_key" "apigee_key" {
+  provider = google
+
+  name            = "apigee-key"
+  key_ring        = google_kms_key_ring.apigee_keyring.id
+}
+
+resource "google_project_service_identity" "apigee_sa" {
+  provider = google
+
+  project = google_project.project.project_id
+  service = google_project_service.apigee.service
+}
+
+resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
+  provider = google
+
+  crypto_key_id = google_kms_crypto_key.apigee_key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+  member = google_project_service_identity.apigee_sa.member
+}
+
+resource "google_apigee_organization" "org" {
+  provider = google
+
+  display_name                         = "apigee-org"
+  description                          = "Terraform-managed Apigee Org"
+  analytics_region                     = "us-central1"
+  project_id                           = google_project.project.project_id
+  authorized_network                   = google_compute_network.apigee_network.id
+  billing_type                         = "EVALUATION"
+  runtime_database_encryption_key_name = google_kms_crypto_key.apigee_key.id
+  properties {
+    property {
+      name = "features.hybrid.enabled"
+      value = "true"
+    }
+    property {
+      name = "features.mart.connect.enabled"
+      value = "true"
+    }
+  }
+
+  depends_on = [
+    google_service_networking_connection.apigee_vpc_connection,
+    google_kms_crypto_key_iam_member.apigee_sa_keyuser,
+  ]
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_organization_update_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_organization_update_test.go
@@ -158,7 +158,7 @@ resource "google_apigee_organization" "org" {
   provider = google
 
   display_name                         = "apigee-org"
-  description                          = "%{org_description}"
+  description                          = "Terraform-managed Apigee Org"
   analytics_region                     = "us-central1"
   project_id                           = google_project.project.project_id
   authorized_network                   = google_compute_network.apigee_network.id
@@ -287,7 +287,7 @@ resource "google_apigee_organization" "org" {
   provider = google
 
   display_name                         = "apigee-org"
-  description                          = "Terraform-managed Apigee Org"
+  description                          = "%{org_description}"
   analytics_region                     = "us-central1"
   project_id                           = google_project.project.project_id
   authorized_network                   = google_compute_network.apigee_network.id

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_organization_update_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_organization_update_test.go
@@ -31,7 +31,7 @@ func TestAccApigeeOrganization_update(t *testing.T) {
 				Config: testAccApigeeOrganization_full(default_context),
 			},
 			{
-				ResourceName:            "google_apigee_organization.org",
+				ResourceName:            "google_apigee_organization.apigee_org",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"project_id", "properties", "retention"},
@@ -40,12 +40,12 @@ func TestAccApigeeOrganization_update(t *testing.T) {
 				Config: testAccApigeeOrganization_update(update_context),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction("google_apigee_organization.org", plancheck.ResourceActionUpdate),
+						plancheck.ExpectResourceAction("google_apigee_organization.apigee_org", plancheck.ResourceActionUpdate),
 					},
 				},
 			},
 			{
-				ResourceName:            "google_apigee_organization.org",
+				ResourceName:            "google_apigee_organization.apigee_org",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"project_id", "properties", "retention"},


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/15947.
 
This PR fixes the `ApigeeOrganization` update response type according to the public documentation.
 
The issue is related to the fact that after requesting the update to `ApigeeOrganization` [here](https://github.com/hashicorp/terraform-provider-google/blob/v6.12.0/google/services/apigee/resource_apigee_organization.go#L538), the provider expects that the response will contain the [Operation](https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.operations#Operation) details to then wait for the `Operation` to complete [here](https://github.com/hashicorp/terraform-provider-google/blob/v6.12.0/google/services/apigee/resource_apigee_organization.go#L555). Unlike [Organization create request](https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations/create), which returns `Operation`, the update response is an [Organization instance](https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations#Organization) according to the [public docs](https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations/update), meaning that the [ApigeeOperationWaitTime](https://github.com/hashicorp/terraform-provider-google/blob/v6.12.0/google/services/apigee/resource_apigee_organization.go#L555) tries to process the `Organization` as `Operation`.

The Operation has a `name` key that is used to track its progress. However, the `Organization` also has a `name` key, that contains the name of the `Organization`. That's why the users see a weird `apigee.googleapis.com/v1/<org-name>?alt=json` `GET` request in a linked [GitHub issue](https://github.com/hashicorp/terraform-provider-google/issues/15947). In that case, the `ApigeeOperationWaitTime` interprets `<org-name>` as the operation name.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
apigee: fixed error 404 for `organization` update requests.
```
