### PR TITLE
Fix ApigeeEnvironment update response type.

### DIFF
--- a/mmv1/products/apigee/Environment.yaml
+++ b/mmv1/products/apigee/Environment.yaml
@@ -35,7 +35,7 @@ timeouts:
   delete_minutes: 30
 autogen_async: true
 async:
-  actions: ['create', 'delete', 'update']
+  actions: ['create', 'delete']
   type: 'OpAsync'
   operation:
     base_url: '{{op_id}}'


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
This PR fixes the `ApigeeEnvironment` update response type according to the public documentation.
 
The issue is related to the fact that after requesting the update to `ApigeeEnvironment` [here](https://github.com/hashicorp/terraform-provider-google/blob/v6.12.0/google/services/apigee/resource_apigee_environment.go#L414), the provider expects that the response will contain the [Operation](https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.operations#Operation) details to then wait for the `Operation` to complete [here](https://github.com/hashicorp/terraform-provider-google/blob/v6.12.0/google/services/apigee/resource_apigee_environment.go#L431). Unlike [Environment create request](https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.environments/create), which returns `Operation`, the update response has a type [Environment](https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.environments#Environment) according to the [public docs](https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.environments/update), meaning that the [ApigeeOperationWaitTime](https://github.com/hashicorp/terraform-provider-google/blob/v6.12.0/google/services/apigee/resource_apigee_environment.go#L431) tries to process the `Environment` as `Operation`.

The Operation has a `name` key that is used to track its progress. However, the `Environment` also has a `name` key that contains the name of the `Environment`. That's why the users may see a weird `apigee.googleapis.com/v1/<env-name>?alt=json` `GET` requests that result in `404 Not Found` while doing an update to their environments. In that case, the `ApigeeOperationWaitTime` interprets `<env-name>` as the operation name.

Here's a fix to a similar issue for the `ApigeeOrganization`: https://github.com/GoogleCloudPlatform/magic-modules/pull/12413

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
apigee: fixed error 404 for `environment` update requests.
```
