### PR TITLE
Add Intercept resources to Network Security.

### DIFF
--- a/mmv1/products/networksecurity/InterceptDeployment.yaml
+++ b/mmv1/products/networksecurity/InterceptDeployment.yaml
@@ -1,0 +1,121 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'InterceptDeployment'
+description: InterceptDeployment represents the collectors within a Zone and is associated with a deployment group.
+min_version: 'beta'
+docs:
+id_format: 'projects/{{project}}/locations/{{location}}/interceptDeployments/{{intercept_deployment_id}}'
+base_url: 'projects/{{project}}/locations/{{location}}/interceptDeployments'
+self_link: 'projects/{{project}}/locations/{{location}}/interceptDeployments/{{intercept_deployment_id}}'
+create_url: 'projects/{{project}}/locations/{{location}}/interceptDeployments?interceptDeploymentId={{intercept_deployment_id}}'
+update_verb: 'PATCH'
+update_mask: true
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/interceptDeployments/{{intercept_deployment_id}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+autogen_async: true
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+    path: 'name'
+    wait_ms: 1000
+  result:
+    path: 'response'
+    resource_inside_response: true
+  error:
+    path: 'error'
+    message: 'message'
+custom_code:
+examples:
+  - name: 'network_security_intercept_deployment_basic'
+    config_path: 'templates/terraform/examples/network_security_intercept_deployment_basic.tf.tmpl'
+    primary_resource_id: 'default'
+    vars:
+      network_name: 'example-network'
+      subnetwork_name: 'example-subnet'
+      health_check_name: 'example-hc'
+      backend_service_name: 'example-bs'
+      forwarding_rule_name: 'example-fwr'
+      deployment_group_id: 'example-dg'
+      deployment_id: 'example-deployment'
+parameters:
+  - name: 'location'
+    type: String
+    description: 'Resource ID segment making up resource `name`. It identifies the resource
+    within its parent collection as described in https://google.aip.dev/122. See documentation
+    for resource type `networksecurity.googleapis.com/InterceptDeployment`. '
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+  - name: 'interceptDeploymentId'
+    type: String
+    description: "Required. Id of the requesting object\nIf auto-generating Id server-side,
+    remove this field and\nintercept_deployment_id from the method_signature of Create
+    RPC "
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+properties:
+  - name: 'name'
+    type: String
+    description: 'Output only. Identifier. The name of the InterceptDeployment. '
+    min_version: 'beta'
+    output: true
+  - name: 'createTime'
+    type: String
+    description: 'Output only. [Output only] Create time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'updateTime'
+    type: String
+    description: 'Output only. [Output only] Update time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'labels'
+    type: KeyValueLabels
+    description: 'Optional. Labels as key value pairs '
+    min_version: 'beta'
+  - name: 'forwardingRule'
+    type: String
+    description: "Required. Immutable. The regional load balancer which the intercepted
+    traffic should be forwarded\nto. Format is:\nprojects/{project}/regions/{region}/forwardingRules/{forwardingRule} "
+    min_version: 'beta'
+    required: true
+    immutable: true
+  - name: 'interceptDeploymentGroup'
+    type: String
+    description: "Required. Immutable. The Intercept Deployment Group that this resource
+    is part of. Format is:\n`projects/{project}/locations/global/interceptDeploymentGroups/{interceptDeploymentGroup}` "
+    min_version: 'beta'
+    required: true
+    immutable: true
+  - name: 'state'
+    type: String
+    description: "Output only. Current state of the deployment. \n Possible values:\n
+    STATE_UNSPECIFIED\nACTIVE\nCREATING\nDELETING\nOUT_OF_SYNC\nDELETE_FAILED"
+    min_version: 'beta'
+    output: true
+  - name: 'reconciling'
+    type: Boolean
+    description: "Output only. Whether reconciling is in progress, recommended per\nhttps://google.aip.dev/128. "
+    min_version: 'beta'
+    output: true

--- a/mmv1/products/networksecurity/InterceptDeploymentGroup.yaml
+++ b/mmv1/products/networksecurity/InterceptDeploymentGroup.yaml
@@ -1,0 +1,124 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'InterceptDeploymentGroup'
+description: A Deployment Group represents the collector deployments across different zones within an organization.
+min_version: 'beta'
+docs:
+id_format: 'projects/{{project}}/locations/{{location}}/interceptDeploymentGroups/{{intercept_deployment_group_id}}'
+base_url: 'projects/{{project}}/locations/{{location}}/interceptDeploymentGroups'
+self_link: 'projects/{{project}}/locations/{{location}}/interceptDeploymentGroups/{{intercept_deployment_group_id}}'
+create_url: 'projects/{{project}}/locations/{{location}}/interceptDeploymentGroups?interceptDeploymentGroupId={{intercept_deployment_group_id}}'
+update_verb: 'PATCH'
+update_mask: true
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/interceptDeploymentGroups/{{intercept_deployment_group_id}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+autogen_async: true
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+    path: 'name'
+    wait_ms: 1000
+  result:
+    path: 'response'
+    resource_inside_response: true
+  error:
+    path: 'error'
+    message: 'message'
+custom_code:
+examples:
+  - name: 'network_security_intercept_deployment_group_basic'
+    config_path: 'templates/terraform/examples/network_security_intercept_deployment_group_basic.tf.tmpl'
+    primary_resource_id: 'default'
+    vars:
+      network_name: 'example-network'
+      subnetwork_name: 'example-subnet'
+      deployment_group_id: 'example-dg'
+parameters:
+  - name: 'location'
+    type: String
+    description: 'Resource ID segment making up resource `name`. It identifies the resource
+    within its parent collection as described in https://google.aip.dev/122. See documentation
+    for resource type `networksecurity.googleapis.com/InterceptDeploymentGroup`. '
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+  - name: 'interceptDeploymentGroupId'
+    type: String
+    description: "Required. Id of the requesting object\nIf auto-generating Id server-side,
+    remove this field and\nintercept_deployment_group_id from the method_signature
+    of Create RPC "
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+properties:
+  - name: 'name'
+    type: String
+    description: 'Output only. Identifier. Then name of the InterceptDeploymentGroup. '
+    min_version: 'beta'
+    output: true
+  - name: 'createTime'
+    type: String
+    description: 'Output only. [Output only] Create time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'updateTime'
+    type: String
+    description: 'Output only. [Output only] Update time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'labels'
+    type: KeyValueLabels
+    description: 'Optional. Labels as key value pairs '
+    min_version: 'beta'
+  - name: 'network'
+    type: String
+    description: "Required. Immutable. The network that is being used for the deployment.
+    Format is:\nprojects/{project}/global/networks/{network}. "
+    min_version: 'beta'
+    required: true
+    immutable: true
+  - name: 'connectedEndpointGroups'
+    type: Array
+    min_version: 'beta'
+    description: 'Output only. The list of Intercept Endpoint Groups that are connected
+      to this resource. '
+    output: true
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'name'
+          type: String
+          description: 'Output only. A connected intercept endpoint group. '
+          min_version: 'beta'
+          output: true
+  - name: 'state'
+    type: String
+    description: "Output only. Current state of the deployment group. \n Possible values:\n
+    STATE_UNSPECIFIED\nACTIVE\nCREATING\nDELETING"
+    min_version: 'beta'
+    output: true
+  - name: 'reconciling'
+    type: Boolean
+    description: "Output only. Whether reconciling is in progress, recommended per\nhttps://google.aip.dev/128. "
+    min_version: 'beta'
+    output: true

--- a/mmv1/products/networksecurity/InterceptEndpointGroup.yaml
+++ b/mmv1/products/networksecurity/InterceptEndpointGroup.yaml
@@ -1,0 +1,110 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'InterceptEndpointGroup'
+description: An intercept endpoint group is a global resource in the consumer account representing the producer’s deployment group.
+min_version: 'beta'
+docs:
+id_format: 'projects/{{project}}/locations/{{location}}/interceptEndpointGroups/{{intercept_endpoint_group_id}}'
+base_url: 'projects/{{project}}/locations/{{location}}/interceptEndpointGroups'
+self_link: 'projects/{{project}}/locations/{{location}}/interceptEndpointGroups/{{intercept_endpoint_group_id}}'
+create_url: 'projects/{{project}}/locations/{{location}}/interceptEndpointGroups?interceptEndpointGroupId={{intercept_endpoint_group_id}}'
+update_verb: 'PATCH'
+update_mask: true
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/interceptEndpointGroups/{{intercept_endpoint_group_id}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+autogen_async: true
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+    path: 'name'
+    wait_ms: 1000
+  result:
+    path: 'response'
+    resource_inside_response: true
+  error:
+    path: 'error'
+    message: 'message'
+custom_code:
+examples:
+  - name: 'network_security_intercept_endpoint_group_basic'
+    config_path: 'templates/terraform/examples/network_security_intercept_endpoint_group_basic.tf.tmpl'
+    primary_resource_id: 'default'
+    vars:
+      network_name: 'example-network'
+      deployment_group_id: 'example-dg'
+      endpoint_group_id: 'example-eg'
+parameters:
+  - name: 'location'
+    type: String
+    description: 'Resource ID segment making up resource `name`. It identifies the resource
+    within its parent collection as described in https://google.aip.dev/122. See documentation
+    for resource type `networksecurity.googleapis.com/InterceptEndpointGroup`. '
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+  - name: 'interceptEndpointGroupId'
+    type: String
+    description: "Required. Id of the requesting object\nIf auto-generating Id server-side,
+    remove this field and\nintercept_endpoint_group_id from the method_signature of
+    Create RPC "
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+properties:
+  - name: 'name'
+    type: String
+    description: 'Output only. Identifier. The name of the InterceptEndpointGroup. '
+    min_version: 'beta'
+    output: true
+  - name: 'createTime'
+    type: String
+    description: 'Output only. [Output only] Create time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'updateTime'
+    type: String
+    description: 'Output only. [Output only] Update time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'labels'
+    type: KeyValueLabels
+    description: 'Optional. Labels as key value pairs '
+    min_version: 'beta'
+  - name: 'interceptDeploymentGroup'
+    type: String
+    description: "Required. Immutable. The Intercept Deployment Group that this resource
+    is connected to. Format\nis:\n`projects/{project}/locations/global/interceptDeploymentGroups/{interceptDeploymentGroup}` "
+    min_version: 'beta'
+    required: true
+    immutable: true
+  - name: 'state'
+    type: String
+    description: "Output only. Current state of the endpoint group. \n Possible values:\n
+    STATE_UNSPECIFIED\nACTIVE\nCLOSED\nCREATING\nDELETING\nOUT_OF_SYNC"
+    min_version: 'beta'
+    output: true
+  - name: 'reconciling'
+    type: Boolean
+    description: "Output only. Whether reconciling is in progress, recommended per\nhttps://google.aip.dev/128. "
+    min_version: 'beta'
+    output: true

--- a/mmv1/products/networksecurity/InterceptEndpointGroupAssociation.yaml
+++ b/mmv1/products/networksecurity/InterceptEndpointGroupAssociation.yaml
@@ -1,0 +1,137 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'InterceptEndpointGroupAssociation'
+description: Creates an association between a VPC and an intercept endpoint group in order to intercept traffic in that VPC.
+min_version: 'beta'
+docs:
+id_format: 'projects/{{project}}/locations/{{location}}/interceptEndpointGroupAssociations/{{intercept_endpoint_group_association_id}}'
+base_url: 'projects/{{project}}/locations/{{location}}/interceptEndpointGroupAssociations'
+self_link: 'projects/{{project}}/locations/{{location}}/interceptEndpointGroupAssociations/{{intercept_endpoint_group_association_id}}'
+create_url: 'projects/{{project}}/locations/{{location}}/interceptEndpointGroupAssociations?interceptEndpointGroupAssociationId={{intercept_endpoint_group_association_id}}'
+update_verb: 'PATCH'
+update_mask: true
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/interceptEndpointGroupAssociations/{{intercept_endpoint_group_association_id}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+autogen_async: true
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+    path: 'name'
+    wait_ms: 1000
+  result:
+    path: 'response'
+    resource_inside_response: true
+  error:
+    path: 'error'
+    message: 'message'
+custom_code:
+examples:
+  - name: 'network_security_intercept_endpoint_group_association_basic'
+    config_path: 'templates/terraform/examples/network_security_intercept_endpoint_group_association_basic.tf.tmpl'
+    primary_resource_id: 'default'
+    vars:
+      producer_network_name: 'example-prod-network'
+      consumer_network_name: 'example-cons-network'
+      deployment_group_id: 'example-dg'
+      endpoint_group_id: 'example-eg'
+      endpoint_group_association_id: 'example-ega'
+parameters:
+  - name: 'location'
+    type: String
+    description: 'Resource ID segment making up resource `name`. It identifies the resource
+    within its parent collection as described in https://google.aip.dev/122. See documentation
+    for resource type `networksecurity.googleapis.com/InterceptEndpointGroupAssociation`. '
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+  - name: 'interceptEndpointGroupAssociationId'
+    type: String
+    description: "Optional. Id of the requesting object\nIf auto-generating Id server-side,
+    remove this field and\nintercept_endpoint_group_association_id from the method_signature
+    of Create\nRPC "
+    min_version: 'beta'
+    url_param_only: true
+    immutable: true
+properties:
+  - name: 'name'
+    type: String
+    description: 'Output only. Identifier. The name of the InterceptEndpointGroupAssociation. '
+    min_version: 'beta'
+    output: true
+  - name: 'createTime'
+    type: String
+    description: 'Output only. [Output only] Create time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'updateTime'
+    type: String
+    description: 'Output only. [Output only] Update time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'labels'
+    type: KeyValueLabels
+    description: 'Optional. Labels as key value pairs '
+    min_version: 'beta'
+  - name: 'interceptEndpointGroup'
+    type: String
+    description: "Required. Immutable. The Intercept Endpoint Group that this resource
+    is connected to. Format\nis:\n`projects/{project}/locations/global/interceptEndpointGroups/{interceptEndpointGroup}` "
+    min_version: 'beta'
+    required: true
+    immutable: true
+  - name: 'network'
+    type: String
+    description: "Required. Immutable. The VPC network associated. Format:\nprojects/{project}/global/networks/{network}. "
+    min_version: 'beta'
+    required: true
+    immutable: true
+  - name: 'locationsDetails'
+    type: Array
+    description: 'Output only. The list of locations that this association is in and
+      its details. '
+    min_version: 'beta'
+    output: true
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'location'
+          type: String
+          min_version: 'beta'
+          description: 'Output only. The cloud location. '
+          output: true
+        - name: 'state'
+          type: String
+          description: "Output only. The association state in this location. \n Possible
+            values:\n STATE_UNSPECIFIED\nACTIVE\nOUT_OF_SYNC"
+          min_version: 'beta'
+          output: true
+  - name: 'state'
+    type: String
+    description: "Output only. Current state of the endpoint group association. \n Possible
+      values:\n STATE_UNSPECIFIED\nACTIVE\nCREATING\nDELETING\nCLOSED\nOUT_OF_SYNC\nDELETE_FAILED"
+    min_version: 'beta'
+    output: true
+  - name: 'reconciling'
+    type: Boolean
+    description: "Output only. Whether reconciling is in progress, recommended per\nhttps://google.aip.dev/128. "
+    min_version: 'beta'
+    output: true

--- a/mmv1/templates/terraform/examples/network_security_intercept_deployment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_deployment_basic.tf.tmpl
@@ -1,0 +1,61 @@
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "{{index $.Vars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  provider      = google-beta
+  name          = "{{index $.Vars "subnetwork_name"}}"
+  region        = "us-central1"
+  ip_cidr_range = "10.1.0.0/16"
+  network       = google_compute_network.network.name
+}
+
+resource "google_compute_region_health_check" "health_check" {
+  provider = google-beta
+  name     = "{{index $.Vars "health_check_name"}}"
+  region   = "us-central1"
+  http_health_check {
+    port = 80
+  }
+}
+
+resource "google_compute_region_backend_service" "backend_service" {
+  provider              = google-beta
+  name                  = "{{index $.Vars "backend_service_name"}}"
+  region                = "us-central1"
+  health_checks         = [google_compute_region_health_check.health_check.id]
+  protocol              = "UDP"
+  load_balancing_scheme = "INTERNAL"
+}
+
+resource "google_compute_forwarding_rule" "forwarding_rule" {
+  provider               = google-beta
+  name                   = "{{index $.Vars "forwarding_rule_name"}}"
+  region                 = "us-central1"
+  network                = google_compute_network.network.name
+  subnetwork             = google_compute_subnetwork.subnetwork.name
+  backend_service        = google_compute_region_backend_service.backend_service.id
+  load_balancing_scheme  = "INTERNAL"
+  ports                  = [6081]
+  ip_protocol            = "UDP"
+}
+
+resource "google_network_security_intercept_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+}
+
+resource "google_network_security_intercept_deployment" "{{$.PrimaryResourceId}}" {
+  provider                   = google-beta
+  intercept_deployment_id    = "{{index $.Vars "deployment_id"}}"
+  location                   = "us-central1-a"
+  forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id
+  intercept_deployment_group = google_network_security_intercept_deployment_group.deployment_group.id
+  labels = {
+    foo = "bar"
+  }
+}

--- a/mmv1/templates/terraform/examples/network_security_intercept_deployment_group_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_deployment_group_basic.tf.tmpl
@@ -1,0 +1,15 @@
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "{{index $.Vars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "{{$.PrimaryResourceId}}" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+  labels = {
+    foo = "bar"
+  }
+}

--- a/mmv1/templates/terraform/examples/network_security_intercept_endpoint_group_association_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_endpoint_group_association_basic.tf.tmpl
@@ -1,0 +1,36 @@
+resource "google_compute_network" "producer_network" {
+  provider                = google-beta
+  name                    = "{{index $.Vars "producer_network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_network" "consumer_network" {
+  provider                = google-beta
+  name                    = "{{index $.Vars "consumer_network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
+  location                      = "global"
+  network                       = google_compute_network.producer_network.id
+}
+
+resource "google_network_security_intercept_endpoint_group" "endpoint_group" {
+  provider                      = google-beta
+  intercept_endpoint_group_id   = "{{index $.Vars "endpoint_group_id"}}"
+  location                      = "global"
+  intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
+}
+
+resource "google_network_security_intercept_endpoint_group_association" "{{$.PrimaryResourceId}}" {
+  provider                                = google-beta
+  intercept_endpoint_group_association_id = "{{index $.Vars "endpoint_group_association_id"}}"
+  location                                = "global"
+  network                                 = google_compute_network.consumer_network.id
+  intercept_endpoint_group                = google_network_security_intercept_endpoint_group.endpoint_group.id
+  labels = {
+    foo = "bar"
+  }
+}

--- a/mmv1/templates/terraform/examples/network_security_intercept_endpoint_group_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_endpoint_group_basic.tf.tmpl
@@ -1,0 +1,22 @@
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "{{index $.Vars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+}
+
+resource "google_network_security_intercept_endpoint_group" "{{$.PrimaryResourceId}}" {
+  provider                      = google-beta
+  intercept_endpoint_group_id   = "{{index $.Vars "endpoint_group_id"}}"
+  location                      = "global"
+  intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
+  labels = {
+    foo = "bar"
+  }
+}

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_deployment_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_deployment_generated_test.go.tmpl
@@ -1,0 +1,183 @@
+package networksecurity_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccNetworkSecurityInterceptDeployment_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkSecurityInterceptDeployment_basic(context),
+			},
+			{
+				ResourceName:            "google_network_security_intercept_deployment.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccNetworkSecurityInterceptDeployment_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_network_security_intercept_deployment.default", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_network_security_intercept_deployment.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"update_time", "labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccNetworkSecurityInterceptDeployment_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "tf-test-example-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  provider      = google-beta
+  name          = "tf-test-example-subnet%{random_suffix}"
+  region        = "us-central1"
+  ip_cidr_range = "10.1.0.0/16"
+  network       = google_compute_network.network.name
+}
+
+resource "google_compute_region_health_check" "health_check" {
+  provider = google-beta
+  name     = "tf-test-example-hc%{random_suffix}"
+  region   = "us-central1"
+  http_health_check {
+    port = 80
+  }
+}
+
+resource "google_compute_region_backend_service" "backend_service" {
+  provider              = google-beta
+  name                  = "tf-test-example-bs%{random_suffix}"
+  region                = "us-central1"
+  health_checks         = [google_compute_region_health_check.health_check.id]
+  protocol              = "UDP"
+  load_balancing_scheme = "INTERNAL"
+}
+
+resource "google_compute_forwarding_rule" "forwarding_rule" {
+  provider               = google-beta
+  name                   = "tf-test-example-fwr%{random_suffix}"
+  region                 = "us-central1"
+  network                = google_compute_network.network.name
+  subnetwork             = google_compute_subnetwork.subnetwork.name
+  backend_service        = google_compute_region_backend_service.backend_service.id
+  load_balancing_scheme  = "INTERNAL"
+  ports                  = [6081]
+  ip_protocol            = "UDP"
+}
+
+resource "google_network_security_intercept_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+}
+
+resource "google_network_security_intercept_deployment" "default" {
+  provider                   = google-beta
+  intercept_deployment_id    = "tf-test-example-deployment%{random_suffix}"
+  location                   = "us-central1-a"
+  forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id
+  intercept_deployment_group = google_network_security_intercept_deployment_group.deployment_group.id
+  labels = {
+    foo = "bar"
+  }
+}
+`, context)
+}
+
+func testAccNetworkSecurityInterceptDeployment_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "tf-test-example-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  provider      = google-beta
+  name          = "tf-test-example-subnet%{random_suffix}"
+  region        = "us-central1"
+  ip_cidr_range = "10.1.0.0/16"
+  network       = google_compute_network.network.name
+}
+
+resource "google_compute_region_health_check" "health_check" {
+  provider = google-beta
+  name     = "tf-test-example-hc%{random_suffix}"
+  region   = "us-central1"
+  http_health_check {
+    port = 80
+  }
+}
+
+resource "google_compute_region_backend_service" "backend_service" {
+  provider              = google-beta
+  name                  = "tf-test-example-bs%{random_suffix}"
+  region                = "us-central1"
+  health_checks         = [google_compute_region_health_check.health_check.id]
+  protocol              = "UDP"
+  load_balancing_scheme = "INTERNAL"
+}
+
+resource "google_compute_forwarding_rule" "forwarding_rule" {
+  provider               = google-beta
+  name                   = "tf-test-example-fwr%{random_suffix}"
+  region                 = "us-central1"
+  network                = google_compute_network.network.name
+  subnetwork             = google_compute_subnetwork.subnetwork.name
+  backend_service        = google_compute_region_backend_service.backend_service.id
+  load_balancing_scheme  = "INTERNAL"
+  ports                  = [6081]
+  ip_protocol            = "UDP"
+}
+
+resource "google_network_security_intercept_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+}
+
+resource "google_network_security_intercept_deployment" "default" {
+  provider                   = google-beta
+  intercept_deployment_id    = "tf-test-example-deployment%{random_suffix}"
+  location                   = "us-central1-a"
+  forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id
+  intercept_deployment_group = google_network_security_intercept_deployment_group.deployment_group.id
+  labels = {
+    foo = "goo"
+  }
+}
+`, context)
+}
+
+{{ end }}

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_deployment_group_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_deployment_group_generated_test.go.tmpl
@@ -1,0 +1,91 @@
+package networksecurity_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccNetworkSecurityInterceptDeploymentGroup_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkSecurityInterceptDeploymentGroup_basic(context),
+			},
+			{
+				ResourceName:            "google_network_security_intercept_deployment_group.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccNetworkSecurityInterceptDeploymentGroup_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_network_security_intercept_deployment_group.default", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_network_security_intercept_deployment_group.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"update_time", "labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccNetworkSecurityInterceptDeploymentGroup_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "tf-test-example-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "default" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+  labels = {
+    foo = "bar"
+  }
+}
+`, context)
+}
+
+func testAccNetworkSecurityInterceptDeploymentGroup_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "tf-test-example-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "default" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+  labels = {
+    foo = "goo"
+  }
+}
+`, context)
+}
+
+{{ end }}

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_endpoint_group_association_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_endpoint_group_association_generated_test.go.tmpl
@@ -1,0 +1,133 @@
+package networksecurity_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccNetworkSecurityInterceptEndpointGroupAssociation_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkSecurityInterceptEndpointGroupAssociation_basic(context),
+			},
+			{
+				ResourceName:            "google_network_security_intercept_endpoint_group_association.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccNetworkSecurityInterceptEndpointGroupAssociation_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_network_security_intercept_endpoint_group_association.default", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_network_security_intercept_endpoint_group_association.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"update_time", "labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccNetworkSecurityInterceptEndpointGroupAssociation_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "producer_network" {
+  provider                = google-beta
+  name                    = "tf-test-example-prod-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_network" "consumer_network" {
+  provider                = google-beta
+  name                    = "tf-test-example-cons-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.producer_network.id
+}
+
+resource "google_network_security_intercept_endpoint_group" "endpoint_group" {
+  provider                      = google-beta
+  intercept_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
+  location                      = "global"
+  intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
+}
+
+resource "google_network_security_intercept_endpoint_group_association" "default" {
+  provider                                = google-beta
+  intercept_endpoint_group_association_id = "tf-test-example-ega%{random_suffix}"
+  location                                = "global"
+  network                                 = google_compute_network.consumer_network.id
+  intercept_endpoint_group                = google_network_security_intercept_endpoint_group.endpoint_group.id
+  labels = {
+    foo = "bar"
+  }
+}
+`, context)
+}
+
+func testAccNetworkSecurityInterceptEndpointGroupAssociation_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "producer_network" {
+  provider                = google-beta
+  name                    = "tf-test-example-prod-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_network" "consumer_network" {
+  provider                = google-beta
+  name                    = "tf-test-example-cons-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.producer_network.id
+}
+
+resource "google_network_security_intercept_endpoint_group" "endpoint_group" {
+  provider                      = google-beta
+  intercept_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
+  location                      = "global"
+  intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
+}
+
+resource "google_network_security_intercept_endpoint_group_association" "default" {
+  provider                                = google-beta
+  intercept_endpoint_group_association_id = "tf-test-example-ega%{random_suffix}"
+  location                                = "global"
+  network                                 = google_compute_network.consumer_network.id
+  intercept_endpoint_group                = google_network_security_intercept_endpoint_group.endpoint_group.id
+  labels = {
+    foo = "goo"
+  }
+}
+`, context)
+}
+
+{{ end }}

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_endpoint_group_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_endpoint_group_generated_test.go.tmpl
@@ -1,0 +1,105 @@
+package networksecurity_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccNetworkSecurityInterceptEndpointGroup_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkSecurityInterceptEndpointGroup_basic(context),
+			},
+			{
+				ResourceName:            "google_network_security_intercept_endpoint_group.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccNetworkSecurityInterceptEndpointGroup_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_network_security_intercept_endpoint_group.default", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_network_security_intercept_endpoint_group.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"update_time", "labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccNetworkSecurityInterceptEndpointGroup_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "tf-test-example-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+}
+
+resource "google_network_security_intercept_endpoint_group" "default" {
+  provider                      = google-beta
+  intercept_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
+  location                      = "global"
+  intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
+  labels = {
+    foo = "bar"
+  }
+}
+`, context)
+}
+
+func testAccNetworkSecurityInterceptEndpointGroup_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "tf-test-example-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+}
+
+resource "google_network_security_intercept_endpoint_group" "default" {
+  provider                      = google-beta
+  intercept_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
+  location                      = "global"
+  intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
+  labels = {
+    foo = "goo"
+  }
+}
+`, context)
+}
+
+{{ end }}


### PR DESCRIPTION
This PR is a promotion from google-private provider.
Removal CL: https://cloud-internal-review.git.corp.google.com/c/cloud-graphite-eng/magic-modules-private-overrides/+/49230

All Intercept resources are bundled together in one PR because they're dependent on one another and cannot be tested separately.

```release-note:new-resource
`google_network_security_intercept_deployment`, `google_network_security_intercept_deployment_group`, `google_network_security_intercept_endpoint_group_association`, `google_network_security_intercept_endpoint_group`
```