### PR TITLE
TF: plan -refresh=false for google_compute_ha_vpn_gateway with gcs backend has resource replacement

### DIFF
--- a/mmv1/products/compute/HaVpnGateway.yaml
+++ b/mmv1/products/compute/HaVpnGateway.yaml
@@ -140,7 +140,6 @@ properties:
     description: |
       The IP family of the gateway IPs for the HA-VPN gateway interfaces. If not specified, IPV4 will be used.
     immutable: true
-    custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.tmpl'
     default_value: "IPV4"
     enum_values:
       - 'IPV4'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.tmpl
@@ -449,7 +449,7 @@ func resourceComputeRouterBgpPeerCreate(d *schema.ResourceData, meta interface{}
 	customLearnedRoutePriorityProp, err := expandNestedComputeRouterBgpPeerCustomLearnedRoutePriority(d.Get("custom_learned_route_priority"), d, config)
 	if err != nil {
 		return err
-	} else if v, ok := d.GetOkExists("custom_learned_route_priority"); ok || !reflect.DeepEqual(v, customLearnedRoutePriorityProp) {
+	} else if v, ok := d.GetOk("custom_learned_route_priority"); ok || !reflect.DeepEqual(v, customLearnedRoutePriorityProp) {
 		obj["customLearnedRoutePriority"] =customLearnedRoutePriorityProp
 	}
 	bfdProp, err := expandNestedComputeRouterBgpPeerBfd(d.Get("bfd"), d, config)
@@ -802,7 +802,7 @@ func resourceComputeRouterBgpPeerUpdate(d *schema.ResourceData, meta interface{}
 	customLearnedRoutePriorityProp, err := expandNestedComputeRouterBgpPeerCustomLearnedRoutePriority(d.Get("custom_learned_route_priority"), d, config)
 	if err != nil {
 		return err
-	} else if v, ok := d.GetOkExists("custom_learned_route_priority"); ok || !reflect.DeepEqual(v, customLearnedRoutePriorityProp) {
+	} else if v, ok := d.GetOk("custom_learned_route_priority"); ok || !reflect.DeepEqual(v, customLearnedRoutePriorityProp) {
 		obj["customLearnedRoutePriority"] = customLearnedRoutePriorityProp
 	}
 	bfdProp, err := expandNestedComputeRouterBgpPeerBfd(d.Get("bfd"), d, config)


### PR DESCRIPTION
Bug: b/376368181
Issue: TF: plan -refresh=false for google_compute_ha_vpn_gateway with gcs backend has resource replacement

This particular change is the main culprit of this issue https://screenshot.googleplex.com/79xwUXBEcc5SYAg.
Looks like this issue start occurring from the release v5.40.0 https://screenshot.googleplex.com/367U6wou3dHnzaJ.

Open Issue Link https://github.com/hashicorp/terraform-provider-google/issues/19978

***Release Note Template for Downstream PRs (will be copied)***
```
Fixed  TF: plan -refresh=false for google_compute_ha_vpn_gateway with gcs backend has resource replacement

```