### PR TITLE
TF: plan -refresh=false for google_compute_ha_vpn_gateway with gcs backend has resource replacement

### DIFF
--- a/mmv1/products/compute/HaVpnGateway.yaml
+++ b/mmv1/products/compute/HaVpnGateway.yaml
@@ -140,7 +140,6 @@ properties:
     description: |
       The IP family of the gateway IPs for the HA-VPN gateway interfaces. If not specified, IPV4 will be used.
     immutable: true
-    custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.tmpl'
     default_value: "IPV4"
     enum_values:
       - 'IPV4'

--- a/mmv1/products/compute/HaVpnGateway.yaml
+++ b/mmv1/products/compute/HaVpnGateway.yaml
@@ -48,6 +48,8 @@ async:
     message: 'message'
 collection_url_key: 'items'
 custom_code:
+schema_version: 1
+state_upgraders: true
 examples:
   - name: 'ha_vpn_gateway_basic'
     primary_resource_id: 'ha_gateway1'
@@ -140,6 +142,7 @@ properties:
     description: |
       The IP family of the gateway IPs for the HA-VPN gateway interfaces. If not specified, IPV4 will be used.
     immutable: true
+    custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.tmpl'
     default_value: "IPV4"
     enum_values:
       - 'IPV4'

--- a/mmv1/templates/terraform/state_migrations/compute_ha_vpn_gateway.go.tmpl
+++ b/mmv1/templates/terraform/state_migrations/compute_ha_vpn_gateway.go.tmpl
@@ -1,0 +1,107 @@
+func resourceComputeHaVpnGatewayResourceV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidateGCEName,
+				Description: `Name of the resource. Provided by the client when the resource is
+created. The name must be 1-63 characters long, and comply with
+RFC1035.  Specifically, the name must be 1-63 characters long and
+match the regular expression '[a-z]([-a-z0-9]*[a-z0-9])?' which means
+the first character must be a lowercase letter, and all following
+characters must be a dash, lowercase letter, or digit, except the last
+character, which cannot be a dash.`,
+			},
+			"network": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName,
+				Description:      `The network this VPN gateway is accepting traffic for.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `An optional description of this resource.`,
+			},
+			"gateway_ip_version": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidateEnum([]string{"IPV4", "IPV6", ""}),
+				Description:  `The IP family of the gateway IPs for the HA-VPN gateway interfaces. If not specified, IPV4 will be used. Default value: "IPV4" Possible values: ["IPV4", "IPV6"]`,
+				Default:      "IPV4",
+			},
+			"region": {
+				Type:             schema.TypeString,
+				Computed:         true,
+				Optional:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName,
+				Description:      `The region this gateway should sit in.`,
+			},
+			"stack_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: verify.ValidateEnum([]string{"IPV4_ONLY", "IPV4_IPV6", "IPV6_ONLY", ""}),
+				Description: `The stack type for this VPN gateway to identify the IP protocols that are enabled.
+If not specified, IPV4_ONLY will be used. Default value: "IPV4_ONLY" Possible values: ["IPV4_ONLY", "IPV4_IPV6", "IPV6_ONLY"]`,
+				Default: "IPV4_ONLY",
+			},
+			"vpn_interfaces": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `A list of interfaces on this VPN gateway.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `The numeric ID of this VPN gateway interface.`,
+						},
+						"interconnect_attachment": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							ForceNew:         true,
+							DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName,
+							Description: `URL of the interconnect attachment resource. When the value
+of this field is present, the VPN Gateway will be used for
+IPsec-encrypted Cloud Interconnect; all Egress or Ingress
+traffic for this VPN Gateway interface will go through the
+specified interconnect attachment resource.
+
+Not currently available publicly.`,
+						},
+						"ip_address": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The external IP address for this VPN gateway interface.`,
+						},
+					},
+				},
+			},
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"self_link": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+		UseJSONNumber: true,
+	}
+}
+
+func ResourceComputeHaVpnGatewayUpgradeV0(_ context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	return tpgresource.TerraformLabelsStateUpgrade(rawState)
+}

--- a/mmv1/templates/terraform/state_migrations/compute_ha_vpn_gateway.go.tmpl
+++ b/mmv1/templates/terraform/state_migrations/compute_ha_vpn_gateway.go.tmpl
@@ -103,5 +103,17 @@ Not currently available publicly.`,
 }
 
 func ResourceComputeHaVpnGatewayUpgradeV0(_ context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	return tpgresource.TerraformLabelsStateUpgrade(rawState)
+    log.Printf("[DEBUG] Attributes before migration: %#v", rawState)
+
+
+    // Check if "gateway_ip_version" already exists
+    if _, ok := rawState["gateway_ip_version"]; !ok {
+        // Add the missing attribute with the default value
+        rawState["gateway_ip_version"] = "IPV4" 
+    } else {
+        log.Printf("[DEBUG] 'gateway_ip_version' already exists: %#v", rawState["gateway_ip_version"])
+    }
+
+    log.Printf("[DEBUG] Attributes after migration: %#v", rawState)
+    return rawState, nil 
 }


### PR DESCRIPTION
Bug: b/376368181
Issue: https://github.com/hashicorp/terraform-provider-google/issues/19978
This particular change is the main culprit of this issue https://screenshot.googleplex.com/79xwUXBEcc5SYAg.
Looks like this issue start occurring from the release v5.40.0 https://screenshot.googleplex.com/367U6wou3dHnzaJ.


**Release Note Template for Downstream PRs (will be copied)**
```release-note:enhancement
bug: fixed an issue where `terraform plan -refresh=false` with `google_compute_ha_vpn_gateway.gateway_ip_version` would plan a resource replacement if a full refresh had not been run yet. Terraform now assumes that the value is the default value, `IPV4`, until a refresh is completed.
```