### PR TITLE
add the healthcare_fhir enum value to the industry vertical property in the discovery engine search engine

### DIFF
--- a/mmv1/products/discoveryengine/SearchEngine.yaml
+++ b/mmv1/products/discoveryengine/SearchEngine.yaml
@@ -89,6 +89,7 @@ properties:
     enum_values:
       - 'GENERIC'
       - 'MEDIA'
+      - 'HEALTHCARE_FHIR'
   - name: 'displayName'
     type: String
     description: |


### PR DESCRIPTION
The industry vertical value is supported by the discovery engine data store.
When setting up a search engine with a data store, the value of industry vertical
has to be the same in both the store and the engine.
With this change, it allows users to create a search engine of the healthcare fhir industry vertical.

This can already be done in the UI today, but has not been possible with terraform otherwise.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/20467

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**
```release-note:enhancement
discoveryengine: added `HEALTHCARE_FHIR` to `industry_vertical` field in `google_discovery_engine_search_engine`
```
