### PR TITLE
Update the reviewer bot to notify based on draft reopen time in addition to event time

### DIFF
--- a/.ci/magician/cmd/scheduled_pr_reminders.go
+++ b/.ci/magician/cmd/scheduled_pr_reminders.go
@@ -267,29 +267,20 @@ func (s pullRequestReviewState) String() string {
 // We don't specially handle cases where the contributor has "acted" because it would be
 // significant additional effort, and this case is already handled by re-requesting review
 // automatically based on contributor actions.
-func notificationState(pr *github.PullRequest, issueEvents []*github.IssueEvent, reviews []*github.PullRequestReview) (pullRequestReviewState, time.Time, error) {
-	slices.SortFunc(issueEvents, func(a, b *github.IssueEvent) int {
-		if a.CreatedAt.Before(*b.CreatedAt.GetTime()) {
-			return 1
+func notificationState(pr *github.PullRequest, issueEventsDesc []*github.IssueEvent, reviewsDesc []*github.PullRequestReview) (pullRequestReviewState, time.Time, error) {
+	issueEventsDesc = sortedEventsDesc(issueEventsDesc)
+	reviewsDesc = sortedReviewsDesc(reviewsDesc)
+
+	var readyForReviewTime = *pr.CreatedAt.GetTime()
+	for _, event := range issueEventsDesc {
+		if "ready_for_review" == *event.Event {
+			readyForReviewTime = maxTime(*event.CreatedAt.GetTime(), readyForReviewTime)
 		}
-		if a.CreatedAt.After(*b.CreatedAt.GetTime()) {
-			return -1
-		}
-		return 0
-	})
-	slices.SortFunc(reviews, func(a, b *github.PullRequestReview) int {
-		if a.SubmittedAt.Before(*b.SubmittedAt.GetTime()) {
-			return 1
-		}
-		if a.SubmittedAt.After(*b.SubmittedAt.GetTime()) {
-			return -1
-		}
-		return 0
-	})
+	}
 
 	var latestReviewRequest *github.IssueEvent
 	removedRequests := map[string]struct{}{}
-	for _, event := range issueEvents {
+	for _, event := range issueEventsDesc {
 		if *event.Event == "review_request_removed" && event.RequestedReviewer != nil {
 			removedRequests[*event.RequestedReviewer.Login] = struct{}{}
 			continue
@@ -320,7 +311,7 @@ func notificationState(pr *github.PullRequest, issueEvents []*github.IssueEvent,
 	var earliestCommented *github.PullRequestReview
 
 	ignoreBy := map[string]struct{}{}
-	for _, review := range reviews {
+	for _, review := range reviewsDesc {
 		if review.SubmittedAt.Before(*latestReviewRequest.CreatedAt.GetTime()) {
 			break
 		}
@@ -355,15 +346,59 @@ func notificationState(pr *github.PullRequest, issueEvents []*github.IssueEvent,
 	}
 
 	if earliestChangesRequested != nil {
-		return waitingForContributor, *earliestChangesRequested.SubmittedAt.GetTime(), nil
+		timeState := maxTime(*earliestChangesRequested.SubmittedAt.GetTime(), readyForReviewTime)
+		return waitingForContributor, timeState, nil
 	}
 	if earliestApproved != nil {
-		return waitingForMerge, *earliestApproved.SubmittedAt.GetTime(), nil
+		timeState := maxTime(*earliestApproved.SubmittedAt.GetTime(), readyForReviewTime)
+		return waitingForMerge, timeState, nil
 	}
 	if earliestCommented != nil {
-		return waitingForContributor, *earliestCommented.SubmittedAt.GetTime(), nil
+		timeState := maxTime(*earliestCommented.SubmittedAt.GetTime(), readyForReviewTime)
+		return waitingForContributor, timeState, nil
 	}
-	return waitingForReview, *latestReviewRequest.CreatedAt.GetTime(), nil
+	timeState := maxTime(*latestReviewRequest.CreatedAt.GetTime(), readyForReviewTime)
+	return waitingForReview, timeState, nil
+}
+
+// compareTimeDesc returns sort ordering for descending time comparison (newest first)
+func compareTimeDesc(a, b time.Time) int {
+	if a.Before(b) {
+		return 1
+	}
+	if a.After(b) {
+		return -1
+	}
+	return 0
+}
+
+// sortedEventsDesc returns events sorted by creation time, newest first
+func sortedEventsDesc(events []*github.IssueEvent) []*github.IssueEvent {
+	sortedEvents := make([]*github.IssueEvent, len(events))
+	copy(sortedEvents, events)
+	slices.SortFunc(sortedEvents, func(a, b *github.IssueEvent) int {
+		return compareTimeDesc(*a.CreatedAt.GetTime(), *b.CreatedAt.GetTime())
+	})
+	return sortedEvents
+}
+
+// sortedReviewsDesc returns reviews sorted by submission time, newest first
+func sortedReviewsDesc(reviews []*github.PullRequestReview) []*github.PullRequestReview {
+	sortedReviews := make([]*github.PullRequestReview, len(reviews))
+	copy(sortedReviews, reviews)
+	slices.SortFunc(sortedReviews, func(a, b *github.PullRequestReview) int {
+		return compareTimeDesc(*a.SubmittedAt.GetTime(), *b.SubmittedAt.GetTime())
+	})
+	return sortedReviews
+}
+
+// maxTime - returns whichever time occured after the other
+func maxTime(time1, time2 time.Time) time.Time {
+	// Return the later time
+	if time1.After(time2) {
+		return time1
+	}
+	return time2
 }
 
 // Calculates the number of PDT days between from and to (by calendar date, not # of hours).

--- a/.ci/magician/cmd/scheduled_pr_reminders.go
+++ b/.ci/magician/cmd/scheduled_pr_reminders.go
@@ -311,7 +311,6 @@ func notificationState(pr *github.PullRequest, issueEventsDesc []*github.IssueEv
 	var earliestCommented *github.PullRequestReview
 
 	ignoreBy := map[string]struct{}{}
-	dismissedReviewer := map[string]struct{}{}
 	for _, review := range reviewsDesc {
 		if review.SubmittedAt.Before(*latestReviewRequest.CreatedAt.GetTime()) {
 			break
@@ -332,16 +331,12 @@ func notificationState(pr *github.PullRequest, issueEventsDesc []*github.IssueEv
 		switch *review.State {
 		case "DISMISSED":
 			// ignore dismissed reviews
-			dismissedReviewer[reviewer] = struct{}{}
 			continue
 		case "APPROVED":
 			earliestApproved = review
 			// ignore all earlier reviews from this reviewer
 			ignoreBy[reviewer] = struct{}{}
 		case "CHANGES_REQUESTED":
-			if _, ok := dismissedReviewer[reviewer]; ok {
-				continue
-			}
 			earliestChangesRequested = review
 			// ignore all earlier reviews from this reviewer
 			ignoreBy[reviewer] = struct{}{}

--- a/.ci/magician/cmd/scheduled_pr_reminders.go
+++ b/.ci/magician/cmd/scheduled_pr_reminders.go
@@ -311,6 +311,7 @@ func notificationState(pr *github.PullRequest, issueEventsDesc []*github.IssueEv
 	var earliestCommented *github.PullRequestReview
 
 	ignoreBy := map[string]struct{}{}
+	dismissedReviewer := map[string]struct{}{}
 	for _, review := range reviewsDesc {
 		if review.SubmittedAt.Before(*latestReviewRequest.CreatedAt.GetTime()) {
 			break
@@ -331,12 +332,16 @@ func notificationState(pr *github.PullRequest, issueEventsDesc []*github.IssueEv
 		switch *review.State {
 		case "DISMISSED":
 			// ignore dismissed reviews
+			dismissedReviewer[reviewer] = struct{}{}
 			continue
 		case "APPROVED":
 			earliestApproved = review
 			// ignore all earlier reviews from this reviewer
 			ignoreBy[reviewer] = struct{}{}
 		case "CHANGES_REQUESTED":
+			if _, ok := dismissedReviewer[reviewer]; ok {
+				continue
+			}
 			earliestChangesRequested = review
 			// ignore all earlier reviews from this reviewer
 			ignoreBy[reviewer] = struct{}{}

--- a/.ci/magician/cmd/scheduled_pr_reminders_test.go
+++ b/.ci/magician/cmd/scheduled_pr_reminders_test.go
@@ -442,6 +442,183 @@ func TestNotificationState(t *testing.T) {
 			expectState: waitingForMerge,
 			expectSince: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC),
 		},
+		"ready_for_review event after creation": {
+			pullRequest: &github.PullRequest{
+				User:      &github.User{Login: github.String("author")},
+				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+			},
+			issueEvents: []*github.IssueEvent{
+				&github.IssueEvent{
+					Event:             github.String("review_requested"),
+					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
+					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+				},
+				&github.IssueEvent{
+					Event:     github.String("ready_for_review"),
+					CreatedAt: &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
+				},
+			},
+			expectState: waitingForReview,
+			expectSince: time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC),
+		},
+
+		"ready_for_review event before review request": {
+			pullRequest: &github.PullRequest{
+				User:      &github.User{Login: github.String("author")},
+				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+			},
+			issueEvents: []*github.IssueEvent{
+				&github.IssueEvent{
+					Event:     github.String("ready_for_review"),
+					CreatedAt: &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
+				},
+				&github.IssueEvent{
+					Event:             github.String("review_requested"),
+					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
+					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+				},
+			},
+			expectState: waitingForReview,
+			expectSince: time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC),
+		},
+
+		"review after ready_for_review": {
+			pullRequest: &github.PullRequest{
+				User:      &github.User{Login: github.String("author")},
+				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+			},
+			issueEvents: []*github.IssueEvent{
+				&github.IssueEvent{
+					Event:     github.String("ready_for_review"),
+					CreatedAt: &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
+				},
+				&github.IssueEvent{
+					Event:             github.String("review_requested"),
+					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
+					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+				},
+			},
+			reviews: []*github.PullRequestReview{
+				&github.PullRequestReview{
+					User:        &github.User{Login: github.String(firstCoreReviewer)},
+					State:       github.String("APPROVED"),
+					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 4, 0, 0, 0, 0, time.UTC)},
+				},
+			},
+			expectState: waitingForMerge,
+			expectSince: time.Date(2024, 1, 4, 0, 0, 0, 0, time.UTC),
+		},
+		"changes_requested after ready_for_review": {
+			pullRequest: &github.PullRequest{
+				User:      &github.User{Login: github.String("author")},
+				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+			},
+			issueEvents: []*github.IssueEvent{
+				&github.IssueEvent{
+					Event:     github.String("ready_for_review"),
+					CreatedAt: &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
+				},
+				&github.IssueEvent{
+					Event:             github.String("review_requested"),
+					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)}, // Earlier request
+					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+				},
+			},
+			reviews: []*github.PullRequestReview{
+				&github.PullRequestReview{
+					User:        &github.User{Login: github.String(firstCoreReviewer)},
+					State:       github.String("CHANGES_REQUESTED"),
+					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)}, // Early changes requested
+				},
+			},
+			expectState: waitingForContributor,
+			expectSince: time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC), // Should use ready_for_review time
+		},
+
+		"changes_requested before ready_for_review": {
+			pullRequest: &github.PullRequest{
+				User:      &github.User{Login: github.String("author")},
+				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+			},
+			issueEvents: []*github.IssueEvent{
+				&github.IssueEvent{
+					Event:             github.String("review_requested"),
+					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
+					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+				},
+				&github.IssueEvent{
+					Event:     github.String("ready_for_review"),
+					CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)}, // Earlier ready
+				},
+			},
+			reviews: []*github.PullRequestReview{
+				&github.PullRequestReview{
+					User:        &github.User{Login: github.String(firstCoreReviewer)},
+					State:       github.String("CHANGES_REQUESTED"),
+					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
+				},
+			},
+			expectState: waitingForContributor,
+			expectSince: time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC), // Should use changes requested time since it's later
+		},
+
+		"comment review after ready_for_review": {
+			pullRequest: &github.PullRequest{
+				User:      &github.User{Login: github.String("author")},
+				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+			},
+			issueEvents: []*github.IssueEvent{
+				&github.IssueEvent{
+					Event:     github.String("ready_for_review"),
+					CreatedAt: &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
+				},
+				&github.IssueEvent{
+					Event:             github.String("review_requested"),
+					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
+					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+				},
+			},
+			reviews: []*github.PullRequestReview{
+				&github.PullRequestReview{
+					User:        &github.User{Login: github.String(firstCoreReviewer)},
+					State:       github.String("COMMENTED"),
+					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
+				},
+			},
+			expectState: waitingForContributor,
+			expectSince: time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC), // Should use ready_for_review time
+		},
+
+		"multiple ready_for_review events": {
+			pullRequest: &github.PullRequest{
+				User:      &github.User{Login: github.String("author")},
+				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+			},
+			issueEvents: []*github.IssueEvent{
+				&github.IssueEvent{
+					Event:     github.String("ready_for_review"),
+					CreatedAt: &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
+				},
+				&github.IssueEvent{
+					Event:             github.String("review_requested"),
+					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
+					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+				},
+				&github.IssueEvent{
+					Event:     github.String("ready_for_review"),
+					CreatedAt: &github.Timestamp{time.Date(2024, 1, 4, 0, 0, 0, 0, time.UTC)}, // Later ready_for_review
+				},
+			},
+			reviews: []*github.PullRequestReview{
+				&github.PullRequestReview{
+					User:        &github.User{Login: github.String(firstCoreReviewer)},
+					State:       github.String("CHANGES_REQUESTED"),
+					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 4, 0, 0, 0, 0, time.UTC)},
+				},
+			},
+			expectState: waitingForContributor,
+			expectSince: time.Date(2024, 1, 4, 0, 0, 0, 0, time.UTC), // Should use latest ready_for_review time
+		},
 	}
 
 	for tn, tc := range cases {

--- a/.ci/magician/cmd/scheduled_pr_reminders_test.go
+++ b/.ci/magician/cmd/scheduled_pr_reminders_test.go
@@ -619,46 +619,6 @@ func TestNotificationState(t *testing.T) {
 			expectState: waitingForContributor,
 			expectSince: time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC), // Should use latest ready_for_review time
 		},
-		"if reviewer dismissed, should ignore earlier review": {
-			pullRequest: &github.PullRequest{
-				User:      &github.User{Login: github.String("author")},
-				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
-			},
-			issueEvents: []*github.IssueEvent{
-				&github.IssueEvent{
-					Event:     github.String("ready_for_review"),
-					CreatedAt: &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
-				},
-				&github.IssueEvent{
-					Event:             github.String("review_requested"),
-					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
-				},
-				&github.IssueEvent{
-					Event:     github.String("ready_for_review"),
-					CreatedAt: &github.Timestamp{time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC)}, // Later ready_for_review
-				},
-			},
-			reviews: []*github.PullRequestReview{
-				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(firstCoreReviewer)},
-					State:       github.String("CHANGES_REQUESTED"),
-					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 6, 0, 0, 0, 0, time.UTC)},
-				},
-				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(firstCoreReviewer)},
-					State:       github.String("DISMISSED"),
-					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 7, 0, 0, 0, 0, time.UTC)},
-				},
-				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(secondCoreReviewer)},
-					State:       github.String("APPROVED"),
-					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 9, 0, 0, 0, 0, time.UTC)},
-				},
-			},
-			expectState: waitingForMerge,
-			expectSince: time.Date(2024, 1, 9, 0, 0, 0, 0, time.UTC), // Should use latest ready_for_review time
-		},
 	}
 
 	for tn, tc := range cases {

--- a/.ci/magician/cmd/scheduled_pr_reminders_test.go
+++ b/.ci/magician/cmd/scheduled_pr_reminders_test.go
@@ -619,6 +619,46 @@ func TestNotificationState(t *testing.T) {
 			expectState: waitingForContributor,
 			expectSince: time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC), // Should use latest ready_for_review time
 		},
+		"if reviewer dismissed, should ignore earlier review": {
+			pullRequest: &github.PullRequest{
+				User:      &github.User{Login: github.String("author")},
+				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
+			},
+			issueEvents: []*github.IssueEvent{
+				&github.IssueEvent{
+					Event:     github.String("ready_for_review"),
+					CreatedAt: &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
+				},
+				&github.IssueEvent{
+					Event:             github.String("review_requested"),
+					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
+					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+				},
+				&github.IssueEvent{
+					Event:     github.String("ready_for_review"),
+					CreatedAt: &github.Timestamp{time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC)}, // Later ready_for_review
+				},
+			},
+			reviews: []*github.PullRequestReview{
+				&github.PullRequestReview{
+					User:        &github.User{Login: github.String(firstCoreReviewer)},
+					State:       github.String("CHANGES_REQUESTED"),
+					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 6, 0, 0, 0, 0, time.UTC)},
+				},
+				&github.PullRequestReview{
+					User:        &github.User{Login: github.String(firstCoreReviewer)},
+					State:       github.String("DISMISSED"),
+					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 7, 0, 0, 0, 0, time.UTC)},
+				},
+				&github.PullRequestReview{
+					User:        &github.User{Login: github.String(secondCoreReviewer)},
+					State:       github.String("APPROVED"),
+					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 9, 0, 0, 0, 0, time.UTC)},
+				},
+			},
+			expectState: waitingForMerge,
+			expectSince: time.Date(2024, 1, 9, 0, 0, 0, 0, time.UTC), // Should use latest ready_for_review time
+		},
 	}
 
 	for tn, tc := range cases {

--- a/.ci/magician/cmd/scheduled_pr_reminders_test.go
+++ b/.ci/magician/cmd/scheduled_pr_reminders_test.go
@@ -515,24 +515,24 @@ func TestNotificationState(t *testing.T) {
 			},
 			issueEvents: []*github.IssueEvent{
 				&github.IssueEvent{
-					Event:     github.String("ready_for_review"),
-					CreatedAt: &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
+					Event:             github.String("review_requested"),
+					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)}, // Earlier request
+					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
 				},
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
-					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)}, // Earlier request
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					Event:     github.String("ready_for_review"),
+					CreatedAt: &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
 				},
 			},
 			reviews: []*github.PullRequestReview{
 				&github.PullRequestReview{
 					User:        &github.User{Login: github.String(firstCoreReviewer)},
 					State:       github.String("CHANGES_REQUESTED"),
-					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)}, // Early changes requested
+					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 4, 0, 0, 0, 0, time.UTC)}, // Early changes requested
 				},
 			},
 			expectState: waitingForContributor,
-			expectSince: time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC), // Should use ready_for_review time
+			expectSince: time.Date(2024, 1, 4, 0, 0, 0, 0, time.UTC), // Should use ready_for_review time
 		},
 
 		"changes_requested before ready_for_review": {
@@ -543,19 +543,19 @@ func TestNotificationState(t *testing.T) {
 			issueEvents: []*github.IssueEvent{
 				&github.IssueEvent{
 					Event:             github.String("review_requested"),
-					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
+					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
 				},
 				&github.IssueEvent{
 					Event:     github.String("ready_for_review"),
-					CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)}, // Earlier ready
+					CreatedAt: &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)}, // Earlier ready
 				},
 			},
 			reviews: []*github.PullRequestReview{
 				&github.PullRequestReview{
 					User:        &github.User{Login: github.String(firstCoreReviewer)},
 					State:       github.String("CHANGES_REQUESTED"),
-					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
+					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
 				},
 			},
 			expectState: waitingForContributor,
@@ -570,7 +570,7 @@ func TestNotificationState(t *testing.T) {
 			issueEvents: []*github.IssueEvent{
 				&github.IssueEvent{
 					Event:     github.String("ready_for_review"),
-					CreatedAt: &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
+					CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 				},
 				&github.IssueEvent{
 					Event:             github.String("review_requested"),
@@ -582,7 +582,7 @@ func TestNotificationState(t *testing.T) {
 				&github.PullRequestReview{
 					User:        &github.User{Login: github.String(firstCoreReviewer)},
 					State:       github.String("COMMENTED"),
-					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
+					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
 				},
 			},
 			expectState: waitingForContributor,
@@ -606,7 +606,7 @@ func TestNotificationState(t *testing.T) {
 				},
 				&github.IssueEvent{
 					Event:     github.String("ready_for_review"),
-					CreatedAt: &github.Timestamp{time.Date(2024, 1, 4, 0, 0, 0, 0, time.UTC)}, // Later ready_for_review
+					CreatedAt: &github.Timestamp{time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC)}, // Later ready_for_review
 				},
 			},
 			reviews: []*github.PullRequestReview{
@@ -617,7 +617,7 @@ func TestNotificationState(t *testing.T) {
 				},
 			},
 			expectState: waitingForContributor,
-			expectSince: time.Date(2024, 1, 4, 0, 0, 0, 0, time.UTC), // Should use latest ready_for_review time
+			expectSince: time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC), // Should use latest ready_for_review time
 		},
 	}
 


### PR DESCRIPTION
closes https://github.com/hashicorp/terraform-provider-google/issues/20142
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
