### PR TITLE
Change markdown links to use ref shortcodes from Hugo

### DIFF
--- a/docs/content/contribution-process.md
+++ b/docs/content/contribution-process.md
@@ -16,7 +16,7 @@ This page explains how you can contribute code and documentation to the	`magic-m
 
 1. Familiarize yourself with [GitHub flow](https://docs.github.com/en/get-started/quickstart/github-flow)
 1. [Fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) the `Magic Modules` repository into your GitHub account
-1. [Set up your development environment](https://googlecloudplatform.github.io/magic-modules/get-started/generate-providers/)
+1. [Set up your development environment]({{< ref "/develop/set-up-dev-environment/" >}})
 1. Check whether the feature you want to work on has already been [requested in the issue tracker](https://github.com/hashicorp/terraform-provider-google/issues).
    - If there's an issue and it already has a dedicated assignee, this indicates that someone might have already started to work on a solution. Otherwise, you're welcome to work on the issue.
 

--- a/docs/content/develop/diffs.md
+++ b/docs/content/develop/diffs.md
@@ -130,7 +130,7 @@ diff_suppress_func: 'tpgresource.CaseDiffSuppress'
 diff_suppress_func: 'resourceNameFieldNameDiffSuppress'
 ```
 
-Define resource-specific functions in a [`custom_code.constants`](https://googlecloudplatform.github.io/magic-modules/develop/custom-code/#add-reusable-variables-and-functions) file.
+Define resource-specific functions in a [`custom_code.constants`]({{< ref "/develop/custom-code/#add-reusable-variables-and-functions" >}}) file.
 
 ```go
 func resourceNameFieldNameDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {

--- a/docs/content/develop/field-reference.md
+++ b/docs/content/develop/field-reference.md
@@ -232,7 +232,7 @@ Example:
 
 ### `diff_suppress_func`
 Specifies the name of a [diff suppress function](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#diffsuppressfunc)
-to use for this field. In many cases, a [custom flattener](https://googlecloudplatform.github.io/magic-modules/develop/custom-code/#custom_flatten)
+to use for this field. In many cases, a [custom flattener]({{< ref "/develop/custom-code/#custom_flatten" >}})
 is preferred because it will allow the user to see a clearer diff when the field actually is being changed. See
 [Fix diffs]({{< ref "/develop/diffs" >}}) for more information and best practices.
 

--- a/docs/content/develop/resource-reference.md
+++ b/docs/content/develop/resource-reference.md
@@ -99,7 +99,7 @@ If true, the resource and all its fields are considered immutable - that is,
 only creatable, not updatable. Individual fields can override this if they
 have a custom update method in the API.
 
-See [Best practices: ForceNew]({{< ref "/best-practices/immutable-fields/" >}}) for more information.
+See [Best practices: Immutable fields]({{< ref "/best-practices/immutable-fields/" >}}) for more information.
 
 Default: `false`
 

--- a/docs/content/develop/resource-reference.md
+++ b/docs/content/develop/resource-reference.md
@@ -99,7 +99,7 @@ If true, the resource and all its fields are considered immutable - that is,
 only creatable, not updatable. Individual fields can override this if they
 have a custom update method in the API.
 
-See [Best practices: ForceNew](https://googlecloudplatform.github.io/magic-modules/best-practices/#forcenew) for more information.
+See [Best practices: ForceNew]({{< ref "/best-practices/immutable-fields/" >}}) for more information.
 
 Default: `false`
 

--- a/docs/content/reference/ruby-go-changes.md
+++ b/docs/content/reference/ruby-go-changes.md
@@ -83,7 +83,7 @@ resource "google_pubsub_topic" "{{$.PrimaryResourceId}}" {
 
 ## Advanced: MMv1-specific generator command
 
-Most contributors should use the make commands referenced in [make-commands](https://googlecloudplatform.github.io/magic-modules/reference/make-commands/) reference page to generate the downstream `google` and `google-beta` providers. The input for these commands have not changed, and have already been correctly switched over to use the new Go engine.
+Most contributors should use the make commands referenced in [make-commands]({{< ref "reference/make-commands/" >}}) reference page to generate the downstream `google` and `google-beta` providers. The input for these commands have not changed, and have already been correctly switched over to use the new Go engine.
 
 Some advanced contributors may be used to running the MMv1 generator commands. These commands have changed from Ruby's `bundle exec` to `go run`.
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/20407

This PR solves the broken link issue above and also replaces other hardcoded links to use ref shortcodes

```release-note:none

```
