### PR TITLE
Add enterprise_config field to GKE cluster object

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -2323,6 +2323,31 @@ func ResourceContainerCluster() *schema.Resource {
 					},
 				},
 				{{- end }}
+			"enterprise_config": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Computed:    true,
+				Description: `Defines the config needed to enable/disable GKE Enterprise`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cluster_tier": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							ValidateFunc:     validation.StringInSlice([]string{"STANDARD", "ENTERPRISE"}, false),
+							Description:      `Indicates the effective cluster tier. Available options include STANDARD and ENTERPRISE.`,
+							DiffSuppressFunc: tpgresource.EmptyOrDefaultStringSuppress("CLUSTER_TIER_UNSPECIFIED"),
+						},
+						"desired_tier": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							ValidateFunc:     validation.StringInSlice([]string{"STANDARD", "ENTERPRISE"}, false),
+							Description:      `Indicates the desired cluster tier. Available options include STANDARD and ENTERPRISE.`,
+							DiffSuppressFunc: tpgresource.EmptyOrDefaultStringSuppress("CLUSTER_TIER_UNSPECIFIED"),
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -2643,6 +2668,10 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 
 	if v, ok := d.GetOk("security_posture_config"); ok {
 		cluster.SecurityPostureConfig = expandSecurityPostureConfig(v)
+	}
+
+	if v, ok := d.GetOk("enterprise_config"); ok {
+		cluster.EnterpriseConfig = expandEnterpriseConfig(v)
 	}
 
   needUpdateAfterCreate := false
@@ -3207,6 +3236,10 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 {{- end }}
+
+	if err := d.Set("enterprise_config", flattenEnterpriseConfig(cluster.EnterpriseConfig)); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -4532,6 +4565,23 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		log.Printf("[INFO] GKE cluster %s node pool auto config linux_node_config parameters have been updated", d.Id())
 	}
 
+	if d.HasChange("enterprise_config") && d.HasChange("enterprise_config.0.desired_tier") {
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				DesiredEnterpriseConfig: &container.DesiredEnterpriseConfig{
+                         		DesiredTier: d.Get("enterprise_config.0.desired_tier").(string),
+                                },
+			},
+		}
+		updateF := updateFunc(req, "updating GKE cluster Enterprise Config")
+		// Call update serially.
+		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] GKE cluster %s Enterprise Config has been updated to %#v", d.Id(), req.Update.DesiredSecurityPostureConfig)
+	}
+
 	d.Partial(false)
 
 {{ if ne $.TargetVersionName `ga` -}}
@@ -5263,6 +5313,36 @@ func flattenSecurityPostureConfig(spc *container.SecurityPostureConfig) []map[st
 
 	result["mode"] = spc.Mode
 	result["vulnerability_mode"] = spc.VulnerabilityMode
+
+	return []map[string]interface{}{result}
+}
+
+func expandEnterpriseConfig(configured interface{}) *container.EnterpriseConfig {
+	l := configured.([]interface{})
+	if len(l) == 0 {
+		return nil
+	}
+
+	ec := &container.EnterpriseConfig{}
+	enterpriseConfig := l[0].(map[string]interface{})
+	if v, ok := enterpriseConfig["cluster_tier"]; ok {
+		ec.ClusterTier = v.(string)
+	}
+
+	if v, ok := enterpriseConfig["desired_tier"]; ok {
+		ec.DesiredTier = v.(string)
+	}
+	return ec
+}
+
+func flattenEnterpriseConfig(ec *container.Enterprise) []map[string]interface{} {
+	if ec == nil {
+		return nil
+	}
+	result := make(map[string]interface{})
+
+	result["cluster_tier"] = ec.ClusterTier
+	result["desired_tier"] = ec.DesiredTier
 
 	return []map[string]interface{}{result}
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -2333,14 +2333,13 @@ func ResourceContainerCluster() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"cluster_tier": {
 							Type:             schema.TypeString,
-							Optional:         true,
-							ValidateFunc:     validation.StringInSlice([]string{"STANDARD", "ENTERPRISE"}, false),
+							Computed:         true,
 							Description:      `Indicates the effective cluster tier. Available options include STANDARD and ENTERPRISE.`,
-							DiffSuppressFunc: tpgresource.EmptyOrDefaultStringSuppress("CLUSTER_TIER_UNSPECIFIED"),
 						},
 						"desired_tier": {
 							Type:             schema.TypeString,
 							Optional:         true,
+							Computed:         true,
 							ValidateFunc:     validation.StringInSlice([]string{"STANDARD", "ENTERPRISE"}, false),
 							Description:      `Indicates the desired cluster tier. Available options include STANDARD and ENTERPRISE.`,
 							DiffSuppressFunc: tpgresource.EmptyOrDefaultStringSuppress("CLUSTER_TIER_UNSPECIFIED"),
@@ -5335,7 +5334,7 @@ func expandEnterpriseConfig(configured interface{}) *container.EnterpriseConfig 
 	return ec
 }
 
-func flattenEnterpriseConfig(ec *container.Enterprise) []map[string]interface{} {
+func flattenEnterpriseConfig(ec *container.EnterpriseConfig) []map[string]interface{} {
 	if ec == nil {
 		return nil
 	}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -12834,6 +12834,15 @@ func TestAccContainerCluster_withEnterpriseConfig(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
+			{
+				Config: testAccContainerCluster_removeEnterpriseConfig(pid, clusterName, networkName, subnetworkName),
+			},
+			{
+				ResourceName:      "google_container_cluster.with_enterprise_config",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
 		},
 	})
 }
@@ -12841,21 +12850,39 @@ func TestAccContainerCluster_withEnterpriseConfig(t *testing.T) {
 func testAccContainerCluster_updateEnterpriseConfig(projectID, clusterName, networkName, subnetworkName string, desiredTier string) string {
         return fmt.Sprintf(`
 data "google_project" "project" {
-  project_id = "%s"             
-}                               
-                                
+  project_id = "%s"
+}
+
 resource "google_container_cluster" "with_enterprise_config" {
   name               = "%s"
   location           = "us-central1-a"
-  initial_node_count = 1        
-  enterprise_config {              
-    desired_tier = "%s"        
-  }                             
-  network    = "%s"             
-  subnetwork = "%s"             
-                                
+  initial_node_count = 1
+  enterprise_config {
+    desired_tier = "%s"
+  }
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
-}               
+}
 `, projectID, clusterName, desiredTier, networkName, subnetworkName)
+}
+
+func testAccContainerCluster_removeEnterpriseConfig(projectID, clusterName, networkName, subnetworkName string) string {
+        return fmt.Sprintf(`
+data "google_project" "project" {
+  project_id = "%s"
+}
+
+resource "google_container_cluster" "with_enterprise_config" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  network    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
+}
+`, projectID, clusterName, networkName, subnetworkName)
 }  
 

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -12802,3 +12802,60 @@ resource "google_container_cluster" "primary" {
 }
   `, name, cgroupMode)
 }
+
+func TestAccContainerCluster_withEnterpriseConfig(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+	pid := envvar.GetTestProjectFromEnv()
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_updateEnterpriseConfig(pid, clusterName, networkName, subnetworkName, "STANDARD"),
+			},
+			{
+				ResourceName:      "google_container_cluster.with_enterprise_config",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_updateEnterpriseConfig(pid, clusterName, networkName, subnetworkName, "ENTERPRISE"),
+			},
+			{
+				ResourceName:      "google_container_cluster.with_enterprise_config",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+func testAccContainerCluster_updateEnterpriseConfig(projectID, clusterName, networkName, subnetworkName string, desiredTier string) string {
+        return fmt.Sprintf(`
+data "google_project" "project" {
+  project_id = "%s"             
+}                               
+                                
+resource "google_container_cluster" "with_enterprise_config" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1        
+  enterprise_config {              
+    desired_tier = "%s"        
+  }                             
+  network    = "%s"             
+  subnetwork = "%s"             
+                                
+  deletion_protection = false
+}               
+`, projectID, clusterName, desiredTier, networkName, subnetworkName)
+}  
+

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1440,7 +1440,6 @@ linux_node_config {
 
 * `desired_tier` - (Optional) Sets the tier of the cluster. Available options include `STANDARD` and `ENTERPRISE`.
 
-* `cluster_tier` - (Output) Sets the tier of the cluster. Available options include `STANDARD` and `ENTERPRISE`.
 
 ## Attributes Reference
 
@@ -1490,6 +1489,8 @@ exported:
 * `fleet.0.membership_id` - The short name of the fleet membership, extracted from `fleet.0.membership`. You can use this field to configure `membership_id` under [google_gkehub_feature_membership](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/gke_hub_feature_membership).
 
 * `fleet.0.membership_location` - The location of the fleet membership,  extracted from `fleet.0.membership`. You can use this field to configure `membership_location` under [google_gkehub_feature_membership](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/gke_hub_feature_membership).
+
+* `enterprise_config.0.cluster_tier` - The effective tier of the cluster.
 
 ## Timeouts
 

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -404,6 +404,10 @@ Fleet configuration for the cluster. Structure is [documented below](#nested_fle
 * `workload_alts_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
   Configuration for [direct-path (via ALTS) with workload identity.](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#workloadaltsconfig). Structure is [documented below](#nested_workload_alts_config).
 
+* `enterprise_config` - (Optional)
+  Configuration for [Enterprise edition].(https://cloud.google.com/kubernetes-engine/enterprise/docs/concepts/gke-editions). Structure is [documented below](#nested_enterprise_config).
+
+
 <a name="nested_default_snat_status"></a>The `default_snat_status` block supports
 
 *  `disabled` - (Required) Whether the cluster disables default in-node sNAT rules. In-node sNAT rules will be disabled when defaultSnatStatus is disabled.When disabled is set to false, default IP masquerade rules will be applied to the nodes to prevent sNAT on cluster internal traffic
@@ -1431,6 +1435,12 @@ linux_node_config {
 <a name="nested_workload_alts_config"></a>The `workload_alts_config` block supports:
 
 * `enable_alts` - (Required) Whether the alts handshaker should be enabled or not for direct-path. Requires Workload Identity ([workloadPool]((#nested_workload_identity_config)) must be non-empty).
+
+<a name="nested_enterprise_config"></a>The `enterprise_config` block supports:
+
+* `desired_tier` - (Optional) Sets the tier of the cluster. Available options include `STANDARD` and `ENTERPRISE`.
+
+* `cluster_tier` - (Output) Sets the tier of the cluster. Available options include `STANDARD` and `ENTERPRISE`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR adds support for configuring enterprise_config for GKE clusters (see https://cloud.google.com/kubernetes-engine/docs/how-to/enable-gkee#gcp-cluster).

Bug: b/380901610
Terraform Issue: https://github.com/hashicorp/terraform-provider-google/issues/20355

```release-note:enhancement
container: added `enterprise_config` field to `google_container_cluster` resource
```
