### PR TITLE
Add gemini_enabled to Looker Core + Example

### DIFF
--- a/mmv1/products/looker/Instance.yaml
+++ b/mmv1/products/looker/Instance.yaml
@@ -293,6 +293,10 @@ properties:
     type: Boolean
     description: |
       FIPS 140-2 Encryption enablement for Looker (Google Cloud Core).
+  - name: 'geminiEnabled'
+    type: Boolean
+    description: |
+      Gemini feature enablement for Looker (Google Cloud Core).
   - name: 'ingressPrivateIp'
     type: String
     description: |

--- a/mmv1/products/looker/Instance.yaml
+++ b/mmv1/products/looker/Instance.yaml
@@ -66,6 +66,12 @@ examples:
       instance_name: 'my-instance-fips'
       client_id: 'my-client-id'
       client_secret: 'my-client-secret'
+  - name: 'looker_instance_gemini'
+    primary_resource_id: 'looker-instance'
+    vars:
+      instance_name: 'my-instance-gemini'
+      client_id: 'my-client-id'
+      client_secret: 'my-client-secret'
   - name: 'looker_instance_enterprise_full'
     primary_resource_id: 'looker-instance'
     vars:

--- a/mmv1/templates/terraform/examples/looker_instance_fips.tf.tmpl
+++ b/mmv1/templates/terraform/examples/looker_instance_fips.tf.tmpl
@@ -4,6 +4,7 @@ resource "google_looker_instance" "{{$.PrimaryResourceId}}" {
   region             = "us-central1"
   public_ip_enabled  = true
   fips_enabled = true
+  gemini_enabled = true
   oauth_config {
     client_id = "{{index $.Vars "client_id"}}"
     client_secret = "{{index $.Vars "client_secret"}}"

--- a/mmv1/templates/terraform/examples/looker_instance_gemini.tf.tmpl
+++ b/mmv1/templates/terraform/examples/looker_instance_gemini.tf.tmpl
@@ -3,7 +3,7 @@ resource "google_looker_instance" "{{$.PrimaryResourceId}}" {
   platform_edition   = "LOOKER_CORE_ENTERPRISE_ANNUAL"
   region             = "us-central1"
   public_ip_enabled  = true
-  fips_enabled = true
+  gemini_enabled = true
   oauth_config {
     client_id = "{{index $.Vars "client_id"}}"
     client_secret = "{{index $.Vars "client_secret"}}"


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
LOOKER_GEMINI: added `gemini_enabled` field to `google_looker_instance` resource
```

Added example / tests