### PR TITLE
Fix flakey magician test `TestFormatReminderComment`

### DIFF
--- a/.ci/magician/cmd/scheduled_pr_reminders_test.go
+++ b/.ci/magician/cmd/scheduled_pr_reminders_test.go
@@ -11,8 +11,9 @@ import (
 )
 
 func TestNotificationState(t *testing.T) {
-	firstCoreReviewer := membership.AvailableReviewers()[0]
-	secondCoreReviewer := membership.AvailableReviewers()[1]
+	availableReviewers := membership.AvailableReviewers()
+	firstCoreReviewer := availableReviewers[0]
+	secondCoreReviewer := availableReviewers[1]
 	cases := map[string]struct {
 		pullRequest *github.PullRequest
 		issueEvents []*github.IssueEvent
@@ -786,8 +787,9 @@ func TestShouldNotify(t *testing.T) {
 }
 
 func TestFormatReminderComment(t *testing.T) {
-	firstCoreReviewer := membership.AvailableReviewers()[0]
-	secondCoreReviewer := membership.AvailableReviewers()[1]
+	availableReviewers := membership.AvailableReviewers()
+	firstCoreReviewer := availableReviewers[0]
+	secondCoreReviewer := availableReviewers[1]
 	cases := map[string]struct {
 		pullRequest        *github.PullRequest
 		state              pullRequestReviewState


### PR DESCRIPTION
Test currently has low rate flakey-ness 
seen [here](https://github.com/GoogleCloudPlatform/magic-modules/actions/runs/11618565021/job/32356237733?pr=12176) and [here](https://github.com/GoogleCloudPlatform/magic-modules/actions/runs/12021166086/job/33511156041?pr=12428)

ran `go test ./... -count=1000` locally

There was a super small chance the secondary reviewer would equal the primary reviewer by using the function in this current/previous way.
 
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
