### PR TITLE
Correct triple-negative documentation.

### DIFF
--- a/mmv1/products/oracledatabase/CloudVmCluster.yaml
+++ b/mmv1/products/oracledatabase/CloudVmCluster.yaml
@@ -84,9 +84,9 @@ virtual_fields:
   - name: 'deletion_protection'
     type: Boolean
     default_value: true
-    description: 'Whether or not to allow Terraform to destroy the instance.
-    Unless this field is set to false in Terraform state, a terraform destroy
-    or terraform apply that would delete the instance will fail.'
+    description: 'Whether Terraform will be prevented from destroying the cluster.
+    Deleting this cluster via terraform destroy or terraform apply will only
+    succeed if this field is false in the Terraform state.'
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -121,9 +121,10 @@ locations. In contrast, in a regional cluster, cluster master nodes are present
 in multiple zones in the region. For that reason, regional clusters should be
 preferred.
 
-* `deletion_protection` - (Optional) Whether or not to allow Terraform to destroy
-the cluster. Unless this field is set to false in Terraform state, a
-`terraform destroy` or `terraform apply` that would delete the cluster will fail.
+* `deletion_protection` - (Optional) Whether Terraform will be prevented from
+destroying the cluster.  Deleting this cluster via `terraform destroy` or
+`terraform apply` will only succeed if this field is `false` in the Terraform
+state.
 
 * `addons_config` - (Optional) The configuration for addons supported by GKE.
     Structure is [documented below](#nested_addons_config).


### PR DESCRIPTION
This documentation was incorrect and poorly worded.  "Whether or not" implies that a `true` value allows deletion and a `false` value prevents deletion, but that's the opposite of what `deletion_protection` does.

The sentence beginning with "Unless" was a bit mind-bending. "Unless" is a negative, "set to false" is a negative, and "will fail" is a negative.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
Corrected documentation for `deletion_protection` in Oracle and GKE clusters.
```
