### PR TITLE
Add support for disabling metric validation in PromQL AlertPolicy

### DIFF
--- a/mmv1/products/monitoring/AlertPolicy.yaml
+++ b/mmv1/products/monitoring/AlertPolicy.yaml
@@ -913,6 +913,17 @@ properties:
 
                 This field is optional. If this field is not empty, then it must be a
                 valid Prometheus label name.
+            - name: 'disableMetricValidation'
+              type: Boolean
+              description: |
+                Whether to disable metric existence validation for this condition.
+                
+                This allows alerting policies to be defined on metrics that do not yet
+                exist, improving advanced customer workflows such as configuring
+                alerting policies using Terraform.
+      
+                Users with the `monitoring.alertPolicyViewer` role are able to see the
+                name of the non-existent metric in the alerting policy condition.
   - name: 'notificationChannels'
     type: Array
     # TODO chrisst - turn this into a resource ref

--- a/mmv1/products/monitoring/AlertPolicy.yaml
+++ b/mmv1/products/monitoring/AlertPolicy.yaml
@@ -917,11 +917,11 @@ properties:
               type: Boolean
               description: |
                 Whether to disable metric existence validation for this condition.
-                
+
                 This allows alerting policies to be defined on metrics that do not yet
                 exist, improving advanced customer workflows such as configuring
                 alerting policies using Terraform.
-      
+
                 Users with the `monitoring.alertPolicyViewer` role are able to see the
                 name of the non-existent metric in the alerting policy condition.
   - name: 'notificationChannels'

--- a/mmv1/third_party/terraform/services/monitoring/resource_monitoring_alert_policy_test.go
+++ b/mmv1/third_party/terraform/services/monitoring/resource_monitoring_alert_policy_test.go
@@ -461,6 +461,7 @@ resource "google_monitoring_alert_policy" "promql" {
       }
       alert_rule      = "AlwaysOn"
       rule_group      = "abc"
+      disable_metric_validation = false
     }
   }
 

--- a/mmv1/third_party/terraform/services/monitoring/resource_monitoring_alert_policy_test.go
+++ b/mmv1/third_party/terraform/services/monitoring/resource_monitoring_alert_policy_test.go
@@ -461,7 +461,7 @@ resource "google_monitoring_alert_policy" "promql" {
       }
       alert_rule      = "AlwaysOn"
       rule_group      = "abc"
-      disable_metric_validation = false
+      disable_metric_validation = true
     }
   }
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Resolves https://github.com/hashicorp/terraform-provider-google/issues/20491.

Add support for disabling metric validation in PromQL AlertPolicy.

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [make test and make lint](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
- [x] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/develop/run-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
monitoring: added `disable_metric_validation` field to `google_monitoring_alert_policy` resource
```
