### PR TITLE
`compute.disk`: move several parameters into properties since they arent used in URL

### DIFF
--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -100,6 +100,23 @@ parameters:
     custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
     resource: 'Zone'
     imports: 'name'
+  - name: 'snapshot'
+    type: ResourceRef
+    description: |
+      The source snapshot used to create this disk. You can provide this as
+      a partial or full URL to the resource. If the snapshot is in another
+      project than this disk, you must supply a full URL. For example, the
+      following are valid values:
+
+      * `https://www.googleapis.com/compute/v1/projects/project/global/snapshots/snapshot`
+      * `projects/project/global/snapshots/snapshot`
+      * `global/snapshots/snapshot`
+      * `snapshot`
+    api_name: sourceSnapshot
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'Snapshot'
+    imports: 'selfLink'
+properties:
   - name: 'sourceImageEncryptionKey'
     type: NestedObject
     description: |
@@ -194,22 +211,6 @@ parameters:
         description: |
           The service account used for the encryption request for the given KMS key.
           If absent, the Compute Engine Service Agent service account is used.
-  - name: 'snapshot'
-    type: ResourceRef
-    description: |
-      The source snapshot used to create this disk. You can provide this as
-      a partial or full URL to the resource. If the snapshot is in another
-      project than this disk, you must supply a full URL. For example, the
-      following are valid values:
-
-      * `https://www.googleapis.com/compute/v1/projects/project/global/snapshots/snapshot`
-      * `projects/project/global/snapshots/snapshot`
-      * `global/snapshots/snapshot`
-      * `snapshot`
-    api_name: sourceSnapshot
-    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
-    resource: 'Snapshot'
-    imports: 'selfLink'
   - name: 'sourceSnapshotEncryptionKey'
     type: NestedObject
     description: |
@@ -255,7 +256,7 @@ parameters:
       snapshot ID would identify the exact version of the snapshot that was
       used.
     output: true
-properties:
+
   - name: 'labelFingerprint'
     type: Fingerprint
     description: |


### PR DESCRIPTION
This moves some fields in `resource_compute_disk` that don't follow the parameters description found in the MMv1 docs:
[`Contains a list of fields By convention, these should be the fields that are part URL parameters such as location and name.`](https://googlecloudplatform.github.io/magic-modules/develop/resource-reference/#parameters)

This was found after discovering that `conflicts` does not work if fields are set as a `parameter` rather than `properties`.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
