### PR TITLE
Add tags field to Filestore Instances for TagsR2401

### DIFF
--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -328,3 +328,12 @@ properties:
             description: |
               The number of IOPS to provision for the instance.
               max_iops must be in multiple of 1000.
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags_.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456.
+      The field is ignored (both PUT & PATCH) when empty.
+    immutable: true
+    ignore_read: true

--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -331,7 +331,7 @@ properties:
   - name: 'tags'
     type: KeyValuePairs
     description: |
-      A map of resource manager tags_.
+      A map of resource manager tags.
       Resource manager tag keys and values have the same definition as resource manager tags.
       Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456.
       The field is ignored (both PUT & PATCH) when empty.

--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -331,9 +331,14 @@ properties:
   - name: 'tags'
     type: KeyValuePairs
     description: |
-      A map of resource manager tags.
-      Resource manager tag keys and values have the same definition as resource manager tags.
-      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456.
-      The field is ignored (both PUT & PATCH) when empty.
+      A map of resource manager tags. Resource manager tag keys
+      and values have the same definition as resource manager
+      tags. Keys must be in the format tagKeys/{tag_key_id},
+      and values are in the format tagValues/456. The field is
+      ignored when empty. The field is immutable and causes
+      resource replacement when mutated. This field is only set
+      at create time and modifying this field after creation
+      will trigger recreation. To apply tags to an existing
+      resource, see the `google_tags_tag_value` resource.
     immutable: true
     ignore_read: true

--- a/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
+++ b/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
@@ -438,7 +438,7 @@ func TestAccFilestoreInstance_tags(t *testing.T) {
 func testAccFileInstanceTags(name string, tags map[string]string) string {
 	r := fmt.Sprintf(`
 resource "google_filestore_instance" "instance" {
-  name = "tf-instance-%s"
+  name = "tf-test-instance-%s"
   zone = "us-central1-b"
   tier = "BASIC_HDD"
   file_shares {

--- a/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
+++ b/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
@@ -412,8 +412,8 @@ resource "google_filestore_instance" "instance" {
 
 func TestAccFilestoreInstance_tags(t *testing.T) {
 	t.Parallel()
-        name := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
-        org := envvar.GetTestOrgFromEnv(t)
+	name := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+	org := envvar.GetTestOrgFromEnv(t)
 	tagKey := acctest.BootstrapSharedTestTagKey(t, "filestore-instances-tagkey")
 	tagValue := acctest.BootstrapSharedTestTagValue(t, "filestore-instances-tagvalue", tagKey)
 

--- a/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
+++ b/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
@@ -6,10 +6,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	"github.com/hashicorp/terraform-provider-google/google/services/filestore"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/filestore"
 )
 
 func testResourceFilestoreInstanceStateDataV0() map[string]interface{} {

--- a/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
+++ b/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go
@@ -409,3 +409,54 @@ resource "google_filestore_instance" "instance" {
 }
 `, name, location, tier)
 }
+
+func TestAccFilestoreInstance_tags(t *testing.T) {
+	t.Parallel()
+        name := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+        org := envvar.GetTestOrgFromEnv(t)
+	tagKey := acctest.BootstrapSharedTestTagKey(t, "filestore-instances-tagkey")
+	tagValue := acctest.BootstrapSharedTestTagValue(t, "filestore-instances-tagvalue", tagKey)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckFilestoreInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFileInstanceTags(name, map[string]string{org + "/" + tagKey: tagValue}),
+			},
+			{
+				ResourceName:            "google_filestore_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"zone", "location", "networks.0.reserved_ip_range", "tags"},
+			},
+		},
+	})
+}
+
+func testAccFileInstanceTags(name string, tags map[string]string) string {
+	r := fmt.Sprintf(`
+resource "google_filestore_instance" "instance" {
+  name = "tf-instance-%s"
+  zone = "us-central1-b"
+  tier = "BASIC_HDD"
+  file_shares {
+    capacity_gb = 1024
+    name        = "share1"
+  }
+  networks {
+    network           = "default"
+    modes             = ["MODE_IPV4"]
+    reserved_ip_range = "172.19.31.8/29"
+  }
+tags = {`, name)
+
+	l := ""
+	for key, value := range tags {
+		l += fmt.Sprintf("%q = %q\n", key, value)
+	}
+
+	l += fmt.Sprintf("}\n}")
+	return r + l
+}


### PR DESCRIPTION
Add tags field to instance resource to allow setting tags on instance resources at creation time.
Part of b/364841739

```release-note:enhancement
filestore: added `tags` field to `filstore_instance` to allow setting tags for instances at creation time
```

```
The contents of this code are entirely owned by Google LLC in accordance with the agreement between Google LLC and the third party submitting this code into Google's open source repository
```