### PR TITLE
Add tags field to Filestore Backups for TagsR2401

### DIFF
--- a/mmv1/products/filestore/Backup.yaml
+++ b/mmv1/products/filestore/Backup.yaml
@@ -146,3 +146,12 @@ properties:
     description: |
       KMS key name used for data encryption.
     output: true
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+      The field is ignored (both PUT & PATCH) when empty.
+    immutable: true
+    ignore_read: true

--- a/mmv1/third_party/terraform/services/filestore/resource_filestore_backup_test.go
+++ b/mmv1/third_party/terraform/services/filestore/resource_filestore_backup_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestAccFilestoreBackup_update(t *testing.T) {
@@ -112,4 +113,73 @@ resource "google_filestore_backup" "backup" {
 }
 
 `, instName, bkupName)
+}
+
+func TestAccFilestoreBackup_tags(t *testing.T) {
+	t.Parallel()
+
+        org := envvar.GetTestOrgFromEnv(t)
+	instanceName := fmt.Sprintf("tf-fs-inst-%d", acctest.RandInt(t))
+	backupName := fmt.Sprintf("tf-fs-bkup-%d", acctest.RandInt(t))
+	tagKey := acctest.BootstrapSharedTestTagKey(t, "filestore-backups-tagkey")
+	tagValue := acctest.BootstrapSharedTestTagValue(t, "filestore-backups-tagvalue", tagKey)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckFilestoreBackupDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFilestoreBackupTags(instanceName, backupName, map[string]string{org + "/" + tagKey: tagValue}),
+			},
+			{
+				ResourceName:            "google_filestore_backup.backup",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels", "description", "location", "tags"},
+			},
+		},
+	})
+}
+
+func testAccFilestoreBackupTags(instanceName string, backupName string, tags map[string]string) string {
+
+	r := fmt.Sprintf(`
+	resource "google_filestore_instance" "instance" {
+          name     = "%s"
+          location = "us-central1-b"
+          tier     = "BASIC_HDD"
+
+            file_shares {
+              capacity_gb = 1024
+              name        = "share1"
+            }
+
+            networks {
+              network      = "default"
+              modes        = ["MODE_IPV4"]
+              connect_mode = "DIRECT_PEERING"
+            }
+        }
+
+        resource "google_filestore_backup" "backup" {
+          name              = "%s"
+          location          = "us-central1"
+          description       = "This is a filestore backup for the test instance"
+          source_instance   = google_filestore_instance.instance.id
+          source_file_share = "share1"
+
+          labels = {
+            "files":"label1",
+            "other-label": "label2"
+          }
+	  tags = {`, instanceName, backupName)
+
+	l := ""
+	for key, value := range tags {
+		l += fmt.Sprintf("%q = %q\n", key, value)
+	}
+
+	l += fmt.Sprintf("}\n}")
+	return r + l
 }


### PR DESCRIPTION
Add tags field to backup resource to allow setting tags on backup resources at creation time.
Part of b/364923942

release-note:none
```
filestore: added `tags` field to `filstore_backup` to allow setting tags for backups at creation time
```

```
The contents of this code are entirely owned by Google LLC in accordance with the agreement between Google LLC and the third party submitting this code into Google's open source repository
```