### PR TITLE
Update org_policy_policy documentation to make resource definition clearer

### DIFF
--- a/mmv1/templates/terraform/examples/org_policy_policy_enforce.tf.tmpl
+++ b/mmv1/templates/terraform/examples/org_policy_policy_enforce.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_org_policy_policy" "primary" {
-  name   = "projects/${google_project.basic.name}/policies/iam.disableServiceAccountKeyUpload"
-  parent = "projects/${google_project.basic.name}"
+  name   = "projects/${google_project.basic.project_id}/policies/iam.disableServiceAccountKeyUpload"
+  parent = "projects/${google_project.basic.project_id}"
 
   spec {
     rules {

--- a/mmv1/templates/terraform/examples/org_policy_policy_project.tf.tmpl
+++ b/mmv1/templates/terraform/examples/org_policy_policy_project.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_org_policy_policy" "primary" {
-  name   = "projects/${google_project.basic.name}/policies/gcp.resourceLocations"
-  parent = "projects/${google_project.basic.name}"
+  name   = "projects/${google_project.basic.project_id}/policies/gcp.resourceLocations"
+  parent = "projects/${google_project.basic.project_id}"
 
   spec {
     rules {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This PR:
- Updates the documentation to make it explicit that what is required for the resource definition is the project id, not the project name.

The project name may differ from the project id in google. For example, you may have a project ID `sandbox-123123` while the project name is `sandbox`. If in this case using the project name the role creation will fail.

**Release Note Template for Downstream PRs**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
updated org_policy_policy examples to use project_id instead of project name
```
