### PR TITLE
Update documentation for ephemeral resources: remove broken examples, add notes, misc fixes

### DIFF
--- a/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_access_token.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_access_token.html.markdown
@@ -35,10 +35,6 @@ In the example below, `google_project` will run as `service_B`.
 provider "google" {
 }
 
-data "google_client_config" "default" {
-  provider = google
-}
-
 ephemeral "google_service_account_access_token" "default" {
   provider               = google
   target_service_account = "service_B@projectB.iam.gserviceaccount.com"

--- a/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_id_token.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_id_token.html.markdown
@@ -49,29 +49,6 @@ For more information see
 
   ```
 
-## Example Usage - Invoking Cloud Run Endpoint
-
-  The following configuration will invoke [Cloud Run](https://cloud.google.com/run/docs/authenticating/service-to-service) endpoint where the service account for Terraform has been granted `roles/run.invoker` role previously.
-
-```hcl
-
-ephemeral "google_service_account_id_token" "oidc" {
-  target_audience = "https://your.cloud.run.app/"
-}
-
-data "http" "cloudrun" {
-  url = "https://your.cloud.run.app/"
-  request_headers  = {
-    Authorization = "Bearer ${ephemeral.google_service_account_id_token.oidc.id_token}"
-  }
-}
-
-
-output "cloud_run_response" {
-  value = data.http.cloudrun.body
-}
-```
-
 ## Argument Reference
 
 The following arguments are supported:

--- a/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_id_token.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_id_token.html.markdown
@@ -21,7 +21,7 @@ For more information see
   ```
 
 ## Example Usage - Service Account Impersonation.
-  `google_service_account_access_token` will use background impersonated credentials provided by [google_service_account_access_token](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/service_account_access_token).
+  Ephemeral resource `google_service_account_id_token` will use background impersonated credentials provided by [google_service_account_access_token](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/service_account_access_token).
 
   Note: to use the following, you must grant `target_service_account` the
   `roles/iam.serviceAccountTokenCreator` role on itself.

--- a/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_id_token.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_id_token.html.markdown
@@ -43,7 +43,6 @@ For more information see
   ephemeral "google_service_account_id_token" "oidc" {
     provider = google.impersonated
     target_service_account = "impersonated-account@project.iam.gserviceaccount.com"
-    delegates = []
     include_email = true
     target_audience = "https://foo.bar/"
   }

--- a/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_id_token.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_id_token.html.markdown
@@ -12,6 +12,9 @@ For more information see
 [OpenID Connect](https://openid.net/specs/openid-connect-core-1_0.html#IDToken).
 
 ## Example Usage - ServiceAccount JSON credential file.
+
+-> **Note:** If you run this example configuration you will be able to see ephemeral.google_service_account_id_token.oidc in terraform plan and apply terminal output but you will not see it in state, as ephemeral resources are excluded from state. In future, when write-only attributes are added to resources in the Google provider, ephemeral resources such as google_service_account_id_token could be used to set field values when creating managed resources.
+
   `google_service_account_id_token` will use the configured [provider credentials](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#credentials-1)
 
   ```hcl
@@ -21,6 +24,9 @@ For more information see
   ```
 
 ## Example Usage - Service Account Impersonation.
+
+-> **Note:** If you run this example configuration you will be able to see ephemeral.google_service_account_id_token.oidc in terraform plan and apply terminal output but you will not see it in state, as ephemeral resources are excluded from state. In future, when write-only attributes are added to resources in the Google provider, ephemeral resources such as google_service_account_id_token could be used to set field values when creating managed resources.
+
   Ephemeral resource `google_service_account_id_token` will use background impersonated credentials provided by [google_service_account_access_token](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/service_account_access_token).
 
   Note: to use the following, you must grant `target_service_account` the

--- a/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_id_token.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_id_token.html.markdown
@@ -49,6 +49,7 @@ For more information see
   ephemeral "google_service_account_id_token" "oidc" {
     provider = google.impersonated
     target_service_account = "impersonated-account@project.iam.gserviceaccount.com"
+    delegates = []
     include_email = true
     target_audience = "https://foo.bar/"
   }

--- a/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_jwt.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_jwt.html.markdown
@@ -10,6 +10,8 @@ This ephemeral resource provides a [self-signed JWT](https://cloud.google.com/ia
 
 ## Example Usage
 
+-> **Note:** If you run this example configuration you will be able to see ephemeral.google_service_account_jwt.foo in terraform plan and apply terminal output but you will not see it in state, as ephemeral resources are excluded from state. In future, when write-only attributes are added to resources in the Google provider, ephemeral resources such as google_service_account_jwt could be used to set field values when creating managed resources.
+
 Note: in order to use the following, the caller must have _at least_ `roles/iam.serviceAccountTokenCreator` on the `target_service_account`.
 
 ```hcl

--- a/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_key.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_key.html.markdown
@@ -10,6 +10,9 @@ Get an ephemeral service account public key. For more information, see [the offi
 
 ## Example Usage
 
+~> **Note:** If you run this example configuration you will be able to see ephemeral.google_service_account_key.mykey in terraform plan and apply terminal output but you will not see it in state, as ephemeral resources are excluded from state. In future, when write-only attributes are added to the Google provider's resources, google_service_account_key ephemeral resources can be used to supply values for fields when creating other resources.
+
+
 ```hcl
 resource "google_service_account" "myaccount" {
   account_id = "dev-foo-account"

--- a/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_key.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_key.html.markdown
@@ -10,7 +10,7 @@ Get an ephemeral service account public key. For more information, see [the offi
 
 ## Example Usage
 
--> **Note:** If you run this example configuration you will be able to see ephemeral.google_service_account_key.mykey in terraform plan and apply terminal output but you will not see it in state, as ephemeral resources are excluded from state. In future, when write-only attributes are added to the Google provider's resources, google_service_account_key ephemeral resources can be used to supply values for fields when creating other resources.
+-> **Note:** If you run this example configuration you will be able to see ephemeral.google_service_account_key.mykey in terraform plan and apply terminal output but you will not see it in state, as ephemeral resources are excluded from state. In future, when write-only attributes are added to resources in the Google provider, ephemeral resources such as google_service_account_key could be used to set field values when creating managed resources.
 
 
 ```hcl

--- a/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_key.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/ephemeral-resources/service_account_key.html.markdown
@@ -10,7 +10,7 @@ Get an ephemeral service account public key. For more information, see [the offi
 
 ## Example Usage
 
-~> **Note:** If you run this example configuration you will be able to see ephemeral.google_service_account_key.mykey in terraform plan and apply terminal output but you will not see it in state, as ephemeral resources are excluded from state. In future, when write-only attributes are added to the Google provider's resources, google_service_account_key ephemeral resources can be used to supply values for fields when creating other resources.
+-> **Note:** If you run this example configuration you will be able to see ephemeral.google_service_account_key.mykey in terraform plan and apply terminal output but you will not see it in state, as ephemeral resources are excluded from state. In future, when write-only attributes are added to the Google provider's resources, google_service_account_key ephemeral resources can be used to supply values for fields when creating other resources.
 
 
 ```hcl


### PR DESCRIPTION
This PR:

- Adds disclaimer notes (`-> **Note:** ...`) to examples that aren't using the ephemeral value for anything. We want users to understand that the example shows the ephemeral resource in action but isn't really valid usage
- Removes an example that passes an ephemeral value into a resource that cannot accept them
- ~Fixes an example broken by delegates=[]~
- Other minor fixes that were copied from the original data source docs

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
