### PR TITLE
 Fix TF: Failing test(s): TestAccDataprocVirtualCluster_basic

### DIFF
--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
@@ -112,7 +112,7 @@ func TestAccDataprocVirtualCluster_basic(t *testing.T) {
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
 	pid := envvar.GetTestProjectFromEnv()
-	version := "3.5-dataproc-19"
+	version := "3.5-dataproc-17"
 	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
 	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
@@ -1445,7 +1445,7 @@ resource "google_dataproc_cluster" "virtual_cluster" {
 		kubernetes_namespace = "tf-test-dproc-%s"
 		kubernetes_software_config {
 		  component_version = {
-			"SPARK": "3.5-dataproc-19",
+			"SPARK": "3.5-dataproc-17",
 		  }
 		}
 		gke_cluster_config {

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
@@ -112,7 +112,7 @@ func TestAccDataprocVirtualCluster_basic(t *testing.T) {
 	var cluster dataproc.Cluster
 	rnd := acctest.RandString(t, 10)
 	pid := envvar.GetTestProjectFromEnv()
-	version := "3.1-dataproc-7"
+	version := "3.5-dataproc-19"
 	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
 	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
@@ -1445,7 +1445,7 @@ resource "google_dataproc_cluster" "virtual_cluster" {
 		kubernetes_namespace = "tf-test-dproc-%s"
 		kubernetes_software_config {
 		  component_version = {
-			"SPARK": "3.1-dataproc-7",
+			"SPARK": "3.5-dataproc-19",
 		  }
 		}
 		gke_cluster_config {

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -214,7 +214,7 @@ resource "google_dataproc_cluster" "accelerated_cluster" {
 
         kubernetes_software_config {
           component_version = {
-            "SPARK" : "3.1-dataproc-7"
+            "SPARK" : "3.5-dataproc-17"
           }
 
           properties = {


### PR DESCRIPTION
* Updates dataproc virtual gke cluster version 3.1-dataproc-7 to 3.5-dataproc-19
* Fixes https://github.com/hashicorp/terraform-provider-google/issues/19076

```release-note:none
dataproc: fixed test failure due to usage of deprecated version
```
