### PR TITLE
Fixed recaptcha_options permadiff causing rules being recreated

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
@@ -24,6 +24,26 @@ import (
 {{- end }}
 )
 
+func verifyRulePriorityCompareEmptyValues(d *schema.ResourceData, rulePriority int, schemaKey string) bool {
+	if schemaRules, ok := d.GetOk("rule"); ok {
+		for _, itemRaw := range schemaRules.(*schema.Set).List() {
+			if itemRaw == nil {
+				continue
+			}
+			item := itemRaw.(map[string]interface{})
+
+			schemaPriority := item["priority"].(int)
+			if rulePriority == schemaPriority {
+				if tpgresource.IsEmptyValue(reflect.ValueOf(item[schemaKey])) {
+					return true
+				}
+				break
+			}
+		}
+	}
+	return false
+}
+
 // IsEmptyValue does not consider a empty PreconfiguredWafConfig object as empty so we check it's nested values
 func preconfiguredWafConfigIsEmptyValue(config *compute.SecurityPolicyRulePreconfiguredWafConfig) bool {
 	if (tpgresource.IsEmptyValue(reflect.ValueOf(config.Exclusions)) &&
@@ -1188,7 +1208,7 @@ func flattenSecurityPolicyRules(rules []*compute.SecurityPolicyRule, d *schema.R
 			"priority":                 rule.Priority,
 			"action":                   rule.Action,
 			"preview":                  rule.Preview,
-			"match":                    flattenMatch(rule.Match),
+			"match":                    flattenMatch(rule.Match, d, int(rule.Priority)),
 			"preconfigured_waf_config": flattenPreconfiguredWafConfig(rule.PreconfiguredWafConfig, d, int(rule.Priority)),
 			"rate_limit_options":	      flattenSecurityPolicyRuleRateLimitOptions(rule.RateLimitOptions),
 			"redirect_options":         flattenSecurityPolicyRedirectOptions(rule.RedirectOptions),
@@ -1199,7 +1219,7 @@ func flattenSecurityPolicyRules(rules []*compute.SecurityPolicyRule, d *schema.R
 	return rulesSchema
 }
 
-func flattenMatch(match *compute.SecurityPolicyRuleMatcher) []map[string]interface{} {
+func flattenMatch(match *compute.SecurityPolicyRuleMatcher, d *schema.ResourceData, rulePriority int) []map[string]interface{} {
 	if match == nil {
 		return nil
 	}
@@ -1208,7 +1228,7 @@ func flattenMatch(match *compute.SecurityPolicyRuleMatcher) []map[string]interfa
 		"versioned_expr": match.VersionedExpr,
 		"config":         flattenMatchConfig(match.Config),
 		"expr":           flattenMatchExpr(match),
-		"expr_options":   flattenMatchExprOptions(match.ExprOptions),
+		"expr_options":   flattenMatchExprOptions(match.ExprOptions, d, rulePriority),
 	}
 
 	return []map[string]interface{}{data}
@@ -1226,20 +1246,27 @@ func flattenMatchConfig(conf *compute.SecurityPolicyRuleMatcherConfig) []map[str
 	return []map[string]interface{}{data}
 }
 
-func flattenMatchExprOptions(exprOptions *compute.SecurityPolicyRuleMatcherExprOptions) []map[string]interface{} {
+func flattenMatchExprOptions(exprOptions *compute.SecurityPolicyRuleMatcherExprOptions, d *schema.ResourceData, rulePriority int) []map[string]interface{} {
 	if exprOptions == nil {
 		return nil
 	}
 
 	data := map[string]interface{}{
-		"recaptcha_options": flattenMatchExprOptionsRecaptchaOptions(exprOptions.RecaptchaOptions),
+		"recaptcha_options": flattenMatchExprOptionsRecaptchaOptions(exprOptions.RecaptchaOptions, d, rulePriority),
 	}
 
 	return []map[string]interface{}{data}
 }
 
-func flattenMatchExprOptionsRecaptchaOptions(recaptchaOptions *compute.SecurityPolicyRuleMatcherExprOptionsRecaptchaOptions) []map[string]interface{} {
+func flattenMatchExprOptionsRecaptchaOptions(recaptchaOptions *compute.SecurityPolicyRuleMatcherExprOptionsRecaptchaOptions, d *schema.ResourceData, rulePriority int) []map[string]interface{} {
 	if recaptchaOptions == nil {
+		return nil
+	}
+
+	// We check if the API is returning a empty non-null value then we find the current value for this field in the rule config and check if its empty
+	if (tpgresource.IsEmptyValue(reflect.ValueOf(recaptchaOptions.ActionTokenSiteKeys)) &&
+		tpgresource.IsEmptyValue(reflect.ValueOf(recaptchaOptions.SessionTokenSiteKeys))) &&
+		verifyRulePriorityCompareEmptyValues(d, rulePriority, "recaptcha_options") {
 		return nil
 	}
 
@@ -1272,22 +1299,9 @@ func flattenPreconfiguredWafConfig(config *compute.SecurityPolicyRulePreconfigur
 		return nil
 	}
 
-	// We find the current value for this field in the config and check if its empty, then check if the API is returning a empty non-null value
-	if schemaRules, ok := d.GetOk("rule"); ok {
-		for _, itemRaw := range schemaRules.(*schema.Set).List() {
-			if itemRaw == nil {
-				continue
-			}
-			item := itemRaw.(map[string]interface{})
-
-			schemaPriority := item["priority"].(int)
-			if rulePriority == schemaPriority {
-				if preconfiguredWafConfigIsEmptyValue(config) && tpgresource.IsEmptyValue(reflect.ValueOf(item["preconfigured_waf_config"])) {
-					return nil
-				}
-				break
-			}
-		}
+	// We check if the API is returning a empty non-null value then we find the current value for this field in the rule config and check if its empty
+	if preconfiguredWafConfigIsEmptyValue(config) && verifyRulePriorityCompareEmptyValues(d, rulePriority, "preconfigured_waf_config") {
+		return nil
 	}
 
 	data := map[string]interface{}{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
@@ -1251,22 +1251,22 @@ func flattenMatchExprOptions(exprOptions *compute.SecurityPolicyRuleMatcherExprO
 		return nil
 	}
 
+  // We check if the API is returning a empty non-null value then we find the current value for this field in the rule config and check if its empty
+	if (tpgresource.IsEmptyValue(reflect.ValueOf(exprOptions.RecaptchaOptions.ActionTokenSiteKeys)) &&
+		tpgresource.IsEmptyValue(reflect.ValueOf(exprOptions.RecaptchaOptions.SessionTokenSiteKeys))) &&
+		verifyRulePriorityCompareEmptyValues(d, rulePriority, "recaptcha_options") {
+		return nil
+	}
+
 	data := map[string]interface{}{
-		"recaptcha_options": flattenMatchExprOptionsRecaptchaOptions(exprOptions.RecaptchaOptions, d, rulePriority),
+		"recaptcha_options": flattenMatchExprOptionsRecaptchaOptions(exprOptions.RecaptchaOptions),
 	}
 
 	return []map[string]interface{}{data}
 }
 
-func flattenMatchExprOptionsRecaptchaOptions(recaptchaOptions *compute.SecurityPolicyRuleMatcherExprOptionsRecaptchaOptions, d *schema.ResourceData, rulePriority int) []map[string]interface{} {
+func flattenMatchExprOptionsRecaptchaOptions(recaptchaOptions *compute.SecurityPolicyRuleMatcherExprOptionsRecaptchaOptions) []map[string]interface{} {
 	if recaptchaOptions == nil {
-		return nil
-	}
-
-	// We check if the API is returning a empty non-null value then we find the current value for this field in the rule config and check if its empty
-	if (tpgresource.IsEmptyValue(reflect.ValueOf(recaptchaOptions.ActionTokenSiteKeys)) &&
-		tpgresource.IsEmptyValue(reflect.ValueOf(recaptchaOptions.SessionTokenSiteKeys))) &&
-		verifyRulePriorityCompareEmptyValues(d, rulePriority, "recaptcha_options") {
 		return nil
 	}
 


### PR DESCRIPTION
Fixes a permadiff related to the `recaptcha_options` field in google_compute_security_policy.
Also code cleanup for the same fix previously applied to `preconfigured_waf_config` field;

Part of: https://github.com/hashicorp/terraform-provider-google/issues/16882, https://github.com/hashicorp/terraform-provider-google/issues/18596

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fixed permadiff on the `recaptcha_options` field for `google_compute_security_policy` resource
```