### PR TITLE
compute: added `subnetwork_id` to compute subnet data source

### DIFF
--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_subnetwork.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_subnetwork.go.tmpl
@@ -31,6 +31,10 @@ func DataSourceGoogleComputeSubnetwork() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"subnetwork_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 			"ip_cidr_range": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -98,6 +102,10 @@ func dataSourceGoogleComputeSubnetworkRead(d *schema.ResourceData, meta interfac
 	subnetwork, err := config.NewComputeClient(userAgent).Subnetworks.Get(project, region, name).Do()
 	if err != nil {
 		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Subnetwork Not Found : %s", name), id)
+	}
+
+	if err := d.Set("subnetwork_id", subnetwork.Id); err != nil {
+		return fmt.Errorf("Error setting subnetwork_id: %s", err)
 	}
 
 	if err := d.Set("ip_cidr_range", subnetwork.IpCidrRange); err != nil {

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_subnetwork_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_subnetwork_test.go
@@ -47,6 +47,7 @@ func testAccDataSourceGoogleSubnetworkCheck(data_source_name string, resource_na
 			"id",
 			"name",
 			"description",
+			"subnetwork_id",
 			"ip_cidr_range",
 			"private_ip_google_access",
 			"internal_ipv6_prefix",

--- a/mmv1/third_party/terraform/website/docs/d/compute_subnetwork.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_subnetwork.html.markdown
@@ -40,6 +40,8 @@ In addition to the arguments listed above, the following attributes are exported
 * `network` - The network name or resource link to the parent
     network of this subnetwork.
 
+* `subnetwork_id` - The numeric ID of the resource.
+
 * `description` - Description of this subnetwork.
 
 * `ip_cidr_range` - The IP address range that machines in this


### PR DESCRIPTION
Added `subnetwork_id` to `google_compute_subnetwork` data source

Picked from #12285 (comment [here](https://github.com/GoogleCloudPlatform/magic-modules/pull/12285#issuecomment-2487032879))
Followup to #12351
Related to hashicorp/terraform-provider-google#20223
Related to hashicorp/terraform-provider-google#20530

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `subnetwork_id` to `google_compute_subnetwork` data source
```
