### PR TITLE
Fix Failing test TestAccSecurityCenterManagement Folder SHA Custom Module

### DIFF
--- a/mmv1/third_party/terraform/services/securitycentermanagement/resource_scc_management_folder_security_health_analytics_custom_module_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/securitycentermanagement/resource_scc_management_folder_security_health_analytics_custom_module_test.go.tmpl
@@ -15,7 +15,7 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
-// Custom Module tests cannot be run in parallel without running into 409 Conflict reponses.
+// Custom Module tests cannot be run in parallel without running into 409 Conflict responses.
 // Run them as individual steps of an update test instead.
 func testAccSecurityCenterManagementFolderSecurityHealthAnalyticsCustomModule(t *testing.T) {
 
@@ -25,6 +25,9 @@ func testAccSecurityCenterManagementFolderSecurityHealthAnalyticsCustomModule(t 
 		"sleep":         true,
 		"random_suffix": acctest.RandString(t, 10),
 	}
+
+	// Log the organization ID for debugging purposes
+	t.Logf("Using Organization ID: %s", context["org_id"])
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -75,10 +78,9 @@ resource "google_folder" "folder" {
   deletion_protection = false
 }
 
-resource "time_sleep" "wait_1_minute" {
+resource "time_sleep" "wait_5_minute" {
 	depends_on = [google_folder.folder]
-
-	create_duration = "2m"
+	create_duration = "5m"
 }
 
 resource "google_scc_management_folder_security_health_analytics_custom_module" "example" {
@@ -101,8 +103,7 @@ resource "google_scc_management_folder_security_health_analytics_custom_module" 
 		severity = "MEDIUM"
 	}
 
-
-	depends_on = [time_sleep.wait_1_minute]
+	depends_on = [time_sleep.wait_5_minute]
 }
 `, context)
 }
@@ -114,6 +115,11 @@ resource "google_folder" "folder" {
   parent       = "organizations/%{org_id}"
   display_name = "tf-test-folder-name%{random_suffix}"
   deletion_protection = false
+}
+
+resource "time_sleep" "wait_5_minute" {
+	depends_on = [google_folder.folder]
+	create_duration = "5m"
 }
 
 resource "google_scc_management_folder_security_health_analytics_custom_module" "example" {
@@ -149,6 +155,8 @@ resource "google_scc_management_folder_security_health_analytics_custom_module" 
 		description = "Description of the custom module"
 		recommendation = "Steps to resolve violation"
 	}
+
+	depends_on = [time_sleep.wait_5_minute]
 }
 `, context)
 }
@@ -160,6 +168,11 @@ resource "google_folder" "folder" {
   parent       = "organizations/%{org_id}"
   display_name = "tf-test-folder-name%{random_suffix}"
   deletion_protection = false
+}
+
+resource "time_sleep" "wait_3_minute" {
+	depends_on = [google_folder.folder]
+	create_duration = "3m"
 }
 
 resource "google_scc_management_folder_security_health_analytics_custom_module" "example" {
@@ -195,6 +208,9 @@ resource "google_scc_management_folder_security_health_analytics_custom_module" 
 		description = "Updated description of the custom module"
 		recommendation = "Updated steps to resolve violation"
 	}
+
+	depends_on = [time_sleep.wait_3_minute]
+
 }
 `, context)
 }


### PR DESCRIPTION
This PR aims to fix the TestAccSecurityCenterManagement Folder SHA Custom Module failing issue, raised in #[20275](https://github.com/hashicorp/terraform-provider-google/issues/20275)
Bug link: [378169051](https://b.corp.google.com/issues/378169051)

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
securitycentermanagement: fixed Failing test(s): TestAccSecurityCenterManagement
```
