### PR TITLE
Update the wait time to 5m for scc mgt folder sha test

### DIFF
--- a/mmv1/third_party/terraform/services/securitycentermanagement/resource_scc_management_folder_security_health_analytics_custom_module_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/securitycentermanagement/resource_scc_management_folder_security_health_analytics_custom_module_test.go.tmpl
@@ -170,9 +170,9 @@ resource "google_folder" "folder" {
   deletion_protection = false
 }
 
-resource "time_sleep" "wait_3_minute" {
+resource "time_sleep" "wait_5_minute" {
 	depends_on = [google_folder.folder]
-	create_duration = "3m"
+	create_duration = "5m"
 }
 
 resource "google_scc_management_folder_security_health_analytics_custom_module" "example" {
@@ -209,7 +209,7 @@ resource "google_scc_management_folder_security_health_analytics_custom_module" 
 		recommendation = "Updated steps to resolve violation"
 	}
 
-	depends_on = [time_sleep.wait_3_minute]
+	depends_on = [time_sleep.wait_5_minute]
 
 }
 `, context)


### PR DESCRIPTION
This PR is to update the wait time to 5m in a test for the merged PR #12462 

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
securitycentermanagement: fixed Failing test(s): TestAccSecurityCenterManagement
```
