### PR TITLE
`VCR`: Update build-environment image to use Terraform 1.10.0

### DIFF
--- a/.ci/containers/build-environment/Dockerfile
+++ b/.ci/containers/build-environment/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 WORKDIR $GOPATH
 
 # terraform binary used by tfv/tgc
-COPY --from=hashicorp/terraform:1.8.3 /bin/terraform /bin/terraform
+COPY --from=hashicorp/terraform:1.10.0 /bin/terraform /bin/terraform
 
 SHELL ["/bin/bash", "-c"]
 

--- a/.ci/containers/go-plus/Dockerfile
+++ b/.ci/containers/go-plus/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN wget https://releases.hashicorp.com/terraform/1.8.3/terraform_1.8.3_linux_amd64.zip \
-    && unzip terraform_1.8.3_linux_amd64.zip \
-    && rm terraform_1.8.3_linux_amd64.zip \
+RUN wget https://releases.hashicorp.com/terraform/1.10.0/terraform_1.10.0_linux_amd64.zip \
+    && unzip terraform_1.10.0_linux_amd64.zip \
+    && rm terraform_1.10.0_linux_amd64.zip \
     && mv ./terraform /bin/terraform


### PR DESCRIPTION
PR enables running ephemeral-resources in VCR, as they're a new feature introduced in 1.10.0

Referencing https://github.com/hashicorp/terraform-provider-google/issues/19685 since this will allow us a chance to investigate why VCR cassettes are invalidated when updating the TF version. This occurred in the last Terraform version bump to `1.8.3`

`
When the TF version is next updated we should be prepared for VCR cassettes to be invalidated and try to learn why it happens, assuming it does.
`

Merge once we have [`Default TF Version set to 1.10.0 in TeamCity`](https://github.com/GoogleCloudPlatform/magic-modules/pull/12470)

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
