### PR TITLE
Add NetworkTier for GlobalForwardingRule.

### DIFF
--- a/mmv1/products/compute/GlobalForwardingRule.yaml
+++ b/mmv1/products/compute/GlobalForwardingRule.yaml
@@ -485,6 +485,25 @@ properties:
     update_url: 'projects/{{project}}/global/forwardingRules/{{name}}/setTarget'
     update_verb: 'POST'
     diff_suppress_func: 'tpgresource.CompareSelfLinkRelativePaths'
+  - name: 'networkTier'
+    type: Enum
+    description: |
+      This signifies the networking tier used for configuring
+      this load balancer and can only take the following values:
+      `PREMIUM`, `STANDARD`.
+
+      For regional ForwardingRule, the valid values are `PREMIUM` and
+      `STANDARD`. For GlobalForwardingRule, the valid value is
+      `PREMIUM`.
+
+      If this field is not specified, it is assumed to be `PREMIUM`.
+      If `IPAddress` is specified, this value must be equal to the
+      networkTier of the Address.
+    immutable: true
+    default_from_api: true
+    enum_values:
+      - 'PREMIUM'
+      - 'STANDARD'
   - name: 'serviceDirectoryRegistrations'
     type: Array
     description: |

--- a/mmv1/templates/terraform/examples/global_forwarding_rule_external_managed.tf.tmpl
+++ b/mmv1/templates/terraform/examples/global_forwarding_rule_external_managed.tf.tmpl
@@ -3,6 +3,7 @@ resource "google_compute_global_forwarding_rule" "default" {
   target                = google_compute_target_http_proxy.default.id
   port_range            = "80"
   load_balancing_scheme = "EXTERNAL_MANAGED"
+  network_tier          = "PREMIUM"
 }
 
 resource "google_compute_target_http_proxy" "default" {


### PR DESCRIPTION
Adds a NetworkTier for GlobalForwardingRule.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/20514


**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `network_tier` field to `google_compute_global_forwarding_rule` resource
```
