### PR TITLE
Make `google_oracle_database_autonomous_database` and `google_oracle_database_cloud_exadata_infrastructure` generated tests use sweepable unique resource names

### DIFF
--- a/mmv1/products/oracledatabase/AutonomousDatabase.yaml
+++ b/mmv1/products/oracledatabase/AutonomousDatabase.yaml
@@ -61,7 +61,6 @@ examples:
     test_vars_overrides:
       'deletion_protection': 'false'
       'project': '"oci-terraform-testing"'
-      'autonomous_database_id': '"my-adb-instance-id"'
   - name: 'oracledatabase_autonomous_database_full'
     primary_resource_id: 'myADB'
     vars:
@@ -72,7 +71,6 @@ examples:
       - 'deletion_protection'
     test_vars_overrides:
       'project': '"oci-terraform-testing"'
-      'autonomous_database_id': '"my-adb-instance-id-2"'
       'deletion_protection': 'false'
 virtual_fields:
   - name: 'deletion_protection'

--- a/mmv1/products/oracledatabase/CloudExadataInfrastructure.yaml
+++ b/mmv1/products/oracledatabase/CloudExadataInfrastructure.yaml
@@ -61,7 +61,6 @@ examples:
     test_vars_overrides:
       'project': '"oci-terraform-testing"'
       'deletion_protection': 'false'
-      'cloud_exadata_infrastructure_id': '"ofake-exadata-basic"'
   - name: 'oracledatabase_cloud_exadata_infrastructure_full'
     primary_resource_id: 'my-cloud-exadata'
     vars:
@@ -73,7 +72,6 @@ examples:
     test_vars_overrides:
       'project': '"oci-terraform-testing"'
       'deletion_protection': 'false'
-      'cloud_exadata_infrastructure_id': '"ofake-exadata-full"'
 virtual_fields:
   - name: 'deletion_protection'
     type: Boolean


### PR DESCRIPTION

Addressing non-sweepable, non-unique resource names being used in some tests, see: https://github.com/hashicorp/terraform-provider-google/issues/19983#issuecomment-2514129494

That issue shows that TestAccOracleDatabaseAutonomousDatabase_oracledatabaseAutonomousDatabaseFullExample is failing in nightly tests due to a hardcoded name.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
