### PR TITLE
Test and document the `configmanagement.config_sync.stop_syncing` field

### DIFF
--- a/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.tmpl
@@ -160,9 +160,9 @@ resource "google_gke_hub_feature_membership" "feature_member_1" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership.membership_id
   configmanagement {
-    version = "1.18.2"
     config_sync {
       source_format = "hierarchy"
+      stop_syncing  = true
       enabled       = true
       git {
         sync_repo   = "https://github.com/GoogleCloudPlatform/magic-modules"

--- a/mmv1/third_party/terraform/website/docs/r/gke_hub_feature_membership.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/gke_hub_feature_membership.html.markdown
@@ -418,11 +418,15 @@ The following arguments are supported:
 
 * `prevent_drift` -
   (Optional)
-  Supported from Config Sync versions 1.10.0 onwards. Set to true to enable the Config Sync admission webhook to prevent drifts. If set to "false", disables the Config Sync admission webhook and does not prevent drifts.
+  Supported from Config Sync versions 1.10.0 onwards. Set to `true` to enable the Config Sync admission webhook to prevent drifts. If set to `false`, disables the Config Sync admission webhook and does not prevent drifts.
     
 * `source_format` -
   (Optional)
   Specifies whether the Config Sync Repo is in "hierarchical" or "unstructured" mode.
+
+* `stop_syncing` -
+  (Optional)
+  Set to `true` to stop syncing configurations for a single cluster. This field is only available on clusters using Config Sync [auto-upgrades](http://cloud/kubernetes-engine/enterprise/config-sync/docs/how-to/upgrade-config-sync#auto-upgrade-config) or on Config Sync version 1.20.0 or later. Defaults: `false`.
     
 <a name="nested_git"></a>The `git` block supports:
     


### PR DESCRIPTION
This field was added to `google_gke_hub_feature_membership` resource in DCL 1.76.0: https://github.com/GoogleCloudPlatform/magic-modules/pull/12392.

This PR does not need a separate release note since https://github.com/GoogleCloudPlatform/magic-modules/pull/12392 already includes a note for this new field.
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
