### PR TITLE
Add NetworkConfigs and NetworkConfig.QueueCount to TPU v2 VM

### DIFF
--- a/mmv1/products/tpuv2/Vm.yaml
+++ b/mmv1/products/tpuv2/Vm.yaml
@@ -127,6 +127,8 @@ properties:
     min_version: 'beta'
     immutable: true
     default_from_api: true
+    conflicts:
+      - network_configs
     properties:
       - name: 'network'
         type: String
@@ -164,6 +166,66 @@ properties:
         min_version: 'beta'
         immutable: true
         send_empty_value: true
+      - name: 'queueCount'
+        type: Integer
+        description: Specifies networking queue count for TPU VM instance's network interface.
+        min_version: 'beta'
+        immutable: true
+        default_from_api: true
+  - name: 'networkConfigs'
+    type: Array
+    description: |
+      Repeated network configurations for the TPU node. This field is used to specify multiple
+      network configs for the TPU node.
+    min_version: 'beta'
+    immutable: true
+    conflicts:
+      - network_config
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'network'
+          type: String
+          description: |
+            The name of the network for the TPU node. It must be a preexisting Google Compute Engine
+            network. If both network and subnetwork are specified, the given subnetwork must belong
+            to the given network. If network is not specified, it will be looked up from the
+            subnetwork if one is provided, or otherwise use "default".
+          min_version: 'beta'
+          immutable: true
+          default_from_api: true
+        - name: 'subnetwork'
+          type: String
+          description: |
+            The name of the subnetwork for the TPU node. It must be a preexisting Google Compute
+            Engine subnetwork. If both network and subnetwork are specified, the given subnetwork
+            must belong to the given network. If subnetwork is not specified, the subnetwork with the
+            same name as the network will be used.
+          min_version: 'beta'
+          immutable: true
+          default_from_api: true
+        - name: 'enableExternalIps'
+          type: Boolean
+          description: |
+            Indicates that external IP addresses would be associated with the TPU workers. If set to
+            false, the specified subnetwork or network should have Private Google Access enabled.
+          min_version: 'beta'
+          immutable: true
+          send_empty_value: true
+        - name: 'canIpForward'
+          type: Boolean
+          description: |
+            Allows the TPU node to send and receive packets with non-matching destination or source
+            IPs. This is required if you plan to use the TPU workers to forward routes.
+          min_version: 'beta'
+          immutable: true
+          send_empty_value: true
+        - name: 'queueCount'
+          type: Integer
+          description: Specifies networking queue count for TPU VM instance's network interface.
+          min_version: 'beta'
+          immutable: true
+          default_from_api: true
   - name: 'serviceAccount'
     type: NestedObject
     description: |

--- a/mmv1/products/tpuv2/Vm.yaml
+++ b/mmv1/products/tpuv2/Vm.yaml
@@ -169,7 +169,6 @@ properties:
         required: false
         min_version: 'beta'
         immutable: true
-        default_from_api: true
   - name: 'networkConfigs'
     type: Array
     description: |
@@ -221,7 +220,6 @@ properties:
           required: false
           min_version: 'beta'
           immutable: true
-          default_from_api: true
   - name: 'serviceAccount'
     type: NestedObject
     description: |

--- a/mmv1/products/tpuv2/Vm.yaml
+++ b/mmv1/products/tpuv2/Vm.yaml
@@ -134,9 +134,7 @@ properties:
         type: String
         description: |
           The name of the network for the TPU node. It must be a preexisting Google Compute Engine
-          network. If both network and subnetwork are specified, the given subnetwork must belong
-          to the given network. If network is not specified, it will be looked up from the
-          subnetwork if one is provided, or otherwise use "default".
+          network. If none is provided, "default" will be used.
         min_version: 'beta'
         immutable: true
         default_from_api: true
@@ -144,9 +142,7 @@ properties:
         type: String
         description: |
           The name of the subnetwork for the TPU node. It must be a preexisting Google Compute
-          Engine subnetwork. If both network and subnetwork are specified, the given subnetwork
-          must belong to the given network. If subnetwork is not specified, the subnetwork with the
-          same name as the network will be used.
+          Engine subnetwork. If none is provided, "default" will be used.
         min_version: 'beta'
         immutable: true
         default_from_api: true
@@ -168,7 +164,9 @@ properties:
         send_empty_value: true
       - name: 'queueCount'
         type: Integer
-        description: Specifies networking queue count for TPU VM instance's network interface.
+        description: |
+          Specifies networking queue count for TPU VM instance's network interface.
+        required: false
         min_version: 'beta'
         immutable: true
         default_from_api: true
@@ -188,9 +186,7 @@ properties:
           type: String
           description: |
             The name of the network for the TPU node. It must be a preexisting Google Compute Engine
-            network. If both network and subnetwork are specified, the given subnetwork must belong
-            to the given network. If network is not specified, it will be looked up from the
-            subnetwork if one is provided, or otherwise use "default".
+            network. If none is provided, "default" will be used.
           min_version: 'beta'
           immutable: true
           default_from_api: true
@@ -198,9 +194,7 @@ properties:
           type: String
           description: |
             The name of the subnetwork for the TPU node. It must be a preexisting Google Compute
-            Engine subnetwork. If both network and subnetwork are specified, the given subnetwork
-            must belong to the given network. If subnetwork is not specified, the subnetwork with the
-            same name as the network will be used.
+            Engine subnetwork. If none is provided, "default" will be used.
           min_version: 'beta'
           immutable: true
           default_from_api: true
@@ -222,7 +216,9 @@ properties:
           send_empty_value: true
         - name: 'queueCount'
           type: Integer
-          description: Specifies networking queue count for TPU VM instance's network interface.
+          description: |
+            Specifies networking queue count for TPU VM instance's network interface.
+          required: false
           min_version: 'beta'
           immutable: true
           default_from_api: true

--- a/mmv1/templates/terraform/examples/tpu_v2_vm_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/tpu_v2_vm_full.tf.tmpl
@@ -27,6 +27,7 @@ resource "google_tpu_v2_vm" "{{$.PrimaryResourceId}}" {
     enable_external_ips = true
     network             = google_compute_network.network.id
     subnetwork          = google_compute_subnetwork.subnet.id
+    queue_count         = 32
   }
   
   scheduling_config {


### PR DESCRIPTION
Add NetworkConfigs and NetworkConfig.QueueCount fields. NetworkConfigs (array) and NetworkConfig (singular) conflict. NetworkConfigs should be the field to specify multiple NetworkConfig, so I copied over the NetworkConfig NestedObject properties to its array form, NetworkConfigs.

```release-note:enhancement
tpuv2: added `network_configs` and `network_config.queue_count` fields to `google_tpu_v2_vm` resource
```
