### PR TITLE
Allow for `IPV6_ONLY` stackType configurations

### DIFF
--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -131,7 +131,7 @@ examples:
       subnetwork_name: 'subnet-ipv6-only'
       network_name: 'network-ipv6-only'
   - name: 'subnetwork_ipv6_only_external'
-    primary_resource_id: 'subnetwork-ipv6-only-external'
+    primary_resource_id: 'subnetwork-ipv6-only'
     exclude_docs: true
     vars:
       subnetwork_name: 'subnet-ipv6-only'

--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -124,6 +124,18 @@ examples:
       network_name: 'network-reserved-secondary-range'
       primary_range_name: 'reserved-primary'
       secondary_range_name: 'reserved-secondary'
+  - name: 'subnetwork_ipv6_only_internal'
+    primary_resource_id: 'subnetwork-ipv6-only'
+    exclude_docs: true
+    vars:
+      subnetwork_name: 'subnet-ipv6-only'
+      network_name: 'network-ipv6-only'
+  - name: 'subnetwork_ipv6_only_external'
+    primary_resource_id: 'subnetwork-ipv6-only-external'
+    exclude_docs: true
+    vars:
+      subnetwork_name: 'subnet-ipv6-only'
+      network_name: 'network-ipv6-only'
 virtual_fields:
   - name: 'send_secondary_ip_range_if_empty'
     description: |

--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -403,6 +403,7 @@ properties:
     enum_values:
       - 'IPV4_ONLY'
       - 'IPV4_IPV6'
+      - 'IPV6_ONLY'
   - name: 'ipv6AccessType'
     type: Enum
     description: |

--- a/mmv1/templates/terraform/examples/subnetwork_ipv6_only_external.tf.tmpl
+++ b/mmv1/templates/terraform/examples/subnetwork_ipv6_only_external.tf.tmpl
@@ -1,0 +1,12 @@
+resource "google_compute_subnetwork" "subnetwork-ipv6-only" {
+  name          = "{{index $.Vars "subnetwork_name"}}"
+  region        = "us-central1"
+  network       = google_compute_network.custom-test.id
+  stack_type    = "IPV6_ONLY"
+  ipv6_access_type = "EXTERNAL"
+}
+
+resource "google_compute_network" "custom-test" {
+  name                    = "{{index $.Vars "network_name"}}"
+  auto_create_subnetworks = false
+}

--- a/mmv1/templates/terraform/examples/subnetwork_ipv6_only_internal.tf.tmpl
+++ b/mmv1/templates/terraform/examples/subnetwork_ipv6_only_internal.tf.tmpl
@@ -1,0 +1,12 @@
+resource "google_compute_subnetwork" "subnetwork-ipv6-only" {
+  name          = "{{index $.Vars "subnetwork_name"}}"
+  region        = "us-central1"
+  network       = google_compute_network.custom-test.id
+  stack_type    = "IPV6_ONLY"
+  ipv6_access_type = "INTERNAL"
+}
+
+resource "google_compute_network" "custom-test" {
+  name                    = "{{index $.Vars "network_name"}}"
+  auto_create_subnetworks = false
+}

--- a/mmv1/templates/terraform/examples/subnetwork_ipv6_only_internal.tf.tmpl
+++ b/mmv1/templates/terraform/examples/subnetwork_ipv6_only_internal.tf.tmpl
@@ -9,4 +9,5 @@ resource "google_compute_subnetwork" "subnetwork-ipv6-only" {
 resource "google_compute_network" "custom-test" {
   name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = false
+  enable_ula_internal_ipv6 = true
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -536,7 +536,7 @@ func ResourceComputeInstance() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Computed:     true,
-							ValidateFunc: validation.StringInSlice([]string{"IPV4_ONLY", "IPV4_IPV6", ""}, false),
+							ValidateFunc: validation.StringInSlice([]string{"IPV4_ONLY", "IPV4_IPV6", "IPV6_ONLY", ""}, false),
 							Description: `The stack type for this network interface to identify whether the IPv6 feature is enabled or not. If not specified, IPV4_ONLY will be used.`,
 						},
 
@@ -548,7 +548,8 @@ func ResourceComputeInstance() *schema.Resource {
 
 						"ipv6_access_config": {
 							Type:        schema.TypeList,
-                                                        Optional:    true,
+                            Optional:    true,
+							Computed:    true,
 							Description: `An array of IPv6 access configurations for this interface. Currently, only one IPv6 access config, DIRECT_IPV6, is supported. If there is no ipv6AccessConfig specified, then this instance will have no external IPv6 Internet access.`,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -549,7 +549,6 @@ func ResourceComputeInstance() *schema.Resource {
 						"ipv6_access_config": {
 							Type:        schema.TypeList,
                             Optional:    true,
-							Computed:    true,
 							Description: `An array of IPv6 access configurations for this interface. Currently, only one IPv6 access config, DIRECT_IPV6, is supported. If there is no ipv6AccessConfig specified, then this instance will have no external IPv6 Internet access.`,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
@@ -570,7 +570,6 @@ Google Cloud KMS.`,
 						"ipv6_access_config": {
 							Type:        schema.TypeList,
 							Optional:    true,
-							Computed:    true,
 							ForceNew:    true,
 							Description: `An array of IPv6 access configurations for this interface. Currently, only one IPv6 access config, DIRECT_IPV6, is supported. If there is no ipv6AccessConfig specified, then this instance will have no external IPv6 Internet access.`,
 							Elem: &schema.Resource{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
@@ -556,7 +556,7 @@ Google Cloud KMS.`,
 							Optional:     true,
 							Computed:     true,
 							ForceNew:    true,
-							ValidateFunc: validation.StringInSlice([]string{"IPV4_ONLY", "IPV4_IPV6", ""}, false),
+							ValidateFunc: validation.StringInSlice([]string{"IPV4_ONLY", "IPV4_IPV6", "IPV6_ONLY", ""}, false),
 							Description: `The stack type for this network interface to identify whether the IPv6 feature is enabled or not. If not specified, IPV4_ONLY will be used.`,
 						},
 
@@ -570,6 +570,7 @@ Google Cloud KMS.`,
 						"ipv6_access_config": {
 							Type:        schema.TypeList,
 							Optional:    true,
+							Computed:    true,
 							ForceNew:    true,
 							Description: `An array of IPv6 access configurations for this interface. Currently, only one IPv6 access config, DIRECT_IPV6, is supported. If there is no ipv6AccessConfig specified, then this instance will have no external IPv6 Internet access.`,
 							Elem: &schema.Resource{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -4278,6 +4278,27 @@ func TestAccComputeInstance_NicStackTypeUpdate(t *testing.T) {
 	})
 }
 
+func TestAccComputeINstance_NicStackType_IPV6(t *testing.T) {
+	t.Parallel()
+	context := map[string]interface{}{
+		"instance_name": fmt.Sprintf("tf-test-compute-instance-%s", acctest.RandString(t, 10)),
+		"suffix":        acctest.RandString(t, 10),
+		"env_region":    envvar.GetTestRegionFromEnv(),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_nicStackTypeUpdate_ipv6(context),
+			},
+		},
+	})
+}
+
+
 func testAccCheckComputeInstanceDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
@@ -11365,6 +11386,46 @@ resource "google_compute_instance" "foobar" {
 	}
 
 	key_revocation_action_type = %{key_revocation_action_type}
+}
+`, context)
+}
+
+func testAccComputeInstance_nicStackTypeUpdate_ipv6(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-11"
+	project = "debian-cloud"
+}
+
+resource "google_compute_network" "inst-test-network" {
+	name = "tf-test-network-%{suffix}"
+	auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "inst-test-subnetwork" {
+	name          = "tf-test-compute-subnet-%{suffix}"
+	region        = "%{env_region}"
+	ipv6_access_type = "EXTERNAL"
+	stack_type = "IPV6_ONLY"
+	network       = google_compute_network.inst-test-network.id
+}
+
+resource "google_compute_instance" "foobar" {
+	name         = "%{instance_name}"
+	machine_type = "e2-medium"
+	zone         = "%{env_region}-a"
+
+	boot_disk {
+		initialize_params {
+			image = data.google_compute_image.my_image.self_link
+		}
+	}
+
+	network_interface {
+		network = google_compute_network.inst-test-network.id
+		subnetwork = google_compute_subnetwork.inst-test-subnetwork.id
+		stack_type = "IPV6_ONLY"
+	}
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -4278,7 +4278,7 @@ func TestAccComputeInstance_NicStackTypeUpdate(t *testing.T) {
 	})
 }
 
-func TestAccComputeINstance_NicStackType_IPV6(t *testing.T) {
+func TestAccComputeInstance_NicStackType_IPV6(t *testing.T) {
 	t.Parallel()
 	context := map[string]interface{}{
 		"instance_name": fmt.Sprintf("tf-test-compute-instance-%s", acctest.RandString(t, 10)),
@@ -11425,6 +11425,10 @@ resource "google_compute_instance" "foobar" {
 		network = google_compute_network.inst-test-network.id
 		subnetwork = google_compute_subnetwork.inst-test-subnetwork.id
 		stack_type = "IPV6_ONLY"
+
+		ipv6_access_config {
+			network_tier = "PREMIUM"
+	  	}
 	}
 }
 `, context)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
@@ -524,7 +524,7 @@ Google Cloud KMS.`,
 							Optional:     true,
 							Computed:     true,
 							ForceNew:     true,
-							ValidateFunc: validation.StringInSlice([]string{"IPV4_ONLY", "IPV4_IPV6", ""}, false),
+							ValidateFunc: validation.StringInSlice([]string{"IPV4_ONLY", "IPV4_IPV6","IPV6_ONLY", ""}, false),
 							Description:  `The stack type for this network interface to identify whether the IPv6 feature is enabled or not. If not specified, IPV4_ONLY will be used.`,
 						},
 
@@ -538,6 +538,7 @@ Google Cloud KMS.`,
 						"ipv6_access_config": {
 							Type:        schema.TypeList,
 							Optional:    true,
+							Computed:    true,
 							ForceNew:    true,
 							Description: `An array of IPv6 access configurations for this interface. Currently, only one IPv6 access config, DIRECT_IPV6, is supported. If there is no ipv6AccessConfig specified, then this instance will have no external IPv6 Internet access.`,
 							Elem: &schema.Resource{

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -401,7 +401,7 @@ is desired, you will need to modify your state file manually using
 
 * `network_attachment` - (Optional) [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) The URL of the network attachment that this interface should connect to in the following format: `projects/{projectNumber}/regions/{region_name}/networkAttachments/{network_attachment_name}`.
 
-* `stack_type` - (Optional) The stack type for this network interface to identify whether the IPv6 feature is enabled or not. Values are IPV4_IPV6 or IPV4_ONLY. If not specified, IPV4_ONLY will be used.
+* `stack_type` - (Optional) The stack type for this network interface to identify whether the IPv6 feature is enabled or not. Values are IPV4_IPV6, IPV6_ONLY or IPV4_ONLY. If not specified, IPV4_ONLY will be used.
 
 * `ipv6_access_config` - (Optional) An array of IPv6 access configurations for this interface.
 Currently, only one IPv6 access config, DIRECT_IPV6, is supported. If there is no ipv6AccessConfig

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -563,7 +563,7 @@ The following arguments are supported:
 
 * `nic_type` - (Optional) The type of vNIC to be used on this interface. Possible values: GVNIC, VIRTIO_NET. In the beta provider the additional values of MRDMA and IRDMA are supported.
 
-* `stack_type` - (Optional) The stack type for this network interface to identify whether the IPv6 feature is enabled or not. Values are IPV4_IPV6 or IPV4_ONLY. If not specified, IPV4_ONLY will be used.
+* `stack_type` - (Optional) The stack type for this network interface to identify whether the IPv6 feature is enabled or not. Values are IPV4_IPV6, IPV6_ONLY or IPV4_ONLY. If not specified, IPV4_ONLY will be used.
 
 * `ipv6_access_config` - (Optional) An array of IPv6 access configurations for this interface.
 Currently, only one IPv6 access config, DIRECT_IPV6, is supported. If there is no ipv6AccessConfig

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
@@ -529,7 +529,7 @@ The following arguments are supported:
 
 * `nic_type` - (Optional) The type of vNIC to be used on this interface. Possible values: GVNIC, VIRTIO_NET. In the beta provider the additional values of MRDMA and IRDMA are supported.
 
-* `stack_type` - (Optional) The stack type for this network interface to identify whether the IPv6 feature is enabled or not. Values are IPV4_IPV6 or IPV4_ONLY. If not specified, IPV4_ONLY will be used.
+* `stack_type` - (Optional) The stack type for this network interface to identify whether the IPv6 feature is enabled or not. Values are IPV4_IPV6, IPV6_ONLY or IPV4_ONLY. If not specified, IPV4_ONLY will be used.
 
 * `ipv6_access_config` - (Optional) An array of IPv6 access configurations for this interface.
 Currently, only one IPv6 access config, DIRECT_IPV6, is supported. If there is no ipv6AccessConfig


### PR DESCRIPTION
reopen of https://github.com/GoogleCloudPlatform/magic-modules/pull/12283
related to b/360733056

This got rolled back because it was failing `TestAccComputeInstanceNetworkIntefaceWithSecurityPolicy`. I don't have Cloud Armor on my private cloud environment so can i get a detailed test log to see why it fails and debug it? Preferably with `TF_LOG=DEBUG` while the test is running

- Supports `IPV6_ONLY` stackType for instances and subnetworks
- `ipv6_access_config` is now Computed because when providing an IPV6 subnet the access config will get autofilled from the API

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added support for `IPV6_ONLY` stack_type to `google_compute_subnetwork`, `google_compute_instance`, `google_compute_instance_template` and `google_compute_region_instance_template`.
```
