### PR TITLE
Add Intercept Deployment Group resource to Network Security.

### DIFF
--- a/mmv1/products/networksecurity/InterceptDeploymentGroup.yaml
+++ b/mmv1/products/networksecurity/InterceptDeploymentGroup.yaml
@@ -1,0 +1,124 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'InterceptDeploymentGroup'
+description: A Deployment Group represents the collector deployments across different zones within an organization.
+min_version: 'beta'
+docs:
+id_format: 'projects/{{project}}/locations/{{location}}/interceptDeploymentGroups/{{intercept_deployment_group_id}}'
+base_url: 'projects/{{project}}/locations/{{location}}/interceptDeploymentGroups'
+self_link: 'projects/{{project}}/locations/{{location}}/interceptDeploymentGroups/{{intercept_deployment_group_id}}'
+create_url: 'projects/{{project}}/locations/{{location}}/interceptDeploymentGroups?interceptDeploymentGroupId={{intercept_deployment_group_id}}'
+update_verb: 'PATCH'
+update_mask: true
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/interceptDeploymentGroups/{{intercept_deployment_group_id}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+autogen_async: true
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+    path: 'name'
+    wait_ms: 1000
+  result:
+    path: 'response'
+    resource_inside_response: true
+  error:
+    path: 'error'
+    message: 'message'
+custom_code:
+examples:
+  - name: 'network_security_intercept_deployment_group_basic'
+    config_path: 'templates/terraform/examples/network_security_intercept_deployment_group_basic.tf.tmpl'
+    primary_resource_id: 'default'
+    vars:
+      network_name: 'example-network'
+      subnetwork_name: 'example-subnet'
+      deployment_group_id: 'example-dg'
+parameters:
+  - name: 'location'
+    type: String
+    description: 'Resource ID segment making up resource `name`. It identifies the resource
+    within its parent collection as described in https://google.aip.dev/122. See documentation
+    for resource type `networksecurity.googleapis.com/InterceptDeploymentGroup`. '
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+  - name: 'interceptDeploymentGroupId'
+    type: String
+    description: "Required. Id of the requesting object\nIf auto-generating Id server-side,
+    remove this field and\nintercept_deployment_group_id from the method_signature
+    of Create RPC "
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+properties:
+  - name: 'name'
+    type: String
+    description: 'Output only. Identifier. Then name of the InterceptDeploymentGroup. '
+    min_version: 'beta'
+    output: true
+  - name: 'createTime'
+    type: String
+    description: 'Output only. [Output only] Create time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'updateTime'
+    type: String
+    description: 'Output only. [Output only] Update time stamp '
+    min_version: 'beta'
+    output: true
+  - name: 'labels'
+    type: KeyValueLabels
+    description: 'Optional. Labels as key value pairs '
+    min_version: 'beta'
+  - name: 'network'
+    type: String
+    description: "Required. Immutable. The network that is being used for the deployment.
+    Format is:\nprojects/{project}/global/networks/{network}. "
+    min_version: 'beta'
+    required: true
+    immutable: true
+  - name: 'connectedEndpointGroups'
+    type: Array
+    min_version: 'beta'
+    description: 'Output only. The list of Intercept Endpoint Groups that are connected
+      to this resource. '
+    output: true
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'name'
+          type: String
+          description: 'Output only. A connected intercept endpoint group. '
+          min_version: 'beta'
+          output: true
+  - name: 'state'
+    type: String
+    description: "Output only. Current state of the deployment group. \n Possible values:\n
+    STATE_UNSPECIFIED\nACTIVE\nCREATING\nDELETING"
+    min_version: 'beta'
+    output: true
+  - name: 'reconciling'
+    type: Boolean
+    description: "Output only. Whether reconciling is in progress, recommended per\nhttps://google.aip.dev/128. "
+    min_version: 'beta'
+    output: true

--- a/mmv1/templates/terraform/examples/network_security_intercept_deployment_group_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_deployment_group_basic.tf.tmpl
@@ -1,0 +1,15 @@
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "{{index $.Vars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "{{$.PrimaryResourceId}}" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+  labels = {
+    foo = "bar"
+  }
+}

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_deployment_group_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_deployment_group_generated_test.go.tmpl
@@ -1,0 +1,91 @@
+package networksecurity_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccNetworkSecurityInterceptDeploymentGroup_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkSecurityInterceptDeploymentGroup_basic(context),
+			},
+			{
+				ResourceName:            "google_network_security_intercept_deployment_group.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccNetworkSecurityInterceptDeploymentGroup_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_network_security_intercept_deployment_group.default", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_network_security_intercept_deployment_group.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"update_time", "labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccNetworkSecurityInterceptDeploymentGroup_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "tf-test-example-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "default" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+  labels = {
+    foo = "bar"
+  }
+}
+`, context)
+}
+
+func testAccNetworkSecurityInterceptDeploymentGroup_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "tf-test-example-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "default" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+  labels = {
+    foo = "goo"
+  }
+}
+`, context)
+}
+
+{{ end }}


### PR DESCRIPTION
This PR is a promotion from google-private provider.
Removal CL: https://cloud-internal-review.git.corp.google.com/c/cloud-graphite-eng/magic-modules-private-overrides/+/49230

```release-note:new-resource
`google_network_security_intercept_deployment_group`
```
