### PR TITLE
Make `google_compute_instance_guest_attributes` return empty results when queried for nonexistent values

### DIFF
--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance_guest_attributes.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance_guest_attributes.go.tmpl
@@ -92,9 +92,14 @@ func dataSourceGoogleComputeInstanceGuestAttributesRead(d *schema.ResourceData, 
 		return err
 	}
 
+	//Check if instance exists
 	id := fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, zone, name)
-	instanceGuestAttributes := &compute.GuestAttributes{}
+	_, err = config.NewComputeClient(userAgent).Instances.Get(project, zone, name).Do()
+	if err != nil {
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Instance %s", name), id)
+	}
 
+	instanceGuestAttributes := &compute.GuestAttributes{}
 	// You can either query based on variable_key, query_path or just get the first value
 	if d.Get("query_path").(string) != "" {
 		instanceGuestAttributes, err = config.NewComputeClient(userAgent).Instances.GetGuestAttributes(project, zone, name).QueryPath(d.Get("query_path").(string)).Do()
@@ -104,7 +109,7 @@ func dataSourceGoogleComputeInstanceGuestAttributesRead(d *schema.ResourceData, 
 		instanceGuestAttributes, err = config.NewComputeClient(userAgent).Instances.GetGuestAttributes(project, zone, name).Do()
 	}
 	if err != nil {
-		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Instance's Guest Attributes %s", name), id)
+		return nil
 	}
 
 	// Set query results

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance_guest_attributes_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance_guest_attributes_test.go.tmpl
@@ -25,6 +25,12 @@ func TestAccDataSourceComputeInstanceGuestAttributes_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
+				Config: testAccDataSourceComputeInstanceGuestAttributesConfig_queryPath_empty(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("data.google_compute_instance_guest_attributes.bar", "query_value"),
+				),
+			},
+			{
 				//need to create the guest_attributes metadata from startup script first
 				Config: testAccDataSourceComputeInstanceGuestAttributesInitialConfig(instanceName),
 				Check:  testAccCheckComputeInstanceExists(t, "google_compute_instance.foo", &instance),
@@ -42,6 +48,12 @@ func TestAccDataSourceComputeInstanceGuestAttributes_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.google_compute_instance_guest_attributes.bar", "query_path", "testing/"),
 					resource.TestCheckResourceAttr("data.google_compute_instance_guest_attributes.bar", "query_value.0.value", "test1"),
 					resource.TestCheckResourceAttr("data.google_compute_instance_guest_attributes.bar", "query_value.1.value", "test2"),
+				),
+			},
+			{
+				Config: testAccDataSourceComputeInstanceGuestAttributesConfig_queryPath_nonExistent(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("data.google_compute_instance_guest_attributes.bar", "query_value"),
 				),
 			},
 		},
@@ -114,6 +126,77 @@ data "google_compute_instance_guest_attributes" "bar" {
   name = google_compute_instance.foo.name
   zone = "us-central1-a"
   query_path = "testing/"
+}
+`, instanceName)
+}
+
+func testAccDataSourceComputeInstanceGuestAttributesConfig_queryPath_nonExistent(instanceName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_instance" "foo" {
+  name           = "%s"
+  machine_type   = "n1-standard-1"
+  zone           = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-8-jessie-v20160803"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+  metadata = {
+    enable-guest-attributes = "TRUE"
+  }
+
+  metadata_startup_script = <<-EOF
+  curl -X PUT --data "test1" http://metadata.google.internal/computeMetadata/v1/instance/guest-attributes/testing/key1 -H "Metadata-Flavor: Google"
+  curl -X PUT --data "test2" http://metadata.google.internal/computeMetadata/v1/instance/guest-attributes/testing/key2 -H "Metadata-Flavor: Google"
+  EOF
+}
+
+data "google_compute_instance_guest_attributes" "bar" {
+  name = google_compute_instance.foo.name
+  zone = "us-central1-a"
+  query_path = "test/"
+}
+`, instanceName)
+}
+
+func testAccDataSourceComputeInstanceGuestAttributesConfig_queryPath_empty(instanceName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_instance" "foo" {
+  name           = "%s"
+  machine_type   = "n1-standard-1"
+  zone           = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-8-jessie-v20160803"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      // Ephemeral IP
+    }
+  }
+
+  metadata = {
+    enable-guest-attributes = "TRUE"
+  }
+}
+
+data "google_compute_instance_guest_attributes" "bar" {
+  name = google_compute_instance.foo.name
+  zone = "us-central1-a"
+  query_path = "test/"
 }
 `, instanceName)
 }


### PR DESCRIPTION
closes https://github.com/hashicorp/terraform-provider-google/issues/20346

- Removed error thrown on Instances.GetGuestAttributes calls
- Added additional Instances.Get call to see if the instance exists at all

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: `google_compute_instance_guest_attributes` will return empty arrays and lists when queried values don't exist instead of throwing an error
```
