### PR TITLE
Allow brand new setup for google_developer_connect_connection

### DIFF
--- a/mmv1/products/developerconnect/Connection.yaml
+++ b/mmv1/products/developerconnect/Connection.yaml
@@ -45,13 +45,24 @@ async:
     message: 'message'
 custom_code:
 examples:
-  - name: 'developer_connect_connection_basic'
+  - name: 'developer_connect_connection_new'
     primary_resource_id: 'my-connection'
-    primary_resource_name: 'fmt.Sprintf("tf-test-connection%s", context["random_suffix"])'
+    primary_resource_name: 'fmt.Sprintf("tf-test-connection-new%s", context["random_suffix"])'
     min_version: 'beta'
     vars:
-      connection_name: 'tf-test-connection'
-  - name: 'developer_connect_connection_github_doc'
+      connection_name: 'tf-test-connection-new'
+    test_env_vars:
+      project: 'PROJECT_NAME'
+  - name: 'developer_connect_connection_existing_credentials'
+    primary_resource_id: 'my-connection'
+    primary_resource_name: 'fmt.Sprintf("tf-test-connection-cred%s", context["random_suffix"])'
+    min_version: 'beta'
+    vars:
+      connection_name: 'tf-test-connection-cred'
+      secret_name: "projects/your-project/secrets/your-secret-id/versions/latest"
+    test_vars_overrides:
+      secret_name: '"projects/devconnect-terraform-creds/secrets/tf-test-do-not-change-github-oauthtoken-e0b9e7/versions/1"'
+  - name: 'developer_connect_connection_existing_installation'
     min_version: 'beta'
     exclude_test: true
 parameters:
@@ -99,6 +110,7 @@ properties:
           Represents an OAuth token of the account that authorized the Connection,and
           associated metadata.
         min_version: 'beta'
+        default_from_api: true
         properties:
           - name: 'oauthTokenSecretVersion'
             type: String
@@ -119,6 +131,7 @@ properties:
         description: |
           Optional. GitHub App installation id.
         min_version: 'beta'
+        default_from_api: true
       - name: 'installationUri'
         type: String
         description: |

--- a/mmv1/templates/terraform/examples/developer_connect_connection_existing_credentials.tf.tmpl
+++ b/mmv1/templates/terraform/examples/developer_connect_connection_existing_credentials.tf.tmpl
@@ -7,7 +7,12 @@ resource "google_developer_connect_connection" "{{$.PrimaryResourceId}}" {
     github_app = "DEVELOPER_CONNECT"
 
     authorizer_credential {
-      oauth_token_secret_version = "projects/devconnect-terraform-creds/secrets/tf-test-do-not-change-github-oauthtoken-e0b9e7/versions/1"
+      oauth_token_secret_version = "{{index $.Vars "secret_name"}}"
     }
   }
+}
+
+output "next_steps" {
+  description = "Follow the action_uri if present to continue setup"
+  value = google_developer_connect_connection.{{$.PrimaryResourceId}}.installation_state
 }

--- a/mmv1/templates/terraform/examples/developer_connect_connection_existing_installation.tf.tmpl
+++ b/mmv1/templates/terraform/examples/developer_connect_connection_existing_installation.tf.tmpl
@@ -15,11 +15,17 @@ resource "google_secret_manager_secret_version" "github-token-secret-version" {
   secret_data = file("my-github-token.txt")
 }
 
+resource "google_project_service_identity" "devconnect-p4sa" {
+  provider = google-beta
+
+  service = "developerconnect.googleapis.com"
+}
+
 data "google_iam_policy" "p4sa-secretAccessor" {
   binding {
     role = "roles/secretmanager.secretAccessor"
     // Here, 123456789 is the Google Cloud project number for the project that contains the connection.
-    members = ["serviceAccount:service-123456789@gcp-sa-devconnect.iam.gserviceaccount.com"]
+    members = [google_project_service_identity.devconnect-p4sa.member]
   }
 }
 

--- a/mmv1/templates/terraform/examples/developer_connect_connection_new.tf.tmpl
+++ b/mmv1/templates/terraform/examples/developer_connect_connection_new.tf.tmpl
@@ -1,0 +1,31 @@
+resource "google_developer_connect_connection" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+  location = "us-central1"
+  connection_id = "{{index $.Vars "connection_name"}}"
+
+  github_config {
+    github_app = "FIREBASE"
+  }
+
+  depends_on = [google_project_iam_member.devconnect-secret]
+}
+
+output "next_steps" {
+  description = "Follow the action_uri if present to continue setup"
+  value = google_developer_connect_connection.{{$.PrimaryResourceId}}.installation_state
+}
+
+# Setup permissions. Only needed once per project
+resource "google_project_service_identity" "devconnect-p4sa" {
+  provider = google-beta
+
+  service = "developerconnect.googleapis.com"
+}
+
+resource "google_project_iam_member" "devconnect-secret" {
+  provider = google-beta
+
+  project  = "{{index $.TestEnvVars "project"}}"
+  role     = "roles/secretmanager.admin"
+  member   = google_project_service_identity.devconnect-p4sa.member
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
developerconnect: added support for setting up a brand new `google_developer_connect_connection`
```
