### PR TITLE
Fix an issue which cause failure when updating a sub-CA

### DIFF
--- a/mmv1/templates/terraform/pre_update/privateca_certificate_authority.go.tmpl
+++ b/mmv1/templates/terraform/pre_update/privateca_certificate_authority.go.tmpl
@@ -41,3 +41,19 @@ if d.HasChange("desired_state") {
 		}
 	}
 }
+
+
+// `subordinateConfig.certificateAuthority` is not directly passed 
+// to the backend when activating a sub-CA. Instead, it is used to sign CA cert
+// and activate the sub-CA at client side. See b/332548736 for details.
+// Drop this field to avoid both `subordinateConfig.certificateAuthority` 
+// and `subordinateConfig.pemIssuerChain` to be passed to the backend.
+if _, ok := obj["subordinateConfig"]; ok {
+	subConfig := obj["subordinateConfig"].(map[string]interface{})
+	// There could be case which a sub-CA was activated via `subordinateConfig.certificateAuthority`
+	// directly by older version of providers.
+	// For backward compatibility, delete `certificateAuthority` only if `pemIssuerChain` is presented.
+	if _, ok := subConfig["pemIssuerChain"]; ok {
+		delete(subConfig, "certificateAuthority")
+	}
+}

--- a/mmv1/third_party/terraform/services/privateca/resource_privateca_certificate_authority_test.go
+++ b/mmv1/third_party/terraform/services/privateca/resource_privateca_certificate_authority_test.go
@@ -126,9 +126,10 @@ func TestAccPrivatecaCertificateAuthority_subordinateCaActivatedByFirstPartyIssu
 
 	random_suffix := acctest.RandString(t, 10)
 	context := map[string]interface{}{
-		"root_location": "us-central1",
-		"sub_location":  "australia-southeast1",
-		"random_suffix": random_suffix,
+		"root_location":     "us-central1",
+		"sub_location":      "australia-southeast1",
+		"random_suffix":     random_suffix,
+		"first_label_value": "bar",
 	}
 
 	resourceName := "google_privateca_certificate_authority.sub-1"
@@ -168,6 +169,47 @@ func TestAccPrivatecaCertificateAuthority_subordinateCaActivatedByFirstPartyIssu
 				Config: testAccPrivatecaCertificateAuthority_privatecaCertificateAuthoritySubordinateStagedWithFirstPartyIssuer(context),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "state", "STAGED"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPrivatecaCertificateAuthority_subordinateCaCanUpdateLabel(t *testing.T) {
+	t.Parallel()
+	acctest.SkipIfVcr(t)
+
+	random_suffix := acctest.RandString(t, 10)
+	context1 := map[string]interface{}{
+		"root_location":     "us-central1",
+		"sub_location":      "australia-southeast1",
+		"random_suffix":     random_suffix,
+		"first_label_value": "bar-1",
+	}
+
+	context2 := map[string]interface{}{
+		"root_location":     "us-central1",
+		"sub_location":      "australia-southeast1",
+		"random_suffix":     random_suffix,
+		"first_label_value": "bar-2",
+	}
+
+	resourceName := "google_privateca_certificate_authority.sub-1"
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckPrivatecaCertificateAuthorityDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivatecaCertificateAuthority_privatecaCertificateAuthoritySubordinateWithFirstPartyIssuer(context1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "labels.first_label", context1["first_label_value"].(string)),
+				),
+			},
+			{
+				Config: testAccPrivatecaCertificateAuthority_privatecaCertificateAuthoritySubordinateWithFirstPartyIssuer(context2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "labels.first_label", context2["first_label_value"].(string)),
 				),
 			},
 		},
@@ -467,6 +509,10 @@ resource "google_privateca_certificate_authority" "sub-1" {
 		algorithm = "RSA_PKCS1_4096_SHA256"
 	}
 	type = "SUBORDINATE"
+
+	labels = {
+		first_label = "%{first_label_value}"
+	}
 
 	// Disable CA deletion related safe checks for easier cleanup.
 	deletion_protection                    = false


### PR DESCRIPTION
See b/382313978 for details

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: bug
privateca: fixed an issue which causes error when updating labels for activated sub-CA
```
