### PR TITLE
Fix settings.data_cache_config permadiff when set to false

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -2247,6 +2247,12 @@ func flattenSettings(settings *sqladmin.Settings, d *schema.ResourceData) []map[
 
 	if settings.DataCacheConfig != nil {
 		data["data_cache_config"] = flattenDataCacheConfig(settings.DataCacheConfig)
+	} else {
+		data["data_cache_config"] = []map[string]interface{}{
+			{
+				"data_cache_enabled": false,
+			},
+		}
 	}
 
 	if settings.AdvancedMachineFeatures != nil {
@@ -2258,7 +2264,11 @@ func flattenSettings(settings *sqladmin.Settings, d *schema.ResourceData) []map[
 
 func flattenDataCacheConfig(d *sqladmin.DataCacheConfig) []map[string]interface{} {
 	if d == nil {
-		return nil
+		return []map[string]interface{}{
+			{
+				"data_cache_enabled": false,
+			},
+		}
 	}
 	return []map[string]interface{}{
 		{

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -1771,7 +1771,7 @@ func TestAccSQLDatabaseInstance_sqlMysqlDataCacheConfig(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("google_sql_database_instance.instance", "settings.0.data_cache_config.0.data_cache_enabled", "true"),
 				),
-			},			
+			},
 		},
 	})
 }
@@ -1810,7 +1810,7 @@ func TestAccSQLDatabaseInstance_sqlPostgresDataCacheConfig(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
-			},			
+			},
 			{
 				Config: testGoogleSqlDatabaseInstance_sqlPostgresDataCacheConfig(enterpriseInstanceName, enterpriseTier, "ENTERPRISE", true),
 				ExpectError: regexp.MustCompile(

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -1755,9 +1755,9 @@ func TestAccSQLDatabaseInstance_sqlMysqlDataCacheConfig(t *testing.T) {
 		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testGoogleSqlDatabaseInstance_sqlMysqlDataCacheConfig(instanceName),
+				Config: testGoogleSqlDatabaseInstance_sqlMysqlDataCacheConfig(instanceName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("google_sql_database_instance.instance", "settings.0.data_cache_config.0.data_cache_enabled", "true"),
+					resource.TestCheckResourceAttr("google_sql_database_instance.instance", "settings.0.data_cache_config.0.data_cache_enabled", "false"),
 				),
 			},
 			{
@@ -1766,6 +1766,12 @@ func TestAccSQLDatabaseInstance_sqlMysqlDataCacheConfig(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
+			{
+				Config: testGoogleSqlDatabaseInstance_sqlMysqlDataCacheConfig(instanceName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("google_sql_database_instance.instance", "settings.0.data_cache_config.0.data_cache_enabled", "true"),
+				),
+			},			
 		},
 	})
 }
@@ -1782,7 +1788,7 @@ func TestAccSQLDatabaseInstance_sqlPostgresDataCacheConfig(t *testing.T) {
 		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testGoogleSqlDatabaseInstance_sqlPostgresDataCacheConfig(enterprisePlusInstanceName, enterprisePlusTier, "ENTERPRISE_PLUS"),
+				Config: testGoogleSqlDatabaseInstance_sqlPostgresDataCacheConfig(enterprisePlusInstanceName, enterprisePlusTier, "ENTERPRISE_PLUS", true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("google_sql_database_instance.instance", "settings.0.data_cache_config.0.data_cache_enabled", "true"),
 				),
@@ -1794,7 +1800,19 @@ func TestAccSQLDatabaseInstance_sqlPostgresDataCacheConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testGoogleSqlDatabaseInstance_sqlPostgresDataCacheConfig(enterpriseInstanceName, enterpriseTier, "ENTERPRISE"),
+				Config: testGoogleSqlDatabaseInstance_sqlPostgresDataCacheConfig(enterprisePlusInstanceName, enterprisePlusTier, "ENTERPRISE_PLUS", false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("google_sql_database_instance.instance", "settings.0.data_cache_config.0.data_cache_enabled", "false"),
+				),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},			
+			{
+				Config: testGoogleSqlDatabaseInstance_sqlPostgresDataCacheConfig(enterpriseInstanceName, enterpriseTier, "ENTERPRISE", true),
 				ExpectError: regexp.MustCompile(
 					fmt.Sprintf("Error, failed to create instance %s: googleapi: Error 400: Invalid request: Only ENTERPRISE PLUS edition supports data cache", enterpriseInstanceName)),
 			},
@@ -1824,7 +1842,7 @@ func TestAccSqlDatabaseInstance_Mysql_Edition_Upgrade(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testGoogleSqlDatabaseInstance_sqlMysqlDataCacheConfig(editionUpgrade),
+				Config: testGoogleSqlDatabaseInstance_sqlMysqlDataCacheConfig(editionUpgrade, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("google_sql_database_instance.instance", "settings.0.edition", "ENTERPRISE_PLUS"),
 					resource.TestCheckResourceAttr("google_sql_database_instance.instance", "settings.0.data_cache_config.0.data_cache_enabled", "true"),
@@ -2899,7 +2917,7 @@ resource "google_sql_database_instance" "instance" {
 }`, databaseName, tier)
 }
 
-func testGoogleSqlDatabaseInstance_sqlMysqlDataCacheConfig(instanceName string) string {
+func testGoogleSqlDatabaseInstance_sqlMysqlDataCacheConfig(instanceName string, datacache bool) string {
 	return fmt.Sprintf(`
 
 resource "google_sql_database_instance" "instance" {
@@ -2911,13 +2929,13 @@ resource "google_sql_database_instance" "instance" {
     tier = "db-perf-optimized-N-2"
     edition = "ENTERPRISE_PLUS"
     data_cache_config {
-        data_cache_enabled = true
+        data_cache_enabled = "%t"
     }
   }
-}`, instanceName)
+}`, instanceName, datacache)
 }
 
-func testGoogleSqlDatabaseInstance_sqlPostgresDataCacheConfig(instanceName, tier, edition string) string {
+func testGoogleSqlDatabaseInstance_sqlPostgresDataCacheConfig(instanceName, tier, edition string, datacache bool) string {
 	return fmt.Sprintf(`
 
 resource "google_sql_database_instance" "instance" {
@@ -2929,10 +2947,10 @@ resource "google_sql_database_instance" "instance" {
     tier = "%s"
     edition = "%s"
     data_cache_config {
-        data_cache_enabled = true
+        data_cache_enabled = "%t"
     }
   }
-}`, instanceName, tier, edition)
+}`, instanceName, tier, edition, datacache)
 }
 
 func testGoogleSqlDatabaseInstance_SqlServerTimezone(instance, rootPassword, timezone string) string {


### PR DESCRIPTION
When settings.data_cache_config false a permadiff will result. This is due to the fact that CloudSQL API will not return  data_cache_config when there is no data cache. Update terraform to match CloudSQL API by representing non existent data cache config as set to false .

Mentioned in:
https://github.com/hashicorp/terraform-provider-google/issues/15227
https://github.com/hashicorp/terraform-provider-google/issues/19144

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
sql: fixed permadiff when 'settings.data_cache_config' is set to false for 'google_sql_database_instance' resource
```
