### PR TITLE
Update oracledatabase acceptance tests to use unique names with ofake- prefix

### DIFF
--- a/mmv1/products/oracledatabase/CloudExadataInfrastructure.yaml
+++ b/mmv1/products/oracledatabase/CloudExadataInfrastructure.yaml
@@ -61,6 +61,11 @@ examples:
     test_vars_overrides:
       'project': '"oci-terraform-testing"'
       'deletion_protection': 'false'
+      # ofake- prefix is needed to create a dummy resource for testing purposes only
+      # See: https://github.com/hashicorp/terraform-provider-google/issues/19983#issuecomment-2516403770
+      # As a result these resources are not sweepable
+      # See: https://github.com/hashicorp/terraform-provider-google/issues/20599
+      cloud_exadata_infrastructure_id: '"ofake-tf-test-exadata-basic-%{random_suffix}"'
   - name: 'oracledatabase_cloud_exadata_infrastructure_full'
     primary_resource_id: 'my-cloud-exadata'
     vars:
@@ -72,6 +77,11 @@ examples:
     test_vars_overrides:
       'project': '"oci-terraform-testing"'
       'deletion_protection': 'false'
+      # ofake- prefix is needed to create a dummy resource for testing purposes only
+      # See: https://github.com/hashicorp/terraform-provider-google/issues/19983#issuecomment-2516403770
+      # As a result these resources are not sweepable
+      # See: https://github.com/hashicorp/terraform-provider-google/issues/20599
+      cloud_exadata_infrastructure_id: '"ofake-tf-test-exadata-full-%{random_suffix}"'
 virtual_fields:
   - name: 'deletion_protection'
     type: Boolean

--- a/mmv1/products/oracledatabase/CloudExadataInfrastructure.yaml
+++ b/mmv1/products/oracledatabase/CloudExadataInfrastructure.yaml
@@ -65,7 +65,7 @@ examples:
       # See: https://github.com/hashicorp/terraform-provider-google/issues/19983#issuecomment-2516403770
       # As a result these resources are not sweepable
       # See: https://github.com/hashicorp/terraform-provider-google/issues/20599
-      cloud_exadata_infrastructure_id: '"ofake-tf-test-exadata-basic-%{random_suffix}"'
+      cloud_exadata_infrastructure_id: 'fmt.Sprintf("ofake-tf-test-exadata-basic-%s", acctest.RandString(t, 10))'
   - name: 'oracledatabase_cloud_exadata_infrastructure_full'
     primary_resource_id: 'my-cloud-exadata'
     vars:
@@ -81,7 +81,7 @@ examples:
       # See: https://github.com/hashicorp/terraform-provider-google/issues/19983#issuecomment-2516403770
       # As a result these resources are not sweepable
       # See: https://github.com/hashicorp/terraform-provider-google/issues/20599
-      cloud_exadata_infrastructure_id: '"ofake-tf-test-exadata-full-%{random_suffix}"'
+      cloud_exadata_infrastructure_id: 'fmt.Sprintf("ofake-tf-test-exadata-full-%s", acctest.RandString(t, 10))'
 virtual_fields:
   - name: 'deletion_protection'
     type: Boolean

--- a/mmv1/products/oracledatabase/CloudVmCluster.yaml
+++ b/mmv1/products/oracledatabase/CloudVmCluster.yaml
@@ -68,8 +68,8 @@ examples:
       # See: https://github.com/hashicorp/terraform-provider-google/issues/19983#issuecomment-2516403770
       # As a result these resources are not sweepable
       # See: https://github.com/hashicorp/terraform-provider-google/issues/20599
-      cloud_vm_cluster_id: '"ofake-tf-test-basic-%{random_suffix}"'
-      cloud_exadata_infrastructure_id: '"ofake-tf-test-basic-%{random_suffix}"'
+      cloud_vm_cluster_id: 'fmt.Sprintf("ofake-tf-test-basic-%s", acctest.RandString(t, 10))'
+      cloud_exadata_infrastructure_id: 'fmt.Sprintf("ofake-tf-test-basic-%s", acctest.RandString(t, 10))'
   - name: 'oracledatabase_cloud_vmcluster_full'
     primary_resource_id: 'my_vmcluster'
     vars:
@@ -86,8 +86,8 @@ examples:
       # See: https://github.com/hashicorp/terraform-provider-google/issues/19983#issuecomment-2516403770
       # As a result these resources are not sweepable
       # See: https://github.com/hashicorp/terraform-provider-google/issues/20599
-      cloud_vm_cluster_id: '"ofake-tf-test-full-%{random_suffix}"'
-      cloud_exadata_infrastructure_id: '"ofake-tf-test-full-%{random_suffix}"'
+      cloud_vm_cluster_id: 'fmt.Sprintf("ofake-tf-test-full-%s", acctest.RandString(t, 10))'
+      cloud_exadata_infrastructure_id: 'fmt.Sprintf("ofake-tf-test-full-%s", acctest.RandString(t, 10))'
 virtual_fields:
   - name: 'deletion_protection'
     type: Boolean

--- a/mmv1/products/oracledatabase/CloudVmCluster.yaml
+++ b/mmv1/products/oracledatabase/CloudVmCluster.yaml
@@ -64,8 +64,12 @@ examples:
     test_vars_overrides:
       'deletion_protection': 'false'
       'project': '"oci-terraform-testing"'
-      cloud_vm_cluster_id: '"ofake-vmcluster-basic-%{random_suffix}"'
-      cloud_exadata_infrastructure_id: '"ofake-vmcluster-basic-%{random_suffix}"'
+      # ofake- prefix is needed to create a dummy resource for testing purposes only
+      # See: https://github.com/hashicorp/terraform-provider-google/issues/19983#issuecomment-2516403770
+      # As a result these resources are not sweepable
+      # See: https://github.com/hashicorp/terraform-provider-google/issues/20599
+      cloud_vm_cluster_id: '"ofake-tf-test-basic-%{random_suffix}"'
+      cloud_exadata_infrastructure_id: '"ofake-tf-test-basic-%{random_suffix}"'
   - name: 'oracledatabase_cloud_vmcluster_full'
     primary_resource_id: 'my_vmcluster'
     vars:
@@ -78,8 +82,12 @@ examples:
     test_vars_overrides:
       'deletion_protection': 'false'
       'project': '"oci-terraform-testing"'
-      cloud_vm_cluster_id: '"ofake-vmcluster-full-%{random_suffix}"'
-      cloud_exadata_infrastructure_id: '"ofake-vmcluster-full-%{random_suffix}"'
+      # ofake- prefix is needed to create a dummy resource for testing purposes only
+      # See: https://github.com/hashicorp/terraform-provider-google/issues/19983#issuecomment-2516403770
+      # As a result these resources are not sweepable
+      # See: https://github.com/hashicorp/terraform-provider-google/issues/20599
+      cloud_vm_cluster_id: '"ofake-tf-test-full-%{random_suffix}"'
+      cloud_exadata_infrastructure_id: '"ofake-tf-test-full-%{random_suffix}"'
 virtual_fields:
   - name: 'deletion_protection'
     type: Boolean

--- a/mmv1/products/oracledatabase/CloudVmCluster.yaml
+++ b/mmv1/products/oracledatabase/CloudVmCluster.yaml
@@ -68,8 +68,8 @@ examples:
       # See: https://github.com/hashicorp/terraform-provider-google/issues/19983#issuecomment-2516403770
       # As a result these resources are not sweepable
       # See: https://github.com/hashicorp/terraform-provider-google/issues/20599
-      cloud_vm_cluster_id: 'fmt.Sprintf("ofake-tf-test-basic-%s", acctest.RandString(t, 10))'
-      cloud_exadata_infrastructure_id: 'fmt.Sprintf("ofake-tf-test-basic-%s", acctest.RandString(t, 10))'
+      cloud_vm_cluster_id: 'fmt.Sprintf("ofake-tf-test-vmcluster-basic-%s", acctest.RandString(t, 10))'
+      cloud_exadata_infrastructure_id: 'fmt.Sprintf("ofake-tf-test-exadata-for-vmcluster-basic-%s", acctest.RandString(t, 10))'
   - name: 'oracledatabase_cloud_vmcluster_full'
     primary_resource_id: 'my_vmcluster'
     vars:
@@ -86,8 +86,8 @@ examples:
       # See: https://github.com/hashicorp/terraform-provider-google/issues/19983#issuecomment-2516403770
       # As a result these resources are not sweepable
       # See: https://github.com/hashicorp/terraform-provider-google/issues/20599
-      cloud_vm_cluster_id: 'fmt.Sprintf("ofake-tf-test-full-%s", acctest.RandString(t, 10))'
-      cloud_exadata_infrastructure_id: 'fmt.Sprintf("ofake-tf-test-full-%s", acctest.RandString(t, 10))'
+      cloud_vm_cluster_id: 'fmt.Sprintf("ofake-tf-test-vmcluster-full-%s", acctest.RandString(t, 10))'
+      cloud_exadata_infrastructure_id: 'fmt.Sprintf("ofake-tf-test-exadata-for-vmcluster-full-%s", acctest.RandString(t, 10))'
 virtual_fields:
   - name: 'deletion_protection'
     type: Boolean

--- a/mmv1/products/oracledatabase/CloudVmCluster.yaml
+++ b/mmv1/products/oracledatabase/CloudVmCluster.yaml
@@ -64,6 +64,8 @@ examples:
     test_vars_overrides:
       'deletion_protection': 'false'
       'project': '"oci-terraform-testing"'
+      cloud_vm_cluster_id: '"ofake-vmcluster-basic-%{random_suffix}"'
+      cloud_exadata_infrastructure_id: '"ofake-vmcluster-basic-%{random_suffix}"'
   - name: 'oracledatabase_cloud_vmcluster_full'
     primary_resource_id: 'my_vmcluster'
     vars:
@@ -76,6 +78,8 @@ examples:
     test_vars_overrides:
       'deletion_protection': 'false'
       'project': '"oci-terraform-testing"'
+      cloud_vm_cluster_id: '"ofake-vmcluster-full-%{random_suffix}"'
+      cloud_exadata_infrastructure_id: '"ofake-vmcluster-full-%{random_suffix}"'
 virtual_fields:
   - name: 'deletion_protection'
     type: Boolean


### PR DESCRIPTION
Making these names use the service's ofake- prefix (see https://github.com/hashicorp/terraform-provider-google/issues/19983#issuecomment-2516403770)

Previously the generator would automatically add the tf-test- prefix and a random suffix, but this isn't compatible with use of `ofake-`. This PR enables the names to still be unique while using that service specific prefix.

I've used a prefix of ofake-tf-test- with the intention of this being added to the list of sweepable prefixes: https://github.com/hashicorp/terraform-provider-google/issues/20599


```release-note:none

```
