### PR TITLE
Update Looker to include nonprod looker editions

### DIFF
--- a/mmv1/products/looker/Instance.yaml
+++ b/mmv1/products/looker/Instance.yaml
@@ -412,6 +412,9 @@ properties:
       - LOOKER_CORE_STANDARD_ANNUAL: subscription standard instance
       - LOOKER_CORE_ENTERPRISE_ANNUAL: subscription enterprise instance
       - LOOKER_CORE_EMBED_ANNUAL: subscription embed instance
+      - LOOKER_CORE_NONPROD_STANDARD_ANNUAL: nonprod subscription standard instance
+      - LOOKER_CORE_NONPROD_ENTERPRISE_ANNUAL: nonprod subscription enterprise instance
+      - LOOKER_CORE_NONPROD_EMBED_ANNUAL: nonprod subscription embed instance
     immutable: true
     default_value: "LOOKER_CORE_TRIAL"
     enum_values:
@@ -420,6 +423,9 @@ properties:
       - 'LOOKER_CORE_STANDARD_ANNUAL'
       - 'LOOKER_CORE_ENTERPRISE_ANNUAL'
       - 'LOOKER_CORE_EMBED_ANNUAL'
+      - 'LOOKER_CORE_NONPROD_STANDARD_ANNUAL'
+      - 'LOOKER_CORE_NONPROD_ENTERPRISE_ANNUAL'
+      - 'LOOKER_CORE_NONPROD_EMBED_ANNUAL'
   - name: 'privateIpEnabled'
     type: Boolean
     description: |


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
looker: added `LOOKER_CORE_NONPROD_STANDARD_ANNUAL`, `LOOKER_CORE_NONPROD_ENTERPRISE_ANNUAL`, and `LOOKER_CORE_NONPROD_EMBED_ANNUAL` as platform editions to `google_looker_instance` resource.
```
