### PR TITLE
compute: added `network_id` to `google_compute_network`

### DIFF
--- a/mmv1/products/compute/Network.yaml
+++ b/mmv1/products/compute/Network.yaml
@@ -116,10 +116,16 @@ properties:
     immutable: true
     validation:
       function: 'verify.ValidateGCEName'
+  - name: 'networkId'
+    description: |
+      The unique identifier for the resource. This identifier is defined by the server.
+    api_name: id
+    output: true
   - name: 'numericId'
     type: String
     description: |
-      The unique identifier for the resource. This identifier is defined by the server.
+      (Deprecated) The unique identifier for the resource. This identifier is defined by the server.
+      Use `network_id` instead.
     output: true
   - name: 'autoCreateSubnetworks'
     type: Boolean

--- a/mmv1/products/compute/Network.yaml
+++ b/mmv1/products/compute/Network.yaml
@@ -124,8 +124,8 @@ properties:
   - name: 'numericId'
     type: String
     description: |
-      (Deprecated) The unique identifier for the resource. This identifier is defined by the server.
-      Use `network_id` instead.
+      The unique identifier for the resource. This identifier is defined by the server.
+    deprecation_message: '`numeric_id` is deprecated and will be removed in a future major release. Use `network_id` instead.'
     output: true
   - name: 'autoCreateSubnetworks'
     type: Boolean

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_network.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_network.go.tmpl
@@ -24,9 +24,12 @@ func DataSourceGoogleComputeNetwork() *schema.Resource {
 				Computed: true,
 			},
 
-			// TODO: this should eventually be TypeInt, but leaving as
-			// string for now to match the resource and to avoid a
-			// breaking change.
+			"network_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			// Deprecated in favor of network_id
 			"numeric_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -103,6 +106,9 @@ func dataSourceGoogleComputeNetworkRead(d *schema.ResourceData, meta interface{}
 	}
 	if err := d.Set("description", network.Description); err != nil {
 		return fmt.Errorf("Error setting description: %s", err)
+	}
+	if err := d.Set("network_id", network.Id); err != nil {
+		return fmt.Errorf("Error setting network_id: %s", err)
 	}
 	if err := d.Set("numeric_id", strconv.Itoa(int(network.Id))); err != nil {
 		return fmt.Errorf("Error setting numeric_id: %s", err)

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_network.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_network.go.tmpl
@@ -33,6 +33,7 @@ func DataSourceGoogleComputeNetwork() *schema.Resource {
 			"numeric_id": {
 				Type:     schema.TypeString,
 				Computed: true,
+				Deprecated: "`numeric_id` is deprecated and will be removed in a future major release. Use `network_id` instead.",
 			},
 
 			"gateway_ipv4": {

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_network_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_network_test.go
@@ -45,6 +45,7 @@ func testAccDataSourceGoogleNetworkCheck(data_source_name string, resource_name 
 		network_attrs_to_test := []string{
 			"id",
 			"name",
+			"network_id",
 			"numeric_id",
 			"description",
 			"internal_ipv6_range",

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_test.go.tmpl
@@ -262,6 +262,7 @@ func TestAccComputeNetwork_numericId(t *testing.T) {
 			{
 				Config: testAccComputeNetwork_basic(networkName),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("google_compute_network.bar", "network_id",regexp.MustCompile("^\\d{16,48}$")),
 					resource.TestMatchResourceAttr("google_compute_network.bar", "numeric_id",regexp.MustCompile("^\\d{16,48}$")),
 					resource.TestCheckResourceAttr("google_compute_network.bar", "id", networkId),
 				),

--- a/mmv1/third_party/terraform/website/docs/d/compute_network.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_network.html.markdown
@@ -36,7 +36,9 @@ In addition to the arguments listed above, the following attributes are exported
 
 * `description` - Description of this network.
 
-* `numeric_id` - The numeric unique identifier for the resource.
+* `network_id` - The numeric unique identifier for the resource.
+
+* `numeric_id` - (Deprecated) The numeric unique identifier for the resource. Use `network_id` instead.
 
 * `gateway_ipv4` - The IP address of the gateway.
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_network.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_network.html.markdown
@@ -38,7 +38,7 @@ In addition to the arguments listed above, the following attributes are exported
 
 * `network_id` - The numeric unique identifier for the resource.
 
-* `numeric_id` - (Deprecated) The numeric unique identifier for the resource. Use `network_id` instead.
+* `numeric_id` - (Deprecated) The numeric unique identifier for the resource. `numeric_id` is deprecated and will be removed in a future major release. Use `network_id` instead.
 
 * `gateway_ipv4` - The IP address of the gateway.
 


### PR DESCRIPTION
Add `network_id` to `google_compute_network`.

It's an integer, not a string, and follows the expected convention for naming.

This adds a note deprecating `numeric_id` (to be potentially removed at some later date), which will have the same value, but as a string.

Part of terraform-provider-google#20530

See also #12351 and #12339, in particular [this comment](https://github.com/GoogleCloudPlatform/magic-modules/pull/12285#issuecomment-2479649536), [this comment](https://github.com/GoogleCloudPlatform/magic-modules/pull/12339#pullrequestreview-2473999839), and [this discussion](https://github.com/GoogleCloudPlatform/magic-modules/pull/12339#discussion_r1844406188)

Let me know if you want me to break this up into two separate release notes.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `network_id` (integer) to `google_compute_network` resource and data source
```

```release-note: deprecation
compute: deprecated `numeric_id` (string) field in `google_compute_network` resource. Use the new `network_id` (integer)  field instead 
```
