### PR TITLE
`computet`: rename network name for `NetworkProfile` test to be sweepable

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_test.go.tmpl
@@ -224,7 +224,7 @@ func TestAccComputeNetwork_networkProfile(t *testing.T) {
 
    var network compute.Network
    suffixName := acctest.RandString(t, 10)
-   networkName := fmt.Sprintf("tf-network-profile-%s", suffixName)
+   networkName := fmt.Sprintf("tf-test-network-profile-%s", suffixName)
    projectId := envvar.GetTestProjectFromEnv()
    profileURL := fmt.Sprintf("https://www.googleapis.com/compute/beta/projects/%s/global/networkProfiles/europe-west1-b-vpc-roce", projectId)
 


### PR DESCRIPTION
This should resolve some networks not being sweeped due to the network name not starting with `tf-test` which is necessary for it to be sweeped. This is mentioned [here](https://googlecloudplatform.github.io/magic-modules/test/test/#add-a-create-test)

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
