### PR TITLE
(Beta) Add support for regional Meshes.

### DIFF
--- a/mmv1/products/networkservices/Mesh.yaml
+++ b/mmv1/products/networkservices/Mesh.yaml
@@ -22,13 +22,13 @@ references:
   guides:
   api: 'https://cloud.google.com/traffic-director/docs/reference/network-services/rest/v1beta1/projects.locations.meshes'
 docs:
-base_url: 'projects/{{project}}/locations/global/meshes'
-self_link: 'projects/{{project}}/locations/global/meshes/{{name}}'
-create_url: 'projects/{{project}}/locations/global/meshes?meshId={{name}}'
+base_url: 'projects/{{project}}/locations/{{location}}/meshes'
+self_link: 'projects/{{project}}/locations/{{location}}/meshes/{{name}}'
+create_url: 'projects/{{project}}/locations/{{location}}/meshes?meshId={{name}}'
 update_verb: 'PATCH'
 update_mask: true
 import_format:
-  - 'projects/{{project}}/locations/global/meshes/{{name}}'
+  - 'projects/{{project}}/locations/{{location}}/meshes/{{name}}'
 timeouts:
   insert_minutes: 30
   update_minutes: 30
@@ -63,6 +63,11 @@ examples:
     min_version: 'beta'
     vars:
       resource_name: 'my-mesh-noport'
+  - name: 'network_services_mesh_regional'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      resource_name: 'regional-mesh'
 parameters:
   - name: 'name'
     type: String
@@ -71,6 +76,15 @@ parameters:
     min_version: 'beta'
     url_param_only: true
     required: true
+   - name: 'location'
+    type: String
+    description: |
+      Location (region) of the Mesh resource to be created. Defaults to global if omitted.
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+    default_value: 'global'
 properties:
   - name: 'selfLink'
     type: String

--- a/mmv1/products/networkservices/Mesh.yaml
+++ b/mmv1/products/networkservices/Mesh.yaml
@@ -76,13 +76,12 @@ parameters:
     min_version: 'beta'
     url_param_only: true
     required: true
-   - name: 'location'
+  - name: 'location'
     type: String
     description: |
       Location (region) of the Mesh resource to be created. Defaults to global if omitted.
     min_version: 'beta'
     url_param_only: true
-    required: true
     immutable: true
     default_value: 'global'
 properties:

--- a/mmv1/templates/terraform/examples/network_services_mesh_regional.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_services_mesh_regional.tf.tmpl
@@ -1,0 +1,5 @@
+resource "google_network_services_mesh" "{{$.PrimaryResourceId}}" {
+  provider    = google-beta
+  name        = "{{index $.Vars "resource_name"}}"
+  region      = "us-central1"
+}

--- a/mmv1/templates/terraform/examples/network_services_mesh_regional.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_services_mesh_regional.tf.tmpl
@@ -1,5 +1,5 @@
 resource "google_network_services_mesh" "{{$.PrimaryResourceId}}" {
   provider    = google-beta
   name        = "{{index $.Vars "resource_name"}}"
-  region      = "us-central1"
+  location      = "us-central1"
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

The new optional `location` field accepts a region, which is used to create a regional Mesh resource. If `location` is omitted, the Mesh location defaults to `global`.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
networkservices: added `location` field to `google_network_services_mesh` resource (beta)
```
