### PR TITLE
Add nullFields logic to `guest_flush` on `resource_google_compute_resource_policy`

### DIFF
--- a/mmv1/products/compute/ResourcePolicy.yaml
+++ b/mmv1/products/compute/ResourcePolicy.yaml
@@ -258,7 +258,7 @@ properties:
             type: Boolean
             description: |
               Whether to perform a 'guest aware' snapshot.
-            send_empty_value: true
+            send_empty_value: false
             at_least_one_of:
               - 'snapshot_schedule_policy.0.snapshot_properties.0.labels'
               - 'snapshot_schedule_policy.0.snapshot_properties.0.storage_locations'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_resource_policy_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_resource_policy_test.go
@@ -69,6 +69,56 @@ func TestAccComputeResourcePolicy_attached(t *testing.T) {
 	})
 }
 
+func TestAccComputeResourcePolicy_guestFlushEmptyValue(t *testing.T) {
+	t.Parallel()
+
+	context_1 := map[string]interface{}{
+		"suffix":              fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"snapshot_properties": ``,
+	}
+
+	context_2 := map[string]interface{}{
+		"suffix": context_1["suffix"],
+		"snapshot_properties": `
+		snapshot_properties {
+          labels = {
+            foo = "bar"
+          }
+        }
+		`,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeResourcePolicyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeResourcePolicy_guestFlushEmptyValue(context_1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("google_compute_resource_policy.foo", "guest_flush"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_resource_policy.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeResourcePolicy_guestFlushEmptyValue(context_2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("google_compute_resource_policy.foo", "guest_flush"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_resource_policy.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccComputeResourcePolicy_attached(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
@@ -118,4 +168,22 @@ resource "google_compute_resource_policy" "foo" {
 }
 
 `, suffix, suffix)
+}
+
+func testAccComputeResourcePolicy_guestFlushEmptyValue(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_resource_policy" "foo" {
+  name   = "tf-test-gce-policy%{suffix}"
+  region = "us-central1"
+  snapshot_schedule_policy {
+	schedule {
+	  daily_schedule {
+		days_in_cycle = 1
+		start_time    = "04:00"
+	  }
+	}
+	%{snapshot_properties}
+  }
+}
+`, context)
 }


### PR DESCRIPTION
closes https://github.com/hashicorp/terraform-provider-google/issues/20499
closes https://github.com/hashicorp/terraform-provider-google/issues/16936

This field cannot be patched and is set to false automatically when the parent block is added into the configuration causing an error on every change to this block.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: Updating labels on `resource_google_compute_resource_policy` will no longer fail because of a Patch error with `guest_flush`
```
