### PR TITLE
Make google_oracle_database_autonomous_database.name field unique per acceptance test

### DIFF
--- a/mmv1/products/oracledatabase/AutonomousDatabase.yaml
+++ b/mmv1/products/oracledatabase/AutonomousDatabase.yaml
@@ -55,12 +55,14 @@ examples:
     vars:
       project: 'my-project'
       autonomous_database_id: 'my-instance'
+      database_name: 'mydatabase'
       deletion_protection: 'true'
     ignore_read_extra:
       - 'deletion_protection'
     test_vars_overrides:
-      'deletion_protection': 'false'
-      'project': '"oci-terraform-testing"'
+      deletion_protection: 'false'
+      project: '"oci-terraform-testing"'
+      database_name: 'fmt.Sprintf("tftestdatabase%s", acctest.RandString(t, 10))'
   - name: 'oracledatabase_autonomous_database_full'
     primary_resource_id: 'myADB'
     vars:
@@ -70,8 +72,9 @@ examples:
     ignore_read_extra:
       - 'deletion_protection'
     test_vars_overrides:
-      'project': '"oci-terraform-testing"'
-      'deletion_protection': 'false'
+      project: '"oci-terraform-testing"'
+      deletion_protection: 'false'
+      database_name: 'fmt.Sprintf("tftestdatabase%s", acctest.RandString(t, 10))'
 virtual_fields:
   - name: 'deletion_protection'
     type: Boolean

--- a/mmv1/products/oracledatabase/AutonomousDatabase.yaml
+++ b/mmv1/products/oracledatabase/AutonomousDatabase.yaml
@@ -68,6 +68,7 @@ examples:
     vars:
       project: 'my-project'
       autonomous_database_id: 'my-instance'
+      database_name: 'mydatabase'
       deletion_protection: 'true'
     ignore_read_extra:
       - 'deletion_protection'

--- a/mmv1/templates/terraform/examples/oracledatabase_autonomous_database_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/oracledatabase_autonomous_database_basic.tf.tmpl
@@ -2,7 +2,7 @@ resource "google_oracle_database_autonomous_database" "{{$.PrimaryResourceId}}"{
   autonomous_database_id = "{{index $.Vars "autonomous_database_id"}}"
   location = "us-east4"
   project = "{{index $.Vars "project"}}"
-  database = "{{index $.Vars "autonomous_database_id"}}"
+  database = "{{index $.Vars "database_name"}}"
   admin_password = "123Abpassword"
   network = data.google_compute_network.default.id
   cidr = "10.5.0.0/24"

--- a/mmv1/templates/terraform/examples/oracledatabase_autonomous_database_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/oracledatabase_autonomous_database_basic.tf.tmpl
@@ -2,7 +2,7 @@ resource "google_oracle_database_autonomous_database" "{{$.PrimaryResourceId}}"{
   autonomous_database_id = "{{index $.Vars "autonomous_database_id"}}"
   location = "us-east4"
   project = "{{index $.Vars "project"}}"
-  database = "testdb"
+  database = "{{index $.Vars "autonomous_database_id"}}"
   admin_password = "123Abpassword"
   network = data.google_compute_network.default.id
   cidr = "10.5.0.0/24"

--- a/mmv1/templates/terraform/examples/oracledatabase_autonomous_database_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/oracledatabase_autonomous_database_full.tf.tmpl
@@ -3,7 +3,7 @@ resource "google_oracle_database_autonomous_database" "{{$.PrimaryResourceId}}"{
   location = "us-east4"
   project = "{{index $.Vars "project"}}"
   display_name = "autonomousDatabase displayname"
-  database = "{{index $.Vars "autonomous_database_id"}}"
+  database = "{{index $.Vars "database_name"}}"
   admin_password = "123Abpassword"
   network = data.google_compute_network.default.id
   cidr = "10.5.0.0/24"

--- a/mmv1/templates/terraform/examples/oracledatabase_autonomous_database_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/oracledatabase_autonomous_database_full.tf.tmpl
@@ -3,7 +3,7 @@ resource "google_oracle_database_autonomous_database" "{{$.PrimaryResourceId}}"{
   location = "us-east4"
   project = "{{index $.Vars "project"}}"
   display_name = "autonomousDatabase displayname"
-  database = "testdatabase"
+  database = "{{index $.Vars "autonomous_database_id"}}"
   admin_password = "123Abpassword"
   network = data.google_compute_network.default.id
   cidr = "10.5.0.0/24"


### PR DESCRIPTION
Latest PR in my effort to close [the ticket about failing Oracle resource tests](https://github.com/hashicorp/terraform-provider-google/issues/19983). This PR is to address this issue that impacts:
- TestAccOracleDatabaseAutonomousDatabase_oracledatabaseAutonomousDatabaseFullExample
- TestAccOracleDatabaseAutonomousDatabase_oracledatabaseAutonomousDatabaseBasicExample

```
------- Stdout: -------
=== RUN   TestAccOracleDatabaseAutonomousDatabase_oracledatabaseAutonomousDatabaseFullExample
=== PAUSE TestAccOracleDatabaseAutonomousDatabase_oracledatabaseAutonomousDatabaseFullExample
=== CONT  TestAccOracleDatabaseAutonomousDatabase_oracledatabaseAutonomousDatabaseFullExample
    resource_oracle_database_autonomous_database_generated_test.go:96: Step 1/2 error: Error running apply: exit status 1
        Error: Error waiting to create AutonomousDatabase: Error waiting for Creating AutonomousDatabase: Error code 3, message: generic::invalid_argument: InvalidParameter: Provisioning Autonomous Database failed Cause: Provisioning failed because a database named testdatabase already exists in compartment 466158962507. The name must be unique among all Autonomous Data Warehouses and Autonomous Databases in your tenancy in the same region. Specify a different database name and try again.
          with google_oracle_database_autonomous_database.myADB,
          on terraform_plugin_test.tf line 2, in resource "google_oracle_database_autonomous_database" "myADB":
           2: resource "google_oracle_database_autonomous_database" "myADB"{
--- FAIL: TestAccOracleDatabaseAutonomousDatabase_oracledatabaseAutonomousDatabaseFullExample (503.35s)
FAIL
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
