### PR TITLE
(Beta) Add support for regional GRPCRoutes.

### DIFF
--- a/mmv1/products/networkservices/GrpcRoute.yaml
+++ b/mmv1/products/networkservices/GrpcRoute.yaml
@@ -20,13 +20,13 @@ references:
   guides:
   api: 'https://cloud.google.com/traffic-director/docs/reference/network-services/rest/v1beta1/projects.locations.grpcRoutes'
 docs:
-base_url: 'projects/{{project}}/locations/global/grpcRoutes'
-self_link: 'projects/{{project}}/locations/global/grpcRoutes/{{name}}'
-create_url: 'projects/{{project}}/locations/global/grpcRoutes?grpcRouteId={{name}}'
+base_url: 'projects/{{project}}/locations/{{location}}/grpcRoutes'
+self_link: 'projects/{{project}}/locations/{{location}}/grpcRoutes/{{name}}'
+create_url: 'projects/{{project}}/locations/{{location}}/grpcRoutes?grpcRouteId={{name}}'
 update_verb: 'PATCH'
 update_mask: true
 import_format:
-  - 'projects/{{project}}/locations/global/grpcRoutes/{{name}}'
+  - 'projects/{{project}}/locations/{{location}}/grpcRoutes/{{name}}'
 timeouts:
   insert_minutes: 30
   update_minutes: 30
@@ -66,6 +66,11 @@ examples:
     min_version: 'beta'
     vars:
       resource_name: 'my-grpc-route'
+  - name: 'network_services_grpc_route_regional'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      resource_name: 'regional-grpc-route'
 parameters:
   - name: 'name'
     type: String
@@ -75,6 +80,14 @@ parameters:
     url_param_only: true
     required: true
     immutable: true
+  - name: 'location'
+    type: String
+    description: |
+      Location (region) of the GrpcRoute resource. Defaults to global if omitted.
+    min_version: 'beta'
+    url_param_only: true
+    immutable: true
+    default_value: 'global'
 properties:
   - name: 'selfLink'
     type: String

--- a/mmv1/templates/terraform/examples/network_services_grpc_route_regional.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_services_grpc_route_regional.tf.tmpl
@@ -1,0 +1,20 @@
+resource "google_network_services_grpc_route" "{{$.PrimaryResourceId}}" {
+  provider               = google-beta
+  name                   = "{{index $.Vars "resource_name"}}"
+  location               = "us-central1"
+  hostnames              = ["example"]
+  rules                   {
+    matches {
+      headers {
+        key = "key"
+        value = "value"
+      }
+    }
+    action {
+      retry_policy {
+          retry_conditions = ["cancelled"]
+          num_retries = 1
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

The new optional location field accepts a region, which is used to create a regional GRPCRoute resource. If location is omitted, the GRPCRoute location defaults to global.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
networkservices: added `location` field to `google_network_services_grpc_route` resource (beta)
```
