### PR TITLE
Update Network Connectivity Spoke Router and VPN Tunnels

### DIFF
--- a/mmv1/products/networkconnectivity/Spoke.yaml
+++ b/mmv1/products/networkconnectivity/Spoke.yaml
@@ -125,7 +125,6 @@ properties:
   - name: 'linkedVpnTunnels'
     type: NestedObject
     description: The URIs of linked VPN tunnel resources
-    immutable: true
     conflicts:
       - linked_interconnect_attachments
       - linked_router_appliance_instances
@@ -156,7 +155,6 @@ properties:
   - name: 'linkedInterconnectAttachments'
     type: NestedObject
     description: A collection of VLAN attachment resources. These resources should be redundant attachments that all advertise the same prefixes to Google Cloud. Alternatively, in active/passive configurations, all attachments should be capable of advertising the same prefixes.
-    immutable: true
     conflicts:
       - linked_vpn_tunnels
       - linked_router_appliance_instances

--- a/mmv1/products/networkconnectivity/Spoke.yaml
+++ b/mmv1/products/networkconnectivity/Spoke.yaml
@@ -131,6 +131,8 @@ properties:
       - linked_router_appliance_instances
       - linked_vpc_network
       - linked_producer_vpc_network
+    update_mask_fields:
+      - 'linkedVpnTunnels.includeImportRanges'
     properties:
       - name: 'uris'
         type: Array
@@ -160,6 +162,8 @@ properties:
       - linked_router_appliance_instances
       - linked_vpc_network
       - linked_producer_vpc_network
+    update_mask_fields:
+      - "linkedInterconnectAttachments.includeImportRanges'
     properties:
       - name: 'uris'
         type: Array
@@ -183,12 +187,14 @@ properties:
   - name: 'linkedRouterApplianceInstances'
     type: NestedObject
     description: The URIs of linked Router appliance resources
-    immutable: true
     conflicts:
       - linked_interconnect_attachments
       - linked_vpn_tunnels
       - linked_vpc_network
       - linked_producer_vpc_network
+    update_mask_fields:
+      - 'linkedRouterApplianceInstances.instances'
+      - 'linkedRouterApplianceInstances.includeImportRanges'
     properties:
       - name: 'instances'
         type: Array
@@ -203,11 +209,13 @@ properties:
               type: String
               description: The URI of the virtual machine resource
               immutable: true
+              required: true
               diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
             - name: 'ipAddress'
               type: String
               description: The IP address on the VM to use for peering.
               immutable: true
+              required: true
       - name: 'siteToSiteDataTransfer'
         type: Boolean
         description: A value that controls whether site-to-site data transfer is enabled for these resources. Note that data transfer is available only in supported locations.

--- a/mmv1/products/networkconnectivity/Spoke.yaml
+++ b/mmv1/products/networkconnectivity/Spoke.yaml
@@ -163,7 +163,7 @@ properties:
       - linked_vpc_network
       - linked_producer_vpc_network
     update_mask_fields:
-      - "linkedInterconnectAttachments.includeImportRanges'
+      - 'linkedInterconnectAttachments.includeImportRanges'
     properties:
       - name: 'uris'
         type: Array

--- a/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_spoke_test.go
+++ b/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_spoke_test.go
@@ -555,8 +555,8 @@ resource "google_compute_subnetwork" "subnetwork" {
   network       = google_compute_network.network.self_link
 }
 
-resource "google_compute_instance" "instance" {
-  name         = "tf-test-instance%{random_suffix}"
+resource "google_compute_instance" "router-instance1" {
+  name         = "tf-test-router-instance1%{random_suffix}"
   machine_type = "e2-medium"
   can_ip_forward = true
   zone         = "%{zone}"
@@ -587,14 +587,14 @@ resource "google_network_connectivity_hub" "basic_hub" {
 resource "google_network_connectivity_spoke" "primary" {
   name = "tf-test-name%{random_suffix}"
   location = "%{region}"
-  description = "A sample spoke with a linked routher appliance instance"
+  description = "A sample spoke with a single linked routher appliance instance"
   labels = {
     label-one = "value-one"
   }
   hub =  google_network_connectivity_hub.basic_hub.id
   linked_router_appliance_instances {
     instances {
-        virtual_machine = google_compute_instance.instance.self_link
+        virtual_machine = google_compute_instance.router-instance1.self_link
         ip_address = "10.0.0.2"
     }
     site_to_site_data_transfer = true
@@ -650,7 +650,7 @@ resource "google_network_connectivity_hub" "basic_hub" {
 resource "google_network_connectivity_spoke" "primary" {
   name = "tf-test-name%{random_suffix}"
   location = "%{region}"
-  description = "An UPDATED sample spoke with a linked routher appliance instance"
+  description = "An UPDATED sample spoke with a single linked routher appliance instance"
   labels = {
     label-two = "value-two"
   }
@@ -734,7 +734,7 @@ resource "google_network_connectivity_hub" "basic_hub" {
 resource "google_network_connectivity_spoke" "primary" {
   name = "tf-test-name%{random_suffix}"
   location = "%{region}"
-  description = "An UPDATED sample spoke with a linked routher appliance instance"
+  description = "An UPDATED sample spoke with two linked routher appliance instances"
   labels = {
     label-two = "value-two"
   }

--- a/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_spoke_test.go
+++ b/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_spoke_test.go
@@ -169,6 +169,79 @@ func TestAccNetworkConnectivitySpoke_RouterApplianceHandWrittenLongForm(t *testi
 		},
 	})
 }
+
+func TestAccNetworkConnectivitySpoke_VPNTunnelHandWrittenHandWritten(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project_name":  envvar.GetTestProjectFromEnv(),
+		"region":        envvar.GetTestRegionFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckNetworkConnectivitySpokeDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkConnectivitySpoke_VPNTunnelHandWrittenHandWritten(context),
+			},
+			{
+				ResourceName:            "google_network_connectivity_spoke.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccNetworkConnectivitySpoke_VPNTunnelHandWrittenHandWrittenUpdate0(context),
+			},
+			{
+				ResourceName:            "google_network_connectivity_spoke.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func TestAccNetworkConnectivitySpoke_InterconnectAttachmentHandWrittenHandWritten(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project_name":  envvar.GetTestProjectFromEnv(),
+		"region":        envvar.GetTestRegionFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckNetworkConnectivitySpokeDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkConnectivitySpoke_InterconnectAttachmentHandWrittenHandWritten(context),
+			},
+			{
+				ResourceName:            "google_network_connectivity_spoke.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccNetworkConnectivitySpoke_InterconnectAttachmentHandWrittenHandWrittenUpdate0(context),
+			},
+			{
+				ResourceName:            "google_network_connectivity_spoke.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
 func testAccNetworkConnectivitySpoke_LinkedVPCNetworkHandWritten(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 
@@ -750,6 +823,293 @@ resource "google_network_connectivity_spoke" "primary" {
     }
     include_import_ranges = ["ALL_IPV4_RANGES"]
     site_to_site_data_transfer = true
+  }
+}
+`, context)
+}
+
+func testAccNetworkConnectivitySpoke_VPNTunnelHandWrittenHandWritten(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+
+resource "google_compute_network" "network" {
+  name                    = "tf-test-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  name          = "tf-test-subnet%{random_suffix}"
+  ip_cidr_range = "10.0.0.0/28"
+  region        = "%{region}"
+  network       = google_compute_network.network.self_link
+}
+
+resource "google_compute_ha_vpn_gateway" "gateway" {
+  name    = "tf-test-gw%{random_suffix}"
+  network = google_compute_network.network.id
+}
+
+resource "google_compute_external_vpn_gateway" "external_vpn_gw" {
+  name            = "tf-test-external-gw%{random_suffix}"
+  redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
+  description     = "An externally managed VPN gateway"
+  interface {
+    id         = 0
+    ip_address = "8.8.8.8"
+  }
+}
+
+resource "google_compute_router" "router" {
+  name    = "tf-test-router%{random_suffix}"
+  region  = "%{region}"
+  network = google_compute_network.network.name
+  bgp {
+    asn = 64514
+  }
+}
+
+resource "google_compute_vpn_tunnel" "tunnel" {
+  name                            = "tf-test-tunnel%{random_suffix}"
+  region                          = "%{region}"
+  vpn_gateway                     = google_compute_ha_vpn_gateway.gateway.id
+  peer_external_gateway           = google_compute_external_vpn_gateway.external_vpn_gw.id
+  peer_external_gateway_interface = 0
+  shared_secret                   = "a secret message"
+  router                          = google_compute_router.router.id
+  vpn_gateway_interface           = 0
+}
+
+resource "google_compute_router_interface" "router_interface" {
+  name       = "tf-test-ri%{random_suffix}"
+  router     = google_compute_router.router.name
+  region     = "%{region}"
+  ip_range   = "169.254.0.1/30"
+  vpn_tunnel = google_compute_vpn_tunnel.tunnel.name
+}
+
+resource "google_compute_router_peer" "router_peer" {
+  name                      = "tf-test-peer%{random_suffix}"
+  router                    = google_compute_router.router.name
+  region                    = "%{region}"
+  peer_ip_address           = "169.254.0.2"
+  peer_asn                  = 64515
+  advertised_route_priority = 100
+  interface                 = google_compute_router_interface.router_interface.name
+}
+
+resource "google_network_connectivity_hub" "basic_hub" {
+  name        = "tf-test-hub%{random_suffix}"
+  description = "A sample hub"
+  labels = {
+    label-two = "value-one"
+  }
+}
+
+resource "google_network_connectivity_spoke" "primary" {
+  name = "tf-test-name%{random_suffix}"
+  location = "%{region}"
+  description = "A sample spoke with a linked VPN Tunnel, no include_import_ranges yet"
+  labels = {
+    label-one = "value-one"
+  }
+  hub = google_network_connectivity_hub.basic_hub.id
+  linked_vpn_tunnels {
+    uris                       = [google_compute_vpn_tunnel.tunnel.self_link]
+    site_to_site_data_transfer = true
+  }
+}
+`, context)
+}
+
+func testAccNetworkConnectivitySpoke_VPNTunnelHandWrittenHandWrittenUpdate0(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+
+resource "google_compute_network" "network" {
+  name                    = "tf-test-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  name          = "tf-test-subnet%{random_suffix}"
+  ip_cidr_range = "10.0.0.0/28"
+  region        = "%{region}"
+  network       = google_compute_network.network.self_link
+}
+
+resource "google_compute_ha_vpn_gateway" "gateway" {
+  name    = "tf-test-gw%{random_suffix}"
+  network = google_compute_network.network.id
+}
+
+resource "google_compute_external_vpn_gateway" "external_vpn_gw" {
+  name            = "tf-test-external-gw%{random_suffix}"
+  redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
+  description     = "An externally managed VPN gateway"
+  interface {
+    id         = 0
+    ip_address = "8.8.8.8"
+  }
+}
+
+resource "google_compute_router" "router" {
+  name    = "tf-test-router%{random_suffix}"
+  region  = "%{region}"
+  network = google_compute_network.network.name
+  bgp {
+    asn = 64514
+  }
+}
+
+resource "google_compute_vpn_tunnel" "tunnel" {
+  name                            = "tf-test-tunnel%{random_suffix}"
+  region                          = "%{region}"
+  vpn_gateway                     = google_compute_ha_vpn_gateway.gateway.id
+  peer_external_gateway           = google_compute_external_vpn_gateway.external_vpn_gw.id
+  peer_external_gateway_interface = 0
+  shared_secret                   = "a secret message"
+  router                          = google_compute_router.router.id
+  vpn_gateway_interface           = 0
+}
+
+resource "google_compute_router_interface" "router_interface" {
+  name       = "tf-test-ri%{random_suffix}"
+  router     = google_compute_router.router.name
+  region     = "%{region}"
+  ip_range   = "169.254.0.1/30"
+  vpn_tunnel = google_compute_vpn_tunnel.tunnel.name
+}
+
+resource "google_compute_router_peer" "router_peer" {
+  name                      = "tf-test-peer%{random_suffix}"
+  router                    = google_compute_router.router.name
+  region                    = "%{region}"
+  peer_ip_address           = "169.254.0.2"
+  peer_asn                  = 64515
+  advertised_route_priority = 100
+  interface                 = google_compute_router_interface.router_interface.name
+}
+
+resource "google_network_connectivity_hub" "basic_hub" {
+  name        = "tf-test-hub%{random_suffix}"
+  description = "A sample hub"
+  labels = {
+    label-two = "value-one"
+  }
+}
+
+resource "google_network_connectivity_spoke" "primary" {
+  name = "tf-test-name%{random_suffix}"
+  location = "%{region}"
+  description = "An UPDATED sample spoke with a linked VPN Tunnel, now includes ALL_IPV4_RANGES"
+  labels = {
+    label-one = "value-one"
+  }
+  hub = google_network_connectivity_hub.basic_hub.id
+  linked_vpn_tunnels {
+    uris                       = [google_compute_vpn_tunnel.tunnel.self_link]
+    site_to_site_data_transfer = true
+    include_import_ranges = ["ALL_IPV4_RANGES"]
+  }
+}
+`, context)
+}
+
+func testAccNetworkConnectivitySpoke_InterconnectAttachmentHandWrittenHandWritten(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+
+resource "google_network_connectivity_hub" "basic_hub" {
+  name        = "tf-test-hub%{random_suffix}"
+  description = "A sample hub"
+  labels = {
+    label-two = "value-one"
+  }
+}
+
+resource "google_compute_network" "network" {
+  name                    = "tf-test-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_router" "router" {
+  name    = "tf-test-router%{random_suffix}"
+  region  = "%{region}"
+  network = google_compute_network.network.name
+  bgp {
+    asn = 16550
+  }
+}
+
+resource "google_compute_interconnect_attachment" "interconnect_attachment" {
+  name                     = "tf-test-ia%{random_suffix}"
+  edge_availability_domain = "AVAILABILITY_DOMAIN_1"
+  type                     = "PARTNER"
+  router                   = google_compute_router.router.id
+  mtu                      = 1500
+  region                   = "%{region}"
+}
+
+resource "google_network_connectivity_spoke" "primary" {
+  name        = "tf-test-spoke-ia%{random_suffix}"
+  location    = "%{region}"
+  description = "A sample spoke with a linked interconnect_attachment, no include_import_ranges yet"
+  labels = {
+    label-one = "value-one"
+  }
+  hub = google_network_connectivity_hub.basic_hub.id
+  linked_interconnect_attachments {
+    uris                       = [google_compute_interconnect_attachment.interconnect_attachment.self_link]
+    site_to_site_data_transfer = true
+    # include_import_ranges not set initially
+  }
+}
+`, context)
+}
+
+func testAccNetworkConnectivitySpoke_InterconnectAttachmentHandWrittenHandWrittenUpdate0(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+
+resource "google_network_connectivity_hub" "basic_hub" {
+  name        = "tf-test-hub%{random_suffix}"
+  description = "A sample hub"
+  labels = {
+    label-two = "value-one"
+  }
+}
+
+resource "google_compute_network" "network" {
+  name                    = "tf-test-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_router" "router" {
+  name    = "tf-test-router%{random_suffix}"
+  region  = "%{region}"
+  network = google_compute_network.network.name
+  bgp {
+    asn = 16550
+  }
+}
+
+resource "google_compute_interconnect_attachment" "interconnect_attachment" {
+  name                     = "tf-test-ia%{random_suffix}"
+  edge_availability_domain = "AVAILABILITY_DOMAIN_1"
+  type                     = "PARTNER"
+  router                   = google_compute_router.router.id
+  mtu                      = 1500
+  region                   = "%{region}"
+}
+
+resource "google_network_connectivity_spoke" "primary" {
+  name        = "tf-test-spoke-ia%{random_suffix}"
+  location    = "%{region}"
+  description = "An updated sample spoke with interconnect_attachment, now includes ALL_IPV4_RANGES"
+  labels = {
+    label-one = "value-one"
+  }
+  hub = google_network_connectivity_hub.basic_hub.id
+  linked_interconnect_attachments {
+    uris                       = [google_compute_interconnect_attachment.interconnect_attachment.self_link]
+    site_to_site_data_transfer = true
+    include_import_ranges      = ["ALL_IPV4_RANGES"]
   }
 }
 `, context)


### PR DESCRIPTION
- Remove immutable flag from VPN Tunnels to support:
  * includeImportRanges updates
- Remove immutable flag from Router Appliances to support:
  * Instance count updates
  * includeImportRanges updates
- Add correct update_mask_fields for VPN Tunnels and Router Appliances
- Fix Router Appliance instance attributes to be properly marked as required
- Update tests to verify:
  * Router Appliance scaling from 1 to 2 instances
  * Import range modifications
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
networkconnectivity: added support for updating `linked_vpn_tunnels.include_import_ranges`, `linked_interconnect_attachments.include_import_ranges`, `linked_router_appliance_instances. instances` and `linked_router_appliance_instances.include_import_ranges` in `google_network_connectivity_spoke`
```
```release-note:bug
networkconnectivity: fixed `linked_router_appliance_instances.instances.virtual_machine` and `linked_router_appliance_instances.instances.ip_address` attributes in `google_network_connectivity_spoke` to be correctly marked as required. Otherwise the request to create the resource will fail.
```

