### PR TITLE
Make `private_endpoint_label` unique per test run of `TestAccOracleDatabaseAutonomousDatabase_oracledatabaseAutonomousDatabaseFullExample`

### DIFF
--- a/mmv1/products/oracledatabase/AutonomousDatabase.yaml
+++ b/mmv1/products/oracledatabase/AutonomousDatabase.yaml
@@ -63,6 +63,7 @@ examples:
       project: 'my-project'
       autonomous_database_id: 'my-instance'
       database_name: 'mydatabase'
+      endpoint_name: 'myendpoint'
       deletion_protection: 'true'
     ignore_read_extra:
       - 'deletion_protection'
@@ -70,6 +71,7 @@ examples:
       project: '"oci-terraform-testing"'
       deletion_protection: 'false'
       database_name: 'fmt.Sprintf("tftestdatabase%s", acctest.RandString(t, 10))'
+      endpoint_name: 'fmt.Sprintf("tftestendpoint%s", acctest.RandString(t, 10))'
 virtual_fields:
   - name: 'deletion_protection'
     type: Boolean

--- a/mmv1/templates/terraform/examples/oracledatabase_autonomous_database_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/oracledatabase_autonomous_database_full.tf.tmpl
@@ -29,7 +29,7 @@ resource "google_oracle_database_autonomous_database" "{{$.PrimaryResourceId}}"{
       email = "xyz@example.com"
     }
     private_endpoint_ip    = "10.5.0.11"
-    private_endpoint_label = "testhost"
+    private_endpoint_label = "{{index $.Vars "endpoint_name"}}"
   }
   deletion_protection = "{{index $.Vars "deletion_protection"}}"
 }


### PR DESCRIPTION
Final, final PR to close https://github.com/hashicorp/terraform-provider-google/issues/19983

TestAccOracleDatabaseAutonomousDatabase_oracledatabaseAutonomousDatabaseFullExample currently fails with:

```
------- Stdout: -------
=== RUN   TestAccOracleDatabaseAutonomousDatabase_oracledatabaseAutonomousDatabaseFullExample
=== PAUSE TestAccOracleDatabaseAutonomousDatabase_oracledatabaseAutonomousDatabaseFullExample
=== CONT  TestAccOracleDatabaseAutonomousDatabase_oracledatabaseAutonomousDatabaseFullExample
    resource_oracle_database_autonomous_database_generated_test.go:98: Step 1/2 error: Error running apply: exit status 1
        Error: Error waiting to create AutonomousDatabase: Error waiting for Creating AutonomousDatabase: Error code 3, message: generic::invalid_argument: InvalidParameter: Provisioning Autonomous Database failed Cause: Operation failed because a private endpoint with the specified hostname prefix testhost already exists in the tenancy. Specify a different hostname prefix and try again.
          with google_oracle_database_autonomous_database.myADB,
          on terraform_plugin_test.tf line 2, in resource "google_oracle_database_autonomous_database" "myADB":
           2: resource "google_oracle_database_autonomous_database" "myADB"{
--- FAIL: TestAccOracleDatabaseAutonomousDatabase_oracledatabaseAutonomousDatabaseFullExample (612.81s)
FAIL
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
