### PR TITLE
Fixed sweeping of incidentally-created queues

### DIFF
--- a/mmv1/third_party/terraform/sweeper/gcp_sweeper.go
+++ b/mmv1/third_party/terraform/sweeper/gcp_sweeper.go
@@ -21,6 +21,7 @@ var testResourcePrefixes = []string{
 	// include a "-" or "_" respectively, and they are the preferred prefix for our test resources to use
 	"tf-test",
 	"tf_test",
+	// Resource-specific prefixes that should be moved to the corresponding resource sweeper as part of https://github.com/hashicorp/terraform-provider-google/issues/20638
 	"tfgen",
 	"gke-us-central1-tf",  // composer-created disks which are abandoned by design (https://cloud.google.com/composer/pricing)
 	"gcs-bucket-tf-test-", // https://github.com/hashicorp/terraform-provider-google/issues/8909
@@ -28,6 +29,7 @@ var testResourcePrefixes = []string{
 	"resourcegroup-",      // https://github.com/hashicorp/terraform-provider-google/issues/8924
 	"cluster-",            // https://github.com/hashicorp/terraform-provider-google/issues/8924
 	"k8s-fw-",             // firewall rules are getting created and not cleaned up by k8 resources using this prefix
+	"ext-tf-test",         // Cloud Tasks Queues created automatically by tests for `google_firebase_extensions_instance`.
 }
 
 // SharedConfigForRegion returns a common config setup needed for the sweeper


### PR DESCRIPTION
It turns out that tests for google_firebase_extensions_instance create queues in Cloud Tasks that have names like ext-tf-test-storage-resize-imageszzjeplxr9e-backfillResizedImag. We need to prune these to ensure that we don't run out of quota.

I've already run the sweeper with this code to clear out the 1000 stale queues.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
