### PR TITLE
changed mirrored_resources nested objects to set

### DIFF
--- a/mmv1/products/compute/PacketMirroring.yaml
+++ b/mmv1/products/compute/PacketMirroring.yaml
@@ -144,6 +144,7 @@ properties:
     properties:
       - name: 'subnetworks'
         type: Array
+        is_set: true
         description: |
           All instances in one of these subnetworks will be mirrored.
         at_least_one_of:
@@ -165,6 +166,7 @@ properties:
               imports: 'selfLink'
       - name: 'instances'
         type: Array
+        is_set: true
         description: |
           All the listed instances will be mirrored.  Specify at most 50.
         at_least_one_of:


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/20637

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:breaking-change
compute: retyped `subnetworks` and `instances` of `google_compute_packet_mirroring` to sets

```
