### PR TITLE
Add `group` field to `google_network_connectivity_spoke`

### DIFF
--- a/mmv1/products/networkconnectivity/Spoke.yaml
+++ b/mmv1/products/networkconnectivity/Spoke.yaml
@@ -122,6 +122,11 @@ properties:
     immutable: true
     resource: 'hub'
     imports: 'name'
+  - name: 'group'
+    type: String
+    description: The name of the group that this spoke is associated with.
+    default_from_api: true
+    custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.tmpl'
   - name: 'linkedVpnTunnels'
     type: NestedObject
     description: The URIs of linked VPN tunnel resources

--- a/mmv1/products/networkconnectivity/Spoke.yaml
+++ b/mmv1/products/networkconnectivity/Spoke.yaml
@@ -44,6 +44,12 @@ examples:
       network_name: 'net'
       hub_name: 'hub1'
       spoke_name: 'spoke1'
+  - name: 'network_connectivity_spoke_linked_vpc_network_group'
+    primary_resource_id: 'primary'
+    vars:
+      network_name: 'net'
+      hub_name: 'hub1'
+      spoke_name: 'spoke1'
   - name: 'network_connectivity_spoke_router_appliance_basic'
     primary_resource_id: 'primary'
     vars:

--- a/mmv1/products/networkconnectivity/Spoke.yaml
+++ b/mmv1/products/networkconnectivity/Spoke.yaml
@@ -47,9 +47,9 @@ examples:
   - name: 'network_connectivity_spoke_linked_vpc_network_group'
     primary_resource_id: 'primary'
     vars:
-      network_name: 'net'
-      hub_name: 'hub1'
-      spoke_name: 'spoke1'
+      network_name: 'net-spoke'
+      hub_name: 'hub1-spoke'
+      spoke_name: 'group-spoke1'
   - name: 'network_connectivity_spoke_router_appliance_basic'
     primary_resource_id: 'primary'
     vars:
@@ -131,6 +131,7 @@ properties:
   - name: 'group'
     type: String
     description: The name of the group that this spoke is associated with.
+    immutable: true
     default_from_api: true
   - name: 'linkedVpnTunnels'
     type: NestedObject

--- a/mmv1/products/networkconnectivity/Spoke.yaml
+++ b/mmv1/products/networkconnectivity/Spoke.yaml
@@ -126,7 +126,6 @@ properties:
     type: String
     description: The name of the group that this spoke is associated with.
     default_from_api: true
-    custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.tmpl'
   - name: 'linkedVpnTunnels'
     type: NestedObject
     description: The URIs of linked VPN tunnel resources

--- a/mmv1/templates/terraform/examples/network_connectivity_spoke_linked_vpc_network_group.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_connectivity_spoke_linked_vpc_network_group.tf.tmpl
@@ -1,0 +1,33 @@
+resource "google_compute_network" "network" {
+  name                    = "{{index $.Vars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_connectivity_hub" "basic_hub" {
+  name        = "{{index $.Vars "hub_name"}}"
+  description = "A sample hub"
+  labels = {
+    label-two = "value-one"
+  }
+}
+
+resource "google_network_connectivity_spoke" "{{$.PrimaryResourceId}}"  {
+  name = "{{index $.Vars "spoke_name"}}"
+  location = "global"
+  description = "A sample spoke with a linked router appliance instance"
+  labels = {
+    label-one = "value-one"
+  }
+  hub = google_network_connectivity_hub.basic_hub.id
+  linked_vpc_network {
+    exclude_export_ranges = [
+      "198.51.100.0/24",
+      "10.10.0.0/16"
+    ]
+    include_export_ranges = [
+      "198.51.100.0/23", 
+      "10.0.0.0/8"
+    ]
+    uri = google_compute_network.network.self_link
+  }
+}

--- a/mmv1/templates/terraform/examples/network_connectivity_spoke_linked_vpc_network_group.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_connectivity_spoke_linked_vpc_network_group.tf.tmpl
@@ -11,10 +11,16 @@ resource "google_network_connectivity_hub" "basic_hub" {
   }
 }
 
+resource "google_network_connectivity_group" "default_group"  {
+ hub         = google_network_connectivity_hub.basic_hub.id
+ name        = "default"
+ description = "A sample hub group"
+}
+
 resource "google_network_connectivity_spoke" "{{$.PrimaryResourceId}}"  {
   name = "{{index $.Vars "spoke_name"}}"
   location = "global"
-  description = "A sample spoke with a linked router appliance instance"
+  description = "A sample spoke with a linked VPC"
   labels = {
     label-one = "value-one"
   }
@@ -25,9 +31,10 @@ resource "google_network_connectivity_spoke" "{{$.PrimaryResourceId}}"  {
       "10.10.0.0/16"
     ]
     include_export_ranges = [
-      "198.51.100.0/23", 
+      "198.51.100.0/23",
       "10.0.0.0/8"
     ]
     uri = google_compute_network.network.self_link
   }
+  group = google_network_connectivity_group.default_group.id
 }


### PR DESCRIPTION
- **Add `group` field to Spoke resource.**

Fixes https://github.com/hashicorp/terraform-provider-google/issues/18297


```release-note:enhancement
networkconnectivity: added `group` field to `google_network_connectivity_spoke` resource
```
